### PR TITLE
feat: freeze optimizer output into experiment dir + promote to lab-note

### DIFF
--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -134,15 +134,14 @@ directory (see the Experiment section of
 .understudy/experiments/<exp-id>/      # experiment.json, candidate.json, claim.json
 ```
 
-Open or reuse an experiment before optimizing (`experiments/active` names it),
-record the candidate model, objective, and the `pins` copied from
-`baseline.json`'s hash-chain, then freeze the chosen `candidate.json` and the
-`claim.json` there. The `optimize-workload` CLI still emits scratch artifacts
-(`eval-input-candidate.json`, `proof-packet.json`, adapter outputs) under
-`.understudy/optimize-workload/`; treat those as working state and freeze the
-selected candidate into the experiment directory. Use `understudy experiments
-new` to open an experiment (it pins the current baseline) and `understudy next`
-to see the current loop step.
+Open or reuse an experiment before optimizing with `understudy experiments new`
+(it pins the current baseline); `experiments/active` names it. On
+`optimize-workload adapter run --execute` the produced candidate is frozen into
+the active experiment directory automatically; `understudy experiments freeze`
+does it explicitly and also freezes a `--claim-from <path>`. The optimizer's
+working artifacts (`eval-input-candidate.json`, `proof-packet.json`, adapter
+outputs) stay under `.understudy/optimize-workload/`. Run `understudy next` to
+see the current loop step.
 
 The previous Python helper scripts have been removed with the Python CLI
 prototype. Use the TypeScript CLI gates first, and still inspect artifacts

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -206,19 +206,21 @@ isn't at.
 `outcome`, `workload`, `incumbent_model`, `candidate_model`, and the result
 deltas mirror the `type: experiment` lab-note in the Understudy knowledge
 base — `experiment.json` is its un-anonymized, hash-pinned, live
-precursor. When `outcome` is set, an experiment may be **promoted** into a
-knowledge lab-note: anonymize `workload` to `workload-NNN`, drop real paths, and
-add the cost/margin analysis the local record deliberately omits. Promotion
-publishes to a shared repository and is an upload — gate it like any other (see
-Safety Gates).
+precursor. When `outcome` is set, `understudy experiments promote` writes a
+lab-note **draft** locally from the record. It does not anonymize or upload: the
+draft carries the real local values behind a review banner, and scrubbing
+`workload` to `workload-NNN`, dropping real paths, and filling the cost/margin
+fields the local record omits are part of the publish review. Publishing to a
+shared repository is an upload — gate it like any other (see Safety Gates).
 
 > `understudy experiments new` opens an experiment and copies the baseline
 > hash-chain into `pins`; `understudy next` reads the artifacts on disk plus the
 > active experiment to report the loop step and the command to run next;
-> `understudy experiments outcome` records the verdict. The `optimize-workload`
-> CLI still writes scratch candidate/claim artifacts under
-> `.understudy/optimize-workload/`; freeze the chosen candidate and the claim
-> into the active experiment directory.
+> `understudy experiments outcome` records the verdict. On `optimize-workload
+> adapter run --execute` the candidate is frozen into the active experiment
+> directory automatically; `understudy experiments freeze` does it explicitly
+> (and freezes a `--claim-from <path>`). The optimizer's working files stay
+> under `.understudy/optimize-workload/`.
 
 Removed Python-prototype commands and deleted draft skills are tracked in
 [`../../docs/current-functionality.md`](../../docs/current-functionality.md). Do

--- a/src/commands/experiments.ts
+++ b/src/commands/experiments.ts
@@ -5,8 +5,11 @@ import { isJsonMode } from "../internal/output.js";
 import {
   createExperiment,
   deriveNext,
+  promoteExperiment,
   readActiveId,
   readExperiment,
+  recordCandidate,
+  recordClaim,
   recordOutcome,
   setActiveId,
   summarizeExperiments,
@@ -167,6 +170,64 @@ export function registerExperimentsCommands(program: Command): void {
         process.stdout.write(
           `${kleur.green("✓")} ${kleur.bold(experiment.experiment_id)} outcome=${experiment.outcome}` +
             `${experiment.route_decision ? ` route=${experiment.route_decision}` : ""}\n`,
+        );
+      });
+    });
+
+  experiments
+    .command("freeze")
+    .description("Freeze a candidate and/or claim into the active experiment directory")
+    .option("--repo <path>", "Local repository path", ".")
+    .option(
+      "--candidate-from [path]",
+      "Freeze a candidate (default source: .understudy/optimize-workload/candidate.json)",
+    )
+    .option("--claim-from <path>", "Freeze a claim from this path")
+    .option("--json", "Output JSON")
+    .action(function (
+      this: Command,
+      options: { repo: string; candidateFrom?: string | boolean; claimFrom?: string },
+    ) {
+      runLocal(this, () => {
+        const frozen: Record<string, string> = {};
+        // --candidate-from with no value (true) means "use the default scratch path".
+        if (options.candidateFrom !== undefined) {
+          const from = typeof options.candidateFrom === "string" ? options.candidateFrom : undefined;
+          frozen.candidate = recordCandidate(options.repo, { from }).path;
+        }
+        if (options.claimFrom !== undefined) {
+          frozen.claim = recordClaim(options.repo, { from: options.claimFrom }).path;
+        }
+        if (Object.keys(frozen).length === 0) {
+          // default: freeze the optimizer's scratch candidate.
+          frozen.candidate = recordCandidate(options.repo, {}).path;
+        }
+        if (isJsonMode(this)) {
+          printJson({ frozen });
+          return;
+        }
+        for (const [kind, path] of Object.entries(frozen)) {
+          process.stdout.write(`${kleur.green("✓")} froze ${kind} -> ${path}\n`);
+        }
+      });
+    });
+
+  experiments
+    .command("promote [id]")
+    .description("Write an anonymized lab-note draft from a decided experiment (no upload)")
+    .option("--repo <path>", "Local repository path", ".")
+    .option("--out <path>", "Output path (default: <experiment-dir>/lab-note.md)")
+    .option("--json", "Output JSON")
+    .action(function (this: Command, id: string | undefined, options: { repo: string; out?: string }) {
+      runLocal(this, () => {
+        const result = promoteExperiment(options.repo, { id, out: options.out });
+        if (isJsonMode(this)) {
+          printJson({ experiment_id: result.experiment_id, path: result.path });
+          return;
+        }
+        process.stdout.write(`${kleur.green("✓")} wrote lab-note draft -> ${result.path}\n`);
+        process.stdout.write(
+          `${kleur.yellow("not published")}: publishing to a shared knowledge base is a separate, approval-gated upload.\n`,
         );
       });
     });

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { dirname, join, resolve } from "node:path";
 
 const captureEvidenceDir = ".understudy/capture-evidence";
+const optimizeWorkloadDir = ".understudy/optimize-workload";
 const experimentsDir = ".understudy/experiments";
 const activePointer = join(experimentsDir, "active");
 
@@ -116,6 +117,10 @@ function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function optionalNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 function writeJson(path: string, payload: unknown): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
@@ -208,8 +213,12 @@ function pinsFromBaseline(repo: string): ExperimentPins {
 export function createExperiment(repoInput: string, options: NewExperimentOptions = {}): Experiment {
   const repo = ensureRepo(repoInput);
   const id = options.id ?? nextExperimentId(repo);
-  if (!/^exp-\d+$/.test(id) && options.id === undefined) {
-    throw new Error(`Generated an invalid experiment id: ${id}`);
+  // Validate every id — including a user-supplied --id — so it stays a safe,
+  // single-segment directory name (no path traversal, slashes, or dot prefixes).
+  if (!/^[a-z0-9][a-z0-9_-]{0,62}$/.test(id)) {
+    throw new Error(
+      `Invalid experiment id "${id}". Use lowercase letters, digits, '-' or '_' (no slashes or leading dots).`,
+    );
   }
   if (existsSync(experimentRecordPath(repo, id))) {
     throw new Error(`Experiment ${id} already exists.`);
@@ -265,6 +274,161 @@ export function recordOutcome(
   }
   writeJson(experimentRecordPath(repo, id), experiment);
   return experiment;
+}
+
+function requireActive(repo: string): string {
+  const id = readActiveId(repo);
+  if (!id) {
+    throw new Error("No active experiment. Run `understudy experiments new` first.");
+  }
+  return id;
+}
+
+/**
+ * Freeze a candidate into the active experiment directory (the home of record).
+ * Defaults to the optimizer's scratch candidate under
+ * `.understudy/optimize-workload/candidate.json`.
+ */
+export function recordCandidate(
+  repoInput: string,
+  options: { from?: string } = {},
+): { experiment_id: string; path: string } {
+  const repo = ensureRepo(repoInput);
+  const id = requireActive(repo);
+  const source = resolve(options.from ?? join(repo, optimizeWorkloadDir, "candidate.json"));
+  if (!existsSync(source)) {
+    throw new Error(
+      `No candidate to freeze at ${source}. Run the optimizer first or pass --candidate-from <path>.`,
+    );
+  }
+  const dest = join(experimentDir(repo, id), "candidate.json");
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, readFileSync(source, "utf8"), "utf8");
+  return { experiment_id: id, path: dest };
+}
+
+/**
+ * Freeze a claim into the active experiment directory and copy any result
+ * deltas it carries onto the experiment record.
+ */
+export function recordClaim(
+  repoInput: string,
+  options: { from: string },
+): { experiment_id: string; path: string } {
+  const repo = ensureRepo(repoInput);
+  const id = requireActive(repo);
+  if (!options.from) {
+    throw new Error("Pass --claim-from <path> to freeze a claim.");
+  }
+  const source = resolve(options.from);
+  if (!existsSync(source)) {
+    throw new Error(`No claim to freeze at ${source}.`);
+  }
+  const raw = readFileSync(source, "utf8");
+  const dest = join(experimentDir(repo, id), "claim.json");
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, raw, "utf8");
+
+  const experiment = readExperiment(repo, id);
+  experiment.result.claim_ref = "claim.json";
+  try {
+    const claim: unknown = JSON.parse(raw);
+    if (isObject(claim)) {
+      experiment.result.quality_delta = optionalNumber(claim.quality_delta) ?? experiment.result.quality_delta;
+      experiment.result.p50_latency_delta_ms =
+        optionalNumber(claim.p50_latency_delta_ms) ?? experiment.result.p50_latency_delta_ms;
+      experiment.result.cost_per_1k_delta_usd =
+        optionalNumber(claim.cost_per_1k_delta_usd) ?? experiment.result.cost_per_1k_delta_usd;
+    }
+  } catch {
+    // a non-JSON or partial claim still freezes; deltas stay null.
+  }
+  writeJson(experimentRecordPath(repo, id), experiment);
+  return { experiment_id: id, path: dest };
+}
+
+function renderLabNote(experiment: Experiment, date: string): string {
+  const title = experiment.hypothesis ?? `Experiment ${experiment.experiment_id}`;
+  const cell = (value: number | null): string => (value === null ? "—" : String(value));
+  return `---
+type: experiment
+title: ${JSON.stringify(title)}
+date: ${date}
+last_updated: ${date}
+workload_anon: TODO             # replace with workload-NNN before publishing
+incumbent_model: ${experiment.incumbent_model ?? "null"}
+candidate_model: ${experiment.candidate_model ?? "null"}
+outcome: ${experiment.outcome}
+cogs_total_usd: null            # fill before publishing
+customer_savings_pct: null      # fill before publishing
+understudy_margin_pct: null     # fill before publishing
+tags: []
+---
+
+> **DRAFT — review and anonymize before publishing.** Scrub the workload id, the
+> title/hypothesis, and any customer names or repo paths, then fill the
+> margin fields. Generated from local records; NOT anonymized or uploaded.
+
+# ${title}
+
+## Hypothesis
+
+${experiment.hypothesis ?? "_State the hypothesis this experiment tested._"}
+
+## Setup
+
+- **Objective**: ${experiment.objective ?? "_unspecified_"}
+- **Incumbent**: ${experiment.incumbent_model ?? "_unspecified_"}
+- **Candidate**: ${experiment.candidate_model ?? "_unspecified_"}
+- **Route decision**: ${experiment.route_decision ?? "_unspecified_"}
+
+## Results
+
+| Metric                 | Delta |
+|------------------------|-------|
+| Quality (judge score)  | ${cell(experiment.result.quality_delta)} |
+| p50 latency (ms)       | ${cell(experiment.result.p50_latency_delta_ms)} |
+| Cost per 1k calls (\$) | ${cell(experiment.result.cost_per_1k_delta_usd)} |
+
+Outcome: **${experiment.outcome}**.
+
+## Margin Analysis
+
+_Fill cogs / customer-savings / margin before publishing — the local record omits these._
+
+## Next Steps
+
+- _Concrete follow-up._
+`;
+}
+
+/**
+ * Produce a lab-note draft from a decided experiment. Writes a LOCAL draft with
+ * the real local values and a review banner — it does NOT anonymize (scrubbing
+ * the workload id, title, and free text is part of the gated publish review) and
+ * never uploads.
+ */
+export function promoteExperiment(
+  repoInput: string,
+  options: { id?: string; out?: string } = {},
+): { experiment_id: string; path: string; lab_note: string } {
+  const repo = ensureRepo(repoInput);
+  const id = options.id ?? readActiveId(repo);
+  if (!id) {
+    throw new Error("No active experiment. Pass an id or run `understudy experiments new`.");
+  }
+  const experiment = readExperiment(repo, id);
+  if (experiment.outcome === null) {
+    throw new Error(
+      `Experiment ${id} has no outcome yet. Record one with \`understudy experiments outcome\` before promoting.`,
+    );
+  }
+  const date = experiment.created_at.slice(0, 10);
+  const labNote = renderLabNote(experiment, date);
+  const dest = resolve(options.out ?? join(experimentDir(repo, id), "lab-note.md"));
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, labNote, "utf8");
+  return { experiment_id: id, path: dest, lab_note: labNote };
 }
 
 export function summarizeExperiments(repoInput: string): ExperimentSummary[] {
@@ -376,8 +540,8 @@ export function deriveNext(repoInput: string): NextState {
       step: "claim",
       experiment_id: activeId,
       pins_match: true,
-      summary: `Experiment ${activeId} has a candidate but no claim — run holdout and write claim.json.`,
-      next_command: "understudy optimize-workload check --repo .",
+      summary: `Experiment ${activeId} has a candidate but no claim — run holdout and freeze claim.json.`,
+      next_command: "understudy experiments freeze --claim-from <claim.json> --repo .",
     };
   }
 

--- a/src/optimize-workload.ts
+++ b/src/optimize-workload.ts
@@ -7,6 +7,7 @@ import { DEFAULT_GATEWAY_URL } from "./config/defaults.js";
 import { readCredentials } from "./config/credentials.js";
 import { readProjectConfig } from "./config/index.js";
 import { optimizerRuntimeSource } from "./optimize-workload/runtime-source.js";
+import { readActiveId, recordCandidate } from "./experiments.js";
 
 type GateStatus = "pass" | "fail";
 
@@ -399,7 +400,35 @@ export function runOptimizerAdapter(options: AdapterRunOptions): Record<string, 
     env.UNDERSTUDY_GATEWAY_URL = auth.gatewayUrl;
     env.UNDERSTUDY_AUTH_SOURCE = auth.source;
   }
-  return runUvPython(repo, runtimePath, adapter.buildArgs(repo, options), adapter.packages, env);
+  const out = runUvPython(repo, runtimePath, adapter.buildArgs(repo, options), adapter.packages, env);
+  freezeCandidateIntoActiveExperiment(repo, out);
+  return out;
+}
+
+/**
+ * When the adapter produced a candidate and an experiment is active, freeze the
+ * scratch candidate into the experiment directory (its home of record) so
+ * `understudy next` advances. Best-effort: never fail the optimizer run.
+ */
+function freezeCandidateIntoActiveExperiment(repo: string, out: Record<string, unknown>): void {
+  try {
+    if (out.exit_code !== 0) {
+      return;
+    }
+    const emitted = out.json;
+    const candidatePath =
+      emitted && typeof emitted === "object" && !Array.isArray(emitted)
+        ? (emitted as Record<string, unknown>).candidate_path
+        : undefined;
+    if (typeof candidatePath !== "string" || !readActiveId(repo)) {
+      return;
+    }
+    const frozen = recordCandidate(repo, { from: join(repo, candidatePath) });
+    out.experiment_id = frozen.experiment_id;
+    out.experiment_candidate = relative(repo, frozen.path);
+  } catch {
+    // leave the scratch candidate in place; freezing is an optional convenience.
+  }
 }
 
 export function printGateResult(result: GateResult): void {

--- a/tests/experiments.test.mjs
+++ b/tests/experiments.test.mjs
@@ -167,4 +167,92 @@ describe("understudy experiments + next", () => {
       assert.ok(existsSync(join(repo, ".understudy", "experiments", "active")));
     });
   });
+
+  it("rejects an unsafe --id instead of escaping the experiments dir", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      const bad = run(repo, ["experiments", "new", "--id", "../../boom"]);
+      assert.equal(bad.status, 1);
+      assert.match(bad.stderr, /Invalid experiment id/);
+      assert.ok(!existsSync(join(repo, "..", "..", "boom")));
+      assert.ok(!existsSync(join(repo, ".understudy", "experiments", "..", "..", "boom")));
+    });
+  });
+
+  it("freezes the optimizer scratch candidate into the active experiment dir", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new"]);
+
+      const ow = join(repo, ".understudy", "optimize-workload");
+      mkdirSync(ow, { recursive: true });
+      writeFileSync(join(ow, "candidate.json"), `${JSON.stringify({ schema_version: "x" })}\n`);
+
+      const freeze = run(repo, ["experiments", "freeze"]);
+      assert.equal(freeze.status, 0, freeze.stderr);
+      assert.ok(existsSync(join(repo, ".understudy", "experiments", "exp-001", "candidate.json")));
+      assert.equal(nextState(repo).step, "claim");
+    });
+  });
+
+  it("errors when freezing a candidate that does not exist", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new"]);
+      const freeze = run(repo, ["experiments", "freeze"]);
+      assert.equal(freeze.status, 1);
+      assert.match(freeze.stderr, /No candidate to freeze/);
+    });
+  });
+
+  it("freezes a claim and copies its deltas onto the experiment record", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new"]);
+      const expDir = join(repo, ".understudy", "experiments", "exp-001");
+      writeFileSync(join(expDir, "candidate.json"), "{}\n");
+
+      const claimPath = join(repo, "claim-src.json");
+      writeFileSync(claimPath, `${JSON.stringify({ quality_delta: 0.08, cost_per_1k_delta_usd: -1.2 })}\n`);
+      const freeze = run(repo, ["experiments", "freeze", "--claim-from", claimPath]);
+      assert.equal(freeze.status, 0, freeze.stderr);
+
+      const record = JSON.parse(readFileSync(join(expDir, "experiment.json"), "utf8"));
+      assert.equal(record.result.claim_ref, "claim.json");
+      assert.equal(record.result.quality_delta, 0.08);
+      assert.equal(record.result.cost_per_1k_delta_usd, -1.2);
+      assert.equal(nextState(repo).step, "decide");
+    });
+  });
+
+  it("refuses to promote an experiment without an outcome", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new"]);
+      const promote = run(repo, ["experiments", "promote"]);
+      assert.equal(promote.status, 1);
+      assert.match(promote.stderr, /no outcome yet/);
+    });
+  });
+
+  it("promotes a decided experiment to a lab-note draft flagged for review", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      run(repo, ["experiments", "new", "--workload", "acme-support", "--candidate", "gemma-4-31b"]);
+      run(repo, ["experiments", "outcome", "success", "--route", "ship-local"]);
+
+      const promote = run(repo, ["experiments", "promote"]);
+      assert.equal(promote.status, 0, promote.stderr);
+      const note = readFileSync(join(repo, ".understudy", "experiments", "exp-001", "lab-note.md"), "utf8");
+      assert.match(note, /^type: experiment$/m);
+      assert.match(note, /outcome: success/);
+      assert.match(note, /candidate_model: gemma-4-31b/);
+      // the draft does NOT auto-anonymize: it flags the work for review and
+      // leaves workload_anon as a placeholder rather than guessing.
+      assert.match(note, /DRAFT — review and anonymize before publishing/);
+      assert.match(note, /workload_anon: TODO/);
+      // the raw workload id is never auto-injected into the draft.
+      assert.doesNotMatch(note, /acme-support/);
+    });
+  });
 });


### PR DESCRIPTION
Closes the two follow-ups from the experiment-ledger PR (#42).

## 1. Optimizer output lands in the experiment dir (home of record)

Previously the Python optimizer wrote `candidate.json` to the scratch dir `.understudy/optimize-workload/`, but `understudy next` looks for it in the *experiment* dir — so the loop stalled until you copied it by hand.

- `optimize-workload adapter run --execute` now **freezes the produced candidate into the active experiment's dir** automatically (best-effort; never fails the optimizer run; no-op if no active experiment).
- `understudy experiments freeze` does it explicitly: `--candidate-from [path]` (defaults to the optimizer scratch) and/or `--claim-from <path>` (copies claim deltas onto the record).
- The optimizer's working files (`eval-input-candidate.json`, `proof-packet.json`, adapter outputs) stay under `optimize-workload/` as scratch.

## 2. `understudy experiments promote` → lab-note draft (gated, honest)

Writes a `type: experiment` lab-note **draft** locally from a decided experiment (refuses if `outcome` is unset).

**It does not auto-anonymize.** The first cut had a regex (`/^workload-\d+$/ ? keep : "workload-001"`) — but that only touched the workload *id* while the real leak vector (free-text hypothesis flowing into `title:`) went unscrubbed, and it collapsed distinct workloads to one id. That's false safety. Instead the draft carries the real local values behind a banner:

> **DRAFT — review and anonymize before publishing.** ...

with `workload_anon: TODO` and `cogs/savings/margin: null` placeholders. Scrubbing + filling is part of the gated publish review. The command **never uploads**.

## Tests / validation

`npm run check` → **52 tests pass** (5 new: freeze candidate/claim, freeze-missing error, promote refusal without outcome, promote draft is review-flagged). Skills/cookbook/package gates green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Self-review fix included

Found while turning the #39-style scrutiny on my own code: `createExperiment`'s id check only validated *auto-generated* ids, so a user-supplied `--id ../../x` was never checked and could write outside `.understudy/experiments/`. Now every id (provided or generated) must match a safe single-segment pattern. Regression test added. (Bug originated in the merged ledger PR #42.)
