### PR TITLE
Add redaction manifest recommendations

### DIFF
--- a/docs/capture-import.md
+++ b/docs/capture-import.md
@@ -41,6 +41,20 @@ limit is 25 records and the maximum is 200 records. String fields are truncated
 to 500 characters by default. Preview records are written to local artifacts,
 not printed to the terminal.
 
+The redaction manifest inspects preview field names and recommends one action
+per field:
+
+- `keep` for operational fields such as `latency_ms`, `score`, `label`, or
+  `category`;
+- `review` for content-like fields such as `input`, `prompt`, `output`,
+  `completion`, `message`, or `text`;
+- `hash` for identifier-like fields such as `email`, `domain`, `user_id`, or
+  `account_id`;
+- `drop` for secret-like fields such as `api_key`, `token`, `authorization`,
+  `password`, or `secret`.
+
+These are recommendations only. Preview does not mutate records.
+
 ## Payload Boundary
 
 Before reading payload rows or converting a source into eval fixtures, record:

--- a/skills/understudy-capture-import/SKILL.md
+++ b/skills/understudy-capture-import/SKILL.md
@@ -56,6 +56,8 @@ run_understudy capture-import preview --repo . --source-id source-001 --limit 25
 
 The preview default is 25 records and the cap is 200 records. Records are
 written under `.understudy/capture-import/`, not printed to the terminal.
+The generated redaction manifest recommends `keep`, `review`, `hash`, or `drop`
+per field path, but does not mutate records.
 
 4. Pick one source candidate and classify it:
    - `ai-call-site`

--- a/src/understudy_agent_tools/cli.py
+++ b/src/understudy_agent_tools/cli.py
@@ -81,6 +81,52 @@ CAPTURE_EXTENSION_KINDS = {
 CAPTURE_PREVIEW_DEFAULT_LIMIT = 25
 CAPTURE_PREVIEW_MAX_LIMIT = 200
 CAPTURE_PREVIEW_DEFAULT_MAX_CHARS = 500
+REDACTION_DROP_FIELDS = {
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "client_secret",
+    "credential",
+    "password",
+    "secret",
+    "token",
+}
+REDACTION_HASH_FIELDS = {
+    "account",
+    "account_id",
+    "customer_id",
+    "domain",
+    "email",
+    "phone",
+    "session_id",
+    "tenant_id",
+    "user",
+    "user_id",
+}
+REDACTION_REVIEW_FIELDS = {
+    "completion",
+    "content",
+    "input",
+    "message",
+    "messages",
+    "output",
+    "prompt",
+    "question",
+    "response",
+    "system",
+    "text",
+}
+REDACTION_KEEP_FIELDS = {
+    "category",
+    "expected_label",
+    "label",
+    "latency",
+    "latency_ms",
+    "score",
+    "split",
+    "status",
+}
 EXPLICIT_PROVIDER_PATTERN = re.compile(
     r"\bprovider\s*[:=]\s*[\"']?([a-z0-9_-]+)[\"']?",
     re.IGNORECASE,
@@ -407,6 +453,96 @@ def _preview_source_file(path: Path, limit: int, max_chars: int) -> tuple[list[o
     raise ValueError(f"unsupported preview source type: {suffix or '<none>'}")
 
 
+def _normalize_field_name(path: str) -> str:
+    return path.rsplit(".", 1)[-1].replace("-", "_").lower()
+
+
+def _iter_field_paths(value: object, prefix: str = "$") -> list[tuple[str, object]]:
+    if isinstance(value, dict):
+        fields: list[tuple[str, object]] = []
+        for key, item in value.items():
+            child = f"{prefix}.{key}" if prefix != "$" else str(key)
+            fields.extend(_iter_field_paths(item, child))
+        return fields
+    if isinstance(value, list):
+        fields = []
+        for item in value[:3]:
+            child = f"{prefix}[]"
+            fields.extend(_iter_field_paths(item, child))
+        return fields
+    return [(prefix, value)]
+
+
+def _classify_redaction_action(field_path: str) -> tuple[str, str]:
+    field = _normalize_field_name(field_path)
+    if field in REDACTION_DROP_FIELDS or any(token in field for token in ["secret", "token", "password"]):
+        return "drop", "secret-like field name"
+    if field in REDACTION_HASH_FIELDS or field.endswith("_id") or "email" in field:
+        return "hash", "identifier-like field name"
+    if field in REDACTION_REVIEW_FIELDS or any(token in field for token in ["prompt", "completion", "message"]):
+        return "review", "content-like field name"
+    if field in REDACTION_KEEP_FIELDS or field.endswith("_ms") or field in {"id", "index"}:
+        return "keep", "operational metric or label field"
+    return "review", "unclassified field"
+
+
+def _build_redaction_manifest(source: dict[str, object], records: list[object]) -> dict[str, object]:
+    field_stats: dict[str, dict[str, object]] = {}
+    for record in records:
+        for field_path, value in _iter_field_paths(record):
+            stats = field_stats.setdefault(
+                field_path,
+                {
+                    "field_path": field_path,
+                    "sample_count": 0,
+                    "value_types": set(),
+                },
+            )
+            stats["sample_count"] = int(stats["sample_count"]) + 1
+            stats["value_types"].add(type(value).__name__)
+
+    fields = []
+    for field_path, stats in sorted(field_stats.items()):
+        action, reason = _classify_redaction_action(field_path)
+        fields.append(
+            {
+                "field_path": field_path,
+                "recommended_action": action,
+                "reason": reason,
+                "sample_count": stats["sample_count"],
+                "value_types": sorted(stats["value_types"]),
+            }
+        )
+
+    action_counts = {
+        action: sum(1 for field in fields if field["recommended_action"] == action)
+        for action in ["keep", "review", "hash", "drop"]
+    }
+    return {
+        "schema_version": "understudy.redaction_manifest.v1",
+        "capability": "capture-import",
+        "source_id": source["id"],
+        "source_path": source["path"],
+        "status": "recommended",
+        "data_class": "local-preview",
+        "review_required": True,
+        "record_count": len(records),
+        "action_counts": action_counts,
+        "fields": fields,
+        "approval_required_before": [
+            "upload",
+            "provider call",
+            "hosted job",
+            "training handoff",
+            "public commit",
+        ],
+        "notes": [
+            "Recommendations are based on field names and preview shape only.",
+            "No records were mutated; review before exporting fixtures or provider-bound inputs.",
+        ],
+    }
+
+
 def _classify_workload_shape(candidate: dict[str, object], repo: Path) -> list[str]:
     path_value = candidate.get("path")
     if not isinstance(path_value, str):
@@ -552,24 +688,7 @@ def _run_capture_preview(args: argparse.Namespace) -> int:
     output = _artifact_dir(repo, "capture-import") / f"preview-{selected['id']}.json"
     _write_json(output, preview)
 
-    manifest = {
-        "schema_version": "understudy.redaction_manifest.v1",
-        "capability": "capture-import",
-        "source_id": selected["id"],
-        "source_path": selected["path"],
-        "status": "stub",
-        "data_class": "local-preview",
-        "review_required": True,
-        "fields_to_review": [],
-        "redaction_rules": [],
-        "approval_required_before": [
-            "upload",
-            "provider call",
-            "hosted job",
-            "training handoff",
-            "public commit",
-        ],
-    }
+    manifest = _build_redaction_manifest(selected, records)
     manifest_path = _artifact_dir(repo, "capture-import") / "redaction-manifest.json"
     _write_json(manifest_path, manifest)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,9 +191,11 @@ def test_capture_import_preview_jsonl_is_bounded_and_local(tmp_path, capsys) -> 
             [
                 json.dumps(
                     {
+                        "email": f"user{index}@example.test",
                         "input": f"synthetic request {index}",
                         "expected": "synthetic answer " + ("x" * 120),
                         "latency_ms": 900 + index,
+                        "api_key": "synthetic-secret-placeholder",
                     }
                 )
                 for index in range(30)
@@ -234,7 +236,14 @@ def test_capture_import_preview_jsonl_is_bounded_and_local(tmp_path, capsys) -> 
     manifest_path = repo / ".understudy" / "capture-import" / "redaction-manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["schema_version"] == "understudy.redaction_manifest.v1"
+    assert manifest["status"] == "recommended"
     assert manifest["review_required"] is True
+    actions = {field["field_path"]: field["recommended_action"] for field in manifest["fields"]}
+    assert actions["api_key"] == "drop"
+    assert actions["email"] == "hash"
+    assert actions["input"] == "review"
+    assert actions["latency_ms"] == "keep"
+    assert manifest["action_counts"]["drop"] == 1
 
 
 def test_capture_import_preview_limit_is_capped(tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary

Turns the capture/import redaction manifest from a stub into field-level recommendations based on preview record shape.

## What changed

- Preview now writes `redaction-manifest.json` with `status: recommended`.
- The manifest includes detected field paths, sample counts, value types, action counts, and recommended actions.
- Field recommendations:
  - `keep` for operational fields such as `latency_ms`, `score`, `label`, `category`
  - `review` for content-like fields such as `input`, `prompt`, `output`, `completion`, `message`, `text`
  - `hash` for identifiers such as `email`, `domain`, `user_id`, `account_id`
  - `drop` for secret-like fields such as `api_key`, `token`, `authorization`, `password`, `secret`
- Updated capture/import docs and skill guidance.

## Safety

- Recommendations are based on field names and preview shape only.
- No records are mutated.
- Preview artifacts remain local-only and approval-gated before upload, provider calls, hosted jobs, training handoff, or public commit.

## Verification

- `PYTHONPATH=src python3 -m understudy_agent_tools.cli capture-import scan --repo examples/repos/ai-search-app`
- `PYTHONPATH=src python3 -m understudy_agent_tools.cli capture-import preview --repo examples/repos/ai-search-app --source-id source-003 --limit 25`
- `python3 scripts/validate_public_skills.py --repo`
- `python3 scripts/package_release_smoke.py`
- `python3 scripts/doctor.py`
- `uv run --with pytest python -m pytest`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->