### PR TITLE
Skills: introduce the experiment artifact contract

### DIFF
--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -126,11 +126,22 @@ validator kinds in [`reference.md`](reference.md):
 8. Run holdout only once the candidate is frozen, and record score, failures,
    latency basis, cost basis, fallback route, demotion trigger, and caveats.
 
-Write optimization and validation artifacts under:
+The home of record for an optimization run is the **active experiment**
+directory (see the Experiment section of
+[`../understudy/SKILL.md`](../understudy/SKILL.md) for the record shape):
 
 ```text
-.understudy/optimize-workload/
+.understudy/experiments/<exp-id>/      # experiment.json, candidate.json, claim.json
 ```
+
+Open or reuse an experiment before optimizing (`experiments/active` names it),
+record the candidate model, objective, and the `pins` copied from
+`baseline.json`'s hash-chain, then freeze the chosen `candidate.json` and the
+`claim.json` there. The `optimize-workload` CLI still emits scratch artifacts
+(`eval-input-candidate.json`, `proof-packet.json`, adapter outputs) under
+`.understudy/optimize-workload/`; treat those as working state and freeze the
+selected candidate into the experiment directory. An experiment-aware CLI is a
+tracked follow-up.
 
 The previous Python helper scripts have been removed with the Python CLI
 prototype. Use the TypeScript CLI gates first, and still inspect artifacts
@@ -157,7 +168,7 @@ uv pip install --python .understudy/venvs/optimize/bin/python 'gepa>=0.0.27,<0.1
 Do not claim savings without:
 
 ```text
-.understudy/optimize-workload/claim.json
+.understudy/experiments/<exp-id>/claim.json
 ```
 
 `claim.json` must cite `harness.json`, `metric.json`, `splits.json`,

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -153,15 +153,70 @@ use fresh data and label assumptions ([`reference.md`](reference.md)).
 .understudy/capture-evidence/metric.json
 .understudy/capture-evidence/splits.json
 .understudy/capture-evidence/baseline.json
-.understudy/optimize-workload/candidate.json
-.understudy/optimize-workload/claim.json
+.understudy/experiments/<exp-id>/experiment.json
+.understudy/experiments/<exp-id>/candidate.json
+.understudy/experiments/<exp-id>/claim.json
+.understudy/experiments/active            # pointer to the active <exp-id>
 ```
 
-`capture-evidence` creates or refreshes the first five. `optimize-workload` may
-optimize only from fresh copies of `harness.json`, `metric.json`, `splits.json`,
-and `baseline.json`. Freshness is hash-bound: `baseline.json` carries
-`harness_sha256`, `metric_sha256`, and `splits_sha256`; any later change to the
-harness, metric, validator, or splits routes back to `capture-evidence`.
+`capture-evidence` creates or refreshes the first five — the **workload
+evidence** every experiment runs against. Freshness is hash-bound:
+`baseline.json` carries `harness_sha256`, `metric_sha256`, and `splits_sha256`;
+any later change to the harness, metric, validator, or splits routes back to
+`capture-evidence`.
+
+### Experiment
+
+An **experiment** is one measured episode over a frozen workload: an incumbent
+baseline versus a candidate, under a pinned metric and split, producing a claim
+and an outcome. It is the unit `optimize-workload` writes and the unit that
+graduates into the knowledge base. Each experiment owns a directory under
+`.understudy/experiments/<exp-id>/`; `experiments/active` names the one in
+flight, so a workload can hold more than one without overwriting prior results.
+
+`experiment.json` is the record of that episode:
+
+```jsonc
+{
+  "experiment_id": "exp-001",
+  "workload": "workload-001",          // real id locally; anonymized only on promotion
+  "objective": "cost",                 // cost | speed | quality | reliability | compliance | weighted
+  "hypothesis": "Gemma-4-31b replaces the incumbent for triage tool-calls under break-even",
+  "pins": {                            // copied from baseline.json's hash-chain
+    "harness_sha256": "…",
+    "metric_sha256": "…",
+    "splits_sha256": "…"
+  },
+  "incumbent_model": "openai/gpt-4o",
+  "candidate_model": "google/gemma-4-31b-it",
+  "result": { "claim_ref": "claim.json", "quality_delta": null,
+              "p50_latency_delta_ms": null, "cost_per_1k_delta_usd": null },
+  "outcome": null,                     // success | partial | abandoned
+  "route_decision": null               // ship-local | local-as-router | hybrid | remote
+}
+```
+
+The record stores **identity + input-pins + verdict** — never a loop-step
+counter. Where you are in the loop is *derived*: re-hash the artifacts on disk
+and compare to `pins` (a changed hash means re-baseline); a present
+`candidate.json` with a null `outcome` means you are at compare. The filesystem
+and the pins are the truth, so the record cannot drift into reporting a step it
+isn't at.
+
+`outcome`, `workload`, `incumbent_model`, `candidate_model`, and the result
+deltas mirror the `type: experiment` lab-note in the Understudy knowledge
+base — `experiment.json` is its un-anonymized, hash-pinned, live
+precursor. When `outcome` is set, an experiment may be **promoted** into a
+knowledge lab-note: anonymize `workload` to `workload-NNN`, drop real paths, and
+add the cost/margin analysis the local record deliberately omits. Promotion
+publishes to a shared repository and is an upload — gate it like any other (see
+Safety Gates).
+
+> The `experiments/` layout is the target artifact contract. The
+> `optimize-workload` CLI still writes scratch candidate/claim artifacts under
+> `.understudy/optimize-workload/`; an experiment-aware CLI (`understudy next`,
+> an experiment ledger) is a tracked follow-up. Until then, freeze the chosen
+> candidate and the claim into the active experiment directory by hand.
 
 Removed Python-prototype commands and deleted draft skills are tracked in
 [`../../docs/current-functionality.md`](../../docs/current-functionality.md). Do


### PR DESCRIPTION
## What

Makes **experiment** a first-class entity in the local `.understudy/` artifact contract. Skill-only — no CLI code changes.

Today the improvement loop has no experiment concept: the implicit `baseline.json → candidate.json → claim.json` chain is a single anonymous slot that each optimize run overwrites. No identity, no history, no side-by-side experiments. Meanwhile the entity already exists *upstream* (Prime Intellect `verifiers` rollout/rubric vocab — the measurement source) and *downstream* (the Understudy knowledge base's `type: experiment` lab-notes — the published, anonymized form). This PR fills the missing middle.

## Changes

**`skills/understudy/SKILL.md`** — new **Experiment** section + reshaped MVP Artifact Contract:

```
.understudy/experiments/<exp-id>/experiment.json
.understudy/experiments/<exp-id>/candidate.json
.understudy/experiments/<exp-id>/claim.json
.understudy/experiments/active            # pointer to the active <exp-id>
```

- `experiment.json` stores **identity + input-pins + verdict** — `pins` generalizes the existing `baseline.json` hash-chain (`harness/metric/splits_sha256`).
- **No loop-step counter.** Step position is *derived* by re-hashing artifacts on disk against `pins`, so the record can't drift into reporting a step it isn't at. (This is the answer to "why not a single state file?" — the anchor is the experiment, not a step tracker.)
- Field names/enums (`outcome: success|partial|abandoned`, `incumbent_model`, `candidate_model`, result deltas) mirror the knowledge-base `type: experiment` lab-note. `experiment.json` is its un-anonymized, hash-pinned, **live precursor**; promotion anonymizes `workload → workload-NNN`, adds cost/margin math, and is gated as an upload.

**`skills/optimize-workload/SKILL.md`** — home of record moves to the active experiment dir; CLI scratch stays under `optimize-workload/` with a transition note.

## Scope / follow-ups

- Skill-only by design. The experiment-aware CLI (`understudy next`, an experiment ledger that powers loop-state and scaffold) is the tracked follow-up.
- The `optimize-workload` CLI still writes scratch `candidate.json`/`claim.json` under `.understudy/optimize-workload/`; the skill notes this and instructs freezing into the experiment dir by hand until the CLI is experiment-aware.

## Validation

`npm run skills:validate` → `ok 8 public skill(s)` (passes the public-safety gate — no private repo names).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->