### PR TITLE
Improve agentic workflow optimization skills

### DIFF
--- a/docs/agentic-rollout-gepa.md
+++ b/docs/agentic-rollout-gepa.md
@@ -1,0 +1,47 @@
+# Agentic Rollout GEPA Adapter
+
+Use this pattern when prompt optimization must be scored by a live, multi-step
+tool harness instead of flat prompt-to-output rows.
+
+The public CLI adapters are intentionally narrow:
+
+- `eval-input-gepa` optimizes flat rows with local metric functions.
+- `dspy-gepa` optimizes DSPy-style samples.
+
+For an AutomationBench-style workload, the faithful adapter wraps the benchmark:
+
+1. Candidate state is a small component map, usually `{ "system_prompt": "..." }`.
+2. `evaluate(batch, candidate)` writes the candidate prompt to a local env var or
+   prompt file and runs the harness on train/dev rows only.
+3. The harness command exports JSON, for example:
+
+   ```sh
+   AB_SIMPLE_SYSTEM_PROMPT="$CANDIDATE_PROMPT" \
+   uv run auto-bench \
+     --model "$LOCAL_MODEL" \
+     --base-url http://127.0.0.1:8081/v1 \
+     --api-key local \
+     --api chat_completions \
+     --domains simple \
+     --toolset limited_zapier \
+     --tasks "$TASKS" \
+     --export-json "$EXPORT_JSON"
+   ```
+
+4. The adapter parses the export into scores and per-row failure feedback:
+   wrong endpoint, missing write, forbidden write, invalid schema, empty response,
+   bad recovery, or final-state diff.
+5. Reflection uses an approved model and explicit spend cap. Student rollouts stay
+   local when the student endpoint is local.
+6. Holdout rows are never passed to GEPA. They are run once after the winning
+   candidate is frozen.
+
+For API workflows, first ask whether a cheaper structural target is enough:
+
+- If `api` or `zapier` fails but `limited_zapier` succeeds, optimize retrieval or
+  endpoint catalog selection before prompt mutation.
+- If the right tools are present and the model still misses writes, policies, or
+  schemas, prompt GEPA has real signal.
+
+Record the adapter path, prompt hook, task ids, train/dev split, reflection model,
+spend cap, and final candidate in `.understudy/capture-evidence/`.

--- a/docs/agentic-rollout-gepa.md
+++ b/docs/agentic-rollout-gepa.md
@@ -1,14 +1,16 @@
 # Agentic Rollout GEPA Adapter
 
 Use this pattern when prompt optimization must be scored by a live, multi-step
-tool harness instead of flat prompt-to-output rows.
+tool harness instead of flat prompt-to-output rows. The important boundary is
+that every candidate is evaluated by rerunning the same resettable workload, not
+by scoring a detached transcript.
 
 The public CLI adapters are intentionally narrow:
 
 - `eval-input-gepa` optimizes flat rows with local metric functions.
 - `dspy-gepa` optimizes DSPy-style samples.
 
-For an AutomationBench-style workload, the faithful adapter wraps the benchmark:
+For a stateful agent workload, the faithful adapter wraps the harness:
 
 1. Candidate state is a small component map, usually `{ "system_prompt": "..." }`.
 2. `evaluate(batch, candidate)` writes the candidate prompt to a local env var or
@@ -16,15 +18,12 @@ For an AutomationBench-style workload, the faithful adapter wraps the benchmark:
 3. The harness command exports JSON, for example:
 
    ```sh
-   AB_SIMPLE_SYSTEM_PROMPT="$CANDIDATE_PROMPT" \
-   uv run auto-bench \
-     --model "$LOCAL_MODEL" \
-     --base-url http://127.0.0.1:8081/v1 \
-     --api-key local \
-     --api chat_completions \
-     --domains simple \
-     --toolset limited_zapier \
-     --tasks "$TASKS" \
+   CANDIDATE_SYSTEM_PROMPT="$CANDIDATE_PROMPT" \
+   "$HARNESS_CMD" \
+     --model "$STUDENT_MODEL" \
+     --endpoint "$STUDENT_ENDPOINT" \
+     --split train \
+     --rows "$TRAIN_ROWS" \
      --export-json "$EXPORT_JSON"
    ```
 
@@ -38,8 +37,9 @@ For an AutomationBench-style workload, the faithful adapter wraps the benchmark:
 
 For API workflows, first ask whether a cheaper structural target is enough:
 
-- If `api` or `zapier` fails but `limited_zapier` succeeds, optimize retrieval or
-  endpoint catalog selection before prompt mutation.
+- If broad tool access fails but a curated or oracle tool subset succeeds,
+  optimize retrieval, endpoint catalog selection, or tool descriptions before
+  prompt mutation.
 - If the right tools are present and the model still misses writes, policies, or
   schemas, prompt GEPA has real signal.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,11 +23,11 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   reruns the incumbent baseline. (Discovery + capture/import folded into its
   [`reference.md`](capture-evidence/reference.md).)
 - [`optimize-api-workflow`](optimize-api-workflow/SKILL.md) evaluates and
-  optimizes cross-application REST/API workflow agents such as
-  AutomationBench-style tasks: seeded state, fixed API schemas, policy docs,
-  request logs, final-state validators, and side-effect safety before any RL
-  handoff. (Artifact schemas, AutomationBench mapping, A/B procedure, and GEPA
-  bridge in its [`reference.md`](optimize-api-workflow/reference.md).)
+  optimizes cross-application REST/API workflow agents with seeded state, fixed
+  API schemas, policy docs, request logs, final-state validators, and
+  side-effect safety before any RL handoff. (Artifact schemas, harness mapping,
+  A/B procedure, and GEPA bridge in its
+  [`reference.md`](optimize-api-workflow/reference.md).)
 - [`optimize-workload`](optimize-workload/SKILL.md) refuses stale
   artifacts, preserves train/dev/holdout boundaries, writes dry-run proof
   packets, and requires `claim.json` before public claims. (Evaluate, optimize,

--- a/skills/README.md
+++ b/skills/README.md
@@ -55,6 +55,9 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
 - [`run-local-model-lab`](run-local-model-lab/SKILL.md) evaluates local or
   workstation-hosted models against the same frozen workload/eval, keeps model
   downloads behind approval, and compares local, hybrid, and remote routes.
+- [`compare-model-sweep`](compare-model-sweep/SKILL.md) runs a frozen eval across
+  a candidate matrix and writes Pareto-style quality, latency, cost, reliability,
+  and caveat artifacts for route decisions.
 - [`specialize-local-model`](specialize-local-model/SKILL.md) sequences the local
   model product loop: pick the smallest task-reasonable local rung, open it in
   Pi against a frontier model, diagnose the gap, then choose model climb, GEPA,

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: compare-model-sweep
+description: Use when a developer wants to run the same eval or benchmark across multiple local, gateway, or frontier models and produce a Pareto-style quality, latency, cost, and reliability comparison.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Compare Model Sweep
+
+Use this worker when the question is not "can one model pass this eval?" but
+"which candidate sits on the useful frontier for this workload?" The skill runs
+one frozen harness across a candidate matrix, records each run, and emits a
+small Pareto report an agent can use for route decisions.
+
+Prefer this after [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md),
+[`../optimize-api-workflow/SKILL.md`](../optimize-api-workflow/SKILL.md), or
+[`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) has already
+identified a resettable eval and a first local candidate.
+
+## Safety Gates
+
+Get explicit approval before provider spend, remote gateway calls, benchmark
+submissions, uploads, or new model downloads. Local cached model runs are fine
+when the user has already approved the local harness. Never mix private traces or
+customer data into a public sweep report; use synthetic, anonymized, or local-only
+artifacts.
+
+Do not claim a model is cheaper, faster, or better unless the sweep used the same
+rows, harness, metric, toolset, prompt, seed, and state reset for every candidate.
+If those differ, label the result as an ablation or diagnostic, not a Pareto
+comparison.
+
+## Flow
+
+1. **Freeze the comparison contract.** Record workload id, harness command,
+   split/row ids, metric, prompt, toolset, seed, timeout, concurrency, and budget.
+   Write it to `.understudy/model-sweeps/<timestamp>/sweep-plan.json`.
+
+2. **Normalize candidate routes.** Include each model id, endpoint/base URL,
+   loader/runtime, local-vs-remote boundary, max tokens, reasoning effort,
+   pricing basis, and whether the model is cached or requires download.
+
+3. **Run a smoke row first.** Each candidate must complete one row without
+   connection errors, empty responses, or bad model aliases. For local MLX, prefer
+   verified filesystem paths or Understudy snapshot aliases over arbitrary
+   Hugging Face ids.
+
+4. **Run the frozen matrix.** For AutomationBench, call `auto-bench` once per
+   candidate with the same `--domains`, `--tasks` or `--num-examples`,
+   `--toolset`, and `--export-json`. Keep each export under
+   `.understudy/model-sweeps/<timestamp>/candidate-runs/<candidate>/`.
+
+5. **Summarize at the same grain.** Build `summary.csv` with candidate, route,
+   model family, toolset, task count, pass rate, partial credit, total tokens,
+   cost/task, run seconds, errors, empty responses, and caveats. If per-task
+   latency is unavailable, use run-level duration and say so.
+
+6. **Compute the frontier.** A candidate is dominated when another candidate has
+   equal or better quality and equal or lower cost and latency, with no worse
+   error rate or safety result. Write `pareto.json` with dominated reasons.
+
+7. **Report the decision.** Write `report.md` with the top frontier candidates,
+   the cheapest acceptable model at the agreed quality floor, and the next action:
+   ship route, build retrieval/tooling, run GEPA, climb local model, or use remote.
+
+## AutomationBench Pattern
+
+Use AutomationBench's JSON exports directly:
+
+```sh
+uv run auto-bench \
+  --model "$MODEL" \
+  --base-url "$BASE_URL" \
+  --api-key "$API_KEY" \
+  --api chat_completions \
+  --domains simple \
+  --toolset api \
+  --tasks "$TASKS" \
+  --export-json ".understudy/model-sweeps/$RUN/candidate-runs/$ID/results.json"
+```
+
+For API-workflow sweeps, keep toolset interpretation explicit:
+
+- `api` and `zapier` are realistic tool-discovery comparisons.
+- `limited_zapier` is an oracle-tool diagnostic unless a retriever/advisor is
+  being evaluated and scored separately.
+
+## Output Standard
+
+End with the sweep path, candidate count, split size, quality/cost/latency axes,
+which candidates are on the frontier, which are dominated, and the recommended
+next action.

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -29,14 +29,16 @@ customer data into a public sweep report; use synthetic, anonymized, or local-on
 artifacts.
 
 Do not claim a model is cheaper, faster, or better unless the sweep used the same
-rows, harness, metric, toolset, prompt, seed, and state reset for every candidate.
+rows, harness, metric, tool-access mode, prompt, seed, and state reset for every
+candidate.
 If those differ, label the result as an ablation or diagnostic, not a Pareto
 comparison.
 
 ## Flow
 
 1. **Freeze the comparison contract.** Record workload id, harness command,
-   split/row ids, metric, prompt, toolset, seed, timeout, concurrency, and budget.
+   split/row ids, metric, prompt, tool-access mode, seed, timeout, concurrency,
+   and budget.
    Write it to `.understudy/model-sweeps/<timestamp>/sweep-plan.json`.
 
 2. **Normalize candidate routes.** Include each model id, endpoint/base URL,
@@ -48,15 +50,15 @@ comparison.
    verified filesystem paths or Understudy snapshot aliases over arbitrary
    Hugging Face ids.
 
-4. **Run the frozen matrix.** For AutomationBench, call `auto-bench` once per
-   candidate with the same `--domains`, `--tasks` or `--num-examples`,
-   `--toolset`, and `--export-json`. Keep each export under
+4. **Run the frozen matrix.** Call the same harness once per candidate with the
+   same rows, split, tool-access mode, prompt, seed, and export path. Keep each
+   export under
    `.understudy/model-sweeps/<timestamp>/candidate-runs/<candidate>/`.
 
 5. **Summarize at the same grain.** Build `summary.csv` with candidate, route,
-   model family, toolset, task count, pass rate, partial credit, total tokens,
-   cost/task, run seconds, errors, empty responses, and caveats. If per-task
-   latency is unavailable, use run-level duration and say so.
+   model family, tool-access mode, task count, pass rate, partial credit, total
+   tokens, cost/task, run seconds, errors, empty responses, and caveats. If
+   per-task latency is unavailable, use run-level duration and say so.
 
 6. **Compute the frontier.** A candidate is dominated when another candidate has
    equal or better quality and equal or lower cost and latency, with no worse
@@ -66,27 +68,25 @@ comparison.
    the cheapest acceptable model at the agreed quality floor, and the next action:
    ship route, build retrieval/tooling, run GEPA, climb local model, or use remote.
 
-## AutomationBench Pattern
+## Harness Pattern
 
-Use AutomationBench's JSON exports directly:
+Use the workload harness's JSON exports directly. Keep the command concrete in
+`sweep-plan.json`, but avoid changing anything except the candidate route:
 
 ```sh
-uv run auto-bench \
+"$HARNESS_CMD" \
   --model "$MODEL" \
-  --base-url "$BASE_URL" \
-  --api-key "$API_KEY" \
-  --api chat_completions \
-  --domains simple \
-  --toolset api \
-  --tasks "$TASKS" \
+  --endpoint "$ENDPOINT" \
+  --rows "$ROWS" \
+  --tool-access "$TOOL_ACCESS" \
   --export-json ".understudy/model-sweeps/$RUN/candidate-runs/$ID/results.json"
 ```
 
-For API-workflow sweeps, keep toolset interpretation explicit:
+For API-workflow sweeps, keep tool-access interpretation explicit:
 
-- `api` and `zapier` are realistic tool-discovery comparisons.
-- `limited_zapier` is an oracle-tool diagnostic unless a retriever/advisor is
-  being evaluated and scored separately.
+- Broad or production tool access is the deployable baseline.
+- Curated, narrow, or oracle tool access is diagnostic unless a retriever or
+  advisor is being evaluated and scored separately.
 
 ## Output Standard
 

--- a/skills/mlx-arena/arena.sh
+++ b/skills/mlx-arena/arena.sh
@@ -260,6 +260,7 @@ _refresh_agent_card() { # name repo port loader provider tmux-session
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const childProcess = require("node:child_process");
 
 const home = os.homedir();
 const now = new Date().toISOString();
@@ -331,6 +332,7 @@ if (companionState && typeof companionState === "object") {
 const config = readJson(configPath) || {};
 const model = process.env.UNDERSTUDY_CARD_MODEL;
 const endpoint = process.env.UNDERSTUDY_CARD_ENDPOINT;
+const port = process.env.UNDERSTUDY_CARD_PORT;
 const payload = {
   model,
   messages: [{ role: "user", content: "Say hello from my local Understudy." }],
@@ -341,6 +343,39 @@ function shellSingleQuote(value) {
 }
 const howToTalk = `curl -s ${endpoint}/chat/completions -H 'Content-Type: application/json' -d ${shellSingleQuote(JSON.stringify(payload))}`;
 const cwd = process.env.UNDERSTUDY_CARD_CWD || process.cwd();
+function observeListener(portValue) {
+  if (!portValue) return { pid: null, command: null };
+  try {
+    const out = childProcess.execFileSync("lsof", ["-nP", `-iTCP:${portValue}`, "-sTCP:LISTEN", "-Fp"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const pid = out.split("\n").find((line) => /^p\d+$/.test(line))?.slice(1);
+    if (!pid) return { pid: null, command: null };
+    const command = childProcess.execFileSync("ps", ["-p", pid, "-o", "command="], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return { pid: Number(pid), command: command || null };
+  } catch {
+    return { pid: null, command: null };
+  }
+}
+function inferRuntime(requestedLoader, observedCommand) {
+  const command = observedCommand || "";
+  if (command.includes("mlx_vlm.server") || command.includes("mlx-vlm")) {
+    return { runtime: "mlx_vlm", served_by: "mlx_vlm.server" };
+  }
+  if (command.includes("mlx_lm") || command.includes("mlx-lm")) {
+    return { runtime: "mlx_lm", served_by: "mlx_lm.server" };
+  }
+  if (requestedLoader === "mlx_vlm") {
+    return { runtime: "mlx_vlm", served_by: "mlx_vlm.server" };
+  }
+  return { runtime: requestedLoader || null, served_by: requestedLoader ? `${requestedLoader}.server` : null };
+}
+const observed = observeListener(port);
+const runtime = inferRuntime(process.env.UNDERSTUDY_CARD_LOADER, observed.command);
 
 const card = {
   schema_version: "understudy.agent_card.v1",
@@ -352,8 +387,10 @@ const card = {
     endpoint,
     health_url: process.env.UNDERSTUDY_CARD_HEALTH_URL,
     healthy: process.env.UNDERSTUDY_CARD_HEALTHY === "true",
-    served_by: process.env.UNDERSTUDY_CARD_LOADER === "mlx_vlm" ? "mlx_vlm.server" : "mlx_lm.server",
-    runtime: process.env.UNDERSTUDY_CARD_LOADER,
+    served_by: runtime.served_by,
+    runtime: runtime.runtime,
+    requested_loader: process.env.UNDERSTUDY_CARD_LOADER || null,
+    observed_listener: observed,
     provider: process.env.UNDERSTUDY_CARD_PROVIDER,
     tmux_session: process.env.UNDERSTUDY_CARD_SESSION,
     logs: process.env.UNDERSTUDY_CARD_LOGS,

--- a/skills/optimize-api-workflow/SKILL.md
+++ b/skills/optimize-api-workflow/SKILL.md
@@ -94,22 +94,31 @@ can write to live systems.
    Latency and cost are per workflow rollout. The metric must emit
    natural-language feedback tied to the failing step or invariant.
 
-4. **Run the incumbent baseline.** Execute the frozen harness on train/dev or a
+4. **Separate tool discovery from task execution.** For small/local models, first
+   ask whether the failure is "could not find the right tool" rather than "could
+   not do the task." In AutomationBench terms, always report the realistic
+   toolset result (`api` or `zapier`) next to any oracle-tool result
+   (`limited_zapier` from `info["zapier_tools"]`). Treat oracle-tool matching as
+   a diagnostic or advisor-training target, not as a route-superiority claim.
+
+5. **Run the incumbent baseline.** Execute the frozen harness on train/dev or a
    small sanctioned sample, write per-task pass/fail and request-log summaries,
    and include `harness_sha256`, `metric_sha256`, and `splits_sha256` in
    `baseline.json`. Do not optimize until the baseline is measured.
 
-5. **Pick the cheapest intervention.** Try parser/schema repair, prompt or
-   policy-instruction repair, context trimming, endpoint-catalog compression,
-   model A/B, or route changes before any training. Treat fewer unsafe writes,
-   fewer redundant calls, and cleaner recovery behavior as first-class wins.
+6. **Pick the cheapest intervention.** For API discovery failures, try toolset
+   structure, endpoint-catalog compression, or a stateless tool-retrieval advisor
+   before prompt-GEPA or model climb. Then try parser/schema repair, prompt or
+   policy-instruction repair, context trimming, model A/B, or route changes
+   before any training. Treat fewer unsafe writes, fewer redundant calls, and
+   cleaner recovery behavior as first-class wins.
 
-6. **Optimize only with fresh artifacts.** For prompt or route optimization, hand
+7. **Optimize only with fresh artifacts.** For prompt or route optimization, hand
    to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) after the
    evidence artifacts are fresh and hash-bound. GEPA may use train/dev feedback
    only; never tune on holdout.
 
-7. **Validate holdout last.** Freeze the candidate, then run holdout once.
+8. **Validate holdout last.** Freeze the candidate, then run holdout once.
    Claims require `claim.json` with sample size, split, quality delta, latency
    basis, cost basis, request-volume assumption, fallback route, demotion
    trigger, and caveats.

--- a/skills/optimize-api-workflow/SKILL.md
+++ b/skills/optimize-api-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize-api-workflow
-description: Use to evaluate and optimize cross-application API workflow agents, including AutomationBench-like REST orchestration tasks where an agent discovers endpoints, follows policy docs, mutates state, and must pass final-state validators before any RL handoff.
+description: Use to evaluate and optimize cross-application API workflow agents where an agent discovers or selects tools, follows policy docs, mutates state, and must pass final-state validators before any RL handoff.
 metadata:
   understudy:
     mode: interactive
@@ -13,9 +13,9 @@ metadata:
 Use this worker when the workload is an **API workflow agent**: a multi-step LLM
 or agent loop that reads task instructions and policy docs, discovers or selects
 REST endpoints, performs writes across one or more business systems, and is
-judged by final state plus policy compliance. AutomationBench-style workflows
-fit here better than generic search because correctness depends on stateful API
-effects, not only the final answer.
+judged by final state plus policy compliance. These workflows fit here better
+than generic search because correctness depends on stateful API effects, not
+only the final answer.
 
 This is still an evaluation, A/B, prompt, route, parser, and harness skill. It
 is not RL training. Route to
@@ -24,8 +24,8 @@ only after local evidence shows that model choice and prompt/route optimization
 cannot satisfy a stateful policy-learning requirement.
 
 When executing, read [`reference.md`](reference.md) for concrete artifact
-schemas, AutomationBench command mapping, model A/B, GEPA bridging, and
-workload-card fill values.
+schemas, harness mapping, model A/B, GEPA bridging, and workload-card fill
+values.
 
 ## Safety Gates
 
@@ -96,19 +96,19 @@ can write to live systems.
 
 4. **Separate tool discovery from task execution.** For small/local models, first
    ask whether the failure is "could not find the right tool" rather than "could
-   not do the task." In AutomationBench terms, always report the realistic
-   toolset result (`api` or `zapier`) next to any oracle-tool result
-   (`limited_zapier` from `info["zapier_tools"]`). Treat oracle-tool matching as
-   a diagnostic or advisor-training target, not as a route-superiority claim.
+   not do the task." Always report the realistic tool-access result beside any
+   curated or oracle-tool result. Treat oracle-tool matching as a diagnostic or
+   advisor-training target, not as a route-superiority claim.
 
 5. **Run the incumbent baseline.** Execute the frozen harness on train/dev or a
    small sanctioned sample, write per-task pass/fail and request-log summaries,
    and include `harness_sha256`, `metric_sha256`, and `splits_sha256` in
    `baseline.json`. Do not optimize until the baseline is measured.
 
-6. **Pick the cheapest intervention.** For API discovery failures, try toolset
-   structure, endpoint-catalog compression, or a stateless tool-retrieval advisor
-   before prompt-GEPA or model climb. Then try parser/schema repair, prompt or
+6. **Pick the cheapest intervention.** For API discovery failures, try
+   tool-access structure, endpoint-catalog compression, or a stateless
+   tool-retrieval advisor before prompt-GEPA or model climb. Then try
+   parser/schema repair, prompt or
    policy-instruction repair, context trimming, model A/B, or route changes
    before any training. Treat fewer unsafe writes, fewer redundant calls, and
    cleaner recovery behavior as first-class wins.

--- a/skills/optimize-api-workflow/reference.md
+++ b/skills/optimize-api-workflow/reference.md
@@ -1,10 +1,8 @@
 # Optimize API Workflow — reference
 
-Deep detail for [`SKILL.md`](SKILL.md). AutomationBench evaluates AI agents on
-realistic, multi-step business workflows across CRM, email, calendar, and 47
-simulated SaaS tools; read this reference when wiring that kind of API workflow
-into the Understudy artifact contract, measuring a baseline, and comparing model
-or prompt candidates.
+Deep detail for [`SKILL.md`](SKILL.md). Use this reference when wiring a
+resettable API workflow into the Understudy artifact contract, measuring a
+baseline, and comparing model, route, prompt, tool-access, or parser candidates.
 
 All examples here are synthetic. Use local fixtures or benchmark sandboxes unless
 the developer explicitly approves provider spend, hosted execution, uploads, or
@@ -43,18 +41,18 @@ docs, validator, and network boundary stay fixed.
 {
   "schema_version": "understudy.harness.v1",
   "kind": "api-workflow-rollout",
-  "benchmark": "automationbench",
-  "command": "uv run auto-bench --model ${MODEL} --domains ${DOMAINS} --num-examples ${N} --export-json ${EXPORT_JSON}",
-  "agent_entrypoint": "auto-bench",
+  "benchmark": "local-or-public-sandbox",
+  "command": "${HARNESS_CMD} --model ${MODEL} --rows ${ROWS} --export-json ${EXPORT_JSON}",
+  "agent_entrypoint": "${HARNESS_CMD}",
   "policy_model_slot": "${MODEL}",
-  "task_source": "automationbench.synthetic",
+  "task_source": "synthetic-api-workflow",
   "api_schema": {
     "kind": "openapi",
     "path": ".understudy/capture-evidence/api-schema.json"
   },
   "policy_docs": [".understudy/capture-evidence/policy.md"],
   "seeded_state": {
-    "reset_command": "uv run auto-bench reset --seed ${SEED}",
+    "reset_command": "${HARNESS_CMD} reset --seed ${SEED}",
     "seed": 7,
     "state_fixture": ".understudy/capture-evidence/seed-state.json"
   },
@@ -62,16 +60,16 @@ docs, validator, and network boundary stay fixed.
   "request_log": ".understudy/capture-evidence/request-log.jsonl",
   "final_state_validator": {
     "kind": "command",
-    "command": "uv run auto-bench validate --export-json ${EXPORT_JSON}"
+    "command": "${HARNESS_CMD} validate --export-json ${EXPORT_JSON}"
   },
   "timeout_s": 300,
   "network_boundary": "benchmark-sandbox"
 }
 ```
 
-If `uv run auto-bench` is unavailable in the current repo, do not invent a
-replacement command. Record the missing command as a blocker and keep the rest of
-the artifact draft local.
+If the harness command is unavailable in the current repo, do not invent a
+replacement command. Record the missing command as a blocker and keep the rest
+of the artifact draft local.
 
 ### `environment.json` — resettable sandbox
 
@@ -101,9 +99,9 @@ the artifact draft local.
 
 ### `metric.json` — rollout score plus feedback
 
-Map AutomationBench-style `task_completed_correctly` to final-state correctness
-and `partial_credit` to the weighted rubric. The rubric must emit natural
-language feedback tied to the failing step, endpoint, invariant, or state diff.
+Map the harness's primary pass/fail field to final-state correctness and its
+graded score to the weighted rubric. The rubric must emit natural-language
+feedback tied to the failing step, endpoint, invariant, or state diff.
 
 ```json
 {
@@ -111,7 +109,7 @@ language feedback tied to the failing step, endpoint, invariant, or state diff.
   "approved": true,
   "validator": {
     "kind": "api-workflow-rubric",
-    "source": "automationbench-export",
+    "source": "harness-export",
     "feedback_required": true
   },
   "objectives": {
@@ -152,16 +150,16 @@ language feedback tied to the failing step, endpoint, invariant, or state diff.
 }
 ```
 
-### `splits.json` — domain/task freeze
+### `splits.json` — task freeze
 
-AutomationBench domains are useful split units because they expose distribution
-shift across workflow families. Keep holdout domains or rows untouched after the
-first baseline.
+Use domains, workflow families, customer segments, or row ids as split units
+when they expose meaningful distribution shift. Keep holdout groups or rows
+untouched after the first baseline.
 
 ```json
 {
   "schema_version": "understudy.splits.v1",
-  "source": "automationbench",
+  "source": "synthetic-api-workflow",
   "seed": 7,
   "split_strategy": "domain-and-row-id",
   "train": {
@@ -185,7 +183,7 @@ first baseline.
 ```json
 {
   "schema_version": "understudy.baseline.v1",
-  "command": "understudy run -- uv run auto-bench --model gpt-5.x --domains finance --num-examples 8 --export-json .understudy/capture-evidence/baseline-export.json",
+  "command": "understudy run -- ${HARNESS_CMD} --model incumbent-model-id --rows dev.jsonl --export-json .understudy/capture-evidence/baseline-export.json",
   "split": "dev",
   "sample_size": 8,
   "quality": {
@@ -218,15 +216,16 @@ first baseline.
 }
 ```
 
-## AutomationBench Command Mapping
+## Harness Command Mapping
 
-Use the benchmark command as the harness instead of inventing a CLI surface:
+Use the existing benchmark, eval, or local runner as the harness instead of
+inventing a new CLI surface:
 
 ```sh
-uv run auto-bench \
+"$HARNESS_CMD" \
   --model <model-id> \
-  --domains sales,marketing \
-  --num-examples 8 \
+  --rows dev.jsonl \
+  --tool-access production \
   --export-json .understudy/capture-evidence/<run-name>.json
 ```
 
@@ -235,39 +234,41 @@ Map flags and export fields into artifacts:
 | Command / export field | Artifact field |
 | --- | --- |
 | `--model <model-id>` | `harness.policy_model_slot`, `baseline.command`, candidate model id |
-| `--domains <domains>` | `splits.train.domains`, `splits.dev.domains`, or `splits.holdout.domains` |
-| `--num-examples <n>` | `baseline.sample_size`, candidate sample size |
+| row, domain, or task selector | `splits.train`, `splits.dev`, or `splits.holdout` |
+| example/task count | `baseline.sample_size`, candidate sample size |
+| tool-access selector | `harness.tool_access_mode`, candidate caveats |
 | `--export-json <path>` | `baseline.export_json`, candidate artifact path |
-| `task_completed_correctly` | `metric.objectives.quality.primary`, `baseline.quality.task_completed_correctly_rate` |
-| `partial_credit` | `metric.objectives.quality.partial_credit`, `baseline.quality.partial_credit_mean` |
+| primary pass/fail field | `metric.objectives.quality.primary`, `baseline.quality.task_completed_correctly_rate` |
+| graded score field | `metric.objectives.quality.partial_credit`, `baseline.quality.partial_credit_mean` |
 | request/tool trace | `harness.request_log`, `baseline.request_log_summary` |
 | seeded state/reset metadata | `harness.seeded_state`, `environment.resettable` |
 
-AutomationBench's seeded state is the determinism guarantee. Prefer it over
-hand-rolled mocks when available; the agent should record the seed and reset
-command, then run every candidate against the same rows and state.
+Seeded state is the determinism guarantee. Prefer an existing resettable
+benchmark or sandbox over hand-rolled mocks when available; the agent should
+record the seed and reset command, then run every candidate against the same rows
+and state.
 
-### Toolset Reporting
+### Tool-Access Reporting
 
-AutomationBench exposes three materially different tool surfaces:
+Most API-workflow harnesses can expose materially different tool surfaces. Keep
+those surfaces explicit because they support different claims:
 
-| Toolset | What it measures | Claim status |
+| Tool-access mode | What it measures | Claim status |
 | --- | --- | --- |
-| `api` | Blind endpoint discovery over REST/API schemas | Realistic baseline |
-| `zapier` | Structured meta-search over the tool catalog | Realistic/assisted baseline |
-| `limited_zapier` | Gold tools from each row's `info["zapier_tools"]` | Oracle diagnostic only |
+| Broad production access | Discovery or selection over the deployable API/tool catalog | Realistic baseline |
+| Structured retrieval access | Search, ranking, or advisor selection over the catalog | Realistic if the retriever is deployable |
+| Curated or oracle access | Relevant tools supplied from labels, fixtures, or a narrow test slice | Diagnostic only unless the curator is deployable |
 
-Always report a realistic-toolset number (`api` or `zapier`) beside any
-`limited_zapier` result. A `limited_zapier` win proves the model can execute the
-task once discovery is solved; it does not prove a deployable route unless a
-real retriever/advisor supplies the same tool subset without looking at gold
-labels.
+Always report a realistic tool-access number beside any curated or oracle-tool
+result. An oracle-tool win proves the model can execute the task once discovery
+is solved; it does not prove a deployable route unless a real retriever or
+advisor supplies the same tool subset without looking at labels.
 
-For small local models, treat the spread between realistic toolsets and
-`limited_zapier` as the tool-retrieval opportunity. A useful advisor report
-should include recall, precision, exact-set match, catalog size, gold tool count
-distribution, latency, and whether the catalog prefix is byte-stable enough for
-prompt caching.
+For small local models, treat the spread between realistic tool access and
+curated/oracle tool access as the tool-retrieval opportunity. A useful advisor
+report should include recall, precision, exact-set match, catalog size, target
+tool count distribution, latency, and whether the catalog prefix is byte-stable
+enough for prompt caching.
 
 ## Workload Card Fill Values
 
@@ -277,17 +278,17 @@ workflow semantics before registering or routing it:
 ```json
 {
   "schema_version": "understudy.workload_card.v1",
-  "workload_id": "automationbench-api-workflow",
-  "workload_name": "AutomationBench API workflow",
+  "workload_id": "api-workflow-eval",
+  "workload_name": "API workflow eval",
   "workload_shape": ["api-workflow", "multi-step-rollout", "stateful-tools"],
-  "data_class": "synthetic-benchmark-state",
+  "data_class": "synthetic-or-local-sandbox-state",
   "success_metric": "task_completed_correctly_rate with partial_credit_mean and side-effect safety",
   "validator": {
     "type": "final-state-plus-policy-rubric",
     "artifact": ".understudy/capture-evidence/metric.json"
   },
   "harness": {
-    "command": "uv run auto-bench --model ${MODEL} --domains ${DOMAINS} --num-examples ${N} --export-json ${EXPORT_JSON}",
+    "command": "${HARNESS_CMD} --model ${MODEL} --rows ${ROWS} --export-json ${EXPORT_JSON}",
     "artifact": ".understudy/capture-evidence/harness.json"
   },
   "baseline": {
@@ -303,20 +304,18 @@ Keep `baseline.model` factual. If the incumbent is unknown, write
 ## Model A/B Procedure
 
 For API workflows, A/B is simpler than live traffic routing: run the same
-benchmark rows twice with only `--model` changed.
+harness rows twice with only the candidate route changed.
 
 ```sh
-understudy run -- uv run auto-bench \
-  --model gpt-5.x \
-  --domains sales,marketing \
-  --num-examples 8 \
-  --export-json .understudy/capture-evidence/baseline-gpt5x.json
+understudy run -- "$HARNESS_CMD" \
+  --model incumbent-model-id \
+  --rows dev.jsonl \
+  --export-json .understudy/capture-evidence/baseline-incumbent.json
 
-understudy run -- uv run auto-bench \
-  --model glm-5.1 \
-  --domains sales,marketing \
-  --num-examples 8 \
-  --export-json .understudy/capture-evidence/candidate-glm51.json
+understudy run -- "$HARNESS_CMD" \
+  --model candidate-model-id \
+  --rows dev.jsonl \
+  --export-json .understudy/capture-evidence/candidate-local.json
 ```
 
 Compare:
@@ -355,7 +354,7 @@ Minimal manifest shape for a future adapter:
 {
   "schema_version": "understudy.eval_input_manifest.v1",
   "kind": "api-workflow-rollout",
-  "student_model": "glm-5.1",
+  "student_model": "candidate-model-id",
   "reflection_lm": "frontier-model-id",
   "train_rows": ".understudy/capture-evidence/gepa-train-rollouts.jsonl",
   "dev_rows": ".understudy/capture-evidence/gepa-dev-rollouts.jsonl",
@@ -369,28 +368,28 @@ Do not optimize the entire agent in one opaque string if a cheaper target matche
 the failures. Prefer system prompt, tool descriptions, endpoint catalog wording,
 or retry policy before broader program changes.
 
-For AutomationBench-like harnesses, the faithful version of GEPA is a live
-rollout adapter: each candidate prompt is injected into the harness, train/dev
-rows are re-run with `auto-bench --tasks ...`, and the adapter returns rubric
-scores plus natural-language failure feedback. The current public CLI adapters
-(`eval-input-gepa` and `dspy-gepa`) optimize flat prompt-to-output rows; use them
-for decomposed subtasks such as tool retrieval, or use the live-rollout recipe in
-[`../../docs/agentic-rollout-gepa.md`](../../docs/agentic-rollout-gepa.md)
-when the score must come from real tool execution.
+For stateful tool harnesses, the faithful version of GEPA is a live rollout
+adapter: each candidate prompt is injected into the harness, train/dev rows are
+re-run, and the adapter returns rubric scores plus natural-language failure
+feedback. The current public CLI adapters (`eval-input-gepa` and `dspy-gepa`)
+optimize flat prompt-to-output rows; use them for decomposed subtasks such as
+tool retrieval, or use the live-rollout recipe in
+[`../../docs/agentic-rollout-gepa.md`](../../docs/agentic-rollout-gepa.md) when
+the score must come from real tool execution.
 
 If the harness has no prompt parameter, do not edit benchmark source as an
-undocumented side effect. Prefer a checked local patch or env hook such as
-`AB_SIMPLE_SYSTEM_PROMPT`, record it in `harness.json`, save the candidate prompt
-or patch as evidence, and restore external benchmark files before claiming a
-result. If you own the harness, add `--system-prompt-file` or a per-domain env
-override.
+undocumented side effect. Prefer a checked local patch, prompt file, or env hook
+such as `CANDIDATE_SYSTEM_PROMPT`, record it in `harness.json`, save the
+candidate prompt or patch as evidence, and restore external benchmark files
+before claiming a result. If you own the harness, add `--system-prompt-file` or
+an equivalent per-suite override.
 
 ## Failure Modes And Cheapest Interventions
 
 | Failure mode | Evidence | First intervention |
 | --- | --- | --- |
-| Wrong endpoint selected | request log shows plausible but wrong route | compare `api`/`zapier` vs `limited_zapier`, then build or improve tool retrieval |
-| Gold tools succeed but realistic search fails | `limited_zapier` high, `api`/`zapier` low | stateless advisor: task -> compact tool subset, scored by recall/precision vs gold |
+| Wrong endpoint selected | request log shows plausible but wrong route | compare production tool access vs curated/oracle access, then build or improve tool retrieval |
+| Curated tools succeed but production discovery fails | curated/oracle score high, production score low | stateless advisor: task -> compact tool subset, scored by recall/precision vs target tools |
 | Missing required write | final-state diff missing expected mutation | prompt repair around completion criteria |
 | Forbidden write | request log has disallowed mutation | hard safety instruction plus deterministic preflight guard |
 | Invalid request schema | 4xx or validator schema failure | parser/schema repair before model swap |

--- a/skills/optimize-api-workflow/reference.md
+++ b/skills/optimize-api-workflow/reference.md
@@ -247,6 +247,28 @@ AutomationBench's seeded state is the determinism guarantee. Prefer it over
 hand-rolled mocks when available; the agent should record the seed and reset
 command, then run every candidate against the same rows and state.
 
+### Toolset Reporting
+
+AutomationBench exposes three materially different tool surfaces:
+
+| Toolset | What it measures | Claim status |
+| --- | --- | --- |
+| `api` | Blind endpoint discovery over REST/API schemas | Realistic baseline |
+| `zapier` | Structured meta-search over the tool catalog | Realistic/assisted baseline |
+| `limited_zapier` | Gold tools from each row's `info["zapier_tools"]` | Oracle diagnostic only |
+
+Always report a realistic-toolset number (`api` or `zapier`) beside any
+`limited_zapier` result. A `limited_zapier` win proves the model can execute the
+task once discovery is solved; it does not prove a deployable route unless a
+real retriever/advisor supplies the same tool subset without looking at gold
+labels.
+
+For small local models, treat the spread between realistic toolsets and
+`limited_zapier` as the tool-retrieval opportunity. A useful advisor report
+should include recall, precision, exact-set match, catalog size, gold tool count
+distribution, latency, and whether the catalog prefix is byte-stable enough for
+prompt caching.
+
 ## Workload Card Fill Values
 
 When `capture-evidence` produces a mostly-null workload card, fill the known API
@@ -347,11 +369,28 @@ Do not optimize the entire agent in one opaque string if a cheaper target matche
 the failures. Prefer system prompt, tool descriptions, endpoint catalog wording,
 or retry policy before broader program changes.
 
+For AutomationBench-like harnesses, the faithful version of GEPA is a live
+rollout adapter: each candidate prompt is injected into the harness, train/dev
+rows are re-run with `auto-bench --tasks ...`, and the adapter returns rubric
+scores plus natural-language failure feedback. The current public CLI adapters
+(`eval-input-gepa` and `dspy-gepa`) optimize flat prompt-to-output rows; use them
+for decomposed subtasks such as tool retrieval, or use the live-rollout recipe in
+[`../../docs/agentic-rollout-gepa.md`](../../docs/agentic-rollout-gepa.md)
+when the score must come from real tool execution.
+
+If the harness has no prompt parameter, do not edit benchmark source as an
+undocumented side effect. Prefer a checked local patch or env hook such as
+`AB_SIMPLE_SYSTEM_PROMPT`, record it in `harness.json`, save the candidate prompt
+or patch as evidence, and restore external benchmark files before claiming a
+result. If you own the harness, add `--system-prompt-file` or a per-domain env
+override.
+
 ## Failure Modes And Cheapest Interventions
 
 | Failure mode | Evidence | First intervention |
 | --- | --- | --- |
-| Wrong endpoint selected | request log shows plausible but wrong route | tighten tool descriptions and endpoint catalog examples |
+| Wrong endpoint selected | request log shows plausible but wrong route | compare `api`/`zapier` vs `limited_zapier`, then build or improve tool retrieval |
+| Gold tools succeed but realistic search fails | `limited_zapier` high, `api`/`zapier` low | stateless advisor: task -> compact tool subset, scored by recall/precision vs gold |
 | Missing required write | final-state diff missing expected mutation | prompt repair around completion criteria |
 | Forbidden write | request log has disallowed mutation | hard safety instruction plus deterministic preflight guard |
 | Invalid request schema | 4xx or validator schema failure | parser/schema repair before model swap |

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -145,6 +145,10 @@ Identify the developer's current stage and load exactly one:
   workstation-hosted model through the same frozen workload/eval, choose a
   runtime, compare local vs remote, or satisfy ZDR / no-upload constraints →
   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
+- **Multi-model sweep / Pareto comparison** — the developer has a frozen eval and
+  wants to run the same rows across several local, gateway, or frontier models to
+  compare quality, latency, cost, and reliability →
+  [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md).
 - **Local understudy specialization loop** — the developer wants the smallest
   task-reasonable local model opened in Pi and optionally compared against a
   frontier model, then wants the observed gap to drive workload understanding,

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -159,7 +159,7 @@ Identify the developer's current stage and load exactly one:
   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
 - **API workflow optimization** — multi-step REST/API agent that discovers
   endpoints, follows policy docs, mutates state, and must pass final-state
-  validators (AutomationBench-style) →
+  validators →
   [`../optimize-api-workflow/SKILL.md`](../optimize-api-workflow/SKILL.md).
 - **Agentic / tool-use optimization** — multi-turn agent that calls tools (e.g.
   web search); evaluate, A/B-compare models, or optimize its prompt/route →

--- a/src/commands/experiments.ts
+++ b/src/commands/experiments.ts
@@ -61,6 +61,7 @@ export function registerExperimentsCommands(program: Command): void {
           const outcome = row.outcome ?? "open";
           process.stdout.write(
             `${marker}${kleur.bold(row.experiment_id)}  ${row.workload}  outcome=${outcome}` +
+              `${row.name ? `  name=${row.name}` : ""}` +
               `${row.candidate_model ? `  candidate=${row.candidate_model}` : ""}\n`,
           );
         }
@@ -72,6 +73,7 @@ export function registerExperimentsCommands(program: Command): void {
     .description("Open a new experiment, pin the current baseline, and make it active")
     .option("--repo <path>", "Local repository path", ".")
     .option("--id <id>", "Experiment id (default: next exp-NNN)")
+    .option("--name <label>", "Human-readable experiment name.")
     .option("--workload <id>", "Workload id this experiment runs against")
     .option("--objective <objective>", "cost | speed | quality | reliability | compliance | weighted")
     .option("--hypothesis <text>", "One-line hypothesis")
@@ -83,6 +85,7 @@ export function registerExperimentsCommands(program: Command): void {
       options: {
         repo: string;
         id?: string;
+        name?: string;
         workload?: string;
         objective?: string;
         hypothesis?: string;
@@ -93,6 +96,7 @@ export function registerExperimentsCommands(program: Command): void {
       runLocal(this, () => {
         const experiment = createExperiment(options.repo, {
           id: options.id,
+          name: options.name,
           workload: options.workload,
           objective: options.objective,
           hypothesis: options.hypothesis,
@@ -105,7 +109,9 @@ export function registerExperimentsCommands(program: Command): void {
         }
         const pinned = experiment.pins.harness_sha256 && experiment.pins.metric_sha256 && experiment.pins.splits_sha256;
         process.stdout.write(
-          `${kleur.green("✓")} Created ${kleur.bold(experiment.experiment_id)} (active) for ${experiment.workload}\n`,
+          `${kleur.green("✓")} Created ${kleur.bold(experiment.experiment_id)} (active)` +
+            `${experiment.name ? ` ${kleur.gray(`"${experiment.name}"`)}` : ""}` +
+            ` for ${experiment.workload}\n`,
         );
         process.stdout.write(
           pinned

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -36,6 +36,7 @@ export type ExperimentResult = {
 export type Experiment = {
   schema_version: "understudy.experiment.v1";
   experiment_id: string;
+  name: string | null;
   workload: string;
   objective: string | null;
   hypothesis: string | null;
@@ -50,6 +51,7 @@ export type Experiment = {
 
 export type NewExperimentOptions = {
   id?: string;
+  name?: string;
   workload?: string;
   objective?: string;
   hypothesis?: string;
@@ -79,6 +81,7 @@ export type NextState = {
 
 export type ExperimentSummary = {
   experiment_id: string;
+  name: string | null;
   workload: string;
   outcome: ExperimentOutcome | null;
   candidate_model: string | null;
@@ -226,6 +229,7 @@ export function createExperiment(repoInput: string, options: NewExperimentOption
   const experiment: Experiment = {
     schema_version: "understudy.experiment.v1",
     experiment_id: id,
+    name: options.name ?? null,
     workload: options.workload ?? "workload-001",
     objective: options.objective ?? null,
     hypothesis: options.hypothesis ?? null,
@@ -348,7 +352,7 @@ export function recordClaim(
 }
 
 function renderLabNote(experiment: Experiment, date: string): string {
-  const title = experiment.hypothesis ?? `Experiment ${experiment.experiment_id}`;
+  const title = experiment.name ?? experiment.hypothesis ?? `Experiment ${experiment.experiment_id}`;
   const cell = (value: number | null): string => (value === null ? "—" : String(value));
   return `---
 type: experiment
@@ -438,6 +442,7 @@ export function summarizeExperiments(repoInput: string): ExperimentSummary[] {
     const experiment = readExperiment(repo, id);
     return {
       experiment_id: id,
+      name: experiment.name ?? null,
       workload: experiment.workload,
       outcome: experiment.outcome,
       candidate_model: experiment.candidate_model,

--- a/tests/experiments.test.mjs
+++ b/tests/experiments.test.mjs
@@ -87,6 +87,7 @@ describe("understudy experiments + next", () => {
       const experiment = JSON.parse(created.stdout);
       assert.equal(experiment.experiment_id, "exp-001");
       assert.equal(experiment.schema_version, "understudy.experiment.v1");
+      assert.equal(experiment.name, null);
       // pins are copied from baseline.json's hash-chain (exactly three).
       assert.deepEqual(Object.keys(experiment.pins).sort(), ["harness_sha256", "metric_sha256", "splits_sha256"]);
       assert.ok(experiment.pins.harness_sha256);
@@ -165,6 +166,22 @@ describe("understudy experiments + next", () => {
       run(repo, ["experiments", "new"]);
       assert.ok(existsSync(join(repo, ".understudy", "experiments", "exp-001", "experiment.json")));
       assert.ok(existsSync(join(repo, ".understudy", "experiments", "active")));
+    });
+  });
+
+  it("accepts a human-readable experiment name", () => {
+    withRepo((repo) => {
+      seedEvidence(repo);
+      const created = run(repo, ["experiments", "new", "--json", "--name", "gepa-simple-limzap"]);
+      assert.equal(created.status, 0, created.stderr);
+      const experiment = JSON.parse(created.stdout);
+      assert.equal(experiment.experiment_id, "exp-001");
+      assert.equal(experiment.name, "gepa-simple-limzap");
+
+      const list = run(repo, ["experiments", "list", "--json"]);
+      assert.equal(list.status, 0, list.stderr);
+      const rows = JSON.parse(list.stdout).experiments;
+      assert.equal(rows[0].name, "gepa-simple-limzap");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add a compare-model-sweep skill for Pareto-style model sweeps over frozen evals
- Update optimize-api-workflow to foreground tool retrieval, oracle-tool reporting, and live-rollout GEPA guidance
- Add a tracked agentic rollout GEPA recipe doc
- Fix agent-card runtime metadata by observing the listening server process
- Add `understudy experiments new --name` for human-readable experiment labels

## Validation

- `bash -n skills/mlx-arena/arena.sh`
- `git diff --check`
- `npm run check`

## Notes

This is grounded in the AutomationBench dogfood: local Gemma E2B failed broad endpoint discovery, succeeded when tool retrieval was solved, and GEPA needed a live-rollout adapter rather than flat prompt rows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->