### PR TITLE
Rewrite optimization and training skills

### DIFF
--- a/skills/understudy-optimize/SKILL.md
+++ b/skills/understudy-optimize/SKILL.md
@@ -1,35 +1,119 @@
 ---
 name: understudy-optimize
-description: Improve a measured workload using prompt, routing, repair, or candidate-search steps while protecting holdout evidence.
+description: Use when improving a measured workload through prompt, routing, repair, candidate-search, or cost-quality changes.
 metadata:
   understudy:
     mode: interactive
-    safety: approval-required
+    safety: local-first
     cli_required: true
 ---
 
-# Optimize
+# Understudy Optimize
 
-Use only after a baseline exists.
+Use this skill when the developer asks to improve a measured workload, beat a
+baseline, lower cost, repair failures, compare routes, or promote a candidate.
 
-Workflow:
-
-1. Preserve the holdout split for measurement only.
-2. Start with cheap interventions: prompt repair, renderer repair, parsing,
-   routing, and context trimming.
-3. Promote a candidate only with repeatable command, metric delta, cost delta,
-   fallback route, and demotion trigger.
-4. Treat failed screens as experiment inputs, not dead ends.
-
-Do not claim replacement readiness from train-only or validation-only lift.
+Do not use this skill when no baseline exists. Route first measurement to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md). Route
+training, SFT, LoRA, preference-data, or hosted-training requests to
+[`../understudy-train/SKILL.md`](../understudy-train/SKILL.md).
 
 ## Resolve CLI
 
-Open and read `../_resources/cli-bootstrap.md`, then define the shared
-`run_understudy` shell function before running CLI commands.
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, activate
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
 
 ## Safety Gates
 
-Never tune on validation or held-out test data. Keep live calls, uploads, and
-hosted optimization behind explicit approval, a budget cap, and a reviewed
-dry-run artifact.
+Default to local-only, no-upload, no-spend work. Start with replay, dry-run,
+schema repair, parser repair, prompt variants, renderer changes, context
+trimming, and local routing checks.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- reviewed dry-run or preview artifact;
+- visible output path under `.understudy/`.
+
+Never tune on heldout rows. Preserve validation and heldout boundaries in every
+candidate card, score artifact, and recommendation.
+
+## Intake
+
+1. Inspect the current baseline report, candidate card, decision packet, eval
+   artifact, or workload profile.
+2. Confirm metrics, incumbent route, split boundaries, sample size, failure
+   classes, cost, latency, and fallback route.
+3. Identify the cheapest intervention class that matches observed failures.
+4. Run the smallest no-spend status or dry-run command.
+5. Summarize current evidence before proposing paid, hosted, or upload steps.
+
+## Flow
+
+1. Check local CLI health and optimization surfaces:
+
+```sh
+run_understudy --help
+run_understudy optimize --help
+```
+
+2. Inspect existing local experiment or optimization state:
+
+```sh
+run_understudy optimize status --local
+```
+
+3. If no durable plan exists, create a local dry-run plan before running work:
+
+```sh
+run_understudy optimize plan --dry-run --local
+```
+
+4. Run cheap local interventions first:
+
+```sh
+run_understudy optimize run --dry-run --local
+```
+
+5. Read generated artifacts under:
+
+```text
+.understudy/optimize/
+```
+
+6. Promote narrowly. A candidate needs a repeatable command, split refs,
+   failure taxonomy, baseline comparison, cost and latency deltas, fallback
+   route, demotion trigger, and known limitations.
+
+7. Treat failed screens as next-step inputs, not terminal conclusions.
+
+## References
+
+Load deeper material only when needed:
+
+- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
+  and interpretation rules.
+- [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md)
+  - baseline and comparison measurement.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- incumbent route, candidate route, metric delta, cost delta, and caveats;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-train/SKILL.md
+++ b/skills/understudy-train/SKILL.md
@@ -1,34 +1,119 @@
 ---
 name: understudy-train
-description: Prepare local training handoffs for SFT, preference data, RL trajectories, LoRA adapters, or hosted training jobs.
+description: Use when preparing local training handoffs for SFT, preference data, RL trajectories, LoRA adapters, or hosted jobs.
 metadata:
   understudy:
     mode: interactive
-    safety: approval-required
+    safety: local-first
     cli_required: true
 ---
 
-# Train
+# Understudy Train
 
-Use when the user asks about fine-tuning, adapters, SFT, preference data, RL,
-or hosted training.
+Use this skill when the developer asks about fine-tuning, SFT, adapters,
+preference data, RL trajectories, LoRA artifacts, local training preparation,
+or hosted training jobs.
 
-Workflow:
-
-1. Confirm a measured baseline and failure taxonomy exist.
-2. Export local training records with split IDs and provenance.
-3. Keep validation and test rows out of training.
-4. Hash local adapter artifacts before promotion.
-5. Treat hosted jobs as explicit approval-required actions.
-
-Training is a handoff until the user approves spend/upload.
+Do not use this skill for first-pass model comparison. Route evaluation to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
+For post-baseline prompt, routing, or repair improvements, route to
+[`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
 
 ## Resolve CLI
 
-Open and read `../_resources/cli-bootstrap.md`, then define the shared
-`run_understudy` shell function before running CLI commands.
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, activate
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
 
 ## Safety Gates
 
-Do not upload data or start hosted training without explicit upload approval,
-training approval, and a budget cap in the current thread.
+Default to local-only, no-upload, no-spend work. Training starts as a local
+handoff: data audit, export preview, split validation, provenance check, and
+artifact hashing.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- reviewed dry-run or preview artifact;
+- visible output path under `.understudy/`.
+
+Do not train on validation or heldout test rows. Do not start hosted training,
+upload datasets, or publish adapters without exact approval in the current
+thread.
+
+## Intake
+
+1. Inspect the measured baseline, failure taxonomy, candidate-card evidence, or
+   evaluation report that justifies training.
+2. Confirm training objective: SFT behavior repair, argument normalization,
+   preference tuning, reward modeling, adapter export, or hosted job handoff.
+3. Verify source rows, labels, split IDs, provenance, license constraints, and
+   sanitization status.
+4. Run the smallest no-spend status, export preview, or validation command.
+5. Summarize current state before proposing paid, hosted, or upload steps.
+
+## Flow
+
+1. Check local CLI health and training surfaces:
+
+```sh
+run_understudy --help
+run_understudy train --help
+```
+
+2. Inspect local training readiness:
+
+```sh
+run_understudy train status --local
+```
+
+3. Preview the export before writing or uploading any training data:
+
+```sh
+run_understudy train export --dry-run --local
+```
+
+4. Validate split integrity and provenance:
+
+```sh
+run_understudy train validate --dry-run --local
+```
+
+5. Read generated artifacts under:
+
+```text
+.understudy/train/
+```
+
+6. Hash local data and adapter artifacts before promotion. Report hashes and
+   exact paths instead of copying payload contents into chat.
+
+7. Treat hosted training as an approval-gated next step, not a default action.
+
+## References
+
+- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
+  and interpretation rules.
+- [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md)
+  - baseline evidence and split-aware measurement.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- split boundary, provenance status, artifact hashes, and caveats;
+- approval-gated next step, if any;
+- one recommended command.


### PR DESCRIPTION
## Purpose
Define the public improvement and training-handoff layer.

This PR separates post-baseline optimization from training preparation, while keeping hosted training and uploads behind explicit approval.

## Changes
- Rewrites `skills/understudy-optimize/SKILL.md` around conservative post-baseline improvement.
- Rewrites `skills/understudy-train/SKILL.md` as local training handoff: data audit, export preview, split validation, provenance, and artifact hashing.
- Keeps candidate promotion evidence and heldout protection explicit.

## Public Safety Boundary
- Optimization starts with local/dry-run interventions.
- Training is a handoff until upload/training/spend are explicitly approved.
- Validation and heldout rows are never training data.
- No internal provider-lane strategy or sprint doctrine.

## Manual Proofread Checklist
- Split discipline is clear and strong.
- Training language does not imply automatic hosted jobs.
- Candidate promotion requirements are useful without leaking private replacement methodology.

## Verification
- `python3 scripts/validate_public_skills.py`
- `git diff --check`
