### PR TITLE
Skills: run-local-model-lab + open-model spotlight (Gemma 4 & Nemotron 3)

### DIFF
--- a/docs/open-model-spotlight.md
+++ b/docs/open-model-spotlight.md
@@ -1,0 +1,95 @@
+# Open-Model Spotlight: Gemma 4 & Nemotron 3
+
+Two American, open-weight, well-documented model families that pair cleanly with
+Understudy's **remote ↔ local** pattern. This doc is the reusable reference for
+[`skills/use-understudy-gateway`](../skills/use-understudy-gateway/SKILL.md)
+(remote inference + routing) and
+[`skills/run-local-model-lab`](../skills/run-local-model-lab/SKILL.md) (local
+experimentation).
+
+Verify model ids, sizes, and prices against official sources before quoting —
+prices below are indicative (~June 2026, third-party hosts) and move.
+
+## The remote ↔ local pattern (the reusable part)
+
+Iterate cheaply and privately on a **small local** model, then graduate to a
+**larger remote** model in the Understudy catalog when you need the quality —
+ideally within the **same family**, so prompts and behavior transfer:
+
+```
+local (small, $0 inference, private, ZDR/SOC2-safe)
+        →  remote (larger, via Understudy: `understudy models` / `workloads` route)
+same family ⇒ optimized prompts carry over with minimal rework
+```
+
+Run local with `run-local-model-lab`; route/serve remote with
+`use-understudy-gateway`; compare both on one frozen eval (capture-evidence).
+
+## Google Gemma 4
+
+Launched **2026-04-02** (E2B, E4B, 26B-A4B MoE, 31B Dense); **12B Unified
+~2026-06** (multimodal incl. audio, encoder-free). Optimizes the small-to-mid,
+multimodal, on-device end.
+
+| Variant | Size (active) | Context | Modalities |
+|---|---|---|---|
+| E2B / E4B | 2.3B / 4.5B eff. | 128K | text, image, audio |
+| 12B Unified | 12B | 256K | text, image, audio |
+| 26B A4B (MoE) | 25B / ~3.8B | 256K | text, image |
+| 31B Dense | 30.7B | 256K | text, image |
+| `*-it-assistant` | — | — | speculative-decoding **drafters**, not standalone |
+
+Benchmarks (instruct): 31B — MMLU-Pro 85, GPQA 84, LiveCodeBench 80; 26B —
+83/82/77; 12B — 77/79/72. Cloud (31B, indicative /1M): ~$0.12 in / $0.37 out
+(third-party hosts; free tiers exist).
+
+**Via Understudy** — remote: `gemma-4-31b-it`. Local (`run-local-model-lab`):
+E2B / E4B / 12B / 26B-MoE / 31B — **$0 inference**.
+
+## NVIDIA Nemotron 3
+
+Hybrid **Mamba-Transformer MoE**, **1M-token context**, throughput-first,
+agentic-reasoning focus, and the **most open release** (weights + ~3T pretraining
+tokens + 18M post-training samples + RL gym environments). Nano launched
+**2026-04-28**; Super & Ultra rolling out through 2026.
+
+| Variant | Size (active) | Notable |
+|---|---|---|
+| Nano | 30B (3B) | smallest gen-3 chat; 4× throughput vs gen-2; Nano-Omni adds multimodal |
+| Super | ~120B (~12B) | high-accuracy reasoning |
+| Ultra | 550B (55B) | flagship, 300+ tok/s |
+
+Cloud (indicative /1M): Nano ~$0.05 in / $0.20 out; Super ~$0.10 / $0.50 (free
+tiers available); Ultra ~$0.60 / $3.60.
+
+**Via Understudy** — remote: `nemotron-3-nano`, `nemotron-3-super`,
+`nemotron-3-ultra`. Local (`run-local-model-lab`): Nano 30B-A3B (smallest gen-3;
+the MoE means it runs ~at 4B speed; Nano-Omni adds multimodal). Super 120B fits a
+high-memory workstation (e.g. 64–128 GB Apple Silicon); Ultra is remote-only.
+
+## Remote ↔ local at a glance
+
+| Family | Remote (Understudy catalog) | Local (run-local-model-lab) |
+|---|---|---|
+| Gemma 4 | `gemma-4-31b-it` | E2B / E4B / 12B / 26B-MoE / 31B |
+| Nemotron 3 | `nemotron-3-nano`, `nemotron-3-super`, `nemotron-3-ultra` | Nano 30B-A3B (Super 120B on big-RAM) |
+
+Hardware rule of thumb (local, q4): ~0.5 GB/param of weights + KV cache; an MoE
+holds all experts in memory but runs at the active-parameter speed. A 30B-A3B
+fits comfortably on a 32 GB+ machine; a 120B-A12B needs ~64–80 GB.
+
+## Run it
+
+```bash
+# remote: pick a catalog model and route a workload to it
+understudy models
+understudy workloads route --model-id nemotron-3-nano --traffic-pct 100
+understudy run -- <your eval>
+
+# local: serve a small model OpenAI-compatibly and run the same eval
+#   ollama run gemma-4-e4b   (or a Nemotron 3 Nano GGUF)
+#   then point the eval's base_url at the local endpoint
+```
+
+Pick the smallest model that passes your frozen eval; escalate only when it
+doesn't. Never claim a cost/latency/quality win without a measured before/after.

--- a/docs/open-model-spotlight.md
+++ b/docs/open-model-spotlight.md
@@ -63,16 +63,17 @@ Cloud (indicative /1M): Nano ~$0.05 in / $0.20 out; Super ~$0.10 / $0.50 (free
 tiers available); Ultra ~$0.60 / $3.60.
 
 **Via Understudy** — remote: `nemotron-3-nano`, `nemotron-3-super`,
-`nemotron-3-ultra`. Local (`run-local-model-lab`): Nano 30B-A3B (smallest gen-3;
-the MoE means it runs ~at 4B speed; Nano-Omni adds multimodal). Super 120B fits a
-high-memory workstation (e.g. 64–128 GB Apple Silicon); Ultra is remote-only.
+`nemotron-3-ultra`. Local (`run-local-model-lab`): Nano **4B** (smallest, dense —
+laptop/edge) or Nano **30B-A3B** (MoE, ~4B speed; Nano-Omni adds multimodal).
+Super 120B fits a high-memory workstation (64–128 GB Apple Silicon); Ultra is
+remote-only.
 
 ## Remote ↔ local at a glance
 
 | Family | Remote (Understudy catalog) | Local (run-local-model-lab) |
 |---|---|---|
 | Gemma 4 | `gemma-4-31b-it` | E2B / E4B / 12B / 26B-MoE / 31B |
-| Nemotron 3 | `nemotron-3-nano`, `nemotron-3-super`, `nemotron-3-ultra` | Nano 30B-A3B (Super 120B on big-RAM) |
+| Nemotron 3 | `nemotron-3-nano`, `nemotron-3-super`, `nemotron-3-ultra` | Nano 4B / 30B-A3B (Super 120B on big-RAM) |
 
 Hardware rule of thumb (local, q4): ~0.5 GB/param of weights + KV cache; an MoE
 holds all experts in memory but runs at the active-parameter speed. A 30B-A3B

--- a/docs/open-model-spotlight.md
+++ b/docs/open-model-spotlight.md
@@ -83,7 +83,7 @@ fits comfortably on a 32 GB+ machine; a 120B-A12B needs ~64–80 GB.
 ```bash
 # remote: pick a catalog model and route a workload to it
 understudy models
-understudy workloads route --model-id nemotron-3-nano --traffic-pct 100
+understudy workloads route <workload-id> --project-id <project-id> --model-id nemotron-3-nano --traffic-pct 100
 understudy run -- <your eval>
 
 # local: serve a small model OpenAI-compatibly and run the same eval

--- a/skills/README.md
+++ b/skills/README.md
@@ -30,6 +30,9 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   authenticated gateway inference, project/key readiness, public model listing,
   workload route percentages, `understudy run`, and monitored durable CLI
   execution.
+- [`run-local-model-lab`](run-local-model-lab/SKILL.md) evaluates local or
+  workstation-hosted models against the same frozen workload/eval, keeps model
+  downloads behind approval, and compares local, hybrid, and remote routes.
 - [`prepare-verifier-handoff`](prepare-verifier-handoff/SKILL.md) is a
   future-release stub for stateful RL verifier/environment handoffs. It does not
   execute training; it prepares evidence and actively refers suitable workloads

--- a/skills/run-local-model-lab/SKILL.md
+++ b/skills/run-local-model-lab/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: run-local-model-lab
+description: Use when a developer wants to run a local or workstation-hosted model (e.g. a Gemma 4 variant via llama.cpp/MLX) against an existing Understudy workload/eval before spending on hosted providers or routing remote traffic — to inventory hardware, pick a model tier, measure quality/latency/cost locally, compare against remote, and produce a route decision (ship local, local-as-router, hybrid, or remote).
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Run Local Model Lab
+
+Run a local model against an existing Understudy workload/eval to see whether it
+is good enough before spending on hosted providers or routing remote traffic.
+Local inference is $0, private, and the only legal path under ZDR / SOC2 /
+local-only constraints — so it is the cheapest rung of the ladder. Same-family
+models (e.g. local Gemma 4 → remote Gemma 4 31B via the gateway) graduate cleanly.
+
+This skill measures and recommends; it does not download weights or change
+production routing on its own.
+
+## When to use
+
+A workload already has (or can get) a frozen eval — see
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) — and the developer
+wants a local candidate evaluated before remote spend, or needs a local-only
+route for compliance. For pure remote inference/routing use
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+
+## Safety Gates
+
+- **No weight downloads without explicit approval** and a stated size cap. Model
+  weights are large; confirm the exact model + quantization + disk size first.
+- **Local-first, no upload.** Keep traces, prompts, and outputs local unless the
+  developer approves a specific upload. This is the compliant path — do not
+  break it.
+- **Gated weights** (Gemma, etc.) need license acceptance + an HF token; never
+  print or commit the token.
+- **Never evaluate an `-assistant` drafter on its own.** The `*-it-assistant`
+  models are speculative-decoding drafters (MTP), not standalone models — they
+  only speed up a paired target while preserving its quality. See
+  [`reference.md`](reference.md).
+
+## Flow
+
+1. **Inventory hardware + runtime.** Detect OS/chip (Apple Silicon vs CUDA),
+   RAM, and VRAM/unified memory; check installed runtimes (Ollama, llama.cpp, LM
+   Studio, vLLM, Transformers, MLX). Recommend a runtime for the platform. Do not
+   download anything yet. Surface what you found.
+2. **Pick a candidate tier** (candidate chooser + hardware-fit guidance in [`reference.md`](reference.md)):
+   - Tiny smoke — E2B / E4B class (fast, on-device; routing/triage/easy cases).
+   - Real local eval — 12B class if hardware permits.
+   - Workstation/server — 26B A4B (MoE, ~4B active so fast) or 31B dense.
+   - Speculative-decoding path — a target model **plus its matching
+     `-assistant` drafter** (a latency optimization, not a quality change).
+3. **Freeze the workload contract.** Reuse the same eval rows, prompt, tool
+   stubs, and scoring as the incumbent (the `capture-evidence` harness/metric/
+   splits). Serve the local model behind an **OpenAI-compatible endpoint** (e.g.
+   llama.cpp `llama-server` or MLX `mlx_lm.server` at `http://localhost:8080/v1`)
+   and run the existing loop by pointing
+   `base_url` at it — no harness rewrite. Write artifacts to
+   `.understudy/local-model-lab/`, recording: model id, quantization, runtime,
+   hardware, context length, latency, tokens/sec, and score.
+4. **Compare against remote.** Score the local candidate vs the remote route
+   (gateway / Lilac / frontier) on the objective:
+   - Local wins if it is *good enough* and cheaper / faster / private.
+   - Remote wins if the quality gap blocks shipping, or local ops cost exceeds
+     provider spend at the real volume.
+   - Hybrid if local handles triage / extraction / routing and remote handles
+     the hard cases (cascade). Use
+     [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)
+     for the remote side and to register the chosen route.
+5. **Produce a route decision** — one of: *ship local*, *use local for replay
+   only*, *use local as a router/triage tier*, *hybrid* (local for easy/private
+   stages, remote for hard cases), *remote only*, or *escalate to a
+   workstation/GPU*. Record cost/latency/quality tradeoffs and feed
+   route-selection ([`../understudy/reference.md`](../understudy/reference.md)).
+
+Make cost/availability/spec claims from fresh data (HF / official model cards /
+the gateway catalog), never from memory — label assumptions.
+
+## Output Standard
+
+End with: hardware + runtime found; candidate tier(s) and why; the frozen
+contract used; local vs remote scores with latency/cost/quality; the route
+decision and its trigger to revisit; and any approval still needed (download,
+upload, deploy). Fold results into the Understudy Agent Improvement Report
+([`../understudy/reference.md`](../understudy/reference.md)).

--- a/skills/run-local-model-lab/reference.md
+++ b/skills/run-local-model-lab/reference.md
@@ -40,7 +40,10 @@ OpenAI-compatible endpoint, so the frozen eval just swaps `base_url`.
 brew install llama.cpp                 # macOS; else build from source / package mgr
 export HF_TOKEN=...                     # only for gated repos; never commit it
 # downloads the GGUF from HF and serves OpenAI-compatible at :8080/v1
-llama-server -hf ggml-org/gemma-4-e4b-it-GGUF:Q4_K_M --port 8080 --jinja
+llama-server -hf unsloth/gemma-4-E4B-it-GGUF:Q4_K_M --port 8080 --jinja
+# Nemotron 3 Nano — smallest gen-3 is the 4B dense; 30B-A3B is the MoE:
+#   llama-server -hf nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF:Q4_K_M --port 8080 --jinja
+#   llama-server -hf unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Q4_K_M --port 8080 --jinja
 ```
 
 ### MLX — Apple Silicon native (best throughput on a Mac)
@@ -49,6 +52,7 @@ llama-server -hf ggml-org/gemma-4-e4b-it-GGUF:Q4_K_M --port 8080 --jinja
 pip install mlx-lm                       # or: uv pip install mlx-lm
 # pulls the MLX build from HF and serves OpenAI-compatible at :8080/v1
 mlx_lm.server --model mlx-community/gemma-4-e4b-it-4bit --port 8080
+# Nemotron 3 Nano on MLX: mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit
 ```
 
 (Ollama / LM Studio also serve OpenAI-compatible if a developer already runs one,
@@ -62,7 +66,7 @@ pull straight from Hugging Face the day weights drop.)
 # accept the model's terms on its HF page first, then:
 export HF_TOKEN=...                       # gated models only; never commit
 hf download google/gemma-4-e4b-it --local-dir ./models/gemma-4-e4b-it
-# or a prebuilt quant: hf download ggml-org/gemma-4-e4b-it-GGUF <file>.gguf
+# or a prebuilt quant: hf download unsloth/gemma-4-E4B-it-GGUF <file>.gguf
 ```
 
 ### Smoke-test the local endpoint, then run the eval
@@ -76,11 +80,42 @@ curl -sS http://localhost:8080/v1/chat/completions \
 Then run the frozen eval with `base_url=http://localhost:8080/v1` (or the gateway
 primitive's `--api-base-url`) — same harness, local model.
 
-Notes: exact repo ids and quant tags drift — verify on the model card (Gemma
-`e4b` / `12b`; Nemotron 3 Nano `30b-a3b`). On Apple Silicon prefer an MLX 4-bit
-build; for portability use a llama.cpp GGUF `Q4_K_M`. Nemotron 3 Nano is a
-30B-A3B MoE — it needs the full weights resident (~16–18 GB at q4) but runs at
-~4B speed, so it's comfortable on 32 GB+ (trivial on your 128 GB).
+Notes: exact repo ids and quant tags drift — verify on the model card. On Apple
+Silicon prefer an MLX 4-bit build; for portability use a llama.cpp GGUF `Q4_K_M`.
+Nemotron 3 Nano comes as a small **4B dense** (truly laptop/edge — a few GB at q4)
+and a **30B-A3B MoE** (holds all experts in memory, ~16–18 GB at q4, but runs at
+~4B speed). Use the 4B for cheap local smoke; the MoE for stronger local quality
+on 32 GB+. (Nemotron is a reasoning model — final text follows a `reasoning`
+block, so parse the last assistant `content`, not the reasoning.)
+
+## Compare local vs remote (recipe + measured example)
+
+Run the SAME frozen rows + prompt against the local endpoint and the remote
+catalog model, score the objective + latency, and let the route decision fall out.
+
+```bash
+# remote side: route a workload to a catalog model, then run the eval via the gateway
+understudy workloads route --model-id gemma-4-31b-it --traffic-pct 100
+BASE=https://api.understudylabs.com/v1 KEY="$UNDERSTUDY_SK" MODEL=x  node eval.mjs  # remote
+BASE=http://127.0.0.1:8080/v1          KEY=local             MODEL=x node eval.mjs  # local
+```
+
+Measured example — 6 support-triage rows, exact-match category + latency, on an
+Apple Silicon laptop:
+
+| | Local — Gemma 4 E4B (llama.cpp) | Remote — Gemma 4 31B (gateway) |
+| --- | --- | --- |
+| Accuracy | 5/6 | 6/6 |
+| Latency p50 | ~77 ms | ~526 ms |
+| Cost | $0 | provider pennies |
+| Privacy | fully local | via gateway |
+
+Decision: the small local model is ~7× faster, $0, and private, and handled the
+easy cases; its one miss (a login/reset ticket it called `technical` while the 31B
+got `account`) is the signal to escalate ambiguous cases. → **local-as-router /
+hybrid**: serve easy traffic locally, escalate hard cases to the remote model.
+Same family (Gemma E4B ↔ Gemma 31B) means the prompt transfers unchanged. Record
+the run in `.understudy/local-model-lab/`.
 
 ## Candidate chooser
 
@@ -93,6 +128,8 @@ availability, license, checkpoint format, and runtime support before use.
 | 12B | Main laptop eval, multimodal/audio tasks, stronger reasoning without workstation hardware | Google announced Gemma 4 12B on 2026-06-03 as a unified encoder-free multimodal model designed for laptops with 16GB VRAM or unified memory. |
 | 26B A4B MoE | Strong local text/image candidate on serious desktop/workstation hardware | Treat as the local quality/latency sweet spot when the runtime and memory fit. MoE active parameters do not remove the need to fit the checkpoint/KV cache. |
 | 31B dense | Maximum local quality when hardware is available, or remote graduation target | Prefer remote/gateway if local ops friction or memory pressure slows the experiment. |
+| Nemotron 3 Nano 4B | Smallest local Nemotron; routing/triage/edge on any laptop | Dense ~4B; GGUF at `nvidia/` and `unsloth/`. The cheapest gen-3 Nemotron rung. |
+| Nemotron 3 Nano 30B-A3B | Stronger local Nemotron on 32 GB+; agentic/reasoning, long context | MoE (3B active) → ~4B speed; reasoning model. Mirrors remote `nemotron-3-nano`/`super`. |
 | Target + `-assistant` | Latency optimization through speculative decoding | The `*-it-assistant` models are MTP drafters. Evaluate the target model's quality; measure the assistant as speedup only. |
 
 ## Gemma 4 facts to verify fresh

--- a/skills/run-local-model-lab/reference.md
+++ b/skills/run-local-model-lab/reference.md
@@ -1,0 +1,175 @@
+# Run Local Model Lab Reference
+
+Depth for [`SKILL.md`](SKILL.md). Keep this reference current by checking
+official model cards, runtime docs, and local hardware before recommending a
+download or route change.
+
+## Runtime chooser
+
+Use the easiest OpenAI-compatible endpoint that fits the developer's machine and
+workload:
+
+- **llama.cpp / GGUF** — default for cross-platform and coding-sandbox use: a
+  single binary, no daemon, and `llama-server -hf <repo>:<quant>` pulls weights
+  straight from Hugging Face (works the day a model drops).
+- **MLX** — default on Apple Silicon when an MLX build exists; best throughput on
+  a Mac, pulls from Hugging Face.
+- **Ollama / LM Studio** — optional convenience fallback if a developer already
+  runs one; skip as the default because their library tags lag new HF releases.
+- **vLLM / SGLang** — prefer on NVIDIA or server GPUs when batching,
+  throughput, or OpenAI-compatible serving matters.
+- **Transformers / LiteRT-LM** — use for modality-specific demos, QAT/mobile
+  checkpoints, or when the model card's reference path is the only reliable
+  implementation.
+
+Always record the endpoint, runtime, model id, quantization, context setting,
+and hardware in `.understudy/local-model-lab/`.
+
+## Install → download → serve → infer (the operational path)
+
+Most developers — and agents in coding sandboxes — won't have a runtime or
+weights yet, so the skill has to bootstrap both. Only act after the SKILL's
+gates: no downloads without an explicit size cap, and gated weights (Gemma) need
+the model terms accepted + an `HF_TOKEN` (a token authorizes a download; it is
+not approval to download). Pick the lightest runtime that fits; each exposes an
+OpenAI-compatible endpoint, so the frozen eval just swaps `base_url`.
+
+### llama.cpp — cross-platform, single binary, best for sandboxes (pulls weights itself)
+
+```bash
+brew install llama.cpp                 # macOS; else build from source / package mgr
+export HF_TOKEN=...                     # only for gated repos; never commit it
+# downloads the GGUF from HF and serves OpenAI-compatible at :8080/v1
+llama-server -hf ggml-org/gemma-4-e4b-it-GGUF:Q4_K_M --port 8080 --jinja
+```
+
+### MLX — Apple Silicon native (best throughput on a Mac)
+
+```bash
+pip install mlx-lm                       # or: uv pip install mlx-lm
+# pulls the MLX build from HF and serves OpenAI-compatible at :8080/v1
+mlx_lm.server --model mlx-community/gemma-4-e4b-it-4bit --port 8080
+```
+
+(Ollama / LM Studio also serve OpenAI-compatible if a developer already runs one,
+but skip them as the default: their library tags lag new HF releases, so brand-new
+models like Gemma 4 / Nemotron 3 may not have a tag yet — `llama.cpp -hf` and MLX
+pull straight from Hugging Face the day weights drop.)
+
+### Download weights explicitly (any runtime)
+
+```bash
+# accept the model's terms on its HF page first, then:
+export HF_TOKEN=...                       # gated models only; never commit
+hf download google/gemma-4-e4b-it --local-dir ./models/gemma-4-e4b-it
+# or a prebuilt quant: hf download ggml-org/gemma-4-e4b-it-GGUF <file>.gguf
+```
+
+### Smoke-test the local endpoint, then run the eval
+
+```bash
+curl -sS http://localhost:8080/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"local","messages":[{"role":"user","content":"reply: pong"}],"max_tokens":20}'
+```
+
+Then run the frozen eval with `base_url=http://localhost:8080/v1` (or the gateway
+primitive's `--api-base-url`) — same harness, local model.
+
+Notes: exact repo ids and quant tags drift — verify on the model card (Gemma
+`e4b` / `12b`; Nemotron 3 Nano `30b-a3b`). On Apple Silicon prefer an MLX 4-bit
+build; for portability use a llama.cpp GGUF `Q4_K_M`. Nemotron 3 Nano is a
+30B-A3B MoE — it needs the full weights resident (~16–18 GB at q4) but runs at
+~4B speed, so it's comfortable on 32 GB+ (trivial on your 128 GB).
+
+## Candidate chooser
+
+This is a starting heuristic, not a benchmark claim. Verify current model card
+availability, license, checkpoint format, and runtime support before use.
+
+| Candidate class | Use when | Notes |
+| --- | --- | --- |
+| E2B / E4B | Router, triage, extraction, easy classification, edge/mobile, audio-first smoke tests | Smallest Gemma 4 rungs. Good for cheap local iteration and compliance-constrained routing. |
+| 12B | Main laptop eval, multimodal/audio tasks, stronger reasoning without workstation hardware | Google announced Gemma 4 12B on 2026-06-03 as a unified encoder-free multimodal model designed for laptops with 16GB VRAM or unified memory. |
+| 26B A4B MoE | Strong local text/image candidate on serious desktop/workstation hardware | Treat as the local quality/latency sweet spot when the runtime and memory fit. MoE active parameters do not remove the need to fit the checkpoint/KV cache. |
+| 31B dense | Maximum local quality when hardware is available, or remote graduation target | Prefer remote/gateway if local ops friction or memory pressure slows the experiment. |
+| Target + `-assistant` | Latency optimization through speculative decoding | The `*-it-assistant` models are MTP drafters. Evaluate the target model's quality; measure the assistant as speedup only. |
+
+## Gemma 4 facts to verify fresh
+
+As of 2026-06-05, the official public shape is:
+
+- Initial Gemma 4 family: E2B, E4B, 26B A4B MoE, and 31B Dense.
+- Gemma 4 12B was added on 2026-06-03 to bridge E4B and 26B, with unified
+  encoder-free multimodal architecture and native audio input.
+- Gemma 4 QAT checkpoints were announced on 2026-06-05 for lower memory local
+  deployment, including Q4_0/GGUF-oriented and mobile-oriented formats.
+- Google lists common local/runtime paths including Ollama, LM Studio,
+  llama.cpp, MLX, vLLM, SGLang, LiteRT-LM, Transformers, and Google AI Edge
+  Gallery.
+- Gemma access may require accepting model terms and using a Hugging Face token.
+  A local token is authorization to download gated weights, not approval to
+  download them in this workflow.
+
+Do not encode stale footprint guesses as requirements. Approximate RAM/VRAM
+numbers depend on quantization, context length, modality components, KV cache,
+runtime, and batching. Use them only as planning estimates after checking the
+exact artifact.
+
+## Artifact schema
+
+Write a small JSON record per run:
+
+```json
+{
+  "runtime": "ollama|lmstudio|llama.cpp|mlx|vllm|sglang|transformers|litert-lm",
+  "endpoint": "http://localhost:11434/v1",
+  "model": "string",
+  "model_role": "target|draft|router|judge|candidate",
+  "quantization": "string|null",
+  "hardware": {
+    "device": "string",
+    "ram_gb": 0,
+    "vram_or_unified_memory_gb": 0
+  },
+  "workload": {
+    "id": "string",
+    "eval_rows": 0,
+    "data_boundary": "local-only"
+  },
+  "results": {
+    "score": 0,
+    "latency_p50_ms": 0,
+    "latency_p95_ms": 0,
+    "tokens_per_second": 0,
+    "failures": []
+  },
+  "decision": "ship-local|local-replay|local-router|hybrid|remote|escalate"
+}
+```
+
+## Decision rules
+
+- **Ship local** when quality is within the agreed regression band and privacy,
+  latency, or unit economics beat the remote route at realistic volume.
+- **Local replay only** when local is useful for no-spend iteration but not good
+  enough for production behavior.
+- **Local router / triage tier** when a small model reliably detects easy cases
+  or routes hard cases to a stronger model.
+- **Hybrid** when local handles private or easy stages and remote handles the
+  high-value completion path.
+- **Remote only** when local quality, latency, hardware setup, or ops burden
+  slows the company more than provider spend would.
+- **Escalate to workstation/GPU** only when the evidence says a larger local
+  model could materially change the route decision.
+
+## Anti-patterns
+
+- Treating a local model as free without measuring setup time, hardware
+  contention, latency, and maintenance.
+- Comparing local and remote runs with different prompts, tools, eval rows, or
+  validators.
+- Downloading gated weights because a token exists.
+- Evaluating `*-assistant` drafters as quality candidates.
+- Claiming QAT or quantized quality from a model-card headline without running
+  the workload's own heldout rows.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -96,6 +96,10 @@ Identify the developer's current stage and load exactly one:
   gateway trace capture, project/key management, model A/B via route traffic %,
   `understudy run`, or registering an improved route →
   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+- **Local model experiment / local-only route** — evaluate a local or
+  workstation-hosted model through the same frozen workload/eval, choose a
+  runtime, compare local vs remote, or satisfy ZDR / no-upload constraints →
+  [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
 - **Single-output optimization** — fresh artifacts exist and the developer wants
   to validate, optimize (GEPA), compare candidates, or claim readiness →
   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).


### PR DESCRIPTION
## What

Adds the **local** half of Understudy's remote↔local model story, plus a reusable spotlight on the two American open-weight families now wired into the gateway. All skills/docs — no product code. Builds on #32 (agent-improvement orchestrator).

## Changes

- **`skills/run-local-model-lab/`** (new worker) — download + locally serve an open model against the *same frozen eval* before remote spend or routing. Inventory hardware → pick a tier → freeze the contract → compare vs remote → produce a route decision (ship local / replay / router / hybrid / remote / escalate). Includes an **`install → download → serve → infer` runbook** targeted at devs/agents in coding sandboxes:
  - **llama.cpp** (single binary, `-hf` pulls from HF) and **MLX** (Apple Silicon) as defaults — they serve brand-new models the day weights drop.
  - Ollama/LM Studio de-emphasized (library tags lag new releases).
  - `*-it-assistant` correctly treated as **speculative-decoding drafters**, not standalone models.
- **`understudy` router + `skills/README.md`** — route local-experiment / local-only (ZDR/SOC2) intents to `run-local-model-lab`.
- **`docs/open-model-spotlight.md`** — reusable reference: Gemma 4 (E2B→31B) + Nemotron 3 (Nano/Super/Ultra), the remote↔local pattern, benchmarks, indicative pricing (labeled verify), and run-it snippets. Linkable from both local + remote skills.

## Context (live in the gateway catalog)

- Gemma 4: remote `gemma-4-31b-it`; local E2B–31B.
- Nemotron 3: remote `nemotron-3-nano`/`nemotron-3-super` (NVIDIA), `nemotron-3-ultra` (Together); local Nano 30B-A3B.

## Validation

`npm run check` green — `ok 7 public skills`, cookbook, package dry-run. Public boundary respected (public model ids, indicative pricing, no secrets/internal ids).

> Agent-drafted (with a parallel agent on the reference). Please review the prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->