### PR TITLE
[codex] Add workloads create command

### DIFF
--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -28,6 +28,7 @@ understudy skills --search gateway
 understudy skills --inspect understudy
 understudy doctor
 understudy models list --json
+understudy workloads create --project-id <project-id> --from-card .understudy/workload-discovery/workload-card.json
 understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 10
 understudy workloads route <workload-id> --project-id <project-id> --clear
 understudy setup-code --client openai --file src/client.ts --json

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -68,9 +68,10 @@ node dist/bin.js status --json
 
 4. For frontier-vs-Understudy A/B routing, list public model IDs and set a
    bounded workload route — see the **A/B model routing** recipe below for the
-   commands and the split mechanics. The agent must not expose or ask for
-   supplier/provider details; the app keeps calling the normal gateway path while
-   the control-plane route decides the split.
+   commands and the split mechanics. Register the local Workload Card first if
+   the gateway does not know the workload yet. The agent must not expose or ask
+   for supplier/provider details; the app keeps calling the normal gateway path
+   while the control-plane route decides the split.
 
 5. Run the local command through the gateway wrapper only after approval:
 
@@ -95,7 +96,17 @@ comparing a workload's quality and cost across the split.
    understudy models list --json
    ```
 
-2. Route a workload to a model at a traffic percentage — a per-request split
+2. Register the local Workload Card if this workload is not already known by the
+   gateway:
+
+   ```sh
+   understudy workloads create --project-id <project-id> \
+     --from-card .understudy/workload-discovery/workload-card.json
+   ```
+
+   The command returns the server-assigned workload id used by `route`.
+
+3. Route a workload to a model at a traffic percentage — a per-request split
    where that share goes to the routed model and the rest stays on passthrough.
    Pick a bounded share (e.g. 30%) to keep the comparison small.
 
@@ -106,7 +117,7 @@ comparing a workload's quality and cost across the split.
    Clearing the route (`--clear` in place of the model/traffic flags) returns the
    workload to full passthrough.
 
-3. Run the eval through the gateway so the routed model serves its share. Any
+4. Run the eval through the gateway so the routed model serves its share. Any
    local command works; an eval harness like a verifiers `vf-eval` run is typical.
 
    ```sh

--- a/skills/use-understudy-gateway/reference.md
+++ b/skills/use-understudy-gateway/reference.md
@@ -85,13 +85,17 @@ rules below apply to every upload, spend, credential, deploy, or route change.
    editing hardcoded call sites: a model swap, a routed traffic split, a prompt
    variant, or a parser fix is usually enough. Editing call sites directly is the
    last resort and must be reversible.
-3. **Register / route the improved behavior through the inference layer.** Use
-   the workloads route API to send a bounded share of traffic to the improved
-   model. The app keeps calling the normal gateway path; the control-plane route
-   decides the split. The traffic percentage is a per-request share.
+3. **Register / route the improved behavior through the inference layer.**
+   Register the local Workload Card if the gateway does not know this workload
+   yet, then use the workloads route API to send a bounded share of traffic to
+   the improved model. The app keeps calling the normal gateway path; the
+   control-plane route decides the split. The traffic percentage is a per-request
+   share.
 
    ```sh
    understudy models list --json
+   understudy workloads create --project-id <project-id> \
+     --from-card .understudy/workload-discovery/workload-card.json
    understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 10
    ```
 

--- a/src/commands/workloads.ts
+++ b/src/commands/workloads.ts
@@ -1,4 +1,6 @@
 import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import kleur from "kleur";
 import { z } from "zod";
 
@@ -13,8 +15,28 @@ const RouteResponseSchema = z.object({
   route_traffic_pct: z.number().nullable().optional(),
 }).passthrough();
 
+const WorkloadCardSchema = z.object({
+  schema_version: z.literal("understudy.workload_card.v1"),
+  workload_id: z.string().min(1),
+  workload_name: z.string().nullable().optional(),
+  workload_shape: z.array(z.string()).optional(),
+  data_class: z.string().optional(),
+}).passthrough();
+
+const CreateWorkloadResponseSchema = z.object({
+  workload_id: z.string().optional(),
+  id: z.string().optional(),
+  project_id: z.string().optional(),
+  created: z.boolean().optional(),
+}).passthrough();
+
 interface OrgOpt {
   org?: string;
+}
+
+interface CreateOpts extends OrgOpt {
+  projectId: string;
+  fromCard: string;
 }
 
 interface RouteOpts extends OrgOpt {
@@ -30,6 +52,16 @@ export function registerWorkloadsCommand(program: Command): void {
     .description("Manage project workload route configuration.");
 
   workloads
+    .command("create")
+    .description("Register a local workload card on the Understudy gateway.")
+    .requiredOption("--project-id <id>", "Project id from `understudy projects list --json`.")
+    .requiredOption("--from-card <path>", "Path to an understudy.workload_card.v1 JSON file.")
+    .option("--org <id>", "Org id to use (default: only org in credentials).")
+    .action(async function (this: Command, opts: CreateOpts) {
+      await runAction(this, () => runCreate(this, opts));
+    });
+
+  workloads
     .command("route <workload-id>")
     .description("Set or clear an Understudy model traffic route for a workload.")
     .requiredOption("--project-id <id>", "Project id from `understudy projects list --json`.")
@@ -40,6 +72,48 @@ export function registerWorkloadsCommand(program: Command): void {
     .action(async function (this: Command, workloadId: string, opts: RouteOpts) {
       await runAction(this, () => runRoute(this, workloadId, opts));
     });
+}
+
+async function runCreate(cmd: Command, opts: CreateOpts): Promise<void> {
+  const cardPath = resolve(opts.fromCard);
+  const card = readWorkloadCard(cardPath);
+  const auth = resolveAuth(opts.org);
+  const res = await request(
+    {
+      url: `/admin/v1/orgs/${auth.orgId}/projects/${encodeURIComponent(opts.projectId)}/workloads`,
+      orgId: auth.orgId,
+      method: "POST",
+      body: {
+        workload_card: card,
+        source: {
+          kind: "workload_card",
+          path: opts.fromCard,
+        },
+      },
+    },
+    CreateWorkloadResponseSchema,
+  );
+  const workloadId = res.data.workload_id ?? res.data.id;
+  if (!workloadId) {
+    throw new Error("Gateway response did not include workload_id.");
+  }
+  trackControlPlaneAction({
+    resource: "workloads",
+    action: "created",
+    orgId: auth.orgId,
+    resultCount: 1,
+  });
+
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(res.data)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `${kleur.green("✓")} Registered workload ${kleur.bold(workloadId)} from ${kleur.bold(opts.fromCard)}\n`,
+  );
+  process.stdout.write(
+    `${kleur.gray(`Next: understudy workloads route ${workloadId} --project-id ${opts.projectId} --model-id <model-id> --traffic-pct 10`)}\n`,
+  );
 }
 
 async function runRoute(cmd: Command, workloadId: string, opts: RouteOpts): Promise<void> {
@@ -97,4 +171,22 @@ function parseTrafficPct(value: string): number {
     throw new Error(`Expected --traffic-pct between 0 and 100, got: ${value}`);
   }
   return parsed;
+}
+
+function readWorkloadCard(path: string): z.infer<typeof WorkloadCardSchema> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (cause) {
+    throw new Error(`Failed to read workload card at ${path}: ${(cause as Error).message}`, {
+      cause,
+    });
+  }
+  try {
+    return WorkloadCardSchema.parse(parsed);
+  } catch (cause) {
+    throw new Error(`Malformed workload card at ${path}: expected schema_version understudy.workload_card.v1`, {
+      cause,
+    });
+  }
 }

--- a/src/commands/workloads.ts
+++ b/src/commands/workloads.ts
@@ -24,10 +24,11 @@ const WorkloadCardSchema = z.object({
 }).passthrough();
 
 const CreateWorkloadResponseSchema = z.object({
-  workload_id: z.string().optional(),
-  id: z.string().optional(),
+  id: z.string(),
   project_id: z.string().optional(),
-  created: z.boolean().optional(),
+  name: z.string().optional(),
+  capture_enabled: z.boolean().optional(),
+  created_at: z.string().optional(),
 }).passthrough();
 
 interface OrgOpt {
@@ -84,19 +85,13 @@ async function runCreate(cmd: Command, opts: CreateOpts): Promise<void> {
       orgId: auth.orgId,
       method: "POST",
       body: {
-        workload_card: card,
-        source: {
-          kind: "workload_card",
-          path: opts.fromCard,
-        },
+        name: workloadNameFromCard(card),
+        capture_enabled: false,
       },
     },
     CreateWorkloadResponseSchema,
   );
-  const workloadId = res.data.workload_id ?? res.data.id;
-  if (!workloadId) {
-    throw new Error("Gateway response did not include workload_id.");
-  }
+  const workloadId = res.data.id;
   trackControlPlaneAction({
     resource: "workloads",
     action: "created",
@@ -189,4 +184,13 @@ function readWorkloadCard(path: string): z.infer<typeof WorkloadCardSchema> {
       cause,
     });
   }
+}
+
+function workloadNameFromCard(card: z.infer<typeof WorkloadCardSchema>): string {
+  const raw = (card.workload_id || card.workload_name || "workload").toLowerCase();
+  const normalized = raw.replace(/[^a-z0-9_-]+/g, "-").replace(/^-+/, "").slice(0, 63);
+  if (!/^[a-z0-9][a-z0-9_-]{0,62}$/.test(normalized)) {
+    throw new Error(`Workload card has no routable workload name: ${card.workload_id}`);
+  }
+  return normalized;
 }

--- a/src/internal/telemetry.ts
+++ b/src/internal/telemetry.ts
@@ -59,7 +59,7 @@ interface StatusCheckedEvent {
 }
 
 interface ControlPlaneEvent {
-  resource: "api_keys" | "projects" | "models" | "workload_routes";
+  resource: "api_keys" | "projects" | "models" | "workloads" | "workload_routes";
   action: "listed" | "created" | "revoked" | "switched" | "deleted" | "updated" | "cleared";
   orgId: string | null;
   projectSlug?: string | null;

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, it } from "node:test";
@@ -25,6 +26,34 @@ function runWithHome(args, home, cwd = process.cwd()) {
       HOME: home,
       USERPROFILE: home,
     },
+  });
+}
+
+function runWithHomeAsync(args, home, cwd = process.cwd()) {
+  return new Promise((resolveRun) => {
+    const child = spawn(cli[0], [cli[1], ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TELEMETRY: "0",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (status) => {
+      resolveRun({ status, stdout, stderr });
+    });
   });
 }
 
@@ -120,6 +149,63 @@ function withCaptureFixtureRepo(fn) {
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }
+}
+
+async function withMockGateway(handler, fn) {
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+    const bodyText = Buffer.concat(chunks).toString("utf8");
+    const record = {
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: bodyText ? JSON.parse(bodyText) : null,
+    };
+    requests.push(record);
+    try {
+      const response = await handler(record);
+      res.statusCode = response.status ?? 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(response.body ?? {}));
+    } catch (error) {
+      res.statusCode = 500;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ message: error instanceof Error ? error.message : String(error) }));
+    }
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const address = server.address();
+  const gatewayUrl = `http://127.0.0.1:${address.port}`;
+  try {
+    return await fn({ gatewayUrl, requests });
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+}
+
+function writeTestCredentials(home, gatewayUrl) {
+  const configDir = join(home, ".understudy");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    join(configDir, "credentials.json"),
+    `${JSON.stringify(
+      {
+        gateway_url: gatewayUrl,
+        orgs: {
+          org_test: {
+            api_key: "sk_test_workloads",
+            gateway_url: gatewayUrl,
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
 }
 
 function withValueFixtureRepo({ measured = false } = {}, fn) {
@@ -760,11 +846,90 @@ describe("understudy CLI", () => {
     assert.match(root.stdout, /models/);
     assert.match(root.stdout, /workloads/);
 
+    const create = run(["workloads", "create", "--help"]);
+    assert.equal(create.status, 0, create.stderr);
+    assert.match(create.stdout, /--project-id/);
+    assert.match(create.stdout, /--from-card/);
+
     const route = run(["workloads", "route", "--help"]);
     assert.equal(route.status, 0, route.stderr);
     assert.match(route.stdout, /--model-id/);
     assert.match(route.stdout, /--traffic-pct/);
     assert.match(route.stdout, /--clear/);
+  });
+
+  it("registers a local workload card on the gateway", async () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-workloads-home-"));
+    const repo = mkdtempSync(join(tmpdir(), "understudy-workloads-repo-"));
+    try {
+      const card = {
+        schema_version: "understudy.workload_card.v1",
+        workload_id: "workload-001",
+        workload_name: "Synthetic workflow",
+        workload_shape: ["api-workflow"],
+        data_class: "source-metadata-only",
+      };
+      const cardPath = join(repo, "workload-card.json");
+      writeFileSync(cardPath, `${JSON.stringify(card, null, 2)}\n`);
+
+      await withMockGateway(
+        (request) => {
+          if (request.url === "/v1/agent/events") {
+            return { body: { ok: true } };
+          }
+          assert.equal(request.method, "POST");
+          assert.equal(request.url, "/admin/v1/orgs/org_test/projects/proj_test/workloads");
+          assert.equal(request.headers.authorization, "Bearer sk_test_workloads");
+          assert.equal(request.body.workload_card.schema_version, "understudy.workload_card.v1");
+          assert.equal(request.body.workload_card.workload_id, "workload-001");
+          assert.equal(request.body.source.kind, "workload_card");
+          return {
+            status: 201,
+            body: {
+              workload_id: "wl_server_123",
+              project_id: "proj_test",
+              created: true,
+            },
+          };
+        },
+        async ({ gatewayUrl, requests }) => {
+          writeTestCredentials(home, gatewayUrl);
+          const result = await runWithHomeAsync(
+            ["--json", "workloads", "create", "--project-id", "proj_test", "--from-card", cardPath],
+            home,
+            repo,
+          );
+          assert.equal(result.status, 0, result.stderr);
+          const payload = JSON.parse(result.stdout);
+          assert.equal(payload.workload_id, "wl_server_123");
+          assert.equal(payload.project_id, "proj_test");
+          assert.ok(requests.some((request) => request.url === "/admin/v1/orgs/org_test/projects/proj_test/workloads"));
+        },
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to register a malformed workload card", () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-workloads-home-"));
+    const repo = mkdtempSync(join(tmpdir(), "understudy-workloads-repo-"));
+    try {
+      const cardPath = join(repo, "workload-card.json");
+      writeFileSync(cardPath, "{\"schema_version\":\"wrong\"}\n");
+      writeTestCredentials(home, "http://127.0.0.1:1");
+      const result = runWithHome(
+        ["--json", "workloads", "create", "--project-id", "proj_test", "--from-card", cardPath],
+        home,
+        repo,
+      );
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /expected schema_version understudy\.workload_card\.v1/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 
   it("scans capture/import sources with metadata only and writes a redaction manifest", () =>

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -880,15 +880,15 @@ describe("understudy CLI", () => {
           assert.equal(request.method, "POST");
           assert.equal(request.url, "/admin/v1/orgs/org_test/projects/proj_test/workloads");
           assert.equal(request.headers.authorization, "Bearer sk_test_workloads");
-          assert.equal(request.body.workload_card.schema_version, "understudy.workload_card.v1");
-          assert.equal(request.body.workload_card.workload_id, "workload-001");
-          assert.equal(request.body.source.kind, "workload_card");
+          assert.equal(request.body.name, "workload-001");
+          assert.equal(request.body.capture_enabled, false);
           return {
             status: 201,
             body: {
-              workload_id: "wl_server_123",
+              id: "wl_server_123",
               project_id: "proj_test",
-              created: true,
+              name: "workload-001",
+              capture_enabled: false,
             },
           };
         },
@@ -901,9 +901,11 @@ describe("understudy CLI", () => {
           );
           assert.equal(result.status, 0, result.stderr);
           const payload = JSON.parse(result.stdout);
-          assert.equal(payload.workload_id, "wl_server_123");
+          assert.equal(payload.id, "wl_server_123");
           assert.equal(payload.project_id, "proj_test");
-          assert.ok(requests.some((request) => request.url === "/admin/v1/orgs/org_test/projects/proj_test/workloads"));
+          assert.ok(
+            requests.some((request) => request.url === "/admin/v1/orgs/org_test/projects/proj_test/workloads"),
+          );
         },
       );
     } finally {


### PR DESCRIPTION
## Summary

Adds `understudy workloads create --project-id <id> --from-card <path>` so agents can register a local `understudy.workload_card.v1` with the gateway before routing traffic.

The command reads and validates the local Workload Card, calls the customer admin workload registration surface, and prints the server-assigned workload id for the follow-on `workloads route` command. It also updates the gateway skill docs so agents follow the register-then-route sequence.

Closes #36.

## Validation

- `npm run check`