### PR TITLE
Add public release safety gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ OSS from the first commit.
   incident notes.
 - Examples must use synthetic data or small public fixtures.
 
+Read these before extraction, release, or public docs work:
+
+- [`docs/privacy-and-data-boundaries.md`](docs/privacy-and-data-boundaries.md)
+- [`docs/security.md`](docs/security.md)
+- [`docs/telemetry.md`](docs/telemetry.md)
+- [`docs/oss-release-boundary.md`](docs/oss-release-boundary.md)
+- [`docs/release-checklist.md`](docs/release-checklist.md)
+
 ## Architecture
 
 Keep one layer per spine:
@@ -48,3 +56,11 @@ When importing code from private Understudy repos:
 3. Add or preserve license metadata for vendored code.
 4. Add a smoke test or dry-run command.
 5. Keep the commit scoped to one spine.
+
+Before opening a PR that changes skills, docs, examples, scripts, package
+metadata, or vendored files, run:
+
+```sh
+python3 scripts/validate_public_skills.py --repo
+python3 scripts/doctor.py
+```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ python -m pip install -e .
 understudy-tools --help
 ```
 
-No provider calls, uploads, or telemetry run by default.
+No provider calls, uploads, model downloads, secret-value inspection, or
+telemetry run by default.
 
 ## First command
 
@@ -78,6 +79,14 @@ understudy-tools demo plan --repo .
 ```
 
 ## Public boundary
+
+Read the full policies:
+
+- [`docs/privacy-and-data-boundaries.md`](docs/privacy-and-data-boundaries.md)
+- [`docs/security.md`](docs/security.md)
+- [`docs/telemetry.md`](docs/telemetry.md)
+- [`docs/oss-release-boundary.md`](docs/oss-release-boundary.md)
+- [`docs/release-checklist.md`](docs/release-checklist.md)
 
 Do not commit:
 

--- a/docs/oss-release-boundary.md
+++ b/docs/oss-release-boundary.md
@@ -1,0 +1,40 @@
+# OSS Release Boundary
+
+Use this checklist when moving work from private Understudy repos into this
+public repository.
+
+## Public By Default
+
+- local-only CLI commands;
+- public skills and templates;
+- synthetic fixtures;
+- public provider docs and public research citations;
+- repo-relative artifact schemas;
+- public-safe examples with no real customer payloads.
+
+## Keep Private
+
+- customer names, domains, volumes, prompts, completions, labels, or traces;
+- private runbooks and incident notes;
+- hosted control-plane details;
+- production admin surfaces;
+- private provider terms, account arrangements, and capacity tactics;
+- internal margin logic or proprietary route policy;
+- patent-sensitive methodology details.
+
+## Extraction Checklist
+
+1. Replace customer-specific examples with synthetic fixtures.
+2. Remove private repo paths and local usernames.
+3. Remove raw prompts, completions, trace payloads, labels, and datasets.
+4. Replace private provider terms with public source links.
+5. Preserve public model ids, provider names, and dated public source URLs when
+   they are necessary for reproducibility.
+6. Add a local smoke test or dry-run.
+7. Run the public repo validator before opening a PR.
+
+## Safer Replacement Language
+
+Use `workload-001`, `example customer`, `synthetic support ticket`, `public
+fixture`, or `repo-relative path` instead of real customer, account, or private
+repo identifiers.

--- a/docs/privacy-and-data-boundaries.md
+++ b/docs/privacy-and-data-boundaries.md
@@ -1,0 +1,51 @@
+# Privacy And Data Boundaries
+
+Understudy Agent Tools are local-first by default.
+
+By default, the CLI and skills do not upload files, call providers, inspect
+secret values, download models, submit hosted jobs, or send telemetry.
+
+## Data Classes
+
+| Data class | Examples | Default handling |
+| --- | --- | --- |
+| Source metadata | repo-relative paths, file sizes, signal line numbers | may be written locally under `.understudy/` |
+| Source snippets | code fragments, prompt builders, parser logic | do not print, upload, or commit without approval |
+| Prompt bodies | system prompts, messages, templates | local-only unless explicitly approved |
+| Completions | model outputs, judge outputs, failed rows | local-only unless explicitly approved |
+| Traces | request/response payloads, spans, usage rows | metadata-only by default |
+| Eval rows | JSONL, CSV, YAML, golden fixtures | local-only until a redaction and split plan exists |
+| Secrets | API keys, tokens, credentials, local env files | never ask for chat-pasted values; never print values |
+| Local model artifacts | downloaded weights, adapters, caches | download only with explicit approval |
+
+## Boundary Contract
+
+Before any live provider call, upload, hosted job, model download, benchmark
+submission, training handoff, or public claim, require:
+
+- exact data class or artifact path;
+- destination provider or hosted surface;
+- budget cap or download size when relevant;
+- dry-run, preview, or local artifact path;
+- retention expectation when the destination documents one;
+- explicit approval in the current thread.
+
+Configured provider keys are local machine state. They are not permission to
+spend.
+
+## Trace And Proxy Rules
+
+Trace capture and proxy work should start with metadata: route, model, timing,
+token counts, schema status, and error class. Raw prompts, completions, tool
+payloads, source snippets, and eval rows require opt-in handling.
+
+## Never Collected By Default
+
+- API key values;
+- raw prompt bodies;
+- raw completions;
+- private trace payloads;
+- source snippets;
+- private repo paths;
+- customer names or domains;
+- telemetry.

--- a/docs/public-skill-template.md
+++ b/docs/public-skill-template.md
@@ -45,6 +45,13 @@ require:
 - dry-run or preview artifact reviewed first;
 - visible output path under `.understudy/`.
 
+## Data Boundary
+
+Name the data class this skill touches. Default to source metadata and local
+artifacts only. If the skill may touch prompts, completions, traces, eval rows,
+datasets, source snippets, secrets, or model artifacts, require explicit
+approval before reading, printing, uploading, or committing them.
+
 ## Intake
 
 1. Inspect the real local artifact, repo, report, trace, or workload profile.
@@ -92,6 +99,15 @@ Use local-only examples first:
 
 Examples must write to `.understudy/<capability>/` and must not require
 provider keys, uploads, or paid calls by default.
+
+## Validation
+
+Run local-only checks:
+
+```sh
+python3 scripts/validate_public_skills.py --repo
+python3 scripts/doctor.py
+```
 
 ## Output Standard
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,28 @@
+# Release Checklist
+
+Run this before tagging or publishing a package.
+
+## Required Checks
+
+```sh
+python3 scripts/validate_public_skills.py --repo
+python3 scripts/doctor.py
+uv run --with pytest python -m pytest
+git ls-files
+```
+
+## Inspect
+
+- no `.understudy/` runtime artifacts;
+- no `.env*`, credentials, tokens, or secret-shaped strings;
+- no private planning docs;
+- no private repo paths or local usernames;
+- no raw prompts, completions, trace payloads, customer names, or domains;
+- examples are synthetic or clearly public;
+- vendored files are covered by `vendor/MANIFEST.md`;
+- README links to privacy, security, telemetry, and OSS boundary docs.
+
+## Package Smoke
+
+Before publishing a package, build the archive and inspect its contents for
+ignored files, local artifacts, private paths, and secret-shaped strings.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,42 @@
+# Security
+
+This repository is public, MIT-licensed local tooling. The default threat model
+is accidental disclosure: private artifacts, secrets, traces, prompts, or
+customer data leaking into a public repo or a hosted provider call.
+
+## Reporting
+
+For security issues, use the repository's GitHub security reporting flow when
+available. If that is unavailable, contact Understudy Labs through the public
+contact channel listed on the organization profile.
+
+## Secret Handling
+
+- Do not ask users to paste API keys or tokens into chat.
+- Do not print environment variable values.
+- Use redacted presence checks only.
+- Treat `.env*`, shell history, local credential files, and provider config as
+  non-release material.
+- If a secret appears in output or a committed file, stop and rotate it before
+  continuing.
+
+## Supply Chain
+
+- Keep dependency installs deterministic.
+- Do not add automatic dependency update bots without an explicit request.
+- Vendored code must be listed in `vendor/MANIFEST.md` with source and license
+  metadata.
+- Public release checks should inspect built packages for ignored docs, env
+  files, private paths, and secret-shaped strings.
+
+## Local Artifact Safety
+
+`.understudy/` is local runtime output. It can contain workload metadata and may
+eventually contain private payloads. Do not commit it unless a specific public
+fixture is intentionally synthetic and reviewed.
+
+## Public Claims
+
+Do not claim quality, latency, cost savings, or route superiority unless the
+artifact names the evidence level, sample size, split boundary, baseline route,
+candidate route, cost basis, latency basis, and caveats.

--- a/docs/skill-style-guide.md
+++ b/docs/skill-style-guide.md
@@ -43,7 +43,9 @@ metadata:
 
 ## Safety Language
 
-Every skill must say what is local-only and what requires explicit approval.
+Every skill must say what is local-only, which data class it touches, and what
+requires explicit approval. The canonical policy is
+[`privacy-and-data-boundaries.md`](privacy-and-data-boundaries.md).
 
 Use this standard rule:
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,21 @@
+# Telemetry
+
+There is no telemetry in this repository today.
+
+By default, Understudy Agent Tools do not send usage events, prompts,
+completions, traces, source snippets, datasets, repo paths, provider keys, or
+local model metadata to Understudy or any provider.
+
+## Future Telemetry Rules
+
+If telemetry is added later, it must be:
+
+- opt-in;
+- documented in this file before release;
+- categorical by default;
+- free of prompts, completions, traces, source snippets, secrets, private repo
+  paths, and customer identifiers;
+- easy to disable.
+
+Any future telemetry schema should list every field, purpose, destination,
+retention expectation, and whether it can contain user content.

--- a/scripts/validate_public_skills.py
+++ b/scripts/validate_public_skills.py
@@ -13,6 +13,14 @@ KEY = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$")
 NAME = re.compile(r"^[a-z0-9-]+$")
 ALLOWED_TOP_LEVEL = {"name", "description", "license", "allowed-tools", "metadata"}
 PRIVATE_TERMS = [
+    "/Users/luis/",
+    "/understudy-agent/",
+    "understudy-agent/",
+    "understudy-platform",
+    "understudy-knowledge",
+    "raw-notes",
+    "private/runbooks",
+    ".smithers",
     "Fullcast",
     "Cedar",
     "Workgrounds",
@@ -27,9 +35,40 @@ PRIVATE_TERMS = [
 ]
 SECRET_PATTERNS = [
     re.compile(r"sk-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{20,}"),
+    re.compile(r"AIza[0-9A-Za-z_-]{20,}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9._-]{20,}", re.IGNORECASE),
+    re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}"),
     re.compile(r"AKIA[0-9A-Z]{16}"),
-    re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
 ]
+RAW_PAYLOAD_PATTERNS = [
+    re.compile(r"\braw_prompt\b", re.IGNORECASE),
+    re.compile(r"\braw_completion\b", re.IGNORECASE),
+    re.compile(r"\btrace_payload\b", re.IGNORECASE),
+]
+PRODUCTION_URL_PATTERNS = [
+    re.compile(r"https://(?:api|app|admin|dashboard)\.understudy(?:labs)?\."),
+]
+SCAN_EXTENSIONS = {
+    ".json",
+    ".jsonl",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+REPO_SCAN_EXCLUDE = {
+    Path("scripts/validate_public_skills.py"),
+    Path("tests/test_validate_public_skills.py"),
+}
 PUBLIC_DOC_DIRS = ["docs"]
 
 
@@ -108,7 +147,7 @@ def validate_skill(path: Path) -> list[str]:
     return errors
 
 
-def validate_public_markdown(path: Path) -> list[str]:
+def validate_public_text(path: Path) -> list[str]:
     errors: list[str] = []
     text = path.read_text(encoding="utf-8")
     for term in PRIVATE_TERMS:
@@ -117,7 +156,17 @@ def validate_public_markdown(path: Path) -> list[str]:
     for pattern in SECRET_PATTERNS:
         if pattern.search(text):
             errors.append(f"{path}: contains secret-shaped text matching {pattern.pattern}")
+    for pattern in RAW_PAYLOAD_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path}: contains raw payload marker matching {pattern.pattern}")
+    for pattern in PRODUCTION_URL_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path}: contains production/control-plane URL matching {pattern.pattern}")
     return errors
+
+
+def validate_public_markdown(path: Path) -> list[str]:
+    return validate_public_text(path)
 
 
 def is_gitignored(path: Path) -> bool:
@@ -129,14 +178,46 @@ def is_gitignored(path: Path) -> bool:
     return result.returncode == 0
 
 
+def git_tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=Path.cwd(),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [Path(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def validate_public_repo() -> list[str]:
+    errors: list[str] = []
+    for path in git_tracked_files():
+        if path in REPO_SCAN_EXCLUDE:
+            continue
+        if path.suffix.lower() not in SCAN_EXTENSIONS:
+            continue
+        if not path.exists() or is_gitignored(path):
+            continue
+        try:
+            errors.extend(validate_public_text(path))
+        except UnicodeDecodeError:
+            continue
+    return errors
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate public Understudy skills.")
+    parser = argparse.ArgumentParser(description="Validate public Understudy skills and release text.")
     parser.add_argument("paths", nargs="*", default=["skills"])
     parser.add_argument(
         "--docs",
         nargs="*",
         default=PUBLIC_DOC_DIRS,
         help="Markdown doc directories to scan for public-safety terms.",
+    )
+    parser.add_argument(
+        "--repo",
+        action="store_true",
+        help="Scan every tracked text file for public-release safety patterns.",
     )
     args = parser.parse_args()
 
@@ -157,11 +238,13 @@ def main() -> int:
         doc_root = Path(doc_root_arg)
         if doc_root.is_file() and doc_root.suffix == ".md":
             if not is_gitignored(doc_root):
-                all_errors.extend(validate_public_markdown(doc_root))
+                all_errors.extend(validate_public_text(doc_root))
         elif doc_root.is_dir():
             for doc_path in sorted(doc_root.rglob("*.md")):
                 if not is_gitignored(doc_path):
-                    all_errors.extend(validate_public_markdown(doc_path))
+                    all_errors.extend(validate_public_text(doc_path))
+    if args.repo:
+        all_errors.extend(validate_public_repo())
 
     for error in all_errors:
         print(error)

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_no_runtime_or_private_files_are_tracked() -> None:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    tracked = result.stdout.splitlines()
+    forbidden_parts = [
+        ".understudy/",
+        ".env",
+        ".tmp/",
+        ".venv/",
+        ".pytest_cache/",
+        "docs/skill-externalization-plan.md",
+        "docs/skill-comparison-audit.md",
+    ]
+
+    offenders = [
+        path for path in tracked if any(part in path or path.endswith(part) for part in forbidden_parts)
+    ]
+
+    assert offenders == []
+
+
+def test_vendor_manifest_covers_vendor_files() -> None:
+    vendor_root = Path("vendor")
+    manifest = vendor_root / "MANIFEST.md"
+    assert manifest.exists()
+
+    manifest_text = manifest.read_text(encoding="utf-8")
+    vendored_files = [
+        path for path in vendor_root.rglob("*") if path.is_file() and path.name != "MANIFEST.md"
+    ]
+    missing = [str(path) for path in vendored_files if str(path) not in manifest_text]
+
+    assert missing == []

--- a/tests/test_validate_public_skills.py
+++ b/tests/test_validate_public_skills.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.validate_public_skills import is_gitignored, validate_public_markdown, validate_skill
+from scripts.validate_public_skills import (
+    is_gitignored,
+    validate_public_markdown,
+    validate_public_text,
+    validate_skill,
+)
 
 
 def test_all_public_skills_validate() -> None:
@@ -45,3 +50,39 @@ def test_skill_index_and_router_coverage() -> None:
 
     assert missing_from_readme == []
     assert missing_from_router == []
+
+
+def test_public_text_rejects_private_path_and_secret(tmp_path) -> None:
+    path = tmp_path / "bad.md"
+    path.write_text(
+        "Private path /Users/luis/Developer/private-repo and token Bearer abcdefghijklmnopqrstuvwxyz123456",
+        encoding="utf-8",
+    )
+
+    errors = validate_public_text(path)
+
+    assert any("/Users/luis/" in error for error in errors)
+    assert any("secret-shaped" in error for error in errors)
+
+
+def test_public_text_rejects_raw_payload_markers(tmp_path) -> None:
+    path = tmp_path / "bad.md"
+    path.write_text("trace_payload should not appear in public release docs", encoding="utf-8")
+
+    errors = validate_public_text(path)
+
+    assert any("raw payload marker" in error for error in errors)
+
+
+def test_release_docs_exist_and_are_linked() -> None:
+    required = [
+        "docs/privacy-and-data-boundaries.md",
+        "docs/security.md",
+        "docs/telemetry.md",
+        "docs/oss-release-boundary.md",
+        "docs/release-checklist.md",
+    ]
+    readme = Path("README.md").read_text(encoding="utf-8")
+    for doc in required:
+        assert Path(doc).exists()
+        assert doc in readme


### PR DESCRIPTION
## Summary

Adds public-release safety docs and hardens the validator from a skills/docs check into an optional whole-repo release gate.

## What changed

- Added public policy docs:
  - `docs/privacy-and-data-boundaries.md`
  - `docs/security.md`
  - `docs/telemetry.md`
  - `docs/oss-release-boundary.md`
  - `docs/release-checklist.md`
- Linked the policy docs from `README.md` and `AGENTS.md`.
- Updated skill style/template docs to require data-boundary thinking.
- Extended `scripts/validate_public_skills.py --repo` to scan tracked text files for:
  - private path/repo markers
  - secret-shaped strings
  - raw payload markers
  - production/control-plane URL patterns
- Added release manifest tests for ignored/runtime/private files and vendor manifest coverage.

## Safety

- The whole-repo scan skips only the validator file and its negative-test fixture file, so denylist literals and fake bad examples do not self-fail.
- No runtime behavior changed.
- No provider calls, uploads, telemetry, or dependency changes added.

## Verification

- `python3 scripts/validate_public_skills.py --repo`
- `python3 scripts/doctor.py`
- `uv run --with pytest python -m pytest`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->