### PR TITLE
Plugin-first onboarding, engagement doctrine, and local-model management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,79 @@ status: draft
 
 # AGENTS.md
 
+This file tells a coding agent how to operate in this repo. There are two
+audiences — serve the right one.
+
+## Are you helping a user, or editing the library?
+
+- **Helping a user get value from Understudy** (improve an LLM app, cut
+  cost/latency, run a local model, pick a route) → start with **Install the
+  plugin** below, then run onboarding. This is the common case.
+- **Contributing to this repo** (changing skills, CLI, docs) → skip to
+  [Working on this repo](#working-on-this-repo).
+
+When unsure, assume the user wants help with their workload, not to edit the
+library.
+
+## Install the plugin (do this first for users)
+
+Understudy is delivered as a **Claude Code plugin**. Install it — do not try to
+operate from the raw source tree. The plugin loads the skills, and **the skills
+are the product**: they are what let you explain what Understudy is, why it
+matters, and walk the user from a captured trace to a measured, shipped
+improvement. Without them you are guessing; with them you have the playbooks, the
+safety gates, and the local-first optimization loop.
+
+Recommend installation to the user in plain terms, e.g.: *"Understudy works best
+as a Claude Code plugin — it installs locally, makes no network calls, and gives
+me the playbooks to actually improve your LLM workload. Want me to install it?"*
+Then use the [`install-plugin`](skills/install-plugin/SKILL.md) skill:
+
+```bash
+claude plugin marketplace add "$(git rev-parse --show-toplevel)"
+claude plugin install understudy@understudy-skills
+```
+
+The user then types `/reload-plugins` once — **no restart needed**. You cannot
+run that step yourself; surface it and wait.
+
+### It is reversible — say so
+
+Installing is low-risk and fully reversible. Tell the user the uninstall path up
+front so saying yes feels safe:
+
+```bash
+claude plugin uninstall understudy@understudy-skills   # remove the plugin
+claude plugin marketplace remove understudy-skills      # forget the local source
+```
+
+Nothing outside Claude Code's own plugin registry is touched, and nothing
+uploads or spends. Mention uninstall exists — then recommend they keep it
+installed to get the most out of Understudy.
+
+## Then onboard the user
+
+Once installed (and `/reload-plugins` run), run the
+[`onboard`](skills/onboard/SKILL.md) skill. It is the engaging first-run
+experience: it backgrounds a small American open-model download while it profiles
+the machine and interviews the user, then writes a durable
+`~/.understudy/profile.json` so every later skill can meet the user where they
+are. Onboarding hands off to the [`understudy`](skills/understudy/SKILL.md)
+orchestrator.
+
+## How to behave with users
+
+Follow [`docs/engagement-and-pacing.md`](docs/engagement-and-pacing.md): plan up
+front, announce time estimates *before* starting long work, background blocking
+tasks and stay interactive while they run (start the long download first, then
+interview during it), fill wall-clock with useful analysis (alternative-model
+cost estimates, benchmark lookups), and keep telling the user where they are in
+the loop.
+
+---
+
+## Working on this repo
+
 This repository is public and MIT licensed. Treat every file as future-facing
 OSS from the first commit.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and any coding agent) working in this repository.
+
+**The operating guide for agents is [`AGENTS.md`](AGENTS.md). Read it first.**
+It covers the two ways an agent is used here and what to do in each.
+
+## Prime directive (the 10-second version)
+
+There are two kinds of visitor to this repo. Figure out which one you have
+before doing anything else:
+
+- **A user who wants to *use* Understudy** — improve an LLM app, cut cost, run a
+  local model, pick a route. **Install the plugin first** (the
+  [`install-plugin`](skills/install-plugin/SKILL.md) skill), then run the
+  [`onboard`](skills/onboard/SKILL.md) skill. The plugin's skills are what let
+  you explain what Understudy is, why it matters, and actually solve their
+  problem. Don't try to wing it from the source tree.
+- **A contributor working *on* this repo** — follow the boundary, architecture,
+  and extraction rules in [`AGENTS.md`](AGENTS.md).
+
+When in doubt, assume the first. Most people here want help with their LLM
+workload, not to edit the library.
+
+## How to behave
+
+Adopt the engagement doctrine in
+[`docs/engagement-and-pacing.md`](docs/engagement-and-pacing.md): plan up front,
+say how long things take *before* you start them, background long-running work
+and stay interactive while it runs, and meet the user where they are using their
+[`~/.understudy/profile.json`](skills/onboard/reference.md). The
+[`understudy`](skills/understudy/SKILL.md) skill is the orchestrator for the
+whole improvement loop.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ with `UNDERSTUDY_TELEMETRY=0`.
 
 The skills in [`skills/`](skills/) ship as a Claude Code plugin, declared in
 [`.claude-plugin/`](.claude-plugin/) (`plugin.json` + `marketplace.json`).
-Installing it registers all nine invocable skills (`understudy`,
-`capture-evidence`, `use-understudy-gateway`, `run-local-model-lab`,
-`optimize-workload`, `optimize-api-workflow`, `optimize-agentic-search`,
-`prepare-verifier-handoff`, `install-plugin`).
+Installing it registers all eleven invocable skills (`understudy`, `onboard`,
+`capture-evidence`, `use-understudy-gateway`, `manage-local-models`,
+`run-local-model-lab`, `optimize-workload`, `optimize-api-workflow`,
+`optimize-agentic-search`, `prepare-verifier-handoff`, `install-plugin`).
 
 From a clone of this repo:
 
@@ -75,6 +75,17 @@ restart required**. The equivalent interactive flow is `/plugin marketplace add
 <path>` then `/plugin install understudy@understudy-skills`. The
 [`install-plugin`](skills/install-plugin/SKILL.md) skill automates this and
 reports whether the plugin is already installed.
+
+Installing as a plugin is the recommended way to use Understudy: the skills are
+what let a coding agent explain what Understudy is and walk you from a trace to a
+shipped improvement. It is also fully reversible —
+
+```bash
+claude plugin uninstall understudy@understudy-skills
+claude plugin marketplace remove understudy-skills
+```
+
+— and nothing outside Claude Code's plugin registry is touched.
 
 ## First Commands
 
@@ -148,9 +159,12 @@ Current examples:
 `skills/understudy/SKILL.md` is the public entrypoint. It routes to exactly one
 capability worker:
 
+- `skills/onboard/SKILL.md` (first-run: profiles the machine + user, backgrounds a small model)
 - `skills/capture-evidence/SKILL.md`
 - `skills/optimize-workload/SKILL.md`
 - `skills/use-understudy-gateway/SKILL.md`
+- `skills/manage-local-models/SKILL.md` (acquire, cache, and explain local open-weight models)
+- `skills/run-local-model-lab/SKILL.md`
 - `skills/prepare-verifier-handoff/SKILL.md`
 
 Everything else stays outside the discovered surface until real usage proves it

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -80,14 +80,25 @@ The public workflow now lives in the MVP skill tree:
 
 ```text
 skills/understudy/SKILL.md
+skills/onboard/SKILL.md
 skills/capture-evidence/SKILL.md
 skills/optimize-workload/SKILL.md
 skills/use-understudy-gateway/SKILL.md
+skills/manage-local-models/SKILL.md
+skills/run-local-model-lab/SKILL.md
 skills/prepare-verifier-handoff/SKILL.md
 ```
 
 Agents should use those skills to inspect local artifacts and guide users, but
 they should not claim that removed Python commands still exist.
+
+`onboard` is the engaging first-run experience (machine + user profiling,
+interview, durable `~/.understudy/profile.json`); it backgrounds a small
+open-model download per the engagement doctrine in
+`docs/engagement-and-pacing.md` and hands off to `understudy`.
+`manage-local-models` acquires, caches, and explains local open-weight models
+(Gemma 4, Nemotron 3) — distinct from `run-local-model-lab`, which evaluates a
+local model against a frozen workload.
 
 `prepare-verifier-handoff` is a future-release stub, not an executable CLI
 surface. It helps agents recognize workloads that need stateful RL

--- a/docs/engagement-and-pacing.md
+++ b/docs/engagement-and-pacing.md
@@ -1,0 +1,108 @@
+# Engagement & Pacing
+
+How an Understudy agent should *feel* to work with. The optimization loop has
+genuinely slow steps — model downloads, baselines, sweeps — and a good agent
+keeps the user oriented and engaged across that wall-clock instead of going dark.
+Every skill in this repo should follow these rules; onboarding and the
+`understudy` orchestrator enforce them.
+
+The one-line version: **plan up front, background the slow thing first, then fill
+the wait with fast interactive work — and always say how long things take before
+you start them.**
+
+## 1. Estimate before you start
+
+Never kick off a long action silently. Say what it is, how long it should take,
+and what it costs, *before* running it. The user decides with that in hand.
+
+- "The operations baseline is 100 tasks. At ~3 min/task with 20 in parallel
+  that's ~15–20 min wall-clock and ~$31 on Sonnet. I'll run it in the
+  background."
+- "Pulling Nemotron 3 Nano is a ~18 GB download — ~4 min on a fast connection.
+  Starting it now."
+
+If you don't know the rate, measure a small sample first (a 3-task smoke), report
+the per-unit cost/time, then project the full run. Label projections as
+projections.
+
+## 2. Background the slow thing — first
+
+Long or blocking work goes to the background (a background bash task, a monitor,
+or a sub-agent), and it goes there **before** the interactive part, so it runs
+*during* the conversation, not after it.
+
+The ordering rule: **if a step needs a long-running background task, start that
+task before you do a batch of interactive steps.** Onboarding is the canonical
+example — start the small-model download, *then* profile the machine and
+interview the user while the bytes arrive. By the time the interview is done, the
+model is cached.
+
+- Use background tasks / monitors for downloads, baselines, sweeps, installs.
+- Announce the ETA, then move on to interactive work — do not block the user
+  watching a progress bar.
+- Surface a notification when it lands; do not silently poll.
+
+## 3. Fill the wall-clock with useful work
+
+A running baseline is free thinking time. Use it. While a long task runs, do
+analysis that will matter when it finishes, and show partial findings as they
+land:
+
+- **Cost-model the alternatives.** While the incumbent baseline runs, compute
+  what the candidate models would cost at the user's real request volume (pull
+  fresh per-token prices; label assumptions). The user sees the decision taking
+  shape before the baseline even finishes.
+- **Pull benchmark/spec context.** Look up the candidate models' published
+  benchmarks, context windows, licenses, and local hardware fit (see
+  [`open-model-spotlight.md`](open-model-spotlight.md)) so the comparison table
+  is ready the moment scores arrive.
+- **Prepare the next step.** Scaffold the evidence artifacts, draft the splits,
+  write the claim-packet skeleton — anything that removes latency from the next
+  turn.
+
+Bring the profiling forward too: detect hardware and installed tooling early
+(during the first download), not after.
+
+## 4. Plan up front, then show progress
+
+- Open multi-step work with a short, concrete plan — what runs, in what order,
+  what's backgrounded, and where the decision points are. A tracked task list is
+  good; it doubles as the "where are we" map.
+- Tell the user **where they are in the loop** at each turn: capture → baseline →
+  optimize/compare → validate → decide. Re-derive it from artifacts on disk
+  (see the experiment contract in [`../skills/understudy/SKILL.md`](../skills/understudy/SKILL.md)),
+  not from memory.
+- Prefer many fast, visible actions over one long opaque one. Momentum keeps the
+  user engaged.
+
+## 5. Use AskUserQuestion well
+
+- Ask only what you genuinely cannot infer from the repo, the machine, or
+  sensible defaults — inspect first.
+- Batch related decisions into one question set rather than drip-feeding.
+- Frame the *consequence* of each option, and gate real spend / downloads /
+  uploads behind an explicit choice.
+- Don't use it to ask permission to keep going on work the user already asked
+  for.
+
+## 6. Meet the user where they are
+
+Read [`~/.understudy/profile.json`](../skills/onboard/reference.md) and adapt:
+
+- **Vocabulary** — match their level; expand jargon for newcomers, use it
+  directly with practitioners.
+- **Coaching depth** — explain the "why" for first-timers; stay terse for
+  experts.
+- **Opinion strength** — give newcomers one clear recommended path; offer
+  experienced users the trade-offs and let them choose.
+
+If there's no profile yet, run [`onboard`](../skills/onboard/SKILL.md) first.
+
+## Anti-patterns
+
+- Running a 20-minute job in the foreground while the user waits.
+- Starting a long task without saying how long it takes or what it costs.
+- Going silent during a background run instead of doing analysis.
+- Doing the interactive interview *after* the download instead of during it.
+- Re-asking for information already in the profile or already on disk.
+- Claiming a cost/latency/quality win without measured before/after evidence.

--- a/docs/skill-style-guide.md
+++ b/docs/skill-style-guide.md
@@ -31,7 +31,7 @@ Descriptions are activation-only. Keep under 512 characters.
 
 ```yaml
 ---
-name: understudy-<capability>
+name: <capability>   # must match the skill's directory name (validated)
 description: Use when...
 metadata:
   understudy:

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,6 +12,12 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
 
 ## Capability Skills
 
+- [`onboard`](onboard/SKILL.md) is the engaging first-run experience: it
+  backgrounds a small American open-model download while it profiles the machine,
+  detects ML tooling, interviews the user, and writes a durable
+  `~/.understudy/profile.json` so every later skill meets the user where they are.
+  (Profile schema, interview bank, and tooling map in its
+  [`reference.md`](onboard/reference.md).)
 - [`capture-evidence`](capture-evidence/SKILL.md) attaches the local
   harness/environment, confirms the metric and validator, freezes splits, and
   reruns the incumbent baseline. (Discovery + capture/import folded into its
@@ -36,6 +42,12 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   authenticated gateway inference, project/key readiness, public model listing,
   workload route percentages, `understudy run`, and monitored durable CLI
   execution.
+- [`manage-local-models`](manage-local-models/SKILL.md) acquires, caches,
+  organizes, and explains local open-weight models (Gemma 4, Nemotron 3): where
+  weights come from and live, formats/quantization, gated weights and HF tokens,
+  disk budgeting, start-small-and-cache, and the local→cloud graduation path.
+  (Download locations, registry links, and the quant primer in its
+  [`reference.md`](manage-local-models/reference.md).)
 - [`run-local-model-lab`](run-local-model-lab/SKILL.md) evaluates local or
   workstation-hosted models against the same frozen workload/eval, keeps model
   downloads behind approval, and compares local, hybrid, and remote routes.

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -13,10 +13,10 @@ metadata:
 This repo ships its skills as a Claude Code plugin. The manifests live in
 `.claude-plugin/` (`plugin.json` + `marketplace.json`) and the skills live in
 `skills/`. This skill installs/enables that plugin in the developer's Claude
-Code so all nine skills (`understudy`, `capture-evidence`,
-`use-understudy-gateway`, `run-local-model-lab`, `optimize-workload`,
-`optimize-api-workflow`, `optimize-agentic-search`, `prepare-verifier-handoff`,
-and this `install-plugin` skill) become invocable.
+Code so all eleven skills (`understudy`, `onboard`, `capture-evidence`,
+`use-understudy-gateway`, `manage-local-models`, `run-local-model-lab`,
+`optimize-workload`, `optimize-api-workflow`, `optimize-agentic-search`,
+`prepare-verifier-handoff`, and this `install-plugin` skill) become invocable.
 
 The whole flow is local: it adds a **local filesystem marketplace** pointing at
 this repo and installs from it. Nothing uploads, authenticates, or spends.

--- a/skills/manage-local-models/SKILL.md
+++ b/skills/manage-local-models/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: manage-local-models
+description: Use to acquire, cache, organize, and explain local open-weight models — "download a model", "what models do I have", "where did the weights go", "free up model disk", "which Gemma/Nemotron should I pull", "how do open models work". Covers where weights come from and live, formats/quantization, gated weights and HF tokens, disk budgeting, start-small-and-cache, and the local→cloud graduation path. American families (Gemma 4, Nemotron 3). To score a local model on a workload, use run-local-model-lab.
+metadata:
+  understudy:
+    mode: interactive
+    safety: approval-required
+    cli_required: false
+---
+
+# Manage Local Models
+
+Get open-weight models onto the machine, keep them organized, and teach the user
+enough to choose well. This skill is acquisition + curation + education; to score
+a local model against a workload, use
+[`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
+
+The habit this skill installs: **start with the smallest model that could work,
+cache it, prove the loop, and only step up when an eval says you must.** Small
+local models are free, private, and instant to iterate on; big quality lives one
+`understudy` route away when you actually need it.
+
+## Safety Gates
+
+- **No download without explicit approval + a size cap.** Always state model,
+  quantization, and GB on disk first, then confirm. Weights are large; a wrong
+  pull can fill a disk.
+- **Background big pulls.** Announce the ETA, start the download in the
+  background, and keep working — do not block the user on a progress bar.
+- **Gated weights need consent.** Gemma (and some others) require accepting a
+  license and using a Hugging Face token. Walk the user through acceptance; never
+  print, log, or commit the token. The Ollama path serves Gemma without an HF
+  token.
+- **Local-first, no upload.** Pulling weights is a download only; nothing about
+  the user's data leaves the machine.
+- Make size/spec/price claims from fresh official sources (HF model cards, the
+  Ollama library, vendor pages), never from memory — label anything indicative.
+
+## Intake
+
+Read `~/.understudy/profile.json` for hardware, installed runtimes, and the
+user's experience tier (set tone accordingly). Inventory what is already cached
+before proposing a download — the best pull is often one they already have. Disk
+locations and registry links are in [`reference.md`](reference.md).
+
+## Flow
+
+1. **Inventory.** List installed runtimes and already-cached models, and report
+   free disk. (`ollama list`; Hugging Face cache scan; MLX/LM Studio dirs — see
+   [`reference.md`](reference.md).) Surface total disk used by weights.
+2. **Pick the smallest viable American model.** Match the goal and hardware to a
+   tier, biased small (full ladder + hardware rule-of-thumb in
+   [`reference.md`](reference.md) and
+   [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md)):
+   - **Gemma 4** (Google) — E2B/E4B on-device; 12B mid; 26B-MoE / 31B dense for
+     workstations. Strong small-to-mid, multimodal.
+   - **Nemotron 3** (NVIDIA) — Nano 4B (edge) or Nano 30B-A3B (MoE, ~4B-active
+     speed); Super on big-RAM boxes. Agentic-reasoning, long context.
+3. **Choose source + format for the runtime.** Ollama library (simplest, GGUF,
+   no HF token for Gemma); Hugging Face GGUF (llama.cpp / LM Studio); MLX builds
+   (Apple Silicon). Quantization/format primer in [`reference.md`](reference.md).
+4. **Confirm the size, then background the pull.** State exact GB and ETA, get
+   the go-ahead, run the download in the background, and move on to other work.
+5. **Verify + record.** Once cached, run a one-line generation to confirm it
+   loads and does tool calls if the workload needs them. Append the model to
+   `local_models` in the profile (id, runtime, quant, size, date).
+6. **Curate.** Offer to remove superseded or oversized weights to reclaim disk;
+   show how to relocate the cache to another volume if space is tight
+   ([`reference.md`](reference.md)).
+7. **Point at graduation.** When a local model is good but not quite enough, the
+   path is *same family, larger, remote* via
+   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) —
+   prompts and behavior carry over. Evaluate the gap with
+   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
+
+For first-timers, teach as you go: what an open-weight model is, why local is
+free and private, what quantization trades away, and why MoE "30B but 3B active"
+runs fast. For practitioners, skip it and just name the pick.
+
+## Output Standard
+
+End with: runtimes + models already cached and disk used; the recommended pull
+(model, quant, GB, source link) and why that tier; download status (backgrounded
++ ETA, or cached); profile updated; any approval still pending (gated-weight
+license/token, large download); and one recommended next skill/command.
+
+## References
+
+- [`reference.md`](reference.md) — download locations, registry links, format &
+  quantization primer, gated-weights/token, disk budgeting & relocation.
+- [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md) —
+  Gemma 4 & Nemotron 3 variants, benchmarks, and hardware fit.

--- a/skills/manage-local-models/reference.md
+++ b/skills/manage-local-models/reference.md
@@ -1,0 +1,101 @@
+# Manage Local Models — reference
+
+Where weights come from, where they land, how to read formats, and how to budget
+disk. Verify ids, sizes, and license terms against the official source before
+quoting — links move and quantizations get re-cut.
+
+## Where to get weights (the links users ask for)
+
+| Source | URL | Use it for |
+|---|---|---|
+| Hugging Face Hub | `https://huggingface.co` | Canonical home for open weights + model cards. Search the org, read the card, check the license. |
+| Ollama library | `https://ollama.com/library` | One-command local pulls (GGUF). Simplest path; serves Gemma without an HF token. |
+| LM Studio | `https://lmstudio.ai/models` | GUI model browser + local OpenAI-compatible server. |
+| NVIDIA (Nemotron) | `https://huggingface.co/nvidia` · `https://build.nvidia.com` · `https://developer.nvidia.com/nemotron` | Nemotron 3 weights, cards, and hosted previews. |
+| Google (Gemma) | `https://huggingface.co/google` · `https://ai.google.dev/gemma` · Kaggle Models | Gemma 4 weights and docs (license acceptance required). |
+| Unsloth | `https://huggingface.co/unsloth` | Pre-quantized GGUF/MLX cuts of Gemma & Nemotron, often with day-one fixes. |
+
+Direct examples (confirm before pulling): `ollama.com/library/gemma`,
+`ollama.com/library/nemotron-3-nano`, `huggingface.co/google` (Gemma 4),
+`huggingface.co/nvidia` (Nemotron 3), `huggingface.co/unsloth` (GGUF/MLX).
+
+## Where weights land (cache locations)
+
+| Runtime | Default cache | Relocate with |
+|---|---|---|
+| Ollama | `~/.ollama/models` | `OLLAMA_MODELS=/Volumes/ext/ollama` (export before `ollama serve`) |
+| Hugging Face (transformers, MLX, hf CLI) | `~/.cache/huggingface/hub` | `HF_HOME=/path` or `HF_HUB_CACHE=/path` |
+| LM Studio | `~/.lmstudio/models` | set in the app's settings |
+| llama.cpp | wherever you saved the `.gguf` | manual; keep them in one dir |
+
+Inventory what's already on disk before downloading more:
+
+```bash
+ollama list                                  # cached Ollama models
+du -sh ~/.ollama/models 2>/dev/null          # Ollama disk used
+hf cache scan 2>/dev/null || huggingface-cli scan-cache 2>/dev/null   # HF cache
+du -sh ~/.cache/huggingface/hub 2>/dev/null  # HF disk used
+df -h ~                                       # free space
+```
+
+Reclaim space: `ollama rm <model>`, or `hf cache delete` / `huggingface-cli
+delete-cache` for the HF cache.
+
+## Formats
+
+| Format | Runtimes | Notes |
+|---|---|---|
+| **GGUF** | llama.cpp, Ollama, LM Studio | Quantized, single-file, CPU/GPU. The default for local on a laptop. |
+| **MLX** | MLX / `mlx_lm` | Apple-Silicon-native; best tokens/sec on Macs. |
+| **safetensors** | Transformers, vLLM, SGLang | Full-precision weights; for serving on GPUs or converting to GGUF/MLX. |
+
+## Quantization (what you trade for disk)
+
+Lower precision = smaller + faster, with some quality loss. Common GGUF levels,
+worst→best quality: `Q4_K_M` (the usual sweet spot) → `Q5_K_M` → `Q6_K` → `Q8_0`
+(near-lossless) → `F16` (full). Start at Q4_K_M; only go higher if an eval shows
+the quant is the bottleneck.
+
+**Rule of thumb (q4):** ~0.5 GB of weights per billion parameters, plus KV cache
+for context.
+
+| Model | Params | ~q4 weights on disk |
+|---|---|---|
+| Gemma 4 E4B | ~4.5B eff. | ~3–4 GB |
+| Nemotron 3 Nano 4B | 4B | ~3 GB |
+| Gemma 4 12B | 12B | ~7–8 GB |
+| Nemotron 3 Nano 30B-A3B | 30B total (3B active) | ~18–20 GB (sized by total params) |
+| Gemma 4 31B dense | 30.7B | ~18–20 GB |
+
+**MoE memory vs speed:** a Mixture-of-Experts model holds *all* experts in memory
+(disk/RAM sized by **total** params) but only activates a few per token, so it
+runs at the **active**-param speed. "30B but 3B active" = 30B-sized download, ~4B
+inference speed.
+
+**Context / KV cache:** longer context needs more RAM for the KV cache, on top of
+weights. On tight memory, serve with flash attention and a quantized KV cache —
+e.g. Ollama: `OLLAMA_FLASH_ATTENTION=1 OLLAMA_KV_CACHE_TYPE=q8_0 ollama serve`.
+
+## Gated weights & tokens
+
+Some families (Gemma among them) gate downloads behind license acceptance:
+
+1. Open the model page on Hugging Face and **accept the license** while signed in.
+2. Create a **read** token at `https://huggingface.co/settings/tokens`.
+3. Authenticate: `hf auth login` (or `huggingface-cli login`), or set
+   `HF_TOKEN=...` in the environment for the pull only.
+
+Never print the token, write it to a repo file, or commit it. The **Ollama path
+avoids the token entirely** for Gemma — prefer it for first-timers.
+
+## Hardware fit (local, q4)
+
+- **8–16 GB** — E2B/E4B and Nano-4B class only.
+- **32 GB** — comfortably runs a 30B-A3B MoE or a 12B dense; a 31B dense is tight
+  with long context (quantize the KV cache).
+- **64–128 GB** — Nemotron 3 Super (~120B-A12B) and larger become viable.
+- Everything bigger (e.g. Nemotron Ultra) is remote-only — graduate via
+  [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+
+See [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md) for
+variant tables, benchmarks, and indicative cloud prices.

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: onboard
+description: Use as the engaging first-run experience right after the Understudy plugin is installed, or whenever a developer says "get started", "set me up", "I'm new to this", "onboard me", or asks what Understudy is and where to begin. Backgrounds a small open-model download while it profiles the machine, detects ML tooling, interviews the user to gauge experience and goals, and writes a durable ~/.understudy/profile.json so every later skill can meet the user where they are. Hands off to the understudy orchestrator.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Understudy Onboarding
+
+The first thing a new user experiences. Goal: in a few minutes, leave them with
+(1) a small open model **running locally on their own machine**, (2) a clear
+sense of what Understudy is and why it matters, and (3) a saved profile so you
+never re-ask what you already learned.
+
+Run this after [`install-plugin`](../install-plugin/SKILL.md). It follows the
+engagement doctrine in
+[`../../docs/engagement-and-pacing.md`](../../docs/engagement-and-pacing.md):
+**start the slow download first, then interview while it runs.** Detail —
+profile schema, interview bank, tooling-detection table — is in
+[`reference.md`](reference.md).
+
+## Safety Gates
+
+- **Download approval + size cap.** Name the exact model, quantization, and disk
+  size, and get a quick yes before pulling weights. Default to the *smallest*
+  American open model that gives a real win.
+- **Local-first, no upload.** Profiling, interview answers, and the model run
+  entirely on the machine. The profile is local; it holds preferences and
+  detected tooling — never secrets, keys, or customer data.
+- **Gated weights** (e.g. Gemma via Hugging Face) need license acceptance + an
+  HF token; the Ollama path avoids this. Never print or commit a token.
+
+## Intake
+
+Returning user? If `~/.understudy/profile.json` exists, read it, greet them by
+where they left off, confirm nothing major changed, and skip straight to the
+work — do not re-run the full interview. Only first-timers get the full flow.
+
+## Flow
+
+1. **Start the slow thing first (background).** Detect the model runtime
+   (`ollama`, `llama-server`, `mlx_lm`, `lms`). If one exists, announce the pick
+   + size + ETA and **background** a pull of a small American model — Gemma 4 E4B
+   or Nemotron 3 Nano (see [`open-model-spotlight.md`](../../docs/open-model-spotlight.md)).
+   If no runtime exists, the slow step is *install a runtime + pull* — get one
+   quick approval, then background it. Then immediately move on; do not watch the
+   bar.
+
+2. **Profile the machine (while it downloads).** Detect OS/chip (Apple Silicon
+   vs CUDA), RAM / unified memory, free disk. State what fits locally. This is
+   the hardware inventory from
+   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md), brought
+   to the front.
+
+3. **Detect ML tooling → infer experience.** Check for PyTorch, vLLM,
+   Transformers, TRL/PEFT, MLX, llama.cpp, Ollama, the HF CLI, `nvidia-smi`
+   (table in [`reference.md`](reference.md)). Lots of ML libs ⇒ experienced;
+   none ⇒ likely first-timer. Use this to *pre-fill* the interview, not to
+   skip it.
+
+4. **Interview (one batched AskUserQuestion).** Confirm the inference rather than
+   interrogate: *"I see PyTorch and vLLM here, so I'll assume you're comfortable
+   with ML tooling — right?"* or *"No ML tooling yet — first time running models
+   locally?"* Capture: experience tier, primary goal (cost / latency / quality /
+   learning / compliance), hard constraints (ZDR / local-only / approved
+   providers), and preferred coaching depth. Question bank in
+   [`reference.md`](reference.md).
+
+5. **Write the profile.** Save `~/.understudy/profile.json` (schema in
+   [`reference.md`](reference.md)): experience tier, detected tooling, hardware,
+   goal, constraints, and the three meet-them-where-they-are dials — vocabulary,
+   coaching depth, opinion strength. Append, don't overwrite, the `history` of
+   workloads and decisions.
+
+6. **Land the quick win.** The model is cached by now — run one local generation
+   so they see it answer **on their machine, $0, private**. Briefly teach the
+   idea: an open-weight model is downloadable weights you run yourself; local is
+   free and ZDR-safe; you iterate small and local, then *graduate* to a larger
+   model in the same family via the gateway when you need the quality.
+
+7. **Route onward.** Hand to the [`understudy`](../understudy/SKILL.md)
+   orchestrator for the improvement loop;
+   [`manage-local-models`](../manage-local-models/SKILL.md) to grow and organize
+   the local model library; [`run-local-model-lab`](../run-local-model-lab/SKILL.md)
+   to evaluate a local candidate against a real workload.
+
+Adapt everything to the profile: expand jargon and give first-timers one clear
+recommended path; stay terse and offer trade-offs to practitioners.
+
+## Output Standard
+
+End with: runtime + model downloading (and ETA, or "cached"); hardware found and
+what fits locally; inferred experience tier and the dials set; the profile path
+written; the quick-win result (local generation shown or pending); and one
+recommended next skill/command.
+
+## References
+
+- [`reference.md`](reference.md) — profile schema, interview bank, tooling map,
+  experience→coaching dials.
+- [`../../docs/engagement-and-pacing.md`](../../docs/engagement-and-pacing.md) —
+  the background-first, fill-the-wait doctrine.
+- [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md) —
+  Gemma 4 & Nemotron 3 picks and hardware fit.

--- a/skills/onboard/frontmatter.md
+++ b/skills/onboard/frontmatter.md
@@ -1,5 +1,0 @@
----
-name: understudy-onboard
-description: Convert an existing application to route LLM calls through the Understudy gateway at UNDERSTUDY_GATEWAY_URL, or add thin Understudy cookbooks such as a DSPy-style GEPA prompt optimizer. Use when the user asks to "convert to Understudy", "set up Understudy in this repo", "route through Understudy", "siphon traffic to Understudy", "add GEPA", "optimize this prompt", "improve this eval", or any similar phrasing about wiring up Understudy or using an Understudy API key from an agent. Detects the SDK or framework in use (raw Anthropic SDK, raw OpenAI SDK, Mastra, Vercel AI SDK, LangChain, LlamaIndex, DSPy/GEPA, or anything else that speaks Anthropic/OpenAI wire shape) and applies the matching recipe.
----
-

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -1,0 +1,115 @@
+# Onboarding — reference
+
+Deep detail for [`SKILL.md`](SKILL.md): the user profile, the interview, tooling
+detection, and how the profile drives tone. All of it is local; none of it
+uploads.
+
+## The user profile (`~/.understudy/profile.json`)
+
+User-level (home dir), not repo-level — it follows the user across projects. It
+is the durable memory of *who you are working with and what they have done*. Read
+it at the start of every session; create it during onboarding; append to its
+`history` as workloads and decisions accumulate. Never put secrets, keys, tokens,
+prompts, or customer data in it.
+
+```jsonc
+{
+  "schema_version": "understudy.profile.v1",
+  "created_at": "2026-06-06T18:00:00Z",     // shell: date -u +%FT%TZ
+  "updated_at": "2026-06-06T18:00:00Z",
+  "experience": {
+    "tier": "first-timer",                  // first-timer | familiar | practitioner
+    "signals": [],                          // detected tooling that informed the guess
+    "self_reported": true                   // did the user confirm it?
+  },
+  "machine": {
+    "os": "darwin",
+    "chip": "Apple M4",
+    "accelerator": "apple-silicon",         // apple-silicon | cuda | cpu
+    "memory_gb": 32,
+    "vram_gb": null,                        // discrete-GPU VRAM if CUDA
+    "disk_free_gb": 210
+  },
+  "tooling": {
+    "runtimes": [],                         // ollama, llama.cpp, mlx, lm-studio, vllm
+    "python_ml": [],                        // torch, transformers, trl, peft, datasets
+    "hf_cli": false,
+    "cuda": false
+  },
+  "goals": { "primary": "cost", "notes": "" },  // cost | latency | quality | learning | compliance
+  "constraints": [],                            // zdr, local-only, approved-providers, region, budget
+  "preferences": {
+    "vocabulary": "plain",                  // plain | mixed | technical
+    "coaching": "high",                     // high | medium | low
+    "opinion_strength": "prescriptive"      // prescriptive | balanced | options-only
+  },
+  "local_models": [],                       // [{id, runtime, quant, size_gb, pulled_at}]
+  "history": []                             // [{workload, decision, route, at}]
+}
+```
+
+Write it with the smallest correct change: merge new fields, append to `history`
+and `local_models`, bump `updated_at`. If a value is unknown, leave it null
+rather than guessing.
+
+## Tooling detection → experience signal
+
+Run these read-only checks while the model downloads. Each hit is a signal; the
+*set* informs the experience tier (confirm, don't assume).
+
+| Check | Command | Signals |
+|---|---|---|
+| Model runtimes | `which ollama llama-server mlx_lm.generate lms` | can run models locally |
+| PyTorch | `python -c "import torch"` 2>/dev/null | active ML practitioner |
+| vLLM / TGI | `python -c "import vllm"` / `which vllm` | serves models at scale |
+| Transformers / datasets | `python -c "import transformers, datasets"` | trains/evaluates models |
+| TRL / PEFT | `python -c "import trl, peft"` | does fine-tuning / RL |
+| MLX | `python -c "import mlx"` / `which mlx_lm.generate` | Apple-silicon ML |
+| HF CLI | `which huggingface-cli hf` | pulls weights from the Hub |
+| NVIDIA GPU | `nvidia-smi` | CUDA box, bigger models in play |
+
+Rough mapping: **none** of these ⇒ likely *first-timer*; a runtime + the HF CLI
+⇒ *familiar*; PyTorch/vLLM/Transformers/TRL present ⇒ *practitioner*. Always
+confirm with the user — detection is a starting guess, not a verdict.
+
+## Interview bank (batch into one AskUserQuestion)
+
+Pre-fill each from detection; phrase as confirmation. Ask only what you can't
+infer.
+
+1. **Experience** — "First time running models locally, or are you already deep
+   in this?" → `first-timer | familiar | practitioner`.
+2. **Primary goal** — "What are you here to do?" → cut cost / cut latency / raise
+   quality / learn how this works / meet a compliance constraint.
+3. **Constraints** — "Anything that must hold?" → ZDR / data stays local /
+   approved providers only / region / budget / none.
+4. **Coaching depth** — "How much should I explain as we go?" → walk me through
+   it / balanced / just do it and keep it terse.
+
+## Experience → tone dials (defaults)
+
+Set `preferences` from the tier, then let the coaching answer override.
+
+| Tier | vocabulary | coaching | opinion_strength | In practice |
+|---|---|---|---|---|
+| first-timer | plain | high | prescriptive | Expand every term. Give one clear recommended path. Show the win before the theory. |
+| familiar | mixed | medium | balanced | Use common terms freely. Offer the main option plus one alternative. |
+| practitioner | technical | low | options-only | Assume fluency. Lay out trade-offs and let them choose. Skip the hand-holding. |
+
+These dials are read by every skill (via
+[`../../docs/engagement-and-pacing.md`](../../docs/engagement-and-pacing.md)),
+so the whole experience adapts to the one profile.
+
+## First local model — pick small, American, cached
+
+Default first pull is the smallest model that still feels real, biased to the
+American open families (see
+[`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md)):
+
+- **Apple Silicon, any RAM** — Gemma 4 E4B (~4.5B eff.) or Nemotron 3 Nano 4B
+  via Ollama or MLX. Fast, tiny download, runs everywhere.
+- **32 GB+** — can step up to Nemotron 3 Nano 30B-A3B (MoE, ~4B active speed) or
+  Gemma 4 12B once the tiny one proves the loop.
+
+Acquisition, caching, disk locations, and the larger ladder live in
+[`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md).

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -61,6 +61,27 @@ Show partial findings early ("found 3 LLM call sites"; "app uses LiteLLM, so
 gateway insertion is low-risk"; "no evals — I'll build a small harness first";
 "stated ZDR constraint blocks hosted upload unless approved").
 
+## Engagement & pacing
+
+Keep the user oriented and engaged across the loop's slow steps. Full doctrine in
+[`../../docs/engagement-and-pacing.md`](../../docs/engagement-and-pacing.md); the
+rules:
+
+- **Estimate before you start.** Say how long a step takes and what it costs
+  before running it (e.g. "100-task baseline ≈ 15–20 min, ~$31"). Measure a small
+  sample first if you don't know the rate.
+- **Background the slow thing — first.** Downloads, baselines, and sweeps run in
+  the background, started *before* the interactive part so they finish during it.
+- **Fill the wait.** While a long run goes, cost-model the candidate models at
+  the user's real volume and pull their benchmarks so the comparison is ready the
+  moment scores land.
+- **Plan up front; show where they are.** Open with a concrete plan; each turn,
+  state the loop stage (capture → baseline → optimize/compare → validate →
+  decide), re-derived from artifacts on disk.
+- **Meet them where they are.** Read `~/.understudy/profile.json` and set
+  vocabulary, coaching depth, and opinion strength to match. No profile yet → run
+  [`../onboard/SKILL.md`](../onboard/SKILL.md) first.
+
 ## Inspect before you ask
 
 Answer from the repo before asking the developer. Read package files, provider/
@@ -88,6 +109,10 @@ and worked examples.
 
 Identify the developer's current stage and load exactly one:
 
+- **First run / new user / no profile yet** — the developer is new, just
+  installed the plugin, or asks "where do I start?" and `~/.understudy/profile.json`
+  is missing → [`../onboard/SKILL.md`](../onboard/SKILL.md) (backgrounds a small
+  model, profiles the machine, interviews, writes the profile).
 - **Codebase / evidence not yet pinned down** — LLM call sites, current model/
   harness, traces, metric, splits, or incumbent baseline are missing, ambiguous,
   or stale → [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)
@@ -96,6 +121,10 @@ Identify the developer's current stage and load exactly one:
   gateway trace capture, project/key management, model A/B via route traffic %,
   `understudy run`, or registering an improved route →
   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+- **Acquire / cache / organize local models** — download a model, see what's
+  already cached, free up model disk, pick which Gemma/Nemotron to pull, or
+  explain how open weights work →
+  [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md).
 - **Local model experiment / local-only route** — evaluate a local or
   workstation-hosted model through the same frozen workload/eval, choose a
   runtime, compare local vs remote, or satisfy ZDR / no-upload constraints →


### PR DESCRIPTION
## Why

Reframe the agent experience around **installing the plugin** and **meeting the user where they are**, and make the agent proactive across the optimization loop's slow steps (downloads, baselines, sweeps) instead of going dark.

## What changed

**Entry points**
- **`CLAUDE.md`** (new) — links to `AGENTS.md`; prime directive: distinguish *user vs contributor*; users install the plugin + onboard first.
- **`AGENTS.md`** — leads with plugin install: why the skills *are* the product, plain-language recommendation, **uninstall path up front (reversible)**, then onboarding. Contributor content preserved below.

**New skills**
- **`onboard`** — engaging first-run experience. Backgrounds a small American open model (Gemma 4 / Nemotron 3) while profiling hardware + ML tooling, interviewing the user, and writing a durable **`~/.understudy/profile.json`** (vocabulary / coaching / opinion dials). Reuses `skills/onboard/` (previously code-conversion recipes with no `SKILL.md`) as a clean superset.
- **`manage-local-models`** — acquire, cache, organize, and explain local open-weight models: sources + links, cache locations, format/quant primer, gated weights + HF token, disk budgeting, start-small-and-cache, local→cloud graduation. Distinct from `run-local-model-lab` (evaluation).

**Engagement doctrine (cross-cutting)**
- **`docs/engagement-and-pacing.md`** (new) — estimate before starting, **background the slow thing first**, fill the wait with alt-model cost models + benchmark pulls, plan up front + show where-you-are, meet-them-where-they-are via the profile.
- **`skills/understudy/SKILL.md`** — adds an Engagement & pacing section + routes to `onboard` and `manage-local-models`.

**Consistency**
- nine → eleven skills in `README` + `install-plugin`; both added to `skills/README` and the migration ledger; stale unreferenced `onboard/frontmatter.md` removed; style-guide frontmatter example fixed (name must match dir, per validator).

## Decisions worth a look
1. **Reused `skills/onboard/` for the human experience** (it had only code-conversion recipes, no `SKILL.md`); the `setup-code` recipes remain reachable.
2. **Split `manage-local-models` from `run-local-model-lab`** — acquisition/caching/education vs. evaluation-against-a-workload.

## Validation
- `node scripts/validate-public-skills.mjs --repo` → `ok 11 public skill(s)`
- `git diff --check` clean; internal doc links resolve.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->