### PR TITLE
docs: feedback + prototypes for agentic (API-workflow) optimization

### DIFF
--- a/docs/proposals/agentic-workload-optimization-feedback.md
+++ b/docs/proposals/agentic-workload-optimization-feedback.md
@@ -1,0 +1,68 @@
+# Proposal: close the gaps for agentic (API-workflow) optimization
+
+**Source:** a full dogfood run — `onboard → choose-frontier-keys → optimize-api-workflow → optimize-workload (live GEPA) → recursive-language-model` — against AutomationBench `simple`, local Gemma-4-E2B (`:8081`) vs Claude Opus 4.8. Everything below is grounded in friction actually hit, with file:line citations into the current tree.
+
+## TL;DR
+
+The single-output optimization story is solid; the **agentic** story has two load-bearing holes and one correctness trap. Three changes unlock it:
+
+1. **A live-rollout GEPA adapter wired to `auto-bench`** (P0).
+2. **A prompt-injection hook in the rollout harness** (P0).
+3. **A first-class tool-retrieval recall/precision oracle + a stateless-advisor recipe** (P0), plus a **guard against claiming oracle-tool (`limited_zapier`) wins as generalizable**.
+
+## Evidence from the run
+
+| Toolset (local Gemma-4-E2B, `simple`) | Pass | What it measures |
+|---|---|---|
+| `api` (blind `api_search` over all schemas) | 33% | realistic discovery |
+| `zapier` (structured meta-search) | 40% | realistic discovery |
+| `limited_zapier` (oracle tools from `info["zapier_tools"]`) | 100% | discovery *removed* |
+
+Opus on `api` (`simple` dev): 100% @ ~$0.057/task, 26× the input tokens. The ~60-pt gap between realistic discovery and oracle-tools **is** the tool-discovery / context-rot problem. `runner.py` confirms `limited_zapier` just injects the gold subset. GEPA on the live `simple` system prompt **selected the seed** (no prompt beat baseline on dev — dev saturates once the toolset is fixed): the lever was the toolset, not the prompt.
+
+## P0 — load-bearing
+
+### 1. GEPA has no path to the agentic harness
+`skills/optimize-api-workflow/reference.md:330` calls a live-rollout manifest "a **future** adapter." The shipped adapters (`src/optimize-workload.ts:104` — `dspy-gepa`, `eval-input-gepa`) only optimize flat prompt→output rows; they can't re-run an `auto-bench` rollout per candidate. To GEPA the policy I had to hand-write a custom `GEPAAdapter` that shells out to `auto-bench --tasks … --toolset …`, parses the export, and synthesizes per-row NL feedback (~120 lines).
+**Proposal:** ship that as a first-class `auto-bench-gepa` (or generic `rollout-gepa`) adapter: candidate = component string(s); `evaluate` = run the harness on a row set + return score + per-row feedback; reflection on train/dev only.
+
+### 2. The rollout harness exposes no prompt parameter
+`auto-bench` has no `--system-prompt`; the cheapest recommended lever (prompt repair) required editing `automationbench/domains/<d>/tasks.py` and adding an `AB_*_SYSTEM_PROMPT` env hook by hand, then restoring. (AutomationBench is vendored/external, so the fix is to **document the env-hook decomposition as the supported pattern** in the skill, and upstream a `--system-prompt-file` if we own the fork.)
+
+### 3. Tool-retrieval is the real workload — make it first-class
+Quantified: **549 tools in catalog, gold 1–4/task (median 2)**. A stateless "advisor" (catalog prefix + task → tool subset, nuked each call so the prefix is byte-stable and **prompt-cacheable**) is the generalizable version of the `limited_zapier` win and the direct fix for context rot.
+- **Advisor v0 (local Gemma-4-E2B, zero-shot): dev recall 0.78 / precision 0.83, `cacheable_prefix_frac 0.994`, 0.75s/task.** Statelessness→cache-stability confirmed.
+- The recall/precision-vs-gold oracle **already exists** in `skills/design-simulated-environment/SKILL.md:31,54,76` — wire it into the optimize-api-workflow tool-discovery path.
+- Because retrieval is a flat `task→tool-list vs gold` task, **`eval-input-gepa` fits it natively** — the interim answer to gap #1: decompose, then point the existing adapter at retrieval.
+
+### Guard: don't let oracle-tool wins masquerade as generalizable
+`optimize-api-workflow` never mentions `limited_zapier`/`zapier_tools`/oracle. **Require reporting the realistic-toolset (`api`/`zapier`) number alongside any `limited_zapier` result, and treat oracle-tool matching as a non-claim.**
+
+## P1 — correctness
+
+- **Agent-card mislabels runtime.** `skills/mlx-arena/arena.sh:355` sets `served_by`/`runtime` from `UNDERSTUDY_CARD_LOADER` env, not from detecting the live process — it recorded `mlx_vlm.server` though `mlx_vlm` wasn't installed (model served by an `mlx_lm` router). `project.cwd` was the skill dir, not the user's project. Header (`arena.sh:4`) vs onboard/reference also disagree (`mlx_lm.server` vs `mlx_vlm.server`). Detect, don't assume.
+- **metric.json rubric is aspirational.** The 9 weighted criteria in `reference.md` (endpoint_selection, forbidden_writes_avoided, …) have no mapping to what `auto-bench` emits (`partial_credit`, `task_completed_correctly`, assertions). Align to emitted signals or document the derivation.
+- **pricing lags new models.** AutomationBench `pricing.py` lacks `claude-opus-4-8` → cost came back `N/A`. Add nearest-version fallback.
+
+## P2 — guidance / robustness
+
+- **Foreground the toolset lever** in the failure→intervention table: for small models on discovery tasks, try the structured toolset *before* prompt/GEPA.
+- **`EmptyModelResponseError` aborts whole rollouts** (killed a full-200 export). Retry-on-empty / graceful per-rollout zero — this hits exactly the small models the skills target.
+- **Onboarding assumes a cold machine.** "Start the slow download first" is moot when the snapshot is cached and the user has a rich model library; detect and skip the loading-screen theater for practitioners.
+- **(UX nit)** `understudy experiments new` takes no `--name`; `projects` does (`src/commands/projects.ts:62`). Parity affordance.
+
+## Reproduction & code slices
+
+Prototype scripts from the run (environment-specific `ROOT`/model paths hardcoded for the dogfood; no secrets — keys come from env):
+
+- **`docs/proposals/examples/gepa_drive_live_rollout_adapter.py`** — the missing **P0#1** artifact: a custom `gepa.GEPAAdapter` whose `evaluate()` shells out to `auto-bench --tasks … --toolset limited_zapier` (local student, free), parses the export into per-row scores, and `make_reflective_dataset()` emits per-row NL failure feedback; reflection = Opus (BYO) with a hard spend cap. This is roughly what `auto-bench-gepa` should become.
+- **`docs/proposals/examples/rlm_tool_retrieval_advisor.py`** — the **P0#3** artifact: the stateless catalog-prefix advisor; scores recall/precision vs gold `zapier_tools`, reports `cacheable_prefix_frac`.
+
+Working evidence (local, not committed — under the AutomationBench testbed, `…/testing-environments/AutomationBench/.understudy/capture-evidence/`):
+`harness.json`, `metric.json`, `splits.json`, `baseline.json`, `claim.json` (sha-bound), `gepa-result.json`, `advisor-dev.json`, `simple-gold-tools.json`, `tool-catalog.json`, plus the per-run `auto-bench` exports. Full prose feedback: the dogfooding project's `.understudy/skills-feedback-2026-06-06.md`.
+
+## Kept / praised
+
+- `choose-frontier-keys` presence-only key discipline (parse `.env` by var-name, never print) — safe and easy to follow. One gap: it only searches the project dir; my keys lived in a sibling repo.
+- The sha-bound evidence contract + holdout seal made the GEPA refusal gate meaningful and kept claims honest (lead vs heldout). Don't loosen it.
+- Letting a real captured env (AutomationBench) replace the toy sandbox was higher value than the default simulated env.

--- a/docs/proposals/examples/gepa_drive_live_rollout_adapter.py
+++ b/docs/proposals/examples/gepa_drive_live_rollout_adapter.py
@@ -1,0 +1,131 @@
+"""Faithful live-rollout GEPA for the AutomationBench `simple` system prompt.
+
+Student rollouts run locally (free) via auto-bench --toolset limited_zapier.
+Reflection = Opus 4.8 (BYO) with a hard spend cap. Train/dev only; holdout sealed.
+"""
+from __future__ import annotations
+import json, os, subprocess, sys, tempfile, time
+from dataclasses import dataclass
+import gepa
+from gepa.core.adapter import GEPAAdapter, EvaluationBatch
+import anthropic
+
+ROOT = "/Users/luis/Developer/understudy/testing-environments/AutomationBench"
+EV = f"{ROOT}/.understudy/capture-evidence"
+LOCAL_MODEL = "/Users/luis/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit"
+BASE_URL = "http://127.0.0.1:8081/v1"
+REFLECT_MODEL = "claude-opus-4-8"
+SPEND_CAP_USD = 2.8
+IN_C, OUT_C = 5e-6, 25e-6  # opus 4.x per-token
+
+splits = json.load(open(f"{EV}/splits.json"))
+TRAIN = splits["train"]["rows"]
+DEV = splits["dev"]["rows"]
+DEFAULT_PROMPT = (
+    "You are a workflow automation agent. Execute the requested task using the available tools.\n"
+    "- Do not ask clarifying questions. Take action instead.\n"
+    "- Referenced data (spreadsheets, policies, guidelines, rosters) exists in the simulated "
+    "environment — discover it by searching email, listing spreadsheets, querying calendars, etc. "
+    "If the prompt says 'our current X policy' or 'the Y guidelines,' search for it.\n"
+    "- Never respond with a list of missing information."
+)
+
+def run_rollouts(prompt: str, tasks: list[str]) -> dict:
+    """Run auto-bench on exactly `tasks` with the candidate prompt injected. Returns {name: rec}."""
+    env = dict(os.environ); env["AB_SIMPLE_SYSTEM_PROMPT"] = prompt
+    with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as tf:
+        out = tf.name
+    cmd = ["uv", "run", "auto-bench", "--model", LOCAL_MODEL, "--base-url", BASE_URL,
+           "--api-key", "local", "--api", "chat_completions", "--domains", "simple",
+           "--toolset", "limited_zapier", "--tasks", ",".join(tasks), "--max-steps", "30",
+           "--max-concurrent", "4", "--input-cost", "0", "--output-cost", "0",
+           "--export-json", out]
+    subprocess.run(cmd, cwd=ROOT, env=env, capture_output=True, text=True, timeout=900)
+    recs = {}
+    try:
+        for r in json.load(open(out))["tasks"]:
+            recs[r["name"]] = r
+    except Exception:
+        pass
+    os.unlink(out)
+    return recs
+
+def diagnose(rec: dict) -> str:
+    """Natural-language feedback tied to the failing rollout step."""
+    if rec is None:
+        return "Rollout failed to run (no output). The agent may have returned an empty response; instruct it to always call a tool or state a result."
+    if rec.get("passed"):
+        return "PASS: final state correct."
+    msgs = rec.get("messages", [])
+    last = next((m for m in reversed(msgs) if m.get("role") == "assistant"), {})
+    txt = (last.get("content") or "").lower()
+    toolresults = " ".join(str(m.get("content", "")) for m in msgs if m.get("role") == "tool").lower()
+    if any(m.get("role") == "assistant" and not m.get("content") and not m.get("tool_calls") for m in msgs):
+        return "FAIL: agent emitted an empty turn (no content, no tool call). Instruct it to never end a turn empty — always call a tool or state the completed result."
+    if "no handler" in toolresults or "404" in toolresults:
+        return "FAIL: called an endpoint from the WRONG app (404/no handler). Instruct it to verify the endpoint's service matches the app named in the task before calling, and to re-search with a more specific query if the app is wrong."
+    if any(w in txt for w in ("unable", "could not find", "no suitable", "cannot find", "not able")):
+        return "FAIL: agent gave up early without completing the write. Instruct it to persist across multiple steps and keep refining its search until the target record is actually updated."
+    ar = rec.get("assertion_results") or []
+    miss = [a for a in ar if not (a.get("passed", True))]
+    if miss:
+        d = miss[0].get("description") or miss[0].get("name") or "a required assertion"
+        return f"FAIL: final state missing required change — {d}. Instruct the agent to complete the specific write the task asks for and verify it before finishing."
+    return "FAIL: task not completed correctly; required final-state change is missing. Be explicit about completing and verifying the requested write."
+
+class ABAdapter(GEPAAdapter):
+    def evaluate(self, batch, candidate, capture_traces=False):
+        prompt = candidate["system_prompt"]
+        recs = run_rollouts(prompt, list(batch))
+        scores, outputs, trajs = [], [], []
+        for name in batch:
+            rec = recs.get(name)
+            sc = float(rec.get("score", 0.0)) if rec else 0.0
+            scores.append(sc)
+            outputs.append({"name": name, "passed": bool(rec and rec.get("passed")), "score": sc})
+            trajs.append({"name": name, "task": (rec or {}).get("messages", [{}, {}])[1].get("content", name)
+                          if rec else name, "feedback": diagnose(rec), "score": sc})
+        return EvaluationBatch(outputs=outputs, scores=scores,
+                               trajectories=trajs if capture_traces else None, objective_scores=None)
+
+    def make_reflective_dataset(self, candidate, eval_batch, components_to_update):
+        items = []
+        for tr in (eval_batch.trajectories or []):
+            items.append({
+                "Inputs": str(tr.get("task"))[:600],
+                "Generated Outputs": f"score={tr['score']:.2f} passed={tr['score']>=1.0}",
+                "Feedback": tr["feedback"],
+            })
+        return {c: items for c in components_to_update}
+
+# --- reflection LM: Opus with spend cap ---
+_client = anthropic.Anthropic()
+_spend = {"in": 0, "out": 0, "calls": 0}
+def reflect(prompt: str) -> str:
+    if _spend["in"] * IN_C + _spend["out"] * OUT_C > SPEND_CAP_USD:
+        # budget exhausted: return the prompt unchanged-ish to let GEPA wind down
+        return prompt
+    r = _client.messages.create(model=REFLECT_MODEL, max_tokens=1500,
+                                messages=[{"role": "user", "content": prompt}])
+    _spend["in"] += r.usage.input_tokens; _spend["out"] += r.usage.output_tokens; _spend["calls"] += 1
+    print(f"[reflect #{_spend['calls']}] spend=${_spend['in']*IN_C+_spend['out']*OUT_C:.3f}", file=sys.stderr)
+    return "".join(b.text for b in r.content if getattr(b, "type", "") == "text")
+
+if __name__ == "__main__":
+    budget = int(os.environ.get("GEPA_MAX_METRIC_CALLS", "150"))
+    t0 = time.time()
+    result = gepa.optimize(
+        seed_candidate={"system_prompt": DEFAULT_PROMPT},
+        trainset=TRAIN, valset=DEV, adapter=ABAdapter(),
+        reflection_lm=reflect, max_metric_calls=budget, reflection_minibatch_size=3,
+        display_progress_bar=False,
+    )
+    best = result.best_candidate["system_prompt"]
+    out = {"best_system_prompt": best,
+           "val_score": getattr(result, "val_aggregate_scores", None),
+           "reflect_calls": _spend["calls"],
+           "reflect_spend_usd": round(_spend["in"]*IN_C + _spend["out"]*OUT_C, 3),
+           "elapsed_s": round(time.time()-t0, 1)}
+    json.dump(out, open(f"{EV}/gepa-result.json", "w"), indent=2)
+    print(json.dumps({k: v for k, v in out.items() if k != "best_system_prompt"}))
+    print("---BEST PROMPT---"); print(best)

--- a/docs/proposals/examples/rlm_tool_retrieval_advisor.py
+++ b/docs/proposals/examples/rlm_tool_retrieval_advisor.py
@@ -1,0 +1,69 @@
+"""Tool-retrieval advisor v0 — stateless, catalog-prefix, scored vs gold zapier_tools.
+
+Measures whether a (local) model can retrieve the right ~2 tools from 549.
+No rollouts: pure recall/precision against gold. The catalog is a stable prefix
+(the cacheable part); only the task query varies per call.
+"""
+from __future__ import annotations
+import json, re, sys, time
+import urllib.request
+
+ROOT = "/Users/luis/Developer/understudy/testing-environments/AutomationBench"
+EV = f"{ROOT}/.understudy/capture-evidence"
+ENDPOINT = "http://127.0.0.1:8081/v1/chat/completions"
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "/Users/luis/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit"
+SPLIT = sys.argv[2] if len(sys.argv) > 2 else "dev"
+
+rows = json.load(open(f"{EV}/simple-gold-tools.json"))
+catalog = json.load(open(f"{EV}/tool-catalog.json"))
+splits = json.load(open(f"{EV}/splits.json"))
+sel = set(splits[SPLIT]["rows"]) if SPLIT in splits else None
+work = [r for r in rows if (sel is None or r["name"] in sel)]
+
+CATALOG_TEXT = "\n".join(f"- {t['name']}: {t['description']}" for t in catalog)
+SYS = (
+    "You are a tool-retrieval advisor. Given a task, return ONLY the tool names from the "
+    "catalog that are needed to complete it, as a compact JSON array of strings.\n"
+    "Rules: prefer the minimal set (usually 1-3). The tool's app/service MUST match the "
+    "system named in the task (e.g. a Salesforce task needs salesforce_* tools, not slack_*). "
+    "Return ONLY the JSON array, nothing else.\n\n"
+    f"CATALOG ({len(catalog)} tools):\n{CATALOG_TEXT}"
+)
+
+def ask(instruction: str):
+    body = json.dumps({"model": MODEL, "messages": [
+        {"role": "system", "content": SYS},
+        {"role": "user", "content": f"TASK: {instruction}\n\nReturn the JSON array of needed tool names."},
+    ], "max_tokens": 200, "temperature": 0}).encode()
+    req = urllib.request.Request(ENDPOINT, data=body, headers={"Content-Type": "application/json"})
+    r = json.load(urllib.request.urlopen(req, timeout=120))
+    txt = r["choices"][0]["message"]["content"] or ""
+    usage = r.get("usage", {})
+    m = re.search(r"\[.*?\]", txt, re.S)
+    try:
+        pred = json.loads(m.group(0)) if m else []
+        pred = [str(x).strip() for x in pred if isinstance(x, (str,))]
+    except Exception:
+        pred = re.findall(r"[a-z0-9_]+_[a-z0-9_]+", txt)
+    return pred, usage
+
+names = {t["name"] for t in catalog}
+R = P = EX = 0.0; n = len(work); per = []
+t0 = time.time(); in_tok = 0
+for r in work:
+    pred, usage = ask(r["instruction"])
+    pred = [p for p in pred if p in names]          # keep only real tool names
+    gold = set(r["gold_tools"]); ps = set(pred)
+    rec = len(ps & gold) / len(gold) if gold else 1.0
+    prec = len(ps & gold) / len(ps) if ps else 0.0
+    ex = 1.0 if ps == gold else 0.0
+    R += rec; P += prec; EX += ex; in_tok += usage.get("prompt_tokens", 0)
+    per.append({"name": r["name"], "gold": sorted(gold), "pred": pred, "recall": rec, "precision": round(prec, 2)})
+out = {"split": SPLIT, "model": MODEL, "n": n,
+       "recall": round(R/n, 3), "precision": round(P/n, 3), "exact_set_match": round(EX/n, 3),
+       "avg_prompt_tokens": int(in_tok/n), "catalog_tools": len(catalog),
+       "cacheable_prefix_frac": round(len(SYS)/(len(SYS)+200), 3), "elapsed_s": round(time.time()-t0, 1)}
+json.dump({"summary": out, "per_task": per}, open(f"{EV}/advisor-{SPLIT}.json", "w"), indent=1)
+print(json.dumps(out))
+for p in per[:6]:
+    print(f"  {p['recall']:.2f}r/{p['precision']:.2f}p  gold={p['gold']}  pred={p['pred']}")


### PR DESCRIPTION
## What

A dogfood-driven feedback proposal + two prototype scripts, landed under `docs/proposals/`.

Source: a full run through the skills — `onboard → choose-frontier-keys → optimize-api-workflow → optimize-workload (live GEPA) → recursive-language-model` — against AutomationBench `simple`, local Gemma-4-E2B (`:8081`) vs Claude Opus 4.8. Every point is grounded in friction actually hit, with file:line citations into the current tree.

## Headline gaps (all in the doc)

- **P0** — no live-rollout GEPA adapter wired to `auto-bench`; shipped adapters (`src/optimize-workload.ts:104`) are flat-row only. `reference.md:330` calls it "a future adapter." Prototype included.
- **P0** — the rollout harness exposes no prompt parameter; prompt repair required source edits + an env hook.
- **P0** — tool-retrieval should be first-class: a stateless, **cacheable** advisor (dev recall 0.78, `cacheable_prefix_frac 0.994`) is the generalizable fix for context rot; the recall/precision-vs-gold oracle already exists in `design-simulated-environment` — wire it in.
- **Guard** — `limited_zapier` (oracle tools) wins are not generalizable: local went 33% (`api`) → 100% (`limited_zapier`). Require the realistic-toolset number alongside.
- **P1** — agent-card mislabels runtime (`arena.sh:355` keys off an env flag, not detection); metric rubric vs emitted signals; pricing lag.

## Included prototypes (`docs/proposals/examples/`)

- `gepa_drive_live_rollout_adapter.py` — the missing live-rollout `GEPAAdapter` (shells to `auto-bench`, per-row NL feedback, Opus reflector w/ spend cap).
- `rlm_tool_retrieval_advisor.py` — the stateless advisor scored vs gold `zapier_tools`.

Docs-only; no code paths changed. Intended as a discussion/triage starting point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->