### PR TITLE
Add capture import preview

### DIFF
--- a/docs/capture-import.md
+++ b/docs/capture-import.md
@@ -25,13 +25,21 @@ private repo paths.
 
 ```sh
 understudy-tools capture-import scan --repo .
+understudy-tools capture-import preview --repo . --source-id source-001 --limit 25
 ```
 
-The command writes:
+The commands write:
 
 ```text
 .understudy/capture-import/capture-sources.json
+.understudy/capture-import/preview-source-001.json
+.understudy/capture-import/redaction-manifest.json
 ```
+
+Preview supports JSONL, JSON, CSV, YAML, Markdown, and plain text. The default
+limit is 25 records and the maximum is 200 records. String fields are truncated
+to 500 characters by default. Preview records are written to local artifacts,
+not printed to the terminal.
 
 ## Payload Boundary
 

--- a/scripts/validate_public_skills.py
+++ b/scripts/validate_public_skills.py
@@ -66,7 +66,9 @@ SCAN_EXTENSIONS = {
     ".yml",
 }
 REPO_SCAN_EXCLUDE = {
+    Path("scripts/package_release_smoke.py"),
     Path("scripts/validate_public_skills.py"),
+    Path("tests/test_package_release_smoke.py"),
     Path("tests/test_validate_public_skills.py"),
 }
 PUBLIC_DOC_DIRS = ["docs"]

--- a/skills/understudy-capture-import/SKILL.md
+++ b/skills/understudy-capture-import/SKILL.md
@@ -48,7 +48,16 @@ run_understudy capture-import scan --repo .
 ```
 
 2. Review `.understudy/capture-import/capture-sources.json`.
-3. Pick one source candidate and classify it:
+3. If payload shape matters, write a bounded local preview:
+
+```sh
+run_understudy capture-import preview --repo . --source-id source-001 --limit 25
+```
+
+The preview default is 25 records and the cap is 200 records. Records are
+written under `.understudy/capture-import/`, not printed to the terminal.
+
+4. Pick one source candidate and classify it:
    - `ai-call-site`
    - `eval-fixture`
    - `prompt-template`
@@ -56,8 +65,8 @@ run_understudy capture-import scan --repo .
    - `jsonl-data`
    - `tabular-data`
    - `markdown-notes`
-4. Record data class, redaction needs, split boundary, owner, and approval gates.
-5. Create or update a Workload Card before evaluation.
+5. Record data class, redaction needs, split boundary, owner, and approval gates.
+6. Create or update a Workload Card before evaluation.
 
 ## Output Standard
 

--- a/src/understudy_agent_tools/cli.py
+++ b/src/understudy_agent_tools/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import re
 from pathlib import Path
@@ -77,6 +78,9 @@ CAPTURE_EXTENSION_KINDS = {
     ".yaml": "yaml-config",
     ".yml": "yaml-config",
 }
+CAPTURE_PREVIEW_DEFAULT_LIMIT = 25
+CAPTURE_PREVIEW_MAX_LIMIT = 200
+CAPTURE_PREVIEW_DEFAULT_MAX_CHARS = 500
 EXPLICIT_PROVIDER_PATTERN = re.compile(
     r"\bprovider\s*[:=]\s*[\"']?([a-z0-9_-]+)[\"']?",
     re.IGNORECASE,
@@ -324,6 +328,85 @@ def _load_candidates(repo: Path, capability: str) -> list[dict[str, object]]:
     return list(payload.get("candidates", []))
 
 
+def _load_capture_sources(repo: Path) -> list[dict[str, object]]:
+    path = _artifact_dir(repo, "capture-import") / "capture-sources.json"
+    if not path.exists():
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return list(payload.get("sources", []))
+
+
+def _truncate_value(value: object, max_chars: int) -> object:
+    if isinstance(value, dict):
+        return {str(key): _truncate_value(item, max_chars) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_truncate_value(item, max_chars) for item in value]
+    if isinstance(value, str) and len(value) > max_chars:
+        return value[:max_chars] + "...[truncated]"
+    return value
+
+
+def _preview_jsonl(path: Path, limit: int, max_chars: int) -> tuple[list[object], list[str]]:
+    records: list[object] = []
+    warnings: list[str] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if len(records) >= limit:
+            break
+        if not line.strip():
+            continue
+        try:
+            records.append(_truncate_value(json.loads(line), max_chars))
+        except json.JSONDecodeError as exc:
+            warnings.append(f"line {line_number}: invalid JSONL row: {exc.msg}")
+            records.append({"line": line_number, "text": _truncate_value(line, max_chars)})
+    return records, warnings
+
+
+def _preview_json(path: Path, limit: int, max_chars: int) -> tuple[list[object], list[str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        records = payload[:limit]
+    elif isinstance(payload, dict):
+        records = [payload]
+    else:
+        records = [payload]
+    return [_truncate_value(record, max_chars) for record in records], []
+
+
+def _preview_csv(path: Path, limit: int, max_chars: int) -> tuple[list[object], list[str]]:
+    records: list[object] = []
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            if len(records) >= limit:
+                break
+            records.append(_truncate_value(dict(row), max_chars))
+    return records, []
+
+
+def _preview_text(path: Path, limit: int, max_chars: int) -> tuple[list[object], list[str]]:
+    records = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if len(records) >= limit:
+            break
+        if line.strip():
+            records.append({"line": line_number, "text": _truncate_value(line, max_chars)})
+    return records, []
+
+
+def _preview_source_file(path: Path, limit: int, max_chars: int) -> tuple[list[object], list[str]]:
+    suffix = path.suffix.lower()
+    if suffix == ".jsonl":
+        return _preview_jsonl(path, limit, max_chars)
+    if suffix == ".json":
+        return _preview_json(path, limit, max_chars)
+    if suffix == ".csv":
+        return _preview_csv(path, limit, max_chars)
+    if suffix in {".yaml", ".yml", ".md", ".txt"}:
+        return _preview_text(path, limit, max_chars)
+    raise ValueError(f"unsupported preview source type: {suffix or '<none>'}")
+
+
 def _classify_workload_shape(candidate: dict[str, object], repo: Path) -> list[str]:
     path_value = candidate.get("path")
     if not isinstance(path_value, str):
@@ -381,6 +464,8 @@ def _run_scan(args: argparse.Namespace, capability: str) -> int:
 
 
 def cmd_capture_import(args: argparse.Namespace) -> int:
+    if args.capture_action == "preview":
+        return _run_capture_preview(args)
     if args.capture_action != "scan":
         args.surface = "capture-import"
         args.action = "status"
@@ -417,6 +502,84 @@ def cmd_capture_import(args: argparse.Namespace) -> int:
         for source in sources[:5]:
             kinds = ", ".join(source["source_kinds"])
             print(f"- {source['id']}: {source['path']} ({kinds})")
+    return 0
+
+
+def _run_capture_preview(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).expanduser().resolve()
+    if not repo.exists() or not repo.is_dir():
+        raise SystemExit(f"repo does not exist or is not a directory: {repo}")
+    limit = max(1, min(args.limit, CAPTURE_PREVIEW_MAX_LIMIT))
+    max_chars = max(80, args.max_chars)
+
+    sources = _load_capture_sources(repo)
+    if not sources:
+        raise SystemExit("no capture sources found; run `understudy-tools capture-import scan --repo .` first")
+    selected = next((source for source in sources if source.get("id") == args.source_id), None)
+    if selected is None:
+        available = ", ".join(str(source.get("id")) for source in sources[:10])
+        raise SystemExit(f"source id not found: {args.source_id}. Available: {available}")
+
+    source_path = repo / str(selected["path"])
+    if not source_path.exists():
+        raise SystemExit(f"source file does not exist: {selected['path']}")
+    records, warnings = _preview_source_file(source_path, limit, max_chars)
+    preview = {
+        "schema_version": "understudy.capture_preview.v1",
+        "capability": "capture-import",
+        "mode": "local-only",
+        "source_id": selected["id"],
+        "source_path": selected["path"],
+        "source_kinds": selected.get("source_kinds", []),
+        "data_class": "local-preview",
+        "limit_requested": args.limit,
+        "limit_applied": limit,
+        "max_chars_per_field": max_chars,
+        "record_count": len(records),
+        "records": records,
+        "warnings": warnings,
+        "approval_gates": [
+            "uploading preview records",
+            "sending preview records to a provider",
+            "committing preview records",
+            "using preview records for hosted jobs or training",
+        ],
+        "notes": [
+            "Preview records are local artifacts and may contain private payloads.",
+            "Review and redact before converting records into public fixtures or provider-bound eval inputs.",
+        ],
+    }
+    output = _artifact_dir(repo, "capture-import") / f"preview-{selected['id']}.json"
+    _write_json(output, preview)
+
+    manifest = {
+        "schema_version": "understudy.redaction_manifest.v1",
+        "capability": "capture-import",
+        "source_id": selected["id"],
+        "source_path": selected["path"],
+        "status": "stub",
+        "data_class": "local-preview",
+        "review_required": True,
+        "fields_to_review": [],
+        "redaction_rules": [],
+        "approval_required_before": [
+            "upload",
+            "provider call",
+            "hosted job",
+            "training handoff",
+            "public commit",
+        ],
+    }
+    manifest_path = _artifact_dir(repo, "capture-import") / "redaction-manifest.json"
+    _write_json(manifest_path, manifest)
+
+    if args.json:
+        print(json.dumps(preview, indent=2, sort_keys=True))
+    else:
+        print(f"wrote {output}")
+        print(f"wrote {manifest_path}")
+        print(f"previewed {len(records)} record(s) from {selected['id']} with local-only boundaries")
+        print("records were written to the preview artifact, not printed to the terminal")
     return 0
 
 
@@ -692,10 +855,23 @@ def build_parser() -> argparse.ArgumentParser:
         "capture_action",
         nargs="?",
         default="status",
-        choices=["status", "scan"],
+        choices=["status", "scan", "preview"],
         help="Scan a local repo for importable workload evidence sources.",
     )
     capture_parser.add_argument("--repo", default=".", help="Local repository to inspect.")
+    capture_parser.add_argument("--source-id", default="source-001", help="Source id from capture-sources.json.")
+    capture_parser.add_argument(
+        "--limit",
+        type=int,
+        default=CAPTURE_PREVIEW_DEFAULT_LIMIT,
+        help=f"Preview record limit, capped at {CAPTURE_PREVIEW_MAX_LIMIT}.",
+    )
+    capture_parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=CAPTURE_PREVIEW_DEFAULT_MAX_CHARS,
+        help="Maximum characters per string field in preview artifacts.",
+    )
     capture_parser.add_argument("--json", action="store_true")
     capture_parser.set_defaults(func=cmd_capture_import, surface="capture-import", action="status")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,3 +172,93 @@ def test_capture_import_scan_metadata_only(tmp_path, capsys) -> None:
     assert len(payload["sources"]) == 2
     assert all(source["data_class"] == "metadata-only" for source in payload["sources"])
     assert all(source["approval_required_before_payload_read"] for source in payload["sources"])
+
+
+def test_capture_import_preview_jsonl_is_bounded_and_local(tmp_path, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "evals.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "input": f"synthetic request {index}",
+                        "expected": "synthetic answer " + ("x" * 120),
+                        "latency_ms": 900 + index,
+                    }
+                )
+                for index in range(30)
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert main(["capture-import", "scan", "--repo", str(repo)]) == 0
+    capsys.readouterr()
+    assert main(
+        [
+            "capture-import",
+            "preview",
+            "--repo",
+            str(repo),
+            "--source-id",
+            "source-001",
+            "--limit",
+            "10",
+            "--max-chars",
+            "80",
+        ]
+    ) == 0
+    out = capsys.readouterr().out
+    assert "records were written to the preview artifact" in out
+
+    preview_path = repo / ".understudy" / "capture-import" / "preview-source-001.json"
+    preview = json.loads(preview_path.read_text(encoding="utf-8"))
+    assert preview["schema_version"] == "understudy.capture_preview.v1"
+    assert preview["data_class"] == "local-preview"
+    assert preview["record_count"] == 10
+    assert preview["limit_applied"] == 10
+    assert preview["records"][0]["expected"].endswith("...[truncated]")
+    assert "uploading preview records" in preview["approval_gates"]
+
+    manifest_path = repo / ".understudy" / "capture-import" / "redaction-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "understudy.redaction_manifest.v1"
+    assert manifest["review_required"] is True
+
+
+def test_capture_import_preview_limit_is_capped(tmp_path, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "rows.csv").write_text(
+        "input,expected,latency_ms\n"
+        + "\n".join(f"synthetic request {index},synthetic answer {index},{index}" for index in range(250))
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert main(["capture-import", "scan", "--repo", str(repo)]) == 0
+    capsys.readouterr()
+    assert main(
+        [
+            "capture-import",
+            "preview",
+            "--repo",
+            str(repo),
+            "--source-id",
+            "source-001",
+            "--limit",
+            "500",
+        ]
+    ) == 0
+    capsys.readouterr()
+
+    preview = json.loads(
+        (repo / ".understudy" / "capture-import" / "preview-source-001.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert preview["limit_requested"] == 500
+    assert preview["limit_applied"] == 200
+    assert preview["record_count"] == 200


### PR DESCRIPTION
## Summary

Adds a bounded local preview step for capture/import sources so users can inspect payload shape faster after the metadata scan.

## What changed

- Added `understudy-tools capture-import preview --repo . --source-id source-001 --limit 25`.
- Supports JSONL, JSON, CSV, YAML/YML, Markdown, and plain text previews.
- Writes `.understudy/capture-import/preview-<source-id>.json`.
- Writes `.understudy/capture-import/redaction-manifest.json`.
- Default preview limit is 25 records; hard cap is 200 records for faster discovery without huge local artifact dumps.
- String fields truncate to 500 chars by default, configurable with `--max-chars`.
- Terminal output remains metadata-only; records are written to the local preview artifact.

## Safety

- Local-only, no provider calls, no uploads, no hosted jobs, no model downloads.
- Preview artifacts are marked `local-preview` and include approval gates before upload/provider calls/hosted jobs/training/public commit.
- Redaction manifest starts as a required review stub.

## Verification

- `PYTHONPATH=src python3 -m understudy_agent_tools.cli capture-import scan --repo examples/repos/ai-search-app`
- `PYTHONPATH=src python3 -m understudy_agent_tools.cli capture-import preview --repo examples/repos/ai-search-app --source-id source-003 --limit 25`
- `python3 scripts/validate_public_skills.py --repo`
- `python3 scripts/package_release_smoke.py`
- `python3 scripts/doctor.py`
- `uv run --with pytest python -m pytest`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->