### PR TITLE
fix: extract Flow/Intake sections into reference.md for evaluate and model-lookup skills

### DIFF
--- a/skills/understudy-evaluate/SKILL.md
+++ b/skills/understudy-evaluate/SKILL.md
@@ -82,98 +82,17 @@ dry-runs. Evaluation reports must label the result type, sample size, split
 boundary, baseline route, candidate route, cost basis, latency basis, and
 caveats.
 
-## Intake
+## References
 
-1. Identify the value target: cost, latency, quality, reliability, portability,
-   local privacy, or model availability.
-2. Inspect the real workload source: trace store, logs, eval report, dataset,
-   prompt set, app route, scorer, or benchmark script.
-3. Capture baseline facts: incumbent route, sample size, metric, latency,
-   cost/request, error rate, and known failure modes.
-4. Identify candidate paths: local model, public model download, existing
-   provider key, Understudy inference, replay, or managed provider.
-5. Choose the smallest comparison that can change the decision.
+Load deeper material only when needed:
 
-Ask at most one clarifying question if the workload source or approval boundary
-is ambiguous.
-
-## Flow
-
-1. Check the CLI and evaluation surface:
-
-```sh
-run_understudy --help
-run_understudy evaluate --help
-```
-
-2. Inspect existing artifacts before creating new work:
-
-```sh
-run_understudy evaluate status --local
-run_understudy evaluate validate --dry-run
-```
-
-3. If there is a plausible local/open candidate, inspect model fit before
-benchmarking:
-
-```sh
-run_understudy local-models doctor --local --dry-run
-run_understudy model lookup --local --dry-run
-```
-
-4. If replay can answer the question, run a local comparison first:
-
-```sh
-run_understudy evaluate run --dry-run --local
-```
-
-5. If replay cannot answer the value question and the developer has approved a
-capped live run, use the smallest live sample that can establish direction.
-Record actual spend, latency, output validity, and quality deltas.
-
-6. Read generated artifacts under:
-
-```text
-.understudy/evaluate/
-.understudy/model-lookup/
-.understudy/local-models/
-```
-
-7. Report the result as a decision, not just a score: promote candidate,
-optimize next, download/run a local model, use Understudy inference, expand the
-sample, or stop because the economics do not justify more work.
-
-## Failure Triage
-
-Before blaming model quality, classify failures:
-
-- context-window or token-cap mismatch;
-- parser or schema failure;
-- route or provider error;
-- scorer/rubric mismatch;
-- missing labels or weak sample size;
-- latency bottleneck outside inference;
-- incompatible tool-call or structured-output format;
-- true quality regression.
-
-Route model fit questions to
-[`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md).
-Route local runner questions to
-[`../understudy-local-models/SKILL.md`](../understudy-local-models/SKILL.md).
-Route post-baseline improvement to
-[`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
-Route decision/value reporting to
-[`../understudy-value-reporting/SKILL.md`](../understudy-value-reporting/SKILL.md).
-
-## Output Standard
-
-End with:
-
-- baseline route, candidate route, and value target;
-- what was inspected or run;
-- artifact paths created or read;
-- result type: dry-run, local smoke, replay, validation, heldout, or live;
-- sample size, metric definitions, latency, cost, and quality caveats;
-- decision unlocked or still blocked;
-- spend/upload/download approval boundary, if any;
-- one recommended command.
+- [`reference.md`](reference.md) - intake checklist, command flow, failure
+  triage, artifact contract, and output standard.
+- [`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md)
+  - model capability and route compatibility checks before benchmarking.
+- [`../understudy-local-models/SKILL.md`](../understudy-local-models/SKILL.md)
+  - local runner questions.
+- [`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md)
+  - post-baseline improvement loop.
+- [`../understudy-value-reporting/SKILL.md`](../understudy-value-reporting/SKILL.md)
+  - decision and value reporting.

--- a/skills/understudy-evaluate/reference.md
+++ b/skills/understudy-evaluate/reference.md
@@ -1,10 +1,7 @@
-# Evaluate Reference
+# Evaluate — Command Reference
 
-Detailed command matrices for evaluation are intentionally not shipped in this
-first public skill pass.
-
-Until the CLI surface is stable, use `understudy-evaluate/SKILL.md` as the
-authoritative workflow.
+Detailed command matrix, artifact contract, and interpretation rules for the
+`understudy-evaluate` skill.
 
 Future commands should preserve the value-first contract:
 
@@ -20,5 +17,98 @@ Future commands should preserve the value-first contract:
 - require explicit approval for upload, spend, hosted jobs, or benchmark
   submission.
 
-Add concrete commands here only when the public CLI implementation and artifact
-paths are committed in this repo.
+## Intake Checklist
+
+1. Identify the value target: cost, latency, quality, reliability, portability,
+   local privacy, or model availability.
+2. Inspect the real workload source: trace store, logs, eval report, dataset,
+   prompt set, app route, scorer, or benchmark script.
+3. Capture baseline facts: incumbent route, sample size, metric, latency,
+   cost/request, error rate, and known failure modes.
+4. Identify candidate paths: local model, public model download, existing
+   provider key, Understudy inference, replay, or managed provider.
+5. Choose the smallest comparison that can change the decision.
+
+Ask at most one clarifying question if the workload source or approval boundary
+is ambiguous.
+
+## Flow
+
+1. Check the CLI and evaluation surface:
+
+```sh
+run_understudy --help
+run_understudy evaluate --help
+```
+
+2. Inspect existing artifacts before creating new work:
+
+```sh
+run_understudy evaluate status --local
+run_understudy evaluate validate --dry-run
+```
+
+3. If there is a plausible local/open candidate, inspect model fit before
+benchmarking:
+
+```sh
+run_understudy local-models doctor --local --dry-run
+run_understudy model lookup --local --dry-run
+```
+
+4. If replay can answer the question, run a local comparison first:
+
+```sh
+run_understudy evaluate run --dry-run --local
+```
+
+5. If replay cannot answer the value question and the developer has approved a
+capped live run, use the smallest live sample that can establish direction.
+Record actual spend, latency, output validity, and quality deltas.
+
+6. Read generated artifacts under:
+
+```text
+.understudy/evaluate/
+.understudy/model-lookup/
+.understudy/local-models/
+```
+
+7. Report the result as a decision, not just a score: promote candidate,
+optimize next, download/run a local model, use Understudy inference, expand the
+sample, or stop because the economics do not justify more work.
+
+## Failure Triage
+
+Before blaming model quality, classify failures:
+
+- context-window or token-cap mismatch;
+- parser or schema failure;
+- route or provider error;
+- scorer/rubric mismatch;
+- missing labels or weak sample size;
+- latency bottleneck outside inference;
+- incompatible tool-call or structured-output format;
+- true quality regression.
+
+Route model fit questions to
+[`../understudy-model-lookup/SKILL.md`](../understudy-model-lookup/SKILL.md).
+Route local runner questions to
+[`../understudy-local-models/SKILL.md`](../understudy-local-models/SKILL.md).
+Route post-baseline improvement to
+[`../understudy-optimize/SKILL.md`](../understudy-optimize/SKILL.md).
+Route decision/value reporting to
+[`../understudy-value-reporting/SKILL.md`](../understudy-value-reporting/SKILL.md).
+
+## Output Standard
+
+End with:
+
+- baseline route, candidate route, and value target;
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, local smoke, replay, validation, heldout, or live;
+- sample size, metric definitions, latency, cost, and quality caveats;
+- decision unlocked or still blocked;
+- spend/upload/download approval boundary, if any;
+- one recommended command.

--- a/skills/understudy-model-lookup/SKILL.md
+++ b/skills/understudy-model-lookup/SKILL.md
@@ -49,68 +49,13 @@ require:
 Model lookup is not benchmark approval. Do not send prompts, traces, datasets,
 or model outputs to providers while checking availability or compatibility.
 
-## Intake
-
-1. Inspect the requested model id, artifact path, adapter path, provider route,
-   runner, quantization, context-window need, modality, and hardware limits.
-2. Separate public catalog facts, local artifact metadata, and measured smoke
-   results.
-3. Check tokenizer, architecture, config, license, quantization, adapter base,
-   tool-call support, structured-output support, and context limit.
-4. Run the smallest local status, manifest, or dry-run route command.
-5. Summarize compatibility before proposing paid, hosted, or upload steps.
-
-## Flow
-
-1. Check local CLI health and lookup surfaces:
-
-```sh
-run_understudy --help
-run_understudy model --help
-```
-
-2. Inspect cached or local model metadata:
-
-```sh
-run_understudy model lookup --local --dry-run
-```
-
-3. If evaluating a route, verify route shape without sending workload payloads:
-
-```sh
-run_understudy model route --dry-run --local
-```
-
-4. If a model seems incompatible, check parser, adapter, tokenizer,
-   architecture, quantization, context window, token cap, modality, and route
-   mismatch before blaming model quality.
-
-5. Read generated artifacts under:
-
-```text
-.understudy/model-lookup/
-```
-
-6. Recommend the next measured step only after lookup evidence is clear.
-
 ## References
 
 Load deeper material only when needed:
 
-- [`reference.md`](reference.md) - detailed command matrix, artifact contract,
-  and interpretation rules.
+- [`reference.md`](reference.md) - intake checklist, command flow, model
+  analysis docs, artifact contract, and output standard.
 - [`../understudy-evaluate/SKILL.md`](../understudy-evaluate/SKILL.md)
   - measured comparison after compatibility is established.
 - [`../understudy-train/SKILL.md`](../understudy-train/SKILL.md)
   - adapter and training handoff checks.
-
-## Output Standard
-
-End with:
-
-- what was inspected or run;
-- artifact paths created or read;
-- result type: dry-run, replay, fake-provider, validation, heldout, or live;
-- catalog facts, local metadata, compatibility result, and caveats;
-- approval-gated next step, if any;
-- one recommended command.

--- a/skills/understudy-model-lookup/reference.md
+++ b/skills/understudy-model-lookup/reference.md
@@ -1,13 +1,20 @@
-# Model Lookup Reference
+# Model Lookup — Command Reference
 
-Detailed model/provider command matrices are intentionally deferred.
+Detailed command matrix, artifact contract, and interpretation rules for the
+`understudy-model-lookup` skill.
 
-Public model lookup should stay evidence-scoped:
+## Intake Checklist
 
-- inspect local metadata and public model cards;
-- separate catalog facts from measured results;
-- verify runner, tokenizer, adapter, modality, context window, and route shape;
-- do not send workload payloads while checking compatibility.
+1. Inspect the requested model id, artifact path, adapter path, provider route,
+   runner, quantization, context-window need, modality, and hardware limits.
+2. Separate public catalog facts, local artifact metadata, and measured smoke
+   results.
+3. Check tokenizer, architecture, config, license, quantization, adapter base,
+   tool-call support, structured-output support, and context limit.
+4. Run the smallest local status, manifest, or dry-run route command.
+5. Summarize compatibility before proposing paid, hosted, or upload steps.
+
+## Model Analysis Docs
 
 Use the public model analysis docs when writing or interpreting model profiles:
 
@@ -15,5 +22,49 @@ Use the public model analysis docs when writing or interpreting model profiles:
 - [`../../docs/model-analysis-profile-template.md`](../../docs/model-analysis-profile-template.md)
 - [`../../docs/model-analysis-profiles.md`](../../docs/model-analysis-profiles.md)
 
+## Flow
+
+1. Check local CLI health and lookup surfaces:
+
+```sh
+run_understudy --help
+run_understudy model --help
+```
+
+2. Inspect cached or local model metadata:
+
+```sh
+run_understudy model lookup --local --dry-run
+```
+
+3. If evaluating a route, verify route shape without sending workload payloads:
+
+```sh
+run_understudy model route --dry-run --local
+```
+
+4. If a model seems incompatible, check parser, adapter, tokenizer,
+   architecture, quantization, context window, token cap, modality, and route
+   mismatch before blaming model quality.
+
+5. Read generated artifacts under:
+
+```text
+.understudy/model-lookup/
+```
+
+6. Recommend the next measured step only after lookup evidence is clear.
+
 Add provider-specific instructions here only after checking current public
 provider documentation.
+
+## Output Standard
+
+End with:
+
+- what was inspected or run;
+- artifact paths created or read;
+- result type: dry-run, replay, fake-provider, validation, heldout, or live;
+- catalog facts, local metadata, compatibility result, and caveats;
+- approval-gated next step, if any;
+- one recommended command.


### PR DESCRIPTION
## Summary

Fixes Devin Review findings from PR #3 — SKILL.md files violated AGENTS.md rule: "Keep specialist skills short and move deeper command notes into `reference.md`."

Extracted into `reference.md`:
- **understudy-evaluate**: Intake, Flow, Failure Triage (with routing instructions), Output Standard (179→98 lines)
- **understudy-model-lookup**: Intake, Flow, Output Standard (116→61 lines)

Preserves all latest main content: value-first contract, Evidence Ladder, model analysis doc links, `understudy-value-reporting` routing, and `local-models doctor` commands. The `reference.md` files merge existing stubs with the extracted command notes.

Validation: `validate_public_skills.py` passes (20 skills), `git diff --check` clean.

Link to Devin session: https://app.devin.ai/sessions/7c17eb7f881740fcb79cd15904903600
Requested by: @lluisinthedesert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->