### PR TITLE
Package skills as a Claude Code plugin + add install-plugin skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "understudy-skills",
+  "owner": {
+    "name": "Understudy Labs"
+  },
+  "metadata": {
+    "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "understudy",
+      "description": "Improve LLM apps and agents from real traces — cost/latency/quality, evals, GEPA, model comparison, and routing.",
+      "source": "./",
+      "strict": true
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "understudy",
+  "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Understudy Labs"
+  },
+  "license": "MIT",
+  "keywords": ["understudy", "llm", "evals", "optimization", "gepa", "routing", "traces", "cost", "latency"],
+  "skills": "skills/"
+}

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ with `UNDERSTUDY_TELEMETRY=0`.
 
 The skills in [`skills/`](skills/) ship as a Claude Code plugin, declared in
 [`.claude-plugin/`](.claude-plugin/) (`plugin.json` + `marketplace.json`).
-Installing it registers the eight worker skills (`understudy`,
+Installing it registers all nine invocable skills (`understudy`,
 `capture-evidence`, `use-understudy-gateway`, `run-local-model-lab`,
 `optimize-workload`, `optimize-api-workflow`, `optimize-agentic-search`,
-`prepare-verifier-handoff`) as invocable skills.
+`prepare-verifier-handoff`, `install-plugin`).
 
 From a clone of this repo:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ jobs run by default. After authentication, the CLI emits bounded product
 telemetry documented in [`docs/telemetry.md`](docs/telemetry.md); disable it
 with `UNDERSTUDY_TELEMETRY=0`.
 
+## Install as a Claude Code plugin
+
+The skills in [`skills/`](skills/) ship as a Claude Code plugin, declared in
+[`.claude-plugin/`](.claude-plugin/) (`plugin.json` + `marketplace.json`).
+Installing it registers the eight worker skills (`understudy`,
+`capture-evidence`, `use-understudy-gateway`, `run-local-model-lab`,
+`optimize-workload`, `optimize-api-workflow`, `optimize-agentic-search`,
+`prepare-verifier-handoff`) as invocable skills.
+
+From a clone of this repo:
+
+```bash
+claude plugin marketplace add /path/to/understudy-agent-tools
+claude plugin install understudy@understudy-skills
+```
+
+Then run `/reload-plugins` in your Claude Code session to activate — **no
+restart required**. The equivalent interactive flow is `/plugin marketplace add
+<path>` then `/plugin install understudy@understudy-skills`. The
+[`install-plugin`](skills/install-plugin/SKILL.md) skill automates this and
+reports whether the plugin is already installed.
+
 ## First Commands
 
 ```bash

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -13,10 +13,10 @@ metadata:
 This repo ships its skills as a Claude Code plugin. The manifests live in
 `.claude-plugin/` (`plugin.json` + `marketplace.json`) and the skills live in
 `skills/`. This skill installs/enables that plugin in the developer's Claude
-Code so the eight worker skills (`understudy`, `capture-evidence`,
+Code so all nine skills (`understudy`, `capture-evidence`,
 `use-understudy-gateway`, `run-local-model-lab`, `optimize-workload`,
-`optimize-api-workflow`, `optimize-agentic-search`, `prepare-verifier-handoff`)
-become invocable.
+`optimize-api-workflow`, `optimize-agentic-search`, `prepare-verifier-handoff`,
+and this `install-plugin` skill) become invocable.
 
 The whole flow is local: it adds a **local filesystem marketplace** pointing at
 this repo and installs from it. Nothing uploads, authenticates, or spends.
@@ -89,7 +89,7 @@ claude plugin list --json
 ```
 
 Confirm `understudy@understudy-skills` is enabled, and confirm to the developer
-that `/understudy` (and the seven workers) are now available.
+that `/understudy` (and the other eight skills) are now available.
 
 ## Fallback: fully interactive path
 

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -102,6 +102,21 @@ equivalents to type themselves:
 /reload-plugins
 ```
 
+## Safety Gates
+
+Local-first and free: adding a local marketplace and installing from it makes no
+provider calls, uploads, spend, or credential changes — do not require login,
+auth, or keys for this skill. The `claude plugin` commands only register
+repo-local skills.
+
+- Confirm before running if the developer asked you only to *show* the commands;
+  otherwise the install is low-risk and may run in the background.
+- You **must not** claim you activated the plugin. `/reload-plugins` and the
+  interactive `/plugin …` commands are user-typed — surface them and wait.
+- Never edit `settings.json` / `settings.local.json` `enabledPlugins` by hand to
+  force-enable; use the documented `claude plugin` CLI so the install is
+  reversible with `claude plugin uninstall`.
+
 ## Output Standard
 
 End with: whether the plugin was already installed / just installed / shown for

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: install-plugin
+description: Use when a developer wants to install, enable, update, reinstall, or verify the Understudy skills as a Claude Code plugin — "install understudy", "add the understudy skills", "set up the plugin", "why can't you see the understudy skill". Runs the non-interactive `claude plugin` CLI (or shows the commands), then tells the developer the one activation step and whether a restart is needed.
+metadata:
+  understudy:
+    mode: automatic
+    safety: local-first
+    cli_required: false
+---
+
+# Install the Understudy plugin
+
+This repo ships its skills as a Claude Code plugin. The manifests live in
+`.claude-plugin/` (`plugin.json` + `marketplace.json`) and the skills live in
+`skills/`. This skill installs/enables that plugin in the developer's Claude
+Code so the eight worker skills (`understudy`, `capture-evidence`,
+`use-understudy-gateway`, `run-local-model-lab`, `optimize-workload`,
+`optimize-api-workflow`, `optimize-agentic-search`, `prepare-verifier-handoff`)
+become invocable.
+
+The whole flow is local: it adds a **local filesystem marketplace** pointing at
+this repo and installs from it. Nothing uploads, authenticates, or spends.
+
+## Key facts (don't get these wrong)
+
+- **No app restart is required.** Plugin skills hot-load. After install, the
+  developer runs `/reload-plugins` **once** in the current session and the
+  skills appear. A full quit/relaunch is only a fallback if reload misbehaves.
+- The CLI is non-interactive and safe to run from a background bash process:
+  `claude plugin marketplace add`, `claude plugin install`, `claude plugin list`.
+- The agent **cannot** run the activation step. `/reload-plugins` (and the
+  interactive `/plugin …` commands) are user-typed slash commands — surface them
+  for the developer; never claim you ran them.
+
+## Procedure
+
+### 1. Find the repo root
+
+The marketplace source is the directory that contains `.claude-plugin/`. Resolve
+it before running anything (it is the root of this `understudy-agent-tools`
+checkout — do not hardcode another user's absolute path):
+
+```bash
+REPO="$(cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && pwd)"
+# Sanity check the manifests exist:
+ls "$REPO/.claude-plugin/marketplace.json" "$REPO/.claude-plugin/plugin.json"
+```
+
+### 2. Check whether it's already installed
+
+```bash
+claude plugin list --json
+```
+
+Look for `understudy` from the `understudy-skills` marketplace. If it's already
+enabled, stop — report installed and skip to step 4 only if the developer wants
+to update (then `claude plugin marketplace update understudy-skills`).
+
+### 3. Add the marketplace and install (background-safe)
+
+Run these from bash. They are idempotent enough to re-run; if the marketplace
+name already exists the add is a no-op/update.
+
+```bash
+claude plugin marketplace add "$REPO"
+claude plugin install understudy@understudy-skills
+```
+
+Prefer running this as a background process and reporting the exit status rather
+than blocking. If the developer would rather run it themselves, **show** the two
+commands instead of executing them.
+
+### 4. Activate in the current session
+
+Tell the developer to type:
+
+```
+/reload-plugins
+```
+
+State plainly: **no restart needed** — `/reload-plugins` loads the skills into
+this session. Only if the skills still don't appear afterward should they fully
+restart Claude Code.
+
+### 5. Verify
+
+```bash
+claude plugin list --json
+```
+
+Confirm `understudy@understudy-skills` is enabled, and confirm to the developer
+that `/understudy` (and the seven workers) are now available.
+
+## Fallback: fully interactive path
+
+If the `claude plugin` CLI is unavailable, give the developer the interactive
+equivalents to type themselves:
+
+```
+/plugin marketplace add <repo-root-path>
+/plugin install understudy@understudy-skills
+/reload-plugins
+```
+
+## Output Standard
+
+End with: whether the plugin was already installed / just installed / shown for
+manual run; the exact activation step (`/reload-plugins`); an explicit
+restart-or-not statement (not needed); and the verification result.


### PR DESCRIPTION
## What

Makes the skill library installable as a **Claude Code plugin** (the same pattern as `tinker-cookbook`), instead of requiring manual symlinks into `.claude/skills/`.

## Changes

- **`.claude-plugin/plugin.json`** — declares the `understudy` plugin; `"skills": "skills/"` points at the existing skills dir (no skills moved).
- **`.claude-plugin/marketplace.json`** — local marketplace `understudy-skills`, sourcing the plugin from the repo root (`./`).
- **`skills/install-plugin/SKILL.md`** — new skill that:
  - runs the non-interactive `claude plugin` CLI (background-safe) or shows the commands,
  - detects whether the plugin is already installed via `claude plugin list --json`,
  - surfaces the one activation step — `/reload-plugins` — and states plainly that **no app restart is required**.
- **`README.md`** — documents the plugin install path.

## Install / verify

```bash
claude plugin marketplace add /path/to/understudy-agent-tools
claude plugin install understudy@understudy-skills
```
Then `/reload-plugins` in-session. Registers all 8 worker skills (`understudy`, `capture-evidence`, `use-understudy-gateway`, `run-local-model-lab`, `optimize-workload`, `optimize-api-workflow`, `optimize-agentic-search`, `prepare-verifier-handoff`).

## Notes

- `skills/_resources/` and `skills/onboard/` have no `SKILL.md`, so the plugin loader skips them — only the 8 real skills register.
- Restart/hot-load behavior confirmed against Claude Code docs: plugin skills hot-load via `/reload-plugins`; full restart is only a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->