### PR TITLE
Rewrite public skill router

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,17 +1,39 @@
-# Skill Library
+# Understudy Skill Library
 
-The library uses progressive disclosure.
+This library uses progressive disclosure: start with the entrypoint, then load
+one specialist skill only when the developer's intent requires it.
 
-Start with `understudy/SKILL.md`. Read a specialist skill only after the user
-intent requires it.
+## Entry Point
 
-Initial specialist skills:
+- [`understudy`](understudy/SKILL.md) routes demo, evaluation, optimization,
+  training handoff, lab notes, local proxying, provider keys, and model lookup.
 
-- `understudy-demo`
-- `understudy-evaluate`
-- `understudy-optimize`
-- `understudy-train`
-- `understudy-lab`
-- `understudy-local-proxy`
-- `understudy-provider-keys`
-- `understudy-model-lookup`
+## Specialist Skills
+
+- [`understudy-demo`](understudy-demo/SKILL.md) shows the product loop with
+  local replay, bundled fixtures, and no provider spend.
+- [`understudy-evaluate`](understudy-evaluate/SKILL.md) compares prompts,
+  traces, eval rows, datasets, or candidate models with explicit split
+  boundaries.
+- [`understudy-optimize`](understudy-optimize/SKILL.md) improves a measured
+  workload while protecting holdout evidence.
+- [`understudy-train`](understudy-train/SKILL.md) prepares SFT, preference, RL,
+  adapter, or hosted-training handoffs.
+- [`understudy-lab`](understudy-lab/SKILL.md) records longer experiment loops,
+  budgets, artifacts, decisions, and next actions.
+- [`understudy-local-proxy`](understudy-local-proxy/SKILL.md) handles local
+  OpenAI-compatible proxying, trace capture, and replay.
+- [`understudy-provider-keys`](understudy-provider-keys/SKILL.md) handles local
+  credential setup and status checks.
+- [`understudy-model-lookup`](understudy-model-lookup/SKILL.md) inspects model
+  availability, runner compatibility, and local-vs-remote options.
+
+## Public Safety
+
+Default to local-only, no-upload, no-spend work. Public examples should use
+synthetic fixtures, local `.understudy/` artifacts, public provider docs, or
+public open-source projects.
+
+Do not include customer names, domains, raw prompts, raw completions, traces,
+secrets, private notes, internal runbooks, or hosted-control details in public
+skills.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: understudy
-description: Public Understudy entrypoint. Use when a developer asks to use Understudy, evaluate an AI workload, compare models, optimize quality or cost, prepare training data, set up a local proxy, or inspect model options. Start with local-only replay and route by intent using progressive disclosure.
+description: Use when a developer asks to use Understudy, evaluate or optimize an AI workload, prepare training data, run a demo, set up local capture or proxying, or inspect model options. Route to the narrow specialist skill before running commands.
 metadata:
   understudy:
     mode: automatic
@@ -10,33 +10,90 @@ metadata:
 
 # Understudy
 
-Use this as the single public entrypoint.
+Use this skill as the public entrypoint for Understudy. Start here when the
+developer names Understudy or asks for help with evaluation, optimization,
+training handoff, local proxying, model choice, provider setup, or a first-run
+demo.
 
-Default rule: demonstrate value before asking for keys, data, provider spend,
-or hosted jobs.
+Do not use this skill as a full runbook. Route to the narrow specialist skill,
+then follow that skill's CLI and safety instructions.
 
-## Route By Intent
+## Resolve CLI
 
-1. Demo or first run: read `../understudy-demo/SKILL.md`.
-2. Existing traces, evals, prompts, or model comparisons: read `../understudy-evaluate/SKILL.md`.
-3. Improve quality, latency, or cost after a baseline: read `../understudy-optimize/SKILL.md`.
-4. Prepare SFT, preference, RL, adapter, or hosted-training handoff: read `../understudy-train/SKILL.md`.
-5. Longer research loops, hypotheses, budgets, or repeated experiments: read `../understudy-lab/SKILL.md`.
-6. Local OpenAI-compatible proxy or trace capture: read `../understudy-local-proxy/SKILL.md`.
-7. Provider key setup: read `../understudy-provider-keys/SKILL.md`.
-8. Model availability, runner compatibility, or local-vs-remote choice: read `../understudy-model-lookup/SKILL.md`.
+Do not resolve the CLI in this routing skill unless the user explicitly asks
+for setup status before the intent is clear.
 
-## Public Boundary
+When a routed specialist skill requires the CLI, open and read
+[`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md), then define
+the `run_understudy` shell function from that shared resource.
 
-- Keep source, prompts, traces, outputs, datasets, and secrets local by default.
-- Use synthetic fixtures for examples.
-- Keep provider calls and uploads behind explicit user action.
-- Report what was measured separately from what is only planned.
+If `run_understudy` returns 127, stop and explain that the Understudy CLI is not
+available in the current shell. Do not guess install paths.
 
 ## Safety Gates
+
+Default to local-only, no-upload, no-spend work.
 
 Do not upload source files, prompts, traces, outputs, datasets, repo paths,
 private notes, provider keys, or secrets unless the developer explicitly
 approves that exact action in the current thread.
 
 Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- dry-run or preview artifact reviewed first;
+- visible output path under `.understudy/`.
+
+Keep public examples synthetic or user-provided. Do not include customer names,
+domains, private runbooks, raw prompts, raw completions, secrets, or internal
+hosted-control details in public skill output.
+
+## Intake
+
+1. Identify the user's intent from the actual request, not from nearby files.
+2. Ask at most one clarifying question if the route is ambiguous.
+3. Prefer a local replay, dry-run, fixture, or status check before provider
+   calls, uploads, or hosted jobs.
+4. State which specialist skill you are using and why.
+
+## Flow
+
+Route by the smallest matching intent:
+
+- New user, product tour, or "show me how this works": read
+  [`../understudy-demo/SKILL.md`](../understudy-demo/SKILL.md).
+- Existing prompts, traces, eval rows, reports, datasets, or model comparison:
+  read [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
+- Improve measured quality, latency, cost, parsing, routing, or reliability:
+  read [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
+- SFT, preference data, RL trajectories, adapters, or hosted training handoff:
+  read [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md).
+- Multi-run research, hypotheses, budgets, experiment notes, or decision logs:
+  read [`../understudy-lab/SKILL.md`](../understudy-lab/SKILL.md).
+- Local OpenAI-compatible proxy, trace capture, or replay through a local
+  endpoint: read
+  [`../understudy-local-proxy/SKILL.md`](../understudy-local-proxy/SKILL.md).
+- Provider key setup or local credential health: read
+  [`../understudy-provider-keys/SKILL.md`](../understudy-provider-keys/SKILL.md).
+- Model availability, runner compatibility, or local-vs-remote candidate
+  choice: read
+  [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md).
+
+If more than one route applies, use this order: demo, evaluate, optimize,
+train, lab, local proxy, provider keys, model lookup. Switch only when the
+evidence changes.
+
+## Output Standard
+
+End with:
+
+- which specialist skill was used or should be used next;
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command from the specialist skill when available.


### PR DESCRIPTION
## Purpose
Establish the public-facing skill router for `understudy-agent-tools`.

This PR makes the root `understudy` skill a concise progressive-disclosure entrypoint instead of a long runbook. It also updates the skill library README so reviewers can see the intended public surface at a glance.

## Changes
- Rewrites `skills/understudy/SKILL.md` as the top-level router.
- Updates `skills/README.md` with the specialist-skill map.
- Makes local-only, no-upload, no-spend defaults explicit.
- Keeps CLI execution delegated to routed specialist skills.

## Public Safety Boundary
- No customer names, domains, traces, prompts, completions, or private runbooks.
- No hosted-control-plane details.
- No provider spend or upload implied by routing.

## Manual Proofread Checklist
- Router order matches the user journey: demo -> evaluate -> optimize -> train -> lab -> proxy/keys/model lookup.
- README mentions only skills we are comfortable shipping publicly.
- Safety language is clear without becoming noisy.

## Verification
- `python3 scripts/validate_public_skills.py`
- `git diff --check`
