### PR TITLE
fix: extract Flow sections into reference.md for evaluate and model-lookup skills

### DIFF
--- a/skills/understudy-evaluate/SKILL.md
+++ b/skills/understudy-evaluate/SKILL.md
@@ -49,71 +49,13 @@ require:
 Keep split boundaries explicit. Do not inspect heldout labels or tune prompts,
 scorers, renderers, or routes against heldout rows.
 
-## Intake
-
-1. Inspect the real local workload source: trace store, dataset, eval report,
-   repo script, prompt set, scorer, or synthetic fixture.
-2. Identify the decision: baseline measurement, route comparison, scorer
-   validation, regression check, or readiness gate.
-3. Record row count, split names, metric definitions, candidate routes, and
-   known missing data before running comparisons.
-4. Run the smallest no-spend status, validation, replay, or dry-run command.
-5. Summarize current state before proposing paid, hosted, or upload steps.
-
-## Flow
-
-1. Check local CLI health and available evaluation surfaces:
-
-```sh
-run_understudy --help
-run_understudy evaluate --help
-```
-
-2. If the workload already has local artifacts, inspect or validate them before
-   creating new runs:
-
-```sh
-run_understudy evaluate status --local
-run_understudy evaluate validate --dry-run
-```
-
-3. If local artifacts are missing, start with fixtures or a replay-only dry run:
-
-```sh
-run_understudy evaluate run --dry-run --local
-```
-
-4. Read generated artifacts under:
-
-```text
-.understudy/evaluate/
-```
-
-5. Separate catalog facts from measured results. A model card, route config, or
-   provider listing is not evaluation evidence.
-
-6. Report failures as actionable inputs: parser mismatch, missing labels,
-   scorer drift, context-window mismatch, token-cap mismatch, route error,
-   sample-size gap, or spend/upload gate.
-
 ## References
 
 Load deeper material only when needed:
 
-- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
-  and interpretation rules.
+- [`reference.md`](reference.md) - intake checklist, command flow, artifact
+  contract, and interpretation rules.
 - [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md)
   - model capability and route compatibility checks before benchmarking.
 - [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md)
   - post-baseline improvement loop.
-
-## Output Standard
-
-End with:
-
-- what was inspected or run;
-- artifact paths created or read;
-- result type: dry-run, replay, fake-provider, validation, heldout, or live;
-- metric definitions, sample size, split boundary, and caveats;
-- approval-gated next step, if any;
-- one recommended command.

--- a/skills/understudy-evaluate/reference.md
+++ b/skills/understudy-evaluate/reference.md
@@ -1,16 +1,62 @@
-# Evaluate Reference
+# Evaluate — Command Reference
 
-Detailed command matrices for evaluation are intentionally not shipped in this
-first public skill pass.
+Detailed command matrix, artifact contract, and interpretation rules for the
+`understudy-evaluate` skill.
 
-Until the CLI surface is stable, use `understudy-evaluate/SKILL.md` as the
-authoritative workflow:
+## Intake Checklist
 
-- inspect local artifacts first;
-- preserve split boundaries;
-- run dry-run or replay paths before live provider calls;
-- require explicit approval for upload, spend, hosted jobs, or benchmark
-  submission.
+1. Inspect the real local workload source: trace store, dataset, eval report,
+   repo script, prompt set, scorer, or synthetic fixture.
+2. Identify the decision: baseline measurement, route comparison, scorer
+   validation, regression check, or readiness gate.
+3. Record row count, split names, metric definitions, candidate routes, and
+   known missing data before running comparisons.
+4. Run the smallest no-spend status, validation, replay, or dry-run command.
+5. Summarize current state before proposing paid, hosted, or upload steps.
 
-Add concrete commands here only when the public CLI implementation and artifact
-paths are committed in this repo.
+## Flow
+
+1. Check local CLI health and available evaluation surfaces:
+
+```sh
+run_understudy --help
+run_understudy evaluate --help
+```
+
+2. If the workload already has local artifacts, inspect or validate them before
+   creating new runs:
+
+```sh
+run_understudy evaluate status --local
+run_understudy evaluate validate --dry-run
+```
+
+3. If local artifacts are missing, start with fixtures or a replay-only dry run:
+
+```sh
+run_understudy evaluate run --dry-run --local
+```
+
+4. Read generated artifacts under:
+
+```text
+.understudy/evaluate/
+```
+
+5. Separate catalog facts from measured results. A model card, route config, or
+   provider listing is not evaluation evidence.
+
+6. Report failures as actionable inputs: parser mismatch, missing labels,
+   scorer drift, context-window mismatch, token-cap mismatch, route error,
+   sample-size gap, or spend/upload gate.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- metric definitions, sample size, split boundary, and caveats;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-model-lookup/SKILL.md
+++ b/skills/understudy-model-lookup/SKILL.md
@@ -49,68 +49,13 @@ require:
 Model lookup is not benchmark approval. Do not send prompts, traces, datasets,
 or model outputs to providers while checking availability or compatibility.
 
-## Intake
-
-1. Inspect the requested model id, artifact path, adapter path, provider route,
-   runner, quantization, context-window need, modality, and hardware limits.
-2. Separate public catalog facts, local artifact metadata, and measured smoke
-   results.
-3. Check tokenizer, architecture, config, license, quantization, adapter base,
-   tool-call support, structured-output support, and context limit.
-4. Run the smallest local status, manifest, or dry-run route command.
-5. Summarize compatibility before proposing paid, hosted, or upload steps.
-
-## Flow
-
-1. Check local CLI health and lookup surfaces:
-
-```sh
-run_understudy --help
-run_understudy model --help
-```
-
-2. Inspect cached or local model metadata:
-
-```sh
-run_understudy model lookup --local --dry-run
-```
-
-3. If evaluating a route, verify route shape without sending workload payloads:
-
-```sh
-run_understudy model route --dry-run --local
-```
-
-4. If a model seems incompatible, check parser, adapter, tokenizer,
-   architecture, quantization, context window, token cap, modality, and route
-   mismatch before blaming model quality.
-
-5. Read generated artifacts under:
-
-```text
-.understudy/model-lookup/
-```
-
-6. Recommend the next measured step only after lookup evidence is clear.
-
 ## References
 
 Load deeper material only when needed:
 
-- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
-  and interpretation rules.
+- [`reference.md`](reference.md) - intake checklist, command flow, artifact
+  contract, and interpretation rules.
 - [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md)
   - measured comparison after compatibility is established.
 - [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md)
   - adapter and training handoff checks.
-
-## Output Standard
-
-End with:
-
-- what was inspected or run;
-- artifact paths created or read;
-- result type: dry-run, replay, fake-provider, validation, heldout, or live;
-- catalog facts, local metadata, compatibility result, and caveats;
-- approval-gated next step, if any;
-- one recommended command.

--- a/skills/understudy-model-lookup/reference.md
+++ b/skills/understudy-model-lookup/reference.md
@@ -1,13 +1,59 @@
-# Model Lookup Reference
+# Model Lookup — Command Reference
 
-Detailed model/provider command matrices are intentionally deferred.
+Detailed command matrix, artifact contract, and interpretation rules for the
+`understudy-model-lookup` skill.
 
-Public model lookup should stay evidence-scoped:
+## Intake Checklist
 
-- inspect local metadata and public model cards;
-- separate catalog facts from measured results;
-- verify runner, tokenizer, adapter, modality, context window, and route shape;
-- do not send workload payloads while checking compatibility.
+1. Inspect the requested model id, artifact path, adapter path, provider route,
+   runner, quantization, context-window need, modality, and hardware limits.
+2. Separate public catalog facts, local artifact metadata, and measured smoke
+   results.
+3. Check tokenizer, architecture, config, license, quantization, adapter base,
+   tool-call support, structured-output support, and context limit.
+4. Run the smallest local status, manifest, or dry-run route command.
+5. Summarize compatibility before proposing paid, hosted, or upload steps.
 
-Add provider-specific instructions here only after checking current public
-provider documentation.
+## Flow
+
+1. Check local CLI health and lookup surfaces:
+
+```sh
+run_understudy --help
+run_understudy model --help
+```
+
+2. Inspect cached or local model metadata:
+
+```sh
+run_understudy model lookup --local --dry-run
+```
+
+3. If evaluating a route, verify route shape without sending workload payloads:
+
+```sh
+run_understudy model route --dry-run --local
+```
+
+4. If a model seems incompatible, check parser, adapter, tokenizer,
+   architecture, quantization, context window, token cap, modality, and route
+   mismatch before blaming model quality.
+
+5. Read generated artifacts under:
+
+```text
+.understudy/model-lookup/
+```
+
+6. Recommend the next measured step only after lookup evidence is clear.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- catalog facts, local metadata, compatibility result, and caveats;
+- approval-gated next step, if any;
+- one recommended command.


### PR DESCRIPTION
## Summary

Fixes the 4 Devin Review findings from PR #3:

1. `understudy-evaluate/SKILL.md` violated AGENTS.md "keep specialist skills short" rule (119→61 lines)
2. `understudy-model-lookup/SKILL.md` same violation (116→61 lines)
3. Missing `reference.md` for evaluate (referenced but never created)
4. Missing `reference.md` for model-lookup (same)

Extracted Intake/Flow/Output Standard sections into new `reference.md` files in each skill directory. The SKILL.md files now contain frontmatter, routing, CLI resolution, safety gates, and a References section pointing to `reference.md` for deeper command notes — matching the pattern prescribed by AGENTS.md line 39-40.

Validation: `python3 scripts/validate_public_skills.py` passes (14 skills ok), `git diff --check` clean.

Link to Devin session: https://app.devin.ai/sessions/7c17eb7f881740fcb79cd15904903600
Requested by: @lluisinthedesert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->