### PR TITLE
Add package release smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Read the full policies:
 - [`docs/oss-release-boundary.md`](docs/oss-release-boundary.md)
 - [`docs/release-checklist.md`](docs/release-checklist.md)
 
+Release archives should pass:
+
+```bash
+python3 scripts/package_release_smoke.py
+```
+
 Do not commit:
 
 - customer names, domains, prompts, completions, traces, or datasets

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -6,6 +6,7 @@ Run this before tagging or publishing a package.
 
 ```sh
 python3 scripts/validate_public_skills.py --repo
+python3 scripts/package_release_smoke.py
 python3 scripts/doctor.py
 uv run --with pytest python -m pytest
 git ls-files
@@ -24,5 +25,12 @@ git ls-files
 
 ## Package Smoke
 
-Before publishing a package, build the archive and inspect its contents for
-ignored files, local artifacts, private paths, and secret-shaped strings.
+Before publishing a package, run:
+
+```sh
+python3 scripts/package_release_smoke.py
+```
+
+It builds wheel/sdist archives into a temporary directory and inspects their
+contents for ignored files, local artifacts, private paths, raw payload markers,
+production/control-plane URLs, and secret-shaped strings.

--- a/scripts/package_release_smoke.py
+++ b/scripts/package_release_smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+try:
+    from scripts.validate_public_skills import (
+        PRODUCTION_URL_PATTERNS,
+        RAW_PAYLOAD_PATTERNS,
+        SECRET_PATTERNS,
+    )
+except ModuleNotFoundError:
+    from validate_public_skills import (
+        PRODUCTION_URL_PATTERNS,
+        RAW_PAYLOAD_PATTERNS,
+        SECRET_PATTERNS,
+    )
+
+
+FORBIDDEN_MEMBER_PARTS = [
+    ".understudy/",
+    ".env",
+    ".pytest_cache/",
+    ".tmp/",
+    ".venv/",
+    "__pycache__/",
+    "docs/skill-comparison-audit.md",
+    "docs/skill-externalization-plan.md",
+]
+FORBIDDEN_TEXT = [
+    "/Users/luis/",
+    "/understudy-agent/",
+    "understudy-agent/",
+    "understudy-platform",
+    "understudy-knowledge",
+    "raw-notes",
+    "private/runbooks",
+    ".smithers",
+    "Fullcast",
+    "Cedar",
+    "Workgrounds",
+    "Super Admin",
+    "super-admin",
+    "D1 mutation",
+    "pool secret",
+    "R2 capture envelope",
+]
+TEXT_EXTENSIONS = {
+    ".json",
+    ".jsonl",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+TEXT_SCAN_EXCLUDE = {
+    "scripts/package_release_smoke.py",
+    "scripts/validate_public_skills.py",
+    "tests/test_package_release_smoke.py",
+    "tests/test_validate_public_skills.py",
+}
+
+
+def _member_path(raw_name: str) -> str:
+    parts = Path(raw_name).parts
+    if len(parts) > 1 and parts[0].endswith((".dist-info", ".egg-info")):
+        return "/".join(parts)
+    if len(parts) > 1 and "-" in parts[0]:
+        return "/".join(parts[1:])
+    return "/".join(parts)
+
+
+def _member_name_errors(name: str) -> list[str]:
+    normalized = _member_path(name)
+    errors = []
+    for forbidden in FORBIDDEN_MEMBER_PARTS:
+        if forbidden in normalized or normalized.endswith(forbidden):
+            errors.append(f"{name}: forbidden packaged path {forbidden!r}")
+    return errors
+
+
+def _text_errors(name: str, data: bytes) -> list[str]:
+    normalized = _member_path(name)
+    if normalized in TEXT_SCAN_EXCLUDE:
+        return []
+    if Path(normalized).suffix.lower() not in TEXT_EXTENSIONS:
+        return []
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return []
+
+    errors = []
+    for term in FORBIDDEN_TEXT:
+        if term in text:
+            errors.append(f"{name}: contains private release term {term!r}")
+    for pattern in [*SECRET_PATTERNS, *RAW_PAYLOAD_PATTERNS, *PRODUCTION_URL_PATTERNS]:
+        if pattern.search(text):
+            errors.append(f"{name}: contains unsafe text matching {pattern.pattern}")
+    return errors
+
+
+def inspect_archive(path: Path) -> list[str]:
+    errors: list[str] = []
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                errors.extend(_member_name_errors(info.filename))
+                errors.extend(_text_errors(info.filename, archive.read(info)))
+    elif path.suffixes[-2:] == [".tar", ".gz"]:
+        with tarfile.open(path, "r:gz") as archive:
+            for member in archive.getmembers():
+                if not member.isfile():
+                    continue
+                errors.extend(_member_name_errors(member.name))
+                extracted = archive.extractfile(member)
+                if extracted is not None:
+                    errors.extend(_text_errors(member.name, extracted.read()))
+    else:
+        errors.append(f"{path}: unsupported archive type")
+    return errors
+
+
+def build_archives(out_dir: Path) -> list[Path]:
+    subprocess.run(
+        ["uv", "build", "--out-dir", str(out_dir)],
+        check=True,
+        cwd=Path.cwd(),
+    )
+    return sorted([*out_dir.glob("*.whl"), *out_dir.glob("*.tar.gz")])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build and inspect public release archives.")
+    parser.add_argument("--dist-dir", type=Path, default=None)
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        dist_dir = args.dist_dir or Path(tmp) / "dist"
+        dist_dir.mkdir(parents=True, exist_ok=True)
+        archives = sorted([*dist_dir.glob("*.whl"), *dist_dir.glob("*.tar.gz")])
+        if not args.skip_build:
+            archives = build_archives(dist_dir)
+        if not archives:
+            print(f"no release archives found in {dist_dir}")
+            return 1
+
+        errors: list[str] = []
+        for archive in archives:
+            errors.extend(inspect_archive(archive))
+        for error in errors:
+            print(error)
+        if errors:
+            return 1
+        print(f"ok {len(archives)} release archive(s)")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_package_release_smoke.py
+++ b/tests/test_package_release_smoke.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.package_release_smoke import inspect_archive
+
+
+def test_inspect_wheel_rejects_runtime_artifact(tmp_path) -> None:
+    wheel = tmp_path / "bad-0.1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("bad/.understudy/workload-card.json", "{}")
+
+    errors = inspect_archive(wheel)
+
+    assert any(".understudy/" in error for error in errors)
+
+
+def test_inspect_sdist_rejects_private_text(tmp_path) -> None:
+    sdist = tmp_path / "bad-0.1.0.tar.gz"
+    source = tmp_path / "source"
+    source.mkdir()
+    bad = source / "README.md"
+    bad.write_text("Private path /Users/luis/Developer/private-repo", encoding="utf-8")
+    with tarfile.open(sdist, "w:gz") as archive:
+        archive.add(bad, arcname="bad-0.1.0/README.md")
+
+    errors = inspect_archive(sdist)
+
+    assert any("/Users/luis/" in error for error in errors)
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv is required for release archive build smoke")
+def test_package_release_smoke_script_builds_clean_archives(tmp_path) -> None:
+    result = subprocess.run(
+        ["python3", "scripts/package_release_smoke.py", "--dist-dir", str(tmp_path)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "release archive" in result.stdout


### PR DESCRIPTION
## Summary

Adds a package release smoke that builds wheel/sdist archives and inspects their contents before publishing.

## What changed

- Added `scripts/package_release_smoke.py`.
- The script runs `uv build --out-dir <temp>` and inspects `.whl` and `.tar.gz` archives.
- Fails on packaged runtime/private artifacts such as `.understudy/`, `.tmp/`, `.venv/`, `.pytest_cache/`, ignored sensitive docs, private path markers, raw payload markers, production/control-plane URLs, and secret-shaped strings.
- Added tests for wheel rejection, sdist rejection, and real clean archive build.
- Updated README and release checklist with the new release command.

## Notes

The archive text scanner intentionally excludes only the validator script and negative-test fixtures, because those files contain denylist literals and fake bad examples by design.

## Verification

- `python3 scripts/package_release_smoke.py`
- `python3 scripts/validate_public_skills.py --repo`
- `python3 scripts/doctor.py`
- `uv run --with pytest python -m pytest`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->