### PR TITLE
feat: experiment ledger + understudy next

### DIFF
--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -140,8 +140,9 @@ record the candidate model, objective, and the `pins` copied from
 `claim.json` there. The `optimize-workload` CLI still emits scratch artifacts
 (`eval-input-candidate.json`, `proof-packet.json`, adapter outputs) under
 `.understudy/optimize-workload/`; treat those as working state and freeze the
-selected candidate into the experiment directory. An experiment-aware CLI is a
-tracked follow-up.
+selected candidate into the experiment directory. Use `understudy experiments
+new` to open an experiment (it pins the current baseline) and `understudy next`
+to see the current loop step.
 
 The previous Python helper scripts have been removed with the Python CLI
 prototype. Use the TypeScript CLI gates first, and still inspect artifacts

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -212,11 +212,13 @@ add the cost/margin analysis the local record deliberately omits. Promotion
 publishes to a shared repository and is an upload — gate it like any other (see
 Safety Gates).
 
-> The `experiments/` layout is the target artifact contract. The
-> `optimize-workload` CLI still writes scratch candidate/claim artifacts under
-> `.understudy/optimize-workload/`; an experiment-aware CLI (`understudy next`,
-> an experiment ledger) is a tracked follow-up. Until then, freeze the chosen
-> candidate and the claim into the active experiment directory by hand.
+> `understudy experiments new` opens an experiment and copies the baseline
+> hash-chain into `pins`; `understudy next` reads the artifacts on disk plus the
+> active experiment to report the loop step and the command to run next;
+> `understudy experiments outcome` records the verdict. The `optimize-workload`
+> CLI still writes scratch candidate/claim artifacts under
+> `.understudy/optimize-workload/`; freeze the chosen candidate and the claim
+> into the active experiment directory.
 
 Removed Python-prototype commands and deleted draft skills are tracked in
 [`../../docs/current-functionality.md`](../../docs/current-functionality.md). Do

--- a/src/commands/experiments.ts
+++ b/src/commands/experiments.ts
@@ -1,0 +1,196 @@
+import { Command } from "commander";
+import kleur from "kleur";
+
+import { isJsonMode } from "../internal/output.js";
+import {
+  createExperiment,
+  deriveNext,
+  readActiveId,
+  readExperiment,
+  recordOutcome,
+  setActiveId,
+  summarizeExperiments,
+  type ExperimentOutcome,
+  type RouteDecision,
+} from "../experiments.js";
+
+function runLocal(cmd: Command, body: () => void): void {
+  try {
+    body();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (isJsonMode(cmd)) {
+      process.stderr.write(`${JSON.stringify({ ok: false, error: message })}\n`);
+    } else {
+      process.stderr.write(`${kleur.red("error")}: ${message}\n`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+function printJson(payload: unknown): void {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+export function registerExperimentsCommands(program: Command): void {
+  const experiments = program
+    .command("experiments")
+    .description("Manage local workload experiments under .understudy/experiments/");
+
+  experiments
+    .command("list")
+    .description("List experiments and mark the active one")
+    .option("--repo <path>", "Local repository path", ".")
+    .option("--json", "Output JSON")
+    .action(function (this: Command, options: { repo: string }) {
+      runLocal(this, () => {
+        const rows = summarizeExperiments(options.repo);
+        if (isJsonMode(this)) {
+          printJson({ experiments: rows });
+          return;
+        }
+        if (rows.length === 0) {
+          process.stdout.write("No experiments yet. Run `understudy experiments new`.\n");
+          return;
+        }
+        for (const row of rows) {
+          const marker = row.active ? kleur.green("* ") : "  ";
+          const outcome = row.outcome ?? "open";
+          process.stdout.write(
+            `${marker}${kleur.bold(row.experiment_id)}  ${row.workload}  outcome=${outcome}` +
+              `${row.candidate_model ? `  candidate=${row.candidate_model}` : ""}\n`,
+          );
+        }
+      });
+    });
+
+  experiments
+    .command("new")
+    .description("Open a new experiment, pin the current baseline, and make it active")
+    .option("--repo <path>", "Local repository path", ".")
+    .option("--id <id>", "Experiment id (default: next exp-NNN)")
+    .option("--workload <id>", "Workload id this experiment runs against")
+    .option("--objective <objective>", "cost | speed | quality | reliability | compliance | weighted")
+    .option("--hypothesis <text>", "One-line hypothesis")
+    .option("--incumbent <model>", "Incumbent model id")
+    .option("--candidate <model>", "Candidate model id")
+    .option("--json", "Output JSON")
+    .action(function (
+      this: Command,
+      options: {
+        repo: string;
+        id?: string;
+        workload?: string;
+        objective?: string;
+        hypothesis?: string;
+        incumbent?: string;
+        candidate?: string;
+      },
+    ) {
+      runLocal(this, () => {
+        const experiment = createExperiment(options.repo, {
+          id: options.id,
+          workload: options.workload,
+          objective: options.objective,
+          hypothesis: options.hypothesis,
+          incumbent: options.incumbent,
+          candidate: options.candidate,
+        });
+        if (isJsonMode(this)) {
+          printJson(experiment);
+          return;
+        }
+        const pinned = experiment.pins.harness_sha256 && experiment.pins.metric_sha256 && experiment.pins.splits_sha256;
+        process.stdout.write(
+          `${kleur.green("✓")} Created ${kleur.bold(experiment.experiment_id)} (active) for ${experiment.workload}\n`,
+        );
+        process.stdout.write(
+          pinned
+            ? `${kleur.gray("pins copied from baseline.json")}\n`
+            : `${kleur.yellow("no baseline pins yet — run capture-evidence to baseline this experiment")}\n`,
+        );
+      });
+    });
+
+  experiments
+    .command("show [id]")
+    .description("Show one experiment record (default: active)")
+    .option("--repo <path>", "Local repository path", ".")
+    .option("--json", "Output JSON")
+    .action(function (this: Command, id: string | undefined, options: { repo: string }) {
+      runLocal(this, () => {
+        const target = id ?? readActiveId(options.repo);
+        if (!target) {
+          throw new Error("No active experiment. Pass an id or run `understudy experiments new`.");
+        }
+        const experiment = readExperiment(options.repo, target);
+        if (isJsonMode(this)) {
+          printJson(experiment);
+          return;
+        }
+        printJson(experiment);
+      });
+    });
+
+  experiments
+    .command("use <id>")
+    .description("Set the active experiment")
+    .option("--repo <path>", "Local repository path", ".")
+    .action(function (this: Command, id: string, options: { repo: string }) {
+      runLocal(this, () => {
+        setActiveId(options.repo, id);
+        process.stdout.write(`${kleur.green("✓")} Active experiment: ${kleur.bold(id)}\n`);
+      });
+    });
+
+  experiments
+    .command("outcome <outcome>")
+    .description("Record an experiment outcome: success | partial | abandoned")
+    .option("--repo <path>", "Local repository path", ".")
+    .option("--id <id>", "Experiment id (default: active)")
+    .option("--route <route>", "ship-local | local-as-router | hybrid | remote")
+    .option("--json", "Output JSON")
+    .action(function (
+      this: Command,
+      outcome: string,
+      options: { repo: string; id?: string; route?: string },
+    ) {
+      runLocal(this, () => {
+        const experiment = recordOutcome(options.repo, outcome as ExperimentOutcome, {
+          id: options.id,
+          route: options.route as RouteDecision | undefined,
+        });
+        if (isJsonMode(this)) {
+          printJson(experiment);
+          return;
+        }
+        process.stdout.write(
+          `${kleur.green("✓")} ${kleur.bold(experiment.experiment_id)} outcome=${experiment.outcome}` +
+            `${experiment.route_decision ? ` route=${experiment.route_decision}` : ""}\n`,
+        );
+      });
+    });
+}
+
+export function registerNextCommand(program: Command): void {
+  program
+    .command("next")
+    .description("Show where the improvement loop stands and the next command to run")
+    .option("--repo <path>", "Local repository path", ".")
+    .option("--json", "Output JSON")
+    .action(function (this: Command, options: { repo: string }) {
+      runLocal(this, () => {
+        const state = deriveNext(options.repo);
+        if (isJsonMode(this)) {
+          printJson(state);
+          return;
+        }
+        process.stdout.write(`${kleur.bold(`step: ${state.step}`)}\n`);
+        if (state.experiment_id) {
+          process.stdout.write(`experiment: ${state.experiment_id}\n`);
+        }
+        process.stdout.write(`${state.summary}\n`);
+        process.stdout.write(`${kleur.cyan("next:")} ${state.next_command}\n`);
+      });
+    });
+}

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -1,0 +1,403 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const captureEvidenceDir = ".understudy/capture-evidence";
+const experimentsDir = ".understudy/experiments";
+const activePointer = join(experimentsDir, "active");
+
+const evidenceArtifacts = [
+  "harness.json",
+  "environment.json",
+  "metric.json",
+  "splits.json",
+  "baseline.json",
+] as const;
+
+const pinnedArtifacts = ["harness.json", "metric.json", "splits.json"] as const;
+
+export type ExperimentPins = {
+  harness_sha256: string | null;
+  metric_sha256: string | null;
+  splits_sha256: string | null;
+};
+
+export type ExperimentOutcome = "success" | "partial" | "abandoned";
+export type RouteDecision = "ship-local" | "local-as-router" | "hybrid" | "remote";
+
+export type ExperimentResult = {
+  claim_ref: string | null;
+  quality_delta: number | null;
+  p50_latency_delta_ms: number | null;
+  cost_per_1k_delta_usd: number | null;
+};
+
+export type Experiment = {
+  schema_version: "understudy.experiment.v1";
+  experiment_id: string;
+  workload: string;
+  objective: string | null;
+  hypothesis: string | null;
+  created_at: string;
+  pins: ExperimentPins;
+  incumbent_model: string | null;
+  candidate_model: string | null;
+  result: ExperimentResult;
+  outcome: ExperimentOutcome | null;
+  route_decision: RouteDecision | null;
+};
+
+export type NewExperimentOptions = {
+  id?: string;
+  workload?: string;
+  objective?: string;
+  hypothesis?: string;
+  incumbent?: string;
+  candidate?: string;
+};
+
+export type LoopStep =
+  | "capture-evidence"
+  | "open-experiment"
+  | "re-baseline"
+  | "optimize"
+  | "claim"
+  | "decide"
+  | "route";
+
+export type NextState = {
+  schema_version: "understudy.next.v1";
+  repo: string;
+  step: LoopStep;
+  experiment_id: string | null;
+  evidence: { present: string[]; missing: string[] };
+  pins_match: boolean | null;
+  summary: string;
+  next_command: string;
+};
+
+export type ExperimentSummary = {
+  experiment_id: string;
+  workload: string;
+  outcome: ExperimentOutcome | null;
+  candidate_model: string | null;
+  active: boolean;
+};
+
+const VALID_OUTCOMES: readonly ExperimentOutcome[] = ["success", "partial", "abandoned"];
+const VALID_ROUTES: readonly RouteDecision[] = ["ship-local", "local-as-router", "hybrid", "remote"];
+
+function ensureRepo(repoInput: string): string {
+  const repo = resolve(repoInput);
+  if (!existsSync(repo) || !statSync(repo).isDirectory()) {
+    throw new Error(`Repo path does not exist or is not a directory: ${repoInput}`);
+  }
+  return repo;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/** sha256 of an artifact's raw bytes, or null if it is absent. */
+function hashArtifact(repo: string, artifact: string): string | null {
+  const path = join(repo, captureEvidenceDir, artifact);
+  if (!existsSync(path)) {
+    return null;
+  }
+  return sha256(readFileSync(path, "utf8"));
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function writeJson(path: string, payload: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function experimentDir(repo: string, id: string): string {
+  return join(repo, experimentsDir, id);
+}
+
+function experimentRecordPath(repo: string, id: string): string {
+  return join(experimentDir(repo, id), "experiment.json");
+}
+
+/** List experiment ids in `exp-NNN` order. */
+export function listExperimentIds(repo: string): string[] {
+  const root = join(repo, experimentsDir);
+  if (!existsSync(root)) {
+    return [];
+  }
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(experimentRecordPath(repo, name)))
+    .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }));
+}
+
+function nextExperimentId(repo: string): string {
+  const ids = listExperimentIds(repo);
+  let max = 0;
+  for (const id of ids) {
+    const match = /^exp-(\d+)$/.exec(id);
+    if (match) {
+      max = Math.max(max, Number.parseInt(match[1]!, 10));
+    }
+  }
+  return `exp-${String(max + 1).padStart(3, "0")}`;
+}
+
+export function readActiveId(repo: string): string | null {
+  const path = join(repo, activePointer);
+  if (!existsSync(path)) {
+    return null;
+  }
+  const id = readFileSync(path, "utf8").trim();
+  return id.length > 0 && existsSync(experimentRecordPath(repo, id)) ? id : null;
+}
+
+export function setActiveId(repoInput: string, id: string): void {
+  const repo = ensureRepo(repoInput);
+  if (!existsSync(experimentRecordPath(repo, id))) {
+    throw new Error(`Unknown experiment: ${id}. Run \`understudy experiments list\`.`);
+  }
+  const path = join(repo, activePointer);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${id}\n`, "utf8");
+}
+
+export function readExperiment(repo: string, id: string): Experiment {
+  const path = experimentRecordPath(repo, id);
+  if (!existsSync(path)) {
+    throw new Error(`Unknown experiment: ${id}. Run \`understudy experiments list\`.`);
+  }
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as Experiment;
+  return parsed;
+}
+
+/** Copy the baseline.json hash-chain into a pins object (nulls if absent). */
+function pinsFromBaseline(repo: string): ExperimentPins {
+  const path = join(repo, captureEvidenceDir, "baseline.json");
+  const empty: ExperimentPins = { harness_sha256: null, metric_sha256: null, splits_sha256: null };
+  if (!existsSync(path)) {
+    return empty;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return empty;
+  }
+  if (!isObject(parsed)) {
+    return empty;
+  }
+  return {
+    harness_sha256: optionalString(parsed.harness_sha256),
+    metric_sha256: optionalString(parsed.metric_sha256),
+    splits_sha256: optionalString(parsed.splits_sha256),
+  };
+}
+
+export function createExperiment(repoInput: string, options: NewExperimentOptions = {}): Experiment {
+  const repo = ensureRepo(repoInput);
+  const id = options.id ?? nextExperimentId(repo);
+  if (!/^exp-\d+$/.test(id) && options.id === undefined) {
+    throw new Error(`Generated an invalid experiment id: ${id}`);
+  }
+  if (existsSync(experimentRecordPath(repo, id))) {
+    throw new Error(`Experiment ${id} already exists.`);
+  }
+  const experiment: Experiment = {
+    schema_version: "understudy.experiment.v1",
+    experiment_id: id,
+    workload: options.workload ?? "workload-001",
+    objective: options.objective ?? null,
+    hypothesis: options.hypothesis ?? null,
+    created_at: new Date().toISOString(),
+    pins: pinsFromBaseline(repo),
+    incumbent_model: options.incumbent ?? null,
+    candidate_model: options.candidate ?? null,
+    result: {
+      claim_ref: null,
+      quality_delta: null,
+      p50_latency_delta_ms: null,
+      cost_per_1k_delta_usd: null,
+    },
+    outcome: null,
+    route_decision: null,
+  };
+  writeJson(experimentRecordPath(repo, id), experiment);
+  setActiveId(repo, id);
+  return experiment;
+}
+
+export function recordOutcome(
+  repoInput: string,
+  outcome: ExperimentOutcome,
+  options: { id?: string; route?: RouteDecision } = {},
+): Experiment {
+  const repo = ensureRepo(repoInput);
+  if (!VALID_OUTCOMES.includes(outcome)) {
+    throw new Error(`Invalid outcome "${outcome}". Use one of: ${VALID_OUTCOMES.join(", ")}.`);
+  }
+  if (options.route !== undefined && !VALID_ROUTES.includes(options.route)) {
+    throw new Error(`Invalid route "${options.route}". Use one of: ${VALID_ROUTES.join(", ")}.`);
+  }
+  const id = options.id ?? readActiveId(repo);
+  if (!id) {
+    throw new Error("No active experiment. Run `understudy experiments new` first.");
+  }
+  const experiment = readExperiment(repo, id);
+  experiment.outcome = outcome;
+  if (options.route !== undefined) {
+    experiment.route_decision = options.route;
+  }
+  const claimPath = join(experimentDir(repo, id), "claim.json");
+  if (existsSync(claimPath)) {
+    experiment.result.claim_ref = "claim.json";
+  }
+  writeJson(experimentRecordPath(repo, id), experiment);
+  return experiment;
+}
+
+export function summarizeExperiments(repoInput: string): ExperimentSummary[] {
+  const repo = ensureRepo(repoInput);
+  const active = readActiveId(repo);
+  return listExperimentIds(repo).map((id) => {
+    const experiment = readExperiment(repo, id);
+    return {
+      experiment_id: id,
+      workload: experiment.workload,
+      outcome: experiment.outcome,
+      candidate_model: experiment.candidate_model,
+      active: id === active,
+    };
+  });
+}
+
+function evidenceState(repo: string): { present: string[]; missing: string[] } {
+  const present: string[] = [];
+  const missing: string[] = [];
+  for (const artifact of evidenceArtifacts) {
+    if (existsSync(join(repo, captureEvidenceDir, artifact))) {
+      present.push(artifact);
+    } else {
+      missing.push(artifact);
+    }
+  }
+  return { present, missing };
+}
+
+/** True only when every pinned hash is set and equals the artifact on disk. */
+function pinsMatchDisk(repo: string, pins: ExperimentPins): boolean {
+  for (const artifact of pinnedArtifacts) {
+    const field = `${artifact.replace(/\.json$/, "")}_sha256` as keyof ExperimentPins;
+    const pinned = pins[field];
+    if (!pinned || hashArtifact(repo, artifact) !== pinned) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Derive where the improvement loop stands purely from artifacts on disk plus
+ * the active experiment's pins — no stored step counter. This is `understudy
+ * next`.
+ */
+export function deriveNext(repoInput: string): NextState {
+  const repo = ensureRepo(repoInput);
+  const evidence = evidenceState(repo);
+  const base = {
+    schema_version: "understudy.next.v1" as const,
+    repo,
+    evidence,
+  };
+
+  if (evidence.missing.length > 0) {
+    return {
+      ...base,
+      step: "capture-evidence",
+      experiment_id: readActiveId(repo),
+      pins_match: null,
+      summary: `Workload evidence incomplete — missing ${evidence.missing.join(", ")}.`,
+      next_command: "understudy capture-evidence check --repo .",
+    };
+  }
+
+  const activeId = readActiveId(repo);
+  if (!activeId) {
+    return {
+      ...base,
+      step: "open-experiment",
+      experiment_id: null,
+      pins_match: null,
+      summary: "Evidence is present but no experiment is open.",
+      next_command: "understudy experiments new --repo .",
+    };
+  }
+
+  const experiment = readExperiment(repo, activeId);
+  const dir = experimentDir(repo, activeId);
+  const pinsMatch = pinsMatchDisk(repo, experiment.pins);
+
+  if (!pinsMatch) {
+    return {
+      ...base,
+      step: "re-baseline",
+      experiment_id: activeId,
+      pins_match: false,
+      summary: `Experiment ${activeId} pins do not match the evidence on disk — re-baseline before optimizing.`,
+      next_command: "understudy capture-evidence check --repo .",
+    };
+  }
+
+  if (!existsSync(join(dir, "candidate.json"))) {
+    return {
+      ...base,
+      step: "optimize",
+      experiment_id: activeId,
+      pins_match: true,
+      summary: `Experiment ${activeId} is baselined — run the optimizer and freeze a candidate.`,
+      next_command: "understudy optimize-workload check --repo .",
+    };
+  }
+
+  if (!existsSync(join(dir, "claim.json"))) {
+    return {
+      ...base,
+      step: "claim",
+      experiment_id: activeId,
+      pins_match: true,
+      summary: `Experiment ${activeId} has a candidate but no claim — run holdout and write claim.json.`,
+      next_command: "understudy optimize-workload check --repo .",
+    };
+  }
+
+  if (experiment.outcome === null) {
+    return {
+      ...base,
+      step: "decide",
+      experiment_id: activeId,
+      pins_match: true,
+      summary: `Experiment ${activeId} has a claim — compare and record the outcome.`,
+      next_command: "understudy experiments outcome <success|partial|abandoned> --repo .",
+    };
+  }
+
+  return {
+    ...base,
+    step: "route",
+    experiment_id: activeId,
+    pins_match: true,
+    summary: `Experiment ${activeId} outcome is ${experiment.outcome} — implement the route or promote a lab-note.`,
+    next_command: "understudy route-decision plan --workload-card .understudy/workload-discovery/workload-card.json",
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { registerSetupCommand } from "./commands/setup.js";
 import { registerStatusCommand } from "./commands/status.js";
 import { registerOptimizeWorkloadCommand } from "./commands/optimize-workload.js";
 import { registerWorkloadsCommand } from "./commands/workloads.js";
+import { registerExperimentsCommands, registerNextCommand } from "./commands/experiments.js";
 
 export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -425,6 +426,8 @@ export function buildProgram(): Command {
   registerCaptureImportCommands(program);
   registerRouteDecisionCommands(program);
   registerValueCommands(program);
+  registerExperimentsCommands(program);
+  registerNextCommand(program);
 
   program.action(printSpine);
   return program;

--- a/tests/experiments.test.mjs
+++ b/tests/experiments.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+
+const cli = ["node", resolve("dist/bin.js")];
+
+function run(repo, args) {
+  return spawnSync(cli[0], [cli[1], ...args, "--repo", repo], { encoding: "utf8" });
+}
+
+function sha256(text) {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/** Write the five capture-evidence artifacts with a baseline that pins three of them. */
+function seedEvidence(repo) {
+  const ce = join(repo, ".understudy", "capture-evidence");
+  mkdirSync(ce, { recursive: true });
+  const harness = `${JSON.stringify({ command: "npm test" }, null, 2)}\n`;
+  const metric = `${JSON.stringify({ approved: true }, null, 2)}\n`;
+  const splits = `${JSON.stringify({ train: [], dev: [], holdout: [] }, null, 2)}\n`;
+  writeFileSync(join(ce, "harness.json"), harness);
+  writeFileSync(join(ce, "environment.json"), `${JSON.stringify({ runtime: "node" }, null, 2)}\n`);
+  writeFileSync(join(ce, "metric.json"), metric);
+  writeFileSync(join(ce, "splits.json"), splits);
+  writeFileSync(
+    join(ce, "baseline.json"),
+    `${JSON.stringify(
+      {
+        harness_sha256: sha256(harness),
+        metric_sha256: sha256(metric),
+        splits_sha256: sha256(splits),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return ce;
+}
+
+function withRepo(fn) {
+  const repo = mkdtempSync(join(tmpdir(), "understudy-experiments-"));
+  try {
+    return fn(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+function nextState(repo) {
+  const result = run(repo, ["next", "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+describe("understudy experiments + next", () => {
+  it("routes to capture-evidence when evidence is incomplete", () => {
+    withRepo((repo) => {
+      const state = nextState(repo);
+      assert.equal(state.step, "capture-evidence");
+      assert.equal(state.experiment_id, null);
+      assert.ok(state.evidence.missing.includes("harness.json"));
+      assert.equal(state.next_command, "understudy capture-evidence check --repo .");
+    });
+  });
+
+  it("routes to open-experiment when evidence is present but no experiment is active", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      const state = nextState(repo);
+      assert.equal(state.step, "open-experiment");
+      assert.equal(state.evidence.missing.length, 0);
+      assert.equal(state.next_command, "understudy experiments new --repo .");
+    });
+  });
+
+  it("walks the loop optimize -> claim -> decide -> route", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+
+      const created = run(repo, ["experiments", "new", "--json", "--workload", "workload-001", "--candidate", "gemma-4-31b"]);
+      assert.equal(created.status, 0, created.stderr);
+      const experiment = JSON.parse(created.stdout);
+      assert.equal(experiment.experiment_id, "exp-001");
+      assert.equal(experiment.schema_version, "understudy.experiment.v1");
+      // pins are copied from baseline.json's hash-chain (exactly three).
+      assert.deepEqual(Object.keys(experiment.pins).sort(), ["harness_sha256", "metric_sha256", "splits_sha256"]);
+      assert.ok(experiment.pins.harness_sha256);
+
+      assert.equal(nextState(repo).step, "optimize");
+
+      const expDir = join(repo, ".understudy", "experiments", "exp-001");
+      writeFileSync(join(expDir, "candidate.json"), "{}\n");
+      assert.equal(nextState(repo).step, "claim");
+
+      writeFileSync(join(expDir, "claim.json"), "{}\n");
+      assert.equal(nextState(repo).step, "decide");
+
+      const outcome = run(repo, ["experiments", "outcome", "success", "--route", "ship-local"]);
+      assert.equal(outcome.status, 0, outcome.stderr);
+
+      const routed = nextState(repo);
+      assert.equal(routed.step, "route");
+      const record = JSON.parse(readFileSync(join(expDir, "experiment.json"), "utf8"));
+      assert.equal(record.outcome, "success");
+      assert.equal(record.route_decision, "ship-local");
+      assert.equal(record.result.claim_ref, "claim.json");
+    });
+  });
+
+  it("detects stale pins and routes back to re-baseline", () => {
+    withRepo((repo) => {
+      const ce = seedEvidence(repo);
+      run(repo, ["experiments", "new"]);
+      assert.equal(nextState(repo).step, "optimize");
+
+      // mutate a pinned artifact: the experiment's pins no longer match disk.
+      writeFileSync(join(ce, "harness.json"), `${JSON.stringify({ command: "npm run eval" }, null, 2)}\n`);
+      const state = nextState(repo);
+      assert.equal(state.step, "re-baseline");
+      assert.equal(state.pins_match, false);
+      assert.equal(state.next_command, "understudy capture-evidence check --repo .");
+    });
+  });
+
+  it("lists experiments, marks the active one, and switches active", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new"]); // exp-001
+      run(repo, ["experiments", "new"]); // exp-002 (now active)
+
+      const list = run(repo, ["experiments", "list", "--json"]);
+      assert.equal(list.status, 0, list.stderr);
+      const rows = JSON.parse(list.stdout).experiments;
+      assert.deepEqual(
+        rows.map((r) => r.experiment_id),
+        ["exp-001", "exp-002"],
+      );
+      assert.equal(rows.find((r) => r.experiment_id === "exp-002").active, true);
+      assert.equal(rows.find((r) => r.experiment_id === "exp-001").active, false);
+
+      const used = run(repo, ["experiments", "use", "exp-001"]);
+      assert.equal(used.status, 0, used.stderr);
+      assert.equal(readFileSync(join(repo, ".understudy", "experiments", "active"), "utf8").trim(), "exp-001");
+    });
+  });
+
+  it("rejects an invalid outcome", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new"]);
+      const bad = run(repo, ["experiments", "outcome", "shipped"]);
+      assert.equal(bad.status, 1);
+      assert.match(bad.stderr, /Invalid outcome/);
+    });
+  });
+
+  it("creates experiment dirs without an active pointer collision", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new"]);
+      assert.ok(existsSync(join(repo, ".understudy", "experiments", "exp-001", "experiment.json")));
+      assert.ok(existsSync(join(repo, ".understudy", "experiments", "active")));
+    });
+  });
+});


### PR DESCRIPTION
Implements the experiment-aware CLI that [#41](https://github.com/understudylabs/understudy-agent-tools/pull/41) described as a follow-up. **Stacked on #41** — review/merge that first; this PR's base is the #41 branch so the diff here is just the ledger.

## What

The experiment contract (#41) defined `.understudy/experiments/<id>/` but said the CLI was a tracked follow-up and artifacts had to be frozen "by hand." This adds the CLI:

- **`understudy next`** — reads the capture-evidence artifacts on disk + the active experiment's `pins` and reports the loop step (`capture-evidence → open-experiment → optimize → claim → decide → route`, or `re-baseline` on drift) and the exact command to run next. **No stored step counter** — step is *derived* by re-hashing the three pinned artifacts and comparing to `pins`, so it can't lie about where you are.
- **`understudy experiments {list,new,show,use,outcome}`** — the ledger. `new` opens `exp-NNN`, copies `baseline.json`'s three-hash chain into `pins`, and sets `active`. `outcome` records `success|partial|abandoned` (+ optional `--route`).

All local-only, no network, `--json` on every command.

## Files

- `src/experiments.ts` — record CRUD + `deriveNext()` state machine; `pins` is exactly the `harness/metric/splits` chain (matches the #41 fix).
- `src/commands/experiments.ts` — command surface; registered in `src/index.ts`.
- `tests/experiments.test.mjs` — full loop walk, stale-pin → re-baseline, list/use/outcome, invalid-outcome rejection (7 tests).
- Updates the two skill notes now that the CLI is real (no longer "by hand").

## Validation

`npm run check` → **47 tests pass**, skills/cookbook/package gates green.

## Not included (next follow-ups)

- The `optimize-workload` CLI still writes scratch `candidate.json`/`claim.json` under `.understudy/optimize-workload/`; wiring it to write directly into the active experiment dir is a separate change.
- Promotion to a knowledge-base lab-note (gated upload) is not implemented.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->