### PR TITLE
Add value-first model and supplier guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/
 
 # Local planning notes that may include sensitive extraction context.
 docs/skill-externalization-plan.md
+docs/skill-comparison-audit.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 !.env.example
 
 .tmp/
+.understudy/
 
 # Local planning notes that may include sensitive extraction context.
 docs/skill-externalization-plan.md

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ That prints the public spine and points agents at `skills/understudy/SKILL.md`.
 `skills/understudy/SKILL.md` is the fat public entrypoint. It routes to
 specialist skills by intent:
 
-- replay/demo
+- local repo workload discovery/demo
 - evaluate
 - optimize
 - train/handoff
@@ -55,8 +55,17 @@ specialist skills by intent:
 - model lookup
 - local models and MLX readiness
 
-The default sequence is replay first, then live evidence, then optimization or
-training only after the user has a measured baseline.
+The default sequence is local repo workload discovery first, then a Workload
+Card draft, then live evidence only after the user approves the provider,
+budget cap, and data class.
+
+Try the public synthetic journey:
+
+```bash
+cd examples/repos/ai-search-app
+understudy-tools demo scan --repo .
+understudy-tools demo plan --repo .
+```
 
 ## Public boundary
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ specialist skills by intent:
 - local proxy
 - provider keys
 - model lookup
+- local models and MLX readiness
 
 The default sequence is replay first, then live evidence, then optimization or
 training only after the user has a measured baseline.

--- a/docs/model-analysis-profile-template.md
+++ b/docs/model-analysis-profile-template.md
@@ -1,0 +1,179 @@
+# Model Analysis Profile Template
+
+Copy this template when creating a public model profile. Keep claims scoped to
+the cited public facts and measured artifacts.
+
+```yaml
+---
+profile_type: model-analysis
+schema_version: model-analysis-profile.v1
+model_family: <glm-5.1|gemma-4|kimi-2.6|gpt-5.5|anthropic-claude|gemini|qwen|other>
+model_id: <exact model id>
+lane: <local-small-open-weight|local-mlx|local-openai-compatible|hosted-open-weight|hosted-training|remote-frontier-incumbent|remote-frontier-judge>
+status: <catalog|runner-smoke|local-smoke|replay|validation|heldout|live>
+date_checked: <YYYY-MM-DD>
+owner_or_provider: <model owner or serving provider>
+license_or_terms: <license or terms summary with citation>
+public_sources:
+  - title: <model card or official docs>
+    url: <https://...>
+    checked: <YYYY-MM-DD>
+  - title: <pricing or runner docs>
+    url: <https://...>
+    checked: <YYYY-MM-DD>
+artificial_analysis:
+  source_url: <https://artificialanalysis.ai/... or API endpoint>
+  checked: <YYYY-MM-DD>
+  model_label: <exact label from Artificial Analysis>
+  leaderboard_slice: <intelligence|quality|speed|price|provider endpoint|other>
+  rank: <rank or null>
+  intelligence_index: <number or null>
+  output_speed_tps: <number or null>
+  latency_ms: <number or null>
+  price_per_million_tokens_usd: <number or null>
+  notes: <external ranking context only; not workload-specific evidence>
+understudy_artifacts:
+  - path: <.understudy/... or none>
+    result_type: <catalog|artificial-analysis|runner-smoke|local-smoke|replay|validation|heldout|live>
+safety:
+  uploads_performed: false
+  provider_spend_usd: 0
+  public_safe: true
+---
+```
+
+# <Model Family / Exact Model ID>
+
+## Decision Summary
+
+One paragraph:
+
+- what this model is useful for;
+- whether to try it locally, through an existing provider key, through
+  Understudy inference, or not yet;
+- what decision the next run should unlock.
+
+## Public Facts
+
+| Fact | Value | Source |
+| --- | --- | --- |
+| Owner | `<owner>` | `<source title>` |
+| Exact model id | `<id>` | `<source title>` |
+| Parameters or architecture | `<if public>` | `<source title>` |
+| Context window | `<if public>` | `<source title>` |
+| Modality | `<text|image|audio|multimodal>` | `<source title>` |
+| License/terms | `<license or terms>` | `<source title>` |
+| Pricing | `<if remote/hosted>` | `<source title>` |
+| Artificial Analysis profile | `<rank/index/speed/price if used>` | `<Artificial Analysis source>` |
+
+Never put an uncited model fact in this table.
+
+## Understudy Fit
+
+| Dimension | Assessment | Evidence |
+| --- | --- | --- |
+| Workload shapes | `<classification|tool-calling|structured-output|rag|agentic|coding|creative|other>` | `<catalog or measured artifact>` |
+| Cost upside | `<none|low|medium|high|unknown>` | `<pricing or measured estimate>` |
+| Latency upside | `<none|low|medium|high|unknown>` | `<runner smoke or live eval>` |
+| Quality risk | `<low|medium|high|unknown>` | `<eval artifact or unknown>` |
+| Local viability | `<yes|maybe|no|unknown>` | `<hardware/runtime evidence>` |
+| Hosted viability | `<yes|maybe|no|unknown>` | `<provider docs or smoke>` |
+| Training/adaptation viability | `<yes|maybe|no|unknown>` | `<public docs or measured handoff>` |
+
+## Artificial Analysis
+
+Use this section only when Artificial Analysis data is cited.
+
+| Field | Value | Source |
+| --- | --- | --- |
+| Model label | `<exact Artificial Analysis label>` | `<source>` |
+| Leaderboard slice | `<intelligence|quality|speed|price|endpoint>` | `<source>` |
+| Rank | `<rank or n/a>` | `<source>` |
+| Intelligence Index | `<score or n/a>` | `<source>` |
+| Output speed | `<tokens/sec or n/a>` | `<source>` |
+| Latency | `<ms or n/a>` | `<source>` |
+| Price | `<USD/Mtok or n/a>` | `<source>` |
+
+State explicitly: Artificial Analysis is external benchmark/ranking context, not
+evidence that this model wins on the user's workload.
+
+## Runtime Plan
+
+Use one section only if relevant.
+
+Before recommending a hosted or local route, create or reference a supplier
+profile using [`model-supplier-profiles.md`](model-supplier-profiles.md).
+
+### Local
+
+- Runner:
+- Hardware:
+- Model id:
+- Quantization:
+- Download size or disk footprint:
+- Command:
+- Artifact path:
+- Approval needed:
+
+### Hosted Open-Weight
+
+- Provider route:
+- Pricing date:
+- Budget cap:
+- Data sent:
+- Command:
+- Artifact path:
+- Approval needed:
+
+### Frontier
+
+- Provider route:
+- Role: incumbent, judge, fallback, teacher, or candidate:
+- Pricing date:
+- Budget cap:
+- Data sent:
+- Command:
+- Artifact path:
+- Approval needed:
+
+## Measured Results
+
+Only include measured results from local artifacts or live runs. Label the result
+type.
+
+| Metric | Baseline | Candidate | Delta | Result type | Artifact |
+| --- | --- | --- | --- | --- | --- |
+| Quality | `<value>` | `<value>` | `<delta>` | `<type>` | `<path>` |
+| Cost/request | `<value>` | `<value>` | `<delta>` | `<type>` | `<path>` |
+| Latency p50/p95 | `<value>` | `<value>` | `<delta>` | `<type>` | `<path>` |
+| Output validity | `<value>` | `<value>` | `<delta>` | `<type>` | `<path>` |
+| Artificial Analysis rank/index | `<value>` | `<value>` | `<delta>` | `artificial-analysis` | `<source URL>` |
+
+## Failure Triage
+
+Check before blaming model quality:
+
+- context-window or token-cap mismatch;
+- tokenizer/chat-template mismatch;
+- parser or schema failure;
+- tool-call wire-format mismatch;
+- route/provider error;
+- latency outside inference;
+- weak sample size;
+- heldout leakage;
+- true quality regression.
+
+## Recommendation
+
+One of:
+
+- Try local smoke.
+- Download public model with approval.
+- Use existing provider key for capped eval.
+- Use Understudy inference for route comparison.
+- Keep as incumbent or judge.
+- Skip for this workload.
+- Escalate to optimization.
+- Escalate to training handoff.
+
+Include one next command and one approval boundary.

--- a/docs/model-analysis-profiles.md
+++ b/docs/model-analysis-profiles.md
@@ -1,0 +1,166 @@
+# Model Analysis Profiles
+
+This is the public-safe profile index for model classes Understudy commonly
+handles. Profiles are intentionally cited and high level. They do not include
+private customer results or private route-promotion methods.
+
+Use [`model-analysis-style-guide.md`](model-analysis-style-guide.md) and
+[`model-analysis-profile-template.md`](model-analysis-profile-template.md) before
+adding or editing profiles. Use
+[`model-supplier-profiles.md`](model-supplier-profiles.md) before recommending a
+specific provider, hosted route, local runner, or training supplier.
+
+Artificial Analysis data can be included for each model class as external
+ranking context. When used, record the exact model label, leaderboard slice,
+rank, Intelligence Index, speed, price, source URL, and date checked. Do not
+present Artificial Analysis rankings as workload-specific Understudy evidence.
+
+Starter Artificial Analysis links:
+
+- https://artificialanalysis.ai/
+- https://artificialanalysis.ai/api-reference/beta
+
+## Open-Weight / Local Candidates
+
+### GLM 5.1
+
+- Lane: hosted open-weight, local quantized route when available, reasoning and
+  coding candidate.
+- Public sources: Z.ai documentation, NVIDIA NIM model card, Hugging Face route
+  when available, and current provider docs.
+- Understudy stance: strong candidate class for coding, reasoning, and
+  long-horizon agentic comparison. Treat provider/runtime support, context
+  behavior, and tool/structured-output compatibility as first-class gates.
+- Profile requirements: exact model id, exact host or runner, context budget,
+  reasoning/direct mode behavior, tool-call/JSON support, latency, cost, and
+  data-upload boundary. Include Artificial Analysis rank/index/speed/price when
+  available for the exact GLM 5.1 label.
+- Starter citations:
+  - https://docs.z.ai/guides/llm/glm-5.1
+  - https://build.nvidia.com/z-ai/glm-5.1/modelcard
+
+### Gemma 4
+
+- Lane: local small open-weight, local MLX, hosted open-weight, hosted training.
+- Public sources: Google/Hugging Face model cards, runner/provider docs.
+- Understudy stance: strong Google open-model candidate class for local,
+  Apple-Silicon, hosted open-weight, and adaptation comparisons. Always profile
+  exact Gemma 4 variant, size, modality, runtime, and whether the checkpoint is
+  text-only or multimodal.
+- Profile requirements: exact model id, parameter or active-parameter shape when
+  public, modality, license/terms, context budget, MLX/Ollama/provider route,
+  quantization, memory fit, and runtime family. Include Artificial Analysis data
+  only when it names the exact Gemma 4 variant or provider endpoint.
+- Starter citations:
+  - https://huggingface.co/google/gemma-4-e2b-it
+  - https://github.com/ml-explore/mlx-lm
+
+### Kimi 2.6
+
+- Lane: hosted open-weight, large MoE, agentic candidate, local only for
+  quantized derivatives or serious infrastructure.
+- Public sources: Moonshot/Hugging Face model card or official technical page.
+- Understudy stance: useful for agentic/tool-heavy and coding-heavy workloads,
+  but local self-hosting should be treated as infrastructure-heavy unless the
+  user selects a smaller derivative, quantized build, or hosted route.
+- Profile requirements: exact variant, total/active parameters if public,
+  context, serving engine, tool-use claims, license/terms, hosted route,
+  expected data upload, latency, and cost. Include Artificial Analysis
+  rank/index/speed/price when available for the exact Kimi 2.6 label.
+- Starter citation:
+  - https://huggingface.co/moonshotai/Kimi-K2.6
+
+### Qwen / Qwen3
+
+- Lane: local small open-weight, hosted open-weight, hosted training.
+- Public sources: Qwen model cards and technical reports.
+- Understudy stance: still a useful local and distillation family, but it is no
+  longer the primary named example in public docs when the current task calls
+  for the latest classes above. Use exact model ids and fresh citations.
+- Profile requirements: exact model id, size, tokenizer/chat template,
+  reasoning mode behavior if relevant, quantization, runner, context budget,
+  structured-output/tool-call behavior, and training/handoff compatibility.
+  Include Artificial Analysis data only for exact model labels still present on
+  the current leaderboard.
+- Starter citations:
+  - https://huggingface.co/Qwen/Qwen3-8B
+  - https://arxiv.org/abs/2505.09388
+
+## Local Runners
+
+### MLX / MLX LM
+
+- Lane: local Apple Silicon / MLX.
+- Public source: MLX LM project docs.
+- Understudy stance: preferred Apple Silicon route when model and adapter
+  compatibility are clear. Always verify runtime family before rejecting a
+  checkpoint.
+- Profile requirements: hardware, memory, MLX package, exact checkpoint,
+  quantization, adapter path, runtime module, generation smoke, and artifact
+  path.
+- Starter citation:
+  - https://github.com/ml-explore/mlx-lm
+
+### Ollama / Local OpenAI-Compatible
+
+- Lane: local OpenAI-compatible.
+- Public source: Ollama API and OpenAI-compatibility docs.
+- Understudy stance: fastest app-integration path when a product already uses an
+  OpenAI-style client and the model is available locally.
+- Profile requirements: installed model name, endpoint, OpenAI-compatible API
+  support, request shape, latency, memory, and app base URL wiring.
+- Starter citations:
+  - https://docs.ollama.com/api
+  - https://docs.ollama.com/api/openai-compatibility
+
+## Remote Frontier Models
+
+### GPT-5.5 Class
+
+- Lane: remote frontier incumbent, judge, fallback, or teacher.
+- Public sources: OpenAI model docs, model comparison docs, launch note, system
+  card, and pricing.
+- Understudy stance: strong frontier baseline and judge class. Evaluate as a
+  route to beat, a capped live comparison route, or a high-quality judge, not as
+  the automatic default for production economics.
+- Profile requirements: exact GPT-5.5 variant, pricing date, tool and
+  structured-output support, context/token cap, role in eval, workload cost
+  estimate, latency, and upload boundary. Include Artificial Analysis rank,
+  Intelligence Index, speed, and price when available for the exact GPT-5.5
+  label and leaderboard slice.
+- Starter citations:
+  - https://developers.openai.com/api/docs/models/gpt-5.5/
+  - https://openai.com/index/introducing-gpt-5-5/
+  - https://openai.com/api/pricing/
+
+### Anthropic Claude Class
+
+- Lane: remote frontier incumbent, judge, fallback, or teacher.
+- Public sources: Anthropic model/pricing docs and system card when relevant.
+- Understudy stance: strong high-quality incumbent/judge route. Pricing, cache
+  behavior, model id, and tool support must be profiled explicitly before cost
+  or quality claims.
+- Profile requirements: exact Claude model id, pricing date, cache pricing,
+  tool support, context/token cap, role in eval, workload cost estimate, and
+  upload boundary. Include Artificial Analysis data for the exact Claude label
+  rather than the family name.
+- Starter citations:
+  - https://www.anthropic.com/claude/opus
+  - https://docs.anthropic.com/en/docs/about-claude/pricing
+
+### Gemini Class
+
+- Lane: remote frontier incumbent, judge, fallback, structured-output route, or
+  multimodal route.
+- Public sources: Gemini API model docs, API reference, and pricing docs when
+  used.
+- Understudy stance: useful for multimodal, structured-output, and frontier
+  comparison routes. Exact model id and API surface matter more than family
+  branding.
+- Profile requirements: exact Gemini model id, modality, structured-output
+  support, context/token cap, pricing date, role in eval, workload cost
+  estimate, latency, and upload boundary. Include Artificial Analysis data for
+  the exact Gemini label rather than the family name.
+- Starter citations:
+  - https://ai.google.dev/gemini-api/docs/models
+  - https://ai.google.dev/api

--- a/docs/model-analysis-style-guide.md
+++ b/docs/model-analysis-style-guide.md
@@ -1,0 +1,204 @@
+# Model Analysis Style Guide
+
+Use this guide when writing public model guidance for Understudy skills,
+reports, or docs. The goal is to help developers reach economic value quickly
+without publishing private customer methodology or stale model folklore.
+
+## Model Lanes
+
+Every model analysis must classify the model into one primary lane.
+
+| Lane | Examples we commonly touch | Default question |
+| --- | --- | --- |
+| Local small open-weight | Qwen3/Qwen3.5 small models, Gemma 4 edge models, GLM 5.1 quantized routes, Kimi 2.6 derivatives when available, Phi/Granite-class small models | Can this run locally fast enough to reduce cost or preserve privacy? |
+| Local Apple Silicon / MLX | MLX-converted Qwen/Gemma/GLM-class checkpoints and adapters | Does this fit memory, use the right MLX runtime, and produce useful latency? |
+| Local OpenAI-compatible | Ollama, llama.cpp server, LM Studio, vLLM, SGLang, Transformers server | Can an existing app route to this with minimal code changes? |
+| Hosted open-weight serverless | Fireworks, Lilac, OpenRouter routes | Can this beat the incumbent on cost or latency with acceptable quality? |
+| Hosted training / adaptation | Fireworks LoRA/SFT, Prime Intellect, Tinker, GCP/Vertex, AWS Bedrock-adjacent paths | Is upload/training justified by measured residual failures? |
+| Remote frontier incumbent | OpenAI GPT-class, Anthropic Claude-class, Google Gemini-class | What is the baseline quality, latency, and cost we must beat or route around? |
+| Remote frontier judge | Claude/OpenAI/Gemini judge routes used offline | Can a judge clarify quality without becoming the production dependency? |
+
+## Public Model Families
+
+These are safe public labels for the model types reflected in private
+Understudy knowledge. Do not copy private benchmark numbers into public docs.
+
+| Family | Public profile stance | Required citations |
+| --- | --- | --- |
+| Gemma 4 | Strong Google open-model candidate class, especially for local, Apple Silicon, hosted open-weight, and adaptation comparison. Profile exact Gemma 4 variant, size, modality, and runtime. | Google/Hugging Face model card; MLX/Ollama/provider docs. |
+| GLM 5.1 | Open-weight/hosted reasoning, coding, and long-horizon agentic candidate. Profile exact GLM 5.1 route and serving support. | Z.ai docs, Hugging Face model card, NVIDIA/model host docs, or technical report. |
+| Kimi 2.6 | Large open-weight MoE/agentic candidate class. Treat local self-hosting as infra-heavy unless using a hosted route or quantized derivative. | Moonshot/Hugging Face model card or official technical page. |
+| GPT-5.5 class | Frontier incumbent, judge, and fallback route. Profile exact GPT-5.5 variant, pricing, tool/structured-output support, and date checked. | OpenAI model docs, launch note, system card, and pricing page. |
+| Anthropic Claude class | Frontier incumbent, judge, and high-quality agentic route. Profile exact Claude model id, pricing/cache behavior, tool support, and date checked. | Anthropic model/pricing/system-card docs. |
+| Gemini class | Frontier incumbent, multimodal route, judge, and structured-output candidate. Profile exact Gemini model id and API surface. | Google AI model/API docs and pricing docs when used. |
+
+## Citation Rules
+
+Model facts drift. Every public model profile must cite current public sources.
+
+Required citations:
+
+- model card or official product/model documentation;
+- license or acceptable-use source for open-weight models;
+- pricing source for any economic claim;
+- runner/provider documentation for local or hosted compatibility;
+- Artificial Analysis source link or API response when using benchmark,
+  ranking, speed, price-performance, or provider-endpoint data;
+- date checked for every pricing, availability, and context-window claim.
+
+Allowed source types:
+
+- official provider docs;
+- Hugging Face model cards from the model owner or clearly named host;
+- arXiv/OpenReview technical reports;
+- runner docs from project maintainers;
+- public benchmark pages only when the profile says the benchmark is external,
+  not Understudy-measured evidence.
+
+Do not cite:
+
+- private Understudy lab notes in public docs;
+- customer artifacts;
+- uncited memory from an agent run;
+- stale pricing copied from old notes;
+- model availability from a provider UI without a stable public page.
+
+## Profile Standard
+
+Each profile must separate four kinds of evidence.
+
+| Evidence type | What it can support | What it cannot support |
+| --- | --- | --- |
+| Catalog fact | Model size, license, context, modality, public availability. | Quality or replacement claims. |
+| Artificial Analysis profile | Public external ranking, benchmark aggregate, speed, and price-performance context. | Workload-specific replacement claims. |
+| Runtime smoke | Loads, generates, route works, rough latency/memory. | Production quality or broad reliability. |
+| Local replay/eval | Directional quality, parser validity, latency, cost estimate on a named sample. | Production rollout unless live traffic shape matches. |
+| Live heldout eval | Candidate decision, promotion, fallback, or training recommendation. | Claims outside the measured workload and split. |
+
+Use these result labels:
+
+- `catalog`
+- `artificial-analysis`
+- `runner-smoke`
+- `local-smoke`
+- `replay`
+- `validation`
+- `heldout`
+- `live`
+
+## Local Model Rules
+
+Be helpful, not timid:
+
+- If the user has Apple Silicon and the model is plausibly local, suggest MLX or
+  Ollama/llama.cpp rather than stopping at a no-op dry run.
+- If a public model download is the fastest route to value, ask for download
+  approval with model id, estimated size, destination, and command.
+- If the model is too large for local hardware, say so and suggest a hosted
+  open-weight route or Understudy inference.
+- If an app already speaks OpenAI-compatible APIs, prefer a local
+  OpenAI-compatible server or proxy smoke before rewriting the app.
+- If latency is the target, measure startup, first-token latency, decode
+  throughput, and steady-state request latency separately.
+
+Local profile fields must include:
+
+- hardware and OS;
+- runner: MLX, Ollama, llama.cpp, LM Studio, vLLM, SGLang, Transformers, other;
+- exact model id and quantization;
+- download size or disk footprint when known;
+- memory pressure or VRAM/RAM requirement;
+- context-window budget;
+- tokenizer/chat-template compatibility;
+- structured-output/tool-call support;
+- measured local smoke command and artifact path.
+
+## Remote Frontier Rules
+
+Frontier models are often the incumbent or judge. Treat them as the baseline to
+beat, not as the default recommendation.
+
+Remote frontier profile fields must include:
+
+- exact model id and provider, for example GPT-5.5, Anthropic Claude, or Gemini-class route;
+- date pricing was checked;
+- input/output/cache pricing when relevant;
+- tool-call and structured-output support;
+- context-window and token-cap fit;
+- observed cost/request and latency on the workload when measured;
+- whether it is production route, judge route, fallback, or teacher route.
+
+## Hosted Open-Weight Rules
+
+Hosted open-weight routes are often the fastest path to savings when local
+hardware is insufficient.
+
+Hosted open-weight profile fields must include:
+
+- exact provider route;
+- model id and version;
+- pricing date;
+- tool-call/JSON/logprob support;
+- context-window fit;
+- latency and throughput;
+- whether data is uploaded to a third-party provider;
+- approval and budget cap used for live runs.
+
+## Artificial Analysis Rules
+
+Artificial Analysis is useful for public, external context: broad model ranking,
+benchmark aggregate, speed, latency, price, and provider endpoint comparison.
+Use it to decide what to try first, not to claim that a model wins on the user's
+workload.
+
+When a model profile uses Artificial Analysis, include:
+
+- source page or API endpoint URL;
+- date checked;
+- model label exactly as Artificial Analysis reports it;
+- Intelligence Index or comparable ranking metric, if present;
+- rank and leaderboard slice, if present;
+- output speed, latency, and price fields, if present;
+- provider endpoint or host, if the data is provider-specific;
+- note that the ranking is external and may not predict task-specific quality.
+
+Do not average Artificial Analysis scores with local Understudy evals. Keep
+them in separate rows: external benchmark context vs measured workload evidence.
+
+## What To Keep Private
+
+Do not publish:
+
+- customer prompts, traces, schemas, labels, rubrics, or outputs;
+- exact route-promotion recipes;
+- private provider negotiations or capacity tactics;
+- internal control-plane or storage details;
+- private margin by customer;
+- patent-sensitive orchestration sequencing.
+
+Public profiles may say "Understudy should compare local/open-weight and
+frontier routes on the user's workload." They should not reveal private
+replacement-loop mechanics.
+
+## Public Source Starter Set
+
+Use these as starter citations, then refresh before publishing time-sensitive
+claims:
+
+- GLM-5.1 docs: https://docs.z.ai/guides/llm/glm-5.1
+- GLM-5.1 NVIDIA model card: https://build.nvidia.com/z-ai/glm-5.1/modelcard
+- Gemma 4 E2B model card: https://huggingface.co/google/gemma-4-e2b-it
+- Kimi K2.6 model card: https://huggingface.co/moonshotai/Kimi-K2.6
+- GPT-5.5 model docs: https://developers.openai.com/api/docs/models/gpt-5.5/
+- GPT-5.5 launch note: https://openai.com/index/introducing-gpt-5-5/
+- Artificial Analysis leaderboard: https://artificialanalysis.ai/
+- Artificial Analysis API reference: https://artificialanalysis.ai/api-reference/beta
+- Supplier profile standard: model-supplier-profiles.md
+- MLX LM: https://github.com/ml-explore/mlx-lm
+- Ollama OpenAI compatibility: https://docs.ollama.com/api/openai-compatibility
+- OpenAI model comparison docs: https://developers.openai.com/api/docs/models/compare
+- OpenAI API pricing: https://openai.com/api/pricing/
+- Anthropic pricing: https://docs.anthropic.com/en/docs/about-claude/pricing
+- Anthropic Claude Opus docs: https://www.anthropic.com/claude/opus
+- Google Gemini model docs: https://ai.google.dev/gemini-api/docs/models
+- Google Gemini API reference: https://ai.google.dev/api

--- a/docs/model-supplier-profiles.md
+++ b/docs/model-supplier-profiles.md
@@ -1,0 +1,121 @@
+# Model Supplier Profiles
+
+Use this when deciding where to run a model. A model profile answers "what is
+this model good for?" A supplier profile answers "where should this model run,
+what will it cost, and what data leaves the machine?"
+
+Pricing and availability drift. Every supplier profile must include a source URL
+and `date_checked`. Do not copy prices from private notes into public docs.
+
+## Supplier Profile Template
+
+```yaml
+---
+profile_type: model-supplier
+schema_version: model-supplier-profile.v1
+supplier: <fireworks|openrouter|prime-intellect|tinker|gcp-vertex|aws-bedrock|lilac|local-mlx|local-ollama|understudy-inference|other>
+route_type: <frontier-api|hosted-open-weight|hosted-training|local-runner|aggregator|understudy-inference>
+models_supported:
+  - <exact model id or model class>
+pricing:
+  date_checked: <YYYY-MM-DD>
+  source_url: <https://...>
+  input_usd_per_1m_tokens: <number|null>
+  output_usd_per_1m_tokens: <number|null>
+  cache_write_usd_per_1m_tokens: <number|null>
+  cache_read_usd_per_1m_tokens: <number|null>
+  training_usd: <description|null>
+  hosting_usd: <description|null>
+  notes: <pricing caveats>
+artificial_analysis:
+  source_url: <https://artificialanalysis.ai/... or API endpoint>
+  checked: <YYYY-MM-DD>
+  endpoint_label: <exact endpoint label or null>
+  intelligence_index: <number|null>
+  output_speed_tps: <number|null>
+  latency_ms: <number|null>
+  price_per_million_tokens_usd: <number|null>
+data_boundary:
+  runs_local: <true|false>
+  uploads_prompt_or_trace: <true|false>
+  uploads_training_data: <true|false>
+  stores_provider_side: <unknown|no|yes>
+  approval_required: <download|spend|upload|training|none>
+---
+```
+
+## Supplier Classes
+
+| Supplier class | Examples | Best use | Pricing profile must include |
+| --- | --- | --- | --- |
+| Aggregator / router | OpenRouter | Fast frontier/open-weight access, model shopping, fallback, broad route discovery. | Exact OpenRouter model id, pricing object, top provider, transforms, supported parameters, date checked. |
+| Hosted open-weight serverless | Fireworks, Lilac | Fast cost/latency comparisons and cheap candidate sweeps. | Exact provider route, price per token/request, latency/speed if public, provider-specific support for JSON/tool/logprobs. |
+| Hosted training/adaptation | Fireworks, Prime Intellect, Tinker, GCP/Vertex, AWS Bedrock/SageMaker-adjacent paths | SFT/LoRA/RL after eval proves residual failures. | Training price shape, hosting/deploy price shape, upload boundary, supported base models. |
+| Cloud platform model garden | GCP/Vertex, AWS Bedrock | Enterprise procurement, cloud credits, VPC/governance, regional controls. | Exact model id, region, input/output/cache pricing, provisioned-throughput options, data policy. |
+| Local runner | MLX, Ollama, llama.cpp, LM Studio, vLLM, SGLang, Transformers | Privacy, zero marginal inference cost, latency tests, app-routing smoke. | Download size, disk/RAM/VRAM fit, local hardware, runner version, no provider token price. |
+| Understudy inference | Understudy API key / managed route | Avoid provider glue and compare routes faster. | Understudy route, data boundary, capped spend, whether it is using BYO or managed keys. |
+
+## Current Model-Class Supplier Coverage
+
+| Model class | Likely suppliers to profile | Current status |
+| --- | --- | --- |
+| GLM 5.1 | OpenRouter, Fireworks, Lilac, GCP, AWS, or local quantized routes when a public route exists; model-owner docs are source evidence only. | Initial public-source profile started; exact supplier availability and pricing must be refreshed before use. |
+| Gemma 4 | Local MLX/Ollama/llama.cpp where supported, plus Fireworks, Lilac, OpenRouter, GCP, or AWS routes when public. | Local and model-card profile started; hosted supplier rows are source-required per exact variant. |
+| Kimi 2.6 | OpenRouter, Fireworks, Lilac, GCP, AWS, or quantized local routes when a public route exists; model-owner docs are source evidence only. | Model-card profile started; exact supplier availability and pricing must be refreshed before use. |
+| GPT-5.5 class | OpenRouter, GCP, AWS, Understudy inference, or direct model-owner route when the user supplies that key. | Exact current model id and pricing source required before cost claims. |
+| Anthropic Claude class | OpenRouter, AWS Bedrock, GCP Vertex, Understudy inference, or direct model-owner route when the user supplies that key. | Exact current model id and cache pricing required before cost claims. |
+| Gemini class | GCP Vertex, OpenRouter, AWS where available, Understudy inference, or direct model-owner route when the user supplies that key. | Exact model id/API surface and pricing source required. |
+
+## Initial Supplier Matrix
+
+These are the provider profiles to maintain. They are seed profiles, not final
+pricing claims. Refresh before using them in a recommendation.
+
+| Supplier | Route type | Model class | Pricing status | Artificial Analysis status | Data boundary | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| Fireworks | hosted-open-weight / hosted-training | Gemma 4 or supported open-weight routes | Source-required per exact serverless or training route; Fireworks documents pay-per-token serverless inference and per-job/LoRA training shapes. | Include provider endpoint if tracked. | Remote provider call or training upload; spend/upload approval required. | https://docs.fireworks.ai/serverless/overview and https://fireworks.ai/training |
+| OpenRouter | aggregator | Frontier and open-weight routes, including GLM/Kimi/GPT/Claude/Gemini classes when listed | Use OpenRouter Models API pricing object per exact model id; aggregator pricing can differ by route/provider and can change frequently. | Use only if Artificial Analysis or OpenRouter exposes exact endpoint. | Remote provider/aggregator call; spend/upload approval required. | https://openrouter.ai/docs/models |
+| Prime Intellect | hosted-training | RL/LoRA training and hosted training environments | Source-required per hosted training run; docs describe dedicated orchestrator plus trainer/inference components and per-token efficiency shape. | Usually not endpoint-ranked unless exposed as model provider. | Hosted training upload/execution; training approval required. | https://docs.primeintellect.ai/hosted-training/what-is-lab and https://primeintellect.mintlify.app/verifiers/training |
+| Tinker | hosted-training | SFT/RL/DPO/LoRA-style training handoff when supported | Source-required per account/job; profile as hosted training, not inference supplier, unless a public inference endpoint is used. | Usually not endpoint-ranked. | Hosted training upload/execution; training approval required. | public Tinker/provider docs required before recommendation |
+| GCP / Vertex | cloud-platform / frontier-api / hosted-training | Gemini class, Model Garden/open-weight routes, Vertex training where supported | Use official Vertex/Gemini pricing per exact model id and region. Include cloud credits only as account-specific context, not public pricing. | Include exact endpoint if Artificial Analysis tracks it; otherwise use as supplier-only profile. | Remote provider call or training upload; spend/upload approval required. | https://cloud.google.com/vertex-ai/generative-ai/pricing and https://ai.google.dev/gemini-api/docs/pricing |
+| AWS Bedrock | cloud-platform / frontier-api | Claude class and Bedrock-supported model garden routes | Use official Bedrock pricing per exact model id and region; include on-demand vs provisioned throughput if relevant. | Include exact endpoint if Artificial Analysis tracks it. | Remote provider call; spend/upload approval required. | https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-pricing.html |
+| Lilac | hosted-open-weight | Supported open-weight routes, including Gemma/Kimi/GLM when listed | Source-required per exact model route; profile token pricing, speed, and support for OpenAI-compatible SDK usage. | Include provider endpoint if tracked. | Remote provider call; spend/upload approval required. | https://getlilac.com/serverless-inference-api |
+| Local MLX | local-runner | Gemma 4, Qwen, compatible local checkpoints | No token price; profile download size, hardware, memory pressure, setup time, and local latency. | Not provider-priced; use Artificial Analysis only for model context if exact label exists. | Local process; download approval may be required. | https://github.com/ml-explore/mlx-lm |
+| Local Ollama / OpenAI-compatible | local-runner | Quantized local models available in library | No token price; profile download size, local endpoint, hardware, and latency. | Not provider-priced; use Artificial Analysis only for model context if exact label exists. | Local process; download approval may be required. | https://docs.ollama.com/api and https://docs.ollama.com/api/openai-compatibility |
+| Understudy inference | understudy-inference | Configured frontier/open-weight routes through selected suppliers | Source-required from Understudy account or docs before public claim; can simplify route comparison across the provider set above. | May attach Artificial Analysis context for underlying exact route. | Depends on BYO vs managed key and route; explicit spend/upload approval required. | Understudy account/config |
+
+## Pricing Rules
+
+- Do not present a supplier as cheaper without a dated pricing source.
+- For remote frontier models, include input, output, and cache pricing where
+  applicable.
+- For hosted open-weight suppliers, include both token price and observed or
+  cited latency/speed when available.
+- For local runners, token price is `0` only for marginal provider spend. Still
+  record hardware, download size, setup time, and memory pressure.
+- For training suppliers, separate training cost from inference hosting cost.
+- For aggregators, record whether the supplier is a pass-through, hosted route,
+  or model-substitution layer when public docs say so.
+- Artificial Analysis price/speed/ranking is external context. Keep it separate
+  from Understudy workload measurements.
+- For cloud providers, record region, quota, procurement path, credits, and
+  whether pricing is first-party model pricing or marketplace/provider pricing.
+
+## Starter Pricing And Supplier Sources
+
+Refresh these before publishing exact numbers:
+
+- Fireworks serverless: https://docs.fireworks.ai/serverless/overview
+- Fireworks training: https://fireworks.ai/training
+- OpenRouter Models API: https://openrouter.ai/docs/models
+- Prime Intellect hosted training: https://docs.primeintellect.ai/hosted-training/what-is-lab
+- Prime Intellect Verifiers training: https://primeintellect.mintlify.app/verifiers/training
+- GCP Vertex generative AI pricing: https://cloud.google.com/vertex-ai/generative-ai/pricing
+- Gemini API pricing: https://ai.google.dev/gemini-api/docs/pricing
+- AWS Bedrock pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-pricing.html
+- Lilac serverless inference: https://getlilac.com/serverless-inference-api
+- MLX LM: https://github.com/ml-explore/mlx-lm
+- Ollama API: https://docs.ollama.com/api
+- Ollama OpenAI compatibility: https://docs.ollama.com/api/openai-compatibility
+- Artificial Analysis: https://artificialanalysis.ai/
+- Artificial Analysis API reference: https://artificialanalysis.ai/api-reference/beta

--- a/docs/skill-style-guide.md
+++ b/docs/skill-style-guide.md
@@ -66,7 +66,8 @@ Allowed:
 Not allowed:
 
 - customer names, domains, volumes, traces, prompts, labels, or completions;
-- internal Super Admin, WorkOS, R2, D1, pool-secret, or hosted-control details;
+- internal admin surfaces, identity-provider wiring, storage internals, database
+  internals, capacity secrets, or hosted-control details;
 - private customer replacement runbooks;
 - aggressive internal spend heuristics;
 - uncited current claims about vendor pricing, model support, ownership, or API

--- a/docs/spine.md
+++ b/docs/spine.md
@@ -20,7 +20,7 @@ specialist skill or run the corresponding script.
 Default path:
 
 ```text
-understudy -> replay/demo -> live evaluation -> optimize -> train/handoff
+understudy -> local repo workload discovery -> live evaluation -> optimize -> train/handoff
 ```
 
 The lab path is always available for longer research work where hypotheses,

--- a/docs/tool-migration-map.md
+++ b/docs/tool-migration-map.md
@@ -1,0 +1,47 @@
+# Tool Migration Map
+
+This repo exposes public skills before every CLI surface is implemented. That
+is intentional: skills show the developer roadmap, while CLI stubs make missing
+runtime behavior explicit and safe.
+
+## Migration Principles
+
+- Migrate local-only, no-upload behavior first.
+- Prefer synthetic fixtures and public documents over private workloads.
+- Keep customer data, private prompts, private traces, internal runbooks, and
+  hosted-control-plane details out of this repo.
+- A compatibility check is not an evaluation result.
+- A runner smoke is not a quality claim.
+
+## Surfaces
+
+| Surface | Public skill | Migrate first | Why | Keep private or deferred |
+| --- | --- | --- | --- | --- |
+| `demo` | `skills/understudy-demo/SKILL.md` | Bundled fixture replay and first-run walkthrough. | Gives new users a no-spend proof of the loop. | Customer demos, private traces, hosted account flows. |
+| `evaluate` | `skills/understudy-evaluate/SKILL.md` | Artifact validation, split checks, dry-run eval planning, synthetic scorer examples. | Workgrounds-style users need quality evidence before route changes. | Customer labels, raw prompts, heldout data, hosted benchmark submissions. |
+| `model` | `skills/understudy-model-lookup/SKILL.md` | Local metadata inspection, public model-card lookup, route-shape dry runs. | Prevents false blame on model quality when the issue is token cap, parser, route, or context mismatch. | Uncited current availability claims, private provider configs. |
+| `local-models` | `skills/understudy-local-models/SKILL.md` | Apple Silicon inventory, MLX/Ollama/llama.cpp/Transformers readiness checks, synthetic smoke artifacts. | Local candidates matter for latency, no-upload workflows, and DevOps-light experimentation. | Customer workload replay, model downloads without approval, hosted fallback execution. |
+| `proxy` | `skills/understudy-local-proxy/SKILL.md` | Local OpenAI-compatible doctor, base URL inspection, fake-provider request path. | Teams need to prove routing and trace capture before touching production apps. | Hosted gateway internals, production routing policy, remote telemetry. |
+| `keys` | `skills/understudy-provider-keys/SKILL.md` | Redacted key presence checks and setup guidance. | Provider setup is necessary, but configured keys are not spend approval. | Secret values, account-specific spend history, internal provider arrangements. |
+| `optimize` | `skills/understudy-optimize/SKILL.md` | Local optimization plan, candidate-card scaffold, parser/prompt/route hypothesis tracking. | Optimization should start after a measured baseline and produce auditable next steps. | Private replacement-loop methods, customer-specific heuristics, hosted optimizer jobs. |
+| `train` | `skills/understudy-train/SKILL.md` | Export preview, split validation, provenance and redaction checks. | Training handoff needs clean data boundaries before any upload. | Provider upload flows, customer trajectories, internal training scripts. |
+| reporting skills | `skills/understudy-publish-results/SKILL.md`, `skills/understudy-value-reporting/SKILL.md`, `skills/understudy-tufte/SKILL.md` | Public summary templates, caveat language, synthetic reports. | Non-engineers need readable evidence and blind review artifacts. | Customer names, private deck formats, private commercial claims. |
+
+## Workgrounds-Shaped Gap
+
+The June 3, 2026 Workgrounds workshop highlighted a common user shape:
+
+- speed matters more than cost in the current phase;
+- AI search latency can be dominated by inference time;
+- model availability and behavior regressions create maintenance pain;
+- a small engineering team cannot absorb heavy DevOps overhead;
+- quality is hard to measure for qualitative search results;
+- non-engineering stakeholders need blind review surfaces.
+
+That implies the next public skills should emphasize:
+
+- local runner readiness, especially MLX and Apple Silicon;
+- latency measurement and route comparison without provider uploads;
+- model portability checks;
+- blind pairwise review artifacts for stakeholders;
+- integration with existing eval suites rather than replacement of them.

--- a/docs/tool-migration-map.md
+++ b/docs/tool-migration-map.md
@@ -18,7 +18,7 @@ runtime behavior explicit and safe.
 | Surface | Public skill | Migrate first | Why | Keep private or deferred |
 | --- | --- | --- | --- | --- |
 | `demo` | `skills/understudy-demo/SKILL.md` | Bundled fixture replay and first-run walkthrough. | Gives new users a no-spend proof of the loop. | Customer demos, private traces, hosted account flows. |
-| `evaluate` | `skills/understudy-evaluate/SKILL.md` | Artifact validation, split checks, dry-run eval planning, synthetic scorer examples. | Workgrounds-style users need quality evidence before route changes. | Customer labels, raw prompts, heldout data, hosted benchmark submissions. |
+| `evaluate` | `skills/understudy-evaluate/SKILL.md` | Artifact validation, split checks, dry-run eval planning, synthetic scorer examples. | Latency-sensitive users need quality evidence before route changes. | Customer labels, raw prompts, heldout data, hosted benchmark submissions. |
 | `model` | `skills/understudy-model-lookup/SKILL.md` | Local metadata inspection, public model-card lookup, route-shape dry runs. | Prevents false blame on model quality when the issue is token cap, parser, route, or context mismatch. | Uncited current availability claims, private provider configs. |
 | `local-models` | `skills/understudy-local-models/SKILL.md` | Apple Silicon inventory, MLX/Ollama/llama.cpp/Transformers readiness checks, synthetic smoke artifacts. | Local candidates matter for latency, no-upload workflows, and DevOps-light experimentation. | Customer workload replay, model downloads without approval, hosted fallback execution. |
 | `proxy` | `skills/understudy-local-proxy/SKILL.md` | Local OpenAI-compatible doctor, base URL inspection, fake-provider request path. | Teams need to prove routing and trace capture before touching production apps. | Hosted gateway internals, production routing policy, remote telemetry. |
@@ -27,9 +27,9 @@ runtime behavior explicit and safe.
 | `train` | `skills/understudy-train/SKILL.md` | Export preview, split validation, provenance and redaction checks. | Training handoff needs clean data boundaries before any upload. | Provider upload flows, customer trajectories, internal training scripts. |
 | reporting skills | `skills/understudy-publish-results/SKILL.md`, `skills/understudy-value-reporting/SKILL.md`, `skills/understudy-tufte/SKILL.md` | Public summary templates, caveat language, synthetic reports. | Non-engineers need readable evidence and blind review artifacts. | Customer names, private deck formats, private commercial claims. |
 
-## Workgrounds-Shaped Gap
+## Latency-First User Shape
 
-The June 3, 2026 Workgrounds workshop highlighted a common user shape:
+A recent developer workshop highlighted a common user shape:
 
 - speed matters more than cost in the current phase;
 - AI search latency can be dominated by inference time;

--- a/docs/tool-migration-map.md
+++ b/docs/tool-migration-map.md
@@ -17,7 +17,7 @@ runtime behavior explicit and safe.
 
 | Surface | Public skill | Migrate first | Why | Keep private or deferred |
 | --- | --- | --- | --- | --- |
-| `demo` | `skills/understudy-demo/SKILL.md` | Bundled fixture replay and first-run walkthrough. | Gives new users a no-spend proof of the loop. | Customer demos, private traces, hosted account flows. |
+| `demo` | `skills/understudy-demo/SKILL.md` | Local repo workload scan, Workload Card draft, and synthetic fixture fallback. | Gives new users a no-spend proof that Understudy can find value in their own code. | Customer demos, private traces, hosted account flows. |
 | `evaluate` | `skills/understudy-evaluate/SKILL.md` | Artifact validation, split checks, dry-run eval planning, synthetic scorer examples. | Latency-sensitive users need quality evidence before route changes. | Customer labels, raw prompts, heldout data, hosted benchmark submissions. |
 | `model` | `skills/understudy-model-lookup/SKILL.md` | Local metadata inspection, public model-card lookup, route-shape dry runs. | Prevents false blame on model quality when the issue is token cap, parser, route, or context mismatch. | Uncited current availability claims, private provider configs. |
 | `local-models` | `skills/understudy-local-models/SKILL.md` | Apple Silicon inventory, MLX/Ollama/llama.cpp/Transformers readiness checks, synthetic smoke artifacts. | Local candidates matter for latency, no-upload workflows, and DevOps-light experimentation. | Customer workload replay, model downloads without approval, hosted fallback execution. |
@@ -40,6 +40,7 @@ A recent developer workshop highlighted a common user shape:
 
 That implies the next public skills should emphasize:
 
+- local repo workload discovery before canned replay;
 - local runner readiness, especially MLX and Apple Silicon;
 - latency measurement and route comparison without provider uploads;
 - model portability checks;

--- a/examples/repos/ai-search-app/README.md
+++ b/examples/repos/ai-search-app/README.md
@@ -1,0 +1,15 @@
+# Synthetic AI Search App
+
+This public fixture demonstrates the recommended first-run Understudy journey:
+scan a local repo, find an AI workload, draft a Workload Card, then decide
+whether a live route comparison is worth approval.
+
+Run from this directory:
+
+```sh
+understudy-tools demo scan --repo .
+understudy-tools demo plan --repo .
+```
+
+The fixture is synthetic. It contains no customer data, private prompts, real
+traces, provider keys, or production URLs.

--- a/examples/repos/ai-search-app/evals/search_cases.yaml
+++ b/examples/repos/ai-search-app/evals/search_cases.yaml
@@ -1,0 +1,10 @@
+cases:
+  - id: neighborhood-family-trip
+    prompt: "Find a quiet hotel area for a family trip near museums."
+    rubric: "Ranks safe, central neighborhoods and explains tradeoffs."
+  - id: airport-layover
+    prompt: "I need a hotel for a short airport layover with easy transit."
+    rubric: "Prioritizes airport access, check-in reliability, and travel time."
+  - id: nightlife-budget
+    prompt: "Suggest budget areas with nightlife and late food."
+    rubric: "Balances price, nightlife, safety, and transport constraints."

--- a/examples/repos/ai-search-app/src/search_pipeline.py
+++ b/examples/repos/ai-search-app/src/search_pipeline.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import time
+
+
+SYSTEM_PROMPT = """You are a travel search assistant.
+Return concise ranked hotel neighborhoods with reasons and tradeoffs.
+"""
+
+
+def build_messages(query: str) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": query},
+    ]
+
+
+def search_hotels(client, query: str) -> dict[str, object]:
+    start = time.perf_counter()
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=build_messages(query),
+        temperature=0.2,
+    )
+    elapsed_ms = round((time.perf_counter() - start) * 1000)
+    return {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "latency_ms": elapsed_ms,
+        "input_tokens": getattr(response.usage, "prompt_tokens", None),
+        "output_tokens": getattr(response.usage, "completion_tokens", None),
+        "answer": response.choices[0].message.content,
+    }

--- a/scripts/validate_public_skills.py
+++ b/scripts/validate_public_skills.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -29,6 +30,7 @@ SECRET_PATTERNS = [
     re.compile(r"AKIA[0-9A-Z]{16}"),
     re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----"),
 ]
+PUBLIC_DOC_DIRS = ["docs"]
 
 
 def parse_frontmatter(text: str) -> tuple[dict[str, str], str] | None:
@@ -106,9 +108,36 @@ def validate_skill(path: Path) -> list[str]:
     return errors
 
 
+def validate_public_markdown(path: Path) -> list[str]:
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    for term in PRIVATE_TERMS:
+        if term in text:
+            errors.append(f"{path}: contains private review term {term!r}")
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path}: contains secret-shaped text matching {pattern.pattern}")
+    return errors
+
+
+def is_gitignored(path: Path) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "--quiet", str(path)],
+        cwd=Path.cwd(),
+        check=False,
+    )
+    return result.returncode == 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Validate public Understudy skills.")
     parser.add_argument("paths", nargs="*", default=["skills"])
+    parser.add_argument(
+        "--docs",
+        nargs="*",
+        default=PUBLIC_DOC_DIRS,
+        help="Markdown doc directories to scan for public-safety terms.",
+    )
     args = parser.parse_args()
 
     roots = [Path(p) for p in args.paths]
@@ -124,6 +153,15 @@ def main() -> int:
     all_errors: list[str] = []
     for skill_dir in skill_dirs:
         all_errors.extend(validate_skill(skill_dir))
+    for doc_root_arg in args.docs:
+        doc_root = Path(doc_root_arg)
+        if doc_root.is_file() and doc_root.suffix == ".md":
+            if not is_gitignored(doc_root):
+                all_errors.extend(validate_public_markdown(doc_root))
+        elif doc_root.is_dir():
+            for doc_path in sorted(doc_root.rglob("*.md")):
+                if not is_gitignored(doc_path):
+                    all_errors.extend(validate_public_markdown(doc_path))
 
     for error in all_errors:
         print(error)

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,8 +11,9 @@ one specialist skill only when the developer's intent requires it.
 
 ## Specialist Skills
 
-- [`understudy-demo`](understudy-demo/SKILL.md) shows the product loop with
-  local replay, bundled fixtures, and no provider spend.
+- [`understudy-demo`](understudy-demo/SKILL.md) scans a local repo for AI
+  workload candidates, drafts a Workload Card, and falls back to synthetic
+  fixtures when no local workload is available.
 - [`understudy-evaluate`](understudy-evaluate/SKILL.md) compares prompts,
   traces, eval rows, datasets, or candidate models with explicit split
   boundaries.

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,8 @@ one specialist skill only when the developer's intent requires it.
 ## Entry Point
 
 - [`understudy`](understudy/SKILL.md) routes demo, evaluation, optimization,
-  training handoff, lab notes, local proxying, provider keys, and model lookup.
+  training handoff, lab notes, local proxying, provider keys, model lookup, and
+  local-model readiness.
 
 ## Specialist Skills
 
@@ -27,6 +28,9 @@ one specialist skill only when the developer's intent requires it.
   credential setup and status checks.
 - [`understudy-model-lookup`](understudy-model-lookup/SKILL.md) inspects model
   availability, runner compatibility, and local-vs-remote options.
+- [`understudy-local-models`](understudy-local-models/SKILL.md) checks MLX,
+  Apple Silicon, Ollama, and local runner readiness before local inference or
+  route comparisons.
 
 ## Public Safety
 

--- a/skills/understudy-demo/SKILL.md
+++ b/skills/understudy-demo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: understudy-demo
-description: Use when a developer wants a first-run Understudy demo or product walkthrough using local replay, bundled fixtures, and no provider spend.
+description: Use when a developer wants a first-run Understudy demo that scans a local repo for AI workload candidates before any provider spend.
 metadata:
   understudy:
     mode: automatic
@@ -12,6 +12,11 @@ metadata:
 
 Use this skill when the developer asks for a demo, first run, product
 walkthrough, or quick explanation of the Understudy replacement loop.
+
+The preferred first value moment is local repo workload discovery: point
+Understudy at the developer's repo, find likely AI workloads, and produce a
+local Workload Card draft. Bundled fixture replay is a fallback when no local
+repo is available.
 
 Do not use this skill for a real workload comparison after the developer has
 provided prompts, traces, datasets, or eval artifacts. Route those requests to
@@ -33,8 +38,9 @@ Do not upload source files, prompts, traces, outputs, datasets, repo paths,
 private notes, provider keys, or secrets unless the developer explicitly
 approves that exact action in the current thread.
 
-Use bundled or synthetic examples only. Do not ask for provider keys before
-showing a local replay unless the developer explicitly skips the replay path.
+Use local static inspection, bundled examples, or synthetic examples only. Do
+not ask for provider keys before showing a local repo scan or fixture replay
+unless the developer explicitly skips local discovery.
 
 Treat configured provider keys as local machine state, not permission to spend.
 Before live calls, hosted jobs, uploads, benchmark submission, or training,
@@ -48,10 +54,11 @@ require:
 
 ## Intake
 
-1. Confirm whether the developer wants a product demo or a real workload run.
-2. Inspect local CLI availability and any bundled demo commands.
-3. Run the smallest no-spend status or replay command before proposing live
-   work.
+1. Confirm the local repo path to inspect. Default to the current working
+   directory if the developer is already inside a repo.
+2. Inspect local CLI availability and demo commands.
+3. Run the smallest no-spend static scan before proposing live work.
+4. If no repo is available, fall back to a bundled or synthetic fixture.
 
 ## Flow
 
@@ -61,25 +68,44 @@ require:
 run_understudy --help
 ```
 
-2. Prefer a bundled demo, doctor, or replay command exposed by the installed
-   CLI. If the exact demo command is not obvious, inspect help first:
+2. Inspect demo help:
 
 ```sh
 run_understudy demo --help
 ```
 
-3. Run a local replay or fixture-only demo that writes under:
+3. Scan the local repo for AI workload candidates:
+
+```sh
+run_understudy demo scan --repo .
+```
+
+This writes under:
 
 ```text
 .understudy/demo/
 ```
 
-4. Explain the replacement loop using only generated or bundled evidence:
-   baseline, candidate, quality signal, cost or latency signal, failure
-   clusters, and next action.
+4. Review the top candidates. Look for provider/model usage, prompts, eval
+   harnesses, latency/cost hints, qualitative review needs, or trace capture
+   points.
 
-5. Offer a live evaluation only after the local replay is understood and the
+5. Create the first local Workload Card draft:
+
+```sh
+run_understudy demo plan --repo .
+```
+
+6. Explain the replacement loop using only generated local evidence:
+   workload candidate, inferred baseline, candidate routes, quality signal,
+   cost or latency signal, stakeholder review surface, and next action.
+
+7. Offer a live evaluation only after the local scan is understood and the
    developer approves the provider, budget cap, and data class.
+
+8. If no candidate is found, use a bundled synthetic fixture repo or ask the
+   developer which local code path contains AI calls. Do not pretend an empty
+   scan proves there is no workload.
 
 ## References
 
@@ -91,6 +117,8 @@ Load deeper material only when needed:
   for local key setup after the replay path.
 - [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md)
   for candidate availability or compatibility questions.
+- [`../../examples/repos/ai-search-app/README.md`](../../examples/repos/ai-search-app/README.md)
+  for the public synthetic repo journey when no local workload is available.
 
 ## Output Standard
 

--- a/skills/understudy-evaluate/SKILL.md
+++ b/skills/understudy-evaluate/SKILL.md
@@ -1,22 +1,27 @@
 ---
 name: understudy-evaluate
-description: Use when comparing prompts, traces, datasets, scorers, routes, or model candidates with local-first evaluation evidence.
+description: Use when comparing prompts, traces, datasets, scorers, routes, local models, provider models, or candidate outputs to find measurable cost, latency, quality, reliability, or portability value.
 metadata:
   understudy:
     mode: interactive
-    safety: local-first
+    safety: value-first
     cli_required: true
 ---
 
 # Understudy Evaluate
 
-Use this skill when the developer asks to evaluate a workload or compare
-quality, latency, reliability, cost, scorers, prompts, routes, or model
-candidates.
+Use this skill when the developer needs a credible answer to: "Can this workload
+run cheaper, faster, more reliably, or more portably without unacceptable quality
+loss?"
+
+Evaluation is the first value moment. Do not turn it into a checklist of
+cost-free probes. Start from the user's real workload when available, establish
+baseline economics, choose the fastest useful candidate path, and run the
+smallest comparison that can change a decision.
 
 Do not use this skill for optimization after a measured baseline exists. Route
 those requests to [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
-For fine-tuning, SFT, adapter, or training-data requests, route to
+For SFT, adapters, preference data, or training handoff, route to
 [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md).
 
 ## Resolve CLI
@@ -27,93 +32,136 @@ then define the `run_understudy` shell function from that shared resource.
 If `run_understudy` returns 127, activate
 [`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
 
+## Value Posture
+
+Prefer the path that produces decision-grade evidence soonest:
+
+- existing eval suite, traces, logs, prompt set, or app route over a toy fixture;
+- local replay when it can estimate quality or regression risk;
+- public local/open models when they can expose cost or latency upside;
+- existing provider keys when the developer has them and approves a capped run;
+- Understudy inference when it reduces setup time or avoids per-provider glue;
+- a small live comparison when replay cannot answer the economic question.
+
+Be explicit about economics:
+
+- current model or route;
+- input/output token shape or request volume;
+- latency target and observed latency;
+- cost/request or cost/month estimate;
+- quality gate and acceptable regression band;
+- candidate route, model, or runner;
+- decision the eval will unlock.
+
 ## Safety Gates
 
-Default to local-only, no-upload, no-spend work. Prefer local artifacts,
-synthetic fixtures, replay data, and dry-run plans before live provider calls.
+Default storage is local. Do not upload source files, prompts, traces, outputs,
+datasets, repo paths, private notes, provider keys, or secrets unless the
+developer explicitly approves that exact action in the current thread.
 
-Do not upload source files, prompts, traces, outputs, datasets, repo paths,
-private notes, provider keys, or secrets unless the developer explicitly
-approves that exact action in the current thread.
+Configured provider keys and Understudy API keys are usable only after approval
+for a named, capped action. Before live calls, hosted runs, uploads, benchmark
+submission, model downloads, or training, require:
 
-Treat configured provider keys as local machine state, not permission to spend.
-Before live calls, hosted jobs, uploads, benchmark submission, or training,
-require:
+- named provider, model, registry, or hosted surface;
+- estimated or capped spend, or estimated download size;
+- exact artifact or data class being sent or downloaded;
+- visible output path under `.understudy/`;
+- dry-run, preview, or local plan when available.
 
-- named provider or hosted surface;
-- estimated or capped budget;
-- exact artifacts or data class being sent;
-- reviewed dry-run or preview artifact;
-- visible output path under `.understudy/`.
-
-Keep split boundaries explicit. Do not inspect heldout labels or tune prompts,
-scorers, renderers, or routes against heldout rows.
+Keep split boundaries explicit. Do not tune prompts, scorers, renderers, or
+routes on heldout rows.
 
 ## Intake
 
-1. Inspect the real local workload source: trace store, dataset, eval report,
-   repo script, prompt set, scorer, or synthetic fixture.
-2. Identify the decision: baseline measurement, route comparison, scorer
-   validation, regression check, or readiness gate.
-3. Record row count, split names, metric definitions, candidate routes, and
-   known missing data before running comparisons.
-4. Run the smallest no-spend status, validation, replay, or dry-run command.
-5. Summarize current state before proposing paid, hosted, or upload steps.
+1. Identify the value target: cost, latency, quality, reliability, portability,
+   local privacy, or model availability.
+2. Inspect the real workload source: trace store, logs, eval report, dataset,
+   prompt set, app route, scorer, or benchmark script.
+3. Capture baseline facts: incumbent route, sample size, metric, latency,
+   cost/request, error rate, and known failure modes.
+4. Identify candidate paths: local model, public model download, existing
+   provider key, Understudy inference, replay, or managed provider.
+5. Choose the smallest comparison that can change the decision.
+
+Ask at most one clarifying question if the workload source or approval boundary
+is ambiguous.
 
 ## Flow
 
-1. Check local CLI health and available evaluation surfaces:
+1. Check the CLI and evaluation surface:
 
 ```sh
 run_understudy --help
 run_understudy evaluate --help
 ```
 
-2. If the workload already has local artifacts, inspect or validate them before
-   creating new runs:
+2. Inspect existing artifacts before creating new work:
 
 ```sh
 run_understudy evaluate status --local
 run_understudy evaluate validate --dry-run
 ```
 
-3. If local artifacts are missing, start with fixtures or a replay-only dry run:
+3. If there is a plausible local/open candidate, inspect model fit before
+benchmarking:
+
+```sh
+run_understudy local-models doctor --local --dry-run
+run_understudy model lookup --local --dry-run
+```
+
+4. If replay can answer the question, run a local comparison first:
 
 ```sh
 run_understudy evaluate run --dry-run --local
 ```
 
-4. Read generated artifacts under:
+5. If replay cannot answer the value question and the developer has approved a
+capped live run, use the smallest live sample that can establish direction.
+Record actual spend, latency, output validity, and quality deltas.
+
+6. Read generated artifacts under:
 
 ```text
 .understudy/evaluate/
+.understudy/model-lookup/
+.understudy/local-models/
 ```
 
-5. Separate catalog facts from measured results. A model card, route config, or
-   provider listing is not evaluation evidence.
+7. Report the result as a decision, not just a score: promote candidate,
+optimize next, download/run a local model, use Understudy inference, expand the
+sample, or stop because the economics do not justify more work.
 
-6. Report failures as actionable inputs: parser mismatch, missing labels,
-   scorer drift, context-window mismatch, token-cap mismatch, route error,
-   sample-size gap, or spend/upload gate.
+## Failure Triage
 
-## References
+Before blaming model quality, classify failures:
 
-Load deeper material only when needed:
+- context-window or token-cap mismatch;
+- parser or schema failure;
+- route or provider error;
+- scorer/rubric mismatch;
+- missing labels or weak sample size;
+- latency bottleneck outside inference;
+- incompatible tool-call or structured-output format;
+- true quality regression.
 
-- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
-  and interpretation rules.
-- [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md)
-  - model capability and route compatibility checks before benchmarking.
-- [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md)
-  - post-baseline improvement loop.
+Route model fit questions to
+[`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md).
+Route local runner questions to
+[`../understudy-local-models/SKILL.md`](../understudy-local-models/SKILL.md).
+Route post-baseline improvement to
+[`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
 
 ## Output Standard
 
 End with:
 
+- baseline route, candidate route, and value target;
 - what was inspected or run;
 - artifact paths created or read;
-- result type: dry-run, replay, fake-provider, validation, heldout, or live;
-- metric definitions, sample size, split boundary, and caveats;
-- approval-gated next step, if any;
+- result type: dry-run, local smoke, replay, validation, heldout, or live;
+- sample size, metric definitions, latency, cost, and quality caveats;
+- decision unlocked or still blocked;
+- spend/upload/download approval boundary, if any;
 - one recommended command.

--- a/skills/understudy-evaluate/reference.md
+++ b/skills/understudy-evaluate/reference.md
@@ -4,11 +4,19 @@ Detailed command matrices for evaluation are intentionally not shipped in this
 first public skill pass.
 
 Until the CLI surface is stable, use `understudy-evaluate/SKILL.md` as the
-authoritative workflow:
+authoritative workflow.
 
-- inspect local artifacts first;
-- preserve split boundaries;
-- run dry-run or replay paths before live provider calls;
+Future commands should preserve the value-first contract:
+
+- start from the user's real workload when available;
+- establish baseline cost, latency, quality, reliability, and sample size;
+- compare against the fastest plausible candidate path: local model, public
+  model download, existing provider key, Understudy inference, replay, or
+  managed route;
+- preserve split boundaries and heldout integrity;
+- run dry-run or replay paths when they can answer the economic question;
+- allow capped live runs when replay cannot answer the value question and the
+  developer approves spend/upload;
 - require explicit approval for upload, spend, hosted jobs, or benchmark
   submission.
 

--- a/skills/understudy-local-models/SKILL.md
+++ b/skills/understudy-local-models/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: understudy-local-models
+description: Use when checking MLX, Apple Silicon, Ollama, llama.cpp, Transformers, or other local model runners before local inference or route comparison.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-only
+    cli_required: true
+---
+
+# Understudy Local Models
+
+Use this skill when the developer asks whether a workload can run locally, how
+to use MLX on Apple Silicon, whether a quantized model fits local hardware, or
+how to compare a local candidate against a hosted route.
+
+Do not use this skill to claim model quality. Route measured comparisons to
+[`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md) after the
+local runner passes a smoke check.
+
+## Resolve CLI
+
+Open and read [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md),
+then define the `run_understudy` shell function from that shared resource.
+
+If `run_understudy` returns 127, activate
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md).
+
+## Safety Gates
+
+Default to local-only, no-upload, no-spend work.
+
+Do not upload prompts, traces, source files, datasets, outputs, local model
+artifacts, repo paths, provider keys, or private notes unless the developer
+explicitly approves that exact action in the current thread.
+
+Local inference readiness is not evaluation evidence. A successful runner smoke
+only proves that the model loads and returns output on the current machine.
+
+Before any live provider call, hosted fallback, remote model download, or
+benchmark submission, require:
+
+- named provider, registry, or hosted surface;
+- estimated download size or spend cap;
+- exact artifacts or data class being sent;
+- reviewed dry-run or preview artifact;
+- visible output path under `.understudy/`.
+
+## Intake
+
+1. Identify the runner: MLX, Ollama, llama.cpp, Transformers, vLLM, local
+   OpenAI-compatible server, or unknown.
+2. Inspect hardware limits: OS, CPU/GPU, Apple Silicon generation, memory,
+   disk, Python version, and whether Metal acceleration is available.
+3. Inspect model requirements: architecture, parameter count, quantization,
+   context window, tokenizer, adapter base, license, and expected modality.
+4. Separate readiness checks from benchmark claims.
+5. Prefer a synthetic prompt or bundled fixture for the first smoke.
+
+## Flow
+
+1. Check local-model command availability:
+
+```sh
+run_understudy local-models --help
+```
+
+2. Inspect local runner readiness without loading private workload data:
+
+```sh
+run_understudy local-models doctor --local --dry-run
+```
+
+3. Inspect model metadata before running inference:
+
+```sh
+run_understudy model lookup --local --dry-run
+```
+
+4. If a local route is being compared against hosted models, validate the
+   route shape without sending workload payloads:
+
+```sh
+run_understudy model route --dry-run --local
+```
+
+5. Run only a synthetic or bundled-fixture smoke first. Record startup time,
+   first-token latency, tokens per second, memory pressure, context limit,
+   output shape, and any fallback path.
+
+6. If the smoke passes, route measured quality or latency comparison to:
+
+```sh
+run_understudy evaluate run --dry-run --local
+```
+
+7. Read generated artifacts under:
+
+```text
+.understudy/local-models/
+.understudy/model-lookup/
+```
+
+## Runner Notes
+
+- MLX: prefer Apple Silicon checks, memory fit, quantization support, and
+  adapter compatibility before running prompts.
+- Ollama: treat installed model names as local machine state, not public
+  availability evidence.
+- llama.cpp: verify quantization, context length, chat template, and Metal
+  acceleration separately.
+- Transformers: verify device placement and tokenizer compatibility before
+  judging speed or quality.
+- Local OpenAI-compatible servers: route through the local proxy skill when
+  app wiring, base URL, or trace capture is the primary task.
+
+## Output Standard
+
+End with:
+
+- runner and hardware inspected;
+- model artifact or model id inspected;
+- artifact paths created or read;
+- result type: dry-run, fixture smoke, local inference, replay, or live;
+- readiness result, latency notes, memory caveats, and unsupported assumptions;
+- approval-gated next step, if any;
+- one recommended command.

--- a/skills/understudy-local-models/reference.md
+++ b/skills/understudy-local-models/reference.md
@@ -1,0 +1,48 @@
+# Understudy Local Models Reference
+
+This public skill is a roadmap surface. It should grow toward a local-only
+runner readiness layer before it grows benchmark or hosted-provider behavior.
+
+## Minimum Public Contract
+
+The first implementation should produce a local readiness artifact with:
+
+- `schema_version`
+- timestamp
+- OS and architecture
+- memory and disk summary
+- detected runner binaries
+- detected local OpenAI-compatible endpoints, if explicitly configured
+- model id or local artifact path, with secrets redacted
+- quantization and context-window notes when available
+- result type: `dry-run`, `fixture-smoke`, or `local-inference`
+- generated artifact paths under `.understudy/local-models/`
+
+## First Migration Targets
+
+Start with no-upload checks:
+
+- hardware inventory for Apple Silicon and generic Linux;
+- MLX import and help checks;
+- Ollama model list parsing with model names only;
+- llama.cpp binary/help checks;
+- Transformers import and device check;
+- synthetic prompt smoke with bounded output and no private payload.
+
+## Model Profile Style
+
+When recommending a public model family or local runner, follow:
+
+- [`../../docs/model-analysis-style-guide.md`](../../docs/model-analysis-style-guide.md)
+- [`../../docs/model-analysis-profile-template.md`](../../docs/model-analysis-profile-template.md)
+- [`../../docs/model-analysis-profiles.md`](../../docs/model-analysis-profiles.md)
+
+Every public model recommendation must separate catalog facts from measured
+results and include citations for model cards, runner support, license/terms,
+pricing, and availability.
+
+## Deferred
+
+Do not migrate customer trace replay, hosted routing, provider-specific
+optimization, benchmark uploads, private eval rows, or internal deployment
+details into this public skill.

--- a/skills/understudy-model-lookup/reference.md
+++ b/skills/understudy-model-lookup/reference.md
@@ -9,5 +9,11 @@ Public model lookup should stay evidence-scoped:
 - verify runner, tokenizer, adapter, modality, context window, and route shape;
 - do not send workload payloads while checking compatibility.
 
+Use the public model analysis docs when writing or interpreting model profiles:
+
+- [`../../docs/model-analysis-style-guide.md`](../../docs/model-analysis-style-guide.md)
+- [`../../docs/model-analysis-profile-template.md`](../../docs/model-analysis-profile-template.md)
+- [`../../docs/model-analysis-profiles.md`](../../docs/model-analysis-profiles.md)
+
 Add provider-specific instructions here only after checking current public
 provider documentation.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -1,52 +1,85 @@
 ---
 name: understudy
-description: Use when a developer asks to use Understudy, evaluate or optimize an AI workload, prepare training data, run a demo, set up local capture or proxying, or inspect model options. Route to the narrow specialist skill before running commands.
+description: Use when a developer asks to use Understudy, reduce AI cost or latency, evaluate or optimize an AI workload, prepare training data, run local/open models, set up capture or proxying, inspect model options, or run a first demo. Route to the narrow specialist skill before running commands.
 metadata:
   understudy:
     mode: automatic
-    safety: local-first
+    safety: value-first
     cli_required: false
 ---
 
 # Understudy
 
-Use this skill as the public entrypoint for Understudy. Start here when the
-developer names Understudy or asks for help with evaluation, optimization,
-training handoff, local proxying, model choice, provider setup, or a first-run
-demo.
+Use this as the public entrypoint for Understudy. The job is to help the
+developer reach measured value quickly: lower cost, lower latency, equal or
+better quality, cleaner evals, or a credible next experiment.
+
+Local-first means start from the user's machine and artifacts. It does not mean
+"only run cost-free checks." If value is likely, guide the developer toward the
+fastest reasonable path: reuse existing provider keys, use an Understudy API key,
+download a public model, run a local MLX/Ollama smoke, or route through a local
+proxy. Ask for approval only at the boundary where spend, upload, or hosted
+execution begins.
 
 Do not use this skill as a full runbook. Route to the narrow specialist skill,
-then follow that skill's CLI and safety instructions.
+then follow that skill's CLI, value, and safety instructions.
 
 ## Resolve CLI
 
-Do not resolve the CLI in this routing skill unless the user explicitly asks
-for setup status before the intent is clear.
+Do not resolve the CLI in this router unless setup status is the user's actual
+request.
 
 When a routed specialist skill requires the CLI, open and read
 [`../_resources/cli-bootstrap.md`](../_resources/cli-bootstrap.md), then define
 the `run_understudy` shell function from that shared resource.
 
-If `run_understudy` returns 127, stop and explain that the Understudy CLI is not
-available in the current shell. Do not guess install paths.
+If `run_understudy` returns 127, route to
+[`../understudy-bootstrap/SKILL.md`](../understudy-bootstrap/SKILL.md). Do not
+stop at "CLI unavailable" if a local install or bootstrap path can move the user
+forward.
+
+## Operating Posture
+
+Optimize for useful evidence, not ritual caution.
+
+- Prefer the user's real workload over synthetic demos when they have one.
+- Prefer an existing eval suite, trace store, prompt set, dataset, or app route
+  over creating a toy benchmark.
+- Prefer local replay and local models when they can answer the economic
+  question quickly.
+- Prefer existing API keys when the user already has them and approves a capped
+  run.
+- Prefer Understudy inference when it saves integration time, provides better
+  routing evidence, or avoids bespoke provider glue.
+- Prefer public open models such as Gemma/Qwen/Llama-class candidates when a
+  download or local smoke can expose a real cost or latency opportunity.
+
+Be concrete about value:
+
+- current route, model, latency, cost/request, and failure rate;
+- candidate route or model;
+- expected savings or speedup hypothesis;
+- quality gate and sample size;
+- next command and approval boundary.
 
 ## Safety Gates
 
-Default to local-only, no-upload, no-spend work.
+Default storage is local. Never upload source files, prompts, traces, outputs,
+datasets, repo paths, private notes, provider keys, or secrets unless the
+developer explicitly approves that exact action in the current thread.
 
-Do not upload source files, prompts, traces, outputs, datasets, repo paths,
-private notes, provider keys, or secrets unless the developer explicitly
-approves that exact action in the current thread.
+Provider keys and Understudy API keys are useful tools, not automatic
+permission. Before live calls, hosted jobs, model downloads, uploads, benchmark
+submission, or training, require:
 
-Treat configured provider keys as local machine state, not permission to spend.
-Before live calls, hosted jobs, uploads, benchmark submission, or training,
-require:
-
-- named provider or hosted surface;
-- estimated or capped budget;
-- exact artifacts or data class being sent;
-- dry-run or preview artifact reviewed first;
+- named provider, model, registry, or hosted surface;
+- estimated or capped spend, or estimated download size;
+- exact artifact or data class being sent or downloaded;
+- reviewed dry-run, preview, or local plan when available;
 - visible output path under `.understudy/`.
+
+Do not ask the user to paste secrets into chat. Inspect configured key presence
+only through redacted local status checks.
 
 Keep public examples synthetic or user-provided. Do not include customer names,
 domains, private runbooks, raw prompts, raw completions, secrets, or internal
@@ -54,46 +87,60 @@ hosted-control details in public skill output.
 
 ## Intake
 
-1. Identify the user's intent from the actual request, not from nearby files.
-2. Ask at most one clarifying question if the route is ambiguous.
-3. Prefer a local replay, dry-run, fixture, or status check before provider
-   calls, uploads, or hosted jobs.
-4. State which specialist skill you are using and why.
+1. Identify the economic target: cost, latency, quality, reliability,
+   portability, local privacy, or training handoff.
+2. Identify the real workload source: app route, prompt, trace store, eval rows,
+   logs, dataset, report, model comparison, or existing benchmark.
+3. Identify current and candidate routes: incumbent model/provider, existing
+   API keys, Understudy key, local runner, public model, or managed provider.
+4. Ask at most one clarifying question when the next action is ambiguous.
+5. Route to the smallest specialist skill that can create useful evidence.
 
 ## Flow
 
-Route by the smallest matching intent:
+Route by value path:
 
-- New user, product tour, or "show me how this works": read
+- "Show me quickly," first-run proof, or no workload yet: read
   [`../understudy-demo/SKILL.md`](../understudy-demo/SKILL.md).
-- Existing prompts, traces, eval rows, reports, datasets, or model comparison:
-  read [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
-- Improve measured quality, latency, cost, parsing, routing, or reliability:
-  read [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
-- SFT, preference data, RL trajectories, adapters, or hosted training handoff:
-  read [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md).
-- Multi-run research, hypotheses, budgets, experiment notes, or decision logs:
-  read [`../understudy-lab/SKILL.md`](../understudy-lab/SKILL.md).
-- Local OpenAI-compatible proxy, trace capture, or replay through a local
-  endpoint: read
-  [`../understudy-local-proxy/SKILL.md`](../understudy-local-proxy/SKILL.md).
-- Provider key setup or local credential health: read
-  [`../understudy-provider-keys/SKILL.md`](../understudy-provider-keys/SKILL.md).
-- Model availability, runner compatibility, or local-vs-remote candidate
-  choice: read
+- Existing prompts, traces, eval rows, reports, datasets, or candidate
+  comparison: read
+  [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md).
+- Reduce cost or latency after a measured baseline, or improve quality,
+  parsing, routing, prompts, or reliability: read
+  [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
+- MLX, Apple Silicon, Ollama, llama.cpp, public local models, model downloads,
+  quantization, memory fit, or local inference latency: read
+  [`../understudy-local-models/SKILL.md`](../understudy-local-models/SKILL.md).
+- Model availability, tokenizer/context/tool-call/logprob compatibility, or
+  local-vs-remote candidate choice: read
   [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md).
+- Local OpenAI-compatible proxy, app routing, trace capture, or replay through a
+  local endpoint: read
+  [`../understudy-local-proxy/SKILL.md`](../understudy-local-proxy/SKILL.md).
+- Provider key, Understudy API key, redacted credential status, or spend-ready
+  setup: read
+  [`../understudy-provider-keys/SKILL.md`](../understudy-provider-keys/SKILL.md).
+- SFT, preference data, RL trajectories, adapters, LoRA, or hosted training
+  handoff: read [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md).
+- Multi-run research, hypotheses, budgets, experiment notes, or stop/go
+  decisions: read [`../understudy-lab/SKILL.md`](../understudy-lab/SKILL.md).
 
-If more than one route applies, use this order: demo, evaluate, optimize,
-train, lab, local proxy, provider keys, model lookup. Switch only when the
-evidence changes.
+If more than one route applies, use this order:
+
+1. evaluate the real workload;
+2. try local/public candidate evidence when plausible;
+3. use existing or Understudy API keys for capped live evidence when needed;
+4. optimize only after a baseline;
+5. train only after simpler levers stop moving the measured gate.
 
 ## Output Standard
 
 End with:
 
-- which specialist skill was used or should be used next;
+- economic target and current best next route;
+- specialist skill used or recommended;
 - what was inspected or run;
 - artifact paths created or read;
-- result type: dry-run, replay, fake-provider, validation, heldout, or live;
-- approval-gated next step, if any;
-- one recommended command from the specialist skill when available.
+- result type: demo, dry-run, local smoke, replay, validation, heldout, or live;
+- spend/upload/download approval boundary, if any;
+- one recommended command.

--- a/src/understudy_agent_tools/cli.py
+++ b/src/understudy_agent_tools/cli.py
@@ -7,6 +7,49 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+ROADMAP_SURFACES: dict[str, dict[str, str]] = {
+    "demo": {
+        "skill": "skills/understudy-demo/SKILL.md",
+        "why": "Replay-first onboarding with bundled or synthetic examples.",
+        "next": "Port a no-provider fixture replay from understudy-agent.",
+    },
+    "evaluate": {
+        "skill": "skills/understudy-evaluate/SKILL.md",
+        "why": "Local-first workload measurement with explicit split boundaries.",
+        "next": "Port artifact validation and dry-run eval planning before live runners.",
+    },
+    "optimize": {
+        "skill": "skills/understudy-optimize/SKILL.md",
+        "why": "Post-baseline prompt, route, parser, and candidate improvement.",
+        "next": "Port local dry-run planning before any optimizer implementation.",
+    },
+    "train": {
+        "skill": "skills/understudy-train/SKILL.md",
+        "why": "Local training handoff: provenance, split validation, and export previews.",
+        "next": "Port export-preview and validation stubs before hosted provider flows.",
+    },
+    "model": {
+        "skill": "skills/understudy-model-lookup/SKILL.md",
+        "why": "Compatibility checks before benchmark or replacement claims.",
+        "next": "Port local metadata inspection and public model-card lookup helpers.",
+    },
+    "local-models": {
+        "skill": "skills/understudy-local-models/SKILL.md",
+        "why": "Apple Silicon, MLX, Ollama, and local runner readiness before live comparison.",
+        "next": "Port local hardware inventory and dry-run runner checks without private workloads.",
+    },
+    "proxy": {
+        "skill": "skills/understudy-local-proxy/SKILL.md",
+        "why": "Local OpenAI-compatible routing and trace-capture setup.",
+        "next": "Port local fixture proxy checks without hosted-control-plane details.",
+    },
+    "keys": {
+        "skill": "skills/understudy-provider-keys/SKILL.md",
+        "why": "Redacted local provider-key status and safe setup guidance.",
+        "next": "Port redacted presence checks only; never print secret values.",
+    },
+}
+
 
 def _spine() -> dict[str, object]:
     return {
@@ -50,6 +93,35 @@ def cmd_skills(args: argparse.Namespace) -> int:
     return 0
 
 
+def _roadmap_payload(surface: str) -> dict[str, str]:
+    spec = ROADMAP_SURFACES[surface]
+    return {
+        "surface": surface,
+        "status": "planned",
+        "implemented": "false",
+        "default_mode": "local-only",
+        "skill": spec["skill"],
+        "why": spec["why"],
+        "next_migration": spec["next"],
+        "migration_plan": "docs/tool-migration-map.md",
+    }
+
+
+def cmd_roadmap_surface(args: argparse.Namespace) -> int:
+    payload = _roadmap_payload(args.surface)
+    if args.action in {"status", "doctor", "lookup", "route", "validate", "run", "plan", "start", "export"}:
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"{payload['surface']}: {payload['status']}")
+            print(f"Skill: {payload['skill']}")
+            print(f"Why: {payload['why']}")
+            print(f"Next migration: {payload['next_migration']}")
+            print(f"Plan: {payload['migration_plan']}")
+        return 0
+    raise ValueError(f"unsupported action: {args.action}")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="understudy-tools")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -61,6 +133,24 @@ def build_parser() -> argparse.ArgumentParser:
     skills = subparsers.add_parser("skills", help="List bundled skills.")
     skills.add_argument("--json", action="store_true")
     skills.set_defaults(func=cmd_skills)
+
+    for surface, spec in ROADMAP_SURFACES.items():
+        surface_parser = subparsers.add_parser(
+            surface,
+            help=f"Planned public surface: {spec['why']}",
+        )
+        surface_parser.add_argument(
+            "action",
+            nargs="?",
+            default="status",
+            choices=["status", "doctor", "lookup", "route", "validate", "run", "plan", "start", "export"],
+            help="Roadmap action stub. All actions report planned status until runtime code lands.",
+        )
+        surface_parser.add_argument("--json", action="store_true")
+        surface_parser.add_argument("--local", action="store_true", help=argparse.SUPPRESS)
+        surface_parser.add_argument("--dry-run", action="store_true", help=argparse.SUPPRESS)
+        surface_parser.add_argument("--redacted", action="store_true", help=argparse.SUPPRESS)
+        surface_parser.set_defaults(func=cmd_roadmap_surface, surface=surface)
 
     return parser
 

--- a/src/understudy_agent_tools/cli.py
+++ b/src/understudy_agent_tools/cli.py
@@ -2,16 +2,63 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_EXCLUDE_DIRS = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".understudy",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "node_modules",
+}
+SCAN_EXTENSIONS = {
+    ".js",
+    ".jsx",
+    ".md",
+    ".mjs",
+    ".py",
+    ".rs",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+PROVIDER_PATTERNS = {
+    "anthropic": re.compile(r"\b(anthropic|claude)\b", re.IGNORECASE),
+    "aws-bedrock": re.compile(r"\b(bedrock|aws\s*bedrock)\b", re.IGNORECASE),
+    "fireworks": re.compile(r"\bfireworks\b", re.IGNORECASE),
+    "gcp-vertex": re.compile(r"\b(vertexai|vertex\s*ai|google\.cloud\.aiplatform)\b", re.IGNORECASE),
+    "gemini": re.compile(r"\b(gemini|google\s+genai)\b", re.IGNORECASE),
+    "lilac": re.compile(r"\blilac\b", re.IGNORECASE),
+    "openai": re.compile(r"\b(openai|gpt-[A-Za-z0-9_.-]+)\b", re.IGNORECASE),
+    "openrouter": re.compile(r"\bopenrouter\b", re.IGNORECASE),
+    "prime-intellect": re.compile(r"\bprime\s*intellect\b", re.IGNORECASE),
+    "tinker": re.compile(r"\btinker\b", re.IGNORECASE),
+}
+MODEL_PATTERN = re.compile(
+    r"\b(?:gpt-[A-Za-z0-9_.-]+|claude-[A-Za-z0-9_.-]+|gemini-[A-Za-z0-9_.-]+|"
+    r"gemma-[A-Za-z0-9_.-]+|glm-[A-Za-z0-9_.-]+|kimi-[A-Za-z0-9_.-]+)\b",
+    re.IGNORECASE,
+)
+PROMPT_PATTERN = re.compile(r"\b(prompt|system_message|system prompt|messages\s*=)\b", re.IGNORECASE)
+EVAL_PATTERN = re.compile(r"\b(eval|benchmark|golden|fixture|test[_-]?prompt|rubric)\b", re.IGNORECASE)
+LATENCY_PATTERN = re.compile(r"\b(latency|timeout|duration|elapsed|p95|p99|slow)\b", re.IGNORECASE)
+COST_PATTERN = re.compile(r"\b(cost|price|pricing|token|usage|input_tokens|output_tokens)\b", re.IGNORECASE)
 
 ROADMAP_SURFACES: dict[str, dict[str, str]] = {
     "demo": {
         "skill": "skills/understudy-demo/SKILL.md",
-        "why": "Replay-first onboarding with bundled or synthetic examples.",
-        "next": "Port a no-provider fixture replay from understudy-agent.",
+        "why": "Local repo workload discovery before provider spend.",
+        "next": "Expand static scan signals and add richer Workload Card validation.",
     },
     "evaluate": {
         "skill": "skills/understudy-evaluate/SKILL.md",
@@ -49,6 +96,182 @@ ROADMAP_SURFACES: dict[str, dict[str, str]] = {
         "next": "Port redacted presence checks only; never print secret values.",
     },
 }
+
+
+def _scan_files(repo: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(repo.rglob("*")):
+        if not path.is_file():
+            continue
+        relative_parts = path.relative_to(repo).parts
+        if any(part in SCAN_EXCLUDE_DIRS for part in relative_parts):
+            continue
+        if path.suffix.lower() not in SCAN_EXTENSIONS:
+            continue
+        if path.stat().st_size > 250_000:
+            continue
+        files.append(path)
+    return files
+
+
+def _line_hits(text: str, pattern: re.Pattern[str]) -> list[int]:
+    return [index for index, line in enumerate(text.splitlines(), start=1) if pattern.search(line)]
+
+
+def _scan_repo(repo: Path) -> list[dict[str, object]]:
+    candidates: list[dict[str, object]] = []
+    for path in _scan_files(repo):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        provider_hits = sorted(
+            provider for provider, pattern in PROVIDER_PATTERNS.items() if pattern.search(text)
+        )
+        models = sorted({match.group(0) for match in MODEL_PATTERN.finditer(text)})
+        prompt_lines = _line_hits(text, PROMPT_PATTERN)
+        eval_lines = _line_hits(text, EVAL_PATTERN)
+        latency_lines = _line_hits(text, LATENCY_PATTERN)
+        cost_lines = _line_hits(text, COST_PATTERN)
+
+        score = (
+            len(provider_hits) * 3
+            + min(len(models), 5) * 2
+            + min(len(prompt_lines), 3)
+            + min(len(eval_lines), 3)
+            + min(len(latency_lines), 2)
+            + min(len(cost_lines), 2)
+        )
+        if score < 3:
+            continue
+
+        relative = path.relative_to(repo)
+        signals: list[str] = []
+        if provider_hits:
+            signals.append("provider")
+        if models:
+            signals.append("model")
+        if prompt_lines:
+            signals.append("prompt")
+        if eval_lines:
+            signals.append("eval")
+        if latency_lines:
+            signals.append("latency")
+        if cost_lines:
+            signals.append("cost")
+
+        candidates.append(
+            {
+                "id": "",
+                "path": str(relative),
+                "score": score,
+                "signals": signals,
+                "providers": provider_hits,
+                "models": models[:10],
+                "evidence_lines": {
+                    "prompt": prompt_lines[:8],
+                    "eval": eval_lines[:8],
+                    "latency": latency_lines[:8],
+                    "cost": cost_lines[:8],
+                },
+            }
+        )
+
+    ranked = sorted(candidates, key=lambda item: (-int(item["score"]), str(item["path"])))
+    for index, candidate in enumerate(ranked, start=1):
+        candidate["id"] = f"candidate-{index:03d}"
+    return ranked
+
+
+def _demo_dir(repo: Path) -> Path:
+    return repo / ".understudy" / "demo"
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_candidates(repo: Path) -> list[dict[str, object]]:
+    path = _demo_dir(repo) / "workload-candidates.json"
+    if not path.exists():
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return list(payload.get("candidates", []))
+
+
+def cmd_demo(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).expanduser().resolve()
+    if not repo.exists() or not repo.is_dir():
+        raise SystemExit(f"repo does not exist or is not a directory: {repo}")
+
+    if args.demo_action == "scan":
+        candidates = _scan_repo(repo)
+        payload = {
+            "schema_version": "understudy.demo.workload_candidates.v1",
+            "repo": str(repo),
+            "mode": "local-only",
+            "notes": [
+                "Static scan only; no provider calls, uploads, model downloads, or secret inspection.",
+                "Review candidates before turning any source code into an eval artifact.",
+            ],
+            "candidates": candidates,
+        }
+        output = _demo_dir(repo) / "workload-candidates.json"
+        _write_json(output, payload)
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"wrote {output}")
+            print(f"found {len(candidates)} workload candidate(s)")
+            for candidate in candidates[:5]:
+                providers = ", ".join(candidate["providers"]) or "unknown-provider"
+                signals = ", ".join(candidate["signals"])
+                print(f"- {candidate['id']}: {candidate['path']} ({providers}; {signals})")
+        return 0
+
+    if args.demo_action == "plan":
+        candidates = _load_candidates(repo)
+        if not candidates:
+            raise SystemExit("no workload candidates found; run `understudy-tools demo scan --repo .` first")
+        selected = next(
+            (candidate for candidate in candidates if candidate["id"] == args.candidate),
+            candidates[0],
+        )
+        plan = {
+            "schema_version": "understudy.demo.workload_card.v1",
+            "candidate_id": selected["id"],
+            "source_path": selected["path"],
+            "mode": "local-only",
+            "inferred_signals": selected["signals"],
+            "inferred_providers": selected["providers"],
+            "inferred_models": selected["models"],
+            "approval_required_before": [
+                "sending source, prompts, traces, or eval rows to any provider",
+                "running live model calls",
+                "downloading local models",
+                "submitting hosted benchmarks or training jobs",
+            ],
+            "recommended_next_steps": [
+                "confirm the workload owner and success metric",
+                "create 10-30 representative public-safe test cases",
+                "record current latency, cost, and quality baseline",
+                "choose a local, existing-key, or hosted candidate route",
+                "prepare blind pairwise review if quality is qualitative",
+            ],
+        }
+        output = _demo_dir(repo) / "workload-card.json"
+        _write_json(output, plan)
+        if args.json:
+            print(json.dumps(plan, indent=2, sort_keys=True))
+        else:
+            print(f"wrote {output}")
+            print(f"planned {selected['id']}: {selected['path']}")
+            print("next: confirm success metric and representative test cases")
+        return 0
+
+    return cmd_roadmap_surface(args)
 
 
 def _spine() -> dict[str, object]:
@@ -134,7 +357,22 @@ def build_parser() -> argparse.ArgumentParser:
     skills.add_argument("--json", action="store_true")
     skills.set_defaults(func=cmd_skills)
 
+    demo_parser = subparsers.add_parser("demo", help="Find and plan a local repo workload demo.")
+    demo_parser.add_argument(
+        "demo_action",
+        nargs="?",
+        default="status",
+        choices=["status", "scan", "plan"],
+        help="Scan a local repo for AI workload candidates or plan the first workload card.",
+    )
+    demo_parser.add_argument("--repo", default=".", help="Local repository to inspect.")
+    demo_parser.add_argument("--candidate", default="", help="Candidate id from workload-candidates.json.")
+    demo_parser.add_argument("--json", action="store_true")
+    demo_parser.set_defaults(func=cmd_demo, surface="demo", action="status")
+
     for surface, spec in ROADMAP_SURFACES.items():
+        if surface == "demo":
+            continue
         surface_parser = subparsers.add_parser(
             surface,
             help=f"Planned public surface: {spec['why']}",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,3 +14,23 @@ def test_skills_command(capsys) -> None:
     assert main(["skills"]) == 0
     out = capsys.readouterr().out
     assert "skills/understudy" in out
+
+
+def test_roadmap_surface_status(capsys) -> None:
+    assert main(["evaluate", "status", "--local"]) == 0
+    out = capsys.readouterr().out
+    assert "evaluate: planned" in out
+    assert "docs/tool-migration-map.md" in out
+
+
+def test_local_models_roadmap_surface(capsys) -> None:
+    assert main(["local-models", "doctor", "--local", "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert "local-models: planned" in out
+    assert "skills/understudy-local-models/SKILL.md" in out
+
+
+def test_keys_roadmap_surface(capsys) -> None:
+    assert main(["keys", "doctor", "--redacted"]) == 0
+    out = capsys.readouterr().out
+    assert "keys: planned" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from understudy_agent_tools.cli import main
 
 
@@ -34,3 +36,37 @@ def test_keys_roadmap_surface(capsys) -> None:
     assert main(["keys", "doctor", "--redacted"]) == 0
     out = capsys.readouterr().out
     assert "keys: planned" in out
+
+
+def test_demo_scan_and_plan(tmp_path, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "search.py"
+    source.write_text(
+        """
+SYSTEM_PROMPT = "rank search results"
+model = "gpt-4o-mini"
+provider = "openrouter"
+latency_budget_ms = 500
+input_tokens = 1200
+""",
+        encoding="utf-8",
+    )
+
+    assert main(["demo", "scan", "--repo", str(repo)]) == 0
+    scan_out = capsys.readouterr().out
+    assert "found 1 workload candidate" in scan_out
+
+    candidates_path = repo / ".understudy" / "demo" / "workload-candidates.json"
+    payload = json.loads(candidates_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "understudy.demo.workload_candidates.v1"
+    assert payload["candidates"][0]["path"] == "search.py"
+    assert "openrouter" in payload["candidates"][0]["providers"]
+
+    assert main(["demo", "plan", "--repo", str(repo)]) == 0
+    plan_out = capsys.readouterr().out
+    assert "planned candidate-001" in plan_out
+    card_path = repo / ".understudy" / "demo" / "workload-card.json"
+    card = json.loads(card_path.read_text(encoding="utf-8"))
+    assert card["schema_version"] == "understudy.demo.workload_card.v1"
+    assert "running live model calls" in card["approval_required_before"]


### PR DESCRIPTION
## Summary
- rewrites the top-level Understudy and evaluate skills around economic value, real workloads, and explicit spend/upload/download boundaries
- adds roadmap CLI stubs for evaluate, optimize, train, model, local-models, proxy, and keys so public users can see the intended spine before private implementation migrates
- adds a local-model readiness skill plus model analysis/profile docs that standardize local, remote frontier, and open-weight evaluation
- narrows supplier guidance to Fireworks, OpenRouter, Prime Intellect, Tinker, GCP/Vertex, AWS/Bedrock, Lilac, local runners, and Understudy inference

## Safety / OSS Hygiene
- keeps `docs/skill-comparison-audit.md` local and gitignored
- does not include private workload data, customer names, raw prompts, API keys, or patent-sensitive methodology details
- treats Artificial Analysis and official provider pages as source/citation surfaces; exact price/rank rows remain source-required per route

## Verification
- `python3 scripts/validate_public_skills.py && python3 scripts/doctor.py`
- `uv run --with pytest python -m pytest tests/test_cli.py`
- direct CLI smoke for evaluate, local-models, and keys stubs

## Review Notes
This is intentionally a draft PR for manual proofread. The supplier/profile docs are a public-safe roadmap, not a claim that every named model class is available on every supplier today.