### PR TITLE
Rewrite evaluation and model lookup skills

### DIFF
--- a/skills/understudy-evaluate/SKILL.md
+++ b/skills/understudy-evaluate/SKILL.md
@@ -1,34 +1,119 @@
 ---
 name: understudy-evaluate
-description: Evaluate prompts, traces, datasets, or model candidates with local-first comparisons and explicit split boundaries.
+description: Use when comparing prompts, traces, datasets, scorers, routes, or model candidates with local-first evaluation evidence.
 metadata:
   understudy:
     mode: interactive
-    safety: approval-required
+    safety: local-first
     cli_required: true
 ---
 
-# Evaluate
+# Understudy Evaluate
 
-Use this when the user has a workload and wants to compare model quality,
-latency, reliability, or cost.
+Use this skill when the developer asks to evaluate a workload or compare
+quality, latency, reliability, cost, scorers, prompts, routes, or model
+candidates.
 
-Workflow:
-
-1. Identify source material: prompts, traces, eval rows, repo scripts, or
-   synthetic fixtures.
-2. Define train, validation, and test boundaries before optimization.
-3. Run the smallest useful local or no-spend smoke.
-4. Report metric definitions, sample size, cost, latency, and known caveats.
-5. Escalate to provider calls only with explicit approval and a budget cap.
+Do not use this skill for optimization after a measured baseline exists. Route
+those requests to [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
+For fine-tuning, SFT, adapter, or training-data requests, route to
+[`../understudy-train/SKILL.md`](../understudy-train/SKILL.md).
 
 ## Resolve CLI
 
-Open and read `../_resources/cli-bootstrap.md`, then define the shared
-`run_understudy` shell function before running CLI commands.
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, activate
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
 
 ## Safety Gates
+
+Default to local-only, no-upload, no-spend work. Prefer local artifacts,
+synthetic fixtures, replay data, and dry-run plans before live provider calls.
 
 Do not upload source files, prompts, traces, outputs, datasets, repo paths,
 private notes, provider keys, or secrets unless the developer explicitly
 approves that exact action in the current thread.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- reviewed dry-run or preview artifact;
+- visible output path under `.understudy/`.
+
+Keep split boundaries explicit. Do not inspect heldout labels or tune prompts,
+scorers, renderers, or routes against heldout rows.
+
+## Intake
+
+1. Inspect the real local workload source: trace store, dataset, eval report,
+   repo script, prompt set, scorer, or synthetic fixture.
+2. Identify the decision: baseline measurement, route comparison, scorer
+   validation, regression check, or readiness gate.
+3. Record row count, split names, metric definitions, candidate routes, and
+   known missing data before running comparisons.
+4. Run the smallest no-spend status, validation, replay, or dry-run command.
+5. Summarize current state before proposing paid, hosted, or upload steps.
+
+## Flow
+
+1. Check local CLI health and available evaluation surfaces:
+
+```sh
+run_understudy --help
+run_understudy evaluate --help
+```
+
+2. If the workload already has local artifacts, inspect or validate them before
+   creating new runs:
+
+```sh
+run_understudy evaluate status --local
+run_understudy evaluate validate --dry-run
+```
+
+3. If local artifacts are missing, start with fixtures or a replay-only dry run:
+
+```sh
+run_understudy evaluate run --dry-run --local
+```
+
+4. Read generated artifacts under:
+
+```text
+.understudy/evaluate/
+```
+
+5. Separate catalog facts from measured results. A model card, route config, or
+   provider listing is not evaluation evidence.
+
+6. Report failures as actionable inputs: parser mismatch, missing labels,
+   scorer drift, context-window mismatch, token-cap mismatch, route error,
+   sample-size gap, or spend/upload gate.
+
+## References
+
+Load deeper material only when needed:
+
+- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
+  and interpretation rules.
+- [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md)
+  - model capability and route compatibility checks before benchmarking.
+- [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md)
+  - post-baseline improvement loop.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- metric definitions, sample size, split boundary, and caveats;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-model-lookup/SKILL.md
+++ b/skills/understudy-model-lookup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: understudy-model-lookup
-description: Inspect model availability, artifact metadata, runner compatibility, and local-vs-remote route choices before benchmarking.
+description: Use when inspecting model availability, metadata, runner compatibility, and route choices before benchmarking.
 metadata:
   understudy:
     mode: interactive
@@ -8,28 +8,109 @@ metadata:
     cli_required: true
 ---
 
-# Model Lookup
+# Understudy Model Lookup
 
-Use before choosing a runner or claiming a model cannot work.
+Use this skill when the developer asks whether a model, adapter, route, runner,
+provider API, local engine, quantization, context window, tokenizer, or
+modality can work for a workload.
 
-Workflow:
-
-1. Inspect model card, config, tokenizer, architecture, modality, and
-   quantization metadata.
-2. Match the artifact to a runner: local, MLX, llama.cpp, OpenAI-compatible,
-   provider API, or hosted endpoint.
-3. Run a tiny smoke before benchmarking.
-4. Report catalog facts separately from measured results.
-
-Check adapter, parser, context-window, token-cap, and route mismatches before
-blaming the model.
+Do not use this skill to claim quality, replacement readiness, or benchmark
+performance. Route measured comparison requests to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
 
 ## Resolve CLI
 
-Open and read `../_resources/cli-bootstrap.md`, then define the shared
-`run_understudy` shell function before running CLI commands.
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, activate
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
 
 ## Safety Gates
 
-Model lookup is not benchmark approval. Do not upload prompts, traces,
-datasets, or model outputs while checking capabilities.
+Default to local-only, no-upload, no-spend work. Model lookup should inspect
+local metadata, public model cards, cached manifests, runner help, and dry-run
+route plans before any live provider call.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- reviewed dry-run or preview artifact;
+- visible output path under `.understudy/`.
+
+Model lookup is not benchmark approval. Do not send prompts, traces, datasets,
+or model outputs to providers while checking availability or compatibility.
+
+## Intake
+
+1. Inspect the requested model id, artifact path, adapter path, provider route,
+   runner, quantization, context-window need, modality, and hardware limits.
+2. Separate public catalog facts, local artifact metadata, and measured smoke
+   results.
+3. Check tokenizer, architecture, config, license, quantization, adapter base,
+   tool-call support, structured-output support, and context limit.
+4. Run the smallest local status, manifest, or dry-run route command.
+5. Summarize compatibility before proposing paid, hosted, or upload steps.
+
+## Flow
+
+1. Check local CLI health and lookup surfaces:
+
+```sh
+run_understudy --help
+run_understudy model --help
+```
+
+2. Inspect cached or local model metadata:
+
+```sh
+run_understudy model lookup --local --dry-run
+```
+
+3. If evaluating a route, verify route shape without sending workload payloads:
+
+```sh
+run_understudy model route --dry-run --local
+```
+
+4. If a model seems incompatible, check parser, adapter, tokenizer,
+   architecture, quantization, context window, token cap, modality, and route
+   mismatch before blaming model quality.
+
+5. Read generated artifacts under:
+
+```text
+.understudy/model-lookup/
+```
+
+6. Recommend the next measured step only after lookup evidence is clear.
+
+## References
+
+Load deeper material only when needed:
+
+- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
+  and interpretation rules.
+- [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md)
+  - measured comparison after compatibility is established.
+- [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md)
+  - adapter and training handoff checks.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- catalog facts, local metadata, compatibility result, and caveats;
+- approval-gated next step, if any;
+- one recommended command.


### PR DESCRIPTION
## Purpose
Define the public measurement layer: evaluate real workloads conservatively, and inspect model compatibility before benchmark claims.

This PR keeps model lookup separate from evaluation so public agents do not confuse catalog facts with measured results.

## Changes
- Rewrites `skills/understudy-evaluate/SKILL.md` as the local-first workload measurement workflow.
- Rewrites `skills/understudy-model-lookup/SKILL.md` as the pre-benchmark compatibility check.
- Adds explicit split-boundary, dry-run-first, and approval-gate language.

## Public Safety Boundary
- No live provider calls, uploads, hosted jobs, benchmark submissions, or training without exact approval in the current thread.
- Heldout rows are measurement-only.
- Model lookup does not authorize benchmarking or quality claims.

## Manual Proofread Checklist
- Evaluation guidance is specific enough to be useful.
- Spend/upload language is conservative and unambiguous.
- Model lookup avoids current vendor/model claims unless backed by public docs.

## Verification
- `python3 scripts/validate_public_skills.py`
- `git diff --check`
