### PR TITLE
Skills: agent-improvement orchestrator + agentic-eval worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist/
 # Local planning notes that may include sensitive extraction context.
 docs/skill-externalization-plan.md
 docs/skill-comparison-audit.md
+
+# local scratch (checklists, notes) — never shipped
+.scratch/

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,6 +20,12 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   artifacts, preserves train/dev/holdout boundaries, writes dry-run proof
   packets, and requires `claim.json` before public claims. (Evaluate, optimize,
   and decide folded into its [`reference.md`](optimize-workload/reference.md).)
+- [`optimize-agentic-search`](optimize-agentic-search/SKILL.md) evaluates and
+  optimizes agentic / tool-use workloads (multi-turn tool-calling loops such as
+  agentic search): holds tools fixed, A/B-tests the policy model on quality,
+  latency, and cost through the gateway, and routes prompt tuning to
+  `optimize-workload` — before any RL handoff. (Verifier-env→artifact bridge and
+  determinism notes in its [`reference.md`](optimize-agentic-search/reference.md).)
 - [`use-understudy-gateway`](use-understudy-gateway/SKILL.md) handles
   authenticated gateway inference, project/key readiness, public model listing,
   workload route percentages, `understudy run`, and monitored durable CLI

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -100,6 +100,16 @@ enough provenance for another agent to repeat the step without guessing.
 
 ## Flow
 
+Inspect the repo first to find where LLM calls happen and the current
+model/provider/harness/eval state, then surface that inventory before building
+anything. The deep inspection checklist (call sites by SDK family, env vars,
+tracing, CI) and the eval-harness discover-then-build playbook live in
+[`reference.md`](reference.md). For cross-cutting objective/constraint framing,
+read [`../understudy/reference.md`](../understudy/reference.md). For multi-turn /
+tool-use / agentic workloads, route the eval to
+[`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md)
+instead of building a single-output harness.
+
 Start from the real local workload:
 
 - app route, eval suite, trace export, benchmark fixture, prompt set, dataset,

--- a/skills/capture-evidence/reference.md
+++ b/skills/capture-evidence/reference.md
@@ -4,6 +4,14 @@ Deep detail for [`SKILL.md`](SKILL.md). Discovery and capture/import are now
 skill-led until TypeScript commands are restored. See
 [`../../docs/current-functionality.md`](../../docs/current-functionality.md).
 
+This worker owns the *understand-the-workload* stage of the loop: inspect the
+repo, build the harness/metric/splits, and run the incumbent baseline. The
+cross-cutting framing — intake questions, objective menus, constraints,
+route selection, the fresh-pricing rule, and the report template — lives in
+[`../understudy/reference.md`](../understudy/reference.md). Do not re-derive it
+here; read it for the objective/constraint context that decides what the metric
+should measure.
+
 ## Workload discovery (find the opportunity)
 
 Before producing artifacts, locate what's worth optimizing — local-only, no
@@ -12,11 +20,99 @@ spend:
 1. Confirm the repo path (default `.` when already inside the target).
 2. Pick the **value lens**: latency, cost, quality, reliability, or portability.
    This decides what the metric should measure.
-3. Scan for AI call sites with `ripgrep`/`ast-grep` (model clients, prompt
-   strings, eval suites, trace exports) — read-only, the developer's tokens.
+3. Inventory LLM call sites and the current model/provider/harness/eval state
+   (see **Repo inspection** below) — read-only, the developer's tokens. Surface
+   this inventory early, before building anything.
 4. Name the single highest-value opportunity (call site + lens) and carry it
    into the harness/metric steps. Ask at most one clarifying question if the
    path or economic target is unclear.
+
+## Repo inspection (find the LLM call sites)
+
+The biggest source of wasted effort is guessing where the model is called and
+which harness already exists. Inspect first; do not assume a framework. This is
+local, read-only, and uses the developer's own checkout — no spend, no upload.
+
+### What to read
+
+Work outward from declared dependencies to live call sites to the eval/CI
+plumbing around them. Read metadata and code, not payloads.
+
+- **Package / dependency files** — `package.json`, `requirements.txt`,
+  `pyproject.toml`, `poetry.lock`, `Pipfile`, `environment.yml`, `go.mod`. The
+  declared SDKs tell you which providers and agent frameworks are even possible
+  before you grep a single line.
+- **Model / provider wrappers** — a project usually centralizes calls in one
+  module (`llm.py`, `client.ts`, `providers/`, `models/`, `ai/`, `genai/`). Find
+  it; it is the cheapest place to later change a route.
+- **Env vars** — names only, never values. `OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `*_BASE_URL`, `*_MODEL`, `*_API_VERSION`, gateway/proxy
+  base URLs. Scan `.env.example`, `*.env`, config loaders, and settings classes.
+  A custom `*_BASE_URL` usually means a gateway or self-hosted endpoint already
+  sits in front of the provider.
+- **LLM SDK usage** — the actual call sites (below).
+- **Agent frameworks** — multi-agent / tool-loop orchestration changes the eval
+  shape (route to verifiers, see below).
+- **Prompt files** — `prompts/`, `*.prompt`, `*.jinja`, `*.j2`, `*.md` templates,
+  or large inlined system strings. These are the optimization surface.
+- **Eval + test dirs** — `evals/`, `eval/`, `benchmarks/`, `tests/`,
+  `__tests__/`, `*.eval.*`, `*.spec.*`, notebooks. The most valuable find:
+  an existing scorer you can reuse instead of inventing a metric.
+- **Tracing / logging** — `langsmith`, `langfuse`, `phoenix`/`arize`,
+  `opentelemetry`, `helicone`, `weave`/`wandb`, or a custom logger that writes
+  request/response records. This is where real traces live (path/count only).
+- **Deploy + CI** — `Dockerfile`, `*.yaml` deploy manifests, serverless/edge
+  handlers, `vercel.json`, `.github/workflows/`, `Makefile`, `justfile`. Tells
+  you how the workload runs in production and whether an eval can run in CI.
+- **Compliance / README / architecture docs** — `README*`, `ARCHITECTURE*`,
+  `docs/`, `SECURITY*`, `COMPLIANCE*`. Constraints (ZDR, approved providers,
+  residency) gate every later action — feed them to
+  [`../understudy/reference.md`](../understudy/reference.md) → Constraints.
+
+### Integration points to recognize (no framework assumption)
+
+Grep for import lines and call patterns. The same provider appears under many
+shapes; recognize the family, not one library.
+
+- **Python** — `openai` (`OpenAI(...).chat.completions.create`,
+  `responses.create`), `anthropic` (`messages.create`), `litellm`
+  (`completion(...)`, a proxy config), `langchain` /
+  `langchain_*` (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`),
+  `llama-index`, `dspy` (`dspy.LM`, signatures, `Predict`), `instructor`,
+  `pydantic-ai` (`Agent(...)`), `autogen`, `crewai`, and **custom provider
+  wrappers** — a hand-rolled `requests`/`httpx` POST to a chat-completions
+  endpoint is still a call site.
+- **TypeScript** — `openai`, `@anthropic-ai/sdk`, the Vercel `ai` SDK
+  (`generateText`, `streamText`, `generateObject`), `langchain` / `@langchain/*`,
+  **custom fetch clients** (`fetch("https://.../chat/completions")`), and
+  **edge / serverless handlers** that wrap a model call in a route function.
+
+Cheap discovery commands (illustrative, read-only):
+
+```sh
+rg -n -i "openai|anthropic|litellm|langchain|llama.?index|dspy|instructor|pydantic.ai|autogen|crewai" --type py
+rg -n -i "openai|@anthropic-ai/sdk|\bai\b|langchain|chat/completions" --type ts
+rg -n -i "chat\.completions|messages\.create|generateText|generateObject|init_chat_model" -g '!**/node_modules/**'
+rg -n -i "_API_KEY|_BASE_URL|_MODEL\b|API_VERSION" --hidden -g '.env*' -g '*.py' -g '*.ts'
+```
+
+### Output of this step
+
+A short **call-site inventory** carried into the harness/environment steps and
+surfaced to the developer early:
+
+- the call sites (file + rough line range), grouped by the wrapper they share;
+- the **current model/provider** in use (id + provider, from config/env names);
+- the **current harness** — app route, existing eval suite, framework runner, or
+  none;
+- the **current eval state** — existing scorer/metric, traces available, or
+  nothing measured yet;
+- any **routing** already present (cascade, fallback, custom `*_BASE_URL`
+  gateway) and any **constraints** found in docs/env.
+
+This inventory directly populates `environment.json` (model/provider/route) and
+points the harness step at the right entrypoint. If nothing measurable exists,
+say so plainly and proceed to the eval-harness build below.
 
 ## Capture / import (get the data local)
 
@@ -30,6 +126,85 @@ Turn the opportunity into a local dataset the harness can run against:
    split boundary, owner, and approval gates.
 4. Feed the selected source into `harness.json` + `splits.json`. Raw rows stay
    local; reports carry path refs, row ids, hashes, counts, and schemas only.
+
+## Eval-harness discovery + build
+
+A baseline is only trustworthy if it runs against a real, repeatable eval. Reuse
+before you build, then build the smallest meaningful harness that scores the
+target behavior. Tie everything to the artifact contract so the next worker can
+trust it by hash.
+
+### Discover existing tests/evals
+
+From the repo inspection above, open the eval/test dirs and read what already
+scores model behavior:
+
+- existing eval suites, golden files, snapshot tests, rubric configs, or judge
+  prompts — reuse the scorer rather than inventing a metric;
+- assertions or notebooks that already encode "good output" for this task;
+- CI jobs that run any of the above (`.github/workflows/`) — a harness that
+  already runs in CI is the cheapest one to make repeatable.
+
+If a usable scorer exists, adopt it as the validator in `metric.json` and record
+where it came from. If none exists, build one (below).
+
+### Identify the target behavior
+
+Name the one behavior this loop improves, tied to the chosen value lens from
+discovery (latency, cost, quality, reliability, portability). The metric must
+measure *that* behavior, not a convenient proxy — optimizing a proxy is how
+prior runs scored 0/12 (see `SKILL.md` → Required Checks step 3).
+
+### Build a small but meaningful eval set
+
+- Prefer **real traces** when the inspection found a tracing/logging tool: pull a
+  bounded, redacted set of recorded inputs (and outputs as references where the
+  task allows). Keep raw rows local; the report carries path refs, row ids,
+  hashes, counts, and schemas only.
+- Cover the **distribution that matters** — easy and hard cases, known failure
+  modes, edge cases the developer cares about — not just the happy path. A
+  focused 20–50 row set that exposes real failures beats a large bland one.
+- If no captured data exists, build a clearly-labeled **synthetic fixture** (see
+  Acquire-fresh) and mark every synthetic result as such.
+
+### Define metrics aligned to the objective
+
+Set the primary metric to the value lens and write it into `metric.json` with the
+validator `kind`, threshold, tie-breakers, and failure taxonomy per `SKILL.md`.
+The metric must emit natural-language *why/what-to-change* feedback, not a bare
+scalar. Keep `schema_pass` separate from `quality_pass`. Get human `approved:
+true` before trusting it.
+
+### Create task fixtures, run the incumbent baseline, store results
+
+- Turn the selected rows into reproducible task fixtures the harness can replay
+  (frozen inputs + expected-behavior refs), recorded in `harness.json` and
+  `splits.json` with a deterministic seed or frozen row ids.
+- Run the **incumbent route** discovered above through the frozen
+  harness/metric/splits. Record per-row pass/fail (not just an aggregate) so the
+  next step can see headroom.
+- Store the run in `baseline.json` with command, timestamp, split, sample size,
+  score, latency basis, cost basis if available, failures, caveats, and the
+  `harness_sha256` / `metric_sha256` / `splits_sha256` of the exact artifacts
+  used. The hash binding is what lets a later candidate be compared on the
+  *same* eval.
+
+### Make it repeatable in CI
+
+Where the inspection found a CI config, express the harness as a command CI can
+run (or note the smallest change that would make it runnable). A baseline that
+re-runs deterministically on every change is the strongest evidence the loop can
+hand forward. Keep it local-only and gate any provider spend per Safety Gates.
+
+### Multi-turn / tool-use / agentic workloads → route out
+
+If the inspection shows a **multi-turn tool-calling loop** (an agent that plans
+over turns and calls live tools), do **not** build a single-output harness here.
+A single-shot prompt/response harness cannot score *how* the agent searches.
+Route the eval to [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md),
+which adopts a verifiers environment as the harness (tools held fixed, policy
+model varied) and still lands in the same `.understudy/capture-evidence/`
+artifact contract. Single output with no tool loop stays here.
 
 ## Acquire-fresh (when no usable data exists)
 

--- a/skills/optimize-agentic-search/SKILL.md
+++ b/skills/optimize-agentic-search/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: optimize-agentic-search
+description: Use to evaluate and optimize an agentic / tool-use workload (a multi-turn LLM tool-calling loop such as agentic web or hotel search) by holding tools fixed and A/B-testing the policy model on quality, latency, and cost — before any RL handoff.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: true
+---
+
+# Optimize Agentic Search
+
+Use this worker when the workload is an **agentic / tool-use loop**: an LLM that
+plans over multiple turns and calls live tools (web search, retrieval, hotel or
+flight lookup, code execution) before producing an answer. The model's policy is
+the variable; the tools are held fixed. The goal is to pick the policy model you
+would ship on a **multi-objective** basis — quality and latency and cost — using
+only skills and the public CLI, with no new product code.
+
+This is not the handoff skill. Reach for
+[`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md)
+only after model A/B and prompt optimization are exhausted and the evidence
+shows the agent must *learn stateful behavior*.
+
+## Safety Gates
+
+Default to the cheapest path that still reaches a decision — not to zero spend (a
+skipped improvement has real opportunity cost). Get the developer's explicit
+approval before any upload, hosted run, or provider spend, including every live
+tool call and every gateway eval run.
+
+Do not run live provider calls, tool calls, hosted jobs, model downloads, or
+uploads without a named surface, capped spend, exact data class, a reviewed
+dry-run or local plan, and a visible output path under `.understudy/`. Follow the
+repo public boundary in
+[`../../docs/privacy-and-data-boundaries.md`](../../docs/privacy-and-data-boundaries.md)
+for prompts, completions, tool outputs, traces, datasets, repo paths, and
+secrets. Do not print or commit `sk_*` values; let
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) inject
+them into the child process only.
+
+## Resolve CLI
+
+Prefer the installed `understudy` binary. If it is unavailable inside a checkout:
+
+```sh
+npm run build
+node dist/bin.js status --json
+```
+
+## When To Use
+
+Use this skill when **all** of these hold:
+
+- the workload runs a tool-calling loop, not a single prompt-in/answer-out call;
+- success depends on *how the agent searches* (turn count, which tools, in what
+  order), not just the final string;
+- the tools are fixed and available to every candidate model;
+- the developer wants to compare candidate policy models, or shrink a frontier
+  model down to a cheaper one without losing quality.
+
+If the workload emits one output with no tool loop, route to
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) then
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) instead — single
+-output optimization does not need a tool environment.
+
+## Flow
+
+1. **Confirm it is agentic.** Inspect the workload for a multi-turn loop and live
+   tool calls. State the fixed tool set and the policy model that varies. If it
+   is single-output, hand back to `capture-evidence`.
+
+2. **Adopt a verifiers environment as the harness.** Use a Prime Intellect
+   `verifiers` environment (a `vf.Environment` + `Rubric`) as the eval. The
+   `vf-eval` command is the runnable harness; the environment holds the tools
+   fixed so only the policy model changes between runs. Capture this into the
+   `.understudy/capture-evidence/` artifact contract — see
+   [`reference.md`](reference.md) for the env → artifact bridge.
+
+3. **Define multi-objective success.** Quality is a per-criterion LLM-judge
+   rubric that returns natural-language *why/what-to-change* feedback, not a bare
+   score. Latency and cost come for free: a verifiers `ToolEnv` emits
+   `num_turns`, tool-call counts, timing, and token usage per rollout — read
+   those for the latency and cost axes instead of inventing a meter. Record all
+   three axes and an acceptable-regression band in `metric.json`.
+
+4. **Snapshot the tools (determinism gate).** Live web/tool calls are
+   non-deterministic and time-varying, which breaks hash-stable harness/splits
+   and holdout integrity. Freeze the query set and **cache the tool outputs** for
+   those queries so the harness replays reproducibly and the holdout stays clean.
+   See [`reference.md`](reference.md) → Determinism.
+
+5. **PRIMARY intervention — model A/B via the CLI.** This is the main move:
+
+   ```sh
+   understudy models list --json
+   understudy workloads route <workload-id> --project-id <project-id> \
+     --model-id glm-5.1 --traffic-pct 100
+   understudy run -- <vf-eval command>
+   ```
+
+   List public model options, route the project workload to a chosen model at a
+   traffic percentage, then run the `vf-eval` harness through the gateway with
+   `understudy run`. Compare quality vs latency vs cost across candidates and
+   pick the model you would ship. Prerequisite: an A/B split sends only the
+   routed share to the chosen model; the non-routed share needs a configured
+   managed frontier fallback so untouched traffic still completes. Clear a route
+   with `--clear`. Routing detail lives in
+   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+
+6. **SECONDARY intervention — optimize the cheap model's prompt.** If a cheaper
+   model wins on latency and cost but trails on quality, close the gap with a
+   train/dev-only GEPA pass against the feedback-rich rubric, keeping the
+   latency/cost win. Hand this off to
+   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md); never tune
+   on holdout.
+
+7. **Escalate only as a true handoff.** If model swap and prompt optimization
+   both stall while real headroom remains and the agent must learn *stateful*
+   multi-step behavior, route to
+   [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md)
+   for the RL / policy-training rung. This repo never runs that training.
+
+Capture evidence before you optimize, exactly as the rest of the MVP loop
+requires (see [`../understudy/SKILL.md`](../understudy/SKILL.md)). The decision
+must rest on a measured baseline, and any savings statement needs the
+`claim.json` packet that `optimize-workload` enforces.
+
+## Output Standard
+
+End with:
+
+- whether the workload was confirmed agentic and the fixed tool set named;
+- the verifiers environment id and `vf-eval` command used as the harness;
+- the three objective axes (quality / latency / cost) and the baseline numbers;
+- whether tool outputs were snapshotted and the holdout stayed clean;
+- the model A/B result and the model you would ship;
+- result type: evidence-capture, evaluation, optimization-lead, heldout, or
+  handoff;
+- one recommended next command or local action.

--- a/skills/optimize-agentic-search/reference.md
+++ b/skills/optimize-agentic-search/reference.md
@@ -1,0 +1,260 @@
+# Optimize Agentic Search — reference
+
+Deep detail for [`SKILL.md`](SKILL.md). Read this when you actually wire a
+verifiers environment into the Understudy artifact contract and run the model
+A/B. See also [`../optimize-workload/reference.md`](../optimize-workload/reference.md)
+(GEPA, feedback functions, validator kinds) and
+[`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md)
+(the RL rung this skill stops short of).
+
+All examples here are synthetic. Use public model ids (e.g. `glm-5.1`,
+`gpt-5.x`) and public CLI commands only.
+
+## Why Agentic Search Is Different
+
+A single-output workload is one prompt and one scored completion. An agentic
+search workload is a **loop**: the policy model reads the task, calls a tool
+(web search, retrieval, hotel lookup), reads the result, decides whether to call
+again, and eventually answers. Three consequences shape the whole playbook:
+
+- The thing you optimize is the **policy**, not a string template. The tools are
+  shared infrastructure held fixed across every candidate, so a fair comparison
+  is "same tools, different model (or prompt)".
+- Cost and latency are first-class, because a worse policy spends more turns and
+  more tokens to reach the same answer. A model that is cheaper per token can
+  still lose on total cost if it searches inefficiently.
+- The trajectory is **non-deterministic** — live tools return different results
+  minute to minute. That fights the hash-stable artifact contract unless you
+  snapshot tool outputs (see Determinism, below).
+
+## Harness: A Verifiers Environment
+
+Use a Prime Intellect `verifiers` environment as the eval harness. The
+environment is a `vf.Environment` (for tool loops, a `ToolEnv`) plus a `Rubric`.
+The runnable command — conceptually `vf-eval <env-id> --model <model> -n <N>` —
+is what the agent executes; the environment supplies the dataset, the fixed
+tools, and the scoring rubric.
+
+Public docs:
+
+- Verifiers overview: `https://docs.primeintellect.ai/verifiers/overview`
+- Verifiers training: `https://docs.primeintellect.ai/verifiers/training`
+
+The key property: a `ToolEnv` runs the model's tool-calling loop and emits, per
+rollout, the metadata you need for the latency and cost axes **for free** —
+`num_turns`, per-tool call counts, wall-clock timing, and token usage. You do not
+build a separate meter; you read these off the rollout records.
+
+## Bridge: verifiers env → `.understudy/` artifact contract
+
+`capture-evidence` writes the artifact contract the rest of the MVP loop trusts.
+Map the verifiers env onto it so the same gates (freshness, holdout, claims)
+apply to an agentic workload:
+
+### `harness.json` — the runnable env
+
+Record the verifiers env id and the exact `vf-eval` command, plus the fixed tool
+set and the policy-model slot that varies. Synthetic shape:
+
+```json
+{
+  "schema_version": "understudy.harness.v1",
+  "kind": "verifiers-toolenv",
+  "env_id": "agentic-web-search-synthetic",
+  "command": "vf-eval agentic-web-search-synthetic --model ${MODEL} -n ${N}",
+  "fixed_tools": ["web_search", "fetch_page"],
+  "policy_model_slot": "${MODEL}",
+  "tool_snapshot": ".understudy/optimize-agentic-search/tool-cache/",
+  "timeout_s": 120
+}
+```
+
+`${MODEL}` is the only thing that changes between A/B runs. Holding `fixed_tools`
+constant is what makes the comparison about the policy.
+
+### `metric.json` — the rubric, with required feedback
+
+The metric is multi-objective. Quality is the verifiers `Rubric` (a per-criterion
+LLM-judge), and each criterion must return **natural-language why/what-to-change
+feedback**, not a bare number — GEPA and human reviewers both need the diagnosis.
+Latency and cost are derived from the `ToolEnv` rollout metadata. Synthetic
+shape:
+
+```json
+{
+  "schema_version": "understudy.metric.v1",
+  "approved": true,
+  "objectives": {
+    "quality": {
+      "validator": { "kind": "rubric" },
+      "criteria": [
+        { "id": "answer_correct", "description": "Final answer matches the snapshotted ground truth", "review": "llm-judge" },
+        { "id": "cited_source",   "description": "Answer cites a page actually retrieved by a tool call", "review": "llm-judge" },
+        { "id": "no_hallucinated_tool", "description": "Every tool call is a real fixed tool with valid args", "review": "deterministic" }
+      ],
+      "feedback_required": true
+    },
+    "latency": { "source": "toolenv", "fields": ["num_turns", "wall_clock_s"] },
+    "cost":    { "source": "toolenv", "fields": ["prompt_tokens", "completion_tokens", "tool_calls"], "price_assumption": "synthetic" }
+  },
+  "acceptable_regression": { "quality": -0.0, "latency_s": 0.5, "cost_pct": 0 }
+}
+```
+
+Debias the LLM-judge with a swapped two-pass score; never single-pass. Bare
+pass/fail feedback wastes a later GEPA pass — see
+[`../optimize-workload/reference.md`](../optimize-workload/reference.md) →
+Feedback Function and Validator Kinds.
+
+### `splits.json` — freeze the query set
+
+Freeze the verifiers env's query set into train / dev / holdout with deterministic
+row ids and a "no holdout mutation" note. Optimization (prompt repair, GEPA, model
+selection) may use train and dev only; holdout is for one final validation after
+the candidate is frozen.
+
+```json
+{
+  "schema_version": "understudy.splits.v1",
+  "source": "agentic-web-search-synthetic",
+  "seed": 7,
+  "train": ["q-001", "q-004", "q-007"],
+  "dev":   ["q-002", "q-005"],
+  "holdout": ["q-003", "q-006", "q-008"],
+  "holdout_rule": "no mutation of holdout rows, labels, tool snapshots, or thresholds after optimization begins"
+}
+```
+
+### `baseline.json` — one `vf-eval` run, hash-bound
+
+Run the incumbent model once through the frozen harness and record the result with
+the per-row pass/fail set (so headroom is visible) and the three axes. It must
+carry `harness_sha256`, `metric_sha256`, and `splits_sha256` so downstream skills
+can prove freshness.
+
+```json
+{
+  "schema_version": "understudy.baseline.v1",
+  "command": "understudy run -- vf-eval agentic-web-search-synthetic --model gpt-5.x -n 8",
+  "split": "holdout",
+  "sample_size": 8,
+  "quality": 0.75,
+  "latency_s_median": 6.2,
+  "avg_num_turns": 3.4,
+  "cost_per_query": "synthetic",
+  "per_row": [{ "id": "q-003", "quality": 1, "num_turns": 2 }],
+  "harness_sha256": "<sha>",
+  "metric_sha256": "<sha>",
+  "splits_sha256": "<sha>"
+}
+```
+
+If any later change touches the harness, rubric, or splits, route back to
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) for a fresh
+baseline — the hashes will not match otherwise.
+
+## Determinism: snapshot the tool outputs
+
+Live web/tool calls are non-deterministic and time-varying. If the harness hits
+the live web on every run, two problems follow:
+
+1. **Hash instability.** The same query returns different tool results, so the
+   effective harness changes between runs; `harness_sha256` no longer means what
+   it claims, and baseline-vs-candidate comparisons mix model effects with
+   web-drift effects.
+2. **Holdout leakage / drift.** A holdout that silently changes content under you
+   is not a clean holdout — you cannot trust a final number measured against a
+   moving target.
+
+Fix: **snapshot / cache the tool outputs for the frozen query set.** Run each
+fixed tool once over the query set, store the responses under
+`.understudy/optimize-agentic-search/tool-cache/` keyed by (tool, normalized
+args), and have the environment replay from that cache during eval. Now:
+
+- the harness is reproducible and its hash is meaningful;
+- every candidate model sees identical tool results, so the comparison is purely
+  about the policy;
+- holdout integrity holds because holdout tool outputs are frozen with the rows.
+
+Record the snapshot timestamp and source in `harness.json` (`tool_snapshot`).
+Note in caveats that the snapshot reflects a point in time; refresh it
+deliberately (and re-baseline) rather than letting live drift in. Treat the
+cache as local artifact data subject to the same public boundary — do not commit
+scraped third-party content or anything proprietary.
+
+## Primary Intervention: Model A/B
+
+The main lever is swapping the policy model with tools held fixed. Procedure:
+
+1. `understudy models list --json` — enumerate public model options.
+2. For each candidate, route the workload to it and run the frozen harness
+   through the gateway:
+
+   ```sh
+   understudy workloads route <workload-id> --project-id <project-id> \
+     --model-id glm-5.1 --traffic-pct 100
+   understudy run -- vf-eval agentic-web-search-synthetic --model glm-5.1 -n 8
+   ```
+
+3. Read quality from the rubric and latency/cost from the `ToolEnv` rollout
+   metadata. Tabulate quality vs latency vs cost across candidates.
+4. Pick the model you would ship under the `acceptable_regression` band: usually
+   the cheapest/fastest model whose quality stays within band, not the absolute
+   top-quality model.
+5. Clear routes you are done with:
+
+   ```sh
+   understudy workloads route <workload-id> --project-id <project-id> --clear
+   ```
+
+**A/B fallback prerequisite (generic).** A traffic split sends only the routed
+share to the chosen model; the remainder must still complete. That non-routed
+share needs a configured managed frontier fallback so untouched traffic keeps
+working during the experiment. Configure it through the normal gateway/project
+setup in
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md); this
+skill does not describe the internal plumbing.
+
+Inference defaults to Understudy after explicit approval via
+`understudy login --email <developer-email>`; BYO provider keys are a fallback if
+the developer prefers. Keep provider, model, budget, and data class in the local
+run artifact before any live call.
+
+## Secondary Intervention: GEPA the Cheap Model's Prompt
+
+If a cheaper model wins latency/cost but trails on quality, optimize its prompt
+to close the gap while keeping the win. GEPA is train/dev-only and feeds on the
+rubric's natural-language feedback, so a feedback-rich `metric.json` is the
+precondition. Hand the actual run to
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md):
+
+- it refuses stale artifacts (hash check) and never touches holdout;
+- it climbs the cheapest-intervention ladder (prompt prefill/repair → context
+  trimming → route swap → GEPA);
+- it requires `claim.json` before any savings statement.
+
+For an agentic loop, useful prompt targets are: when to stop searching (turn
+budget), how to phrase tool queries, and how to cite retrieved sources. Each maps
+to a rubric criterion, so the feedback is actionable.
+
+## When To Escalate To The Handoff
+
+Escalate to [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md)
+only when **all** of these hold:
+
+- model A/B found no shippable model within the regression band;
+- train/dev GEPA stalled with real headroom remaining;
+- the failure is *stateful* — the agent must learn multi-step behavior (when to
+  branch, backtrack, or re-plan) that a single-output reward cannot teach.
+
+That is the RL / policy-training rung. This OSS repo never runs it; the handoff
+skill prepares the evidence packet and refers to Prime Intellect Verifiers.
+
+## Capture-Evidence And Claim Discipline
+
+Everything above sits inside the standard MVP loop: capture a measured baseline
+before optimizing (see [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)
+and [`../understudy/SKILL.md`](../understudy/SKILL.md)), keep holdout untouched
+until the candidate is frozen, and produce the `claim.json` packet before any
+savings or replacement-readiness statement. Below holdout/live validation, report
+an optimization lead, not a win.

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -73,8 +73,15 @@ validator kinds in [`reference.md`](reference.md):
   `understudy login --email <developer-email>`, then
   `understudy run -- <local command>`. Fall back to the developer's own
   provider keys only if they choose BYO. See reference.md → Inference.
-- **Verifier boundary** — optimize the offline validator only; RL
-  verifiers/environments are a later rung, out of scope here.
+- **Scope boundary** — optimizing the prompt, route, or parser of a workload's
+  policy model is in scope, including an *agentic / tool-use* policy. Treat one
+  full agent rollout as the unit and the rubric as the metric. Only RL
+  *trajectory/policy training* and stateful verifier environments are out of
+  scope; that is the handoff in
+  [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
+  For agentic eval/optimization, set up the rollout harness and rubric in
+  [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md)
+  first, then return here for the GEPA prompt pass.
 - **Stopping rule** — if the scorer saturates to 1.0 fast, the surface is too
   easy; strengthen the metric, don't claim. If GEPA stalls with headroom left,
   recommend the next rung (SFT/distillation); this skill does not train.
@@ -86,7 +93,12 @@ validator kinds in [`reference.md`](reference.md):
    basis, cost basis if available, and failure taxonomy.
 3. Select the cheapest intervention that matches the observed failure mode:
    prompt repair, parser/schema repair, context trimming, route change,
-   candidate model comparison, or GEPA.
+   candidate model comparison, or GEPA. Pick the cheapest *target* that matches
+   the failure too — see [`reference.md`](reference.md) → Optimization-Target
+   Menu for the full list. For an agentic workload, treat latency
+   and cost per rollout as first-class objectives alongside the rubric score —
+   tool-call count, redundant calls, and wasted context are common, optimizable
+   failure modes, not just quality misses.
 4. For GEPA/DSPy execution, use a small local `uv` environment only after
    explicit approval. Do not vendor GEPA/DSPy or depend on a full private
    runtime. The CLI owns a registry-backed adapter wrapper:
@@ -97,7 +109,12 @@ validator kinds in [`reference.md`](reference.md):
    through environment only, and runs train/dev rows through the gateway. GEPA's
    edge is natural-language feedback: the metric must return a diagnosis of
    *why* each failing row failed and what to change, not a bare score — bland
-   feedback wastes the optimizer.
+   feedback wastes the optimizer. For an agentic workload this means the
+   per-criterion rubric must emit, per failing row, a short natural-language
+   note tied to the rollout — e.g. "called search 6 times for a fact on the
+   first result page; tighten the stop condition" or "answer omitted the date
+   filter the question required; add it to the query plan" — rather than a bare
+   `0`.
 5. Keep deterministic work in the TypeScript CLI and this skill's templates. Follow
    [`../../docs/optimize-workload-contract.md`](../../docs/optimize-workload-contract.md)
    for adapter, metric feedback, and claim packet details.
@@ -149,7 +166,10 @@ Do not claim savings without:
 baseline contract, plus `baseline_sha256` and the frozen candidate hash. It
 must also include sample size, split used, score delta, latency basis, cost
 basis, price assumptions, request-volume assumption, confidence level, caveats,
-fallback route, and demotion trigger.
+fallback route, and demotion trigger. For an agentic workload, latency and cost
+basis are per-rollout and mandatory, not optional: report the delta in tool-call
+count and end-to-end rollout cost alongside the rubric delta, so a quality gain
+bought with more calls or higher latency is visible rather than hidden.
 
 No claim may imply replacement readiness, production readiness, or recurring
 savings unless those fields are present and the holdout evidence supports the

--- a/skills/optimize-workload/reference.md
+++ b/skills/optimize-workload/reference.md
@@ -106,12 +106,47 @@ swap → GEPA. Confirm metric, incumbent route, split boundaries, sample size, a
 failure taxonomy first; run the smallest dry-run before any paid step; match the
 intervention to the *observed* failure class, not a guess.
 
+## Optimization-Target Menu
+
+The ladder above is *how* you change. This menu is *what* you change. Before
+spending budget, pick the **cheapest target that matches the observed failure
+mode** — changing a tool description is far cheaper than swapping the model.
+State the chosen target and the failure mode it addresses in the run artifact:
+
+- **System prompt** — instructions, role, constraints applied to every call.
+  Cheap; first stop for instruction-following or formatting misses.
+- **User prompt template** — the per-row scaffold around inputs. For misses
+  driven by phrasing, missing fields, or weak few-shot framing.
+- **Tool descriptions** — names, arg docs, and when-to-use text. For wrong-tool,
+  bad-argument, or redundant-call failures in an agentic workload.
+- **Routing policy** — which model/route a request takes. For failures
+  concentrated on a request class a different route handles better.
+- **Model choice** — the student model itself. Higher commitment; only after
+  cheaper targets stall and headroom remains.
+- **Context-window strategy** — what gets packed and trimmed. For truncation,
+  lost-in-the-middle, or cost-from-bloat failures.
+- **Retrieval parameters** — top-k, chunking, reranking, query construction. For
+  missing-evidence or irrelevant-context failures in a RAG workload.
+- **Retry strategy** — retry count, backoff, and reformulation on failure. For
+  intermittent parse or transient-error failures, not systematic quality misses.
+
 **Decide (turn evidence into one call).** Classify the evidence level, then pick
 **exactly one**: promote, hold, rerun, optimize, train, or publish. Below
 holdout/live validation, mark promotion as **blocked** — emit an optimization
 lead, not a win. The decision packet records: decision + evidence level,
 baseline vs candidate, artifact paths, caveats / missing evidence, and the
 approval-gated next step. This is the same gate `claim.json` enforces.
+
+Two principles hold across every target and lane:
+
+- **Keep a candidate history.** Record each candidate you try — target chosen,
+  variant, score, and why it was kept or rejected — so the trail is auditable
+  and a regression can be rolled back to a known-good prior. Do not overwrite
+  prior candidates; append.
+- **Never claim an improvement without measured before/after evidence.** A delta
+  is only real when baseline and candidate were scored on the same metric and
+  split, and the numbers are tied to the hash-bound `claim.json` contract (see
+  SKILL.md → Claim Rules). No before/after, no claim — only a lead.
 
 ## Inference Boundary
 

--- a/skills/prepare-verifier-handoff/SKILL.md
+++ b/skills/prepare-verifier-handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-verifier-handoff
-description: Use when a workload likely needs a stateful RL verifier/environment or hosted training partner handoff after local validation, GEPA, or rubric reward work is insufficient.
+description: Use only when a workload must learn multi-step behavior via stateful RL / policy training that local rungs cannot satisfy, and needs a hosted RL-training partner handoff. Not for evaluating, A/B-comparing, or prompt/route-optimizing agentic workloads.
 metadata:
   understudy:
     mode: future-release
@@ -10,13 +10,32 @@ metadata:
 
 # Prepare Verifier Handoff
 
-Use this future-release stub when the developer's workload appears to need a
-stateful RL verifier or environment rather than another prompt, parser, route,
-or rubric pass.
+Use this future-release stub only when the developer's workload must **learn
+multi-step behavior by training a policy** (stateful RL) and the local rungs
+cannot satisfy that need. This is the narrow training-handoff path, not a
+catch-all for tool-use or verifier work.
+
+You can already run and evaluate verifier-style environments locally. This skill
+is about the one thing the local rungs do not do: **hosted RL policy training**.
 
 This public repo does **not** run RL training, hosted verifier environments,
-uploads, or partner jobs. The current job is to recognize the handoff, preserve
-evidence, and actively refer the developer to the best external path.
+uploads, or partner jobs. The current job is to confirm the training need,
+preserve evidence, and actively refer the developer to the best external path.
+
+## Decision Gate
+
+Check these before routing here. Most agentic tool-use work stays local:
+
+- Want to **evaluate** an agentic workload, **A/B-compare** models, or **GEPA
+  the prompt** of an agentic workload? Stay local — go to
+  [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md),
+  not here.
+- Still missing a fresh harness, metric, splits, or baseline? Go to
+  [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md).
+- Offline validator plus train/dev prompt or route optimization is enough? Go to
+  [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
+- **Only** continue here once the confirmed need is RL / stateful policy
+  training that the local rungs cannot satisfy.
 
 ## Safety Gates
 
@@ -32,25 +51,23 @@ workflow. Mark the result as a **future Understudy release / partner handoff**.
 
 ## When To Route Here
 
-Route here only after cheaper local rungs have been tried or ruled out:
+Route here only after the Decision Gate confirms this is policy training and the
+cheaper local rungs have been tried or ruled out:
 
-- The confirmed validator needs multi-step trajectory reward, not a single
-  output score.
-- GEPA or prompt repair stalls while real headroom remains.
-- A rubric reward is useful but insufficient because the agent must learn
-  stateful behavior across actions.
-- The workload needs an interactive environment, tool-use trajectory reward, or
-  policy-training loop.
-
-If the workload still lacks a fresh harness, metric, splits, or baseline, route
-back to [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md). If the
-validator is offline and train/dev optimization is enough, route back to
-[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
+- The confirmed need is a policy-training loop, not another evaluation, A/B
+  comparison, or prompt/route pass.
+- The reward signal needs multi-step trajectory credit, not a single output
+  score, and the agent must **learn** stateful behavior across actions.
+- Local prompt or route optimization stalls because the headroom requires
+  learned multi-step behavior, not a better prompt.
+- Running and evaluating the environment locally is no longer enough; the
+  workload needs a hosted training loop over that environment.
 
 ## Current Best Referral
 
-Use Prime Intellect Verifiers as the current preferred referral for RL
-environment work:
+Prime Intellect Verifiers is the current preferred **RL-training partner** path.
+You can build, run, and evaluate verifier environments locally already; route
+here when the developer needs hosted RL training over such an environment:
 
 - Prime Intellect Verifiers overview:
   `https://docs.primeintellect.ai/verifiers/overview`
@@ -74,7 +91,9 @@ Recommended fields:
 
 - `schema_version: "understudy.verifier_handoff.v1"`
 - workload id, owner, and source refs;
-- evidence level reached and why local optimization is insufficient;
+- evidence level reached and why evaluation, A/B comparison, and local
+  prompt/route optimization cannot satisfy the need (i.e. it requires learned
+  policy training);
 - validator or reward signal summary;
 - environment shape: stateless, stateful, tool-use, browser, code, simulation;
 - train/dev/holdout boundary and contamination status;

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: understudy
-description: Use when a developer asks Understudy to understand, evaluate, optimize, prove, or run an AI application workload through Understudy.
+description: Use when a developer asks a coding agent to improve an LLM app or agent — reduce cost or latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, pick a model/route, or route behavior through Understudy. Orchestrates trace → evaluate → optimize → compare → deploy via worker skills. Not for generic coding unless LLM behavior, cost, traces, evals, or routing is involved.
 metadata:
   understudy:
     mode: automatic
@@ -10,59 +10,133 @@ metadata:
 
 # Understudy
 
-Use this as the public MVP entrypoint for Understudy. It is only an
-orchestrator: identify the developer's current capability need, then load
-exactly one worker skill.
+Understudy is agent improvement infrastructure: it helps a coding agent improve
+its developer's LLM system from real traces. This skill is the orchestrator —
+it gives your agent the loop and routes each stage to exactly one worker skill.
+It does not do the work inline.
 
-The OSS loop is local-first and does not require registration, auth, provider
-keys, an Understudy account, or hosted gateway access. Start from files the
-developer already has, create auditable local artifacts, and only cross into
-upload, hosted execution, provider spend, or model downloads after explicit
-approval in the current thread.
+The loop is local-first: it needs no registration, auth, provider keys, account,
+or hosted gateway to start. Begin from files the developer already has, produce
+auditable local artifacts, and only cross into upload, hosted execution, provider
+spend, or model downloads after explicit approval in the current thread.
+
+## The improvement loop
+
+1. Understand the codebase — find where LLM calls happen and the current
+   model / provider / harness / routing / eval setup.
+2. Understand the objective (cost, speed, quality, reliability, compliance, or a
+   weighted mix).
+3. Understand the constraints (what must not be violated).
+4. Capture or locate real traces.
+5. Build or improve a small, meaningful eval harness; rerun the incumbent
+   baseline.
+6. Run local optimization against eval failures.
+7. Compare candidate vs baseline on the objective.
+8. Recommend the most efficient route — harness, model, supplier, gateway/
+   inference-layer route, deployment approach.
+9. Implement the selected route safely (smallest viable change).
+10. Produce an Understudy Agent Improvement Report the developer can review.
+
+## Frame every job
+
+Keep these six separate and explicit — say them back before acting:
+
+- **Objective** — what are we optimizing for?
+- **Constraints** — what are we not allowed to violate?
+- **Evidence** — what traces / evals / prices / measurements do we have?
+- **Route** — what harness / model / supplier / deployment path?
+- **Action** — what does the agent actually change?
+- **Verification** — how do we prove the change helped?
+
+## Default mode
+
+- Local-first.
+- Inspect before changing.
+- Measure before optimizing.
+- Optimize before routing.
+- Compare before deploying.
+- Ask before spending money or uploading data.
+
+Show partial findings early ("found 3 LLM call sites"; "app uses LiteLLM, so
+gateway insertion is low-risk"; "no evals — I'll build a small harness first";
+"stated ZDR constraint blocks hosted upload unless approved").
+
+## Inspect before you ask
+
+Answer from the repo before asking the developer. Read package files, provider/
+model wrappers, env vars, LLM SDK usage, agent frameworks, prompt files, eval and
+test dirs, tracing/logging, deploy and CI config, and any compliance/README/
+architecture docs. The repo-inspection and call-site checklist lives in
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) and its
+`reference.md`.
+
+Ask only what you genuinely cannot infer:
+
+1. What are we optimizing for? (cost / speed / quality / reliability / compliance
+   / weighted mix)
+2. What is the target task? (e.g. support triage, tool-use, classification,
+   extraction, retrieval QA)
+3. Which constraints matter? (SOC 2, ZDR, approved providers, no data leaves the
+   machine, max cost/latency, required model family, region)
+4. Which environment? (local-only, Understudy hosted, private gateway, hybrid)
+
+See [`reference.md`](reference.md) for the intake, objective menus, constraints,
+route-selection taxonomy, fresh-pricing rule, the report template, anti-patterns,
+and worked examples.
+
+## Route to one worker
+
+Identify the developer's current stage and load exactly one:
+
+- **Codebase / evidence not yet pinned down** — LLM call sites, current model/
+  harness, traces, metric, splits, or incumbent baseline are missing, ambiguous,
+  or stale → [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)
+  (also owns repo inspection + eval-harness discovery/build).
+- **Inference / routing / capture / auth / deploy** — Understudy inference,
+  gateway trace capture, project/key management, model A/B via route traffic %,
+  `understudy run`, or registering an improved route →
+  [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+- **Single-output optimization** — fresh artifacts exist and the developer wants
+  to validate, optimize (GEPA), compare candidates, or claim readiness →
+  [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
+- **Agentic / tool-use optimization** — multi-turn agent that calls tools (e.g.
+  web search); evaluate, A/B-compare models, or optimize its prompt/route →
+  [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md)
+  (verifiers env, model A/B through the gateway, prompt-GEPA for the cheap model).
+- **RL / stateful-policy training handoff** — local rungs are insufficient and
+  the agent must *learn* multi-step behavior →
+  [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
+
+Multi-turn or tool-use alone is NOT a handoff: agentic evaluation, A/B, and
+prompt/route optimization stay local in `optimize-agentic-search`. Only RL/
+policy *training* routes to `prepare-verifier-handoff`. When in doubt, route to
+`capture-evidence` — optimizing without a current harness/metric/split/baseline
+creates false progress.
 
 ## Safety Gates
 
-Default to the cheapest path that still reaches an optimization outcome — not to
-zero spend (a skipped improvement has real opportunity cost). Get the
-developer's explicit approval before any upload, hosted run, or provider spend.
+Default to the cheapest path that still reaches an outcome — not to zero spend (a
+skipped improvement has real opportunity cost). Require explicit confirmation for
+any action that uploads data, spends money, changes credentials, deploys
+behavior, or alters a production route — unless the developer has configured
+unattended mode.
 
 Do not ask the developer to register, authenticate, paste secrets, or configure
-provider keys before the local evidence loop has identified a concrete need.
-When that concrete need exists, route through `understudy login --email`
-instead of asking for a pasted key.
+provider keys before the local evidence loop has found a concrete need. When that
+need exists, route through `understudy login --email` rather than a pasted key.
 
-Follow the repo public boundary in
+Follow the public boundary in
 [`../../docs/privacy-and-data-boundaries.md`](../../docs/privacy-and-data-boundaries.md):
-do not upload, print, commit, or transmit prompts, completions, traces, labels,
+never upload, print, commit, or transmit prompts, completions, traces, labels,
 datasets, repo paths, secrets, or private notes without explicit approval for
-that exact data class and action.
+that exact data class and action. Honor detected constraints (SOC 2, ZDR,
+local-only, approved providers) — see [`reference.md`](reference.md).
 
-## Route
-
-Route to one worker:
-
-- If the developer asks for Understudy inference, gateway routing, project/key
-  management, hosted execution, authenticated cookbook setup, or durable CLI
-  execution to monitor, read
-  [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
-- If the workload is not yet pinned down, the harness is stale or missing, the
-  scoring metric is ambiguous, split boundaries are not frozen, or the
-  incumbent baseline has not been rerun, read
-  [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md).
-- If fresh workload artifacts already exist and the developer wants to validate,
-  improve, optimize, compare candidates, or claim readiness, read
-  [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
-- If local validation/optimization has exposed a need for a stateful RL
-  verifier or environment, and the developer needs a future-release or partner
-  handoff rather than another local optimizer run, read
-  [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
-
-When in doubt, route to `capture-evidence`. Optimization without a current
-harness, metric, split contract, and incumbent baseline creates false progress.
+Never claim a cost, latency, quality, or availability win without measured
+before/after evidence, and never make pricing/availability claims from memory —
+use fresh data and label assumptions ([`reference.md`](reference.md)).
 
 ## MVP Artifact Contract
-
-The public MVP skill tree uses these local artifacts:
 
 ```text
 .understudy/capture-evidence/harness.json
@@ -74,26 +148,28 @@ The public MVP skill tree uses these local artifacts:
 .understudy/optimize-workload/claim.json
 ```
 
-`capture-evidence` creates or refreshes the first five artifacts.
-`optimize-workload` may only optimize from fresh copies of
-`harness.json`, `metric.json`, `splits.json`, and `baseline.json`.
+`capture-evidence` creates or refreshes the first five. `optimize-workload` may
+optimize only from fresh copies of `harness.json`, `metric.json`, `splits.json`,
+and `baseline.json`. Freshness is hash-bound: `baseline.json` carries
+`harness_sha256`, `metric_sha256`, and `splits_sha256`; any later change to the
+harness, metric, validator, or splits routes back to `capture-evidence`.
 
-Freshness is hash-bound, not a presence check. `baseline.json` must include
-`harness_sha256`, `metric_sha256`, and `splits_sha256` computed from the
-confirmed artifacts it measured. Any later change to the harness, metric,
-validator, or splits routes back to `capture-evidence` for a new incumbent
-baseline.
-
-Removed Python prototype commands and deleted draft skills are tracked in
-[`../../docs/current-functionality.md`](../../docs/current-functionality.md).
-Do not route to deleted skills or commands.
+Removed Python-prototype commands and deleted draft skills are tracked in
+[`../../docs/current-functionality.md`](../../docs/current-functionality.md). Do
+not route to deleted skills or commands.
 
 ## Output Standard
 
 End with:
 
 - worker skill used or recommended;
+- where you are in the loop, and the Objective / Constraints / Evidence / Route /
+  Action / Verification state;
 - artifacts inspected, created, or still missing;
-- result type: evidence-capture, validation, optimization, or blocked;
+- result type: evidence-capture, validation, optimization, route-recommendation,
+  deployment, or blocked;
 - approval boundary for any upload, spend, hosted execution, or download;
 - one recommended next command or local action.
+
+For a completed improvement, produce the **Understudy Agent Improvement Report**
+(template in [`reference.md`](reference.md)).

--- a/skills/understudy/reference.md
+++ b/skills/understudy/reference.md
@@ -1,0 +1,162 @@
+# Understudy orchestrator — reference
+
+Depth for [`SKILL.md`](SKILL.md). The orchestrator routes; the workers do the
+work. This file holds the framing the orchestrator reuses across every job:
+intake, objective menus, constraints, route selection, the fresh-pricing rule,
+the report template, anti-patterns, examples, and a glossary.
+
+## Intake (ask only what you can't infer)
+
+Inspect the repo first (see `capture-evidence`), then ask at most these four:
+
+1. **Objective** — cost, speed, quality, reliability, compliance, or a weighted
+   mix.
+2. **Target task** — e.g. support-ticket triage, coding-agent tool use, bug
+   classification, retrieval QA, extraction, sales-email generation, internal
+   workflow automation.
+3. **Constraints** — SOC 2, ZDR, approved providers, no data leaves the machine,
+   max cost/run, max latency, required model family, hosting region.
+4. **Environment** — local-only, Understudy hosted, private gateway, or hybrid.
+
+Do not ask anything the repo answers. Surface what you found instead.
+
+## Objective menus
+
+- **A. Quality** — task success rate, classification accuracy, tool-use
+  correctness, extraction quality, reliability, fewer hallucinations, better
+  instruction following.
+- **B. Cost** — cheaper model for easy cases, premium model only for hard cases,
+  cache/batch repeats, fewer tokens, prompts that avoid retries, swap a
+  provider/model when equivalent quality is cheaper.
+- **C. Speed** — lower latency, faster provider/model, fewer tool calls,
+  parallelize safe steps, simpler prompts, small models for routing/triage.
+- **D. Constraints** — see below; treat as hard limits, not objectives.
+- **E. Route** — best harness / model / supplier; local vs hosted; when to use
+  the Understudy inference layer, gateway-only, or local-only.
+
+A single change often moves several at once (e.g. a prompt that stops retries
+cuts both cost and latency) — measure all affected axes, not just the target.
+
+## Constraints (detect, respect, gate)
+
+Detect from the repo and the developer: SOC 2, ZDR, local-only, data-retention
+limits, PII handling, credential boundaries, approved-provider lists, budget
+ceilings, latency SLOs, security-review requirements, production change controls.
+Look in compliance docs, READMEs, env var names, provider config, and CI.
+
+Respect them as hard limits. Map each to allowed actions, e.g.:
+
+- **ZDR / no hosted upload** → local-only traces; no hosted trace upload unless
+  explicitly approved; local optimization only.
+- **Approved providers only** → never propose or switch to an unlisted provider.
+- **Region/residency** → only routes/suppliers in the allowed region.
+- **Budget ceiling / latency SLO** → reject candidates that exceed it even if
+  quality wins.
+
+Any action that uploads data, spends money, changes credentials, deploys
+behavior, or alters a production route requires explicit confirmation unless
+unattended mode is configured. State the data class and the exact action.
+
+## Route selection
+
+Recommend the most efficient route across four axes:
+
+- **Harness** — existing app harness, the Understudy trace/eval harness, a
+  framework-specific harness, or a custom lightweight one.
+- **Model** — current, smaller/cheaper, stronger-for-hard-cases, local, or
+  fallback.
+- **Supplier** — current provider, an alternative, the Understudy inference
+  layer, a private deployment, or a local runtime.
+- **Routing strategy** — single model, cascade, router model, confidence-based
+  escalation, or cost-/latency-/compliance-aware routing.
+
+Execute and measure routes through the gateway primitives (see
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)):
+`understudy models` to see public options, `understudy workloads` to route a
+workload to a model at a traffic percentage (A/B), `understudy run` to drive an
+eval through the gateway, and the `route-decision` packet to record the choice.
+
+### Fresh-pricing rule
+
+Never make cost, availability, or capability claims from memory. Use fresh data:
+the Understudy platform/model catalog where available, and official provider docs
+or the web otherwise. Label every assumption and date it. A pricing claim without
+a current source is not a claim — it's a guess.
+
+## Deploy and compare
+
+Keep the baseline reproducible. Apply the smallest viable change — prefer config
+or a workload route over editing hardcoded call sites. Register/route the improved
+behavior through the inference layer when appropriate (gateway route + traffic %),
+or write a local deployment artifact / `understudy.yaml` in local-only mode.
+Always include rollback steps, run comparison evals, show before/after metrics,
+and list regressions — never bury them.
+
+## Understudy Agent Improvement Report
+
+Produce this for every completed improvement attempt:
+
+```text
+# Understudy Agent Improvement Report
+1. Objective
+2. Constraints
+3. Current architecture
+4. Trace source
+5. Eval harness
+6. Baseline results
+7. Optimization method
+8. Candidate changes
+9. Route recommendation
+10. Before/after comparison
+11. Cost / latency / quality tradeoffs
+12. Risks and regressions
+13. Deployment steps
+14. Rollback steps
+15. Open questions
+```
+
+## Anti-patterns (do not let the agent do these)
+
+- Rewrite large parts of the app before measuring a baseline.
+- Optimize without an eval.
+- Claim an improvement without a before/after comparison.
+- Upload traces without confirmation, or expose secrets.
+- Switch providers without checking constraints.
+- Make pricing/availability claims without current data.
+- Deploy production changes without approval.
+- Bury or omit regressions.
+
+## Examples
+
+- **Cheaper support triage** — inspect repo → find provider/prompts → confirm the
+  triage task → build/locate eval → capture traces → measure tokens+latency →
+  split easy/hard → propose a cheaper route → optimize the prompt → compare cost
+  and quality → recommend the route (`capture-evidence` → `optimize-workload` /
+  `use-understudy-gateway`).
+- **Tool-use reliability** — inspect tool defs + traces → build evals from failed
+  tool calls → optimize tool descriptions/system prompt → compare success rate →
+  report regressions (`optimize-agentic-search`).
+- **SOC 2 + ZDR quality** — confirm the data boundary → local-only traces, no
+  hosted upload → approved providers only → local optimization → report suitable
+  for security review.
+- **Fastest safe route** — baseline latency → check current model availability
+  (fresh data) → latency-aware eval → test candidates → recommend by measured
+  latency at a quality threshold (`use-understudy-gateway` route A/B).
+- **Gemma-4 demo** — run a small task suite with Gemma-4 through the Understudy
+  gateway (mock provider if unavailable) → capture → eval → optimize → compare →
+  report the full loop.
+
+## Glossary
+
+- **Harness** — the runnable shape that executes the task and scores it
+  (app-native, Understudy artifact contract, or a verifiers env).
+- **Route** — the chosen harness + model + supplier + routing strategy +
+  deployment path.
+- **Trace** — a recorded LLM/tool call (prompt, response, tool calls, latency,
+  tokens, errors, metadata) captured through the gateway.
+- **Baseline / candidate** — the incumbent vs a proposed change, scored on the
+  same frozen eval split.
+- **Claim** — a hash-bound, evidence-backed statement of measured improvement
+  (`optimize-workload` `claim.json`).
+- **Local-only / hosted / gateway / hybrid** — where work runs and whether data
+  leaves the machine.

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -14,8 +14,8 @@ Use this worker when the developer wants to run an application workload through
 Understudy-managed inference or needs the CLI to execute a durable command while
 the agent monitors status and artifacts.
 
-The local evidence loop does not require auth. Route here only when the
-developer explicitly asks for Understudy inference, gateway routing, project/key
+The local evidence loop does not require auth. Route here only when the developer
+explicitly asks for Understudy inference, gateway routing, project/key
 management, workload route configuration, hosted execution, or an authenticated
 cookbook.
 
@@ -24,17 +24,17 @@ cookbook.
 Do not ask the developer to paste an API key. Use the CLI registration flow and
 let the CLI store credentials outside the repo.
 
-Do not print, commit, or write `sk_*` values into artifacts. `understudy
-run` injects `UNDERSTUDY_API_KEY` and `UNDERSTUDY_GATEWAY_URL` only into the
-child process environment.
+Do not print, commit, or write `sk_*` values into artifacts. `understudy run`
+injects `UNDERSTUDY_API_KEY` and `UNDERSTUDY_GATEWAY_URL` only into the child
+process environment.
 
 Do not run provider calls, uploads, hosted jobs, or model downloads without the
 developer approving the exact command, data class, and spend or download bound.
 
 ## Resolve CLI
 
-Prefer the installed `understudy` binary. If it is unavailable inside a
-repo checkout, run through the package script:
+Prefer the installed `understudy` binary. If it is unavailable inside a repo
+checkout, run through the package script:
 
 ```sh
 npm run build
@@ -55,9 +55,9 @@ node dist/bin.js status --json
    understudy login --email <developer-email>
    ```
 
-   If the current agent has an approved native email connector, it may search
-   narrowly for the fresh Understudy sign-in email, read the one-time code, and
-   enter it into the waiting CLI prompt. Do not print or persist the code.
+   An agent with an approved native email connector may search narrowly for the
+   fresh sign-in email and enter the one-time code into the waiting CLI prompt.
+   Do not print or persist the code.
 
 3. Confirm project/key readiness:
 
@@ -67,21 +67,10 @@ node dist/bin.js status --json
    ```
 
 4. For frontier-vs-Understudy A/B routing, list public model IDs and set a
-   bounded workload route:
-
-   ```sh
-   understudy models list --json
-   understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 10
-   ```
-
-   The agent must not expose or ask for supplier/provider details. The
-   application keeps calling the normal gateway path; the control-plane route
-   decides what percentage goes to the selected Understudy model and what
-   remains passthrough/frontier. To clear the route:
-
-   ```sh
-   understudy workloads route <workload-id> --project-id <project-id> --clear
-   ```
+   bounded workload route — see the **A/B model routing** recipe below for the
+   commands and the split mechanics. The agent must not expose or ask for
+   supplier/provider details; the app keeps calling the normal gateway path while
+   the control-plane route decides the split.
 
 5. Run the local command through the gateway wrapper only after approval:
 
@@ -91,7 +80,44 @@ node dist/bin.js status --json
 
 6. Monitor the command output and local artifacts. For optimization work, route
    back to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) once
-   the gateway-backed run has produced candidate/proof evidence.
+   the run has produced candidate/proof evidence.
+
+## A/B model routing
+
+Use this recipe to A/B a chosen public model against passthrough while an eval
+runs through the gateway. A typical consumer is
+[`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md),
+comparing a workload's quality and cost across the split.
+
+1. Discover public model options (public model IDs only; no supplier detail):
+
+   ```sh
+   understudy models list --json
+   ```
+
+2. Route a workload to a model at a traffic percentage — a per-request split
+   where that share goes to the routed model and the rest stays on passthrough.
+   Pick a bounded share (e.g. 30%) to keep the comparison small.
+
+   ```sh
+   understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 30
+   ```
+
+   Clearing the route (`--clear` in place of the model/traffic flags) returns the
+   workload to full passthrough.
+
+3. Run the eval through the gateway so the routed model serves its share. Any
+   local command works; an eval harness like a verifiers `vf-eval` run is typical.
+
+   ```sh
+   understudy run -- vf-eval <eval-id>
+   ```
+
+4. Prerequisite for a frontier comparison. For the split to compare the routed
+   model against a frontier model, the non-routed (passthrough) share must have a
+   configured managed frontier; without it those requests error. This is usually
+   account setup, not a per-run flag, so confirm it before starting an A/B —
+   otherwise only the routed share returns results.
 
 ## Output Standard
 
@@ -103,3 +129,20 @@ End with:
 - command run or blocked;
 - whether provider calls or hosted execution were approved;
 - local artifact path or next CLI command to monitor.
+
+## References
+
+Domain depth in [`reference.md`](reference.md):
+
+- **Trace capture** — gateway or local trace capture without changing the app
+  interface; capture calls/prompts/responses/tool calls/latency/errors/tokens/
+  metadata; redact; skip upload in local-only / restricted (ZDR) modes; produce a
+  trace inventory (defer call-site discovery to
+  [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)).
+- **Deploy and compare** — reproducible baseline, smallest route/config change
+  via the workloads API (or a local `understudy.yaml`), rollback, comparison
+  evals, before/after metrics, surfaced regressions.
+
+For route selection and the fresh-pricing rule, see
+[`../understudy/reference.md`](../understudy/reference.md); for measured claims,
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).

--- a/skills/use-understudy-gateway/reference.md
+++ b/skills/use-understudy-gateway/reference.md
@@ -1,0 +1,137 @@
+# Use Understudy Gateway — reference
+
+Depth for [`SKILL.md`](SKILL.md). This worker is the inference/routing/capture/
+deploy stage. The cross-cutting framing — intake, objective menus, the
+route-selection taxonomy, and the fresh-pricing rule — lives in the orchestrator
+and is not duplicated here. Read
+[`../understudy/reference.md`](../understudy/reference.md) for route selection
+across harness/model/supplier/strategy and for the rule that pricing,
+availability, and capability claims must come from fresh data, never memory.
+
+The two workflows below are the domain depth this worker owns: capturing model
+calls into a trace inventory, and deploying an improved behavior through the
+inference layer with a measured before/after comparison.
+
+## Workflow 1 — Trace capture
+
+Goal: turn a running app's LLM calls into a local, redacted trace inventory the
+rest of the loop can score, without changing app behavior and without uploading
+anything that the developer has not approved.
+
+1. **Find the LLM call sites.** If the call sites are already known, list them.
+   Otherwise defer discovery to
+   [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md), which scans
+   the repo read-only for model clients, prompt strings, eval suites, and trace
+   exports. Do not duplicate that scan here; carry its inventory forward.
+2. **Determine whether gateway routing is already present.** Check whether calls
+   already go through an Understudy gateway base URL / the `understudy run`
+   wrapper, or hit a provider SDK directly. This decides whether capture is a
+   config flip or needs a collector in front of the existing client.
+
+   ```sh
+   understudy status --json
+   ```
+3. **Configure trace capture, preserving the app interface.** Prefer the path
+   that leaves the application code untouched:
+   - *Gateway already in place* — enable gateway trace capture for the workload
+     so calls are recorded as they pass through. The app keeps calling the same
+     base URL.
+   - *Provider SDK direct* — point the existing client's base URL at the gateway
+     (an OpenAI-compatible base URL plus the injected key from
+     `understudy run`), so the SDK, request shape, and response shape are
+     unchanged and only the endpoint moves.
+   - *Restricted / offline* — when the environment is local-only or hosted
+     capture is disallowed (for example a ZDR constraint, see
+     [`../understudy/reference.md`](../understudy/reference.md) → Constraints),
+     do **not** route through the hosted gateway. Stand up a local trace
+     collector (a logging wrapper or local proxy in front of the existing
+     client) that writes traces to disk only.
+4. **Capture the full record per call.** Each trace row should include: the
+   model id requested and served, the rendered request messages, the response
+   text, any tool calls and tool results, latency, error/status, token usage
+   (prompt/completion/total), and run metadata (timestamp, workload id, route,
+   attempt/retry, split or fixture ref). This is what later steps need to score
+   quality, cost, and latency together.
+5. **Redact sensitive values before anything leaves the call site.** Strip or
+   hash secrets, API keys, PII, and customer-identifying fields. Record redacted
+   examples and field schemas rather than full message bodies when the payload
+   class is sensitive. Follow
+   [`../../docs/privacy-and-data-boundaries.md`](../../docs/privacy-and-data-boundaries.md).
+6. **Do not upload in local-only or restricted modes.** In local-only mode, or
+   under a ZDR / no-hosted-upload constraint, traces stay on disk and are never
+   sent to the hosted platform. Hosted capture and any upload require explicit
+   confirmation of the exact action and data class (unless unattended mode is
+   set). State where traces are written.
+7. **Produce a trace inventory.** Summarize counts, the distinct call sites and
+   models covered, the captured fields present per row, latency/token/error
+   distributions, the redaction applied, and the on-disk path — paths, counts,
+   hashes, and schemas, not raw payloads. Hand the inventory to
+   `capture-evidence` to become `harness.json` / `splits.json` / `baseline.json`.
+
+Write capture artifacts under a local path such as
+`.understudy/use-understudy-gateway/traces/`.
+
+## Workflow 2 — Deploy and compare
+
+Goal: ship the smallest viable improvement through the inference layer, prove it
+against the baseline, and make rollback and any regression obvious. Confirmation
+rules below apply to every upload, spend, credential, deploy, or route change.
+
+1. **Keep the baseline reproducible.** Pin the incumbent route, the frozen eval
+   split, and the captured baseline metrics before changing anything. Reuse the
+   `capture-evidence` `baseline.json` contract so the comparison is hash-bound to
+   the same harness, metric, and splits.
+2. **Apply the smallest viable change.** Prefer a config or route change over
+   editing hardcoded call sites: a model swap, a routed traffic split, a prompt
+   variant, or a parser fix is usually enough. Editing call sites directly is the
+   last resort and must be reversible.
+3. **Register / route the improved behavior through the inference layer.** Use
+   the workloads route API to send a bounded share of traffic to the improved
+   model. The app keeps calling the normal gateway path; the control-plane route
+   decides the split. The traffic percentage is a per-request share.
+
+   ```sh
+   understudy models list --json
+   understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 10
+   ```
+
+   See [`SKILL.md`](SKILL.md) → A/B model routing for the full split mechanics
+   and the managed-frontier prerequisite for a frontier comparison.
+4. **Local-only mode: write a deployment artifact instead of routing.** When no
+   hosted route is allowed, write the chosen route to a local deployment artifact
+   / `understudy.yaml` (model id, traffic intent, prompt/parser version, baseline
+   refs) so the change is captured and reproducible without touching the hosted
+   control plane.
+5. **Include rollback steps.** Record the exact command to revert. For a routed
+   change that is clearing the route back to full passthrough:
+
+   ```sh
+   understudy workloads route <workload-id> --project-id <project-id> --clear
+   ```
+
+   For a local artifact, rollback is restoring the previous `understudy.yaml` /
+   config. Always state the demotion trigger that should cause a rollback.
+6. **Run comparison evals.** Drive the same frozen eval through the gateway so
+   the routed share is served by the improved model, and score it on the same
+   metric and split as the baseline.
+
+   ```sh
+   understudy run -- <eval command>
+   ```
+7. **Show before/after metrics and list regressions.** Report the baseline and
+   candidate side by side on every affected axis — quality, cost (tokens and
+   spend), latency, and reliability — and call out per-row or per-axis
+   regressions explicitly. Never bury a regression behind an aggregate win: a
+   quality gain bought with higher latency or more tool calls must be visible.
+   For a measured improvement statement, route the claim through
+   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md), which binds
+   it to a claim packet.
+
+## Confirmation gate
+
+Any action that uploads data, spends provider budget, changes credentials,
+deploys behavior, or alters a production route requires explicit confirmation of
+the exact action and data class in the current thread — unless unattended mode is
+configured. State the surface, the data class, and the spend or traffic bound
+before acting. Discovery, local capture, redaction, and reading status are
+local-only and do not need spend approval.


### PR DESCRIPTION
## What

Folds the "agent-improvement skill pack" into the **existing** skill tree — no parallel pack, **no product code**, all markdown playbooks. The `understudy` router becomes the orchestrator for the full `trace → evaluate → optimize → compare → deploy` loop and delegates each stage to a worker skill.

## Changes

**New worker**
- `optimize-agentic-search` — evaluate/optimize agentic, tool-use workloads (verifiers env, model A/B through the gateway, prompt-GEPA for the cheap model). The local path previously punted to verifier-handoff.

**Orchestrator (the merge)**
- `understudy/SKILL.md` — improvement loop, Objective/Constraints/Evidence/Route/Action/Verification frame, default mode, repo-first intake, worker routing table.
- `understudy/reference.md` (new) — intake, objective menus, constraints detect-and-gate, route-selection taxonomy + **fresh-pricing rule**, the 15-section **Understudy Agent Improvement Report**, anti-patterns, worked examples, glossary.

**Worker depth**
- `capture-evidence` — repo-inspection / LLM-call-site discovery (Python + TS integration points) + eval-harness discovery/build, bound to the artifact contract.
- `use-understudy-gateway` — new `reference.md`: trace-capture (redact, no-upload in local-only/ZDR, inventory) + deploy-and-compare (route register + local fallback + rollback).
- `optimize-workload` — optimization-target menu (prompt / tool descriptions / routing / model / context / retrieval / retry).
- `prepare-verifier-handoff` — narrowed to RL/policy-training handoff with a decision gate.
- `skills/README.md` + router wired to the new worker; `.scratch/` gitignored.

## Why this shape

Enhance the skills we already have rather than ship a second parallel system; thin CLI / fat skills. Every "workflow" is a skill section, so a coding agent can drive the loop on the developer's behalf.

## Validation

`npm run check` green — `ok 6 public skills`, cookbook examples, npm package dry-run; tests `fail 0`. Public boundary respected (synthetic examples, public CLI + model ids; no internal ids/secrets/customers).

> Drafted by a coding agent; please review the skill prose for voice/accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->