### PR TITLE
Rewrite access and safety skills

### DIFF
--- a/skills/understudy-bootstrap/SKILL.md
+++ b/skills/understudy-bootstrap/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: understudy-bootstrap
+description: Use when the Understudy CLI cannot be found or a public setup check is needed before running other skills.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Understudy Bootstrap
+
+Use this skill when another public Understudy skill cannot resolve the
+`understudy` or `understudy-tools` CLI, or when the developer asks for local
+public setup help before running Understudy commands.
+
+Do not use this skill to collect provider keys, configure hosted workflows, or
+change app routing. Route those requests to
+[`../understudy-provider-keys/SKILL.md`](../understudy-provider-keys/SKILL.md)
+or
+[`../understudy-local-proxy/SKILL.md`](../understudy-local-proxy/SKILL.md).
+
+## Safety Gates
+
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Never ask for secrets in chat. Do not inspect shell history. Do not print
+environment values. Setup checks may report command paths, versions, and
+whether expected names are present.
+
+Provider keys are local machine state, not spend approval. Installing or
+finding the CLI does not approve live calls, hosted jobs, uploads, benchmark
+submission, or training.
+
+## Intake
+
+1. Confirm the working directory and the operating system shell.
+2. Check whether `understudy` or `understudy-tools` is already on `PATH`.
+3. Check for local project files that indicate a public installation path, such
+   as `pyproject.toml`, `package.json`, or a checked-in README.
+4. Prefer project-local commands over global installs.
+
+## Flow
+
+1. Run command discovery:
+
+```sh
+command -v understudy
+command -v understudy-tools
+```
+
+2. If neither command exists, inspect local setup files without printing
+   secrets:
+
+```sh
+ls
+```
+
+3. If the current directory is a Python project, prefer a local runner or
+   editable development install documented by the project:
+
+```sh
+python -m pip --version
+python -m pip show understudy understudy-tools
+```
+
+4. If the current directory is a Node project, inspect scripts before running
+   installs:
+
+```sh
+npm pkg get scripts
+```
+
+5. After any setup step, re-define the shared helper:
+
+```sh
+run_understudy() {
+  if command -v understudy >/dev/null 2>&1; then
+    understudy "$@"
+    return $?
+  fi
+  if command -v understudy-tools >/dev/null 2>&1; then
+    understudy-tools "$@"
+    return $?
+  fi
+  return 127
+}
+```
+
+6. Verify with a no-spend version or help command:
+
+```sh
+run_understudy --help
+```
+
+7. If the CLI still cannot be found, stop and report the exact commands run,
+   current directory, and missing command names. Do not guess at private
+   installation surfaces.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-local-proxy/SKILL.md
+++ b/skills/understudy-local-proxy/SKILL.md
@@ -8,25 +8,108 @@ metadata:
     cli_required: true
 ---
 
-# Local Proxy
+# Understudy Local Proxy
 
-Use when the user wants to route an app through a local gateway or capture
-traces.
+Use this skill when the developer asks to route an app, SDK, CLI, or agent
+through a local OpenAI-compatible gateway, inspect base URL wiring, capture
+local traces, or verify proxy behavior without uploading payloads.
 
-Workflow:
-
-1. Inspect the app's current model client configuration.
-2. Identify SDK style and base URL fields.
-3. Start with fixture/local mode.
-4. Verify one request path before recommending production routing.
-5. Keep trace storage local unless the user explicitly uploads.
+Do not use this skill for provider API key setup. Route key and secret handling
+to [`../understudy-provider-keys/SKILL.md`](../understudy-provider-keys/SKILL.md).
 
 ## Resolve CLI
 
-Open and read `../_resources/cli-bootstrap.md`, then define the shared
-`run_understudy` shell function before running CLI commands.
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, activate
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
 
 ## Safety Gates
 
-Never ask for secrets in chat. Keep trace capture local by default and verify
-the app's current client wiring before changing configuration.
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Never ask for secrets in chat. Inspect whether a key reference exists only as a
+configuration name or environment variable name; do not print values.
+
+Trace capture must write to local storage by default. Before any live provider
+call, hosted route, upload, or benchmark submission, require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifact or data class being sent;
+- dry-run or preview artifact reviewed first;
+- visible output path under `.understudy/`.
+
+Provider keys are local machine state, not spend approval.
+
+## Intake
+
+1. Inspect the app's real client wiring, SDK, environment names, and base URL
+   settings.
+2. Identify whether the app uses OpenAI SDK, Vercel AI SDK, LangChain,
+   LiteLLM, direct HTTP, or another OpenAI-compatible client.
+3. Run the smallest no-spend local status or doctor command.
+4. Summarize the current route before proposing configuration edits.
+
+## Flow
+
+1. Check local proxy support:
+
+```sh
+run_understudy proxy --help
+```
+
+2. If a doctor or dry-run command is available, run it before touching app
+   configuration:
+
+```sh
+run_understudy proxy doctor --dry-run
+```
+
+3. Inspect the target app for generic client fields such as:
+
+```text
+OPENAI_BASE_URL
+OPENAI_API_BASE
+baseURL
+base_url
+apiBase
+model
+```
+
+4. Prefer a fixture, fake-provider, or local replay path for the first request.
+   Do not use a configured provider key as permission to make a paid request.
+
+5. Start or validate the proxy only after the target route is understood:
+
+```sh
+run_understudy proxy start --help
+```
+
+6. Verify one request path end to end. Capture only local metadata needed to
+   prove routing, status, latency, and model selection unless the developer
+   approves richer trace capture.
+
+7. Read generated artifacts under:
+
+```text
+.understudy/proxy/
+.understudy/traces/
+```
+
+8. Summarize the observed app route, proxy route, result type, and next command.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-provider-keys/SKILL.md
+++ b/skills/understudy-provider-keys/SKILL.md
@@ -8,25 +8,103 @@ metadata:
     cli_required: true
 ---
 
-# Provider Keys
+# Understudy Provider Keys
 
-Use when a workflow needs Anthropic, OpenAI, Gemini, Fireworks, Together,
-Hugging Face, or another provider.
+Use this skill when the developer needs to check, configure, rotate, or verify
+local provider credentials for Anthropic, OpenAI, Gemini, Fireworks, Together,
+Hugging Face, or another SDK-compatible provider.
 
-Rules:
-
-- Do not ask users to paste keys into chat.
-- Prefer terminal prompts, local env files, or the user's secret manager.
-- Check whether keys are present before asking for new ones.
-- Never print key values.
-- Keep provider spend behind explicit approval and a budget cap.
+Do not use this skill to change app routing or proxy behavior. Route local
+gateway work to
+[`../understudy-local-proxy/SKILL.md`](../understudy-local-proxy/SKILL.md).
 
 ## Resolve CLI
 
-Open and read `../_resources/cli-bootstrap.md`, then define the shared
-`run_understudy` shell function before running CLI commands.
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, activate
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
 
 ## Safety Gates
 
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
 Never let an API key appear in chat, tool output, logs, examples, or committed
 files. If a key is exposed, stop and guide rotation.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- dry-run or preview artifact reviewed first;
+- visible output path under `.understudy/`.
+
+## Intake
+
+1. Identify the provider, SDK, and local runtime that needs credentials.
+2. Check whether credentials are present by name only. Do not print values.
+3. Prefer terminal prompts, local env files, operating-system secret storage, or
+   the developer's secret manager.
+4. Summarize missing or conflicting key names without exposing values.
+
+## Flow
+
+1. Check available credential commands:
+
+```sh
+run_understudy keys --help
+```
+
+2. If a doctor command exists, run it in redacted mode:
+
+```sh
+run_understudy keys doctor --redacted
+```
+
+3. If the CLI does not expose key helpers, inspect only environment variable
+   names and file paths. Safe examples include:
+
+```text
+ANTHROPIC_API_KEY=<present or missing>
+OPENAI_API_KEY=<present or missing>
+GOOGLE_API_KEY=<present or missing>
+FIREWORKS_API_KEY=<present or missing>
+TOGETHER_API_KEY=<present or missing>
+HF_TOKEN=<present or missing>
+```
+
+4. If a key is missing, ask the developer to enter it through a terminal prompt
+   or their secret manager. Do not request the value in chat.
+
+5. If a key was exposed, stop normal work and recommend rotation for that
+   provider before continuing.
+
+6. Verify configuration with a no-spend status check first. A real model call
+   requires explicit approval and a budget cap.
+
+7. Read generated artifacts under:
+
+```text
+.understudy/keys/
+.understudy/provider-checks/
+```
+
+8. Summarize provider readiness as present, missing, conflicting, or exposed.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command.


### PR DESCRIPTION
## Purpose
Define the public access and safety layer: local proxy setup, provider-key handling, and bootstrap fallback.

This PR is about safe setup behavior, not hosted control-plane operations.

## Changes
- Rewrites `skills/understudy-local-proxy/SKILL.md` for generic local proxy and trace-capture setup.
- Rewrites `skills/understudy-provider-keys/SKILL.md` around no-chat secret handling.
- Adds `skills/understudy-bootstrap/SKILL.md` because public skills route unresolved CLI setup there.

## Public Safety Boundary
- Never ask users to paste provider keys into chat.
- Configured keys are local state, not spend approval.
- Local proxy guidance stays generic: inspect SDK/client wiring, use dry runs, and avoid hosted/internal control-plane details.

## Manual Proofread Checklist
- Bootstrap is necessary and scoped tightly enough.
- Secret-handling language is precise.
- Proxy guidance does not imply production routing or hosted admin access.

## Verification
- `python3 scripts/validate_public_skills.py`
- `git diff --check`
