### PR TITLE
Add first Understudy installer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,53 @@ execution, auth injection, artifact writes, or a safety gate.
 
 ## Install Locally
 
+Fast first-run installer for Apple Silicon:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash
+```
+
+After this lands on `main`, this is the URL to hand to Aamir for a clean
+top-of-funnel test:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | sh
+```
+
+Pre-merge branch test:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/yolo/first-understudy-installer/install.sh | UNDERSTUDY_INSTALL_REF=yolo/first-understudy-installer bash -s -- --yes
+```
+
+That installs the CLI and Pi, prepares an isolated MLX runtime, asks before
+downloading the verified Gemma 4 E2B 4-bit first-rung snapshot, and opens a new
+Terminal window so you meet your first local Understudy immediately. For
+non-interactive demos, add `--yes`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --yes
+```
+
+The default model endpoint is a stable Understudy snapshot session generator:
+`https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit`.
+The installer fetches that manifest, then downloads each model file from the
+short-lived signed URL returned in `files[]`. We publish the session URL, not
+the expiring per-object signed URLs. It is overridable with
+`UNDERSTUDY_MODEL_SESSION_URL`.
+
+If a coding agent started the installer, the user can follow the live Pi session
+with `tmux attach -t mlx-arena-first`. Agents should drive Pi through tmux using
+paste-buffer plus an explicit Enter:
+
+```bash
+tmux set-buffer 'Say exactly: local Understudy is online.'
+tmux paste-buffer -t mlx-arena-first
+tmux send-keys -t mlx-arena-first Enter
+```
+
+Developer install from a clone:
+
 ```bash
 npm install
 npm run build
@@ -165,6 +212,7 @@ capability worker:
 - `skills/use-understudy-gateway/SKILL.md`
 - `skills/manage-local-models/SKILL.md` (acquire, cache, and explain local open-weight models)
 - `skills/run-local-model-lab/SKILL.md`
+- `skills/specialize-local-model/SKILL.md` (smallest reasonable local rung → Pi head-to-head → gap-driven improvement)
 - `skills/prepare-verifier-handoff/SKILL.md`
 
 Everything else stays outside the discovered surface until real usage proves it

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -86,6 +86,10 @@ skills/optimize-workload/SKILL.md
 skills/use-understudy-gateway/SKILL.md
 skills/manage-local-models/SKILL.md
 skills/run-local-model-lab/SKILL.md
+skills/mlx-arena/SKILL.md
+skills/design-simulated-environment/SKILL.md
+skills/recursive-language-model/SKILL.md
+skills/specialize-local-model/SKILL.md
 skills/prepare-verifier-handoff/SKILL.md
 ```
 
@@ -99,6 +103,12 @@ open-model download per the engagement doctrine in
 `manage-local-models` acquires, caches, and explains local open-weight models
 (Gemma 4, Nemotron 3) — distinct from `run-local-model-lab`, which evaluates a
 local model against a frozen workload.
+
+`specialize-local-model` sequences the local-understudy product loop: pick the
+smallest task-reasonable local model, open it in the Pi/MLX arena against a
+frontier model, diagnose the gap, then choose model climb, simulated
+environment, GEPA/prompt optimization, RLM decomposition, hybrid route, or
+remote-only.
 
 `prepare-verifier-handoff` is a future-release stub, not an executable CLI
 surface. It helps agents recognize workloads that need stateful RL

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Install Understudy agent tools, prepare the first local model, and open the
+# first-run Understudy window.
+set -euo pipefail
+
+MODEL_SESSION_URL="${UNDERSTUDY_MODEL_SESSION_URL:-https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit&ttl=21600}"
+MODEL_DIR="${UNDERSTUDY_MODEL_DIR:-$HOME/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit}"
+LAB="${UNDERSTUDY_LAB:-$HOME/.understudy/agent-tools}"
+INSTALL_REF="${UNDERSTUDY_INSTALL_REF:-main}"
+INSTALL_PACKAGE="${UNDERSTUDY_INSTALL_PACKAGE:-git+https://github.com/UnderstudyLabs/understudy-agent-tools.git#$INSTALL_REF}"
+YES=0
+NO_MODEL=0
+NO_WINDOW=0
+NO_GAUNTLET=0
+NO_CLAUDE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -y|--yes) YES=1 ;;
+    --no-model) NO_MODEL=1 ;;
+    --no-window) NO_WINDOW=1 ;;
+    --no-gauntlet) NO_GAUNTLET=1 ;;
+    --no-claude) NO_CLAUDE=1 ;;
+    --model-session-url) MODEL_SESSION_URL="${2:?missing URL}"; shift ;;
+    --model-base-url) MODEL_SESSION_URL="${2:?missing URL}"; shift ;;
+    --model-dir) MODEL_DIR="${2:?missing path}"; shift ;;
+    --lab) LAB="${2:?missing path}"; shift ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: install.sh [--yes] [--no-claude] [--no-model] [--no-window] [--no-gauntlet]
+
+Installs the Understudy CLI + Claude skill/plugin surface, prepares Apple MLX,
+downloads the verified Gemma 4 E2B 4-bit first rung, and opens the first local
+Understudy in a new Terminal window on macOS.
+
+Environment overrides:
+  UNDERSTUDY_MODEL_SESSION_URL stable session endpoint that returns signed model file URLs
+  UNDERSTUDY_MODEL_DIR        local model destination
+  UNDERSTUDY_LAB              local runtime/log directory
+  UNDERSTUDY_INSTALL_REF      Git ref for public repo install, default main
+  UNDERSTUDY_INSTALL_PACKAGE  npm package spec, default git+https://github.com/UnderstudyLabs/understudy-agent-tools.git#$UNDERSTUDY_INSTALL_REF
+  SESSION                     tmux session prefix, default mlx-arena
+EOF
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+say() { printf '\033[1munderstudy\033[0m %s\n' "$*"; }
+section() {
+  printf '\n\033[1munderstudy\033[0m %s\n' "$*"
+}
+need() { command -v "$1" >/dev/null 2>&1; }
+confirm() {
+  [ "$YES" = "1" ] && return 0
+  printf "%s [y/N] " "$1"
+  read -r answer
+  case "$answer" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
+}
+
+install_tmux() {
+  need tmux && return 0
+  say "tmux is required for the visible handoff window."
+  if need brew; then
+    confirm "Install tmux with Homebrew now?" || exit 1
+    brew install tmux
+    return 0
+  fi
+  say "Install tmux first, then rerun this installer."
+  say "On macOS with Homebrew: brew install tmux"
+  exit 1
+}
+
+install_claude_plugin() {
+  [ "$NO_CLAUDE" = "1" ] && return 0
+
+  if ! need claude; then
+    say "Claude Code CLI not found; skipping plugin install."
+    say "Later, from a checkout, run: claude plugin marketplace add <repo> && claude plugin install understudy@understudy-skills"
+    return 0
+  fi
+
+  local repo="$PKG_DIR"
+  if [ ! -f "$repo/.claude-plugin/plugin.json" ]; then
+    repo="$(cd "$(dirname "$0")" && pwd)"
+  fi
+  if [ ! -f "$repo/.claude-plugin/plugin.json" ]; then
+    say "Could not find .claude-plugin/plugin.json; skipping Claude Code plugin install."
+    return 0
+  fi
+
+  say "Installing the Understudy Claude Code plugin from $repo."
+  if claude plugin list --json 2>/dev/null | grep -q 'understudy@understudy-skills'; then
+    say "Understudy plugin already appears installed."
+  else
+    claude plugin marketplace add "$repo" >/dev/null
+    claude plugin install understudy@understudy-skills >/dev/null
+    say "Understudy plugin installed."
+  fi
+  say "In your Claude Code session, type /reload-plugins once to activate the skills."
+}
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+  say "This first-run local model installer currently targets Apple Silicon Macs."
+  say "Install the CLI with npm, then use the non-MLX skills for this machine."
+  exit 1
+fi
+
+need npm || {
+  say "npm is required. Install Node.js 20+ first: https://nodejs.org"
+  exit 1
+}
+
+section "Welcome. We are going to create your first local Understudy."
+say "Understudy starts with a small open-weight model on your Mac."
+say "You compare it against a frontier model, then climb the ladder with better data, evals, GEPA/RLM, bigger local models, or remote runs."
+say "The point is concrete: build a replacement model for work you currently send to a frontier model."
+
+if ! need uv; then
+  say "uv is required for the isolated MLX runtime."
+  confirm "Install uv from astral.sh now?" || exit 1
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+install_tmux
+
+section "Step 1/5: install the CLI and Pi harness."
+say "Installing Understudy package from $INSTALL_PACKAGE"
+npm install -g "$INSTALL_PACKAGE" @earendil-works/pi-coding-agent
+
+PKG_DIR="$(npm root -g)/@understudylabs/understudy-agent-tools"
+ARENA="$PKG_DIR/skills/mlx-arena/arena.sh"
+if [ ! -x "$ARENA" ]; then
+  say "Could not find executable arena launcher at $ARENA."
+  say "If this is a local checkout, run from the repo with: skills/mlx-arena/arena.sh first-window"
+  exit 1
+fi
+
+section "Step 2/5: install the Claude Code skills."
+install_claude_plugin
+
+mkdir -p "$LAB" "$MODEL_DIR" "$HOME/.understudy/models"
+if [ ! -x "$LAB/.understudy/venvs/mlx/bin/python" ]; then
+  say "Creating isolated MLX runtime."
+  uv venv "$LAB/.understudy/venvs/mlx" --python 3.12
+  uv pip install --python "$LAB/.understudy/venvs/mlx/bin/python" \
+    'mlx-lm>=0.31' 'mlx-vlm>=0.6' 'huggingface_hub>=0.27'
+fi
+
+download_file() {
+  local name="$1"
+  local url="$2"
+  [ -f "$MODEL_DIR/$name" ] && return 0
+  curl -fL --progress-bar "$url" -o "$MODEL_DIR/$name"
+}
+
+download_model_snapshot() {
+  local manifest="$LAB/model-session.json"
+  curl -fsSL "$MODEL_SESSION_URL" -o "$manifest"
+  "$LAB/.understudy/venvs/mlx/bin/python" - "$manifest" <<'PY' | while IFS=$'\t' read -r name url
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+for item in data["files"]:
+    print(f"{item['name']}\t{item['url']}")
+PY
+  do
+    say "Downloading $name"
+    download_file "$name" "$url"
+  done
+}
+
+if [ "$NO_MODEL" = "0" ]; then
+  section "Step 3/5: download the first local Understudy."
+  say "Model: Gemma 4 E2B IT, MLX-VLM 4-bit, about 3.3GB."
+  say "Why this rung: small enough to run locally, strong enough to make the replacement loop tangible."
+  say "Source: signed Understudy snapshot at $MODEL_SESSION_URL"
+  confirm "Download this verified open-weight snapshot now?" || exit 1
+  download_model_snapshot
+else
+  section "Step 3/5: use the existing local Understudy weights."
+  say "Model directory: $MODEL_DIR"
+fi
+
+section "Step 4/5: meet the local Understudy."
+say "A new Terminal window will show the model loading locally so you can see it is yours, not a hosted frontier call."
+say "If an agent launched this, follow the same session with: tmux attach -t ${SESSION:-mlx-arena}-first"
+if [ "$NO_WINDOW" = "1" ]; then
+  LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
+    FIRST_REPO="$MODEL_DIR" FIRST_LOADER=mlx_vlm "$ARENA" first
+else
+  LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
+    FIRST_REPO="$MODEL_DIR" FIRST_LOADER=mlx_vlm "$ARENA" first-window
+fi
+
+if [ "$NO_GAUNTLET" = "0" ]; then
+  section "Step 5/5: run the local-vs-frontier duel."
+  say "Pi opens a side-by-side harness: local Understudy on the left, frontier baseline on the right."
+  say "The shared tmux session is ${SESSION:-mlx-arena}-play; the agent can send prompts and you can watch or take over."
+  say "After the stock questions, point Understudy at a dataset or codebase."
+  say "Then use the skills to generate task-specific evals and climb: better prompts, GEPA/RLM, larger Gemma/Nemotron, or remote training."
+  if [ "$NO_WINDOW" = "1" ]; then
+    LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
+      LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" "$ARENA" play
+  else
+    LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
+      LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" "$ARENA" play-window
+  fi
+else
+  section "Next: run the local-vs-frontier duel."
+  say "  LAB=\"$LAB\" MLX_PYTHON=\"$LAB/.understudy/venvs/mlx/bin/python\" LEFT_REPO=\"$MODEL_DIR\" LEFT_LOADER=mlx_vlm \"$ARENA\" play"
+fi
+
+section "Where this goes next."
+say "Bring a codebase or dataset. Understudy will make a baseline environment, score local versus frontier, and keep climbing until a cheaper replacement is credible."
+say "If Claude Code was open during install, type /reload-plugins there so the Understudy skills become visible in that same session."

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
+    ".claude-plugin",
+    "install.sh",
     "dist",
     "skills",
     "cookbook",
@@ -24,6 +26,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
+    "prepare": "npm run build",
     "package:smoke": "node scripts/package-smoke.mjs",
     "cookbook:validate": "node scripts/validate-cookbook.mjs",
     "skills:validate": "node scripts/validate-public-skills.mjs --repo",

--- a/skills/README.md
+++ b/skills/README.md
@@ -51,6 +51,10 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
 - [`run-local-model-lab`](run-local-model-lab/SKILL.md) evaluates local or
   workstation-hosted models against the same frozen workload/eval, keeps model
   downloads behind approval, and compares local, hybrid, and remote routes.
+- [`specialize-local-model`](specialize-local-model/SKILL.md) sequences the local
+  model product loop: pick the smallest task-reasonable local rung, open it in
+  Pi against a frontier model, diagnose the gap, then choose model climb, GEPA,
+  simulated environment, RLM decomposition, hybrid route, or remote-only.
 - [`prepare-verifier-handoff`](prepare-verifier-handoff/SKILL.md) is a
   future-release stub for stateful RL verifier/environment handoffs. It does not
   execute training; it prepares evidence and actively refers suitable workloads

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -16,6 +16,29 @@ implementation. The goal: a deterministic, synthetic environment where **any
 candidate model can run the whole agentic task** and be **scored on the final
 state**, so you can compare frontier vs. local and hill-climb the local model.
 
+## Default environment first
+
+Before building a codebase-specific environment, every new local Understudy
+should run in a tiny **default environment** so the user has an immediate,
+repeatable baseline:
+
+- **Task shape:** read a small synthetic inbox / ticket queue / project board,
+  decide what matters, write one structured update, and avoid forbidden writes.
+- **Tools:** `list_records`, `read_record`, `write_note`, `update_status`, and
+  `finish`. All tools mutate in-memory JSON only.
+- **Gold state:** the exact notes/statuses a correct run should produce, plus
+  forbidden writes that must not occur.
+- **Validator axes:** required-write recall, unnecessary-write precision, policy
+  compliance, schema validity, recoverable errors, step count, latency, and cost.
+- **Oracle:** a scripted correct trajectory must score 1.0 before any model is
+  compared.
+
+This default env is not the customer's app and must not be presented as proof
+that local can replace the incumbent. It is the first-run calibration surface:
+"my local model can act in a deterministic tool world, and I can compare it to a
+frontier model." After that, inspect the repo/traces and build the
+workload-specific environment below.
+
 ## Why simulate (the lesson that forces this)
 
 A **recorded** replay (serve the teacher's captured tool_results back) only works
@@ -41,7 +64,9 @@ criteria (recall / precision / policy — not just cost/speed).
 
 ## Recipe
 
-1. **Seed synthetic state.** A few records of each entity the workload touches
+1. **Seed synthetic state.** For the default env, use the built-in synthetic
+   inbox/ticket/project-board fixture. For a workload-specific env, use a few
+   records of each entity the workload touches
    (deals, contacts, activities, a short transcript), small enough to read.
 2. **Implement the tools by intent, leniently.** Group the real tool catalog into
    read / transform / write classes (from understand-workload). For each class,

--- a/skills/manage-local-models/SKILL.md
+++ b/skills/manage-local-models/SKILL.md
@@ -48,14 +48,18 @@ locations and registry links are in [`reference.md`](reference.md).
 1. **Inventory.** List installed runtimes and already-cached models, and report
    free disk. (`ollama list`; Hugging Face cache scan; MLX/LM Studio dirs — see
    [`reference.md`](reference.md).) Surface total disk used by weights.
-2. **Pick the smallest viable American model.** Match the goal and hardware to a
-   tier, biased small (full ladder + hardware rule-of-thumb in
+2. **Pick the smallest viable American model.** For onboarding on Apple Silicon,
+   be prescriptive: start with Understudy's verified
+   `google/gemma-4-e2b-it` MLX-VLM 4-bit snapshot, then climb only when the
+   head-to-head or eval says the rung is too weak. Match later goals and
+   hardware to a tier, biased small (full ladder + hardware rule-of-thumb in
    [`reference.md`](reference.md) and
    [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md)):
-   - **Gemma 4** (Google) — E2B/E4B on-device; 12B mid; 26B-MoE / 31B dense for
-     workstations. Strong small-to-mid, multimodal.
-   - **Nemotron 3** (NVIDIA) — Nano 4B (edge) or Nano 30B-A3B (MoE, ~4B-active
-     speed); Super on big-RAM boxes. Agentic-reasoning, long context.
+   - **Gemma 4** (Google) — verified E2B first; E4B/12B to climb; 26B-MoE / 31B
+     dense for workstation or remote routes. Strong small-to-mid, multimodal.
+   - **Nemotron 3** (NVIDIA) — Nano 4B as an alternate edge rung; Nano 30B-A3B
+     (MoE, ~4B-active speed) or Super on big-RAM boxes. Agentic-reasoning, long
+     context.
 3. **Choose source + format for the runtime.** Ollama library (simplest, GGUF,
    no HF token for Gemma); Hugging Face GGUF (llama.cpp / LM Studio); MLX builds
    (Apple Silicon). Quantization/format primer in [`reference.md`](reference.md).

--- a/skills/manage-local-models/reference.md
+++ b/skills/manage-local-models/reference.md
@@ -59,6 +59,33 @@ the quant is the bottleneck.
 **Rule of thumb (q4):** ~0.5 GB of weights per billion parameters, plus KV cache
 for context.
 
+## Understudy verified MLX ladder
+
+Use this ladder before sending a new user to open-ended model browsing. It keeps
+the first aha moment fast, then gives clear ways to climb within Gemma/Nemotron
+or graduate remote when local quality is the bottleneck.
+
+| Rung | Runtime | Snapshot / source | Use when |
+|---|---|---|---|
+| Gemma 4 E2B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit` | Default onboarding rung. About 3.3 GB; verified local generation, Pi serving, and logprobs/top-logprobs. |
+| Gemma 4 E4B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit` | First climb when E2B understands the task but lacks quality. About 4.8 GB; verified signed snapshot delivery. |
+| Gemma 4 E2B BF16 | `mlx_vlm.server` | Internal/local profiling until a signed session is published | Same model, less quantization loss. About 9.5 GB; use to profile quality/perf when the 4-bit model is close. |
+| Gemma 4 12B | MLX conversion or remote | `google/gemma-4-12B-it` / gateway route | Laptop-plus rung for harder reasoning or multimodal work. Use remote if memory is tight. |
+| Nemotron 3 Nano 4B | MLX / GGUF / remote | NVIDIA source or verified snapshot | Alternate edge rung when agentic reasoning or tool behavior beats Gemma on the workload. |
+| Nemotron 3 Nano 30B-A3B | MLX/GGUF on 32 GB+ or remote | NVIDIA source or gateway route | MoE climb when you need stronger reasoning while keeping active-parameter speed. |
+| Super / Ultra / 31B dense | Remote or workstation | Understudy gateway / provider route | Use when local cannot meet the quality bar or the Mac does not fit the weights comfortably. |
+
+Cloudflare delivery note: public installation uses stable session endpoints from
+`models.understudylabs.com`. Each session response contains short-lived signed
+per-file URLs; publish the session endpoint, not the expiring object URLs. R2
+remains the durable object source.
+
+Remote graduation note: when a local rung is too small, use
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) to
+run `understudy login --email <developer-email>`, store the API key through the
+CLI, list remote model IDs, and route the workload to larger Gemma/Nemotron
+variants without changing application code.
+
 | Model | Params | ~q4 weights on disk |
 |---|---|---|
 | Gemma 4 E4B | ~4.5B eff. | ~3–4 GB |

--- a/skills/mlx-arena/SKILL.md
+++ b/skills/mlx-arena/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mlx-arena
-description: Use to run a frontier model against a small local model on Apple Silicon, blind, then hill-climb the local model toward it — "compare a local model to Opus/GPT", "is a local model good enough for this", "blind model vibe-check", "frontier vs local head-to-head", "hill-climb my local model". Serves the local model with Apple MLX (mlx_lm.server); the frontier is one swappable, provider-agnostic config. Apple Silicon only.
+description: Use to run a frontier model against an opinionated local Understudy on Apple Silicon, blind, then hill-climb the local model toward it — "compare a local model to Opus/GPT", "is a local model good enough for this", "blind model vibe-check", "frontier vs local head-to-head", "hill-climb my local model". Starts with verified Gemma 4 E2B via mlx-vlm; the frontier is one swappable, provider-agnostic config. Apple Silicon only.
 metadata:
   understudy:
     mode: interactive
@@ -20,8 +20,9 @@ only on the genuinely hard tail.
 
 The runnable core is the blind game [`blind_arena.ts`](blind_arena.ts) (TypeScript,
 run by Node ≥22.6 — no Python in the repo); the local
-model is served by `mlx_lm.server` and [`arena.sh`](arena.sh) is the launcher. MLX
-does inference, the game is the surface; the scripts stay thin.
+model is served by `mlx_vlm.server` for the verified Gemma 4 rung or
+`mlx_lm.server` for compatible MLX repos, and [`arena.sh`](arena.sh) is the
+launcher. MLX does inference, the game is the surface; the scripts stay thin.
 
 This is the interactive sibling of
 [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md): the lab
@@ -37,14 +38,15 @@ memory at the best tokens/sec, with no GPU drivers or build step. This skill is
 skill does not apply. (Local models need not be open-weight — any model you can
 serve with `mlx_lm.server` works.)
 
-`mlx_lm.server` exposes an **OpenAI-compatible** endpoint per model
-(`/v1/chat/completions`), one model per process/port. Pi adds each as a custom
-provider in `~/.pi/agent/models.json` (`api: openai-completions`).
+`mlx_vlm.server` and `mlx_lm.server` expose **OpenAI-compatible** endpoints per
+model (`/v1/chat/completions`), one model per process/port. Pi adds each as a
+custom provider in `~/.pi/agent/models.json` (`api: openai-completions`).
 
 ## Safety Gates
 
 - **No weight download without approval + a size cap.** Name the exact MLX repo,
-  quantization, and GB first. Default to the **smallest** model in each family.
+  quantization, and GB first. Default to the **smallest model that is reasonable
+  for the task**, not blindly to the smallest model in the family.
 - **Local-first, no upload.** Weights download from Hugging Face; prompts and
   outputs stay on the machine. No token is required for public `mlx-community`
   repos (a `HF_TOKEN` only raises rate limits).
@@ -55,23 +57,78 @@ provider in `~/.pi/agent/models.json` (`api: openai-completions`).
 
 ## Flow
 
-1. **Inventory + pick two models.** Confirm Apple Silicon, free RAM/disk, and the
-   MLX venv. Pick the **smallest** model from each family to compare (see
+### First out-of-box run
+
+For a new user, start with the verified first rung and open it in Pi immediately:
+
+```bash
+skills/mlx-arena/arena.sh first
+# or, on macOS, open the first Understudy in a distinct Terminal.app window:
+skills/mlx-arena/arena.sh first-window
+```
+
+This starts a branded tmux loading screen, serves the Understudy-verified
+`google/gemma-4-e2b-it` 4-bit MLX-VLM snapshot with `mlx_vlm.server`, then
+replaces the loader with Pi so the user sees: **their first local Understudy is
+ready**. It also creates/updates the local Pi provider entry in
+`~/.pi/agent/models.json`. `first-window` does the same work but opens a
+separate macOS Terminal window attached to the first-run tmux session, so the
+user sees the local Understudy load and then lands in Pi without staying in the
+agent's shell. When a coding agent invokes this, prefer `first-window` and
+`play-window`; always report the follow-along command (`tmux attach -t
+mlx-arena-first` or `tmux attach -t mlx-arena-play`) so the user can watch the
+same session while the agent sends prompts.
+
+Verified snapshot locations:
+
+- 4-bit first rung:
+  `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit`
+  (R2 source:
+  `r2://understudy-model-snapshots/models/google/gemma-4-e2b-it/mlx-vlm-0.6.2/quant-4bit/`)
+- 4-bit E4B climb rung:
+  `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit`
+- Public HTTPS delivery publishes stable session endpoints from
+  `models.understudylabs.com`. Each session response contains short-lived signed
+  per-file URLs; the same R2 prefix is the durable object source.
+
+The 4-bit snapshot is about 3.3 GB, generated `I am ready as your local
+understudy.` in local testing, used about 3.6 GB peak memory, and served
+OpenAI-compatible chat completions with `logprobs` / `top_logprobs`. The E4B
+snapshot is about 4.8 GB and is the first signed quality climb. If the verified
+Gemma 4 snapshot is not reachable, use
+`FIRST_REPO=mlx-community/gemma-3-1b-it-4bit FIRST_LOADER=mlx_lm
+skills/mlx-arena/arena.sh first` only as a fallback.
+
+After the first local prompt or two, move to the frontier head-to-head:
+
+```bash
+skills/mlx-arena/arena.sh play
+```
+
+1. **Inventory + pick the first local rung.** Confirm Apple Silicon, free RAM/disk,
+   and the MLX venv. Classify the task before picking a model: routing /
+   classification, extraction, coding, tool-use/API workflow, long-context
+   reasoning, or stateful policy. Pick the **smallest model that is plausibly
+   reasonable for that task** (see
    [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md) and
-   "Finding MLX models" below). State exact repos + GB, get a quick yes.
+   "Finding MLX models" below). State exact repos + GB, get a quick yes. For a
+   two-local comparison, pick a second rung only after the first local-vs-frontier
+   gap is visible.
 2. **Set up the MLX runtime** (once):
    ```bash
    uv venv .understudy/venvs/mlx --python 3.12
-   uv pip install --python .understudy/venvs/mlx/bin/python 'mlx-lm>=0.31' 'huggingface_hub[cli]>=0.27'
+   uv pip install --python .understudy/venvs/mlx/bin/python 'mlx-lm>=0.31' 'mlx-vlm>=0.6' 'huggingface_hub>=0.27'
    ```
-3. **Download the two models** (backgrounded, announce ETA):
+3. **Download the first model** from the signed Understudy snapshot session:
    ```bash
-   .understudy/venvs/mlx/bin/hf download mlx-community/gemma-3-1b-it-4bit
-   .understudy/venvs/mlx/bin/hf download mlx-community/NVIDIA-Nemotron-3-Nano-4B-4bit
+   curl -fsSL 'https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit' -o /tmp/understudy-model-session.json
+   # install.sh performs the manifest download + signed file sync automatically.
    ```
-4. **Wire Pi** — add one provider per model in `~/.pi/agent/models.json`
-   (`baseUrl: http://127.0.0.1:<port>/v1`, `api: openai-completions`,
-   `apiKey: "mlx"`, `compat.supportsDeveloperRole:false`,
+4. **Wire Pi** — `arena.sh first` creates the first `mlx-gemma4` provider
+   automatically. For later side-by-side local arenas, add one provider per model
+   in `~/.pi/agent/models.json` (`baseUrl: http://127.0.0.1:<port>/v1`,
+   `api: openai-completions`, `apiKey: "mlx"`,
+   `compat.supportsDeveloperRole:false`,
    `compat.supportsReasoningEffort:false`). The model `id` must equal the served
    repo id. Verify with `pi --list-models | grep mlx`.
 5. **Launch the arena** and drive it:
@@ -83,11 +140,24 @@ provider in `~/.pi/agent/models.json` (`api: openai-completions`).
    skills/mlx-arena/arena.sh down               # stop servers + session
    ```
    An agent drives it headlessly with `ask` + `capture`; a human attaches.
-6. **Decide.** Compare answers, latency, tone, and reasoning behavior. Promote the
-   winner to [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md)
-   for a scored, frozen-eval verdict, and graduate to a larger same-family model
-   via [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)
-   when you need more quality.
+   For the first Pi meeting session, use tmux paste-buffer rather than raw
+   literal key injection:
+   ```bash
+   tmux set-buffer 'Say exactly: local Understudy is online.'
+   tmux paste-buffer -t mlx-arena-first
+   tmux send-keys -t mlx-arena-first Enter
+   ```
+6. **Decide the next intervention.** Compare answers, latency, tone, and reasoning
+   behavior. If the model is already good enough, promote it to
+   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) for a
+   scored, frozen-eval verdict. If it fails because the prompt/harness is weak,
+   route to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md). If
+   the task is a workflow with tool state, build a
+   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md).
+   If the small model needs bounded substeps behind the same external call, use
+   [`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md).
+   If quality is simply too low, climb the model ladder or route remote/hybrid via
+   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
 
 ## Blind-vote mode — the Efficient-Intelligence game
 
@@ -105,6 +175,7 @@ Easiest bring-up (downloads the default model if missing, serves it, launches th
 branded game in tmux):
 
 ```bash
+skills/mlx-arena/arena.sh first    # first verified local model in Pi
 skills/mlx-arena/arena.sh play
 # then:  tmux attach -t mlx-arena-play
 ```
@@ -112,7 +183,7 @@ skills/mlx-arena/arena.sh play
 Or run it directly (Node ≥22.6 runs the `.ts` via native type-stripping):
 
 ```bash
-LOCAL_BASE=http://127.0.0.1:8081/v1 LOCAL_MODEL=mlx-community/gemma-3-1b-it-4bit \
+LOCAL_BASE=http://127.0.0.1:8081/v1 LOCAL_MODEL=.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit \
 CATEGORY=coding FRONTIER_MODEL=claude-opus-4-8 \
 node --experimental-strip-types skills/mlx-arena/blind_arena.ts
 ```
@@ -142,11 +213,14 @@ from `ANTHROPIC_LOCAL_KEY`/`ANTHROPIC_API_KEY`; cost is computed from real usage
 (Opus 4.8 $5/$25 per 1M in/out) and shown only on reveal.
 
 For real workloads, ground the questions in a captured trace
-([`../understand-workload/SKILL.md`](../understand-workload/SKILL.md)); and to test
-whether the local model can take over the *whole* task (not just answer questions),
-build a [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
-and hill-climb it with the
-[`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md) harness.
+([`../understand-workload/SKILL.md`](../understand-workload/SKILL.md)). Treat Pi as
+the quick local-proof and gap-finding surface. To test whether the local model can
+take over the *whole* task (not just answer questions), build a
+[`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md),
+then hill-climb it with the
+[`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md)
+harness or prompt optimization through
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
 
 ## Known model-compat gotchas
 
@@ -156,14 +230,15 @@ in [`reference.md`](reference.md).
 
 ## Output Standard
 
-End with: the two models (repo, quant, GB, port); RAM headroom used; the tmux
-session name and how to attach/drive it; a first lockstep comparison (both
-answers, rough latency, any reasoning-trace difference); and the recommended next
-step (score the winner in run-local-model-lab, or swap a corner and re-run).
+End with: task class; the first local rung and why it is the smallest reasonable
+choice; model repo, quant, GB, port, and RAM headroom; the tmux session name and
+how to attach/drive it; the first head-to-head comparison; and the recommended
+next intervention (score in run-local-model-lab, build simulated env, run GEPA,
+try RLM, climb models, or route hybrid/remote).
 
 ## References
 
-- [`arena.sh`](arena.sh) — the launcher/controller (`up|ask|left|right|capture|logs|status|down|attach`).
+- [`arena.sh`](arena.sh) — the launcher/controller (`first|first-window|play|up|ask|left|right|capture|logs|status|down|attach`).
 - [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) — score a model on a frozen eval.
 - [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md) — Gemma & Nemotron variants and hardware fit.
 - [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md) — acquiring/curating local weights.

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -9,6 +9,9 @@
 # boring orchestrator: MLX does inference, Pi is the harness, tmux is the surface.
 #
 # Subcommands:
+#   first         first-run: show loading screen, serve smallest verified model, open Pi
+#   first-window  same as first, but also opens a new macOS Terminal window
+#   play-window   open the blind local-vs-frontier gauntlet in a new macOS Terminal window
 #   up            start both MLX servers + the two-pane tmux arena
 #   ask "<text>"  send the same prompt to BOTH panes (lockstep compare)
 #   left "<text>" / right "<text>"   send a prompt to one pane only
@@ -29,38 +32,92 @@ set -euo pipefail
 
 LAB="${LAB:-$PWD}"
 MLX_PYTHON="${MLX_PYTHON:-$LAB/.understudy/venvs/mlx/bin/python}"
+MLX_BIN="$(dirname "$MLX_PYTHON")"
 SESSION="${SESSION:-mlx-arena}"
 STATE="$LAB/.understudy/local-model-lab/arena"
 LOGS="$STATE/logs"
 SYS_PROMPT="${SYS_PROMPT:-You are a helpful, concise assistant. Answer directly.}"
 
-# Two corners of the arena. Defaults: smallest Google (Gemma) vs smallest NVIDIA (Nemotron), MLX 4-bit.
-# NOTE on Google: Gemma 4 E2B MLX quants don't yet load on mlx_lm 0.31.3 (KV-shared-layer
-# weight mismatch — see SKILL.md "Known model-compat gotchas"). gemma-3-1b-it-4bit is the
-# smallest Google chat model that loads cleanly today; bump LEFT_REPO when mlx_lm adds Gemma 4.
+# Two corners of the arena. Defaults: verified Gemma 4 E2B via mlx-vlm vs
+# smallest NVIDIA (Nemotron), MLX 4-bit. Stock mlx-community Gemma 4 E2B repos
+# had loader/config mismatches in testing; the first rung is Understudy's
+# self-converted snapshot from google/gemma-4-e2b-it.
 LEFT_LABEL="${LEFT_LABEL:-google}"
-LEFT_REPO="${LEFT_REPO:-mlx-community/gemma-3-1b-it-4bit}"
+LEFT_REPO="${LEFT_REPO:-$LAB/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit}"
 LEFT_PORT="${LEFT_PORT:-8081}"
 LEFT_PROVIDER="${LEFT_PROVIDER:-mlx-google}"
+LEFT_LOADER="${LEFT_LOADER:-mlx_vlm}"
 
 RIGHT_LABEL="${RIGHT_LABEL:-nvidia}"
 RIGHT_REPO="${RIGHT_REPO:-mlx-community/NVIDIA-Nemotron-3-Nano-4B-4bit}"
 RIGHT_PORT="${RIGHT_PORT:-8082}"
 RIGHT_PROVIDER="${RIGHT_PROVIDER:-mlx-nvidia}"
+RIGHT_LOADER="${RIGHT_LOADER:-mlx_lm}"
+
+# First-run defaults: smallest verified Gemma 4 rung that generated locally in
+# testing. Serve it with mlx-vlm; use FIRST_REPO=mlx-community/gemma-3-1b-it-4bit
+# FIRST_LOADER=mlx_lm only as a tiny fallback when the Gemma 4 snapshot is absent.
+FIRST_LABEL="${FIRST_LABEL:-gemma4-e2b}"
+FIRST_REPO="${FIRST_REPO:-$LAB/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit}"
+FIRST_PORT="${FIRST_PORT:-8081}"
+FIRST_PROVIDER="${FIRST_PROVIDER:-mlx-gemma4-e2b}"
+FIRST_NAME="${FIRST_NAME:-Gemma 4 E2B 4-bit}"
+FIRST_LOADER="${FIRST_LOADER:-mlx_vlm}"
 
 mkdir -p "$LOGS"
 
 _need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1" >&2; exit 1; }; }
+_need_pi() {
+  command -v pi >/dev/null 2>&1 || {
+    echo "missing dependency: pi" >&2
+    echo "install with: npm install -g --ignore-scripts @earendil-works/pi-coding-agent" >&2
+    exit 1
+  }
+}
 
-_serve() { # label repo port
+_server_command() { # loader repo port
+  local loader="$1" repo="$2" port="$3"
+  case "$loader" in
+    mlx_lm)
+      printf '%q -m mlx_lm server --model %q --host 127.0.0.1 --port %q --trust-remote-code' \
+        "$MLX_PYTHON" "$repo" "$port"
+      ;;
+    mlx_vlm)
+      [ -x "$MLX_BIN/mlx_vlm.server" ] || {
+        echo "missing mlx_vlm.server in $MLX_BIN — install with:" >&2
+        echo "  uv pip install --python $MLX_PYTHON 'mlx-vlm>=0.6'" >&2
+        exit 1
+      }
+      printf '%q --model %q --host 127.0.0.1 --port %q --trust-remote-code --top-logprobs-k 5' \
+        "$MLX_BIN/mlx_vlm.server" "$repo" "$port"
+      ;;
+    *)
+      echo "unknown loader: $loader (expected mlx_lm or mlx_vlm)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+_serve() { # label repo port loader
   local label="$1" repo="$2" port="$3"
+  local loader="${4:-mlx_lm}"
+  _serve_with_loader "$label" "$repo" "$port" "$loader"
+}
+
+_serve_with_loader() { # label repo port loader
+  local label="$1" repo="$2" port="$3" loader="$4"
   if curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$port/v1/models" 2>/dev/null | grep -q 200; then
     echo "  [$label] already serving on :$port"; return 0
   fi
-  echo "  [$label] starting mlx_lm.server $repo on :$port"
-  nohup "$MLX_PYTHON" -m mlx_lm server --model "$repo" --host 127.0.0.1 --port "$port" \
-    --trust-remote-code >"$LOGS/srv-$label.log" 2>&1 &
-  echo "$!" >"$STATE/srv-$label.pid"
+  echo "  [$label] starting $loader $repo on :$port"
+  local server_session="${SESSION}-server-$label"
+  local command_text log_path
+  command_text="$(_server_command "$loader" "$repo" "$port")"
+  log_path="$LOGS/srv-$label.log"
+  tmux kill-session -t "$server_session" 2>/dev/null || true
+  tmux new-session -d -s "$server_session" -n server \
+    "mkdir -p $(printf %q "$LOGS"); exec $command_text >$(printf %q "$log_path") 2>&1"
+  echo "$server_session" >"$STATE/srv-$label.session"
 }
 
 _wait_health() { # port label
@@ -78,22 +135,98 @@ _pi_cmd() { # provider model
     "$1" "$2" "$SYS_PROMPT"
 }
 
+_pi_cmd_with_prompt() { # provider model prompt
+  printf 'pi --provider %q --model %q --no-tools --no-context-files --no-skills --no-extensions --no-prompt-templates --system-prompt %q' \
+    "$1" "$2" "$3"
+}
+
+_ensure_pi_provider() { # provider model port
+  local provider="$1" model="$2" port="$3"
+  _need node
+  PROVIDER="$provider" MODEL="$model" PORT="$port" node <<'NODE'
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const file = path.join(os.homedir(), ".pi", "agent", "models.json");
+const provider = process.env.PROVIDER;
+const model = process.env.MODEL;
+const port = process.env.PORT;
+const modelEntry = {
+  id: model,
+  name: provider,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+};
+const providerEntry = {
+  name: provider,
+  baseUrl: `http://127.0.0.1:${port}/v1`,
+  api: "openai-completions",
+  apiKey: "mlx",
+  compat: {
+    supportsDeveloperRole: false,
+    supportsReasoningEffort: false,
+  },
+  models: [modelEntry],
+};
+
+fs.mkdirSync(path.dirname(file), { recursive: true });
+let config = {};
+if (fs.existsSync(file)) {
+  config = JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+if (Array.isArray(config)) {
+  const previous = config.find((item) => item && item.id === provider);
+  config = { providers: {} };
+  if (previous) config.providers[provider] = previous;
+} else if (config && typeof config === "object") {
+  config.providers = config.providers && typeof config.providers === "object" ? config.providers : {};
+  if (config[provider] && !config.providers[provider]) {
+    config.providers[provider] = config[provider];
+    delete config[provider];
+  }
+} else {
+  config = { providers: {} };
+}
+
+const existing = config.providers[provider] || {};
+const existingModels = Array.isArray(existing.models) ? existing.models : [];
+const withoutModel = existingModels.filter((item) => item && item.id !== model);
+config.providers[provider] = {
+  ...existing,
+  ...providerEntry,
+  models: [modelEntry, ...withoutModel],
+};
+
+fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+console.log(`  [pi] provider ${provider} -> ${providerEntry.baseUrl} (${model})`);
+NODE
+}
+
+_prepare_tmux_session() { # session
+  local session="$1"
+  tmux set-option -t "$session" extended-keys on 2>/dev/null || true
+  tmux set-option -t "$session" extended-keys-format csi-u 2>/dev/null || true
+  tmux set-option -t "$session" pane-border-status top 2>/dev/null || true
+}
+
 cmd_up() {
-  _need tmux; _need curl; _need pi
+  _need tmux; _need curl; _need_pi
   [ -x "$MLX_PYTHON" ] || { echo "MLX_PYTHON not executable: $MLX_PYTHON" >&2; exit 1; }
   echo "Starting MLX servers…"
-  _serve "$LEFT_LABEL"  "$LEFT_REPO"  "$LEFT_PORT"
-  _serve "$RIGHT_LABEL" "$RIGHT_REPO" "$RIGHT_PORT"
+  _serve "$LEFT_LABEL"  "$LEFT_REPO"  "$LEFT_PORT" "$LEFT_LOADER"
+  _serve "$RIGHT_LABEL" "$RIGHT_REPO" "$RIGHT_PORT" "$RIGHT_LOADER"
   _wait_health "$LEFT_PORT"  "$LEFT_LABEL"
   _wait_health "$RIGHT_PORT" "$RIGHT_LABEL"
 
   tmux kill-session -t "$SESSION" 2>/dev/null || true
   tmux new-session  -d -s "$SESSION" -x 220 -y 50 -n arena
+  _prepare_tmux_session "$SESSION"
   tmux send-keys -t "$SESSION:arena.0" "$(_pi_cmd "$LEFT_PROVIDER"  "$LEFT_REPO")"  C-m
   tmux split-window -h -t "$SESSION:arena"
   tmux send-keys -t "$SESSION:arena.1" "$(_pi_cmd "$RIGHT_PROVIDER" "$RIGHT_REPO")" C-m
   tmux select-layout -t "$SESSION:arena" even-horizontal
-  tmux set-option -t "$SESSION" pane-border-status top 2>/dev/null || true
   tmux select-pane -t "$SESSION:arena.0" -T " LEFT · $LEFT_LABEL · $LEFT_REPO " 2>/dev/null || true
   tmux select-pane -t "$SESSION:arena.1" -T " RIGHT · $RIGHT_LABEL · $RIGHT_REPO " 2>/dev/null || true
   sleep 2
@@ -131,11 +264,110 @@ cmd_status() {
 
 cmd_down() {
   tmux kill-session -t "$SESSION" 2>/dev/null || true
+  for f in "$STATE"/srv-*.session; do
+    [ -f "$f" ] && tmux kill-session -t "$(cat "$f")" 2>/dev/null || true
+  done
   for f in "$STATE"/srv-*.pid; do [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null || true; done
-  rm -f "$STATE"/srv-*.pid
+  rm -f "$STATE"/srv-*.pid "$STATE"/srv-*.session
   echo "arena down (servers + session stopped)"
 }
 cmd_attach() { tmux attach -t "$SESSION"; }
+
+_open_terminal_attach() { # tmux-session-name
+  local target="$1"
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "  [window] new terminal windows are only automated on macOS; attach with: tmux attach -t $target"
+    return 0
+  fi
+  command -v osascript >/dev/null 2>&1 || {
+    echo "  [window] osascript not found; attach with: tmux attach -t $target"
+    return 0
+  }
+  TARGET_SESSION="$target" osascript <<'APPLESCRIPT'
+tell application "Terminal"
+  activate
+  do script "tmux attach -t " & quoted form of (system attribute "TARGET_SESSION")
+end tell
+APPLESCRIPT
+  echo "  [window] opened Terminal attached to tmux session '$target'"
+  echo "  [window] follow along with: tmux attach -t $target"
+}
+
+_open_terminal_run() { # command
+  local command_text="$1"
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "  [window] new terminal windows are only automated on macOS; run: $command_text"
+    return 0
+  fi
+  command -v osascript >/dev/null 2>&1 || {
+    echo "  [window] osascript not found; run: $command_text"
+    return 0
+  }
+  TERMINAL_COMMAND="$command_text" osascript <<'APPLESCRIPT'
+tell application "Terminal"
+  activate
+  do script (system attribute "TERMINAL_COMMAND")
+end tell
+APPLESCRIPT
+}
+
+_first_loading_script() {
+  cat <<'SH'
+clear
+printf '\n'
+printf 'UNDERSTUDY LABS\n'
+printf 'Preparing your first local understudy\n'
+printf '\n'
+printf 'Model: %s\n' "$FIRST_REPO"
+printf 'Runtime: %s on Apple MLX\n' "$FIRST_LOADER"
+printf 'Endpoint: http://127.0.0.1:%s/v1\n' "$FIRST_PORT"
+printf '\n'
+printf 'Downloading weights if needed, then loading them into unified memory.\n'
+printf 'This stays on your machine. No prompts or outputs are uploaded.\n'
+printf '\n'
+while :; do
+  printf '.'
+  sleep 1
+done
+SH
+}
+
+_first_pi_system_prompt() {
+  cat <<'PROMPT'
+You are the user's first local Understudy. You are running privately on their Mac through Apple MLX. Start by saying you are ready, then invite them to try one real task. Keep the tone concise and practical. After one or two local-only prompts, suggest running the frontier head-to-head with skills/mlx-arena/arena.sh play so they can feel where local is already enough and where the frontier still wins.
+PROMPT
+}
+
+cmd_first() {
+  _need tmux; _need curl; _need_pi
+  [ -x "$MLX_PYTHON" ] || { echo "MLX python not found: $MLX_PYTHON — create it with:
+  uv venv .understudy/venvs/mlx --python 3.12 && uv pip install --python $MLX_PYTHON 'mlx-lm>=0.31' 'mlx-vlm>=0.6' 'huggingface_hub>=0.27'" >&2; exit 1; }
+
+  local S="${SESSION}-first" first_prompt
+  first_prompt="$(_first_pi_system_prompt)"
+  tmux kill-session -t "$S" 2>/dev/null || true
+  tmux new-session -d -s "$S" -x 112 -y 36 -n first
+  _prepare_tmux_session "$S"
+  tmux setenv -t "$S" FIRST_REPO "$FIRST_REPO"
+  tmux setenv -t "$S" FIRST_LOADER "$FIRST_LOADER"
+  tmux setenv -t "$S" FIRST_PORT "$FIRST_PORT"
+  tmux send-keys -t "$S" "$(_first_loading_script)" C-m
+  if [[ "${OPEN_WINDOW:-0}" = "1" ]]; then
+    _open_terminal_attach "$S"
+  fi
+
+  echo "Preparing first Understudy: $FIRST_REPO via $FIRST_LOADER on :$FIRST_PORT"
+  echo "Loading screen: tmux attach -t $S"
+  _serve_with_loader "$FIRST_LABEL" "$FIRST_REPO" "$FIRST_PORT" "$FIRST_LOADER"
+  _wait_health "$FIRST_PORT" "$FIRST_LABEL"
+  _ensure_pi_provider "$FIRST_PROVIDER" "$FIRST_REPO" "$FIRST_PORT"
+
+  tmux send-keys -t "$S" C-c
+  tmux send-keys -t "$S" "clear && echo 'UNDERSTUDY LABS' && echo 'Your first local understudy is ready.' && echo && echo 'Model: $FIRST_REPO' && echo 'Endpoint: http://127.0.0.1:$FIRST_PORT/v1' && echo && $(_pi_cmd_with_prompt "$FIRST_PROVIDER" "$FIRST_REPO" "$first_prompt")" C-m
+  tmux select-pane -t "$S" -T " FIRST UNDERSTUDY · $FIRST_NAME · $FIRST_REPO " 2>/dev/null || true
+  echo "Ready → attach: tmux attach -t $S"
+  echo "Next head-to-head: skills/mlx-arena/arena.sh play"
+}
 
 # One-command bring-up of the BLIND HEAD-TO-HEAD game (blind_arena.ts):
 # serve the local model with MLX, then launch the TypeScript game in tmux (Node runs the
@@ -144,13 +376,13 @@ cmd_attach() { tmux attach -t "$SESSION"; }
 cmd_play() {
   _need tmux; _need curl; _need node
   [ -x "$MLX_PYTHON" ] || { echo "MLX python not found: $MLX_PYTHON — create it with:
-  uv venv .understudy/venvs/mlx --python 3.12 && uv pip install --python $MLX_PYTHON 'mlx-lm>=0.31' 'huggingface_hub[cli]>=0.27'" >&2; exit 1; }
+  uv venv .understudy/venvs/mlx --python 3.12 && uv pip install --python $MLX_PYTHON 'mlx-lm>=0.31' 'huggingface_hub>=0.27'" >&2; exit 1; }
   node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22||(a===22&&b>=6)?0:1)' \
     || { echo "node >= 22.6 required to run the TypeScript game (have $(node -v))." >&2; exit 1; }
   here="$(cd "$(dirname "$0")" && pwd)"
   ( cd "$here/../.." && [ -d node_modules/openai ] || { echo "Installing arena deps (openai, @anthropic-ai/sdk)…"; npm install >/dev/null 2>&1; } )
   echo "Bringing up local model ${LEFT_REPO} on :${LEFT_PORT} (first run downloads weights)…"
-  _serve "$LEFT_LABEL" "$LEFT_REPO" "$LEFT_PORT"
+  _serve "$LEFT_LABEL" "$LEFT_REPO" "$LEFT_PORT" "$LEFT_LOADER"
   _wait_health "$LEFT_PORT" "$LEFT_LABEL"
   local S="${SESSION}-play"
   # seed the frontier keys into the tmux global env (not echoed) so the game pane inherits them
@@ -159,11 +391,29 @@ cmd_play() {
   tmux setenv -g OPENAI_API_KEY "${OPENAI_API_KEY:-}"
   tmux kill-session -t "$S" 2>/dev/null || true
   tmux new-session -d -s "$S" -x 138 -y 60 -n arena
-  tmux send-keys -t "$S" "clear && LOCAL_BASE=http://127.0.0.1:${LEFT_PORT}/v1 LOCAL_MODEL=${LEFT_REPO} LOCAL_NAME='${LOCAL_NAME:-Gemma 3 1B}' CATEGORY='${CATEGORY:-}' FRONTIER_MODEL='${FRONTIER_MODEL:-}' DATASET='${DATASET:-}' node --experimental-strip-types '$here/blind_arena.ts'" C-m
+  _prepare_tmux_session "$S"
+  tmux send-keys -t "$S" "clear && LOCAL_BASE=http://127.0.0.1:${LEFT_PORT}/v1 LOCAL_MODEL=${LEFT_REPO} LOCAL_NAME='${LOCAL_NAME:-Gemma 4 E2B}' CATEGORY='${CATEGORY:-}' FRONTIER_MODEL='${FRONTIER_MODEL:-}' DATASET='${DATASET:-}' node --experimental-strip-types '$here/blind_arena.ts'" C-m
   echo "Ready → attach and play:   tmux attach -t $S     (detach: Ctrl-b d)"
 }
 
+cmd_play_window() {
+  local here quoted_here quoted_lab quoted_python quoted_repo quoted_loader quoted_name
+  here="$(cd "$(dirname "$0")" && pwd)"
+  quoted_here="$(printf '%q' "$here")"
+  quoted_lab="$(printf '%q' "$LAB")"
+  quoted_python="$(printf '%q' "$MLX_PYTHON")"
+  quoted_repo="$(printf '%q' "$LEFT_REPO")"
+  quoted_loader="$(printf '%q' "$LEFT_LOADER")"
+  quoted_name="$(printf '%q' "${LOCAL_NAME:-Gemma 4 E2B}")"
+  _open_terminal_run "cd $quoted_here/../.. && LAB=$quoted_lab MLX_PYTHON=$quoted_python LEFT_REPO=$quoted_repo LEFT_LOADER=$quoted_loader LOCAL_NAME=$quoted_name '$here/arena.sh' play; tmux attach -t ${SESSION}-play"
+  echo "Opening stock local-vs-frontier gauntlet in a new Terminal window."
+  echo "Follow along with: tmux attach -t ${SESSION}-play"
+}
+
 case "${1:-up}" in
+  first) cmd_first ;;
+  first-window) OPEN_WINDOW=1 cmd_first ;;
+  play-window) cmd_play_window ;;
   up) cmd_up ;;
   play) cmd_play ;;
   ask) shift; cmd_ask "$@" ;;
@@ -174,5 +424,5 @@ case "${1:-up}" in
   status) cmd_status ;;
   down) cmd_down ;;
   attach) cmd_attach ;;
-  *) echo "usage: $0 {play|up|ask <text>|left <text>|right <text>|capture|logs|status|down|attach}" >&2; exit 2 ;;
+  *) echo "usage: $0 {first|first-window|play|play-window|up|ask <text>|left <text>|right <text>|capture|logs|status|down|attach}" >&2; exit 2 ;;
 esac

--- a/skills/mlx-arena/reference.md
+++ b/skills/mlx-arena/reference.md
@@ -19,12 +19,17 @@ those are speculative-decoding drafters, not standalone models.
 
 ## Known model-compat gotchas (hard-won)
 
-- **Gemma 4 E2B doesn't load on mlx_lm 0.31.3.** Its MLX quants store per-layer
-  `k_proj`/`v_proj` for the 20 KV-shared layers, but the `gemma4_text` loader
-  shares them → `ValueError: Received 140 parameters not in model`. Use
-  `gemma-3-1b-it-4bit` as the smallest Google chat model that loads today; revisit
-  Gemma 4 when mlx_lm updates. Multimodal Gemma repos (no `-text`) also fail under
-  text-only `mlx_lm`.
+- **Gemma 4 E2B doesn't load on the tested MLX stack.**
+  `mlx-community/Gemma4-E2B-IT-Text-int4` downloads at about 2.7 GB, but both
+  `mlx_lm.generate` and `mlx_vlm.generate` fail on `mlx-lm 0.31.3` /
+  `mlx-vlm 0.6.2`. Root cause: the config puts `num_kv_shared_layers: 20` under
+  `text_config`, while `mlx_lm` reads top-level `ModelArgs` defaults; the loader
+  then treats layers 15-34 as KV-shared and rejects their per-layer `k_proj` /
+  `v_proj` weights (`ValueError: Received 140 parameters not in model`). Adding a
+  top-level `num_kv_shared_layers: 0` makes K/V weights fit but breaks the
+  double-wide MLP shapes on those layers, so this needs a loader/config fix, not
+  a one-line runtime override. Keep `gemma-3-1b-it-4bit` as the smallest verified
+  Google chat model until Gemma 4 E2B loads cleanly.
 - **Reasoning models (e.g. Nemotron 3 Nano) need token headroom.** They emit a
   hidden/visible reasoning trace before the answer; with a tiny `max_tokens` the
   visible `content` comes back empty. Give ≥256 tokens. Expect higher latency than

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -42,12 +42,24 @@ work — do not re-run the full interview. Only first-timers get the full flow.
 ## Flow
 
 1. **Start the slow thing first (background).** Detect the model runtime
-   (`ollama`, `llama-server`, `mlx_lm`, `lms`). If one exists, announce the pick
-   + size + ETA and **background** a pull of a small American model — Gemma 4 E4B
-   or Nemotron 3 Nano (see [`open-model-spotlight.md`](../../docs/open-model-spotlight.md)).
-   If no runtime exists, the slow step is *install a runtime + pull* — get one
-   quick approval, then background it. Then immediately move on; do not watch the
-   bar.
+   (`mlx_vlm`, `mlx_lm`, `ollama`, `llama-server`, `lms`). On Apple Silicon, the
+   opinionated first out-of-box target is the smallest verified Gemma 4 local
+   Understudy: `google/gemma-4-e2b-it`, converted by Understudy with
+   `mlx-vlm 0.6.2` to 4-bit MLX safetensors. The verified snapshot is stored at
+   `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit`
+   (R2 source:
+   `r2://understudy-model-snapshots/models/google/gemma-4-e2b-it/mlx-vlm-0.6.2/quant-4bit/`).
+   It is about 3.3 GB on disk and generated locally at
+   about 218 tok/s in testing. Announce the model, quantization, size, source,
+   and ETA, get a quick yes, then run
+   `skills/mlx-arena/arena.sh first-window` on macOS so a distinct Terminal.app
+   window opens with the branded loading screen while the model loads, then lands
+   in Pi when the local Understudy is ready. Use `arena.sh first` when a separate
+   window is unavailable. If the MLX runtime is missing, the slow step is
+   *install MLX + pull* — get one quick approval, then background it. If the
+   Gemma 4 snapshot URL is unavailable, fall back to
+   `mlx-community/gemma-3-1b-it-4bit` only to preserve the aha moment. Then
+   immediately move on; do not watch the bar.
 
 2. **Profile the machine (while it downloads).** Detect OS/chip (Apple Silicon
    vs CUDA), RAM / unified memory, free disk. State what fits locally. This is
@@ -75,13 +87,27 @@ work — do not re-run the full interview. Only first-timers get the full flow.
    coaching depth, opinion strength. Append, don't overwrite, the `history` of
    workloads and decisions.
 
-6. **Land the quick win.** The model is cached by now — run one local generation
-   so they see it answer **on their machine, $0, private**. Briefly teach the
-   idea: an open-weight model is downloadable weights you run yourself; local is
-   free and ZDR-safe; you iterate small and local, then *graduate* to a larger
-   model in the same family via the gateway when you need the quality.
+6. **Land the quick win.** The `arena.sh first` pane now says their first local
+   Understudy is ready and opens Pi on verified Gemma 4 E2B. Have them try one
+   real prompt. If Pi is not installed, run one local generation and print:
+   `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`. Briefly
+   teach the idea: an open-weight model is downloadable weights you run yourself;
+   local is free and ZDR-safe; you iterate small and local, then *graduate* to a
+   larger model in the same family via the gateway when you need the quality.
 
-7. **Route onward.** Hand to the [`understudy`](../understudy/SKILL.md)
+7. **Run the first default environment.** After the first local prompt or two,
+   run the built-in deterministic sandbox from
+   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md):
+   synthetic records, in-memory tools, a scripted oracle, and final-state
+   validators. This proves the local Understudy can act in a small tool world
+   before any codebase-specific environment is built.
+
+8. **Start the head-to-head.** After the default environment baseline, route to
+   [`../specialize-local-model/SKILL.md`](../specialize-local-model/SKILL.md) and
+   run `skills/mlx-arena/arena.sh play` so they can compare the local Understudy
+   against a frontier model and decide where local is already enough.
+
+9. **Route onward.** Hand to the [`understudy`](../understudy/SKILL.md)
    orchestrator for the improvement loop;
    [`manage-local-models`](../manage-local-models/SKILL.md) to grow and organize
    the local model library; [`run-local-model-lab`](../run-local-model-lab/SKILL.md)

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -100,16 +100,47 @@ These dials are read by every skill (via
 [`../../docs/engagement-and-pacing.md`](../../docs/engagement-and-pacing.md)),
 so the whole experience adapts to the one profile.
 
-## First local model — pick small, American, cached
+## First local model — opinionated first rung
 
-Default first pull is the smallest model that still feels real, biased to the
-American open families (see
+Default first pull is the smallest verified Gemma 4 MLX chat model, served
+through MLX on Apple Silicon (see
 [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md)):
 
-- **Apple Silicon, any RAM** — Gemma 4 E4B (~4.5B eff.) or Nemotron 3 Nano 4B
-  via Ollama or MLX. Fast, tiny download, runs everywhere.
-- **32 GB+** — can step up to Nemotron 3 Nano 30B-A3B (MoE, ~4B active speed) or
-  Gemma 4 12B once the tiny one proves the loop.
+- **Apple Silicon first rung** — Understudy-verified `google/gemma-4-e2b-it`,
+  converted with `mlx-vlm 0.6.2` to 4-bit MLX safetensors and served with
+  `mlx_vlm.server`. Snapshot:
+  `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit`
+  (R2 source:
+  `r2://understudy-model-snapshots/models/google/gemma-4-e2b-it/mlx-vlm-0.6.2/quant-4bit/`).
+  It is about 3.3 GB on disk, used about 3.6 GB peak memory in testing, generated
+  locally at about 218 tok/s, and exposes logprobs/top-logprobs through the
+  OpenAI-compatible server.
+- **Gemma 4 E4B climb rung** — Understudy-verified `google/gemma-4-E4B-it`,
+  converted with `mlx-vlm 0.6.2` to 4-bit MLX safetensors and served with
+  `mlx_vlm.server`. Snapshot:
+  `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit`.
+  It is about 4.8 GB on disk and is the first quality climb when E2B understands
+  the task but lacks enough capability.
+- **Delivery shape** — publish the stable
+  `models.understudylabs.com/session?model=...` endpoint. It returns a manifest
+  with short-lived signed URLs for the actual model files; do not publish the
+  expiring per-object URLs directly.
+- **BF16 profiling rung** — same E2B source and converter, about 9.5 GB on disk.
+  Keep it as an internal/local profiling option until a signed
+  `models.understudylabs.com` session is published.
+- **Tiny fallback only** — `mlx-community/gemma-3-1b-it-4bit`, served with
+  `mlx_lm.server`. Dry-run download is about 772 MB and it loads on current
+  `mlx-lm 0.31.3`; use it only when the verified Gemma 4 snapshot is unavailable
+  or disk/RAM is severely constrained.
+- **Stock Gemma 4 MLX caveat** — `mlx-community/Gemma4-E2B-IT-Text-int4` and
+  `mlx-community/gemma-4-e2b-it-4bit` failed on the tested stack with a Gemma 4
+  shared-KV weight/config mismatch. The Understudy snapshot exists to give users
+  a known-good first rung instead of sending them into loader debugging.
+- **Do not use `*-assistant` Gemma 4 repos as the first model.** They are MTP
+  draft models for speculative decoding, not standalone chat models.
+- **Next rungs** — Gemma 4 12B, Nemotron 3 Nano 4B, Nemotron 3
+  Nano 30B-A3B, then remote/hybrid Gemma/Nemotron routes after the first
+  local-vs-frontier gap is visible.
 
 Acquisition, caching, disk locations, and the larger ladder live in
 [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md).

--- a/skills/run-local-model-lab/SKILL.md
+++ b/skills/run-local-model-lab/SKILL.md
@@ -57,6 +57,10 @@ route for compliance. For pure remote inference/routing use
    Do not download weights yet. Surface what you found. (Not on Apple Silicon?
    This skill does not apply — local serving here is MLX-only.)
 2. **Pick a candidate tier** (candidate chooser + hardware-fit guidance in [`reference.md`](reference.md)):
+   choose the smallest model that is reasonable for the task, not the smallest
+   model available. If a Pi arena gap report already exists, use it to decide
+   whether to score the current rung, climb to a larger local model, or skip to
+   hybrid/remote.
    - Tiny smoke — E2B / E4B class (fast, on-device; routing/triage/easy cases).
    - Real local eval — 12B class if hardware permits.
    - Workstation/server — 26B A4B (MoE, ~4B active so fast) or 31B dense.

--- a/skills/specialize-local-model/SKILL.md
+++ b/skills/specialize-local-model/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: specialize-local-model
+description: Use when a developer wants the smallest task-reasonable local model opened in Pi against a frontier model, then wants the gap to drive model climb, GEPA, simulated env, RLM, hybrid route, or remote-only. Triggers include "can local do this", "train an understudy", "smallest reasonable model", or "use Pi then simulated env".
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Specialize Local Model
+
+Turn a task into a measured local-model ladder. Start with the **smallest local
+model that is plausibly reasonable for the task**, open it in Pi so the developer
+immediately sees a private model running on their machine, compare it against a
+frontier model, then use the gap to decide whether to climb models, optimize the
+prompt, decompose the task, simulate the environment, or route remote.
+
+This is an orchestration skill. Do not reimplement worker skills inline; sequence
+them and hand off with concrete artifacts.
+
+## Product Loop
+
+```text
+task intake
+  -> smallest reasonable local rung
+  -> Pi frontier-vs-local head-to-head
+  -> default deterministic environment calibration
+  -> gap report
+  -> simulated env / frozen eval when the task is workflow-like
+  -> improve via model climb, GEPA, RLM, or route
+  -> measured route decision
+```
+
+The arena is the emotional proof: "I have a local model running." The default
+environment is the calibration proof: "this model can act in a deterministic
+tool world." The codebase-specific simulated environment and eval loop are the
+proof that the local model can actually do the user's job.
+
+## Safety Gates
+
+- **No model download without approval + size cap.** Name repo, format,
+  quantization, exact or dry-run GB, and why it is the first rung.
+- **Local-first.** Pi prompts, local outputs, traces, and simulation fixtures stay
+  on the machine unless the developer approves a specific upload.
+- **Do not start at the smallest model blindly.** Start at the smallest model
+  that is reasonable for the task. If the task needs tool-use, long context, or
+  high recall, skip toy rungs and explain why.
+- **Do not evaluate `*-assistant` checkpoints as standalone models.** They are
+  drafters for speculative decoding, not quality candidates.
+- **No meet-and-beat claim from vibes.** Pi preference is a gap signal. Claims
+  need frozen evals, simulated final-state validation, or local-model-lab scores.
+
+## Flow
+
+1. **Task intake and class.** Use
+   [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) when the
+   workload is not already decomposed. Classify it:
+   - routing / classification
+   - extraction / summarization
+   - coding / structured generation
+   - tool-use / API workflow
+   - long-context reasoning
+   - stateful multi-step policy
+
+2. **Pick the first local rung.** On Apple Silicon, default to the verified
+   Understudy Gemma 4 E2B 4-bit MLX-VLM snapshot unless the profile says the task
+   is clearly beyond E2B or the machine cannot fit a 3.3 GB local model:
+   `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit`.
+   Use the hardware and model guidance in
+   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) and
+   [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md). The rule:
+   pick the smallest model likely to produce a non-silly first answer.
+   - Easy classification or routing: Gemma 4 E2B first; climb only if it misses
+     obvious boundaries.
+   - Extraction and short summaries: Gemma 4 E2B first, BF16 if the 4-bit model
+     is close but brittle.
+   - Coding / structured generation: Gemma 4 E2B as the fast feel-test, then
+     Gemma 4 E4B/12B if structure or reasoning is weak.
+   - Tool-use/API workflow: E2B only if the tool surface can be bounded;
+     otherwise start at a stronger local rung or local-as-router.
+   - Long-context or high-recall: use local for replay/triage first; expect
+     hybrid or remote if quality is the bottleneck.
+
+3. **Open Pi quickly.** Use [`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md):
+   serve the selected local model with MLX, wire Pi, and open the blind
+   local-vs-frontier game. Use user prompts, a small local dataset, or questions
+   generated from the workload decomposition. Capture preference, guessed
+   frontier identity, latency, cost, and failure notes.
+
+4. **Write a gap report.** Record:
+   - where local already matches or beats frontier;
+   - where frontier wins;
+   - whether the gap is model size, prompt/harness, context/tool surface, missing
+     environment feedback, or true policy learning.
+
+5. **Run the default environment before custom env work.** Use
+   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
+   to run the built-in synthetic inbox/ticket/project-board sandbox with the
+   local model and frontier. Treat this as calibration only: it validates tool
+   calling, schema following, final-state scoring, and the local-vs-frontier
+   comparison path before building anything from the user's codebase.
+
+6. **Choose the next intervention.**
+   - **Model too weak, harness sane** -> climb the local model ladder and rerun
+     Pi / local-model-lab: Gemma 4 E2B 4-bit -> Gemma 4 E2B BF16 -> Gemma 4 E4B
+     -> Gemma 4 12B -> Nemotron 3 Nano 4B/30B-A3B -> remote Gemma/Nemotron.
+   - **Prompt or output contract weak** -> use
+     [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) for
+     train/dev-only GEPA or prompt repair.
+   - **Workflow/tool state matters** -> build a seeded environment with
+     [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md).
+   - **Small model drowns in one giant prompt** -> use
+     [`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md)
+     to keep the external call contract while decomposing internally.
+   - **Local handles easy cases but not hard cases** -> recommend hybrid/local
+     router through [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md)
+     and [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+   - **Local cannot meet quality** -> stay remote and document the revisit trigger
+     (new MLX runtime, new weights, larger hardware, or better env feedback).
+
+7. **Prove the route.** For answer-only tasks, run
+   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) against
+   frozen eval rows. For tool/API workflows, use
+   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
+   and state validators before any live route change.
+
+## Output Standard
+
+End with: task class; first local rung and why it is the smallest reasonable
+choice; Pi arena setup and first head-to-head result; gap diagnosis; chosen next
+intervention; route decision or the exact evidence still needed.
+
+## References
+
+- [`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md) — Pi/tmux local-vs-frontier surface.
+- [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) — frozen eval and route decision.
+- [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md) — final-state simulated env.
+- [`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md) — decomposition behind the same external call.
+- [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) — GEPA / prompt optimization.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -129,6 +129,11 @@ Identify the developer's current stage and load exactly one:
   workstation-hosted model through the same frozen workload/eval, choose a
   runtime, compare local vs remote, or satisfy ZDR / no-upload constraints →
   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
+- **Local understudy specialization loop** — the developer wants the smallest
+  task-reasonable local model opened in Pi against a frontier model, then wants
+  the observed gap to drive a model climb, simulated env, GEPA, RLM, hybrid
+  route, or remote-only decision →
+  [`../specialize-local-model/SKILL.md`](../specialize-local-model/SKILL.md).
 - **Single-output optimization** — fresh artifacts exist and the developer wants
   to validate, optimize (GEPA), compare candidates, or claim readiness →
   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -49,11 +49,16 @@ node dist/bin.js status --json
    understudy status --json
    ```
 
-2. If not signed in, run the email-code flow:
+2. If not signed in, register/sign in with the email-code flow:
 
    ```sh
    understudy login --email <developer-email>
    ```
+
+   This creates or finds the developer's Understudy account, retrieves an API
+   key through the CLI, and stores it outside the repo. The key is used for
+   authenticated gateway inference, project/key management, and remote model
+   routes. Do not ask the developer to paste the key.
 
    An agent with an approved native email connector may search narrowly for the
    fresh sign-in email and enter the one-time code into the waiting CLI prompt.
@@ -95,12 +100,17 @@ comparing a workload's quality and cost across the split.
    understudy models list --json
    ```
 
+   The list is the remote ladder. It should include larger Gemma-family routes
+   when enabled for the account, so the same API key can graduate a workload from
+   the local Gemma 4 E2B first rung to larger Gemma variants or remote/hybrid
+   routes without changing application code.
+
 2. Route a workload to a model at a traffic percentage — a per-request split
    where that share goes to the routed model and the rest stays on passthrough.
    Pick a bounded share (e.g. 30%) to keep the comparison small.
 
    ```sh
-   understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 30
+   understudy workloads route <workload-id> --project-id <project-id> --model-id gemma-4-12b --traffic-pct 30
    ```
 
    Clearing the route (`--clear` in place of the model/traffic flags) returns the


### PR DESCRIPTION
## Summary
- add a one-line Apple Silicon installer that installs the CLI, Pi, Claude Code plugin, MLX runtime, and first verified Gemma 4 E2B snapshot
- extend the MLX arena to open a visible tmux/Pi first-run window and keep the MLX server alive in tmux
- document the opinionated model ladder, signed model endpoints, and agent tmux control pattern

## Verification
- npm run check
- git diff --check
- npm pack --dry-run includes install.sh and .claude-plugin files
- local installer dry run opened Terminal/Pi and answered through the MLX-backed Gemma 4 E2B provider
- signed E2B and E4B model sessions respond from models.understudylabs.com
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->