### PR TITLE
Rewrite first-run public skills

### DIFF
--- a/skills/understudy-demo/SKILL.md
+++ b/skills/understudy-demo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: understudy-demo
-description: Replay-first demo path for explaining the Understudy replacement loop without live keys, uploads, or provider spend.
+description: Use when a developer wants a first-run Understudy demo or product walkthrough using local replay, bundled fixtures, and no provider spend.
 metadata:
   understudy:
     mode: automatic
@@ -10,26 +10,94 @@ metadata:
 
 # Understudy Demo
 
-Use this when the user is new, wants a demo, or wants to understand the product
-shape before running live work.
+Use this skill when the developer asks for a demo, first run, product
+walkthrough, or quick explanation of the Understudy replacement loop.
 
-Workflow:
-
-1. Run a local doctor check.
-2. Use bundled or synthetic examples only.
-3. Show the replacement loop: baseline, candidate, quality delta, cost delta,
-   failure clusters, and next action.
-4. Offer a live evaluation only after the replay is understood.
-
-Do not ask for provider keys before showing the local path unless the user
-explicitly skips replay.
+Do not use this skill for a real workload comparison after the developer has
+provided prompts, traces, datasets, or eval artifacts. Route those requests to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
 
 ## Resolve CLI
 
-Open and read `../_resources/cli-bootstrap.md`, then define the shared
-`run_understudy` shell function before running CLI commands.
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, stop and explain that the Understudy CLI is not
+available in the current shell. Do not invent install commands.
 
 ## Safety Gates
 
-Default to local-only, no-upload, no-spend work. Use bundled or synthetic
-examples only.
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Use bundled or synthetic examples only. Do not ask for provider keys before
+showing a local replay unless the developer explicitly skips the replay path.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- dry-run or preview artifact reviewed first;
+- visible output path under `.understudy/`.
+
+## Intake
+
+1. Confirm whether the developer wants a product demo or a real workload run.
+2. Inspect local CLI availability and any bundled demo commands.
+3. Run the smallest no-spend status or replay command before proposing live
+   work.
+
+## Flow
+
+1. Check the local CLI:
+
+```sh
+run_understudy --help
+```
+
+2. Prefer a bundled demo, doctor, or replay command exposed by the installed
+   CLI. If the exact demo command is not obvious, inspect help first:
+
+```sh
+run_understudy demo --help
+```
+
+3. Run a local replay or fixture-only demo that writes under:
+
+```text
+.understudy/demo/
+```
+
+4. Explain the replacement loop using only generated or bundled evidence:
+   baseline, candidate, quality signal, cost or latency signal, failure
+   clusters, and next action.
+
+5. Offer a live evaluation only after the local replay is understood and the
+   developer approves the provider, budget cap, and data class.
+
+## References
+
+Load deeper material only when needed:
+
+- [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md) for
+  real workload comparisons.
+- [`../understudy-provider-keys/SKILL.md`](../understudy-provider-keys/SKILL.md)
+  for local key setup after the replay path.
+- [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md)
+  for candidate availability or compatibility questions.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-lab/SKILL.md
+++ b/skills/understudy-lab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: understudy-lab
-description: Keep longer experiment loops durable with hypotheses, budgets, artifacts, decisions, and next actions.
+description: Use when Understudy work spans multiple runs and needs durable hypotheses, budgets, artifacts, decisions, and next actions.
 metadata:
   understudy:
     mode: reporting
@@ -8,25 +8,112 @@ metadata:
     cli_required: false
 ---
 
-# Lab
+# Understudy Lab
 
-Use when work spans multiple runs or needs durable research memory.
+Use this skill when the developer is running a longer experiment loop, comparing
+multiple hypotheses, tracking a budget, preserving a decision record, or asking
+for a durable research note.
 
-Record:
+Do not use this skill for a single first-run demo. Route those requests to
+[`../understudy-demo/SKILL.md`](../understudy-demo/SKILL.md). Do not use it as a
+substitute for workload measurement; route measurement to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
 
-- hypothesis
-- method
-- budget
-- data/split boundary
-- command
-- artifact paths
-- result
-- keep/discard decision
-- next idea
+## Resolve CLI
 
-Avoid chat-only learnings. If a result changes future decisions, write it down.
+This skill can write a lab note without the CLI.
+
+When a lab note needs current Understudy status, open and read
+[`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md), then define
+the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, continue with file-based notes only and mark
+the CLI check as unavailable.
 
 ## Safety Gates
 
-Lab notes must not contain raw customer prompts, completions, traces, secrets,
-or private partner identifiers in public repositories.
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Lab notes in public repositories must not contain customer names, domains,
+private partner identifiers, raw prompts, raw completions, raw traces, secrets,
+or private runbook details.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- dry-run or preview artifact reviewed first;
+- visible output path under `.understudy/`.
+
+## Intake
+
+1. Identify the hypothesis, decision, or open question.
+2. Inspect the relevant local artifacts before summarizing results.
+3. Separate observed results from planned next steps.
+4. Record costs, budgets, split boundaries, and commands when available.
+
+## Flow
+
+1. Choose a local note path under:
+
+```text
+.understudy/lab/
+```
+
+2. If the CLI is available and a status check is relevant, run:
+
+```sh
+run_understudy --help
+```
+
+3. Write or update a concise note with these fields:
+
+```text
+hypothesis:
+method:
+budget:
+data_or_split_boundary:
+commands:
+artifact_paths:
+result:
+decision:
+next_action:
+approval_gates:
+```
+
+4. Use anonymized workload labels for reusable public notes. Preserve
+non-sensitive measurements such as model version strings, sample sizes, cost,
+latency, and metric definitions when they are needed to interpret the result.
+
+5. If the note identifies a new real workload measurement, route the next step
+to [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md). If it
+identifies a candidate improvement loop, route to
+[`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
+
+## References
+
+Load deeper material only when needed:
+
+- [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md) for
+  measurement and split boundaries.
+- [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md) for
+  candidate promotion, fallback, and demotion evidence.
+- [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md) for training
+  handoff notes.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command.


### PR DESCRIPTION
## Purpose
Add the first-run public skill surface: a safe demo path and durable local lab notes.

These skills are the lowest-risk onboarding layer. They should let a developer understand the Understudy loop without provider keys, uploads, or customer data.

## Changes
- Rewrites `skills/understudy-demo/SKILL.md` around local replay and bundled/synthetic fixtures.
- Rewrites `skills/understudy-lab/SKILL.md` around local experiment notes, hypotheses, budgets, artifacts, and next actions.
- Uses the public skill template: activation, CLI resolution, safety gates, intake, flow, references, and output standard.

## Public Safety Boundary
- Demo defaults to local replay only.
- Lab notes must not include customer identifiers, raw prompts, raw completions, traces, secrets, or private partner details.
- Provider keys are not requested by the demo path.

## Manual Proofread Checklist
- Demo is concrete enough for a new user without implying unsupported runtime commands.
- Lab note schema is useful but not an internal methodology leak.
- Routing exclusions are clear.

## Verification
- `python3 scripts/validate_public_skills.py`
- `git diff --check`
