### PR TITLE
[codex] Add API workflow optimization skill

### DIFF
--- a/scripts/validate-public-skills.mjs
+++ b/scripts/validate-public-skills.mjs
@@ -9,12 +9,14 @@ const allowedTopLevel = new Set(["name", "description", "license", "allowed-tool
 const mvpPublicSkillNames = [
   "understudy",
   "capture-evidence",
+  "optimize-api-workflow",
   "optimize-workload",
   "use-understudy-gateway",
   "prepare-verifier-handoff",
 ];
 const mvpRouterTargets = [
   "../capture-evidence/SKILL.md",
+  "../optimize-api-workflow/SKILL.md",
   "../optimize-workload/SKILL.md",
   "../use-understudy-gateway/SKILL.md",
   "../prepare-verifier-handoff/SKILL.md",

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,6 +16,11 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   harness/environment, confirms the metric and validator, freezes splits, and
   reruns the incumbent baseline. (Discovery + capture/import folded into its
   [`reference.md`](capture-evidence/reference.md).)
+- [`optimize-api-workflow`](optimize-api-workflow/SKILL.md) evaluates and
+  optimizes cross-application REST/API workflow agents such as
+  AutomationBench-style tasks: seeded state, fixed API schemas, policy docs,
+  request logs, final-state validators, and side-effect safety before any RL
+  handoff.
 - [`optimize-workload`](optimize-workload/SKILL.md) refuses stale
   artifacts, preserves train/dev/holdout boundaries, writes dry-run proof
   packets, and requires `claim.json` before public claims. (Evaluate, optimize,

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -83,6 +83,10 @@ enough provenance for another agent to repeat the step without guessing.
      agreement separately from candidate preference.
    Whatever the kind, the metric must emit **natural-language feedback that
    diagnoses why** an output failed and what to change — not just a scalar.
+   For API workflow benchmarks, record final-state correctness, policy
+   compliance, data accuracy, endpoint discovery, required-write completion,
+   forbidden-write avoidance, unnecessary calls/retries, schema validity, and
+   recoverable errors as separate axes before collapsing to an overall score.
    If the metric or validator is unclear, stop and ask one concrete question.
 4. Freeze splits.
    Write `splits.json` with train/dev/holdout names, sizes, source refs,
@@ -105,8 +109,12 @@ model/provider/harness/eval state, then surface that inventory before building
 anything. The deep inspection checklist (call sites by SDK family, env vars,
 tracing, CI) and the eval-harness discover-then-build playbook live in
 [`reference.md`](reference.md). For cross-cutting objective/constraint framing,
-read [`../understudy/reference.md`](../understudy/reference.md). For multi-turn /
-tool-use / agentic workloads, route the eval to
+read [`../understudy/reference.md`](../understudy/reference.md). For multi-step
+REST/API workflows that mutate state, route to
+[`../optimize-api-workflow/SKILL.md`](../optimize-api-workflow/SKILL.md) so the
+agent records reset/seed state, API schemas, policy docs, request logs, and
+final-state validators as part of the harness. For multi-turn / tool-use /
+agentic search workloads, route the eval to
 [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md)
 instead of building a single-output harness.
 

--- a/skills/optimize-api-workflow/SKILL.md
+++ b/skills/optimize-api-workflow/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: optimize-api-workflow
+description: Use to evaluate and optimize cross-application API workflow agents, including AutomationBench-like REST orchestration tasks where an agent discovers endpoints, follows policy docs, mutates state, and must pass final-state validators before any RL handoff.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Optimize API Workflow
+
+Use this worker when the workload is an **API workflow agent**: a multi-step LLM
+or agent loop that reads task instructions and policy docs, discovers or selects
+REST endpoints, performs writes across one or more business systems, and is
+judged by final state plus policy compliance. AutomationBench-style workflows
+fit here better than generic search because correctness depends on stateful API
+effects, not only the final answer.
+
+This is still an evaluation, A/B, prompt, route, parser, and harness skill. It
+is not RL training. Route to
+[`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md)
+only after local evidence shows that model choice and prompt/route optimization
+cannot satisfy a stateful policy-learning requirement.
+
+## Safety Gates
+
+Default to the cheapest path that still reaches a decision. Get explicit
+approval before any upload, hosted run, provider spend, live SaaS API call,
+credential change, production write, model download, or benchmark submission.
+
+Prefer local mocks, seeded fixtures, recorded schemas, and synthetic business
+data. Do not print, commit, upload, or transmit raw prompts, completions, traces,
+policy docs, customer data, request payloads, private repo paths, credentials, or
+secrets without explicit approval for that exact data class and action. Treat
+write-capable API tokens as production-impacting even when the task looks like an
+eval.
+
+## When To Use
+
+Use this skill when all of these hold:
+
+- the agent performs a multi-step API workflow, not a single prompt response;
+- tools are REST, OpenAPI, RPC, or SDK calls with observable state changes;
+- success requires final-state correctness and policy adherence;
+- the harness can reset or seed state before each task;
+- candidates should be compared on quality, latency, cost, and side-effect
+  safety.
+
+If the workload is live web search or browser/retrieval over read-only tools,
+use [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md).
+If it is single-output, use
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) then
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
+
+## Artifact Pattern
+
+Capture the API workflow into the standard evidence contract:
+
+```text
+.understudy/capture-evidence/harness.json
+.understudy/capture-evidence/environment.json
+.understudy/capture-evidence/metric.json
+.understudy/capture-evidence/splits.json
+.understudy/capture-evidence/baseline.json
+```
+
+For API workflows, `harness.json` must include the reset command, seed fixture,
+task source, API schema or service map, allowed endpoint set, policy-doc refs,
+agent entrypoint, request-log path, final-state validator, timeout, and network
+boundary. `environment.json` must record the local service versions, mock server
+or sandbox setup, required env var names without values, and whether any route
+can write to live systems.
+
+## Flow
+
+1. **Confirm the workflow shape.** Name the apps/services, fixed API tools,
+   policy docs, mutable state, incumbent model, and agent entrypoint. If there is
+   no resettable state or validator, route back to `capture-evidence`.
+
+2. **Freeze determinism.** Prefer local mock services or benchmark sandboxes.
+   Record a deterministic reset: seeded state, API schemas, policy docs, task
+   rows, allowed endpoints, clock/timezone, random seed, and network boundary.
+   Each task run should start from a known state and emit a request log.
+
+3. **Define the metric.** Quality is a weighted API-workflow rubric, not a
+   generic answer score. Include final-state correctness, policy compliance,
+   data accuracy, endpoint discovery, required-write completion, forbidden-write
+   avoidance, unnecessary calls/retries, schema validity, and recoverable errors.
+   Latency and cost are per workflow rollout. The metric must emit
+   natural-language feedback tied to the failing step or invariant.
+
+4. **Run the incumbent baseline.** Execute the frozen harness on train/dev or a
+   small sanctioned sample, write per-task pass/fail and request-log summaries,
+   and include `harness_sha256`, `metric_sha256`, and `splits_sha256` in
+   `baseline.json`. Do not optimize until the baseline is measured.
+
+5. **Pick the cheapest intervention.** Try parser/schema repair, prompt or
+   policy-instruction repair, context trimming, endpoint-catalog compression,
+   model A/B, or route changes before any training. Treat fewer unsafe writes,
+   fewer redundant calls, and cleaner recovery behavior as first-class wins.
+
+6. **Optimize only with fresh artifacts.** For prompt or route optimization, hand
+   to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) after the
+   evidence artifacts are fresh and hash-bound. GEPA may use train/dev feedback
+   only; never tune on holdout.
+
+7. **Validate holdout last.** Freeze the candidate, then run holdout once.
+   Claims require `claim.json` with sample size, split, quality delta, latency
+   basis, cost basis, request-volume assumption, fallback route, demotion
+   trigger, and caveats.
+
+## Output Standard
+
+End with:
+
+- whether the workload was confirmed as an API workflow and the services named;
+- reset/seed/state determinism status;
+- metric axes and incumbent baseline status;
+- request-log and final-state validator paths;
+- candidate intervention or next worker skill;
+- result type: evidence-capture, evaluation, optimization-lead, heldout, or
+  verifier-handoff;
+- one recommended next command or local action.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -103,6 +103,10 @@ Identify the developer's current stage and load exactly one:
 - **Single-output optimization** — fresh artifacts exist and the developer wants
   to validate, optimize (GEPA), compare candidates, or claim readiness →
   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
+- **API workflow optimization** — multi-step REST/API agent that discovers
+  endpoints, follows policy docs, mutates state, and must pass final-state
+  validators (AutomationBench-style) →
+  [`../optimize-api-workflow/SKILL.md`](../optimize-api-workflow/SKILL.md).
 - **Agentic / tool-use optimization** — multi-turn agent that calls tools (e.g.
   web search); evaluate, A/B-compare models, or optimize its prompt/route →
   [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md)
@@ -111,9 +115,10 @@ Identify the developer's current stage and load exactly one:
   the agent must *learn* multi-step behavior →
   [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
 
-Multi-turn or tool-use alone is NOT a handoff: agentic evaluation, A/B, and
-prompt/route optimization stay local in `optimize-agentic-search`. Only RL/
-policy *training* routes to `prepare-verifier-handoff`. When in doubt, route to
+Multi-turn or tool-use alone is NOT a handoff: agentic evaluation, API-workflow
+evaluation, A/B, and prompt/route optimization stay local in
+`optimize-agentic-search` or `optimize-api-workflow`. Only RL/policy *training*
+routes to `prepare-verifier-handoff`. When in doubt, route to
 `capture-evidence` — optimizing without a current harness/metric/split/baseline
 creates false progress.
 


### PR DESCRIPTION
## Summary

Adds a new `optimize-api-workflow` skill for AutomationBench-style cross-application REST/API workflow agents. The skill covers seeded state, fixed API schemas, policy docs, request logs, final-state validators, side-effect safety, and the boundary before RL handoff.

Also updates the Understudy router, capture-evidence guidance, skills index, and public skill validator so API workflow benchmarks route to the new specialist skill instead of the generic agentic-search path.

## Validation

- `npm run check`