### PR TITLE
feat: optimizer lanes — rubric reward + DSPy-program lane

### DIFF
--- a/docs/spine.md
+++ b/docs/spine.md
@@ -27,11 +27,20 @@ understand workload -> attach harness/environment
   -> validate and optimize -> value report
 ```
 
-Registration is not an OSS MVP gate. `register` and `login` belong to the CLI
-or hosted upsell path when a team wants credits, projects, gateway routing, or
-hosted execution. The public repo must still let a developer reach a Workload
-Card, baseline rerun plan, validation plan, optimization plan, and conservative
-Value Report without creating an account.
+Registration is not a hard gate, but it is the **default path for inference**.
+Optimization and evaluation always need a model, so by default the lanes use
+**Understudy inference** — run `understudy login` — and fall back to the
+developer's own provider keys if they'd rather not register. Everything else in
+the OSS loop (Workload Card, baseline rerun plan, validation plan, optimization
+plan, and conservative Value Report) stays reachable without an account; once a
+team wants credits, projects, gateway routing, or hosted execution, `register`
+is the path.
+
+The gateway endpoint is configuration, never hardcoded in the public package:
+`UNDERSTUDY_API_BASE` (set by `understudy login` / env) supplies it, so no
+hosted URL ships in this repo (see `oss-release-boundary.md`). Understudy
+routing needs both the credential and that base; either missing falls back to
+the developer's provider keys.
 
 Baseline rerun is required after the harness, environment, metric, validator,
 or split boundary changes. Pre-existing benchmark numbers can inform intake,

--- a/docs/validate-and-optimize-contract.md
+++ b/docs/validate-and-optimize-contract.md
@@ -123,10 +123,11 @@ artifact is therefore `metric.json`, not the optimizer package.
   "primary_metric": "exact_match",
   "threshold": 0.95,
   "validator": {
-    "kind": "command|callable|schema|human-review",
+    "kind": "command|callable|schema|rubric|llm-judge|human-review",
     "command": null,
     "callable": null,
-    "schema_path": null
+    "schema_path": null,
+    "rubric_path": null
   },
   "feedback": {
     "required": true,
@@ -149,6 +150,10 @@ Rules:
 - Feedback is required and must describe the actual validator failure.
 - If only a proxy metric exists, run diagnostic mode only and do not emit
   `claim.json`.
+- `kind` dispatches the runner: `command`/`callable` run a check; `schema` does a
+  safeParse (separate `schema_pass` from `quality_pass`); `rubric`/`llm-judge`
+  use `scripts/rubric_reward.py` (graded; debias position with a swapped
+  two-pass score); `human-review` is a blind packet. `kind: proxy` is rejected.
 
 ## Eval Input Adapter
 
@@ -207,21 +212,26 @@ Keep deterministic implementation details near the skill:
 
 ```text
 skills/validate-and-optimize/
-  SKILL.md
-  templates/
-    candidate.json
-    claim.json
-    eval.json
-  examples/
-    fresh-baseline-dry-run/
-    stale-baseline/
+  SKILL.md            thin routing prose (Before-You-Optimize gates)
+  reference.md        deep detail: lanes, model selection, validator kinds, inference
+  templates/          candidate.json, claim.json, eval.json, metric.json, rubric.json
+  examples/           fresh-baseline-dry-run/, stale-baseline/
   scripts/
-    check_freshness.py
-    prepare_examples.py
-    gepa_run.py
-    evaluate.py
-    report.py
+    _common.py        shared artifact IO + gate helpers
+    check_freshness.py / validate_metric.py / validate_claim.py   hard gates
+    prepare_examples.py                                           eval-input adapter
+    gepa_run.py                                                   run gate + (dry-run today)
+    _adapter.py       in-place lane: UnderstudyGepaAdapter (single + multi-turn)
+    dspy_program.py   opt-in DSPy-program lane: scaffold + parity_check + dspy.GEPA
+    rubric_reward.py  rubric/llm-judge reward -> (score, feedback)
 ```
+
+Inference is resolved **Understudy-first** by
+`understudy_agent_tools.inference.resolve_backend()` (login -> gateway; else BYO
+provider keys); the gateway base is config (`UNDERSTUDY_API_BASE`), never a
+hosted URL in the package. Two optimization lanes: **in-place** (default,
+`_adapter.py`, truest to prod) and **DSPy-program** (opt-in, `dspy_program.py`,
+gated by `parity_check`). See reference.md.
 
 The CLI should remain a thin wrapper around these proven scripts. Do not move
 the whole workflow into top-level CLI code.

--- a/skills/validate-and-optimize/SKILL.md
+++ b/skills/validate-and-optimize/SKILL.md
@@ -69,8 +69,9 @@ validator kinds in [`reference.md`](reference.md):
   incumbent failures → nothing to optimize. A strong model fails them too →
   task beyond frontier; stop.
 - **Models** — student = a cheap candidate; `reflection_lm` = a strong frontier
-  model (optional, but a weak one caps quality). Both run on the developer's own
-  keys; no account.
+  model (optional, but a weak one caps quality). **Inference defaults to
+  Understudy** (run `understudy login`); falls back to the developer's own
+  provider keys if they'd rather not register. See reference.md → Inference.
 - **Verifier boundary** — optimize the offline validator only; RL
   verifiers/environments are a later rung, out of scope here.
 - **Stopping rule** — if the scorer saturates to 1.0 fast, the surface is too

--- a/skills/validate-and-optimize/reference.md
+++ b/skills/validate-and-optimize/reference.md
@@ -68,9 +68,10 @@ produce `(score, feedback)`:
   not matching a teacher trace verbatim (the proxy-strict-match trap).
 - `rubric` — confirmed criteria list (id, description, review type); auto-drafted
   rubrics need human approval.
-- `llm-judge` — must debias position with a swapped two-pass score
-  `(r_ab − r_ba + 2) / 4`; never single-pass. Report judge-vs-human agreement
-  separately from candidate preference.
+- `llm-judge` / `rubric` — implemented in `rubric_reward.py`. Must debias
+  position with the swapped two-pass score (`(r_ab − r_ba + 1)/2` for [0,1] judge
+  scores; the internal judge uses `÷4` on a [-1,1] scale); never single-pass.
+  Gate on `judge_human_agreement` before trusting the judge.
 - `human-review` — blind, order-randomized packet.
 
 `kind: proxy` is rejected by the gate. If only a proxy is available, run
@@ -113,3 +114,31 @@ holdout/live validation, mark promotion as **blocked** — emit an optimization
 lead, not a win. The decision packet records: decision + evidence level,
 baseline vs candidate, artifact paths, caveats / missing evidence, and the
 approval-gated next step. This is the same gate `claim.json` enforces.
+
+## Optimization Lanes
+
+Two ways to optimize, picked by commitment and workload shape:
+
+1. **In-place prompt optimization (default).** `scripts/_adapter.py`'s
+   `UnderstudyGepaAdapter` runs the developer's *real* workload via an injected
+   `infer` (single call or multi-turn agent loop) and evolves the prompt(s) they
+   already ship. Truest to production, lowest commitment, no DSPy. For MCP /
+   tool-use agents, prefer gepa's built-in `mcp_adapter` / `terminal_bench_adapter`
+   over hand-rolling.
+2. **DSPy-program lane (opt-in).** `scripts/dspy_program.py` scaffolds a DSPy
+   program from the Workload Card + samples, then `dspy.GEPA` optimizes it
+   natively — instructions across predictors + bootstrapped few-shot demos, and
+   `dspy.ReAct` for multi-turn. Richer, but the user must adopt the program as
+   runtime, and it is **gated by `parity_check`**: the scaffolded program must
+   reproduce the incumbent baseline on holdout before GEPA runs, or you optimize a
+   reconstruction that diverges from production.
+
+## Rubric Reward (the OSS half of the verifier rung)
+
+`scripts/rubric_reward.py` turns a human-confirmed `rubric.json` + an injected
+LLM judge into `(score, feedback)` — a graded `metric` (richer than pass/fail)
+usable directly by either lane. `score_pointwise` weights per-criterion judgments
+and surfaces failing-criterion rationales as feedback; `score_pairwise` debiases
+position; `judge_human_agreement` is the calibration gate before trusting a
+rubric judge. The rubric + judgment is OSS-native and valuable on its own; **RL
+training over the reward stays hosted** (the verifier boundary above).

--- a/skills/validate-and-optimize/reference.md
+++ b/skills/validate-and-optimize/reference.md
@@ -115,6 +115,21 @@ lead, not a win. The decision packet records: decision + evidence level,
 baseline vs candidate, artifact paths, caveats / missing evidence, and the
 approval-gated next step. This is the same gate `claim.json` enforces.
 
+## Inference (Understudy-first, BYO fallback)
+
+Optimization always needs inference, so the **default is Understudy inference**.
+`understudy_agent_tools.inference.resolve_backend()` checks for an Understudy
+credential (`UNDERSTUDY_API_KEY` env, then the `Understudy-credentials` keychain
+blob — same resolution as the agent CLI) and, if present, routes model calls
+through the Understudy gateway (one credential, all providers, credit-metered).
+
+When not logged in, the lane **recommends `understudy login`** and falls back to
+the developer's own provider keys — so login is the expected default, not a hard
+gate; BYO stays supported for the register-averse. `build_dspy_lm(model)` /
+`dspy_program.resolve_lm(model)` apply this default for the DSPy lane; the
+in-place adapter's `infer` uses the same backend. The credential is never logged
+(`login_status()` returns only a boolean + source).
+
 ## Optimization Lanes
 
 Two ways to optimize, picked by commitment and workload shape:

--- a/skills/validate-and-optimize/reference.md
+++ b/skills/validate-and-optimize/reference.md
@@ -58,20 +58,20 @@ optimizer.
 
 ## Validator Kinds
 
-`metric.json`'s `validator.kind` selects how a candidate is scored. Each must
-produce `(score, feedback)`:
+`metric.json`'s `validator.kind` dispatches the runner; each kind must produce
+`(score, feedback)`. Invocation fields (`command`, `callable`, `schema_path`,
+`rubric_path`) say *how* to run it:
 
-- `unit-test` / `golden` / `custom-command` — deterministic check; feedback is
-  the failing assertion or diff.
+- `command` / `callable` — run a deterministic check (a unit test, golden-output
+  diff, or any script/function); feedback is the failing assertion or diff.
 - `schema` (Zod / JSON-schema `safeParse`) — separate `schema_pass` from
   `quality_pass`; a valid-shape, valid-enum output must not be failed merely for
   not matching a teacher trace verbatim (the proxy-strict-match trap).
-- `rubric` — confirmed criteria list (id, description, review type); auto-drafted
-  rubrics need human approval.
-- `llm-judge` / `rubric` — implemented in `rubric_reward.py`. Must debias
-  position with the swapped two-pass score (`(r_ab − r_ba + 1)/2` for [0,1] judge
-  scores; the internal judge uses `÷4` on a [-1,1] scale); never single-pass.
-  Gate on `judge_human_agreement` before trusting the judge.
+- `rubric` / `llm-judge` — graded scoring via `scripts/rubric_reward.py` against a
+  confirmed criteria list. Debias position with the swapped two-pass score
+  (`(r_ab − r_ba + 1)/2` for [0,1] judge scores; the internal judge uses `÷4` on a
+  [-1,1] scale); never single-pass. Auto-drafted rubrics need human approval; gate
+  on `judge_human_agreement` before trusting the judge.
 - `human-review` — blind, order-randomized packet.
 
 `kind: proxy` is rejected by the gate. If only a proxy is available, run

--- a/skills/validate-and-optimize/scripts/dspy_program.py
+++ b/skills/validate-and-optimize/scripts/dspy_program.py
@@ -24,8 +24,11 @@ from typing import Any, Callable, Sequence
 
 import dspy
 
-# A dspy metric: (example, prediction[, trace]) -> float in [0,1].
-Metric = Callable[..., float]
+# A dspy metric: (example, prediction[, trace, pred_name, pred_trace]) -> a float
+# in [0,1], OR a `dspy.Prediction(score=..., feedback=...)` to give GEPA
+# natural-language feedback (preferred). Typed Any because the Prediction form
+# can't be referenced here (dspy is lazily imported).
+Metric = Callable[..., Any]
 
 
 def build_signature(

--- a/skills/validate-and-optimize/scripts/dspy_program.py
+++ b/skills/validate-and-optimize/scripts/dspy_program.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""DSPy-program optimization lane (opt-in).
+
+Scaffolds a DSPy program from the Workload Card + sample data, then lets
+`dspy.GEPA` optimize it natively — instructions across predictors **plus**
+few-shot demos bootstrapped from the data, and `dspy.ReAct` for multi-turn
+tool-use. This is the richer, opt-in lane; the default lane optimizes the
+developer's real prompt in place (see `_adapter.py`).
+
+⚠️ The scaffolded program is a *reconstruction* of the workload, not the user's
+real call site. Optimizing a reconstruction that diverges from production is the
+`synthetic-optimizer-before-real-harness-attachment` failure. So the lane is
+**gated by `parity_check`**: the program must reproduce the incumbent baseline on
+the holdout before GEPA is allowed to touch it.
+
+`dspy` is imported lazily (optional install, MIT); import this module only on the
+opt-in DSPy path. Inference is driven by the dspy-configured LM (the developer's
+own keys); tests use `dspy.utils.DummyLM`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Sequence
+
+import dspy
+
+# A dspy metric: (example, prediction[, trace]) -> float in [0,1].
+Metric = Callable[..., float]
+
+
+def build_signature(
+    input_fields: Sequence[str],
+    output_fields: Sequence[str],
+    *,
+    instructions: str = "",
+) -> type:
+    """Dynamic DSPy Signature from the Workload Card's field names."""
+    if not input_fields or not output_fields:
+        raise ValueError("need at least one input and one output field")
+    spec = f"{', '.join(input_fields)} -> {', '.join(output_fields)}"
+    return dspy.Signature(spec, instructions) if instructions else dspy.Signature(spec)
+
+
+def build_program(
+    input_fields: Sequence[str],
+    output_fields: Sequence[str],
+    *,
+    module: str = "predict",
+    tools: list[Callable[..., Any]] | None = None,
+    instructions: str = "",
+) -> "dspy.Module":
+    """Build the program. `react` (with tools) for multi-turn tool-use; otherwise
+    `predict` or `cot`. ReAct gives multi-turn for free — GEPA then evolves the
+    instructions + tool descriptions across the loop."""
+    sig = build_signature(input_fields, output_fields, instructions=instructions)
+    if module == "react":
+        if not tools:
+            raise ValueError("module='react' requires tools")
+        return dspy.ReAct(sig, tools=tools)
+    if module == "cot":
+        return dspy.ChainOfThought(sig)
+    return dspy.Predict(sig)
+
+
+def examples_from_rows(
+    rows: Sequence[dict[str, Any]], input_keys: Sequence[str]
+) -> list["dspy.Example"]:
+    """Map sample rows → dspy.Example trainset (inputs marked)."""
+    out: list[dspy.Example] = []
+    for row in rows:
+        out.append(dspy.Example(**row).with_inputs(*input_keys))
+    return out
+
+
+@dataclass
+class ParityResult:
+    parity: bool
+    program_score: float
+    baseline_score: float
+    delta: float
+    tolerance: float
+    n: int
+
+
+def parity_check(
+    program: "dspy.Module",
+    holdout: Sequence["dspy.Example"],
+    metric: Metric,
+    *,
+    baseline_score: float,
+    input_keys: Sequence[str],
+    tolerance: float = 0.05,
+) -> ParityResult:
+    """Gate: does the scaffolded program reproduce the incumbent on holdout?
+
+    Runs the program on each holdout example, means the metric, and compares to
+    the incumbent `baseline_score`. parity fails if the program is worse than
+    baseline by more than `tolerance` — meaning the reconstruction diverges from
+    production and must be fixed before optimizing (else you optimize a fiction).
+    """
+    if not holdout:
+        raise ValueError("parity_check needs a non-empty holdout")
+    scores: list[float] = []
+    for ex in holdout:
+        pred = program(**{k: ex[k] for k in input_keys})
+        scores.append(float(metric(ex, pred)))
+    program_score = sum(scores) / len(scores)
+    delta = program_score - baseline_score
+    return ParityResult(
+        parity=delta >= -tolerance,
+        program_score=program_score,
+        baseline_score=baseline_score,
+        delta=delta,
+        tolerance=tolerance,
+        n=len(scores),
+    )
+
+
+def optimize(
+    program: "dspy.Module",
+    *,
+    trainset: Sequence["dspy.Example"],
+    valset: Sequence["dspy.Example"],
+    metric: Metric,
+    reflection_lm: Any,
+    auto: str = "light",
+    **gepa_kwargs: Any,
+) -> "dspy.Module":
+    """Compile with dspy.GEPA (instructions + bootstrapped demos).
+
+    Caller MUST have passed `parity_check` first. `metric` may return a
+    `dspy.Prediction(score=..., feedback=...)` to give GEPA natural-language
+    feedback (preferred) instead of a bare float.
+    """
+    optimizer = dspy.GEPA(metric=metric, reflection_lm=reflection_lm, auto=auto, **gepa_kwargs)
+    return optimizer.compile(program, trainset=list(trainset), valset=list(valset))

--- a/skills/validate-and-optimize/scripts/dspy_program.py
+++ b/skills/validate-and-optimize/scripts/dspy_program.py
@@ -116,13 +116,26 @@ def parity_check(
     )
 
 
+def resolve_lm(model: str):
+    """The lane's default LM: **Understudy inference if logged in, else BYO**.
+
+    Delegates to `understudy_agent_tools.inference.build_dspy_lm`, which routes
+    through the Understudy gateway when a credential is present and otherwise
+    builds a native `provider/model` LM on the developer's own keys.
+    """
+    from understudy_agent_tools.inference import build_dspy_lm
+
+    return build_dspy_lm(model)
+
+
 def optimize(
     program: "dspy.Module",
     *,
     trainset: Sequence["dspy.Example"],
     valset: Sequence["dspy.Example"],
     metric: Metric,
-    reflection_lm: Any,
+    reflection_lm: Any | None = None,
+    reflection_model: str | None = None,
     auto: str = "light",
     **gepa_kwargs: Any,
 ) -> "dspy.Module":
@@ -131,6 +144,14 @@ def optimize(
     Caller MUST have passed `parity_check` first. `metric` may return a
     `dspy.Prediction(score=..., feedback=...)` to give GEPA natural-language
     feedback (preferred) instead of a bare float.
+
+    By default the reflection LM is resolved Understudy-first: pass
+    `reflection_model` (a model name) and it routes through Understudy inference
+    when logged in, else BYO. Pass an explicit `reflection_lm` to override.
     """
+    if reflection_lm is None:
+        if reflection_model is None:
+            raise ValueError("pass reflection_lm or reflection_model")
+        reflection_lm = resolve_lm(reflection_model)
     optimizer = dspy.GEPA(metric=metric, reflection_lm=reflection_lm, auto=auto, **gepa_kwargs)
     return optimizer.compile(program, trainset=list(trainset), valset=list(valset))

--- a/skills/validate-and-optimize/scripts/rubric_reward.py
+++ b/skills/validate-and-optimize/scripts/rubric_reward.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Rubric-based reward scorer.
+
+Turns a human-confirmed rubric + an LLM judge into `(score, feedback)` — a richer
+validator kind for the optimize loop, and the **OSS half of the verifier rung**:
+the rubric + judgment is portable and valuable on its own (it immediately makes
+GEPA's metric graded instead of pass/fail); the RL *training* over the reward
+stays hosted (full package), not here.
+
+The judge is **injected** (`judge(prompt) -> verdict_text`) so this is
+provider-agnostic and unit-testable without an LM. Pairwise mode cancels position
+bias by judging both orderings and averaging — the same swapped two-pass idea as
+the internal pairwise judge (here `(r_ab - r_ba + 1) / 2` for [0,1] judge scores;
+the internal one uses `÷4` for a [-1,1] scale).
+
+A rubric reward returns the same `(score, feedback)` shape the GEPA adapter's
+`metric` expects, so a confirmed rubric is a drop-in metric for optimization.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+JudgeFn = Callable[[str], str]
+# Extract a [0,1] score from a judge verdict. Default looks for SCORE: <n>.
+ScoreExtractor = Callable[[str], float]
+
+
+@dataclass(frozen=True)
+class Criterion:
+    id: str
+    description: str
+    weight: float = 1.0
+
+
+def load_criteria(rubric: dict[str, Any]) -> list[Criterion]:
+    raw = rubric.get("criteria")
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("rubric must have a non-empty 'criteria' list")
+    out: list[Criterion] = []
+    for i, item in enumerate(raw, 1):
+        if not isinstance(item, dict):
+            raise ValueError(f"criterion {i} must be an object")
+        cid = str(item.get("id") or f"criterion_{i}")
+        desc = str(item.get("description") or "").strip()
+        if not desc:
+            raise ValueError(f"criterion {cid} needs a description")
+        weight = float(item.get("weight", 1.0))
+        out.append(Criterion(id=cid, description=desc, weight=weight))
+    return out
+
+
+def default_score_extractor(verdict: str) -> float:
+    """Parse `SCORE: 0.7` (0..1) or fall back to PASS/FAIL → 1.0/0.0."""
+    m = re.search(r"score\s*[:=]\s*([01](?:\.\d+)?)", verdict, re.IGNORECASE)
+    if m:
+        return max(0.0, min(1.0, float(m.group(1))))
+    if re.search(r"\bpass\b", verdict, re.IGNORECASE):
+        return 1.0
+    if re.search(r"\bfail\b", verdict, re.IGNORECASE):
+        return 0.0
+    return 0.0
+
+
+@dataclass
+class RubricResult:
+    score: float
+    feedback: str
+    per_criterion: list[dict[str, Any]]
+
+
+def score_pointwise(
+    *,
+    output: Any,
+    criteria: list[Criterion],
+    judge: JudgeFn,
+    extract: ScoreExtractor = default_score_extractor,
+    context: str = "",
+) -> RubricResult:
+    """Judge `output` against each criterion; weighted-mean score + feedback.
+
+    Feedback is the rationale of the criteria that scored below 1.0 — the
+    diagnosis GEPA reflects on, not a bare number.
+    """
+    rows: list[dict[str, Any]] = []
+    weighted_sum = 0.0
+    total_weight = 0.0
+    for c in criteria:
+        prompt = (
+            f"{context}\nCriterion ({c.id}): {c.description}\n\n"
+            f"Output under review:\n{output}\n\n"
+            "Reply with `SCORE: <0..1>` then one sentence of rationale."
+        )
+        verdict = judge(prompt)
+        s = extract(verdict)
+        rationale = verdict.strip()
+        rows.append({"id": c.id, "score": s, "weight": c.weight, "rationale": rationale})
+        weighted_sum += s * c.weight
+        total_weight += c.weight
+    score = (weighted_sum / total_weight) if total_weight else 0.0
+    failing = [r for r in rows if r["score"] < 1.0]
+    if failing:
+        feedback = "Rubric gaps:\n" + "\n".join(
+            f"- [{r['id']} {r['score']:.2f}] {r['rationale']}" for r in failing
+        )
+    else:
+        feedback = "All rubric criteria satisfied."
+    return RubricResult(score=score, feedback=feedback, per_criterion=rows)
+
+
+def score_pairwise(
+    *,
+    candidate_output: Any,
+    incumbent_output: Any,
+    rubric_text: str,
+    judge: JudgeFn,
+    extract: ScoreExtractor = default_score_extractor,
+) -> float:
+    """Swapped two-pass win score in [0,1]; 0.5 = tie. Cancels position bias.
+
+    Both passes ask "how much does A beat B" on a [0,1] scale. With the candidate
+    as A then as B, the debiased candidate-win is `(r_ab + (1 - r_ba)) / 2`,
+    i.e. `(r_ab - r_ba + 1) / 2`. A symmetric (position-only) bias cancels.
+    """
+
+    def _prompt(a: Any, b: Any) -> str:
+        return (
+            f"Rubric:\n{rubric_text}\n\n"
+            f"Response A:\n{a}\n\nResponse B:\n{b}\n\n"
+            "Score how much A beats B with `SCORE: <0..1>` (1 = A clearly better, "
+            "0 = B clearly better, 0.5 = tie)."
+        )
+
+    r_ab = extract(judge(_prompt(candidate_output, incumbent_output)))
+    r_ba = extract(judge(_prompt(incumbent_output, candidate_output)))
+    return max(0.0, min(1.0, (r_ab - r_ba + 1.0) / 2.0))
+
+
+def judge_human_agreement(
+    judge_labels: list[Any], human_labels: list[Any]
+) -> float:
+    """Fraction of items where the judge agrees with the human gold.
+
+    The readiness gate for trusting a rubric judge: low agreement means the
+    rubric or judge is miscalibrated — fix it before optimizing against it.
+    """
+    if len(judge_labels) != len(human_labels) or not judge_labels:
+        raise ValueError("judge_labels and human_labels must be same non-zero length")
+    agree = sum(1 for j, h in zip(judge_labels, human_labels) if j == h)
+    return agree / len(judge_labels)

--- a/skills/validate-and-optimize/templates/rubric.json
+++ b/skills/validate-and-optimize/templates/rubric.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "understudy.rubric.v1",
+  "approved": false,
+  "judge": {
+    "mode": "pointwise",
+    "debias": "swapped_two_pass",
+    "model": "frontier-tier"
+  },
+  "aggregation": "weighted_mean",
+  "criteria": [
+    {
+      "id": "faithful",
+      "description": "The answer is grounded in the provided inputs with no fabricated facts.",
+      "weight": 2.0
+    },
+    {
+      "id": "complete",
+      "description": "The answer addresses every part of the request.",
+      "weight": 1.0
+    },
+    {
+      "id": "format",
+      "description": "The output matches the required schema/format.",
+      "weight": 1.0
+    }
+  ]
+}

--- a/src/understudy_agent_tools/inference.py
+++ b/src/understudy_agent_tools/inference.py
@@ -1,0 +1,143 @@
+"""Default inference backend resolution.
+
+Optimization always needs inference, so the **default path is Understudy
+inference**: the lanes check whether the developer is logged in and route model
+calls through the Understudy gateway (one credential, all providers,
+credit-metered). When not logged in, the lanes **recommend `understudy login`**
+and **fall back to the developer's own provider keys** if they'd rather not
+register. So login is the expected default, not a hard gate — BYO keys remain
+supported for the register-averse.
+
+Credential resolution mirrors the agent CLI (`understudy_agent/auth.py`):
+`UNDERSTUDY_API_KEY` env wins, then the macOS `Understudy-credentials` keychain
+blob. The secret is never logged; `login_status()` returns only a boolean +
+source.
+"""
+from __future__ import annotations
+
+import getpass
+import json
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+UNDERSTUDY_API_KEY_ENV = "UNDERSTUDY_API_KEY"
+UNDERSTUDY_API_BASE_ENV = "UNDERSTUDY_API_BASE"
+CREDENTIALS_SERVICE = "Understudy-credentials"
+
+
+def understudy_inference_base() -> str | None:
+    """The OpenAI-compatible Understudy gateway base, from env, or None.
+
+    The public package never hardcodes the hosted endpoint (oss-release-boundary:
+    no hosted control-plane URLs in public code). `understudy login` / the env
+    supplies `UNDERSTUDY_API_BASE`; we append the `/v1` OpenAI-compatible path.
+    """
+    base = os.environ.get(UNDERSTUDY_API_BASE_ENV, "").strip()
+    if not base:
+        return None
+    return base.rstrip("/") + "/v1"
+
+
+def _keychain_credential() -> str | None:
+    """Best-effort macOS keychain read of the Understudy credential blob."""
+    if platform.system() != "Darwin" or shutil.which("security") is None:
+        return None
+    try:
+        account = getpass.getuser()
+    except Exception:
+        return None
+    try:
+        out = subprocess.run(
+            ["security", "find-generic-password", "-a", account, "-s", CREDENTIALS_SERVICE, "-w"],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if not out:
+        return None
+    try:
+        blob = json.loads(out)
+    except (json.JSONDecodeError, ValueError):
+        return out or None  # legacy: raw key stored directly
+    if isinstance(blob, dict):
+        api_key = blob.get("apiKey")
+        if isinstance(api_key, str) and api_key:
+            return api_key
+        oauth = blob.get("oauth")
+        if isinstance(oauth, dict):
+            token = oauth.get("accessToken")
+            if isinstance(token, str) and token:
+                return token
+    return None
+
+
+def understudy_credential(*, allow_keychain: bool = True) -> str | None:
+    """The usable Understudy bearer, or None. Env wins, then keychain."""
+    env = os.environ.get(UNDERSTUDY_API_KEY_ENV, "").strip()
+    if env:
+        return env
+    return _keychain_credential() if allow_keychain else None
+
+
+def login_status(*, allow_keychain: bool = True) -> dict[str, object]:
+    """Whether the developer is logged in to Understudy, and from where. No secret."""
+    if os.environ.get(UNDERSTUDY_API_KEY_ENV, "").strip():
+        return {"logged_in": True, "source": "env"}
+    if allow_keychain and _keychain_credential():
+        return {"logged_in": True, "source": "keychain"}
+    return {"logged_in": False, "source": None}
+
+
+@dataclass
+class InferenceBackend:
+    kind: str  # "understudy" | "byo"
+    base_url: str | None  # set for understudy; None for byo (provider-native)
+    api_key: str | None  # never logged
+    note: str
+
+
+def resolve_backend(*, prefer_understudy: bool = True, allow_keychain: bool = True) -> InferenceBackend:
+    """Default backend: Understudy inference when logged in + configured, else BYO.
+
+    Routing to Understudy needs both a credential and the gateway base
+    (`UNDERSTUDY_API_BASE`, set by `understudy login`/env). Either missing →
+    recommend login and fall back to the developer's own provider keys.
+    """
+    if prefer_understudy:
+        cred = understudy_credential(allow_keychain=allow_keychain)
+        base = understudy_inference_base()
+        if cred and base:
+            return InferenceBackend(
+                kind="understudy",
+                base_url=base,
+                api_key=cred,
+                note="Logged in to Understudy — routing through Understudy inference.",
+            )
+    return InferenceBackend(
+        kind="byo",
+        base_url=None,
+        api_key=None,
+        note=(
+            "Run `understudy login` to use Understudy inference (one key, all "
+            "providers). Falling back to your own provider keys."
+        ),
+    )
+
+
+def build_dspy_lm(model: str, backend: InferenceBackend | None = None):
+    """Build a `dspy.LM` for the resolved backend (lazy dspy import).
+
+    Understudy: OpenAI-compatible gateway (`openai/<model>` + api_base/api_key).
+    BYO: native `provider/model` (dspy resolves the provider's own env keys).
+    """
+    import dspy
+
+    backend = backend or resolve_backend()
+    if backend.kind == "understudy":
+        return dspy.LM(f"openai/{model}", api_base=backend.base_url, api_key=backend.api_key)
+    return dspy.LM(model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""pytest config.
+
+Makes the skill-local scripts importable so tests don't each manipulate
+`sys.path`. The scripts under `skills/<skill>/scripts/` are not an installed
+package (they're invoked directly by the agent), so we add the
+`validate-and-optimize` scripts dir to the path once, here.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_VAO_SCRIPTS = (
+    Path(__file__).resolve().parents[1] / "skills" / "validate-and-optimize" / "scripts"
+)
+if str(_VAO_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_VAO_SCRIPTS))

--- a/tests/test_dspy_program.py
+++ b/tests/test_dspy_program.py
@@ -1,9 +1,6 @@
 """DSPy-program lane tests. Skips when dspy is absent (optional install)."""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
 
 pytest.importorskip("dspy")
@@ -11,9 +8,7 @@ pytest.importorskip("dspy")
 import dspy  # noqa: E402
 from dspy.utils import DummyLM  # noqa: E402
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "validate-and-optimize" / "scripts"
-sys.path.insert(0, str(_SCRIPTS))
-
+# `validate-and-optimize/scripts` is on sys.path via tests/conftest.py.
 from dspy_program import (  # noqa: E402
     build_program,
     build_signature,

--- a/tests/test_dspy_program.py
+++ b/tests/test_dspy_program.py
@@ -1,0 +1,68 @@
+"""DSPy-program lane tests. Skips when dspy is absent (optional install)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("dspy")
+
+import dspy  # noqa: E402
+from dspy.utils import DummyLM  # noqa: E402
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "validate-and-optimize" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from dspy_program import (  # noqa: E402
+    build_program,
+    build_signature,
+    examples_from_rows,
+    parity_check,
+)
+
+
+def test_build_signature_and_program_structure():
+    sig = build_signature(["question"], ["answer"])
+    assert set(sig.model_fields) == {"question", "answer"}
+    prog = build_program(["question"], ["answer"], module="predict")
+    assert isinstance(prog, dspy.Predict)
+    with pytest.raises(ValueError):
+        build_signature([], ["answer"])
+    with pytest.raises(ValueError):
+        build_program(["q"], ["a"], module="react")  # react needs tools
+
+
+def test_examples_from_rows_marks_inputs():
+    rows = [{"question": "q1", "answer": "a1"}, {"question": "q2", "answer": "a2"}]
+    examples = examples_from_rows(rows, ["question"])
+    assert len(examples) == 2
+    assert examples[0].inputs().toDict() == {"question": "q1"}
+
+
+def _exact_match(example, pred, trace=None) -> float:
+    return 1.0 if getattr(pred, "answer", None) == example["answer"] else 0.0
+
+
+def test_parity_check_passes_when_program_matches_baseline():
+    # DummyLM returns the correct answer for both holdout rows → program_score 1.0.
+    dspy.configure(lm=DummyLM([{"answer": "a1"}, {"answer": "a2"}]))
+    prog = build_program(["question"], ["answer"], module="predict")
+    holdout = examples_from_rows(
+        [{"question": "q1", "answer": "a1"}, {"question": "q2", "answer": "a2"}], ["question"]
+    )
+    res = parity_check(prog, holdout, _exact_match, baseline_score=0.9, input_keys=["question"])
+    assert res.parity is True
+    assert res.program_score == 1.0
+
+
+def test_parity_check_fails_when_program_underperforms_baseline():
+    # DummyLM returns wrong answers → program_score 0.0, well below baseline.
+    dspy.configure(lm=DummyLM([{"answer": "WRONG"}, {"answer": "WRONG"}]))
+    prog = build_program(["question"], ["answer"], module="predict")
+    holdout = examples_from_rows(
+        [{"question": "q1", "answer": "a1"}, {"question": "q2", "answer": "a2"}], ["question"]
+    )
+    res = parity_check(prog, holdout, _exact_match, baseline_score=0.9, input_keys=["question"])
+    assert res.parity is False  # reconstruction diverges from production → gate blocks
+    assert res.program_score == 0.0

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,61 @@
+"""Inference backend resolution — Understudy-first, BYO fallback."""
+from __future__ import annotations
+
+from understudy_agent_tools.inference import (
+    UNDERSTUDY_API_BASE_ENV,
+    UNDERSTUDY_API_KEY_ENV,
+    login_status,
+    resolve_backend,
+    understudy_credential,
+)
+
+# allow_keychain=False keeps these deterministic on any machine (a dev's real
+# keychain credential must not change test outcomes).
+
+
+def test_login_status_env(monkeypatch):
+    monkeypatch.setenv(UNDERSTUDY_API_KEY_ENV, "sk_test")
+    assert login_status(allow_keychain=False) == {"logged_in": True, "source": "env"}
+
+
+def test_login_status_logged_out(monkeypatch):
+    monkeypatch.delenv(UNDERSTUDY_API_KEY_ENV, raising=False)
+    assert login_status(allow_keychain=False) == {"logged_in": False, "source": None}
+
+
+def test_credential_env_wins_and_strips(monkeypatch):
+    monkeypatch.setenv(UNDERSTUDY_API_KEY_ENV, "  sk_x  ")
+    assert understudy_credential(allow_keychain=False) == "sk_x"
+
+
+def test_resolve_backend_defaults_to_understudy_when_logged_in_and_configured(monkeypatch):
+    monkeypatch.setenv(UNDERSTUDY_API_KEY_ENV, "sk_test")
+    monkeypatch.setenv(UNDERSTUDY_API_BASE_ENV, "https://gw.example.com")
+    backend = resolve_backend(allow_keychain=False)
+    assert backend.kind == "understudy"
+    assert backend.base_url == "https://gw.example.com/v1"
+    assert backend.api_key == "sk_test"
+
+
+def test_resolve_backend_byo_when_credential_but_no_base(monkeypatch):
+    monkeypatch.setenv(UNDERSTUDY_API_KEY_ENV, "sk_test")
+    monkeypatch.delenv(UNDERSTUDY_API_BASE_ENV, raising=False)
+    backend = resolve_backend(allow_keychain=False)
+    assert backend.kind == "byo"  # logged in but gateway base not configured
+    assert "understudy login" in backend.note
+
+
+def test_resolve_backend_falls_back_to_byo_and_recommends_login(monkeypatch):
+    monkeypatch.delenv(UNDERSTUDY_API_KEY_ENV, raising=False)
+    monkeypatch.delenv(UNDERSTUDY_API_BASE_ENV, raising=False)
+    backend = resolve_backend(allow_keychain=False)
+    assert backend.kind == "byo"
+    assert backend.base_url is None and backend.api_key is None
+    assert "understudy login" in backend.note  # nudges the default path
+
+
+def test_prefer_understudy_false_forces_byo(monkeypatch):
+    monkeypatch.setenv(UNDERSTUDY_API_KEY_ENV, "sk_test")
+    monkeypatch.setenv(UNDERSTUDY_API_BASE_ENV, "https://gw.example.com")
+    backend = resolve_backend(prefer_understudy=False, allow_keychain=False)
+    assert backend.kind == "byo"

--- a/tests/test_rubric_reward.py
+++ b/tests/test_rubric_reward.py
@@ -1,15 +1,10 @@
 """Rubric reward scorer — pure tests (no LM; the judge is injected)."""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "validate-and-optimize" / "scripts"
-sys.path.insert(0, str(_SCRIPTS))
-
-from rubric_reward import (  # noqa: E402
+# `validate-and-optimize/scripts` is on sys.path via tests/conftest.py.
+from rubric_reward import (
     Criterion,
     default_score_extractor,
     judge_human_agreement,

--- a/tests/test_rubric_reward.py
+++ b/tests/test_rubric_reward.py
@@ -1,0 +1,81 @@
+"""Rubric reward scorer — pure tests (no LM; the judge is injected)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "validate-and-optimize" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from rubric_reward import (  # noqa: E402
+    Criterion,
+    default_score_extractor,
+    judge_human_agreement,
+    load_criteria,
+    score_pairwise,
+    score_pointwise,
+)
+
+
+def test_load_criteria_validates():
+    crit = load_criteria({"criteria": [{"id": "a", "description": "x", "weight": 2.0}]})
+    assert crit == [Criterion(id="a", description="x", weight=2.0)]
+    with pytest.raises(ValueError):
+        load_criteria({"criteria": []})
+    with pytest.raises(ValueError):
+        load_criteria({"criteria": [{"id": "a", "description": ""}]})
+
+
+def test_default_score_extractor():
+    assert default_score_extractor("SCORE: 0.75 looks good") == 0.75
+    assert default_score_extractor("verdict: PASS") == 1.0
+    assert default_score_extractor("this is a FAIL") == 0.0
+    assert default_score_extractor("no signal") == 0.0
+
+
+def test_pointwise_weighted_score_and_feedback():
+    criteria = [
+        Criterion("faithful", "grounded", weight=2.0),
+        Criterion("format", "schema ok", weight=1.0),
+    ]
+    # judge fails 'faithful' (weight 2), passes 'format' (weight 1) → 1/3.
+    def judge(prompt: str) -> str:
+        if "grounded" in prompt:
+            return "SCORE: 0.0 fabricated a statistic"
+        return "SCORE: 1.0 matches schema"
+
+    res = score_pointwise(output="...", criteria=criteria, judge=judge)
+    assert abs(res.score - (1.0 / 3.0)) < 1e-9
+    assert "faithful" in res.feedback and "fabricated" in res.feedback
+    assert "format" not in res.feedback  # only failing criteria surface
+
+
+def test_pairwise_debias_cancels_position_bias():
+    # A position-biased judge that always favors whichever response is "A".
+    def biased_judge(prompt: str) -> str:
+        return "SCORE: 1.0"  # always says A wins
+
+    # r_ab = 1.0, r_ba = 1.0 → (1 - 1 + 2)/4 = 0.5 (tie), bias cancelled.
+    win = score_pairwise(
+        candidate_output="cand", incumbent_output="inc", rubric_text="r", judge=biased_judge
+    )
+    assert win == 0.5
+
+    # A genuinely-better candidate: judge favors candidate regardless of slot.
+    def fair_judge(prompt: str) -> str:
+        a_is_candidate = prompt.index("cand") < prompt.index("inc")
+        return "SCORE: 1.0" if a_is_candidate else "SCORE: 0.0"
+
+    win2 = score_pairwise(
+        candidate_output="cand", incumbent_output="inc", rubric_text="r", judge=fair_judge
+    )
+    # r_ab=1 (cand as A wins), r_ba=0 (cand as B loses) -> (1 - 0 + 1)/2 = 1.0
+    assert win2 == 1.0
+
+
+def test_judge_human_agreement_gate():
+    assert judge_human_agreement(["a", "b", "c", "d"], ["a", "x", "c", "d"]) == 0.75
+    with pytest.raises(ValueError):
+        judge_human_agreement([], [])


### PR DESCRIPTION
Stacked on #20 (now merged). Reopened as a fresh PR to `main` because deleting #20's branch auto-closed the original #21 and GitHub won't reopen a PR whose base no longer exists. Rebased cleanly with `rebase --onto main` (7 commits; `reference.md` conflicts resolved by **combining** the #20 fold sections with the #21 lanes/inference sections).

## What this adds (the optimizer lanes)
- **Rubric reward** (`scripts/rubric_reward.py`) — the OSS half of the verifier rung. Turns a human-confirmed `rubric.json` + injected LLM judge into `(score, feedback)`; pointwise + position-debiased pairwise (`(r_ab − r_ba + 1)/2`); `judge_human_agreement` calibration gate.
- **DSPy-program lane** (`scripts/dspy_program.py`, opt-in) — scaffolds a DSPy program from the Workload Card + samples; **gated by `parity_check`** (must reproduce the incumbent baseline on holdout before GEPA runs).
- **Inference: Understudy-first, BYO fallback** (`src/understudy_agent_tools/inference.py`) — `resolve_backend()` routes through the Understudy gateway when a credential is present (env → keychain), recommends `understudy login` otherwise, falls back to BYO provider keys. Gateway base from `UNDERSTUDY_API_BASE` (no hardcoded hosted URL — oss-release-boundary). Credential never logged.
- **Tidy** — one validator-kind taxonomy (`command|callable|schema|rubric|llm-judge|human-review`); shared `tests/conftest.py` for skill-script imports; spine doc + contract refreshed.

## Gates (local, mirrors CI)
- `validate_public_skills.py` → ok 3 public skills
- `uv run --with pytest pytest -q` → 57 passed, 1 skipped
- `package_release_smoke.py` → ok 2 archives

Backup of pre-rebase tip: tag `backup/optimizer-lanes-pre-rebase` (`4872492`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->