### PR TITLE
Add public output reporting skills

### DIFF
--- a/skills/understudy-deslop/SKILL.md
+++ b/skills/understudy-deslop/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: understudy-deslop
+description: Rewrite Understudy reports, public notes, and result summaries into direct, evidence-grounded prose without private details.
+metadata:
+  understudy:
+    mode: reporting
+    safety: local-first
+    cli_required: false
+---
+
+# Understudy Deslop
+
+Use this skill when the developer asks to tighten, de-hype, polish, shorten,
+or make an Understudy result report sound more direct and human.
+
+Do not use this skill to change the underlying claim, add unsupported
+traction, or soften material caveats. Route missing evidence to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md) or
+[`../understudy-value-reporting/SKILL.md`](../understudy-value-reporting/SKILL.md).
+
+## Safety Gates
+
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Do not preserve private identifiers merely because they appear in the source
+draft. Replace customer names, domains, private repo paths, raw prompts, raw
+completions, trace rows, and secrets with public-safe descriptors or remove the
+sentence.
+
+## Intake
+
+1. Read the source draft and identify the audience, claim, evidence, caveats,
+   and requested output format.
+2. Mark facts that need artifact support before rewriting them as assertions.
+3. Preserve numbers, model names, dates, and result types when they are safe
+   and load-bearing.
+4. Ask for missing audience context only when the rewrite would otherwise
+   change materially.
+
+## Flow
+
+1. Lead with the concrete result or decision.
+2. Replace generic hype with measured evidence.
+3. Use short sentences and active verbs.
+4. Keep caveats attached to the claims they qualify.
+5. Remove filler, invented urgency, vague superlatives, and internal process
+   narration.
+6. Preserve approval gates for uploads, live calls, training, benchmark
+   submission, and provider spend.
+7. Return the rewritten text first, then a short note on any claim that still
+   needs evidence.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command or edit.

--- a/skills/understudy-publish-results/SKILL.md
+++ b/skills/understudy-publish-results/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: understudy-publish-results
+description: Prepare public-safe result summaries from local Understudy artifacts without leaking private prompts, traces, outputs, datasets, or customer context.
+metadata:
+  understudy:
+    mode: reporting
+    safety: local-first
+    cli_required: true
+---
+
+# Understudy Publish Results
+
+Use this skill when the developer asks to publish, share, announce, package, or
+summarize Understudy results for a public audience.
+
+Do not use this skill to generate private customer updates, investor claims, or
+hosted deployment reports. Route measurement questions to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md) first if
+the result has not been measured.
+
+## Resolve CLI
+
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the shared `run_understudy` shell function before running CLI
+commands.
+
+## Safety Gates
+
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- dry-run or preview artifact reviewed first;
+- visible output path under `.understudy/`.
+
+Public result drafts must not include customer names, domains, raw prompts,
+raw completions, trace rows, private repo paths, internal runbook names, or
+unverified current vendor claims.
+
+## Intake
+
+1. Inspect the local result artifacts and identify the measured workload,
+   baseline, candidate, sample size, split boundary, metric names, costs, and
+   caveats.
+2. Separate measured facts from interpretation, recommendations, and planned
+   next steps.
+3. Check whether the target surface is public, partner-facing, internal, or
+   private. Use the strictest audience if unclear.
+4. Run the smallest no-spend command that confirms the skill library and local
+   workspace are visible:
+
+```sh
+run_understudy skills
+```
+
+## Flow
+
+1. Read only the artifacts needed for the requested summary.
+2. Redact or generalize private identifiers before drafting.
+3. Preserve numeric evidence when it is safe: metric deltas, cost deltas,
+   latency ranges, sample sizes, and date of measurement.
+4. Label result type explicitly: dry-run, replay, fake-provider, validation,
+   heldout, or live.
+5. Include failure cases and limitations when they change the interpretation.
+6. End with one concrete next command or approval-gated next step.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-tufte/SKILL.md
+++ b/skills/understudy-tufte/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: understudy-tufte
+description: Review charts, tables, and result visuals for truthful, compact, public-safe Understudy reporting.
+metadata:
+  understudy:
+    mode: reporting
+    safety: local-first
+    cli_required: false
+---
+
+# Understudy Tufte
+
+Use this skill when the developer asks to improve a chart, result visual,
+metric table, executive graphic, or public report figure.
+
+Do not use this skill to create unsupported interactive dashboards or to make
+new measurement claims. Route measurement questions to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md) and value
+claims to
+[`../understudy-value-reporting/SKILL.md`](../understudy-value-reporting/SKILL.md).
+
+## Safety Gates
+
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Do not include raw customer prompts, completions, trace rows, private repo
+paths, or private labels in chart titles, labels, legends, annotations, or
+example data.
+
+## Intake
+
+1. Inspect the chart, table, screenshot, or source data the developer provided.
+2. Identify the intended audience, decision, measured unit, denominator, and
+   comparison baseline from the artifact itself when possible.
+3. Separate visual critique from data correctness. If the metric definition is
+   unclear, mark the critique as conditional.
+4. Prefer local files and screenshots. Do not upload visuals or data to hosted
+   tools without explicit approval.
+
+## Flow
+
+1. Check whether the visual answers one decision question.
+2. Remove non-data ink that does not aid comparison.
+3. Keep labels close to the marks they explain.
+4. Use small multiples or grouped comparisons when they reduce legend chasing.
+5. Preserve uncertainty, sample size, denominator, and result type.
+6. Flag misleading axes, truncated ranges, double axes, over-precise labels,
+   inconsistent units, and claims without denominators.
+7. Recommend the smallest edit that makes the result more truthful and easier
+   to scan.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command or edit.

--- a/skills/understudy-value-reporting/SKILL.md
+++ b/skills/understudy-value-reporting/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: understudy-value-reporting
+description: Turn local evaluation evidence into conservative value reports with measured quality, cost, latency, reliability, and caveats.
+metadata:
+  understudy:
+    mode: reporting
+    safety: local-first
+    cli_required: true
+---
+
+# Understudy Value Reporting
+
+Use this skill when the developer asks for ROI, savings, value, business
+impact, replacement readiness, or decision reporting from Understudy evidence.
+
+Do not use this skill to invent benefits or extrapolate beyond the measured
+sample. Route missing measurement work to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
+
+## Resolve CLI
+
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the shared `run_understudy` shell function before running CLI
+commands.
+
+## Safety Gates
+
+Default to local-only, no-upload, no-spend work.
+
+Do not upload source files, prompts, traces, outputs, datasets, repo paths,
+private notes, provider keys, or secrets unless the developer explicitly
+approves that exact action in the current thread.
+
+Treat configured provider keys as local machine state, not permission to spend.
+Before live calls, hosted jobs, uploads, benchmark submission, or training,
+require:
+
+- named provider or hosted surface;
+- estimated or capped budget;
+- exact artifacts or data class being sent;
+- dry-run or preview artifact reviewed first;
+- visible output path under `.understudy/`.
+
+Value reports must distinguish measured savings from scenario analysis. Do not
+claim production savings, user impact, SLA improvement, or replacement
+readiness without the artifact path and split boundary that support it.
+
+## Intake
+
+1. Inspect the measured result packet, comparison report, eval summary, or
+   local lab note.
+2. Capture baseline route, candidate route, sample size, date, split, metric
+   definitions, cost basis, latency basis, and failure exclusions.
+3. Ask for the decision audience only if the report shape depends on it.
+4. Run a local skill inventory check before assuming commands exist:
+
+```sh
+run_understudy skills
+```
+
+## Flow
+
+1. Build the report around four columns: quality, cost, latency, and risk.
+2. Use absolute values and deltas. If volume is unknown, provide per-unit
+   economics and mark scaled savings as a scenario.
+3. Include denominator and unit for every metric.
+4. Keep recommendations tied to gates: keep baseline, promote candidate,
+   expand eval, collect more traces, or run a live approval-gated test.
+5. Put caveats near the claim they qualify.
+6. If evidence is insufficient, say what artifact is missing and recommend the
+   next local command.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- approval-gated next step, if any;
+- one recommended command.


### PR DESCRIPTION
## Purpose
Add the public output layer for reports, value summaries, chart critique, and prose cleanup.

These skills turn local evidence into readable artifacts without uploading private data or implying unsupported presentation/runtime features.

## Changes
- Adds `skills/understudy-publish-results/SKILL.md`.
- Adds `skills/understudy-value-reporting/SKILL.md`.
- Adds `skills/understudy-tufte/SKILL.md`.
- Adds `skills/understudy-deslop/SKILL.md`.
- Intentionally skips `presentation` because this repo does not yet include a public deck/export runtime or license-checked implementation.

## Public Safety Boundary
- Output workflows are local-first and no-upload by default.
- Private partner/customer volume defaults to scenario analysis, not disclosure.
- Attribution and licensing must be checked before vendoring external style/chart/prose assets.

## Manual Proofread Checklist
- Disclosure rules are strong enough for public reports.
- Tufte/deslop wording does not overclaim vendored/license status.
- No output skill should be deferred until supporting runtime/scripts exist.

## Verification
- `python3 scripts/validate_public_skills.py`
- `git diff --check`
