### PR TITLE
Make onboarding workload-first and agent-led

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,41 +36,32 @@ execution, auth injection, artifact writes, or a safety gate.
 
 ## Install Locally
 
-Fast first-run installer for Apple Silicon:
+Fast first-run installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash
 ```
 
-After this lands on `main`, this is the URL to hand to Aamir for a clean
-top-of-funnel test:
+This installs the CLI, installs or refreshes the Claude Code plugin when
+`claude` is available, then opens Claude Code in the current directory. In
+Claude Code, run:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | sh
+```text
+/reload-plugins
+/understudy:onboard
 ```
 
-Pre-merge branch test:
+The installer intentionally does **not** download model weights, start MLX,
+install Pi, launch tmux/iTerm, or make frontier calls. Those belong inside the
+Claude Code skill flow, where the agent can explain the tradeoffs, ask consent,
+coach the user on opening their preferred terminal, and run the same commands
+itself when appropriate.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/yolo/first-understudy-installer/install.sh | UNDERSTUDY_INSTALL_REF=yolo/first-understudy-installer bash -s -- --yes
-```
-
-That clones the public repo into `~/.understudy/agent-tools/source`, builds and
-installs the CLI locally, installs Pi, prepares an isolated MLX runtime, asks
-before downloading the verified Gemma 4 E2B 4-bit first-rung snapshot, and opens
-a new Terminal window so you meet your first local Understudy immediately. For
-non-interactive demos, add `--yes`:
+For non-interactive installs, add `--yes`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --yes
 ```
-
-The default model endpoint is a stable Understudy snapshot session generator:
-`https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit`.
-The installer fetches that manifest, then downloads each model file from the
-short-lived signed URL returned in `files[]`. We publish the session URL, not
-the expiring per-object signed URLs. It is overridable with
-`UNDERSTUDY_MODEL_SESSION_URL`.
 
 The installer is resumable. It writes step markers under
 `~/.understudy/agent-tools/install-state`; after a failed run, use:
@@ -82,17 +73,7 @@ curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-too
 You can also jump directly to a step:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --from-step 3
-```
-
-If a coding agent started the installer, the user can follow the live Pi session
-with `tmux attach -t mlx-arena-first`. Agents should drive Pi through tmux using
-paste-buffer plus an explicit Enter:
-
-```bash
-tmux set-buffer 'Say exactly: local Understudy is online.'
-tmux paste-buffer -t mlx-arena-first
-tmux send-keys -t mlx-arena-first Enter
+curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --from-step 2
 ```
 
 Developer install from a clone:
@@ -136,6 +117,10 @@ restart required**. The equivalent interactive flow is `/plugin marketplace add
 <path>` then `/plugin install understudy@understudy-skills`. The
 [`install-plugin`](skills/install-plugin/SKILL.md) skill automates this and
 reports whether the plugin is already installed.
+
+After `/reload-plugins`, run `/understudy:onboard`. That is where the coding
+agent guides the first local model, terminal choice, Pi/tmux handoff, and any
+frontier comparison with explicit consent.
 
 Installing as a plugin is the recommended way to use Understudy: the skills are
 what let a coding agent explain what Understudy is and walk you from a trace to a

--- a/install.sh
+++ b/install.sh
@@ -158,9 +158,13 @@ confirm() {
 }
 prompt_choice() {
   local prompt="$1"
-  [ "$YES" = "1" ] && return 1
+  if [ "$YES" = "1" ]; then
+    printf '\n'
+    return 0
+  fi
   if [ ! -r /dev/tty ]; then
-    return 1
+    printf '\n'
+    return 0
   fi
   printf "%s " "$prompt" >/dev/tty
   read -r answer </dev/tty

--- a/install.sh
+++ b/install.sh
@@ -271,10 +271,11 @@ launch_claude_code() {
         return "$status"
       }
     else
-      script -qc "claude --permission-mode '$CLAUDE_PERMISSION_MODE' --plugin-dir '$PKG_DIR' ${UNDERSTUDY_CLAUDE_ARGS:-} '$INITIAL_CLAUDE_PROMPT'" "$claude_log" </dev/tty >/dev/tty 2>&1 || {
+      say "script(1) command syntax varies on non-macOS; launching without a Claude Code transcript."
+      # shellcheck disable=SC2086
+      claude --permission-mode "$CLAUDE_PERMISSION_MODE" --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
         local status="$?"
         say "Claude Code exited with status $status."
-        say "See Claude Code launch log: $claude_log"
         return "$status"
       }
     fi

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ INSTALL_SOURCE_DIR="${UNDERSTUDY_INSTALL_SOURCE_DIR:-$LAB/source/understudy-agen
 STATE_DIR="${UNDERSTUDY_INSTALL_STATE_DIR:-$LAB/install-state}"
 INSTALLER_COMMIT="${UNDERSTUDY_INSTALLER_COMMIT:-unknown}"
 LAUNCH_CLAUDE="${UNDERSTUDY_LAUNCH_CLAUDE:-1}"
+INITIAL_CLAUDE_PROMPT="${UNDERSTUDY_INITIAL_CLAUDE_PROMPT:-Use the Understudy onboarding skill for this project now. Guide me through getting my first local Understudy, choosing my terminal/tmux/Pi handoff, and after the first local-vs-frontier duel, help me pick a real problem or find local data so we can try to make the Understudy beat the frontier on that task slice.}"
 NO_CLAUDE=0
 START_STEP=1
 ONLY_STEP=""
@@ -57,6 +58,7 @@ Environment overrides:
   UNDERSTUDY_INSTALL_PACKAGE     optional npm package spec override
   UNDERSTUDY_LAUNCH_CLAUDE      set to 0 to skip opening Claude Code
   UNDERSTUDY_CLAUDE_ARGS        optional extra args when launching Claude Code
+  UNDERSTUDY_INITIAL_CLAUDE_PROMPT initial prompt passed to Claude Code
 EOF
       exit 0
       ;;
@@ -245,19 +247,19 @@ launch_claude_code() {
 
   section "Step 3/3: open Claude Code."
   say "Claude Code will open in: $(pwd)"
-  say "In Claude Code, type these slash commands:"
-  say "  /reload-plugins"
-  say "  /understudy:onboard"
-  say "The onboarding skill will coach model download, terminal choice, tmux/Pi handoff, and any frontier comparison with explicit consent."
+  say "The Understudy plugin will be loaded for this launch with --plugin-dir."
+  say "Claude Code will receive the first prompt automatically:"
+  say "  $INITIAL_CLAUDE_PROMPT"
+  say "If you open a separate existing Claude Code session later, run /reload-plugins there once."
   say "Launching Claude Code now. Exit Claude to return to this shell."
   claude_log="$LOG_DIR/claude-$(date -u +"%Y%m%dT%H%M%SZ").log"
   say "Claude Code launch log: $claude_log"
-  log "LAUNCH claude ${UNDERSTUDY_CLAUDE_ARGS:-}"
+  log "LAUNCH claude --plugin-dir $PKG_DIR ${UNDERSTUDY_CLAUDE_ARGS:-} <initial-prompt>"
   if need script; then
     # curl | sh leaves stdin attached to the pipe. `script` gives Claude Code a
     # real pseudo-terminal while also capturing the launch output for debugging.
     # shellcheck disable=SC2086
-    script -q "$claude_log" claude ${UNDERSTUDY_CLAUDE_ARGS:-} </dev/tty >/dev/tty 2>&1 || {
+    script -q "$claude_log" claude --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
       local status="$?"
       say "Claude Code exited with status $status."
       say "See Claude Code launch log: $claude_log"
@@ -266,7 +268,7 @@ launch_claude_code() {
   else
     say "script(1) not found; launching without a Claude Code transcript."
     # shellcheck disable=SC2086
-    claude ${UNDERSTUDY_CLAUDE_ARGS:-} </dev/tty >/dev/tty 2>&1 || {
+    claude --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
       local status="$?"
       say "Claude Code exited with status $status."
       return "$status"
@@ -319,8 +321,8 @@ fi
 
 section "Where this goes next."
 say "The installer is done. The next experience belongs inside Claude Code:"
-say "  1. /reload-plugins"
-say "  2. /understudy:onboard"
+say "  The launched Claude Code session receives an Understudy onboarding prompt automatically."
+say "  If you continue in an already-open Claude Code session instead, run /reload-plugins and then /understudy:onboard."
 say "That lets the coding agent explain the first local Understudy, open a terminal of the user's choice when needed, and run the same commands itself when appropriate."
 if should_run_step 3; then
   launch_claude_code

--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,9 @@ Environment overrides:
   UNDERSTUDY_INSTALL_LOG_DIR   install logs, default $UNDERSTUDY_LAB/logs
   UNDERSTUDY_INSTALLER_COMMIT  optional script commit label when caller knows it
   UNDERSTUDY_INSTALL_PACKAGE  optional npm package spec override
+  UNDERSTUDY_DEBUG            set to 1 for arena action logs and verbose launch metadata
+  UNDERSTUDY_WINDOW_HOLD      set to 1 to keep spawned terminal windows open after exit
+  UNDERSTUDY_TERMINAL_APP     auto|iterm|ghostty|terminal, default auto from current terminal
   UNDERSTUDY_FRONTIER_KEY_MODE ask|byo|zdr|skip
   UNDERSTUDY_FRONTIER_ENV_FILE local .env path for BYO frontier keys
   UNDERSTUDY_ZDR_FRONTIER_MODEL model id for Understudy ZDR fallback, default gpt-5.5
@@ -581,6 +584,8 @@ if should_run_step 4; then
   section "Step 4/5: meet the local Understudy."
   say "A new Terminal window will show the model loading locally so you can see it is yours, not a hosted frontier call."
   say "If an agent launched this, follow the same session with: tmux attach -t ${SESSION:-mlx-arena}-first"
+  say "Window diagnostics write to: $LAB/.understudy/local-model-lab/arena/logs/window-launch-*.log"
+  say "If the window flashes closed, rerun with UNDERSTUDY_DEBUG=1 UNDERSTUDY_WINDOW_HOLD=1 or run: LAB=\"$LAB\" \"$ARENA\" diagnose"
   if [ "$NO_WINDOW" = "1" ]; then
     LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
       FIRST_REPO="$MODEL_DIR" FIRST_LOADER=mlx_vlm "$ARENA" first
@@ -604,6 +609,7 @@ if [ "$NO_GAUNTLET" = "0" ]; then
       say "Frontier mode: Understudy ZDR gateway route ($ZDR_FRONTIER_MODEL). No local provider key is read for this duel."
     fi
     say "The shared tmux session is ${SESSION:-mlx-arena}-play; the agent can send prompts and you can watch or take over."
+    say "Window diagnostics write to: $LAB/.understudy/local-model-lab/arena/logs/window-launch-*.log"
     say "After the stock questions, point Understudy at a dataset or codebase."
     say "Then use the skills to generate task-specific evals and climb: better prompts, GEPA/RLM, larger Gemma/Nemotron, or remote training."
     confirm "Launch the remote frontier comparison now?" || {

--- a/install.sh
+++ b/install.sh
@@ -261,13 +261,23 @@ launch_claude_code() {
   if need script; then
     # curl | sh leaves stdin attached to the pipe. `script` gives Claude Code a
     # real pseudo-terminal while also capturing the launch output for debugging.
+    # macOS script(1) takes a positional command; Linux script(1) needs -c.
     # shellcheck disable=SC2086
-    script -q "$claude_log" claude --permission-mode "$CLAUDE_PERMISSION_MODE" --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
-      local status="$?"
-      say "Claude Code exited with status $status."
-      say "See Claude Code launch log: $claude_log"
-      return "$status"
-    }
+    if [ "$(uname -s)" = "Darwin" ]; then
+      script -q "$claude_log" claude --permission-mode "$CLAUDE_PERMISSION_MODE" --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
+        local status="$?"
+        say "Claude Code exited with status $status."
+        say "See Claude Code launch log: $claude_log"
+        return "$status"
+      }
+    else
+      script -qc "claude --permission-mode '$CLAUDE_PERMISSION_MODE' --plugin-dir '$PKG_DIR' ${UNDERSTUDY_CLAUDE_ARGS:-} '$INITIAL_CLAUDE_PROMPT'" "$claude_log" </dev/tty >/dev/tty 2>&1 || {
+        local status="$?"
+        say "Claude Code exited with status $status."
+        say "See Claude Code launch log: $claude_log"
+        return "$status"
+      }
+    fi
   else
     say "script(1) not found; launching without a Claude Code transcript."
     # shellcheck disable=SC2086

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,9 @@ NO_MODEL=0
 NO_WINDOW=0
 NO_GAUNTLET=0
 NO_CLAUDE=0
+FRONTIER_KEY_MODE="${UNDERSTUDY_FRONTIER_KEY_MODE:-ask}"
+FRONTIER_ENV_FILE="${UNDERSTUDY_FRONTIER_ENV_FILE:-}"
+ZDR_FRONTIER_MODEL="${UNDERSTUDY_ZDR_FRONTIER_MODEL:-gpt-5.5}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -28,6 +31,9 @@ while [ "$#" -gt 0 ]; do
     --no-window) NO_WINDOW=1 ;;
     --no-gauntlet) NO_GAUNTLET=1 ;;
     --no-claude) NO_CLAUDE=1 ;;
+    --frontier-key-mode) FRONTIER_KEY_MODE="${2:?missing mode}"; shift ;;
+    --frontier-env-file) FRONTIER_ENV_FILE="${2:?missing path}"; shift ;;
+    --zdr-frontier-model) ZDR_FRONTIER_MODEL="${2:?missing model id}"; shift ;;
     --from-step) START_STEP="${2:?missing step number}"; shift ;;
     --only-step) ONLY_STEP="${2:?missing step number}"; shift ;;
     --resume) RESUME=1 ;;
@@ -43,6 +49,15 @@ Installs the Understudy CLI + Claude skill/plugin surface, prepares Apple MLX,
 downloads the verified Gemma 4 E2B 4-bit first rung, and opens the first local
 Understudy in a new Terminal window on macOS.
 
+Frontier comparison key choices:
+  --frontier-key-mode ask|byo|zdr|skip
+      ask: prompt before the remote comparison (default)
+      byo: import allowed frontier variables from --frontier-env-file or a local .env
+      zdr: use the Understudy ZDR gateway frontier route, no local provider key
+      skip: skip the remote frontier comparison
+  --frontier-env-file PATH   .env file to inspect when --frontier-key-mode=byo
+  --zdr-frontier-model ID    Understudy ZDR model id, default gpt-5.5
+
 Environment overrides:
   UNDERSTUDY_MODEL_SESSION_URL stable session endpoint that returns signed model file URLs
   UNDERSTUDY_MODEL_DIR        local model destination
@@ -54,6 +69,9 @@ Environment overrides:
   UNDERSTUDY_INSTALL_LOG_DIR   install logs, default $UNDERSTUDY_LAB/logs
   UNDERSTUDY_INSTALLER_COMMIT  optional script commit label when caller knows it
   UNDERSTUDY_INSTALL_PACKAGE  optional npm package spec override
+  UNDERSTUDY_FRONTIER_KEY_MODE ask|byo|zdr|skip
+  UNDERSTUDY_FRONTIER_ENV_FILE local .env path for BYO frontier keys
+  UNDERSTUDY_ZDR_FRONTIER_MODEL model id for Understudy ZDR fallback, default gpt-5.5
   SESSION                     tmux session prefix, default mlx-arena
 EOF
       exit 0
@@ -94,6 +112,12 @@ valid_step() {
     *) echo "invalid step: $1 (expected 1-5)" >&2; exit 2 ;;
   esac
 }
+valid_frontier_key_mode() {
+  case "$FRONTIER_KEY_MODE" in
+    ask|byo|zdr|skip) return 0 ;;
+    *) echo "invalid frontier key mode: $FRONTIER_KEY_MODE (expected ask|byo|zdr|skip)" >&2; exit 2 ;;
+  esac
+}
 should_run_step() {
   local step="$1"
   if [ -n "$ONLY_STEP" ]; then
@@ -131,6 +155,169 @@ confirm() {
   printf "%s [y/N] " "$1" >/dev/tty
   read -r answer </dev/tty
   case "$answer" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
+}
+prompt_choice() {
+  local prompt="$1"
+  [ "$YES" = "1" ] && return 1
+  if [ ! -r /dev/tty ]; then
+    return 1
+  fi
+  printf "%s " "$prompt" >/dev/tty
+  read -r answer </dev/tty
+  printf '%s\n' "$answer"
+}
+
+find_frontier_env_file() {
+  local candidate
+  if [ -n "$FRONTIER_ENV_FILE" ] && [ -f "$FRONTIER_ENV_FILE" ]; then
+    printf '%s\n' "$FRONTIER_ENV_FILE"
+    return 0
+  fi
+  for candidate in .env.local .env .env.development.local .env.development; do
+    if [ -f "$candidate" ] && grep -Eq '^(OPENAI_API_KEY|ANTHROPIC_API_KEY|ANTHROPIC_LOCAL_KEY|FRONTIER_API_KEY|AI_GATEWAY_API_KEY|OPENAI_BASE_URL|FRONTIER_BASE_URL|AI_GATEWAY_BASE_URL|OPENAI_MODEL|ANTHROPIC_MODEL|FRONTIER_MODEL|AI_GATEWAY_MODEL)=' "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+has_frontier_shell_env() {
+  [ -n "${OPENAI_API_KEY:-}" ] ||
+    [ -n "${ANTHROPIC_API_KEY:-}" ] ||
+    [ -n "${ANTHROPIC_LOCAL_KEY:-}" ] ||
+    [ -n "${FRONTIER_API_KEY:-}" ] ||
+    [ -n "${AI_GATEWAY_API_KEY:-}" ] ||
+    [ -n "${FRONTIER_BASE_URL:-}" ] ||
+    [ -n "${AI_GATEWAY_BASE_URL:-}" ] ||
+    [ -n "${OPENAI_BASE_URL:-}" ]
+}
+
+load_frontier_env_file() {
+  local file="$1"
+  local line key value
+  [ -f "$file" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      OPENAI_API_KEY=*|ANTHROPIC_API_KEY=*|ANTHROPIC_LOCAL_KEY=*|FRONTIER_API_KEY=*|AI_GATEWAY_API_KEY=*|OPENAI_BASE_URL=*|FRONTIER_BASE_URL=*|AI_GATEWAY_BASE_URL=*|OPENAI_MODEL=*|ANTHROPIC_MODEL=*|FRONTIER_MODEL=*|AI_GATEWAY_MODEL=*)
+        key="${line%%=*}"
+        value="${line#*=}"
+        value="${value%$'\r'}"
+        case "$value" in
+          \"*\") value="${value#\"}"; value="${value%\"}" ;;
+          \'*\') value="${value#\'}"; value="${value%\'}" ;;
+        esac
+        export "$key=$value"
+        ;;
+    esac
+  done <"$file"
+}
+
+write_frontier_choice() {
+  local mode="$1"
+  local env_file="${2:-}"
+  mkdir -p "$STATE_DIR"
+  {
+    printf 'mode=%s\n' "$mode"
+    [ -n "$env_file" ] && printf 'env_file=%s\n' "$env_file"
+    [ "$mode" = "zdr" ] && printf 'model=%s\n' "$ZDR_FRONTIER_MODEL"
+    date -u +"created_at=%Y-%m-%dT%H:%M:%SZ"
+  } >"$STATE_DIR/frontier-choice"
+}
+
+choose_frontier_key_mode() {
+  local answer env_file
+  valid_frontier_key_mode
+  [ "$NO_GAUNTLET" = "1" ] && return 0
+
+  if [ "$FRONTIER_KEY_MODE" = "skip" ]; then
+    NO_GAUNTLET=1
+    write_frontier_choice "skip"
+    return 0
+  fi
+
+  if [ "$FRONTIER_KEY_MODE" = "byo" ]; then
+    if has_frontier_shell_env; then
+      say "Using BYO frontier keys already present in this shell. Values stay local and are not printed."
+      write_frontier_choice "byo" "shell-env"
+      return 0
+    fi
+    env_file="$(find_frontier_env_file || true)"
+    if [ -z "$env_file" ]; then
+      say "No local .env file with known frontier key variables was found."
+      say "Falling back to the Understudy ZDR gateway route."
+      FRONTIER_KEY_MODE="zdr"
+    else
+      load_frontier_env_file "$env_file"
+      say "Using local BYO frontier keys from $env_file. Values stay local and are not printed."
+      write_frontier_choice "byo" "$env_file"
+      return 0
+    fi
+  fi
+
+  if [ "$FRONTIER_KEY_MODE" = "zdr" ]; then
+    say "Using Understudy ZDR gateway frontier route: $ZDR_FRONTIER_MODEL."
+    write_frontier_choice "zdr"
+    return 0
+  fi
+
+  section "Frontier key choice."
+  say "The local model runs on your Mac. The right-side frontier comparison needs a remote model."
+  say "Choose one:"
+  say "  1. Bring your own OpenAI/Anthropic/AI-gateway key from this shell or a local .env file."
+  say "     The key stays on this machine; the selected provider receives the comparison prompts."
+  say "  2. Use the Understudy ZDR gateway route ($ZDR_FRONTIER_MODEL)."
+  say "     No local provider key is read; you use your Understudy account/gateway route."
+  say "  3. Skip the frontier comparison for now."
+  answer="$(prompt_choice "Use BYO shell/.env keys, Understudy ZDR, or skip? [byo/zdr/skip]")"
+  case "$answer" in
+    byo|BYO)
+      if has_frontier_shell_env; then
+        say "Using BYO frontier keys already present in this shell. Values stay local and are not printed."
+        FRONTIER_KEY_MODE="byo"
+        write_frontier_choice "byo" "shell-env"
+        return 0
+      fi
+      if confirm "May Understudy inspect local .env files in this directory for provider key variable names?"; then
+        env_file="$(find_frontier_env_file || true)"
+        if [ -n "$env_file" ]; then
+          load_frontier_env_file "$env_file"
+          say "Using local BYO frontier keys from $env_file. Values stay local and are not printed."
+          FRONTIER_KEY_MODE="byo"
+          write_frontier_choice "byo" "$env_file"
+          return 0
+        fi
+        say "No local .env file with known frontier key variables was found."
+      fi
+      say "Using Understudy ZDR gateway route instead."
+      FRONTIER_KEY_MODE="zdr"
+      write_frontier_choice "zdr"
+      ;;
+    skip|SKIP)
+      say "Skipping remote frontier comparison. You can run it later with --frontier-key-mode byo or --frontier-key-mode zdr."
+      FRONTIER_KEY_MODE="skip"
+      NO_GAUNTLET=1
+      write_frontier_choice "skip"
+      ;;
+    *)
+      say "Using Understudy ZDR gateway route."
+      FRONTIER_KEY_MODE="zdr"
+      write_frontier_choice "zdr"
+      ;;
+  esac
+}
+
+run_arena_play() {
+  local command="$1"
+  shift
+  if [ "$FRONTIER_KEY_MODE" = "zdr" ]; then
+    OPENAI_API_KEY= ANTHROPIC_API_KEY= ANTHROPIC_LOCAL_KEY= \
+      FRONTIER_API_KEY= AI_GATEWAY_API_KEY= \
+      OPENAI_BASE_URL= FRONTIER_BASE_URL= AI_GATEWAY_BASE_URL= \
+      UNDERSTUDY_FALLBACK_MODEL="$ZDR_FRONTIER_MODEL" "$command" "$@"
+    return $?
+  fi
+  "$command" "$@"
 }
 
 install_tmux() {
@@ -241,6 +428,7 @@ need npm || {
 }
 
 configure_resume
+valid_frontier_key_mode
 
 section "Welcome. We are going to create your first local Understudy."
 say "Install log: $LOG_FILE"
@@ -264,13 +452,14 @@ fi
 say "  6. Open a tmux/Pi window so you can meet the local model as your first Understudy."
 if [ "$NO_GAUNTLET" = "0" ]; then
   say "  7. Ask again before running the local-vs-frontier duel."
-  say "     Frontier attempts use local OpenAI/Anthropic keys or a configured AI gateway first, then fall back to Understudy glm-5.1."
+  say "     You choose whether the frontier uses local BYO keys from this shell/.env or the Understudy ZDR gateway route."
 else
   say "  7. Skip the remote frontier duel because --no-gauntlet is set."
 fi
 say ""
 say "This installer writes only under $LAB, $HOME/.understudy, the global npm prefix, and Claude Code plugin state when enabled."
 confirm "Continue with this Understudy installation?" || exit 1
+choose_frontier_key_mode
 
 if ! need uv; then
   say "uv is required for the isolated MLX runtime."
@@ -405,7 +594,11 @@ if [ "$NO_GAUNTLET" = "0" ]; then
     install_tmux
     section "Step 5/5: run the local-vs-frontier duel."
     say "Pi opens a side-by-side harness: local Understudy on the left, frontier baseline on the right."
-    say "This step may make remote frontier calls using a local OpenAI/Anthropic key, a configured AI gateway, or your Understudy gateway fallback."
+    if [ "$FRONTIER_KEY_MODE" = "byo" ]; then
+      say "Frontier mode: BYO local key from .env. The key stays local; the selected provider receives the comparison prompts."
+    else
+      say "Frontier mode: Understudy ZDR gateway route ($ZDR_FRONTIER_MODEL). No local provider key is read for this duel."
+    fi
     say "The shared tmux session is ${SESSION:-mlx-arena}-play; the agent can send prompts and you can watch or take over."
     say "After the stock questions, point Understudy at a dataset or codebase."
     say "Then use the skills to generate task-specific evals and climb: better prompts, GEPA/RLM, larger Gemma/Nemotron, or remote training."
@@ -416,10 +609,12 @@ if [ "$NO_GAUNTLET" = "0" ]; then
     }
     if [ "$NO_WINDOW" = "1" ]; then
       LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
-        LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" "$ARENA" play
+        LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" \
+        run_arena_play "$ARENA" play
     else
       LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
-        LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" "$ARENA" play-window
+        LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" \
+        run_arena_play "$ARENA" play-window
     fi
     mark_step_done 5
   else

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# Install Understudy agent tools, prepare the first local model, and open the
-# first-run Understudy window.
+# Install Understudy agent tools and hand the user back to Claude Code skills.
 set -euo pipefail
 
-MODEL_SESSION_URL="${UNDERSTUDY_MODEL_SESSION_URL:-https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit&ttl=21600}"
-MODEL_DIR="${UNDERSTUDY_MODEL_DIR:-$HOME/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit}"
 LAB="${UNDERSTUDY_LAB:-$HOME/.understudy/agent-tools}"
 INSTALL_REPO_URL="${UNDERSTUDY_INSTALL_REPO_URL:-https://github.com/UnderstudyLabs/understudy-agent-tools.git}"
 INSTALL_REF="${UNDERSTUDY_INSTALL_REF:-main}"
@@ -12,70 +9,54 @@ INSTALL_PACKAGE="${UNDERSTUDY_INSTALL_PACKAGE:-}"
 INSTALL_SOURCE_DIR="${UNDERSTUDY_INSTALL_SOURCE_DIR:-$LAB/source/understudy-agent-tools}"
 STATE_DIR="${UNDERSTUDY_INSTALL_STATE_DIR:-$LAB/install-state}"
 INSTALLER_COMMIT="${UNDERSTUDY_INSTALLER_COMMIT:-unknown}"
+LAUNCH_CLAUDE="${UNDERSTUDY_LAUNCH_CLAUDE:-1}"
+NO_CLAUDE=0
 START_STEP=1
 ONLY_STEP=""
 RESUME=0
 YES=0
-NO_MODEL=0
-NO_WINDOW=0
-NO_GAUNTLET=0
-NO_CLAUDE=0
-FRONTIER_KEY_MODE="${UNDERSTUDY_FRONTIER_KEY_MODE:-ask}"
-FRONTIER_ENV_FILE="${UNDERSTUDY_FRONTIER_ENV_FILE:-}"
-ZDR_FRONTIER_MODEL="${UNDERSTUDY_ZDR_FRONTIER_MODEL:-gpt-5.5}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -y|--yes) YES=1 ;;
-    --no-model) NO_MODEL=1 ;;
-    --no-window) NO_WINDOW=1 ;;
-    --no-gauntlet) NO_GAUNTLET=1 ;;
     --no-claude) NO_CLAUDE=1 ;;
-    --frontier-key-mode) FRONTIER_KEY_MODE="${2:?missing mode}"; shift ;;
-    --frontier-env-file) FRONTIER_ENV_FILE="${2:?missing path}"; shift ;;
-    --zdr-frontier-model) ZDR_FRONTIER_MODEL="${2:?missing model id}"; shift ;;
+    --no-launch-claude) LAUNCH_CLAUDE=0 ;;
+    --launch-claude) LAUNCH_CLAUDE=1 ;;
     --from-step) START_STEP="${2:?missing step number}"; shift ;;
     --only-step) ONLY_STEP="${2:?missing step number}"; shift ;;
     --resume) RESUME=1 ;;
-    --model-session-url) MODEL_SESSION_URL="${2:?missing URL}"; shift ;;
-    --model-base-url) MODEL_SESSION_URL="${2:?missing URL}"; shift ;;
-    --model-dir) MODEL_DIR="${2:?missing path}"; shift ;;
     --lab) LAB="${2:?missing path}"; shift ;;
     -h|--help)
       cat <<'EOF'
-Usage: install.sh [--yes] [--from-step N] [--only-step N] [--resume] [--no-claude] [--no-model] [--no-window] [--no-gauntlet]
+Usage: install.sh [--yes] [--resume] [--from-step N] [--only-step N] [--no-claude] [--no-launch-claude]
 
-Installs the Understudy CLI + Claude skill/plugin surface, prepares Apple MLX,
-downloads the verified Gemma 4 E2B 4-bit first rung, and opens the first local
-Understudy in a new Terminal window on macOS.
+Installs the Understudy CLI + Claude Code skill/plugin surface, then hands the
+user back to Claude Code. It does not download model weights, start MLX, install
+Pi, launch tmux/iTerm, or make frontier calls. Those are guided by the
+/understudy:onboard skill after the user is in their coding agent.
 
-Frontier comparison key choices:
-  --frontier-key-mode ask|byo|zdr|skip
-      ask: prompt before the remote comparison (default)
-      byo: import allowed frontier variables from --frontier-env-file or a local .env
-      zdr: use the Understudy ZDR gateway frontier route, no local provider key
-      skip: skip the remote frontier comparison
-  --frontier-env-file PATH   .env file to inspect when --frontier-key-mode=byo
-  --zdr-frontier-model ID    Understudy ZDR model id, default gpt-5.5
+Options:
+  --yes                 approve the installer prompt
+  --resume              continue from the next unfinished install step
+  --from-step N         start from step 1, 2, or 3
+  --only-step N         run only step 1, 2, or 3
+  --no-claude           skip Claude Code plugin install and final Claude launch
+  --no-launch-claude    install plugin but do not open Claude Code at the end
+  --launch-claude       open Claude Code at the end (default)
+  --lab PATH            local Understudy runtime/log directory
 
 Environment overrides:
-  UNDERSTUDY_MODEL_SESSION_URL stable session endpoint that returns signed model file URLs
-  UNDERSTUDY_MODEL_DIR        local model destination
-  UNDERSTUDY_LAB              local runtime/log directory
-  UNDERSTUDY_INSTALL_REPO_URL public repo URL, default https://github.com/UnderstudyLabs/understudy-agent-tools.git
-  UNDERSTUDY_INSTALL_REF      Git ref for public repo install, default main
-  UNDERSTUDY_INSTALL_SOURCE_DIR local repo checkout, default $UNDERSTUDY_LAB/source/understudy-agent-tools
-  UNDERSTUDY_INSTALL_STATE_DIR install markers, default $UNDERSTUDY_LAB/install-state
-  UNDERSTUDY_INSTALL_LOG_DIR   install logs, default $UNDERSTUDY_LAB/logs
-  UNDERSTUDY_INSTALLER_COMMIT  optional script commit label when caller knows it
-  UNDERSTUDY_INSTALL_PACKAGE  optional npm package spec override
-  UNDERSTUDY_DEBUG            set to 1 for arena action logs and verbose launch metadata
-  UNDERSTUDY_WINDOW_HOLD      set to 1 to keep spawned terminal windows open after exit
-  UNDERSTUDY_TERMINAL_APP     auto|iterm|ghostty|terminal, default auto from current terminal
-  UNDERSTUDY_FRONTIER_KEY_MODE ask|byo|zdr|skip
-  UNDERSTUDY_FRONTIER_ENV_FILE local .env path for BYO frontier keys
-  UNDERSTUDY_ZDR_FRONTIER_MODEL model id for Understudy ZDR fallback, default gpt-5.5
-  SESSION                     tmux session prefix, default mlx-arena
+  UNDERSTUDY_LAB                 local runtime/log directory, default ~/.understudy/agent-tools
+  UNDERSTUDY_INSTALL_REPO_URL    public repo URL, default https://github.com/UnderstudyLabs/understudy-agent-tools.git
+  UNDERSTUDY_INSTALL_REF         Git ref for public repo install, default main
+  UNDERSTUDY_INSTALL_SOURCE_DIR  local repo checkout, default $UNDERSTUDY_LAB/source/understudy-agent-tools
+  UNDERSTUDY_INSTALL_STATE_DIR   install markers, default $UNDERSTUDY_LAB/install-state
+  UNDERSTUDY_INSTALL_LOG_DIR     install logs, default $UNDERSTUDY_LAB/logs
+  UNDERSTUDY_INSTALL_LOG_FILE    exact install log path
+  UNDERSTUDY_INSTALLER_COMMIT    optional script commit label when caller knows it
+  UNDERSTUDY_INSTALL_PACKAGE     optional npm package spec override
+  UNDERSTUDY_LAUNCH_CLAUDE      set to 0 to skip opening Claude Code
+  UNDERSTUDY_CLAUDE_ARGS        optional extra args when launching Claude Code
 EOF
       exit 0
       ;;
@@ -111,14 +92,8 @@ run_logged() {
 need() { command -v "$1" >/dev/null 2>&1; }
 valid_step() {
   case "$1" in
-    1|2|3|4|5) return 0 ;;
-    *) echo "invalid step: $1 (expected 1-5)" >&2; exit 2 ;;
-  esac
-}
-valid_frontier_key_mode() {
-  case "$FRONTIER_KEY_MODE" in
-    ask|byo|zdr|skip) return 0 ;;
-    *) echo "invalid frontier key mode: $FRONTIER_KEY_MODE (expected ask|byo|zdr|skip)" >&2; exit 2 ;;
+    1|2|3) return 0 ;;
+    *) echo "invalid step: $1 (expected 1-3)" >&2; exit 2 ;;
   esac
 }
 should_run_step() {
@@ -142,8 +117,8 @@ configure_resume() {
   if [ "$RESUME" = "1" ] && [ -f "$STATE_DIR/last-step" ]; then
     last_step="$(cat "$STATE_DIR/last-step" 2>/dev/null || true)"
     case "$last_step" in
-      1|2|3|4) START_STEP=$((last_step + 1)) ;;
-      5) START_STEP=5 ;;
+      1|2) START_STEP=$((last_step + 1)) ;;
+      3) START_STEP=3 ;;
     esac
     say "Resuming from step $START_STEP based on $STATE_DIR/last-step"
   fi
@@ -158,186 +133,6 @@ confirm() {
   printf "%s [y/N] " "$1" >/dev/tty
   read -r answer </dev/tty
   case "$answer" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
-}
-prompt_choice() {
-  local prompt="$1"
-  if [ "$YES" = "1" ]; then
-    printf '\n'
-    return 0
-  fi
-  if [ ! -r /dev/tty ]; then
-    printf '\n'
-    return 0
-  fi
-  printf "%s " "$prompt" >/dev/tty
-  read -r answer </dev/tty
-  printf '%s\n' "$answer"
-}
-
-find_frontier_env_file() {
-  local candidate
-  if [ -n "$FRONTIER_ENV_FILE" ] && [ -f "$FRONTIER_ENV_FILE" ]; then
-    printf '%s\n' "$FRONTIER_ENV_FILE"
-    return 0
-  fi
-  for candidate in .env.local .env .env.development.local .env.development; do
-    if [ -f "$candidate" ] && grep -Eq '^(OPENAI_API_KEY|ANTHROPIC_API_KEY|ANTHROPIC_LOCAL_KEY|FRONTIER_API_KEY|AI_GATEWAY_API_KEY|OPENAI_BASE_URL|FRONTIER_BASE_URL|AI_GATEWAY_BASE_URL|OPENAI_MODEL|ANTHROPIC_MODEL|FRONTIER_MODEL|AI_GATEWAY_MODEL)=' "$candidate"; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
-
-has_frontier_shell_env() {
-  [ -n "${OPENAI_API_KEY:-}" ] ||
-    [ -n "${ANTHROPIC_API_KEY:-}" ] ||
-    [ -n "${ANTHROPIC_LOCAL_KEY:-}" ] ||
-    [ -n "${FRONTIER_API_KEY:-}" ] ||
-    [ -n "${AI_GATEWAY_API_KEY:-}" ] ||
-    [ -n "${FRONTIER_BASE_URL:-}" ] ||
-    [ -n "${AI_GATEWAY_BASE_URL:-}" ] ||
-    [ -n "${OPENAI_BASE_URL:-}" ]
-}
-
-load_frontier_env_file() {
-  local file="$1"
-  local line key value
-  [ -f "$file" ] || return 1
-  while IFS= read -r line || [ -n "$line" ]; do
-    case "$line" in
-      OPENAI_API_KEY=*|ANTHROPIC_API_KEY=*|ANTHROPIC_LOCAL_KEY=*|FRONTIER_API_KEY=*|AI_GATEWAY_API_KEY=*|OPENAI_BASE_URL=*|FRONTIER_BASE_URL=*|AI_GATEWAY_BASE_URL=*|OPENAI_MODEL=*|ANTHROPIC_MODEL=*|FRONTIER_MODEL=*|AI_GATEWAY_MODEL=*)
-        key="${line%%=*}"
-        value="${line#*=}"
-        value="${value%$'\r'}"
-        case "$value" in
-          \"*\") value="${value#\"}"; value="${value%\"}" ;;
-          \'*\') value="${value#\'}"; value="${value%\'}" ;;
-        esac
-        export "$key=$value"
-        ;;
-    esac
-  done <"$file"
-}
-
-write_frontier_choice() {
-  local mode="$1"
-  local env_file="${2:-}"
-  mkdir -p "$STATE_DIR"
-  {
-    printf 'mode=%s\n' "$mode"
-    [ -n "$env_file" ] && printf 'env_file=%s\n' "$env_file"
-    [ "$mode" = "zdr" ] && printf 'model=%s\n' "$ZDR_FRONTIER_MODEL"
-    date -u +"created_at=%Y-%m-%dT%H:%M:%SZ"
-  } >"$STATE_DIR/frontier-choice"
-}
-
-choose_frontier_key_mode() {
-  local answer env_file
-  valid_frontier_key_mode
-  [ "$NO_GAUNTLET" = "1" ] && return 0
-
-  if [ "$FRONTIER_KEY_MODE" = "skip" ]; then
-    NO_GAUNTLET=1
-    write_frontier_choice "skip"
-    return 0
-  fi
-
-  if [ "$FRONTIER_KEY_MODE" = "byo" ]; then
-    if has_frontier_shell_env; then
-      say "Using BYO frontier keys already present in this shell. Values stay local and are not printed."
-      write_frontier_choice "byo" "shell-env"
-      return 0
-    fi
-    env_file="$(find_frontier_env_file || true)"
-    if [ -z "$env_file" ]; then
-      say "No local .env file with known frontier key variables was found."
-      say "Falling back to the Understudy ZDR gateway route."
-      FRONTIER_KEY_MODE="zdr"
-    else
-      load_frontier_env_file "$env_file"
-      say "Using local BYO frontier keys from $env_file. Values stay local and are not printed."
-      write_frontier_choice "byo" "$env_file"
-      return 0
-    fi
-  fi
-
-  if [ "$FRONTIER_KEY_MODE" = "zdr" ]; then
-    say "Using Understudy ZDR gateway frontier route: $ZDR_FRONTIER_MODEL."
-    write_frontier_choice "zdr"
-    return 0
-  fi
-
-  section "Frontier key choice."
-  say "The local model runs on your Mac. The right-side frontier comparison needs a remote model."
-  say "Choose one:"
-  say "  1. Bring your own OpenAI/Anthropic/AI-gateway key from this shell or a local .env file."
-  say "     The key stays on this machine; the selected provider receives the comparison prompts."
-  say "  2. Use the Understudy ZDR gateway route ($ZDR_FRONTIER_MODEL)."
-  say "     No local provider key is read; you use your Understudy account/gateway route."
-  say "  3. Skip the frontier comparison for now."
-  answer="$(prompt_choice "Use BYO shell/.env keys, Understudy ZDR, or skip? [byo/zdr/skip]")"
-  case "$answer" in
-    byo|BYO)
-      if has_frontier_shell_env; then
-        say "Using BYO frontier keys already present in this shell. Values stay local and are not printed."
-        FRONTIER_KEY_MODE="byo"
-        write_frontier_choice "byo" "shell-env"
-        return 0
-      fi
-      if confirm "May Understudy inspect local .env files in this directory for provider key variable names?"; then
-        env_file="$(find_frontier_env_file || true)"
-        if [ -n "$env_file" ]; then
-          load_frontier_env_file "$env_file"
-          say "Using local BYO frontier keys from $env_file. Values stay local and are not printed."
-          FRONTIER_KEY_MODE="byo"
-          write_frontier_choice "byo" "$env_file"
-          return 0
-        fi
-        say "No local .env file with known frontier key variables was found."
-      fi
-      say "Using Understudy ZDR gateway route instead."
-      FRONTIER_KEY_MODE="zdr"
-      write_frontier_choice "zdr"
-      ;;
-    skip|SKIP)
-      say "Skipping remote frontier comparison. You can run it later with --frontier-key-mode byo or --frontier-key-mode zdr."
-      FRONTIER_KEY_MODE="skip"
-      NO_GAUNTLET=1
-      write_frontier_choice "skip"
-      ;;
-    *)
-      say "Using Understudy ZDR gateway route."
-      FRONTIER_KEY_MODE="zdr"
-      write_frontier_choice "zdr"
-      ;;
-  esac
-}
-
-run_arena_play() {
-  local command="$1"
-  shift
-  if [ "$FRONTIER_KEY_MODE" = "zdr" ]; then
-    OPENAI_API_KEY= ANTHROPIC_API_KEY= ANTHROPIC_LOCAL_KEY= \
-      FRONTIER_API_KEY= AI_GATEWAY_API_KEY= \
-      OPENAI_BASE_URL= FRONTIER_BASE_URL= AI_GATEWAY_BASE_URL= \
-      UNDERSTUDY_FALLBACK_MODEL="$ZDR_FRONTIER_MODEL" "$command" "$@"
-    return $?
-  fi
-  "$command" "$@"
-}
-
-install_tmux() {
-  need tmux && return 0
-  say "tmux is required for the visible handoff window."
-  if need brew; then
-    confirm "Install tmux with Homebrew now?" || exit 1
-    brew install tmux
-    return 0
-  fi
-  say "Install tmux first, then rerun this installer."
-  say "On macOS with Homebrew: brew install tmux"
-  exit 1
 }
 
 remove_previous_global_package() {
@@ -420,14 +215,50 @@ install_claude_plugin() {
     claude plugin install understudy@understudy-skills >/dev/null
     say "Understudy plugin installed."
   fi
-  say "In your Claude Code session, type /reload-plugins once to activate the skills."
+  say "In Claude Code, type /reload-plugins once to activate the skills."
+  say "Then type /understudy:onboard so the agent can guide the first local Understudy."
 }
 
-if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
-  say "This first-run local model installer currently targets Apple Silicon Macs."
-  say "Install the CLI with npm, then use the non-MLX skills for this machine."
-  exit 1
-fi
+launch_claude_code() {
+  if [ "$NO_CLAUDE" != "0" ]; then
+    say "Skipping Claude Code launch because --no-claude is set."
+    mark_step_done 3
+    return 0
+  fi
+  if [ "$LAUNCH_CLAUDE" != "1" ]; then
+    say "Skipping Claude Code launch because --no-launch-claude is set."
+    mark_step_done 3
+    return 0
+  fi
+  if ! need claude; then
+    say "Claude Code CLI not found; open Claude Code manually and run /reload-plugins then /understudy:onboard."
+    mark_step_done 3
+    return 0
+  fi
+  if [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; then
+    say "No interactive terminal is available for Claude Code."
+    say "Open Claude Code in this directory, then run /reload-plugins and /understudy:onboard."
+    mark_step_done 3
+    return 0
+  fi
+
+  section "Step 3/3: open Claude Code."
+  say "Claude Code will open in: $(pwd)"
+  say "In Claude Code, type these slash commands:"
+  say "  /reload-plugins"
+  say "  /understudy:onboard"
+  say "The onboarding skill will coach model download, terminal choice, tmux/Pi handoff, and any frontier comparison with explicit consent."
+  say "Launching Claude Code now. Exit Claude to return to this shell."
+  log "LAUNCH claude ${UNDERSTUDY_CLAUDE_ARGS:-}"
+  # curl | sh leaves stdin attached to the pipe; reconnect Claude to the user's tty.
+  # shellcheck disable=SC2086
+  claude ${UNDERSTUDY_CLAUDE_ARGS:-} </dev/tty >/dev/tty 2>&1 || {
+    local status="$?"
+    say "Claude Code exited with status $status."
+    return "$status"
+  }
+  mark_step_done 3
+}
 
 need npm || {
   say "npm is required. Install Node.js 20+ first: https://nodejs.org"
@@ -435,211 +266,49 @@ need npm || {
 }
 
 configure_resume
-valid_frontier_key_mode
 
-section "Welcome. We are going to create your first local Understudy."
+section "Welcome. We are going to install Understudy for your coding agent."
 say "Install log: $LOG_FILE"
 say "Installer script commit: $INSTALLER_COMMIT"
 say "Install source ref: $INSTALL_REF"
-say "Understudy starts with a small open-weight model on your Mac."
-say "You compare it against a frontier model, then climb the ladder with better data, evals, GEPA/RLM, bigger local models, or remote runs."
-say "The point is concrete: build a replacement model for work you currently send to a frontier model."
+say "This installer bootstraps the CLI and Claude Code skills, then drops you back into your coding agent."
 say ""
 say "Install plan:"
-say "  1. Download the Understudy CLI and Pi terminal harness from $INSTALL_REPO_URL#$INSTALL_REF."
-say "  2. Install the CLI globally so agents can run durable Understudy commands."
-say "  3. Install the Claude Code skills when Claude Code is available, unless --no-claude is set."
-say "  4. Create an isolated local MLX runtime under $LAB."
-if [ "$NO_MODEL" = "0" ]; then
-  say "  5. Download the first model snapshot into $MODEL_DIR."
-  say "     First rung: Gemma 4 E2B IT, MLX-VLM 4-bit, about 3.3GB."
-else
-  say "  5. Reuse an existing model snapshot at $MODEL_DIR."
-fi
-say "  6. Open a tmux/Pi window so you can meet the local model as your first Understudy."
-if [ "$NO_GAUNTLET" = "0" ]; then
-  say "  7. Ask again before running the local-vs-frontier duel."
-  say "     You choose whether the frontier uses local BYO keys from this shell/.env or the Understudy ZDR gateway route."
-else
-  say "  7. Skip the remote frontier duel because --no-gauntlet is set."
-fi
+say "  1. Download and install the Understudy CLI from $INSTALL_REPO_URL#$INSTALL_REF."
+say "  2. Install or refresh the Claude Code skills when Claude Code is available."
+say "  3. Open Claude Code in this directory and show the next slash commands."
 say ""
+say "Default install does not download weights, start MLX, install Pi, launch tmux/iTerm, or make frontier calls."
+say "Those actions happen later through /understudy:onboard, where the coding agent can coach the user and ask consent."
 say "This installer writes only under $LAB, $HOME/.understudy, the global npm prefix, and Claude Code plugin state when enabled."
 confirm "Continue with this Understudy installation?" || exit 1
-choose_frontier_key_mode
-
-if ! need uv; then
-  say "uv is required for the isolated MLX runtime."
-  confirm "Install uv from astral.sh now?" || exit 1
-  curl -LsSf https://astral.sh/uv/install.sh | sh 2>&1 | tee -a "$LOG_FILE"
-  export PATH="$HOME/.local/bin:$PATH"
-fi
 
 PKG_DIR="$(npm root -g)/@understudylabs/understudy-agent-tools"
-ARENA="$PKG_DIR/skills/mlx-arena/arena.sh"
 
 if should_run_step 1; then
-  section "Step 1/5: install the CLI and Pi harness."
+  section "Step 1/3: install the CLI."
   install_understudy_package
-  run_logged npm install -g @earendil-works/pi-coding-agent
   PKG_DIR="$(npm root -g)/@understudylabs/understudy-agent-tools"
-  ARENA="$PKG_DIR/skills/mlx-arena/arena.sh"
   mark_step_done 1
 else
-  say "Skipping step 1/5: install the CLI and Pi harness."
-fi
-
-if (should_run_step 2 || should_run_step 4 || should_run_step 5) && [ ! -x "$ARENA" ]; then
-  say "Could not find executable arena launcher at $ARENA."
-  say "Rerun from step 1, or install the CLI first."
-  exit 1
+  say "Skipping step 1/3: install the CLI."
 fi
 
 if should_run_step 2; then
-  section "Step 2/5: install the Claude Code skills."
+  section "Step 2/3: install the Claude Code skills."
   install_claude_plugin
   mark_step_done 2
 else
-  say "Skipping step 2/5: install the Claude Code skills."
-fi
-
-if should_run_step 3 || should_run_step 4 || should_run_step 5; then
-  mkdir -p "$LAB" "$MODEL_DIR" "$HOME/.understudy/models"
-  if [ ! -x "$LAB/.understudy/venvs/mlx/bin/python" ]; then
-    say "Creating isolated MLX runtime."
-    run_logged uv venv "$LAB/.understudy/venvs/mlx" --python 3.12
-    run_logged uv pip install --python "$LAB/.understudy/venvs/mlx/bin/python" \
-      'mlx-lm>=0.31' 'mlx-vlm>=0.6' 'huggingface_hub>=0.27'
-  fi
-fi
-
-download_file() {
-  local name="$1"
-  local url="$2"
-  local target="$MODEL_DIR/$name"
-  local partial="$target.part"
-  local expected_size current_size
-  expected_size="$(curl -fsIL "$url" 2>/dev/null | awk 'tolower($1)=="content-length:" {gsub("\r","",$2); size=$2} END {print size}')"
-  if [ -s "$target" ]; then
-    if [ -n "$expected_size" ]; then
-      current_size="$(wc -c <"$target" | tr -d ' ')"
-      [ "$current_size" = "$expected_size" ] && return 0
-      say "Replacing incomplete $name ($current_size/$expected_size bytes)"
-    else
-      return 0
-    fi
-  fi
-  mkdir -p "$(dirname "$target")"
-  rm -f "$target"
-  curl -fL --progress-bar "$url" -o "$partial"
-  if [ -n "$expected_size" ]; then
-    current_size="$(wc -c <"$partial" | tr -d ' ')"
-    if [ "$current_size" != "$expected_size" ]; then
-      rm -f "$partial"
-      say "Downloaded $name has unexpected size ($current_size/$expected_size bytes)."
-      return 1
-    fi
-  fi
-  mv "$partial" "$target"
-}
-
-download_model_snapshot() {
-  local manifest="$LAB/model-session.json"
-  curl -fsSL "$MODEL_SESSION_URL" -o "$manifest"
-  "$LAB/.understudy/venvs/mlx/bin/python" - "$manifest" <<'PY' | while IFS=$'\t' read -r name url
-import json
-import sys
-
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    data = json.load(f)
-for item in data["files"]:
-    print(f"{item['name']}\t{item['url']}")
-PY
-  do
-    say "Downloading $name"
-    download_file "$name" "$url"
-  done
-}
-
-if [ "$NO_MODEL" = "0" ]; then
-  if should_run_step 3; then
-    section "Step 3/5: download the first local Understudy."
-    say "Model: Gemma 4 E2B IT, MLX-VLM 4-bit, about 3.3GB."
-    say "Why this rung: small enough to run locally, strong enough to make the replacement loop tangible."
-    say "Source: signed Understudy snapshot at $MODEL_SESSION_URL"
-    confirm "Download this verified open-weight snapshot now?" || exit 1
-    download_model_snapshot
-    mark_step_done 3
-  else
-    say "Skipping step 3/5: download the first local Understudy."
-  fi
-else
-  section "Step 3/5: use the existing local Understudy weights."
-  say "Model directory: $MODEL_DIR"
-  should_run_step 3 && mark_step_done 3
-fi
-
-if should_run_step 4; then
-  install_tmux
-  section "Step 4/5: meet the local Understudy."
-  say "A new Terminal window will show the model loading locally so you can see it is yours, not a hosted frontier call."
-  say "If an agent launched this, follow the same session with: tmux attach -t ${SESSION:-mlx-arena}-first"
-  say "Window diagnostics write to: $LAB/.understudy/local-model-lab/arena/logs/window-launch-*.log"
-  say "If the window flashes closed, rerun with UNDERSTUDY_DEBUG=1 UNDERSTUDY_WINDOW_HOLD=1 or run: LAB=\"$LAB\" \"$ARENA\" diagnose"
-  if [ "$NO_WINDOW" = "1" ]; then
-    LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
-      FIRST_REPO="$MODEL_DIR" FIRST_LOADER=mlx_vlm "$ARENA" first
-  else
-    LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
-      FIRST_REPO="$MODEL_DIR" FIRST_LOADER=mlx_vlm "$ARENA" first-window
-  fi
-  mark_step_done 4
-else
-  say "Skipping step 4/5: meet the local Understudy."
-fi
-
-if [ "$NO_GAUNTLET" = "0" ]; then
-  if should_run_step 5; then
-    install_tmux
-    section "Step 5/5: run the local-vs-frontier duel."
-    say "Pi opens a side-by-side harness: local Understudy on the left, frontier baseline on the right."
-    if [ "$FRONTIER_KEY_MODE" = "byo" ]; then
-      say "Frontier mode: BYO local key from .env. The key stays local; the selected provider receives the comparison prompts."
-    else
-      say "Frontier mode: Understudy ZDR gateway route ($ZDR_FRONTIER_MODEL). No local provider key is read for this duel."
-    fi
-    say "The shared tmux session is ${SESSION:-mlx-arena}-play; the agent can send prompts and you can watch or take over."
-    say "Window diagnostics write to: $LAB/.understudy/local-model-lab/arena/logs/window-launch-*.log"
-    say "After the stock questions, point Understudy at a dataset or codebase."
-    say "Then use the skills to generate task-specific evals and climb: better prompts, GEPA/RLM, larger Gemma/Nemotron, or remote training."
-    confirm "Launch the remote frontier comparison now?" || {
-      say "Skipping frontier comparison. Run it later with:"
-      say "  LAB=\"$LAB\" MLX_PYTHON=\"$LAB/.understudy/venvs/mlx/bin/python\" LEFT_REPO=\"$MODEL_DIR\" LEFT_LOADER=mlx_vlm \"$ARENA\" play"
-      exit 0
-    }
-    if [ "$NO_WINDOW" = "1" ]; then
-      LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
-        LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" \
-        run_arena_play "$ARENA" play
-    else
-      LAB="$LAB" MLX_PYTHON="$LAB/.understudy/venvs/mlx/bin/python" \
-        LEFT_REPO="$MODEL_DIR" LEFT_LOADER=mlx_vlm LOCAL_NAME="Gemma 4 E2B" \
-        run_arena_play "$ARENA" play-window
-    fi
-    mark_step_done 5
-  else
-    say "Skipping step 5/5: run the local-vs-frontier duel."
-  fi
-else
-  if should_run_step 5; then
-    section "Next: run the local-vs-frontier duel."
-    say "  LAB=\"$LAB\" MLX_PYTHON=\"$LAB/.understudy/venvs/mlx/bin/python\" LEFT_REPO=\"$MODEL_DIR\" LEFT_LOADER=mlx_vlm \"$ARENA\" play"
-    mark_step_done 5
-  else
-    say "Skipping step 5/5: run the local-vs-frontier duel."
-  fi
+  say "Skipping step 2/3: install the Claude Code skills."
 fi
 
 section "Where this goes next."
-say "Bring a codebase or dataset. Understudy will make a baseline environment, score local versus frontier, and keep climbing until a cheaper replacement is credible."
-say "If Claude Code was open during install, type /reload-plugins there so the Understudy skills become visible in that same session."
+say "The installer is done. The next experience belongs inside Claude Code:"
+say "  1. /reload-plugins"
+say "  2. /understudy:onboard"
+say "That lets the coding agent explain the first local Understudy, open a terminal of the user's choice when needed, and run the same commands itself when appropriate."
+if should_run_step 3; then
+  launch_claude_code
+else
+  say "Skipping step 3/3: open Claude Code."
+fi

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ INSTALL_SOURCE_DIR="${UNDERSTUDY_INSTALL_SOURCE_DIR:-$LAB/source/understudy-agen
 STATE_DIR="${UNDERSTUDY_INSTALL_STATE_DIR:-$LAB/install-state}"
 INSTALLER_COMMIT="${UNDERSTUDY_INSTALLER_COMMIT:-unknown}"
 LAUNCH_CLAUDE="${UNDERSTUDY_LAUNCH_CLAUDE:-1}"
+CLAUDE_PERMISSION_MODE="${UNDERSTUDY_CLAUDE_PERMISSION_MODE:-auto}"
 INITIAL_CLAUDE_PROMPT="${UNDERSTUDY_INITIAL_CLAUDE_PROMPT:-Use the Understudy onboarding skill for this project now. Guide me through getting my first local Understudy, choosing my terminal/tmux/Pi handoff, and after the first local-vs-frontier duel, help me pick a real problem or find local data so we can try to make the Understudy beat the frontier on that task slice.}"
 NO_CLAUDE=0
 START_STEP=1
@@ -58,6 +59,7 @@ Environment overrides:
   UNDERSTUDY_INSTALL_PACKAGE     optional npm package spec override
   UNDERSTUDY_LAUNCH_CLAUDE      set to 0 to skip opening Claude Code
   UNDERSTUDY_CLAUDE_ARGS        optional extra args when launching Claude Code
+  UNDERSTUDY_CLAUDE_PERMISSION_MODE Claude Code permission mode, default auto
   UNDERSTUDY_INITIAL_CLAUDE_PROMPT initial prompt passed to Claude Code
 EOF
       exit 0
@@ -248,18 +250,19 @@ launch_claude_code() {
   section "Step 3/3: open Claude Code."
   say "Claude Code will open in: $(pwd)"
   say "The Understudy plugin will be loaded for this launch with --plugin-dir."
+  say "Claude Code permission mode: $CLAUDE_PERMISSION_MODE."
   say "Claude Code will receive the first prompt automatically:"
   say "  $INITIAL_CLAUDE_PROMPT"
   say "If you open a separate existing Claude Code session later, run /reload-plugins there once."
   say "Launching Claude Code now. Exit Claude to return to this shell."
   claude_log="$LOG_DIR/claude-$(date -u +"%Y%m%dT%H%M%SZ").log"
   say "Claude Code launch log: $claude_log"
-  log "LAUNCH claude --plugin-dir $PKG_DIR ${UNDERSTUDY_CLAUDE_ARGS:-} <initial-prompt>"
+  log "LAUNCH claude --permission-mode $CLAUDE_PERMISSION_MODE --plugin-dir $PKG_DIR ${UNDERSTUDY_CLAUDE_ARGS:-} <initial-prompt>"
   if need script; then
     # curl | sh leaves stdin attached to the pipe. `script` gives Claude Code a
     # real pseudo-terminal while also capturing the launch output for debugging.
     # shellcheck disable=SC2086
-    script -q "$claude_log" claude --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
+    script -q "$claude_log" claude --permission-mode "$CLAUDE_PERMISSION_MODE" --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
       local status="$?"
       say "Claude Code exited with status $status."
       say "See Claude Code launch log: $claude_log"
@@ -268,7 +271,7 @@ launch_claude_code() {
   else
     say "script(1) not found; launching without a Claude Code transcript."
     # shellcheck disable=SC2086
-    claude --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
+    claude --permission-mode "$CLAUDE_PERMISSION_MODE" --plugin-dir "$PKG_DIR" ${UNDERSTUDY_CLAUDE_ARGS:-} "$INITIAL_CLAUDE_PROMPT" </dev/tty >/dev/tty 2>&1 || {
       local status="$?"
       say "Claude Code exited with status $status."
       return "$status"

--- a/install.sh
+++ b/install.sh
@@ -220,6 +220,7 @@ install_claude_plugin() {
 }
 
 launch_claude_code() {
+  local claude_log
   if [ "$NO_CLAUDE" != "0" ]; then
     say "Skipping Claude Code launch because --no-claude is set."
     mark_step_done 3
@@ -249,14 +250,28 @@ launch_claude_code() {
   say "  /understudy:onboard"
   say "The onboarding skill will coach model download, terminal choice, tmux/Pi handoff, and any frontier comparison with explicit consent."
   say "Launching Claude Code now. Exit Claude to return to this shell."
+  claude_log="$LOG_DIR/claude-$(date -u +"%Y%m%dT%H%M%SZ").log"
+  say "Claude Code launch log: $claude_log"
   log "LAUNCH claude ${UNDERSTUDY_CLAUDE_ARGS:-}"
-  # curl | sh leaves stdin attached to the pipe; reconnect Claude to the user's tty.
-  # shellcheck disable=SC2086
-  claude ${UNDERSTUDY_CLAUDE_ARGS:-} </dev/tty >/dev/tty 2>&1 || {
-    local status="$?"
-    say "Claude Code exited with status $status."
-    return "$status"
-  }
+  if need script; then
+    # curl | sh leaves stdin attached to the pipe. `script` gives Claude Code a
+    # real pseudo-terminal while also capturing the launch output for debugging.
+    # shellcheck disable=SC2086
+    script -q "$claude_log" claude ${UNDERSTUDY_CLAUDE_ARGS:-} </dev/tty >/dev/tty 2>&1 || {
+      local status="$?"
+      say "Claude Code exited with status $status."
+      say "See Claude Code launch log: $claude_log"
+      return "$status"
+    }
+  else
+    say "script(1) not found; launching without a Claude Code transcript."
+    # shellcheck disable=SC2086
+    claude ${UNDERSTUDY_CLAUDE_ARGS:-} </dev/tty >/dev/tty 2>&1 || {
+      local status="$?"
+      say "Claude Code exited with status $status."
+      return "$status"
+    }
+  fi
   mark_step_done 3
 }
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -42,6 +42,10 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   authenticated gateway inference, project/key readiness, public model listing,
   workload route percentages, `understudy run`, and monitored durable CLI
   execution.
+- [`choose-frontier-keys`](choose-frontier-keys/SKILL.md) handles the first-run
+  choice between BYO provider keys from the current shell or a local `.env`, the
+  Understudy ZDR gateway route, or skipping remote frontier calls. It asks
+  before reading `.env` values and never prints or stores secrets.
 - [`manage-local-models`](manage-local-models/SKILL.md) acquires, caches,
   organizes, and explains local open-weight models (Gemma 4, Nemotron 3): where
   weights come from and live, formats/quantization, gated weights and HF tokens,

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -36,6 +36,7 @@ approval for that exact data class and action.
 Create or refresh these artifacts under `.understudy/capture-evidence/`:
 
 ```text
+workload-profile.md
 harness.json
 environment.json
 metric.json
@@ -48,6 +49,14 @@ enough provenance for another agent to repeat the step without guessing.
 
 ## Required Checks
 
+0. Confirm the workload profile.
+   If `.understudy/capture-evidence/workload-profile.md` is missing or stale,
+   route to [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md)
+   before building metrics. The profile should summarize the task purpose, data
+   or trace distribution, prompt/request structure, code path, tool/action
+   surface, output contract, failure taxonomy, and user-confirmed success
+   criteria. It may cite local paths and hashes, but should not contain raw
+   private payloads unless explicitly approved.
 1. Attach the harness.
    Capture the local runner, command, fixture path, entrypoint, timeout,
    dependency notes, input schema, output schema, and validator invocation in
@@ -106,11 +115,14 @@ enough provenance for another agent to repeat the step without guessing.
 
 Inspect the repo first to find where LLM calls happen and the current
 model/provider/harness/eval state, then surface that inventory before building
-anything. The deep inspection checklist (call sites by SDK family, env vars,
-tracing, CI) and the eval-harness discover-then-build playbook live in
-[`reference.md`](reference.md). For cross-cutting objective/constraint framing,
-read [`../understudy/reference.md`](../understudy/reference.md). For multi-step
-REST/API workflows that mutate state, route to
+anything. If the request/response path, dataset/trace shape, prompt purpose, or
+success criteria are not already clear, route to
+[`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) first and
+use its workload profile as the narrative source of truth. The deep inspection
+checklist (call sites by SDK family, env vars, tracing, CI) and the eval-harness
+discover-then-build playbook live in [`reference.md`](reference.md). For
+cross-cutting objective/constraint framing, read
+[`../understudy/reference.md`](../understudy/reference.md). For multi-step REST/API workflows that mutate state, route to
 [`../optimize-api-workflow/SKILL.md`](../optimize-api-workflow/SKILL.md) so the
 agent records reset/seed state, API schemas, policy docs, request logs, and
 final-state validators as part of the harness. For multi-turn / tool-use /
@@ -136,6 +148,7 @@ local command or inspection, and the next smallest action.
 End with:
 
 - workload source inspected;
+- workload profile status and whether the task understanding was confirmed;
 - artifact paths created or refreshed;
 - metric, validator, split boundary, and incumbent baseline status;
 - result type: evidence-capture or blocked;

--- a/skills/choose-frontier-keys/SKILL.md
+++ b/skills/choose-frontier-keys/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: choose-frontier-keys
+description: Use when onboarding or running a local-vs-frontier comparison and the agent must choose whether to use a developer's local provider keys from a .env file or the Understudy ZDR gateway route. Keeps secrets local, asks before reading .env values, and records the frontier choice without printing keys.
+metadata:
+  understudy:
+    mode: interactive
+    safety: approval-required
+    cli_required: false
+---
+
+# Choose Frontier Keys
+
+Use this before any local-vs-frontier duel, gateway A/B, or first-run installer
+step that needs a remote frontier model. The user must choose one of three
+frontier routes:
+
+1. **BYO local key from shell or `.env`** — use an existing OpenAI, Anthropic,
+   or OpenAI-compatible AI-gateway key already exported in the shell or stored
+   on the developer's machine.
+2. **Understudy ZDR gateway** — use the developer's Understudy account/gateway
+   route, with no local provider key read by the installer or agent.
+3. **Skip** — run local-only now and defer the remote frontier comparison.
+
+## Safety Gates
+
+- Never ask the user to paste a provider key into chat.
+- Never print, summarize, diff, log, or commit secret values.
+- Prefer already-exported shell env vars. Do not read `.env` contents until the
+  user explicitly approves local key use for this run.
+- Only import known frontier variables:
+  `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ANTHROPIC_LOCAL_KEY`,
+  `FRONTIER_API_KEY`, `AI_GATEWAY_API_KEY`, `OPENAI_BASE_URL`,
+  `FRONTIER_BASE_URL`, `AI_GATEWAY_BASE_URL`, `OPENAI_MODEL`,
+  `ANTHROPIC_MODEL`, `FRONTIER_MODEL`, `AI_GATEWAY_MODEL`.
+- If the user chooses Understudy ZDR, clear local provider-key env vars for the
+  duel and set `UNDERSTUDY_FALLBACK_MODEL=gpt-5.5` unless they choose another
+  public Understudy model.
+- If the user chooses BYO, state that the key stays local but the selected
+  upstream provider receives the prompts used in the comparison.
+- If the user chooses ZDR, state that no local provider key is read and the
+  comparison goes through the Understudy gateway route.
+
+## Flow
+
+1. Explain the decision in one sentence:
+   "The local model stays on your Mac; the right-side frontier can use either
+   an already-exported/local `.env` provider key or Understudy's ZDR gateway."
+2. Ask which route they want: BYO shell/`.env`, Understudy ZDR, or skip.
+3. For BYO, first check whether allowed key variables are already present in the
+   shell. If yes, use them without reading `.env` files.
+4. If no shell key is present, ask for permission to inspect local `.env` files in the current
+   project directory for known variable names.
+5. Detect candidate files without printing values:
+   ```bash
+   find . -maxdepth 2 -type f \( -name '.env' -o -name '.env.*' \) \
+     -not -path './node_modules/*' -not -path './.git/*'
+   ```
+6. If a candidate is found, import only the allowlisted variables for the child
+   process. Do not `source` arbitrary `.env` shell. Use a parser that ignores all
+   other lines.
+7. For ZDR, verify the user has an Understudy login when possible:
+   ```bash
+   understudy status --json
+   understudy models list --json
+   ```
+   If not signed in, ask them to run `understudy login` or skip the remote duel.
+8. Record the choice locally without secrets, for example:
+   `.understudy/frontier-choice.json` or
+   `~/.understudy/agent-tools/install-state/frontier-choice`.
+
+## Installer Mapping
+
+The public installer exposes the same choice:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | sh
+
+# non-interactive variants
+UNDERSTUDY_FRONTIER_KEY_MODE=byo UNDERSTUDY_FRONTIER_ENV_FILE=.env \
+  curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | sh
+
+UNDERSTUDY_FRONTIER_KEY_MODE=zdr \
+  curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | sh
+```
+
+The installer stores logs under `~/.understudy/agent-tools/logs` and the
+frontier choice under `~/.understudy/agent-tools/install-state/frontier-choice`.
+It does not store secret values in that choice file.
+
+## Output Standard
+
+End with:
+
+- selected frontier route: `byo`, `zdr`, or `skip`
+- whether shell env or a `.env` file was used, by path only for `.env`
+- which model will be used for ZDR, default `gpt-5.5`
+- reminder that keys were not printed or committed
+- exact command to rerun with the same choice

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -82,14 +82,33 @@ State plainly: **no restart needed** — `/reload-plugins` loads the skills into
 this session. Only if the skills still don't appear afterward should they fully
 restart Claude Code.
 
-### 5. Verify
+### 5. Hand off to onboarding
+
+Once `/reload-plugins` succeeds, the next user-typed command is:
+
+```
+/understudy:onboard
+```
+
+This matters: plugin install only makes the skills visible. Onboarding creates
+the durable `~/.understudy/profile.json`, starts or verifies the first local
+Understudy, and refreshes `~/.understudy/agent-card.json` so future Claude Code
+turns can answer "is my understudy active and how do I talk to it?" without
+guessing.
+
+The agent cannot run `/understudy:onboard` as a slash command on the user's
+behalf. Surface it as the immediate next step and offer to continue once the
+user invokes it.
+
+### 6. Verify
 
 ```bash
 claude plugin list --json
 ```
 
 Confirm `understudy@understudy-skills` is enabled, and confirm to the developer
-that `/understudy` (and the other eight skills) are now available.
+that `/understudy`, `/understudy:onboard`, and the other skills are now
+available.
 
 ## Fallback: fully interactive path
 
@@ -121,4 +140,5 @@ repo-local skills.
 
 End with: whether the plugin was already installed / just installed / shown for
 manual run; the exact activation step (`/reload-plugins`); an explicit
-restart-or-not statement (not needed); and the verification result.
+restart-or-not statement (not needed); the next onboarding command
+(`/understudy:onboard`); and the verification result.

--- a/skills/manage-local-models/SKILL.md
+++ b/skills/manage-local-models/SKILL.md
@@ -63,8 +63,24 @@ locations and registry links are in [`reference.md`](reference.md).
 3. **Choose source + format for the runtime.** Ollama library (simplest, GGUF,
    no HF token for Gemma); Hugging Face GGUF (llama.cpp / LM Studio); MLX builds
    (Apple Silicon). Quantization/format primer in [`reference.md`](reference.md).
-4. **Confirm the size, then background the pull.** State exact GB and ETA, get
-   the go-ahead, run the download in the background, and move on to other work.
+4. **Confirm the size, then use the skill-owned pull helper.** For the
+   Understudy verified MLX ladder, do not send the user to a CLI command or the
+   installer. Resolve the script relative to this skill directory and run it
+   after approval:
+   ```bash
+   node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit
+   ```
+   Use `--dry-run` first when you need to show destination/log paths without
+   downloading:
+   ```bash
+   node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit --dry-run
+   ```
+   The helper downloads signed per-file URLs from
+   `models.understudylabs.com`, writes into `~/.understudy/models`, verifies
+   sizes and hashes when present, and logs progress/ETA to
+   `~/.understudy/agent-tools/logs/model-pull-*.log`. For non-Understudy
+   sources, use the native runtime pull (`ollama pull`, `hf download`, LM
+   Studio) and keep the same approval boundary.
 5. **Verify + record.** Once cached, run a one-line generation to confirm it
    loads and does tool calls if the workload needs them. Append the model to
    `local_models` in the profile (id, runtime, quant, size, date).

--- a/skills/manage-local-models/reference.md
+++ b/skills/manage-local-models/reference.md
@@ -80,6 +80,20 @@ Cloudflare delivery note: public installation uses stable session endpoints from
 per-file URLs; publish the session endpoint, not the expiring object URLs. R2
 remains the durable object source.
 
+Skill-owned pull helper:
+
+```bash
+cd /path/to/skills/manage-local-models
+node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit --dry-run
+node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit
+```
+
+The helper writes verified snapshots to `~/.understudy/models/<model-id>` and
+logs to `~/.understudy/agent-tools/logs/model-pull-*.log`. Use
+`gemma-4-e4b-it-mlx-vlm-4bit` for the first quality climb. It is intentionally a
+skill helper, not a public CLI surface; the coding agent should request approval
+with the model id, source, and GB before running it.
+
 Remote graduation note: when a local rung is too small, use
 [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) to
 run `understudy login --email <developer-email>`, store the API key through the

--- a/skills/manage-local-models/reference.md
+++ b/skills/manage-local-models/reference.md
@@ -69,11 +69,13 @@ or graduate remote when local quality is the bottleneck.
 |---|---|---|---|
 | Gemma 4 E2B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit` | Default onboarding rung. About 3.3 GB; verified local generation, Pi serving, and logprobs/top-logprobs. |
 | Gemma 4 E4B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit` | First climb when E2B understands the task but lacks quality. About 4.8 GB; verified signed snapshot delivery. |
-| Gemma 4 E2B BF16 | `mlx_vlm.server` | Internal/local profiling until a signed session is published | Same model, less quantization loss. About 9.5 GB; use to profile quality/perf when the 4-bit model is close. |
-| Gemma 4 12B | MLX conversion or remote | `google/gemma-4-12B-it` / gateway route | Laptop-plus rung for harder reasoning or multimodal work. Use remote if memory is tight. |
+| Gemma 4 12B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit` | M4/M5 MacBook Pro or high-RAM Air rung when E4B has the right behavior but not enough depth. About 6.3 GB; verified generation plus OpenAI-compatible logprobs/top-logprobs. |
+| Gemma 4 12B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16` | Quality/perf profiling rung on larger-memory Macs. About 22 GB; use when quantization may be the bottleneck. |
+| Gemma 4 26B A4B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit` | MoE-style local climb for strong quality with lower active-parameter cost. About 14 GB; verified generation plus logprobs/top-logprobs. |
+| Gemma 4 31B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-4bit` | Workstation/high-memory local rung when dense capacity matters. About 17 GB; verified generation plus logprobs/top-logprobs. |
 | Nemotron 3 Nano 4B | MLX / GGUF / remote | NVIDIA source or verified snapshot | Alternate edge rung when agentic reasoning or tool behavior beats Gemma on the workload. |
 | Nemotron 3 Nano 30B-A3B | MLX/GGUF on 32 GB+ or remote | NVIDIA source or gateway route | MoE climb when you need stronger reasoning while keeping active-parameter speed. |
-| Super / Ultra / 31B dense | Remote or workstation | Understudy gateway / provider route | Use when local cannot meet the quality bar or the Mac does not fit the weights comfortably. |
+| Super / Ultra | Remote or workstation | Understudy gateway / provider route | Use when local cannot meet the quality bar or the Mac does not fit the weights comfortably. |
 
 Cloudflare delivery note: public installation uses stable session endpoints from
 `models.understudylabs.com`. Each session response contains short-lived signed
@@ -90,7 +92,8 @@ node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit
 
 The helper writes verified snapshots to `~/.understudy/models/<model-id>` and
 logs to `~/.understudy/agent-tools/logs/model-pull-*.log`. Use
-`gemma-4-e4b-it-mlx-vlm-4bit` for the first quality climb. It is intentionally a
+`gemma-4-e4b-it-mlx-vlm-4bit` for the first quality climb, then
+`gemma-4-12b-it-mlx-vlm-4bit` before jumping to remote. It is intentionally a
 skill helper, not a public CLI surface; the coding agent should request approval
 with the model id, source, and GB before running it.
 

--- a/skills/manage-local-models/scripts/pull-understudy-snapshot.mjs
+++ b/skills/manage-local-models/scripts/pull-understudy-snapshot.mjs
@@ -21,6 +21,34 @@ const VERIFIED_MODELS = {
     approxGb: 4.8,
     loader: "mlx_vlm",
   },
+  "gemma-4-12b-it-mlx-vlm-4bit": {
+    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit&ttl=21600",
+    destName: "gemma-4-12b-it-mlx-vlm-4bit",
+    name: "Gemma 4 12B IT MLX-VLM 4-bit",
+    approxGb: 6.3,
+    loader: "mlx_vlm",
+  },
+  "gemma-4-12b-it-mlx-vlm-bf16": {
+    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16&ttl=21600",
+    destName: "gemma-4-12b-it-mlx-vlm-bf16",
+    name: "Gemma 4 12B IT MLX-VLM BF16",
+    approxGb: 22,
+    loader: "mlx_vlm",
+  },
+  "gemma-4-26b-a4b-it-mlx-vlm-4bit": {
+    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit&ttl=21600",
+    destName: "gemma-4-26b-a4b-it-mlx-vlm-4bit",
+    name: "Gemma 4 26B A4B IT MLX-VLM 4-bit",
+    approxGb: 14,
+    loader: "mlx_vlm",
+  },
+  "gemma-4-31b-it-mlx-vlm-4bit": {
+    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-4bit&ttl=21600",
+    destName: "gemma-4-31b-it-mlx-vlm-4bit",
+    name: "Gemma 4 31B IT MLX-VLM 4-bit",
+    approxGb: 17,
+    loader: "mlx_vlm",
+  },
 };
 
 function usage() {

--- a/skills/manage-local-models/scripts/pull-understudy-snapshot.mjs
+++ b/skills/manage-local-models/scripts/pull-understudy-snapshot.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createWriteStream, existsSync, mkdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+const VERIFIED_MODELS = {
+  "gemma-4-e2b-it-mlx-vlm-4bit": {
+    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit&ttl=21600",
+    destName: "gemma-4-e2b-it-mlx-vlm-4bit",
+    name: "Gemma 4 E2B IT MLX-VLM 4-bit",
+    approxGb: 3.3,
+    loader: "mlx_vlm",
+  },
+  "gemma-4-e4b-it-mlx-vlm-4bit": {
+    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit&ttl=21600",
+    destName: "gemma-4-e4b-it-mlx-vlm-4bit",
+    name: "Gemma 4 E4B IT MLX-VLM 4-bit",
+    approxGb: 4.8,
+    loader: "mlx_vlm",
+  },
+};
+
+function usage() {
+  console.log(`Usage: node pull-understudy-snapshot.mjs --model <id> [--dest <dir>] [--session-url <url>] [--dry-run]
+
+Verified ids:
+  ${Object.keys(VERIFIED_MODELS).join("\n  ")}
+
+Downloads signed Understudy model snapshot files into ~/.understudy/models/<id>
+by default. This is a skill helper, not a public CLI command.`);
+}
+
+function parseArgs(argv) {
+  const args = { dryRun: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--model") {
+      args.model = argv[++i];
+    } else if (arg === "--dest") {
+      args.dest = argv[++i];
+    } else if (arg === "--session-url") {
+      args.sessionUrl = argv[++i];
+    } else if (arg === "--log-dir") {
+      args.logDir = argv[++i];
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function nowCompact() {
+  return new Date().toISOString().replace(/[-:]/g, "").replace(/\..+$/, "Z");
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return "unknown";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${value.toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+function formatEta(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return "unknown";
+  if (seconds < 60) return `${Math.ceil(seconds)}s`;
+  if (seconds < 3600) return `${Math.ceil(seconds / 60)}m`;
+  return `${Math.ceil(seconds / 3600)}h`;
+}
+
+function logLine(logFile, message) {
+  const line = `${new Date().toISOString()} ${message}`;
+  console.log(line);
+  if (logFile) {
+    writeFileSync(logFile, `${line}\n`, { flag: "a", mode: 0o600 });
+  }
+}
+
+async function getContentLength(url) {
+  try {
+    const response = await fetch(url, { method: "HEAD" });
+    if (!response.ok) return null;
+    const value = response.headers.get("content-length");
+    return value ? Number(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`session request failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+function fileRows(manifest) {
+  if (!manifest || !Array.isArray(manifest.files)) {
+    throw new Error("session manifest must include files[]");
+  }
+  return manifest.files.map((file) => ({
+    name: file.name || file.path,
+    url: file.url,
+    size: Number(file.size_bytes ?? file.size ?? 0) || null,
+    sha256: file.sha256 || null,
+  }));
+}
+
+function safeTarget(dest, name) {
+  if (isAbsolute(name)) {
+    throw new Error(`manifest file path must be relative: ${name}`);
+  }
+  const root = resolve(dest);
+  const target = resolve(root, name);
+  const rel = relative(root, target);
+  if (rel === ".." || rel.startsWith(`..${sep}`)) {
+    throw new Error(`manifest file path escapes destination: ${name}`);
+  }
+  return target;
+}
+
+async function downloadFile({ row, target, logFile }) {
+  mkdirSync(dirname(target), { recursive: true });
+  const expectedSize = row.size || (await getContentLength(row.url));
+  if (existsSync(target) && expectedSize && statSync(target).size === expectedSize) {
+    logLine(logFile, `cached ${row.name} (${expectedSize} bytes)`);
+    return { name: row.name, bytes: expectedSize, cached: true };
+  }
+  if (existsSync(target) && !expectedSize && statSync(target).size > 0) {
+    logLine(logFile, `cached ${row.name}`);
+    return { name: row.name, bytes: statSync(target).size, cached: true };
+  }
+
+  const partial = `${target}.part`;
+  rmSync(partial, { force: true });
+  logLine(logFile, `downloading ${row.name}${expectedSize ? ` (${expectedSize} bytes)` : ""}`);
+  const response = await fetch(row.url);
+  if (!response.ok || !response.body) {
+    throw new Error(`download failed for ${row.name}: ${response.status} ${response.statusText}`);
+  }
+  const startedAt = Date.now();
+  let lastProgressAt = startedAt;
+  let downloaded = 0;
+  const hash = row.sha256 ? createHash("sha256") : null;
+  const progress = new Transform({
+    transform(chunk, _encoding, callback) {
+      downloaded += chunk.length;
+      if (hash) hash.update(chunk);
+      const now = Date.now();
+      if (expectedSize && (now - lastProgressAt > 5000 || downloaded === expectedSize)) {
+        const elapsedSeconds = Math.max((now - startedAt) / 1000, 0.001);
+        const bytesPerSecond = downloaded / elapsedSeconds;
+        const remainingSeconds = (expectedSize - downloaded) / bytesPerSecond;
+        logLine(
+          logFile,
+          `progress ${row.name} ${formatBytes(downloaded)}/${formatBytes(expectedSize)} eta=${formatEta(remainingSeconds)}`,
+        );
+        lastProgressAt = now;
+      }
+      callback(null, chunk);
+    },
+  });
+  await pipeline(Readable.fromWeb(response.body), progress, createWriteStream(partial, { mode: 0o600 }));
+  const actualSize = statSync(partial).size;
+  if (expectedSize && actualSize !== expectedSize) {
+    rmSync(partial, { force: true });
+    throw new Error(`size mismatch for ${row.name}: got ${actualSize}, expected ${expectedSize}`);
+  }
+  if (hash) {
+    const actualSha = hash.digest("hex");
+    if (actualSha !== row.sha256) {
+      rmSync(partial, { force: true });
+      throw new Error(`sha256 mismatch for ${row.name}: got ${actualSha}, expected ${row.sha256}`);
+    }
+  }
+  renameSync(partial, target);
+  return { name: row.name, bytes: actualSize, cached: false };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    usage();
+    return;
+  }
+  if (!args.model) {
+    throw new Error("--model is required");
+  }
+  const model = VERIFIED_MODELS[args.model];
+  if (!model && !args.sessionUrl) {
+    throw new Error(`unknown verified model id: ${args.model}`);
+  }
+  const modelInfo = model || {
+    sessionUrl: args.sessionUrl,
+    destName: args.model,
+    name: args.model,
+    approxGb: null,
+    loader: null,
+  };
+  const dest = args.dest || join(homedir(), ".understudy", "models", modelInfo.destName);
+  const logDir = args.logDir || join(homedir(), ".understudy", "agent-tools", "logs");
+  mkdirSync(logDir, { recursive: true });
+  const logFile = join(logDir, `model-pull-${modelInfo.destName}-${nowCompact()}.log`);
+
+  logLine(logFile, `model=${args.model}`);
+  logLine(logFile, `name=${modelInfo.name}`);
+  logLine(logFile, `session=${args.sessionUrl || modelInfo.sessionUrl}`);
+  logLine(logFile, `dest=${dest}`);
+  if (modelInfo.approxGb) logLine(logFile, `approx_gb=${modelInfo.approxGb}`);
+  if (args.dryRun) {
+    logLine(logFile, "dry_run=true");
+    console.log(JSON.stringify({ model: args.model, dest, sessionUrl: args.sessionUrl || modelInfo.sessionUrl, logFile }, null, 2));
+    return;
+  }
+
+  mkdirSync(dest, { recursive: true });
+  const manifest = await fetchJson(args.sessionUrl || modelInfo.sessionUrl);
+  const rows = fileRows(manifest);
+  const results = [];
+  for (const row of rows) {
+    if (!row.name || !row.url) {
+      throw new Error("manifest file entries must include name/path and url");
+    }
+    results.push(await downloadFile({ row, target: safeTarget(dest, row.name), logFile }));
+  }
+
+  const metadata = {
+    schema_version: "understudy.model_snapshot.v1",
+    model_id: args.model,
+    name: modelInfo.name,
+    loader: modelInfo.loader,
+    session_url: args.sessionUrl || modelInfo.sessionUrl,
+    pulled_at: new Date().toISOString(),
+    destination: dest,
+    files: results,
+  };
+  writeFileSync(join(dest, ".understudy-snapshot.json"), `${JSON.stringify(metadata, null, 2)}\n`, { mode: 0o600 });
+  logLine(logFile, `complete files=${results.length} dest=${dest}`);
+  console.log(JSON.stringify({ model: args.model, dest, logFile, files: results.length }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(`understudy model pull failed: ${error.message}`);
+  process.exit(1);
+});

--- a/skills/mlx-arena/SKILL.md
+++ b/skills/mlx-arena/SKILL.md
@@ -179,15 +179,24 @@ with `UNDERSTUDY_CLEANUP_PREFIXES="mlx-arena mlx-e2e"` or
 When iTerm/Ghostty/Terminal opens and immediately exits, rerun in debug mode:
 
 ```bash
-UNDERSTUDY_DEBUG=1 LAB=~/.understudy/agent-tools \
+UNDERSTUDY_DEBUG=1 UNDERSTUDY_WINDOW_HOLD=1 LAB=~/.understudy/agent-tools \
   skills/mlx-arena/arena.sh first-window
 ```
 
 Debug mode writes an action trace to
 `~/.understudy/agent-tools/.understudy/local-model-lab/arena/logs/actions.log`.
-Every launched terminal command also writes a
-`window-YYYYMMDDTHHMMSSZ.log` in the same directory and keeps the terminal open
-on command failure.
+Every launched terminal command also writes two files in the same directory:
+`window-launch-YYYYMMDDTHHMMSSZ.log` from the parent process before iTerm opens,
+and `window-YYYYMMDDTHHMMSSZ.log` from inside the spawned terminal. The launch
+log records cwd, LAB, tmux sessions, listeners, AppleScript output, and a
+redacted command fingerprint. `UNDERSTUDY_WINDOW_HOLD=1` keeps the terminal open
+even when the command exits with status 0.
+
+For a quick post-failure snapshot:
+
+```bash
+LAB=~/.understudy/agent-tools skills/mlx-arena/arena.sh diagnose
+```
 
 ## Blind-vote mode — the Efficient-Intelligence game
 

--- a/skills/mlx-arena/SKILL.md
+++ b/skills/mlx-arena/SKILL.md
@@ -53,7 +53,9 @@ custom provider in `~/.pi/agent/models.json` (`api: openai-completions`).
 - **One model per port.** Each `mlx_lm.server` loads one model and holds it in
   unified memory. Two 4-bit ~4B models fit comfortably on 16 GB+; check free RAM
   before adding a third.
-- **Tear down when done** (`arena.sh down`) to free memory.
+- **Tear down when done** (`arena.sh down`) to free memory. If a terminal window
+  flashed and disappeared, or old generators are still listening, run
+  `arena.sh cleanup --dry-run` first and then `arena.sh cleanup --force`.
 
 ## Flow
 
@@ -159,6 +161,34 @@ skills/mlx-arena/arena.sh play
    If quality is simply too low, climb the model ladder or route remote/hybrid via
    [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
 
+## Cleanup and Debug Mode
+
+Use cleanup before retesting a failed installer or after any crashy terminal
+handoff:
+
+```bash
+LAB=~/.understudy/agent-tools skills/mlx-arena/arena.sh cleanup --dry-run
+LAB=~/.understudy/agent-tools skills/mlx-arena/arena.sh cleanup --force
+```
+
+Cleanup kills tmux sessions matching the current `SESSION` prefix and the default
+`mlx-arena` prefix, plus MLX listeners on the configured arena ports. Override
+with `UNDERSTUDY_CLEANUP_PREFIXES="mlx-arena mlx-e2e"` or
+`UNDERSTUDY_CLEANUP_PORTS="8081 8082"` when debugging another install.
+
+When iTerm/Ghostty/Terminal opens and immediately exits, rerun in debug mode:
+
+```bash
+UNDERSTUDY_DEBUG=1 LAB=~/.understudy/agent-tools \
+  skills/mlx-arena/arena.sh first-window
+```
+
+Debug mode writes an action trace to
+`~/.understudy/agent-tools/.understudy/local-model-lab/arena/logs/actions.log`.
+Every launched terminal command also writes a
+`window-YYYYMMDDTHHMMSSZ.log` in the same directory and keeps the terminal open
+on command failure.
+
 ## Blind-vote mode — the Efficient-Intelligence game
 
 [`blind_arena.ts`](blind_arena.ts) is the interactive, blind A/B version of the
@@ -262,7 +292,7 @@ try RLM, climb models, or route hybrid/remote).
 
 ## References
 
-- [`arena.sh`](arena.sh) — the launcher/controller (`first|first-window|play|up|ask|left|right|capture|logs|status|down|attach`).
+- [`arena.sh`](arena.sh) — the launcher/controller (`first|first-window|play|up|ask|left|right|capture|logs|status|down|cleanup|attach`).
 - [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) — score a model on a frozen eval.
 - [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md) — Gemma & Nemotron variants and hardware fit.
 - [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md) — acquiring/curating local weights.

--- a/skills/mlx-arena/SKILL.md
+++ b/skills/mlx-arena/SKILL.md
@@ -47,9 +47,11 @@ custom provider in `~/.pi/agent/models.json` (`api: openai-completions`).
 - **No weight download without approval + a size cap.** Name the exact MLX repo,
   quantization, and GB first. Default to the **smallest model that is reasonable
   for the task**, not blindly to the smallest model in the family.
-- **Local-first, no upload.** Weights download from Hugging Face; prompts and
-  outputs stay on the machine. No token is required for public `mlx-community`
-  repos (a `HF_TOKEN` only raises rate limits).
+- **Local-first, no upload.** The verified first rung downloads from signed
+  Understudy snapshot sessions into `~/.understudy/models`; prompts and outputs
+  stay on the machine. No token is required for the signed snapshots. If you
+  intentionally use a public Hugging Face repo, a `HF_TOKEN` only raises rate
+  limits unless the model is gated.
 - **One model per port.** Each `mlx_lm.server` loads one model and holds it in
   unified memory. Two 4-bit ~4B models fit comfortably on 16 GB+; check free RAM
   before adding a third.
@@ -61,25 +63,31 @@ custom provider in `~/.pi/agent/models.json` (`api: openai-completions`).
 
 ### First out-of-box run
 
-For a new user, start with the verified first rung and open it in Pi immediately:
+For a new user, start with the verified first rung. If it is not already cached,
+route to [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md),
+ask approval for the ~3.3 GB snapshot, and run this skill helper from the
+`manage-local-models` skill directory:
+
+```bash
+node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit
+```
+
+Then open it in Pi:
 
 ```bash
 skills/mlx-arena/arena.sh first
-# or, on macOS, open the first Understudy in a distinct Terminal.app window:
-skills/mlx-arena/arena.sh first-window
 ```
 
 This starts a branded tmux loading screen, serves the Understudy-verified
 `google/gemma-4-e2b-it` 4-bit MLX-VLM snapshot with `mlx_vlm.server`, then
 replaces the loader with Pi so the user sees: **their first local Understudy is
 ready**. It also creates/updates the local Pi provider entry in
-`~/.pi/agent/models.json`. `first-window` does the same work but opens a
-separate macOS Terminal window attached to the first-run tmux session, so the
-user sees the local Understudy load and then lands in Pi without staying in the
-agent's shell. When a coding agent invokes this, prefer `first-window` and
-`play-window`; always report the follow-along command (`tmux attach -t
-mlx-arena-first` or `tmux attach -t mlx-arena-play`) so the user can watch the
-same session while the agent sends prompts.
+`~/.pi/agent/models.json`. Prefer coaching the user to open their own terminal
+and attach to the tmux session over auto-opening iTerm/Ghostty/Terminal from the
+installer. If they explicitly ask the coding agent to open a new window, use
+`first-window` / `play-window` and always report the follow-along command
+(`tmux attach -t mlx-arena-first` or `tmux attach -t mlx-arena-play`) so the
+user can watch the same session while the agent sends prompts.
 
 Verified snapshot locations:
 
@@ -123,8 +131,8 @@ skills/mlx-arena/arena.sh play
    ```
 3. **Download the first model** from the signed Understudy snapshot session:
    ```bash
-   curl -fsSL 'https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit' -o /tmp/understudy-model-session.json
-   # install.sh performs the manifest download + signed file sync automatically.
+   cd skills/manage-local-models
+   node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit
    ```
 4. **Wire Pi** — `arena.sh first` creates the first `mlx-gemma4` provider
    automatically. For later side-by-side local arenas, add one provider per model
@@ -246,8 +254,8 @@ chooses BYO `.env` keys, the Understudy ZDR gateway route, or local-only skip.
 For Understudy ZDR, the installer clears local provider-key env vars and sets
 `UNDERSTUDY_FALLBACK_MODEL=gpt-5.5` by default.
 
-Easiest bring-up (downloads the default model if missing, serves it, launches the
-branded game in tmux):
+Easiest bring-up after the model is cached (serves it, launches the branded game
+in tmux):
 
 ```bash
 skills/mlx-arena/arena.sh first    # first verified local model in Pi

--- a/skills/mlx-arena/SKILL.md
+++ b/skills/mlx-arena/SKILL.md
@@ -211,7 +211,7 @@ fragile:
 1. Use an existing OpenAI-compatible AI gateway if `FRONTIER_BASE_URL`,
    `AI_GATEWAY_BASE_URL`, or `OPENAI_BASE_URL` is set. Use
    `FRONTIER_API_KEY`, `AI_GATEWAY_API_KEY`, or `OPENAI_API_KEY` as available.
-2. Else use an existing `OPENAI_API_KEY` with `gpt-5.1` unless
+2. Else use an existing `OPENAI_API_KEY` with `gpt-5.5` unless
    `FRONTIER_MODEL`/`OPENAI_MODEL` overrides it.
 3. Else use an existing `ANTHROPIC_LOCAL_KEY` or `ANTHROPIC_API_KEY` with
    `claude-opus-4-8` unless `FRONTIER_MODEL`/`ANTHROPIC_MODEL` overrides it.
@@ -223,6 +223,12 @@ fragile:
    `UNDERSTUDY_FALLBACK_MODEL=glm-5.1` through `understudy login`.
 
 Disable fallback only for debugging with `FRONTIER_FALLBACK=0`.
+
+Before a first-run duel, route through
+[`../choose-frontier-keys/SKILL.md`](../choose-frontier-keys/SKILL.md). The user
+chooses BYO `.env` keys, the Understudy ZDR gateway route, or local-only skip.
+For Understudy ZDR, the installer clears local provider-key env vars and sets
+`UNDERSTUDY_FALLBACK_MODEL=gpt-5.5` by default.
 
 Easiest bring-up (downloads the default model if missing, serves it, launches the
 branded game in tmux):
@@ -236,8 +242,8 @@ skills/mlx-arena/arena.sh play
 Or run it directly (Node ≥22.6 runs the `.ts` via native type-stripping):
 
 ```bash
-LOCAL_BASE=http://127.0.0.1:8081/v1 LOCAL_MODEL=.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit \
-CATEGORY=coding FRONTIER_MODEL=gpt-5.1 \
+LOCAL_BASE=http://127.0.0.1:8081/v1 LOCAL_MODEL=~/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit \
+CATEGORY=coding FRONTIER_MODEL=gpt-5.5 FRONTIER_REASONING_EFFORT=none FRONTIER_MAX_COMPLETION_TOKENS=768 \
 node --experimental-strip-types skills/mlx-arena/blind_arena.ts
 ```
 

--- a/skills/mlx-arena/SKILL.md
+++ b/skills/mlx-arena/SKILL.md
@@ -149,14 +149,21 @@ skills/mlx-arena/arena.sh play
    tmux paste-buffer -t mlx-arena-first
    tmux send-keys -t mlx-arena-first Enter
    ```
-6. **Decide the next intervention.** Compare answers, latency, tone, and reasoning
-   behavior. If the model is already good enough, promote it to
-   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) for a
-   scored, frozen-eval verdict. If it fails because the prompt/harness is weak,
-   route to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md). If
-   the task is a workflow with tool state, build a
+6. **Move from stock duel to real work.** Compare answers, latency, tone, and
+   reasoning behavior, then immediately ask the developer to pick a real problem
+   or let the agent find data in the current repo: eval files, prompts, traces,
+   fixtures, tickets, transcripts, golden outputs, failing tests, or API/tool
+   logs. The next step is to freeze a task-specific eval/environment and try to
+   make the local Understudy beat the frontier on that slice.
+
+7. **Route the task-specific hill climb.** If the slice is answer-only, promote
+   it to [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) for
+   scored frontier-vs-local evaluation. If the task is a workflow with tool
+   state, build a
    [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md).
-   If the small model needs bounded substeps behind the same external call, use
+   If the prompt/harness is weak, route to
+   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md). If the small
+   model needs bounded substeps behind the same external call, use
    [`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md).
    If quality is simply too low, climb the model ladder or route remote/hybrid via
    [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).

--- a/skills/mlx-arena/SKILL.md
+++ b/skills/mlx-arena/SKILL.md
@@ -8,15 +8,17 @@ metadata:
     cli_required: false
 ---
 
-# MLX Arena — frontier vs. local, then hill-climb the local
+# MLX Arena — meet the local model, optionally compare it
 
-Put a **frontier model** head-to-head against a **small local model** on an
-**M-series Mac**, blind, and use the gap to **hill-climb the local model** until it
-is good enough to take over. The local side runs on **Apple MLX** ($0, private, no
+Open a **small local model** on an **M-series Mac** so the user can see and talk
+to their first Understudy. A frontier head-to-head is available, but it is an
+optional calibration surface, not the primary evidence loop. The main path is:
+prove local inference exists, then understand the user's real workload, profile
+its traces/data/code path, and run the local model against that frozen task.
+When a visible quality gap helps, put a **frontier model** head-to-head against
+the local model, blind. The local side runs on **Apple MLX** ($0, private, no
 cloud); the frontier is a single **swappable, provider-agnostic** config (Opus,
-GPT, GLM, …) — never a per-provider code path. The aim is *efficient intelligence*:
-prove how much of the work the free local model can do, and pay for the frontier
-only on the genuinely hard tail.
+GPT, GLM, …) — never a per-provider code path.
 
 The runnable core is the blind game [`blind_arena.ts`](blind_arena.ts) (TypeScript,
 run by Node ≥22.6 — no Python in the repo); the local
@@ -26,9 +28,11 @@ launcher. MLX does inference, the game is the surface; the scripts stay thin.
 
 This is the interactive sibling of
 [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md): the lab
-*scores* a model against a frozen eval; the arena lets you *feel* the frontier↔local
-gap by hand, then iterate on the local model. (Two local models can also be run
-side-by-side via `arena.sh up` when picking between local candidates.)
+*scores* a model against a frozen eval; the arena lets you *feel* the local model
+and, optionally, the frontier↔local gap by hand. Do not treat a stock duel as a
+substitute for understanding traces, prompts, datasets, and validators. (Two
+local models can also be run side-by-side via `arena.sh up` when picking between
+local candidates.)
 
 ## Why MLX (and Apple Silicon only)
 
@@ -97,6 +101,14 @@ Verified snapshot locations:
   `r2://understudy-model-snapshots/models/google/gemma-4-e2b-it/mlx-vlm-0.6.2/quant-4bit/`)
 - 4-bit E4B climb rung:
   `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit`
+- 4-bit 12B climb rung:
+  `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit`
+- BF16 12B profiling rung:
+  `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16`
+- 4-bit 26B A4B and 31B local high-memory rungs:
+  `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit`
+  and
+  `https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-4bit`
 - Public HTTPS delivery publishes stable session endpoints from
   `models.understudylabs.com`. Each session response contains short-lived signed
   per-file URLs; the same R2 prefix is the durable object source.
@@ -104,12 +116,23 @@ Verified snapshot locations:
 The 4-bit snapshot is about 3.3 GB, generated `I am ready as your local
 understudy.` in local testing, used about 3.6 GB peak memory, and served
 OpenAI-compatible chat completions with `logprobs` / `top_logprobs`. The E4B
-snapshot is about 4.8 GB and is the first signed quality climb. If the verified
-Gemma 4 snapshot is not reachable, use
+snapshot is about 4.8 GB and is the first signed quality climb. The verified 12B
+4-bit snapshot is about 6.3 GB on disk, the 12B BF16 profile is about 22 GB, the
+26B A4B 4-bit snapshot is about 14 GB, and the 31B 4-bit snapshot is about 17 GB;
+use these only after the workload profile shows the smaller rung is genuinely
+capacity-limited. If the verified Gemma 4 snapshot is not reachable, use
 `FIRST_REPO=mlx-community/gemma-3-1b-it-4bit FIRST_LOADER=mlx_lm
 skills/mlx-arena/arena.sh first` only as a fallback.
 
-After the first local prompt or two, move to the frontier head-to-head:
+After the first local prompt or two, prefer moving to workload understanding:
+
+```bash
+# route the coding agent to:
+/understudy:understand-workload
+```
+
+Use the frontier head-to-head only when it helps the user calibrate taste,
+demonstrate the quality gap, or generate hypotheses tied to a real task:
 
 ```bash
 skills/mlx-arena/arena.sh play
@@ -157,12 +180,13 @@ skills/mlx-arena/arena.sh play
    tmux paste-buffer -t mlx-arena-first
    tmux send-keys -t mlx-arena-first Enter
    ```
-6. **Move from stock duel to real work.** Compare answers, latency, tone, and
-   reasoning behavior, then immediately ask the developer to pick a real problem
-   or let the agent find data in the current repo: eval files, prompts, traces,
-   fixtures, tickets, transcripts, golden outputs, failing tests, or API/tool
-   logs. The next step is to freeze a task-specific eval/environment and try to
-   make the local Understudy beat the frontier on that slice.
+6. **Move from local proof to real work.** After the user sees local inference,
+   ask for a real problem or let the agent find data in the current repo: eval
+   files, prompts, traces, fixtures, tickets, transcripts, golden outputs,
+   failing tests, request logs, API/tool logs, or app routes. Route to
+   [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) to
+   profile the data and trace the request/response path before freezing evals.
+   If a stock duel was run, treat it as hypothesis generation only.
 
 7. **Route the task-specific hill climb.** If the slice is answer-only, promote
    it to [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) for
@@ -254,8 +278,8 @@ chooses BYO `.env` keys, the Understudy ZDR gateway route, or local-only skip.
 For Understudy ZDR, the installer clears local provider-key env vars and sets
 `UNDERSTUDY_FALLBACK_MODEL=gpt-5.5` by default.
 
-Easiest bring-up after the model is cached (serves it, launches the branded game
-in tmux):
+Easiest bring-up after the model is cached (serves the local model, then
+optionally launches the branded game in tmux):
 
 ```bash
 skills/mlx-arena/arena.sh first    # first verified local model in Pi
@@ -298,7 +322,7 @@ the final reveal names the actual route used.
 
 For real workloads, ground the questions in a captured trace
 ([`../understand-workload/SKILL.md`](../understand-workload/SKILL.md)). Treat Pi as
-the quick local-proof and gap-finding surface. To test whether the local model can
+the quick local-proof and optional gap-finding surface. To test whether the local model can
 take over the *whole* task (not just answer questions), build a
 [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md),
 then hill-climb it with the
@@ -314,11 +338,12 @@ in [`reference.md`](reference.md).
 
 ## Output Standard
 
-End with: task class; the first local rung and why it is the smallest reasonable
-choice; model repo, quant, GB, port, and RAM headroom; the tmux session name and
-how to attach/drive it; the first head-to-head comparison; and the recommended
-next intervention (score in run-local-model-lab, build simulated env, run GEPA,
-try RLM, climb models, or route hybrid/remote).
+End with: task class if known; the local rung and why it is the smallest
+reasonable choice; model repo, quant, GB, port, and RAM headroom; the tmux
+session name and how to attach/drive it; whether any head-to-head was run; and
+the recommended next workload-understanding or evidence action (profile traces,
+score in run-local-model-lab, build a real/simulated env, run GEPA, try RLM,
+climb models, or route hybrid/remote).
 
 ## References
 

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -19,6 +19,7 @@
 #   logs          tail both MLX server logs
 #   status        show server health + tmux session state
 #   down          tear everything down (servers + session)
+#   cleanup       remove stale Understudy tmux sessions and MLX listeners
 #   attach        attach your terminal to the arena (interactive)
 #
 # Config via env (defaults target this repo's local MLX venv layout):
@@ -28,6 +29,7 @@
 #   RIGHT_LABEL/RIGHT_REPO/RIGHT_PORT/RIGHT_PROVIDER
 #   SESSION      tmux session name               (default: mlx-arena)
 #   SYS_PROMPT   system prompt for both Pi panes
+#   UNDERSTUDY_DEBUG=1 writes $LAB/.understudy/local-model-lab/arena/logs/actions.log
 set -euo pipefail
 
 LAB="${LAB:-$PWD}"
@@ -39,6 +41,8 @@ LOGS="$STATE/logs"
 SYS_PROMPT="${SYS_PROMPT:-You are a helpful, concise assistant. Answer directly.}"
 UNDERSTUDY_TERMINAL_APP="${UNDERSTUDY_TERMINAL_APP:-auto}"
 UNDERSTUDY_TERMINAL_PROFILE="${UNDERSTUDY_TERMINAL_PROFILE:-}"
+UNDERSTUDY_DEBUG="${UNDERSTUDY_DEBUG:-0}"
+UNDERSTUDY_CLEANUP_PREFIXES="${UNDERSTUDY_CLEANUP_PREFIXES:-$SESSION mlx-arena}"
 
 # Two corners of the arena. Defaults: verified Gemma 4 E2B via mlx-vlm vs
 # smallest NVIDIA (Nemotron), MLX 4-bit. Stock mlx-community Gemma 4 E2B repos
@@ -65,8 +69,21 @@ FIRST_PORT="${FIRST_PORT:-8081}"
 FIRST_PROVIDER="${FIRST_PROVIDER:-mlx-gemma4-e2b}"
 FIRST_NAME="${FIRST_NAME:-Gemma 4 E2B 4-bit}"
 FIRST_LOADER="${FIRST_LOADER:-mlx_vlm}"
+UNDERSTUDY_CLEANUP_PORTS="${UNDERSTUDY_CLEANUP_PORTS:-$LEFT_PORT $RIGHT_PORT $FIRST_PORT}"
 
 mkdir -p "$LOGS"
+
+_now_utc() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+_debug_log() {
+  [ "$UNDERSTUDY_DEBUG" = "1" ] || [ "$UNDERSTUDY_DEBUG" = "true" ] || return 0
+  mkdir -p "$LOGS"
+  printf '%s %s\n' "$(_now_utc)" "$*" >>"$LOGS/actions.log"
+}
+_debug_echo() {
+  _debug_log "$*"
+  [ "$UNDERSTUDY_DEBUG" = "1" ] || [ "$UNDERSTUDY_DEBUG" = "true" ] || return 0
+  printf '  [debug] %s\n' "$*"
+}
 
 _need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1" >&2; exit 1; }; }
 _need_pi() {
@@ -109,6 +126,7 @@ _serve() { # label repo port loader
 _serve_with_loader() { # label repo port loader
   local label="$1" repo="$2" port="$3" loader="$4"
   if curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$port/v1/models" 2>/dev/null | grep -q 200; then
+    _debug_echo "serve skip label=$label port=$port reason=already-healthy"
     echo "  [$label] already serving on :$port"; return 0
   fi
   echo "  [$label] starting $loader $repo on :$port"
@@ -116,6 +134,7 @@ _serve_with_loader() { # label repo port loader
   local command_text log_path
   command_text="$(_server_command "$loader" "$repo" "$port")"
   log_path="$LOGS/srv-$label.log"
+  _debug_echo "serve start label=$label loader=$loader repo=$repo port=$port session=$server_session log=$log_path"
   tmux kill-session -t "$server_session" 2>/dev/null || true
   tmux new-session -d -s "$server_session" -n server \
     "mkdir -p $(printf %q "$LOGS"); exec $command_text >$(printf %q "$log_path") 2>&1"
@@ -124,11 +143,13 @@ _serve_with_loader() { # label repo port loader
 
 _wait_health() { # port label
   local port="$1" label="$2" i
+  _debug_echo "health wait label=$label port=$port"
   for i in $(seq 1 120); do
     [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$port/v1/models" 2>/dev/null)" = "200" ] \
-      && { echo "  [$label] healthy on :$port (${i}s)"; return 0; }
+      && { _debug_echo "health ok label=$label port=$port seconds=$i"; echo "  [$label] healthy on :$port (${i}s)"; return 0; }
     sleep 1
   done
+  _debug_echo "health failed label=$label port=$port log=$LOGS/srv-$label.log"
   echo "  [$label] FAILED to become healthy — see $LOGS/srv-$label.log" >&2; return 1
 }
 
@@ -265,15 +286,94 @@ cmd_status() {
 }
 
 cmd_down() {
+  _debug_echo "down session=$SESSION"
   tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux kill-session -t "${SESSION}-first" 2>/dev/null || true
+  tmux kill-session -t "${SESSION}-play" 2>/dev/null || true
   for f in "$STATE"/srv-*.session; do
-    [ -f "$f" ] && tmux kill-session -t "$(cat "$f")" 2>/dev/null || true
+    [ -f "$f" ] && { _debug_echo "down kill recorded server session=$(cat "$f") file=$f"; tmux kill-session -t "$(cat "$f")" 2>/dev/null || true; }
   done
   for f in "$STATE"/srv-*.pid; do [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null || true; done
   rm -f "$STATE"/srv-*.pid "$STATE"/srv-*.session
   echo "arena down (servers + session stopped)"
 }
 cmd_attach() { tmux attach -t "$SESSION"; }
+
+_cleanup_kill_tmux_prefixes() {
+  local dry_run="$1" name prefix killed=0
+  command -v tmux >/dev/null 2>&1 || return 0
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    for prefix in $UNDERSTUDY_CLEANUP_PREFIXES; do
+      case "$name" in
+        "$prefix"|"$prefix"-*)
+          _debug_echo "cleanup tmux session=$name prefix=$prefix dry_run=$dry_run"
+          if [ "$dry_run" = "1" ]; then
+            echo "  [cleanup] would kill tmux session $name"
+          else
+            tmux kill-session -t "$name" 2>/dev/null || true
+            echo "  [cleanup] killed tmux session $name"
+          fi
+          killed=$((killed + 1))
+          break
+          ;;
+      esac
+    done
+  done <<EOF
+$(tmux list-sessions -F '#S' 2>/dev/null || true)
+EOF
+  [ "$killed" -gt 0 ] || echo "  [cleanup] no matching tmux sessions"
+}
+
+_cleanup_kill_ports() {
+  local dry_run="$1" port pids pid command killed=0
+  command -v lsof >/dev/null 2>&1 || { echo "  [cleanup] lsof not found; skipping port cleanup"; return 0; }
+  for port in $UNDERSTUDY_CLEANUP_PORTS; do
+    pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    [ -n "$pids" ] || continue
+    for pid in $pids; do
+      command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+      case "$command" in
+        *mlx_lm*|*mlx_vlm*|*mlx-vlm*|*uvicorn*)
+          _debug_echo "cleanup port=$port pid=$pid command=$command dry_run=$dry_run"
+          if [ "$dry_run" = "1" ]; then
+            echo "  [cleanup] would kill MLX listener pid=$pid port=$port"
+          else
+            kill "$pid" 2>/dev/null || true
+            echo "  [cleanup] killed MLX listener pid=$pid port=$port"
+          fi
+          killed=$((killed + 1))
+          ;;
+        *)
+          _debug_echo "cleanup skip port=$port pid=$pid command=$command reason=not-mlx"
+          echo "  [cleanup] skipping non-MLX listener pid=$pid port=$port"
+          ;;
+      esac
+    done
+  done
+  [ "$killed" -gt 0 ] || echo "  [cleanup] no MLX listeners on ports: $UNDERSTUDY_CLEANUP_PORTS"
+}
+
+cmd_cleanup() {
+  local dry_run=0
+  case "${1:-}" in
+    --dry-run|-n) dry_run=1 ;;
+    ""|--force) ;;
+    *) echo "usage: $0 cleanup [--dry-run|--force]" >&2; exit 2 ;;
+  esac
+  mkdir -p "$LOGS"
+  _debug_echo "cleanup start dry_run=$dry_run prefixes=$UNDERSTUDY_CLEANUP_PREFIXES ports=$UNDERSTUDY_CLEANUP_PORTS logs=$LOGS"
+  echo "Understudy arena cleanup"
+  echo "  logs: $LOGS"
+  echo "  prefixes: $UNDERSTUDY_CLEANUP_PREFIXES"
+  echo "  ports: $UNDERSTUDY_CLEANUP_PORTS"
+  _cleanup_kill_tmux_prefixes "$dry_run"
+  _cleanup_kill_ports "$dry_run"
+  if [ "$dry_run" = "0" ]; then
+    rm -f "$STATE"/srv-*.pid "$STATE"/srv-*.session
+  fi
+  echo "cleanup complete"
+}
 
 _terminal_kind() {
   local requested="${UNDERSTUDY_TERMINAL_APP:-auto}"
@@ -315,18 +415,22 @@ _open_terminal_run() { # command
   echo "  [window] log: $log_path"
 
   kind="$(_terminal_kind)"
+  _debug_echo "window launch kind=$kind app=${UNDERSTUDY_TERMINAL_APP:-auto} log=$log_path command=$command_text"
   case "$kind" in
     ghostty)
       if command -v ghostty >/dev/null 2>&1; then
         nohup ghostty -e /bin/zsh -lc "$wrapped_command" >/dev/null 2>&1 &
+        _debug_echo "window opened kind=ghostty mode=cli"
         echo "  [window] opened Ghostty"
         return 0
       fi
       if open -Ra Ghostty 2>/dev/null; then
         open -na Ghostty --args -e /bin/zsh -lc "$wrapped_command"
+        _debug_echo "window opened kind=ghostty mode=open"
         echo "  [window] opened Ghostty"
         return 0
       fi
+      _debug_echo "window fallback reason=ghostty-not-found"
       echo "  [window] Ghostty not found; falling back to Terminal.app"
       ;;
     iterm)
@@ -338,6 +442,7 @@ tell application "iTerm2"
 end tell
 APPLESCRIPT
         then
+          _debug_echo "window opened kind=iterm app=iTerm2"
           echo "  [window] opened iTerm2"
           return 0
         fi
@@ -348,15 +453,18 @@ tell application "iTerm"
 end tell
 APPLESCRIPT
         then
+          _debug_echo "window opened kind=iterm app=iTerm"
           echo "  [window] opened iTerm"
           return 0
         fi
       fi
+      _debug_echo "window fallback reason=iterm-not-found-or-applescript-failed"
       echo "  [window] iTerm not found; falling back to Terminal.app"
       ;;
   esac
 
   command -v osascript >/dev/null 2>&1 || {
+    _debug_echo "window unable reason=osascript-not-found command=$command_text"
     echo "  [window] osascript not found; run: $command_text"
     return 0
   }
@@ -380,6 +488,7 @@ tell application "Terminal"
   end if
 end tell
 APPLESCRIPT
+  _debug_echo "window opened kind=terminal app=Terminal.app"
   echo "  [window] opened Terminal.app"
 }
 
@@ -497,6 +606,7 @@ case "${1:-up}" in
   logs) cmd_logs ;;
   status) cmd_status ;;
   down) cmd_down ;;
+  cleanup) shift; cmd_cleanup "$@" ;;
   attach) cmd_attach ;;
-  *) echo "usage: $0 {first|first-window|play|play-window|up|ask <text>|left <text>|right <text>|capture|logs|status|down|attach}" >&2; exit 2 ;;
+  *) echo "usage: $0 {first|first-window|play|play-window|up|ask <text>|left <text>|right <text>|capture|logs|status|down|cleanup [--dry-run|--force]|attach}" >&2; exit 2 ;;
 esac

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -443,6 +443,15 @@ cmd_down() {
   done
   for f in "$STATE"/srv-*.pid; do [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null || true; done
   rm -f "$STATE"/srv-*.pid "$STATE"/srv-*.session
+  # unset API keys from the tmux global environment (set by cmd_play)
+  for _var in ANTHROPIC_LOCAL_KEY ANTHROPIC_API_KEY OPENAI_API_KEY \
+              FRONTIER_API_KEY AI_GATEWAY_API_KEY FRONTIER_BASE_URL \
+              AI_GATEWAY_BASE_URL OPENAI_BASE_URL OPENAI_MODEL \
+              ANTHROPIC_MODEL AI_GATEWAY_MODEL UNDERSTUDY_FALLBACK_MODEL \
+              FRONTIER_FALLBACK FRONTIER_REASONING_EFFORT \
+              FRONTIER_MAX_COMPLETION_TOKENS; do
+    tmux setenv -gu "$_var" 2>/dev/null || true
+  done
   echo "arena down (servers + session stopped)"
 }
 cmd_attach() { tmux attach -t "$SESSION"; }
@@ -519,6 +528,11 @@ cmd_cleanup() {
   _cleanup_kill_ports "$dry_run"
   if [ "$dry_run" = "0" ]; then
     rm -f "$STATE"/srv-*.pid "$STATE"/srv-*.session
+    rm -f "$STATE"/window-env-*.sh
+  else
+    for _envf in "$STATE"/window-env-*.sh; do
+      [ -f "$_envf" ] && echo "  [cleanup] would remove $_envf"
+    done
   fi
   echo "cleanup complete"
 }

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -20,6 +20,7 @@
 #   status        show server health + tmux session state
 #   down          tear everything down (servers + session)
 #   cleanup       remove stale Understudy tmux sessions and MLX listeners
+#   diagnose      print log locations + recent launcher/tmux/listener state
 #   attach        attach your terminal to the arena (interactive)
 #
 # Config via env (defaults target this repo's local MLX venv layout):
@@ -31,6 +32,7 @@
 #   SESSION      tmux session name               (default: mlx-arena)
 #   SYS_PROMPT   system prompt for both Pi panes
 #   UNDERSTUDY_DEBUG=1 writes $LAB/.understudy/local-model-lab/arena/logs/actions.log
+#   UNDERSTUDY_WINDOW_HOLD=1 keeps launched terminal windows open after command exit
 set -euo pipefail
 
 LAB="${LAB:-${UNDERSTUDY_LAB:-$HOME/.understudy/agent-tools}}"
@@ -44,6 +46,7 @@ SYS_PROMPT="${SYS_PROMPT:-You are a helpful, concise assistant. Answer directly.
 UNDERSTUDY_TERMINAL_APP="${UNDERSTUDY_TERMINAL_APP:-auto}"
 UNDERSTUDY_TERMINAL_PROFILE="${UNDERSTUDY_TERMINAL_PROFILE:-}"
 UNDERSTUDY_DEBUG="${UNDERSTUDY_DEBUG:-0}"
+UNDERSTUDY_WINDOW_HOLD="${UNDERSTUDY_WINDOW_HOLD:-0}"
 UNDERSTUDY_CLEANUP_PREFIXES="${UNDERSTUDY_CLEANUP_PREFIXES:-$SESSION mlx-arena}"
 
 # Two corners of the arena. Defaults: verified Gemma 4 E2B via mlx-vlm vs
@@ -76,15 +79,24 @@ UNDERSTUDY_CLEANUP_PORTS="${UNDERSTUDY_CLEANUP_PORTS:-$LEFT_PORT $RIGHT_PORT $FI
 mkdir -p "$LOGS"
 
 _now_utc() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 _debug_log() {
-  [ "$UNDERSTUDY_DEBUG" = "1" ] || [ "$UNDERSTUDY_DEBUG" = "true" ] || return 0
+  _truthy "$UNDERSTUDY_DEBUG" || return 0
   mkdir -p "$LOGS"
   printf '%s %s\n' "$(_now_utc)" "$*" >>"$LOGS/actions.log"
 }
 _debug_echo() {
   _debug_log "$*"
-  [ "$UNDERSTUDY_DEBUG" = "1" ] || [ "$UNDERSTUDY_DEBUG" = "true" ] || return 0
+  _truthy "$UNDERSTUDY_DEBUG" || return 0
   printf '  [debug] %s\n' "$*"
+}
+_cleanup_ports() {
+  printf '%s\n' $UNDERSTUDY_CLEANUP_PORTS | awk 'NF && !seen[$0]++'
 }
 
 _need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1" >&2; exit 1; }; }
@@ -377,6 +389,39 @@ cmd_cleanup() {
   echo "cleanup complete"
 }
 
+cmd_diagnose() {
+  mkdir -p "$LOGS"
+  echo "Understudy arena diagnostics"
+  echo "  LAB: $LAB"
+  echo "  STATE: $STATE"
+  echo "  LOGS: $LOGS"
+  echo "  SESSION: $SESSION"
+  echo "  terminal app: ${UNDERSTUDY_TERMINAL_APP:-auto}"
+  echo "  debug: $UNDERSTUDY_DEBUG"
+  echo "  window hold: $UNDERSTUDY_WINDOW_HOLD"
+  echo
+  echo "Recent launch logs:"
+  ls -1t "$LOGS"/window-launch-*.log 2>/dev/null | head -5 || echo "  none"
+  echo
+  echo "Recent window command logs:"
+  ls -1t "$LOGS"/window-*.log 2>/dev/null | grep -v '/window-launch-' | head -5 || echo "  none"
+  echo
+  echo "Recent install logs:"
+  ls -1t "$LAB"/logs/install-*.log 2>/dev/null | head -5 || echo "  none"
+  echo
+  echo "tmux sessions:"
+  tmux list-sessions 2>/dev/null || echo "  none"
+  echo
+  echo "Configured port listeners:"
+  for port in $(_cleanup_ports); do
+    echo "  :$port"
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || echo "    none"
+  done
+  echo
+  echo "To collect the newest launcher log:"
+  echo "  tail -120 \"\$(ls -1t \"$LOGS\"/window-launch-*.log | head -1)\""
+}
+
 _terminal_kind() {
   local requested="${UNDERSTUDY_TERMINAL_APP:-auto}"
   case "$requested" in
@@ -393,6 +438,61 @@ _terminal_kind() {
     ghostty|Ghostty) echo "ghostty" ;;
     *) echo "terminal" ;;
   esac
+}
+
+_sha256_text() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf 'unavailable'
+  fi
+}
+
+_redact_command() {
+  printf '%s' "$1" | sed -E \
+    -e 's/(OPENAI_API_KEY|ANTHROPIC_API_KEY|ANTHROPIC_LOCAL_KEY|FRONTIER_API_KEY|AI_GATEWAY_API_KEY)=([^ ;]+)/\1=<redacted>/g' \
+    -e 's/(Authorization: Bearer )[A-Za-z0-9._~+\/=-]+/\1<redacted>/g' \
+    -e 's/(api[_-]?key=)[A-Za-z0-9._~+\/=-]+/\1<redacted>/Ig'
+}
+
+_log_window_launch() { # launch-log terminal-kind command window-log
+  local launch_log="$1" kind="$2" command_text="$3" window_log="$4"
+  mkdir -p "$LOGS"
+  {
+    printf 'timestamp=%s\n' "$(_now_utc)"
+    printf 'terminal_kind=%s\n' "$kind"
+    printf 'requested_terminal_app=%s\n' "${UNDERSTUDY_TERMINAL_APP:-auto}"
+    printf 'term_program=%s\n' "${TERM_PROGRAM:-}"
+    printf 'shell=%s\n' "${SHELL:-}"
+    printf 'cwd=%s\n' "$(pwd)"
+    printf 'script=%s\n' "$0"
+    printf 'lab=%s\n' "$LAB"
+    printf 'state=%s\n' "$STATE"
+    printf 'logs=%s\n' "$LOGS"
+    printf 'session=%s\n' "$SESSION"
+    printf 'mlx_python=%s\n' "$MLX_PYTHON"
+    printf 'model_home=%s\n' "$UNDERSTUDY_MODEL_HOME"
+    printf 'window_log=%s\n' "$window_log"
+    printf 'debug=%s\n' "$UNDERSTUDY_DEBUG"
+    printf 'window_hold=%s\n' "$UNDERSTUDY_WINDOW_HOLD"
+    printf 'command_sha256=%s\n' "$(_sha256_text "$command_text")"
+    printf 'command_redacted=%s\n' "$(_redact_command "$command_text")"
+    printf 'has_OPENAI_API_KEY=%s\n' "$([ -n "${OPENAI_API_KEY:-}" ] && echo yes || echo no)"
+    printf 'has_ANTHROPIC_API_KEY=%s\n' "$([ -n "${ANTHROPIC_API_KEY:-}" ] && echo yes || echo no)"
+    printf 'has_ANTHROPIC_LOCAL_KEY=%s\n' "$([ -n "${ANTHROPIC_LOCAL_KEY:-}" ] && echo yes || echo no)"
+    printf 'has_FRONTIER_API_KEY=%s\n' "$([ -n "${FRONTIER_API_KEY:-}" ] && echo yes || echo no)"
+    printf 'has_AI_GATEWAY_API_KEY=%s\n' "$([ -n "${AI_GATEWAY_API_KEY:-}" ] && echo yes || echo no)"
+    printf '\n[tmux sessions]\n'
+    tmux list-sessions 2>&1 || true
+    printf '\n[port listeners]\n'
+    for port in $(_cleanup_ports); do
+      printf 'port %s: ' "$port"
+      lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>&1 || true
+    done
+    printf '\n[apple script output]\n'
+  } >"$launch_log"
 }
 
 _open_terminal_attach() { # tmux-session-name
@@ -428,69 +528,100 @@ _write_window_env_file() {
     printf 'export FRONTIER_FALLBACK=%q\n' "${FRONTIER_FALLBACK:-}"
     printf 'export FRONTIER_REASONING_EFFORT=%q\n' "${FRONTIER_REASONING_EFFORT:-}"
     printf 'export FRONTIER_MAX_COMPLETION_TOKENS=%q\n' "${FRONTIER_MAX_COMPLETION_TOKENS:-}"
+    printf 'export UNDERSTUDY_DEBUG=%q\n' "$UNDERSTUDY_DEBUG"
+    printf 'export UNDERSTUDY_WINDOW_HOLD=%q\n' "$UNDERSTUDY_WINDOW_HOLD"
+    printf 'export UNDERSTUDY_TERMINAL_APP=%q\n' "$UNDERSTUDY_TERMINAL_APP"
+    printf 'export UNDERSTUDY_TERMINAL_PROFILE=%q\n' "$UNDERSTUDY_TERMINAL_PROFILE"
   } >"$env_file"
   chmod 600 "$env_file"
   printf '%s\n' "$env_file"
 }
 
 _open_terminal_run() { # command
-  local command_text="$1" kind log_path quoted_command quoted_log quoted_log_line wrapped_command
+  local command_text="$1" kind stamp log_path launch_log quoted_command quoted_log quoted_log_line quoted_started_line quoted_hold quoted_debug wrapped_command
   if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "  [window] new terminal windows are only automated on macOS; run: $command_text"
     return 0
   fi
 
   mkdir -p "$LOGS"
-  log_path="$LOGS/window-$(date -u +%Y%m%dT%H%M%SZ).log"
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  log_path="$LOGS/window-$stamp.log"
+  launch_log="$LOGS/window-launch-$stamp.log"
   quoted_command="$(printf '%q' "$command_text")"
   quoted_log="$(printf '%q' "$log_path")"
   quoted_log_line="$(printf '%q' "[understudy] command: $command_text")"
-  wrapped_command="echo '[understudy] window command log: $log_path'; printf '%s\n' $quoted_log_line >>$quoted_log; eval $quoted_command 2>&1 | tee -a $quoted_log; status=\${pipestatus[1]:-\$?}; if [ \"\$status\" -ne 0 ]; then echo; echo '[understudy] window command failed with status' \"\$status\"; echo '[understudy] log:' $quoted_log; echo '[understudy] press Return to close this window'; read _; fi; exit \"\$status\""
+  quoted_started_line="$(printf '%q' "[understudy] started: $(_now_utc)")"
+  quoted_hold="$(printf '%q' "$UNDERSTUDY_WINDOW_HOLD")"
+  quoted_debug="$(printf '%q' "$UNDERSTUDY_DEBUG")"
+  wrapped_command="echo '[understudy] window command log: $log_path'; { printf '%s\n' $quoted_started_line $quoted_log_line; printf '[understudy] cwd: %s\n' \"\$PWD\"; printf '[understudy] shell: %s\n' \"\${SHELL:-}\"; } >>$quoted_log; eval $quoted_command 2>&1 | tee -a $quoted_log; status=\${pipestatus[1]:-\$?}; hold=$quoted_hold; debug=$quoted_debug; if [ \"\$status\" -ne 0 ] || [ \"\$hold\" = \"1\" ] || [ \"\$hold\" = \"true\" ] || [ \"\$debug\" = \"1\" ] || [ \"\$debug\" = \"true\" ]; then echo; if [ \"\$status\" -ne 0 ]; then echo '[understudy] window command failed with status' \"\$status\"; else echo '[understudy] window command exited with status 0'; fi; echo '[understudy] log:' $quoted_log; echo '[understudy] press Return to close this window'; read _; fi; exit \"\$status\""
   echo "  [window] log: $log_path"
+  echo "  [window] launch log: $launch_log"
 
   kind="$(_terminal_kind)"
-  _debug_echo "window launch kind=$kind app=${UNDERSTUDY_TERMINAL_APP:-auto} log=$log_path command=$command_text"
+  _log_window_launch "$launch_log" "$kind" "$command_text" "$log_path"
+  _debug_echo "window launch kind=$kind app=${UNDERSTUDY_TERMINAL_APP:-auto} log=$log_path launch_log=$launch_log command_sha256=$(_sha256_text "$command_text")"
   case "$kind" in
     ghostty)
       if command -v ghostty >/dev/null 2>&1; then
-        nohup ghostty -e /bin/zsh -lc "$wrapped_command" >/dev/null 2>&1 &
+        {
+          printf 'launch_method=ghostty-cli\n'
+          nohup ghostty -e /bin/zsh -lc "$wrapped_command" >/dev/null 2>&1 &
+          printf 'launch_status=0\n'
+        } >>"$launch_log" 2>&1
         _debug_echo "window opened kind=ghostty mode=cli"
         echo "  [window] opened Ghostty"
         return 0
       fi
       if open -Ra Ghostty 2>/dev/null; then
-        open -na Ghostty --args -e /bin/zsh -lc "$wrapped_command"
-        _debug_echo "window opened kind=ghostty mode=open"
-        echo "  [window] opened Ghostty"
-        return 0
+        printf 'launch_method=ghostty-open\n' >>"$launch_log"
+        if open -na Ghostty --args -e /bin/zsh -lc "$wrapped_command" >>"$launch_log" 2>&1; then
+          printf 'launch_status=0\n' >>"$launch_log"
+          _debug_echo "window opened kind=ghostty mode=open"
+          echo "  [window] opened Ghostty"
+          return 0
+        else
+          printf 'launch_status=%s\n' "$?" >>"$launch_log"
+          _debug_echo "window fallback reason=ghostty-open-failed"
+          echo "  [window] Ghostty launch failed; falling back to Terminal.app"
+        fi
       fi
       _debug_echo "window fallback reason=ghostty-not-found"
       echo "  [window] Ghostty not found; falling back to Terminal.app"
       ;;
     iterm)
       if command -v osascript >/dev/null 2>&1; then
-        if TERMINAL_COMMAND="$wrapped_command" osascript <<'APPLESCRIPT' >/dev/null 2>&1
+        local status
+        printf 'launch_method=osascript-iterm2\n' >>"$launch_log"
+        if TERMINAL_COMMAND="$wrapped_command" osascript >>"$launch_log" 2>&1 <<'APPLESCRIPT'
 tell application "iTerm2"
   activate
   create window with default profile command (system attribute "TERMINAL_COMMAND")
 end tell
 APPLESCRIPT
         then
+          printf 'launch_status=0\n' >>"$launch_log"
           _debug_echo "window opened kind=iterm app=iTerm2"
           echo "  [window] opened iTerm2"
           return 0
         fi
-        if TERMINAL_COMMAND="$wrapped_command" osascript <<'APPLESCRIPT' >/dev/null 2>&1
+        status="$?"
+        printf 'launch_status=%s\n' "$status" >>"$launch_log"
+        printf '\nlaunch_method=osascript-iterm\n' >>"$launch_log"
+        if TERMINAL_COMMAND="$wrapped_command" osascript >>"$launch_log" 2>&1 <<'APPLESCRIPT'
 tell application "iTerm"
   activate
   create window with default profile command (system attribute "TERMINAL_COMMAND")
 end tell
 APPLESCRIPT
         then
+          printf 'launch_status=0\n' >>"$launch_log"
           _debug_echo "window opened kind=iterm app=iTerm"
           echo "  [window] opened iTerm"
           return 0
         fi
+        status="$?"
+        printf 'launch_status=%s\n' "$status" >>"$launch_log"
       fi
       _debug_echo "window fallback reason=iterm-not-found-or-applescript-failed"
       echo "  [window] iTerm not found; falling back to Terminal.app"
@@ -499,10 +630,12 @@ APPLESCRIPT
 
   command -v osascript >/dev/null 2>&1 || {
     _debug_echo "window unable reason=osascript-not-found command=$command_text"
+    printf 'launch_method=none\nlaunch_status=osascript-not-found\n' >>"$launch_log"
     echo "  [window] osascript not found; run: $command_text"
     return 0
   }
-  TERMINAL_COMMAND="$wrapped_command" UNDERSTUDY_TERMINAL_PROFILE="$UNDERSTUDY_TERMINAL_PROFILE" osascript <<'APPLESCRIPT'
+  printf 'launch_method=osascript-terminal\n' >>"$launch_log"
+  if TERMINAL_COMMAND="$wrapped_command" UNDERSTUDY_TERMINAL_PROFILE="$UNDERSTUDY_TERMINAL_PROFILE" osascript >>"$launch_log" 2>&1 <<'APPLESCRIPT'
 tell application "Terminal"
   activate
   set targetProfile to system attribute "UNDERSTUDY_TERMINAL_PROFILE"
@@ -522,8 +655,17 @@ tell application "Terminal"
   end if
 end tell
 APPLESCRIPT
-  _debug_echo "window opened kind=terminal app=Terminal.app"
-  echo "  [window] opened Terminal.app"
+  then
+    printf 'launch_status=0\n' >>"$launch_log"
+    _debug_echo "window opened kind=terminal app=Terminal.app"
+    echo "  [window] opened Terminal.app"
+  else
+    local status="$?"
+    printf 'launch_status=%s\n' "$status" >>"$launch_log"
+    _debug_echo "window failed kind=terminal app=Terminal.app status=$status"
+    echo "  [window] Terminal.app launch failed; see $launch_log"
+    return "$status"
+  fi
 }
 
 _first_loading_script() {
@@ -651,6 +793,7 @@ case "${1:-up}" in
   status) cmd_status ;;
   down) cmd_down ;;
   cleanup) shift; cmd_cleanup "$@" ;;
+  diagnose) cmd_diagnose ;;
   attach) cmd_attach ;;
-  *) echo "usage: $0 {first|first-window|play|play-window|up|ask <text>|left <text>|right <text>|capture|logs|status|down|cleanup [--dry-run|--force]|attach}" >&2; exit 2 ;;
+  *) echo "usage: $0 {first|first-window|play|play-window|up|ask <text>|left <text>|right <text>|capture|logs|status|down|cleanup [--dry-run|--force]|diagnose|attach}" >&2; exit 2 ;;
 esac

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -24,7 +24,8 @@
 #
 # Config via env (defaults target this repo's local MLX venv layout):
 #   MLX_PYTHON   python with mlx_lm installed   (default: $LAB/.understudy/venvs/mlx/bin/python)
-#   LAB          working dir for logs/state      (default: $PWD)
+#   LAB          working dir for logs/state      (default: ~/.understudy/agent-tools)
+#   UNDERSTUDY_MODEL_HOME local model cache      (default: ~/.understudy/models)
 #   LEFT_LABEL/LEFT_REPO/LEFT_PORT/LEFT_PROVIDER
 #   RIGHT_LABEL/RIGHT_REPO/RIGHT_PORT/RIGHT_PROVIDER
 #   SESSION      tmux session name               (default: mlx-arena)
@@ -32,7 +33,8 @@
 #   UNDERSTUDY_DEBUG=1 writes $LAB/.understudy/local-model-lab/arena/logs/actions.log
 set -euo pipefail
 
-LAB="${LAB:-$PWD}"
+LAB="${LAB:-${UNDERSTUDY_LAB:-$HOME/.understudy/agent-tools}}"
+UNDERSTUDY_MODEL_HOME="${UNDERSTUDY_MODEL_HOME:-$HOME/.understudy/models}"
 MLX_PYTHON="${MLX_PYTHON:-$LAB/.understudy/venvs/mlx/bin/python}"
 MLX_BIN="$(dirname "$MLX_PYTHON")"
 SESSION="${SESSION:-mlx-arena}"
@@ -49,7 +51,7 @@ UNDERSTUDY_CLEANUP_PREFIXES="${UNDERSTUDY_CLEANUP_PREFIXES:-$SESSION mlx-arena}"
 # had loader/config mismatches in testing; the first rung is Understudy's
 # self-converted snapshot from google/gemma-4-e2b-it.
 LEFT_LABEL="${LEFT_LABEL:-google}"
-LEFT_REPO="${LEFT_REPO:-$LAB/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit}"
+LEFT_REPO="${LEFT_REPO:-$UNDERSTUDY_MODEL_HOME/gemma-4-e2b-it-mlx-vlm-4bit}"
 LEFT_PORT="${LEFT_PORT:-8081}"
 LEFT_PROVIDER="${LEFT_PROVIDER:-mlx-google}"
 LEFT_LOADER="${LEFT_LOADER:-mlx_vlm}"
@@ -64,7 +66,7 @@ RIGHT_LOADER="${RIGHT_LOADER:-mlx_lm}"
 # testing. Serve it with mlx-vlm; use FIRST_REPO=mlx-community/gemma-3-1b-it-4bit
 # FIRST_LOADER=mlx_lm only as a tiny fallback when the Gemma 4 snapshot is absent.
 FIRST_LABEL="${FIRST_LABEL:-gemma4-e2b}"
-FIRST_REPO="${FIRST_REPO:-$LAB/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit}"
+FIRST_REPO="${FIRST_REPO:-$UNDERSTUDY_MODEL_HOME/gemma-4-e2b-it-mlx-vlm-4bit}"
 FIRST_PORT="${FIRST_PORT:-8081}"
 FIRST_PROVIDER="${FIRST_PROVIDER:-mlx-gemma4-e2b}"
 FIRST_NAME="${FIRST_NAME:-Gemma 4 E2B 4-bit}"
@@ -399,6 +401,38 @@ _open_terminal_attach() { # tmux-session-name
   echo "  [window] follow along with: tmux attach -t $target"
 }
 
+_write_window_env_file() {
+  local env_file="$STATE/window-env-$(date -u +%Y%m%dT%H%M%SZ).sh"
+  mkdir -p "$STATE"
+  umask 077
+  {
+    printf 'export LAB=%q\n' "$LAB"
+    printf 'export MLX_PYTHON=%q\n' "$MLX_PYTHON"
+    printf 'export LEFT_REPO=%q\n' "$LEFT_REPO"
+    printf 'export LEFT_LOADER=%q\n' "$LEFT_LOADER"
+    printf 'export LOCAL_NAME=%q\n' "${LOCAL_NAME:-Gemma 4 E2B}"
+    printf 'export UNDERSTUDY_MODEL_HOME=%q\n' "$UNDERSTUDY_MODEL_HOME"
+    printf 'export OPENAI_API_KEY=%q\n' "${OPENAI_API_KEY:-}"
+    printf 'export ANTHROPIC_API_KEY=%q\n' "${ANTHROPIC_API_KEY:-}"
+    printf 'export ANTHROPIC_LOCAL_KEY=%q\n' "${ANTHROPIC_LOCAL_KEY:-}"
+    printf 'export FRONTIER_API_KEY=%q\n' "${FRONTIER_API_KEY:-}"
+    printf 'export AI_GATEWAY_API_KEY=%q\n' "${AI_GATEWAY_API_KEY:-}"
+    printf 'export OPENAI_BASE_URL=%q\n' "${OPENAI_BASE_URL:-}"
+    printf 'export FRONTIER_BASE_URL=%q\n' "${FRONTIER_BASE_URL:-}"
+    printf 'export AI_GATEWAY_BASE_URL=%q\n' "${AI_GATEWAY_BASE_URL:-}"
+    printf 'export FRONTIER_MODEL=%q\n' "${FRONTIER_MODEL:-}"
+    printf 'export OPENAI_MODEL=%q\n' "${OPENAI_MODEL:-}"
+    printf 'export ANTHROPIC_MODEL=%q\n' "${ANTHROPIC_MODEL:-}"
+    printf 'export AI_GATEWAY_MODEL=%q\n' "${AI_GATEWAY_MODEL:-}"
+    printf 'export UNDERSTUDY_FALLBACK_MODEL=%q\n' "${UNDERSTUDY_FALLBACK_MODEL:-}"
+    printf 'export FRONTIER_FALLBACK=%q\n' "${FRONTIER_FALLBACK:-}"
+    printf 'export FRONTIER_REASONING_EFFORT=%q\n' "${FRONTIER_REASONING_EFFORT:-}"
+    printf 'export FRONTIER_MAX_COMPLETION_TOKENS=%q\n' "${FRONTIER_MAX_COMPLETION_TOKENS:-}"
+  } >"$env_file"
+  chmod 600 "$env_file"
+  printf '%s\n' "$env_file"
+}
+
 _open_terminal_run() { # command
   local command_text="$1" kind log_path quoted_command quoted_log quoted_log_line wrapped_command
   if [[ "$(uname -s)" != "Darwin" ]]; then
@@ -571,7 +605,20 @@ cmd_play() {
   # seed the frontier keys into the tmux global env (not echoed) so the game pane inherits them
   tmux start-server 2>/dev/null || true
   tmux setenv -g ANTHROPIC_LOCAL_KEY "${ANTHROPIC_LOCAL_KEY:-${ANTHROPIC_API_KEY:-}}"
+  tmux setenv -g ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}"
   tmux setenv -g OPENAI_API_KEY "${OPENAI_API_KEY:-}"
+  tmux setenv -g FRONTIER_API_KEY "${FRONTIER_API_KEY:-}"
+  tmux setenv -g AI_GATEWAY_API_KEY "${AI_GATEWAY_API_KEY:-}"
+  tmux setenv -g FRONTIER_BASE_URL "${FRONTIER_BASE_URL:-}"
+  tmux setenv -g AI_GATEWAY_BASE_URL "${AI_GATEWAY_BASE_URL:-}"
+  tmux setenv -g OPENAI_BASE_URL "${OPENAI_BASE_URL:-}"
+  tmux setenv -g OPENAI_MODEL "${OPENAI_MODEL:-}"
+  tmux setenv -g ANTHROPIC_MODEL "${ANTHROPIC_MODEL:-}"
+  tmux setenv -g AI_GATEWAY_MODEL "${AI_GATEWAY_MODEL:-}"
+  tmux setenv -g UNDERSTUDY_FALLBACK_MODEL "${UNDERSTUDY_FALLBACK_MODEL:-}"
+  tmux setenv -g FRONTIER_FALLBACK "${FRONTIER_FALLBACK:-}"
+  tmux setenv -g FRONTIER_REASONING_EFFORT "${FRONTIER_REASONING_EFFORT:-}"
+  tmux setenv -g FRONTIER_MAX_COMPLETION_TOKENS "${FRONTIER_MAX_COMPLETION_TOKENS:-}"
   tmux kill-session -t "$S" 2>/dev/null || true
   tmux new-session -d -s "$S" -x 138 -y 60 -n arena
   _prepare_tmux_session "$S"
@@ -580,15 +627,12 @@ cmd_play() {
 }
 
 cmd_play_window() {
-  local here quoted_here quoted_lab quoted_python quoted_repo quoted_loader quoted_name
+  local here quoted_here env_file quoted_env_file
   here="$(cd "$(dirname "$0")" && pwd)"
   quoted_here="$(printf '%q' "$here")"
-  quoted_lab="$(printf '%q' "$LAB")"
-  quoted_python="$(printf '%q' "$MLX_PYTHON")"
-  quoted_repo="$(printf '%q' "$LEFT_REPO")"
-  quoted_loader="$(printf '%q' "$LEFT_LOADER")"
-  quoted_name="$(printf '%q' "${LOCAL_NAME:-Gemma 4 E2B}")"
-  _open_terminal_run "cd $quoted_here/../.. && LAB=$quoted_lab MLX_PYTHON=$quoted_python LEFT_REPO=$quoted_repo LEFT_LOADER=$quoted_loader LOCAL_NAME=$quoted_name '$here/arena.sh' play; tmux attach -t ${SESSION}-play"
+  env_file="$(_write_window_env_file)"
+  quoted_env_file="$(printf '%q' "$env_file")"
+  _open_terminal_run ". $quoted_env_file; rm -f $quoted_env_file; cd $quoted_here/../.. && '$here/arena.sh' play; tmux attach -t ${SESSION}-play"
   echo "Opening stock local-vs-frontier gauntlet in a new Terminal window."
   echo "Follow along with: tmux attach -t ${SESSION}-play"
 }

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -241,6 +241,139 @@ console.log(`  [pi] provider ${provider} -> ${providerEntry.baseUrl} (${model})`
 NODE
 }
 
+_refresh_agent_card() { # name repo port loader provider tmux-session
+  local name="$1" repo="$2" port="$3" loader="$4" provider="$5" tmux_session="$6"
+  local health_url="http://127.0.0.1:$port/v1/models" endpoint="http://127.0.0.1:$port/v1" healthy="false"
+  [ "$(curl -s -o /dev/null -w '%{http_code}' "$health_url" 2>/dev/null || true)" = "200" ] && healthy="true"
+  UNDERSTUDY_CARD_NAME="$name" \
+  UNDERSTUDY_CARD_MODEL="$repo" \
+  UNDERSTUDY_CARD_PORT="$port" \
+  UNDERSTUDY_CARD_ENDPOINT="$endpoint" \
+  UNDERSTUDY_CARD_HEALTH_URL="$health_url" \
+  UNDERSTUDY_CARD_HEALTHY="$healthy" \
+  UNDERSTUDY_CARD_LOADER="$loader" \
+  UNDERSTUDY_CARD_PROVIDER="$provider" \
+  UNDERSTUDY_CARD_SESSION="$tmux_session" \
+  UNDERSTUDY_CARD_LOGS="$LOGS" \
+  UNDERSTUDY_CARD_CWD="$(pwd)" \
+  node <<'NODE'
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const home = os.homedir();
+const now = new Date().toISOString();
+const cardPath = path.join(home, ".understudy", "agent-card.json");
+const companionPath = path.join(home, ".understudy", "companion.json");
+const configPath = path.join(home, ".understudy", "config.json");
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonMode600(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {}
+}
+
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const existing = readJson(cardPath) || {};
+const companionState = readJson(companionPath);
+let companion = {
+  alive: false,
+  pid: null,
+  stale_pid: null,
+  path: null,
+  state_file: companionPath,
+};
+
+if (companionState && typeof companionState === "object") {
+  const pid = Number(companionState.pid ?? companionState.process?.pid ?? companionState.companion?.pid);
+  const alive = pidAlive(pid);
+  companion = {
+    alive,
+    pid: alive ? pid : null,
+    stale_pid: !alive && Number.isInteger(pid) && pid > 0 ? pid : null,
+    path: companionState.path ?? companionState.binary ?? companionState.command ?? companionState.process?.path ?? null,
+    state_file: companionPath,
+  };
+  if (!alive && Number.isInteger(pid) && pid > 0) {
+    const cleaned = { ...companionState };
+    if ("pid" in cleaned) cleaned.pid = null;
+    if (cleaned.process && typeof cleaned.process === "object" && "pid" in cleaned.process) {
+      cleaned.process = { ...cleaned.process, pid: null };
+    }
+    if (cleaned.companion && typeof cleaned.companion === "object" && "pid" in cleaned.companion) {
+      cleaned.companion = { ...cleaned.companion, pid: null };
+    }
+    try {
+      writeJsonMode600(companionPath, cleaned);
+    } catch {}
+  }
+}
+
+const config = readJson(configPath) || {};
+const model = process.env.UNDERSTUDY_CARD_MODEL;
+const endpoint = process.env.UNDERSTUDY_CARD_ENDPOINT;
+const payload = {
+  model,
+  messages: [{ role: "user", content: "Say hello from my local Understudy." }],
+  max_tokens: 128,
+};
+function shellSingleQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+const howToTalk = `curl -s ${endpoint}/chat/completions -H 'Content-Type: application/json' -d ${shellSingleQuote(JSON.stringify(payload))}`;
+const cwd = process.env.UNDERSTUDY_CARD_CWD || process.cwd();
+
+const card = {
+  schema_version: "understudy.agent_card.v1",
+  created_at: existing.created_at || now,
+  updated_at: now,
+  understudy: {
+    model,
+    name: process.env.UNDERSTUDY_CARD_NAME || null,
+    endpoint,
+    health_url: process.env.UNDERSTUDY_CARD_HEALTH_URL,
+    healthy: process.env.UNDERSTUDY_CARD_HEALTHY === "true",
+    served_by: process.env.UNDERSTUDY_CARD_LOADER === "mlx_vlm" ? "mlx_vlm.server" : "mlx_lm.server",
+    runtime: process.env.UNDERSTUDY_CARD_LOADER,
+    provider: process.env.UNDERSTUDY_CARD_PROVIDER,
+    tmux_session: process.env.UNDERSTUDY_CARD_SESSION,
+    logs: process.env.UNDERSTUDY_CARD_LOGS,
+    how_to_talk: howToTalk,
+  },
+  companion,
+  project: {
+    cwd,
+    slug: path.basename(cwd),
+  },
+  org: {
+    id: config.org_id ?? config.organization_id ?? config.org?.id ?? null,
+  },
+};
+
+writeJsonMode600(cardPath, card);
+console.log(`  [understudy] agent card -> ${cardPath}`);
+NODE
+}
+
 _prepare_tmux_session() { # session
   local session="$1"
   tmux set-option -t "$session" extended-keys on 2>/dev/null || true
@@ -256,6 +389,7 @@ cmd_up() {
   _serve "$RIGHT_LABEL" "$RIGHT_REPO" "$RIGHT_PORT" "$RIGHT_LOADER"
   _wait_health "$LEFT_PORT"  "$LEFT_LABEL"
   _wait_health "$RIGHT_PORT" "$RIGHT_LABEL"
+  _refresh_agent_card "$LEFT_LABEL" "$LEFT_REPO" "$LEFT_PORT" "$LEFT_LOADER" "$LEFT_PROVIDER" "$SESSION"
 
   tmux kill-session -t "$SESSION" 2>/dev/null || true
   tmux new-session  -d -s "$SESSION" -x 220 -y 50 -n arena
@@ -718,6 +852,7 @@ cmd_first() {
   _serve_with_loader "$FIRST_LABEL" "$FIRST_REPO" "$FIRST_PORT" "$FIRST_LOADER"
   _wait_health "$FIRST_PORT" "$FIRST_LABEL"
   _ensure_pi_provider "$FIRST_PROVIDER" "$FIRST_REPO" "$FIRST_PORT"
+  _refresh_agent_card "$FIRST_NAME" "$FIRST_REPO" "$FIRST_PORT" "$FIRST_LOADER" "$FIRST_PROVIDER" "$S"
 
   tmux send-keys -t "$S" C-c
   tmux send-keys -t "$S" "clear && echo 'UNDERSTUDY LABS' && echo 'Your first local understudy is ready.' && echo && echo 'Model: $FIRST_REPO' && echo 'Endpoint: http://127.0.0.1:$FIRST_PORT/v1' && echo && $(_pi_cmd_with_prompt "$FIRST_PROVIDER" "$FIRST_REPO" "$first_prompt")" C-m
@@ -743,6 +878,7 @@ cmd_play() {
   _serve "$LEFT_LABEL" "$LEFT_REPO" "$LEFT_PORT" "$LEFT_LOADER"
   _wait_health "$LEFT_PORT" "$LEFT_LABEL"
   local S="${SESSION}-play" frontier_model
+  _refresh_agent_card "${LOCAL_NAME:-Gemma 4 E2B}" "$LEFT_REPO" "$LEFT_PORT" "$LEFT_LOADER" "$LEFT_PROVIDER" "$S"
   frontier_model="${FRONTIER_MODEL:-}"
   # seed the frontier keys into the tmux global env (not echoed) so the game pane inherits them
   tmux start-server 2>/dev/null || true

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -825,7 +825,7 @@ SH
 
 _first_pi_system_prompt() {
   cat <<'PROMPT'
-You are the user's first local Understudy. You are running privately on their Mac through Apple MLX. Start by saying you are ready, then invite them to try one real task. Keep the tone concise and practical. After one or two local-only prompts, suggest running the frontier head-to-head with skills/mlx-arena/arena.sh play so they can feel where local is already enough and where the frontier still wins.
+You are the user's first local Understudy. You are running privately on their Mac through Apple MLX. Start by saying you are ready, then invite them to try one real task. Keep the tone concise and practical. After one or two local-only prompts, suggest profiling the user's real AI workload: inspect its prompts, traces, dataset rows, code path, and success criteria before comparing or optimizing models. Mention that a frontier head-to-head is available as an optional calibration step, but the main path is understanding and improving the actual workload.
 PROMPT
 }
 
@@ -858,7 +858,8 @@ cmd_first() {
   tmux send-keys -t "$S" "clear && echo 'UNDERSTUDY LABS' && echo 'Your first local understudy is ready.' && echo && echo 'Model: $FIRST_REPO' && echo 'Endpoint: http://127.0.0.1:$FIRST_PORT/v1' && echo && $(_pi_cmd_with_prompt "$FIRST_PROVIDER" "$FIRST_REPO" "$first_prompt")" C-m
   tmux select-pane -t "$S" -T " FIRST UNDERSTUDY · $FIRST_NAME · $FIRST_REPO " 2>/dev/null || true
   echo "Ready → attach: tmux attach -t $S"
-  echo "Next head-to-head: skills/mlx-arena/arena.sh play"
+  echo "Next: profile a real workload with skills/understand-workload/SKILL.md"
+  echo "Optional calibration: skills/mlx-arena/arena.sh play"
 }
 
 # One-command bring-up of the BLIND HEAD-TO-HEAD game (blind_arena.ts):

--- a/skills/mlx-arena/blind_arena.ts
+++ b/skills/mlx-arena/blind_arena.ts
@@ -51,7 +51,7 @@ const FRONTIER_MAX_COMPLETION_TOKENS = Math.max(
   64,
   Math.min(4096, parseInt(env.FRONTIER_MAX_COMPLETION_TOKENS ?? "768", 10) || 768),
 );
-const FRONTIER_NAME = `${REQUESTED_FRONTIER_MODEL || OPENAI_FRONTIER_MODEL} (high reasoning · cloud · $$)`;
+const FRONTIER_NAME = `${REQUESTED_FRONTIER_MODEL || OPENAI_FRONTIER_MODEL} (cloud · $$)`;
 let activeFrontierName = FRONTIER_NAME;
 
 type FrontierAttempt = {

--- a/skills/mlx-arena/blind_arena.ts
+++ b/skills/mlx-arena/blind_arena.ts
@@ -36,11 +36,21 @@ const ROUNDS = parseInt(env.ROUNDS ?? "6", 10);
 const PANEL_W = 60;
 
 const REQUESTED_FRONTIER_MODEL = env.FRONTIER_MODEL?.trim();
-const OPENAI_FRONTIER_MODEL = env.OPENAI_MODEL?.trim() || REQUESTED_FRONTIER_MODEL || "gpt-5.1";
+const OPENAI_FRONTIER_MODEL = env.OPENAI_MODEL?.trim() || REQUESTED_FRONTIER_MODEL || "gpt-5.5";
 const ANTHROPIC_FRONTIER_MODEL = env.ANTHROPIC_MODEL?.trim() || REQUESTED_FRONTIER_MODEL || "claude-opus-4-8";
 const GATEWAY_FRONTIER_MODEL = env.AI_GATEWAY_MODEL?.trim() || REQUESTED_FRONTIER_MODEL || OPENAI_FRONTIER_MODEL;
 const UNDERSTUDY_FALLBACK_MODEL = env.UNDERSTUDY_FALLBACK_MODEL?.trim() || "glm-5.1";
 const FRONTIER_FALLBACK_ENABLED = env.FRONTIER_FALLBACK === "0" ? false : true;
+const FRONTIER_REASONING_EFFORT = (env.FRONTIER_REASONING_EFFORT?.trim() || "none") as
+  | "none"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
+const FRONTIER_MAX_COMPLETION_TOKENS = Math.max(
+  64,
+  Math.min(4096, parseInt(env.FRONTIER_MAX_COMPLETION_TOKENS ?? "768", 10) || 768),
+);
 const FRONTIER_NAME = `${REQUESTED_FRONTIER_MODEL || OPENAI_FRONTIER_MODEL} (high reasoning · cloud · $$)`;
 let activeFrontierName = FRONTIER_NAME;
 
@@ -82,6 +92,13 @@ function normalizeBaseURL(value: string): string {
   return value.replace(/\/+$/, "").replace(/\/v1$/, "") + "/v1";
 }
 
+function priceForModel(model: string): { in: number; out: number } {
+  if (/^gpt-5\.5(?:-|$)/.test(model)) return { in: 5.0, out: 30.0 };
+  if (/^gpt-5\.4(?:-|$)/.test(model)) return { in: 2.5, out: 15.0 };
+  if (/^gpt-5(?:\.|$|-)/.test(model)) return { in: 1.25, out: 10.0 };
+  return { in: 1.0, out: 5.0 };
+}
+
 function pushUniqueAttempt(attempts: FrontierAttempt[], attempt: FrontierAttempt): void {
   const key = `${attempt.provider}:${attempt.baseURL ?? ""}:${attempt.model}`;
   if (!attempts.some((a) => `${a.provider}:${a.baseURL ?? ""}:${a.model}` === key)) attempts.push(attempt);
@@ -106,14 +123,15 @@ function resolveFrontierAttempts(): FrontierAttempt[] {
   }
 
   if (directOpenAIKey && !customGatewayURL && !REQUESTED_FRONTIER_MODEL?.startsWith("claude")) {
+    const price = priceForModel(OPENAI_FRONTIER_MODEL);
     pushUniqueAttempt(attempts, {
       provider: "openai-compatible",
       model: OPENAI_FRONTIER_MODEL,
       name: `${OPENAI_FRONTIER_MODEL} (OpenAI direct)`,
       apiKey: directOpenAIKey,
       baseURL: "https://api.openai.com/v1",
-      in: 1.25,
-      out: 10.0,
+      in: price.in,
+      out: price.out,
     });
   }
 
@@ -129,19 +147,21 @@ function resolveFrontierAttempts(): FrontierAttempt[] {
   }
 
   if (customGatewayURL) {
+    const price = priceForModel(GATEWAY_FRONTIER_MODEL);
     pushUniqueAttempt(attempts, {
       provider: "openai-compatible",
       model: GATEWAY_FRONTIER_MODEL,
       name: `${GATEWAY_FRONTIER_MODEL} (AI gateway)`,
       apiKey: customGatewayKey || "gateway",
       baseURL: normalizeBaseURL(customGatewayURL),
-      in: 1.25,
-      out: 10.0,
+      in: price.in,
+      out: price.out,
     });
   }
 
   const gateway = loadGateway();
   if (gateway.key && gateway.url) {
+    const price = priceForModel(UNDERSTUDY_FALLBACK_MODEL);
     pushUniqueAttempt(attempts, {
       provider: "understudy-gateway",
       model: UNDERSTUDY_FALLBACK_MODEL,
@@ -149,8 +169,8 @@ function resolveFrontierAttempts(): FrontierAttempt[] {
       apiKey: gateway.key,
       baseURL: normalizeBaseURL(gateway.url),
       headers: { "x-understudy-upstream-key": env.OPENAI_API_KEY ?? "" },
-      in: 1.0,
-      out: 5.0,
+      in: price.in,
+      out: price.out,
     });
   }
 
@@ -323,8 +343,8 @@ async function streamAnthropic(q: string, res: Result, attempt: FrontierAttempt)
   const Anthropic = (await import("@anthropic-ai/sdk")).default;
   const client = new Anthropic({ apiKey: key });
   const stream = client.messages.stream({
-    model: attempt.model, max_tokens: 4000,
-    thinking: { type: "adaptive", display: "summarized" }, output_config: { effort: "high" },
+    model: attempt.model, max_tokens: Math.max(256, Math.min(1600, FRONTIER_MAX_COMPLETION_TOKENS)),
+    thinking: { type: "disabled" }, output_config: { effort: "low" },
     system: SYSTEM, messages: [{ role: "user", content: q }],
   } as any);
   for await (const ev of stream as any) {
@@ -342,17 +362,56 @@ async function streamOpenAICompatible(q: string, res: Result, attempt: FrontierA
   if (!attempt.baseURL) throw new Error(`No base URL for ${attempt.name}.`);
   if (!attempt.apiKey) throw new Error(`No API key for ${attempt.name}.`);
   const client = new OpenAI({ baseURL: attempt.baseURL, apiKey: attempt.apiKey, defaultHeaders: attempt.headers ?? {} });
-  const stream = await client.chat.completions.create({
-    model: attempt.model, max_completion_tokens: 2000, stream: true,
-    stream_options: { include_usage: true }, reasoning_effort: "high",
-    messages: [{ role: "system", content: SYSTEM }, { role: "user", content: q }],
-  } as any);
+  const messages = [{ role: "system", content: SYSTEM }, { role: "user", content: q }];
+  const stream = await createOpenAICompatibleStream(client, attempt.model, messages);
   for await (const chunk of stream as any) {
     if (chunk.usage) { res.inTok = chunk.usage.prompt_tokens || res.inTok; res.outTok = chunk.usage.completion_tokens || res.outTok; }
     const d = chunk.choices?.[0]?.delta?.content;
     if (d) { if (res.tFirst === null) res.tFirst = Date.now(); res.text += d; }
   }
   res.cost = (res.inTok * attempt.in + res.outTok * attempt.out) / 1e6;
+}
+
+function shouldUseReasoningParams(model: string): boolean {
+  return /^(gpt-5|o[134])(?:[.\-_]|$)/.test(model);
+}
+
+async function createOpenAICompatibleStream(client: OpenAI, model: string, messages: Array<{ role: string; content: string }>): Promise<any> {
+  const base: Record<string, unknown> = {
+    model,
+    stream: true,
+    stream_options: { include_usage: true },
+    messages,
+  };
+  if (shouldUseReasoningParams(model)) {
+    base.max_completion_tokens = FRONTIER_MAX_COMPLETION_TOKENS;
+    base.reasoning_effort = FRONTIER_REASONING_EFFORT;
+  } else {
+    base.max_tokens = FRONTIER_MAX_COMPLETION_TOKENS;
+  }
+
+  try {
+    return await client.chat.completions.create(base as any);
+  } catch (err: any) {
+    const message = String(err?.message ?? err);
+    if (/Unsupported parameter: 'reasoning_effort'|unknown parameter.*reasoning_effort/i.test(message)) {
+      delete base.reasoning_effort;
+      return await client.chat.completions.create(base as any);
+    }
+    if (/Unsupported parameter: 'max_completion_tokens'|unknown parameter.*max_completion_tokens/i.test(message)) {
+      delete base.max_completion_tokens;
+      base.max_tokens = FRONTIER_MAX_COMPLETION_TOKENS;
+      delete base.reasoning_effort;
+      return await client.chat.completions.create(base as any);
+    }
+    if (/Unsupported parameter: 'max_tokens'|max_tokens is not supported/i.test(message)) {
+      delete base.max_tokens;
+      base.max_completion_tokens = FRONTIER_MAX_COMPLETION_TOKENS;
+      if (shouldUseReasoningParams(model)) base.reasoning_effort = FRONTIER_REASONING_EFFORT;
+      return await client.chat.completions.create(base as any);
+    }
+    throw err;
+  }
 }
 
 // ---------- rendering ----------

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -81,11 +81,15 @@ work — do not re-run the full interview. Only first-timers get the full flow.
    providers), and preferred coaching depth. Question bank in
    [`reference.md`](reference.md).
 
-5. **Write the profile.** Save `~/.understudy/profile.json` (schema in
+5. **Write the profile and agent card.** Save `~/.understudy/profile.json` (schema in
    [`reference.md`](reference.md)): experience tier, detected tooling, hardware,
    goal, constraints, and the three meet-them-where-they-are dials — vocabulary,
    coaching depth, opinion strength. Append, don't overwrite, the `history` of
-   workloads and decisions.
+   workloads and decisions. Also refresh `~/.understudy/agent-card.json` with
+   live runtime facts: the local model, endpoint, serving process, tmux session,
+   companion status, and the exact command for talking to the local Understudy.
+   If `~/.understudy/companion.json` points at a dead pid, clear it and record
+   the stale pid in the card.
 
 6. **Land the quick win.** The `arena.sh first` pane now says their first local
    Understudy is ready and opens Pi on verified Gemma 4 E2B. Have them try one
@@ -120,8 +124,8 @@ recommended path; stay terse and offer trade-offs to practitioners.
 
 End with: runtime + model downloading (and ETA, or "cached"); hardware found and
 what fits locally; inferred experience tier and the dials set; the profile path
-written; the quick-win result (local generation shown or pending); and one
-recommended next skill/command.
+written; the agent-card path refreshed; the quick-win result (local generation
+shown or pending); and one recommended next skill/command.
 
 ## References
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -96,7 +96,7 @@ work — do not re-run the full interview. Only first-timers get the full flow.
    If `~/.understudy/companion.json` points at a dead pid, clear it and record
    the stale pid in the card.
 
-6. **Land the quick win.** Once the snapshot is cached, route to
+6. **Land the quick win: show the local Understudy exists.** Once the snapshot is cached, route to
    [`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md). Coach the user to open a
    terminal of their choice and attach to the tmux session, or launch it from the
    agent if they ask. Use:
@@ -105,30 +105,35 @@ work — do not re-run the full interview. Only first-timers get the full flow.
      skills/mlx-arena/arena.sh first
    ```
    The pane says their first local Understudy is ready and opens Pi on verified
-   Gemma 4 E2B. Have them try one real prompt. If Pi is not installed, run one
-   local generation and print:
+   Gemma 4 E2B. Have them try one real prompt only to prove local inference is
+   real and inspectable. If Pi is not installed, run one local generation and print:
    `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`. Briefly
    teach the idea: an open-weight model is downloadable weights you run yourself;
    local is free and ZDR-safe; you iterate small and local, then *graduate* to a
    larger model in the same family via the gateway when you need the quality.
 
-7. **Run the first default environment.** After the first local prompt or two,
-   run the built-in deterministic sandbox from
-   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md):
-   synthetic records, in-memory tools, a scripted oracle, and final-state
-   validators. This proves the local Understudy can act in a small tool world
-   before any codebase-specific environment is built.
+7. **Profile the user's real workload.** The main path after the local proof is
+   not a model duel. Ask the user for a codebase, trace folder, dataset, eval
+   runner, prompt file, or app route. If they point at a project, route to
+   [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) first:
+   inspect prompts in situ, trace the request/response path through code,
+   summarize the dataset or trace distribution, name the real task, and confirm
+   that understanding with the user before any optimization. If there is already
+   a real captured environment, skip the toy sandbox. Only use
+   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
+   when there is no resettable real workload yet.
 
-8. **Start the head-to-head.** After the default environment baseline, route to
+8. **Make head-to-head optional.** A frontier-vs-local duel is useful when the
+   user needs to feel the quality gap, calibrate taste, or get buy-in. It is a
+   side quest, not the default evidence path. If the user wants it, route to
    [`../specialize-local-model/SKILL.md`](../specialize-local-model/SKILL.md) and
    run:
    ```bash
    LEFT_REPO="$HOME/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit" \
      skills/mlx-arena/arena.sh play
    ```
-   The coding agent should watch the tmux session with the user, then after the
-   stock duel ask them to pick a real problem or let the agent find local data so
-   Understudy can try to beat the frontier on that task slice.
+   Otherwise keep going through workload understanding, capture evidence, and
+   local evaluation against the actual task slice.
 
 9. **Route onward.** Hand to the [`understudy`](../understudy/SKILL.md)
    orchestrator for the improvement loop;

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -51,13 +51,18 @@ work — do not re-run the full interview. Only first-timers get the full flow.
    `r2://understudy-model-snapshots/models/google/gemma-4-e2b-it/mlx-vlm-0.6.2/quant-4bit/`).
    It is about 3.3 GB on disk and generated locally at
    about 218 tok/s in testing. Announce the model, quantization, size, source,
-   and ETA, get a quick yes, then run
-   `skills/mlx-arena/arena.sh first-window` on macOS so a distinct Terminal.app
-   window opens with the branded loading screen while the model loads, then lands
-   in Pi when the local Understudy is ready. Use `arena.sh first` when a separate
-   window is unavailable. If the MLX runtime is missing, the slow step is
-   *install MLX + pull* — get one quick approval, then background it. If the
-   Gemma 4 snapshot URL is unavailable, fall back to
+   and ETA, get a quick yes, then route through
+   [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md) to run
+   the skill-owned pull helper:
+   ```bash
+   node scripts/pull-understudy-snapshot.mjs --model gemma-4-e2b-it-mlx-vlm-4bit
+   ```
+   Resolve the script relative to the `manage-local-models` skill directory.
+   This caches the first Understudy under
+   `~/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit` and logs progress/ETA under
+   `~/.understudy/agent-tools/logs/`. If the MLX runtime is missing, the slow
+   step is *install MLX + pull* — get one quick approval, then background it. If
+   the Gemma 4 snapshot URL is unavailable, fall back to
    `mlx-community/gemma-3-1b-it-4bit` only to preserve the aha moment. Then
    immediately move on; do not watch the bar.
 
@@ -91,9 +96,17 @@ work — do not re-run the full interview. Only first-timers get the full flow.
    If `~/.understudy/companion.json` points at a dead pid, clear it and record
    the stale pid in the card.
 
-6. **Land the quick win.** The `arena.sh first` pane now says their first local
-   Understudy is ready and opens Pi on verified Gemma 4 E2B. Have them try one
-   real prompt. If Pi is not installed, run one local generation and print:
+6. **Land the quick win.** Once the snapshot is cached, route to
+   [`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md). Coach the user to open a
+   terminal of their choice and attach to the tmux session, or launch it from the
+   agent if they ask. Use:
+   ```bash
+   FIRST_REPO="$HOME/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit" \
+     skills/mlx-arena/arena.sh first
+   ```
+   The pane says their first local Understudy is ready and opens Pi on verified
+   Gemma 4 E2B. Have them try one real prompt. If Pi is not installed, run one
+   local generation and print:
    `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`. Briefly
    teach the idea: an open-weight model is downloadable weights you run yourself;
    local is free and ZDR-safe; you iterate small and local, then *graduate* to a
@@ -108,8 +121,14 @@ work — do not re-run the full interview. Only first-timers get the full flow.
 
 8. **Start the head-to-head.** After the default environment baseline, route to
    [`../specialize-local-model/SKILL.md`](../specialize-local-model/SKILL.md) and
-   run `skills/mlx-arena/arena.sh play` so they can compare the local Understudy
-   against a frontier model and decide where local is already enough.
+   run:
+   ```bash
+   LEFT_REPO="$HOME/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit" \
+     skills/mlx-arena/arena.sh play
+   ```
+   The coding agent should watch the tmux session with the user, then after the
+   stock duel ask them to pick a real problem or let the agent find local data so
+   Understudy can try to beat the frontier on that task slice.
 
 9. **Route onward.** Hand to the [`understudy`](../understudy/SKILL.md)
    orchestrator for the improvement loop;

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -174,9 +174,18 @@ through MLX on Apple Silicon (see
   `models.understudylabs.com/session?model=...` endpoint. It returns a manifest
   with short-lived signed URLs for the actual model files; do not publish the
   expiring per-object URLs directly.
-- **BF16 profiling rung** — same E2B source and converter, about 9.5 GB on disk.
-  Keep it as an internal/local profiling option until a signed
-  `models.understudylabs.com` session is published.
+- **12B local climb rungs** — Understudy-verified `google/gemma-4-12B-it`,
+  converted with `mlx-vlm 0.6.2` and served with `mlx_vlm.server`. Use
+  `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit`
+  first on high-RAM Apple Silicon; it is about 6.3 GB on disk and verified with
+  local generation plus OpenAI-compatible logprobs/top-logprobs. Use
+  `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16`
+  only for larger-memory quality/perf profiling; it is about 22 GB on disk.
+- **Larger local Gemma rungs** — `gemma-4-26b-a4b-it-mlx-vlm-4bit` is the
+  opinionated MoE-style climb at about 14 GB on disk; `gemma-4-31b-it-mlx-vlm-4bit`
+  is the dense high-memory local rung at about 17 GB. Both use stable
+  `https://models.understudylabs.com/session?model=<id>` endpoints and were
+  verified with local generation plus logprobs/top-logprobs.
 - **Tiny fallback only** — `mlx-community/gemma-3-1b-it-4bit`, served with
   `mlx_lm.server`. Dry-run download is about 772 MB and it loads on current
   `mlx-lm 0.31.3`; use it only when the verified Gemma 4 snapshot is unavailable

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -52,6 +52,55 @@ Write it with the smallest correct change: merge new fields, append to `history`
 and `local_models`, bump `updated_at`. If a value is unknown, leave it null
 rather than guessing.
 
+## The agent runtime card (`~/.understudy/agent-card.json`)
+
+Agent-level, not user-interview memory. This is the single file a fresh coding
+agent reads when the user asks, "is my Understudy active?" or "talk to my
+Understudy." It captures live local runtime facts that do not belong in the
+profile. Never put secrets, prompts, outputs, or customer data in it.
+
+```jsonc
+{
+  "schema_version": "understudy.agent_card.v1",
+  "created_at": "2026-06-06T18:00:00Z",
+  "updated_at": "2026-06-06T18:05:00Z",
+  "understudy": {
+    "model": "/Users/me/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit",
+    "name": "Gemma 4 E2B",
+    "endpoint": "http://127.0.0.1:8081/v1",
+    "health_url": "http://127.0.0.1:8081/v1/models",
+    "healthy": true,
+    "served_by": "mlx_vlm.server",
+    "runtime": "mlx_vlm",
+    "provider": "mlx-gemma4-e2b",
+    "tmux_session": "mlx-arena-first",
+    "logs": "~/.understudy/agent-tools/.understudy/local-model-lab/arena/logs",
+    "how_to_talk": "curl -s http://127.0.0.1:8081/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"/Users/me/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello from my local Understudy.\"}],\"max_tokens\":128}'"
+  },
+  "companion": {
+    "alive": false,
+    "pid": null,
+    "stale_pid": 84470,
+    "path": "/Users/me/Documents/understudy-cli/companion/rust/target/debug/us-companion",
+    "state_file": "~/.understudy/companion.json"
+  },
+  "project": {
+    "cwd": "/Users/me/my-app",
+    "slug": "my-app"
+  },
+  "org": {
+    "id": "org_..."
+  }
+}
+```
+
+Refresh this card during onboarding, whenever `arena.sh first|play|up` serves a
+model, and whenever a companion process starts. If `~/.understudy/companion.json`
+contains a dead pid, clear that pid in the companion state file and record it as
+`stale_pid` in the card. A later agent should be able to answer the user's
+runtime question from this card first, using health checks only to refresh stale
+facts.
+
 ## Tooling detection → experience signal
 
 Run these read-only checks while the model downloads. Each hit is a signal; the

--- a/skills/specialize-local-model/SKILL.md
+++ b/skills/specialize-local-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: specialize-local-model
-description: Use when a developer wants the smallest task-reasonable local model opened in Pi against a frontier model, then wants the gap to drive model climb, GEPA, simulated env, RLM, hybrid route, or remote-only. Triggers include "can local do this", "train an understudy", "smallest reasonable model", or "use Pi then simulated env".
+description: Use when a developer wants the smallest task-reasonable local model opened in Pi, then wants the real workload profiled and improved through model climb, GEPA, simulated/real env, RLM, hybrid route, or remote-only. Frontier head-to-head is optional calibration. Triggers include "can local do this", "train an understudy", "smallest reasonable model", or "profile this workload for local".
 metadata:
   understudy:
     mode: interactive
@@ -12,12 +12,12 @@ metadata:
 
 Turn a task into a measured local-model ladder. Start with the **smallest local
 model that is plausibly reasonable for the task**, open it in Pi so the developer
-immediately sees a private model running on their machine, compare it against a
-frontier model, then move immediately from the stock duel into the user's real
-problem: pick a workflow, find or create task-specific data, freeze an eval, and
-try to make the local Understudy outperform the frontier on that slice. Use the
-observed gap to decide whether to climb models, optimize the prompt, decompose
-the task, simulate the environment, or route remote.
+immediately sees a private model running on their machine, then move into the
+user's real problem: inspect prompts/traces/code paths, profile the dataset,
+freeze an eval, and try to make the local Understudy solve that task slice. A
+frontier comparison can be inserted when useful, but the observed workload gaps
+decide whether to climb models, optimize the prompt, decompose the task, simulate
+the environment, or route remote.
 
 This is an orchestration skill. Do not reimplement worker skills inline; sequence
 them and hand off with concrete artifacts.
@@ -26,9 +26,10 @@ them and hand off with concrete artifacts.
 
 ```text
 task intake
+  -> profile prompts/traces/data/code path
   -> smallest reasonable local rung
-  -> Pi stock frontier-vs-local head-to-head
-  -> pick a real problem or find task data
+  -> Pi local proof
+  -> optional frontier-vs-local head-to-head
   -> freeze a task-specific eval/environment
   -> gap report
   -> improve via model climb, GEPA, RLM, env feedback, or route
@@ -36,12 +37,12 @@ task intake
   -> measured route decision
 ```
 
-The arena is the emotional proof: "I have a local model running." The stock duel
-is only the spark, not the end state. The durable product moment is when the
-developer picks a real problem, the agent finds or builds representative data,
-and the local Understudy starts beating the frontier on that specific workload.
-The codebase-specific simulated environment and eval loop are the proof that the
-local model can actually do the user's job.
+The arena is the visible proof: "I have a local model running." The durable
+product moment is when the agent profiles a real workload, the developer confirms
+the task understanding, and the local Understudy starts improving against that
+specific workload. A stock duel can be a spark, but the data profile, request
+path, metric, and eval loop are the proof that the local model can actually do
+the user's job.
 
 ## Safety Gates
 
@@ -89,20 +90,26 @@ local model can actually do the user's job.
      hybrid or remote if quality is the bottleneck.
 
 3. **Open Pi quickly.** Use [`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md):
-   serve the selected local model with MLX, wire Pi, and open the blind
-   local-vs-frontier game. Use user prompts, a small local dataset, or questions
+   serve the selected local model with MLX, wire Pi, and prove the user can talk
+   to the local Understudy. Do not spend the session on generic questions.
+
+4. **Profile the real task slice.** Ask the developer to pick one concrete
+   problem they care about, or inspect the current repo for useful data: eval
+   files, fixtures, traces, support tickets, prompts, transcripts, golden
+   outputs, failing tests, request logs, API/tool logs, or app routes. Route to
+   [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) to trace
+   the request/response path, describe the dataset/traces, and confirm success
+   criteria. If no data exists, synthesize a small public/local fixture that
+   matches the workflow and clearly label it as synthetic. The goal is a bounded
+   slice where the local Understudy can plausibly improve through specialization.
+
+5. **Optionally calibrate against frontier.** If the user needs a visible
+   quality comparison, run the blind frontier-vs-local game using questions
    generated from the workload decomposition. Capture preference, guessed
-   frontier identity, latency, cost, and failure notes.
+   frontier identity, latency, cost, and failure notes as hypotheses only, not
+   claims.
 
-4. **Pick the real task slice.** Do not stop at the stock duel. Ask the developer
-   to pick one concrete problem they care about, or inspect the current repo for
-   useful data: eval files, fixtures, traces, support tickets, prompts,
-   transcripts, golden outputs, failing tests, or API/tool logs. If no data
-   exists, synthesize a small public/local fixture that matches the workflow and
-   clearly label it as synthetic. The goal is a bounded slice where the local
-   Understudy can plausibly beat the frontier through specialization.
-
-5. **Freeze the task-specific eval/environment.** For answer-only work, route to
+6. **Freeze the task-specific eval/environment.** For answer-only work, route to
    [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) and
    [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) to create
    rows, rubric/metric, baseline, and holdout. For workflow/tool tasks, route to
@@ -110,16 +117,20 @@ local model can actually do the user's job.
    to build seeded state, tool contracts, oracle actions, and final-state
    validators. Frontier is the incumbent baseline; local is the candidate.
 
-6. **Write a gap report.** Record:
+7. **Write a gap report.** Record:
    - where local already matches or beats frontier;
    - where frontier wins;
    - whether the gap is model size, prompt/harness, context/tool surface, missing
      environment feedback, or true policy learning.
 
-7. **Choose the next intervention.**
+8. **Choose the next intervention.**
    - **Model too weak, harness sane** -> climb the local model ladder and rerun
-     Pi / local-model-lab: Gemma 4 E2B 4-bit -> Gemma 4 E2B BF16 -> Gemma 4 E4B
-     -> Gemma 4 12B -> Nemotron 3 Nano 4B/30B-A3B -> remote Gemma/Nemotron.
+     Pi / local-model-lab: Gemma 4 E2B 4-bit -> Gemma 4 E4B 4-bit -> Gemma 4
+     12B 4-bit -> Gemma 4 12B BF16 -> Gemma 4 26B A4B 4-bit -> Gemma 4 31B
+     4-bit -> Nemotron 3 Nano 4B/30B-A3B -> remote Gemma/Nemotron. Pull from
+     the stable `models.understudylabs.com/session?model=<id>` snapshots in
+     [`../manage-local-models/reference.md`](../manage-local-models/reference.md)
+     instead of sending the user to open-ended model browsing.
    - **Prompt or output contract weak** -> use
      [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) for
      train/dev-only GEPA or prompt repair.
@@ -134,12 +145,12 @@ local model can actually do the user's job.
    - **Local cannot meet quality** -> stay remote and document the revisit trigger
      (new MLX runtime, new weights, larger hardware, or better env feedback).
 
-8. **Rerun until the claim is real.** Iterate on the chosen intervention against
+9. **Rerun until the claim is real.** Iterate on the chosen intervention against
    the frozen task slice. The win condition is not "local feels good"; it is
    "local beats the frontier baseline on the agreed metric for these tasks" or a
    clear decision that frontier/remote remains the right route.
 
-9. **Prove the route.** For answer-only tasks, run
+10. **Prove the route.** For answer-only tasks, run
    [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) against
    frozen eval rows. For tool/API workflows, use
    [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
@@ -147,10 +158,11 @@ local model can actually do the user's job.
 
 ## Output Standard
 
-End with: task class; first local rung and why it is the smallest reasonable
-choice; Pi arena setup and first head-to-head result; chosen real task/data
-slice; frozen eval/environment path; gap diagnosis; chosen next intervention;
-whether local beat frontier on that slice or the exact evidence still needed.
+End with: task class; workload profile status; first local rung and why it is
+the smallest reasonable choice; Pi/tmux local proof; whether a head-to-head was
+run; chosen real task/data slice; frozen eval/environment path; gap diagnosis;
+chosen next intervention; whether local beat the incumbent on that slice or the
+exact evidence still needed.
 
 ## References
 

--- a/skills/specialize-local-model/SKILL.md
+++ b/skills/specialize-local-model/SKILL.md
@@ -13,8 +13,11 @@ metadata:
 Turn a task into a measured local-model ladder. Start with the **smallest local
 model that is plausibly reasonable for the task**, open it in Pi so the developer
 immediately sees a private model running on their machine, compare it against a
-frontier model, then use the gap to decide whether to climb models, optimize the
-prompt, decompose the task, simulate the environment, or route remote.
+frontier model, then move immediately from the stock duel into the user's real
+problem: pick a workflow, find or create task-specific data, freeze an eval, and
+try to make the local Understudy outperform the frontier on that slice. Use the
+observed gap to decide whether to climb models, optimize the prompt, decompose
+the task, simulate the environment, or route remote.
 
 This is an orchestration skill. Do not reimplement worker skills inline; sequence
 them and hand off with concrete artifacts.
@@ -24,18 +27,21 @@ them and hand off with concrete artifacts.
 ```text
 task intake
   -> smallest reasonable local rung
-  -> Pi frontier-vs-local head-to-head
-  -> default deterministic environment calibration
+  -> Pi stock frontier-vs-local head-to-head
+  -> pick a real problem or find task data
+  -> freeze a task-specific eval/environment
   -> gap report
-  -> simulated env / frozen eval when the task is workflow-like
-  -> improve via model climb, GEPA, RLM, or route
+  -> improve via model climb, GEPA, RLM, env feedback, or route
+  -> rerun until local beats frontier on that task slice or the route stays remote
   -> measured route decision
 ```
 
-The arena is the emotional proof: "I have a local model running." The default
-environment is the calibration proof: "this model can act in a deterministic
-tool world." The codebase-specific simulated environment and eval loop are the
-proof that the local model can actually do the user's job.
+The arena is the emotional proof: "I have a local model running." The stock duel
+is only the spark, not the end state. The durable product moment is when the
+developer picks a real problem, the agent finds or builds representative data,
+and the local Understudy starts beating the frontier on that specific workload.
+The codebase-specific simulated environment and eval loop are the proof that the
+local model can actually do the user's job.
 
 ## Safety Gates
 
@@ -88,20 +94,29 @@ proof that the local model can actually do the user's job.
    generated from the workload decomposition. Capture preference, guessed
    frontier identity, latency, cost, and failure notes.
 
-4. **Write a gap report.** Record:
+4. **Pick the real task slice.** Do not stop at the stock duel. Ask the developer
+   to pick one concrete problem they care about, or inspect the current repo for
+   useful data: eval files, fixtures, traces, support tickets, prompts,
+   transcripts, golden outputs, failing tests, or API/tool logs. If no data
+   exists, synthesize a small public/local fixture that matches the workflow and
+   clearly label it as synthetic. The goal is a bounded slice where the local
+   Understudy can plausibly beat the frontier through specialization.
+
+5. **Freeze the task-specific eval/environment.** For answer-only work, route to
+   [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) and
+   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) to create
+   rows, rubric/metric, baseline, and holdout. For workflow/tool tasks, route to
+   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
+   to build seeded state, tool contracts, oracle actions, and final-state
+   validators. Frontier is the incumbent baseline; local is the candidate.
+
+6. **Write a gap report.** Record:
    - where local already matches or beats frontier;
    - where frontier wins;
    - whether the gap is model size, prompt/harness, context/tool surface, missing
      environment feedback, or true policy learning.
 
-5. **Run the default environment before custom env work.** Use
-   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
-   to run the built-in synthetic inbox/ticket/project-board sandbox with the
-   local model and frontier. Treat this as calibration only: it validates tool
-   calling, schema following, final-state scoring, and the local-vs-frontier
-   comparison path before building anything from the user's codebase.
-
-6. **Choose the next intervention.**
+7. **Choose the next intervention.**
    - **Model too weak, harness sane** -> climb the local model ladder and rerun
      Pi / local-model-lab: Gemma 4 E2B 4-bit -> Gemma 4 E2B BF16 -> Gemma 4 E4B
      -> Gemma 4 12B -> Nemotron 3 Nano 4B/30B-A3B -> remote Gemma/Nemotron.
@@ -119,7 +134,12 @@ proof that the local model can actually do the user's job.
    - **Local cannot meet quality** -> stay remote and document the revisit trigger
      (new MLX runtime, new weights, larger hardware, or better env feedback).
 
-7. **Prove the route.** For answer-only tasks, run
+8. **Rerun until the claim is real.** Iterate on the chosen intervention against
+   the frozen task slice. The win condition is not "local feels good"; it is
+   "local beats the frontier baseline on the agreed metric for these tasks" or a
+   clear decision that frontier/remote remains the right route.
+
+9. **Prove the route.** For answer-only tasks, run
    [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) against
    frozen eval rows. For tool/API workflows, use
    [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
@@ -128,8 +148,9 @@ proof that the local model can actually do the user's job.
 ## Output Standard
 
 End with: task class; first local rung and why it is the smallest reasonable
-choice; Pi arena setup and first head-to-head result; gap diagnosis; chosen next
-intervention; route decision or the exact evidence still needed.
+choice; Pi arena setup and first head-to-head result; chosen real task/data
+slice; frozen eval/environment path; gap diagnosis; chosen next intervention;
+whether local beat frontier on that slice or the exact evidence still needed.
 
 ## References
 

--- a/skills/specialize-local-model/reference.md
+++ b/skills/specialize-local-model/reference.md
@@ -1,0 +1,31 @@
+# Specialize Local Model — Reference
+
+## After the Stock Duel
+
+The stock local-vs-frontier duel is only an activation moment. It proves the
+developer has a local Understudy running and gives a first feel for the quality
+gap. It is not the workload.
+
+Immediately after the duel, move to a task-specific slice:
+
+1. Ask the developer to pick one concrete problem they care about, or inspect
+   the current repo for useful data.
+2. Look for eval files, prompts, traces, fixtures, support tickets, transcripts,
+   golden outputs, failing tests, API/tool logs, or existing datasets.
+3. If no data exists, create a small synthetic local fixture that matches the
+   workflow and label it as synthetic.
+4. Freeze an eval or simulated environment before optimizing.
+5. Treat frontier as the incumbent baseline and the local Understudy as the
+   candidate.
+
+The win condition is specific: local beats the frontier baseline on the agreed
+metric for the chosen task slice. If it cannot, keep the route frontier/remote
+and record the revisit trigger.
+
+## Routing The Slice
+
+- Answer-only rows: use `capture-evidence` then `run-local-model-lab`.
+- Workflow or tool state: use `design-simulated-environment`.
+- Prompt or output contract weakness: use `optimize-workload`.
+- One huge prompt that overwhelms the local model: use `recursive-language-model`.
+- Model capacity gap with a sane harness: climb the Gemma/Nemotron ladder.

--- a/skills/understand-workload/SKILL.md
+++ b/skills/understand-workload/SKILL.md
@@ -8,17 +8,19 @@ metadata:
     cli_required: false
 ---
 
-# Understand the workload (decompose & explain a prompt)
+# Understand the workload (profile traces, data, prompts, and code path)
 
-The intermediate step before you compare models. **You cannot fairly vibe-check
-two models on a workload you don't understand**, and seeing generated questions in
-isolation is useless if the user has never seen what the real prompt does. This
-skill turns one captured prompt into a *shared mental model* — purpose, inputs,
-outputs, steps, tool-call flow, and success criteria — built **with** the user
-through Q&A, and only then derives the comparison questions.
+The intermediate step before you compare, optimize, or route models. **You
+cannot improve an AI workload you cannot explain.** Seeing generated questions
+or a side-by-side duel in isolation is secondary; first help the user understand
+what their workload is meant to accomplish, what data it represents, and how a
+request moves through the app. This skill turns traces, prompt files, datasets,
+and code paths into a *shared mental model* — purpose, inputs, outputs, steps,
+tool-call flow, data shape, failure modes, and success criteria — built **with**
+the user through Q&A.
 
-Every prompt is different, so this is a skill, not a script: the decomposer
-extracts the structure; you supply the meaning and confirm it with the user.
+Every workload is different, so this is a skill, not a script: the agent
+extracts structure from traces and code; the user confirms the task meaning.
 
 ## Safety Gates
 
@@ -31,22 +33,42 @@ extracts the structure; you supply the meaning and confirm it with the user.
   must be synthetic (no customer data) before they can be committed or sent to a
   model.
 - Make cost/latency/model claims from the capture itself, not memory.
+- **No premature duel.** Do not route to a frontier-vs-local head-to-head until
+  the workload purpose, data shape, and success criteria are clear enough that
+  the comparison questions map to real task behavior.
 
 ## Inputs it handles
 
 - **Understudy capture envelopes** (`.jsonl` with a `customer_request_body`).
 - **Raw request JSON** (Anthropic/OpenAI shape: `model`, `system`, `messages`, `tools`).
+- **Prompt/config files** embedded in an app (`prompts/`, route handlers, agent
+  policy files, YAML/JSON configs, eval manifests).
+- **Code paths** that assemble the request, call the provider, parse responses,
+  invoke tools, retry, stream, or write state.
+- **Datasets and eval rows** (`.jsonl`, fixtures, golden outputs, trace exports,
+  benchmark tasks, request logs).
 - A **folder** of captures — pick one or two representative ones (e.g. median and
   largest token count) rather than all of them.
 
 ## Flow
 
-1. **Locate + pick a representative trace.** If given a dataset, list the captures
-   with sizes and pick the median + the largest (size drives the harness story).
-   Understudy captures are envelopes with a `customer_request_body`; parse that to
-   get the request (`model`, `system`, `messages`, `tools`, params).
+1. **Locate the workload surface.** Start from what the user named: codebase,
+   app route, prompt file, dataset, eval suite, trace export, benchmark fixture,
+   request log, or existing runner. List candidate surfaces and identify which
+   one appears to be the actual production or benchmark workload. If given a
+   dataset or trace folder, list row/count/file sizes and pick the median +
+   largest representative cases (size drives the harness story). Understudy
+   captures are envelopes with a `customer_request_body`; parse that to get the
+   request (`model`, `system`, `messages`, `tools`, params).
 
-2. **Decompose the structure, redaction-safe** — extract and report only:
+2. **Trace the request/response path in situ.** Follow the code from user input
+   or eval row to prompt assembly, model/provider call, tool loop, response
+   parsing, retries, streaming, and any writes. Name the files/functions/routes
+   involved, the env var names used for providers, and where logs or traces are
+   emitted. Do not stop at "there is a prompt"; show the whole path the request
+   takes and where the candidate model can safely be swapped in.
+
+3. **Decompose the request structure, redaction-safe** — extract and report only:
    model + params, token size, the **system-prompt outline** (its `#` headings, not
    the body), the **messages** (roles + char sizes — never content), the **tool
    catalog grouped by action class** (read / transform / write / search /
@@ -55,22 +77,31 @@ extracts the structure; you supply the meaning and confirm it with the user.
    re-sent every turn) vs per-call content** — the fixed share is usually the
    surprise and drives the harness story.
 
-3. **Explain it back in plain language** — six facets, each one or two sentences:
+4. **Profile the data or traces.** Before model comparison, describe what the
+   dataset represents: row count, split/source if known, task categories, input
+   size distribution, output shapes, labels/golden fields, tool-call/request-log
+   counts, common failure classes, and outliers. Use metadata, schemas, counts,
+   hashes, and redacted examples. If raw examples are needed, ask for explicit
+   approval and show the smallest safe excerpt.
+
+5. **Explain it back in plain language** — seven facets, each one or two sentences:
    - **Purpose** — what is this prompt trying to accomplish?
    - **Inputs** — what goes in (and roughly how big)?
+   - **Data represented** — what rows/traces/users/tasks does this dataset stand for?
    - **Outputs** — what should come out, in what shape?
    - **Steps** — how many, and what is each step doing?
    - **Tools/actions** — what can it touch, and which calls *mutate state*?
+   - **Code path** — where the request is assembled, called, parsed, and logged.
    - **How we judge success** — the task-level criteria (correct records written,
      right observations extracted, policy followed) — **not just cost and speed.**
 
-4. **Show the flow as a mermaid diagram.** Draw the agent loop and tool classes so
+6. **Show the flow as a mermaid diagram.** Draw the agent loop and tool classes so
    the user can *see* the shape: inputs → system → loop → {read / transform / write}
    → final state. For a multi-turn case, also reconstruct the loop turn-by-turn from
    the (history-carrying) captures — per-request token growth and how context
    compounds as tool results are appended — and render that too.
 
-5. **Q&A discovery — build the understanding WITH the user.** Use `AskUserQuestion`
+7. **Q&A discovery — build the understanding WITH the user.** Use `AskUserQuestion`
    to confirm and fill gaps you can't infer from structure alone, e.g.:
    - "Is the goal *extraction* (read→structured output) or *orchestration*
      (read→decide→write)? I inferred X from the tools — right?"
@@ -80,26 +111,29 @@ extracts the structure; you supply the meaning and confirm it with the user.
    - "Where does the big token cost come from — fixed context or per-item input?"
    Iterate until the user says the picture is right.
 
-6. **Write the success criteria** — the rubric axes for *this* workload, beyond
+8. **Write the success criteria** — the rubric axes for *this* workload, beyond
    cost/latency: final-state correctness, extraction recall/precision, policy
    compliance, no-bad-writes, schema validity. These become the metric the arena /
    `capture-evidence` use.
 
-7. **Use the shared understanding to test models.** Two paths: derive grounded
-   vibe-check questions (each mapping to a real step/criterion) for the frontier-vs-
-   local head-to-head ([`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md)); and, for a
-   whole-case test a small model can't one-shot, build a
-   [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
-   and run the [`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md)
-   decomposition harness to measure what's reachable. Freeze the metric/splits with
-   [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md).
+9. **Use the shared understanding to test or improve models.** Primary path:
+   freeze a workload contract with [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)
+   and run the local model against the real task via
+   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) or the
+   appropriate optimizer skill. Optional side quest: derive grounded vibe-check
+   questions for [`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md), each mapped to
+   a real step/criterion, when the user needs a visible local-vs-frontier feel
+   check. For a whole-case test a small model cannot one-shot, build a simulated
+   environment only when no real resettable workload exists.
 
 ## Output Standard
 
-End with: the representative trace(s) chosen and their size; the six-facet
-explanation; the mermaid flow; the success criteria agreed with the user; and the
-list of grounded questions to take into the arena — each tied to a step or
-criterion. Keep the decomposition doc local; only the synthetic questions leave.
+End with: workload surface inspected; representative trace(s)/dataset rows
+chosen and their size; the request/response code path; data/trace profile; the
+seven-facet explanation; the mermaid flow; success criteria agreed with the
+user; artifact paths for the local workload brief; and the next evidence action.
+If you include arena questions, mark them optional and tie each to a real step
+or criterion. Keep the decomposition doc local; only synthetic questions leave.
 
 ## References
 

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -121,6 +121,10 @@ Identify the developer's current stage and load exactly one:
   gateway trace capture, project/key management, model A/B via route traffic %,
   `understudy run`, or registering an improved route →
   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+- **Frontier key choice** — a local-vs-frontier comparison, installer, or agent
+  run needs to decide between BYO `.env` provider keys, the Understudy ZDR
+  gateway route, or skipping remote frontier calls →
+  [`../choose-frontier-keys/SKILL.md`](../choose-frontier-keys/SKILL.md).
 - **Acquire / cache / organize local models** — download a model, see what's
   already cached, free up model disk, pick which Gemma/Nemotron to pull, or
   explain how open weights work →

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -79,8 +79,12 @@ rules:
   state the loop stage (capture → baseline → optimize/compare → validate →
   decide), re-derived from artifacts on disk.
 - **Meet them where they are.** Read `~/.understudy/profile.json` and set
-  vocabulary, coaching depth, and opinion strength to match. No profile yet → run
-  [`../onboard/SKILL.md`](../onboard/SKILL.md) first.
+  vocabulary, coaching depth, and opinion strength to match. Also read
+  `~/.understudy/agent-card.json` when the user asks whether their Understudy is
+  active or how to talk to it; this card is the agent-facing runtime source of
+  truth for model endpoint, tmux session, companion status, and the exact local
+  chat command. No profile yet → run [`../onboard/SKILL.md`](../onboard/SKILL.md)
+  first.
 
 ## Inspect before you ask
 

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -27,15 +27,18 @@ spend, or model downloads after explicit approval in the current thread.
 2. Understand the objective (cost, speed, quality, reliability, compliance, or a
    weighted mix).
 3. Understand the constraints (what must not be violated).
-4. Capture or locate real traces.
-5. Build or improve a small, meaningful eval harness; rerun the incumbent
+4. Understand the workload — inspect prompts in situ, trace the request/response
+   code path, profile the dataset/traces, and confirm the task meaning with the
+   user.
+5. Capture or locate real traces.
+6. Build or improve a small, meaningful eval harness; rerun the incumbent
    baseline.
-6. Run local optimization against eval failures.
-7. Compare candidate vs baseline on the objective.
-8. Recommend the most efficient route — harness, model, supplier, gateway/
+7. Run local optimization against eval failures.
+8. Compare candidate vs baseline on the objective.
+9. Recommend the most efficient route — harness, model, supplier, gateway/
    inference-layer route, deployment approach.
-9. Implement the selected route safely (smallest viable change).
-10. Produce an Understudy Agent Improvement Report the developer can review.
+10. Implement the selected route safely (smallest viable change).
+11. Produce an Understudy Agent Improvement Report the developer can review.
 
 ## Frame every job
 
@@ -44,6 +47,7 @@ Keep these six separate and explicit — say them back before acting:
 - **Objective** — what are we optimizing for?
 - **Constraints** — what are we not allowed to violate?
 - **Evidence** — what traces / evals / prices / measurements do we have?
+- **Workload** — what task does the prompt/data/code path actually represent?
 - **Route** — what harness / model / supplier / deployment path?
 - **Action** — what does the agent actually change?
 - **Verification** — how do we prove the change helped?
@@ -117,6 +121,10 @@ Identify the developer's current stage and load exactly one:
   installed the plugin, or asks "where do I start?" and `~/.understudy/profile.json`
   is missing → [`../onboard/SKILL.md`](../onboard/SKILL.md) (backgrounds a small
   model, profiles the machine, interviews, writes the profile).
+- **Workload unclear** — the repo has prompts, traces, datasets, eval rows, or
+  LLM call sites, but the task, data shape, request/response path, or success
+  criteria have not been explained and confirmed → [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md).
+  Do this before head-to-head comparisons or optimization.
 - **Codebase / evidence not yet pinned down** — LLM call sites, current model/
   harness, traces, metric, splits, or incumbent baseline are missing, ambiguous,
   or stale → [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)
@@ -138,9 +146,9 @@ Identify the developer's current stage and load exactly one:
   runtime, compare local vs remote, or satisfy ZDR / no-upload constraints →
   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
 - **Local understudy specialization loop** — the developer wants the smallest
-  task-reasonable local model opened in Pi against a frontier model, then wants
-  the observed gap to drive a model climb, simulated env, GEPA, RLM, hybrid
-  route, or remote-only decision →
+  task-reasonable local model opened in Pi and optionally compared against a
+  frontier model, then wants the observed gap to drive workload understanding,
+  model climb, simulated env, GEPA, RLM, hybrid route, or remote-only decision →
   [`../specialize-local-model/SKILL.md`](../specialize-local-model/SKILL.md).
 - **Single-output optimization** — fresh artifacts exist and the developer wants
   to validate, optimize (GEPA), compare candidates, or claim readiness →
@@ -274,7 +282,7 @@ End with:
 
 - worker skill used or recommended;
 - where you are in the loop, and the Objective / Constraints / Evidence / Route /
-  Action / Verification state;
+  Action / Verification state, plus the Workload understanding state;
 - artifacts inspected, created, or still missing;
 - result type: evidence-capture, validation, optimization, route-recommendation,
   deployment, or blocked;


### PR DESCRIPTION
## Summary

This PR makes the first-run Understudy flow ready for Aamir testing:

- moves the installer away from launching fragile terminal arena flows and into Claude Code skill handoff
- adds diagnostics, cleanup, and debug logging around Pi/tmux/MLX arena sessions
- adds frontier-key selection guidance with BYO keys, Understudy gateway fallback, and local-only paths
- moves model acquisition into skills with a resumable verified snapshot pull helper
- reframes onboarding and specialization as workload-first: prove local inference, then profile prompts/traces/data/code paths before optional frontier duels
- expands the Gemma 4 model ladder in skills so agents know the next local rungs after E2B/E4B

## Why

The old installer tried to do too much directly and could fail through terminal/iTerm differences. The new path gets the user back into their coding agent, where the skills can coach tmux inspection, local model proof, workload profiling, and then optional local-vs-frontier calibration.

## Validation

- `npm run check`
- `bash -n skills/mlx-arena/arena.sh`
- `node --check skills/manage-local-models/scripts/pull-understudy-snapshot.mjs`
- `git diff --check`

## Follow-up

The larger Gemma 4 MLX snapshots are being tested/uploaded separately. Once each works locally and is live in Cloudflare R2, we should update the skills with the final verified model availability rather than treating those larger rungs as assumed-ready.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->