### PR TITLE
skill(draft): local-distillation-lab — local post-training weight-update rung

### DIFF
--- a/skills/local-distillation-lab/SKILL.md
+++ b/skills/local-distillation-lab/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: local-distillation-lab
+description: Use when a developer wants to actually fine-tune / distill a local open model on Apple Silicon MLX — run weight-updating training arms (rejection-sampling SFT, off-policy distillation, on-policy / pedagogical self-distillation) on a captured workload, compare them on a held eval with learning curves, and decide distill-vs-pedagogical-vs-climb. This is the weight-update rung between prompt optimization (optimize-workload/GEPA) and the hosted-RL handoff (prepare-verifier-handoff). Covers the Gemma-4→mlx-vlm loader gotcha, the forced-likelihood + weighted-LoRA kernels, the privileged-teacher choice, and overnight orchestration discipline.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Local Distillation Lab
+
+Train a local student model and measure which **post-training method** actually moves a
+captured workload — without spending on hosted training. The student samples/learns on
+your Mac; the only optional spend is a frontier teacher you can almost always avoid.
+
+This is the missing **weight-update rung**: `optimize-workload` (GEPA) explicitly does not
+train; `prepare-verifier-handoff` jumps to hosted RL. This skill is what sits between them.
+
+## When To Use
+
+- The developer has a captured workload with a verifiable reward (final-state validator,
+  recall/precision-vs-gold, etc.) and frozen train/dev/holdout splits.
+- Prompt optimization has plateaued and the question is now "can a weight update close the gap."
+- They want a **method comparison** (SFT-RS vs off-policy distill vs pedagogical/OPSD), not a
+  single blind training run.
+
+If the workload only needs prompt/route changes, use
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md). If it genuinely needs hosted
+multi-step RL, use [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
+
+## Safety Gates
+
+- Local-first: rollouts, training, and eval run on-device. The only network call is an optional
+  teacher; prefer the **privileged self-teacher** (student + gold/ICL) so nothing leaves the box.
+- Get explicit approval before any model download, frontier-teacher spend, or hosted handoff.
+- Never claim a win on oracle-tool / answer-leaked settings (e.g. AutomationBench `limited_zapier`
+  hands the model the gold tools). Report the realistic-setting number alongside.
+- Holdout is sealed until a candidate adapter is frozen.
+
+## The method taxonomy (name the arms)
+
+Dense-biased post-training methods differ by *where the bias points* and *how concentrated* it is
+(the concentration axis is what causes collapse):
+
+| Arm | What | Bias | Note |
+|---|---|---|---|
+| **B** | baseline, no train | — | the floor |
+| **S** | rejection-sampling SFT (STaR) | toward student's own passes | shifts curve up, same ceiling |
+| **O** | off-policy distillation | toward a **same-family** teacher's completions | recipe-matched = cheap signal |
+| **P** | pedagogical / OPSD-style | toward teacher, **surprisal-gated** | down-weights unlearnable tokens |
+
+Not covered yet (add when needed): true **on-policy distillation** — student samples its *own*
+rollout, teacher grades each token by reverse-KL. Its higher practical ceiling comes from
+on-policy state coverage (no exposure-bias gap). Arms O/P here train on teacher *completions*
+(off-policy data) and are honest SFT-family methods.
+
+## Flow
+
+1. **Confirm artifacts.** Workload + reward + frozen splits (reuse the evidence contract from
+   `capture-evidence`). Expand the dataset — a frozen 18/6 overfits instantly; use a real
+   train/dev plus a **held-out domain for OOD transfer**.
+2. **Pick the trainable student + loader** (see Gotchas). Prove a weight update first: loss drops
+   and `param_delta = Σ|after−before|` over trainable params is nonzero.
+3. **Choose the teacher.** Default = **privileged self-teacher** (student + gold/ICL in context;
+   the OPSD/SDFT setup) — robust and same-family by construction. A bigger *same-family* model is
+   the upgrade; a frontier (different-family) teacher is usually a trap (high surprise gap → most
+   tokens discarded — measure it with kernel #1 before trusting it).
+4. **Run the arms** B/S/O/P from the same base, with **eval-checkpoint learning curves** (eval at
+   iter 0, then every ~40 iters) so the curve captures the peak *and* any overfit-collapse. Track
+   `best`. Save adapters.
+5. **Decide.** P>O → surprisal gating helps. O>S → the bigger/same-family teacher adds signal.
+   best≈B → capability bound, climb the rung. Report dev + OOD + concentration (`d_t`).
+6. **Promote.** Fuse the winning adapter and re-serve; only then run holdout once.
+
+## Gotchas that cost real time
+
+- **Gemma-4 will not load in `mlx_lm`** (even 0.31.3, which ships `gemma4_text.py`): the mlx-vlm
+  conversions carry a `language_model.` multimodal prefix and the text-int4 fails on `k_norm`
+  (QK-norm). **Train Gemma-4 via `mlx-vlm 0.6.2`**: `mlx_vlm.load(path) -> (model, processor)`,
+  text forward = `model.language_model(ids) -> logits`, inject LoRA into `model.language_model`
+  with `mlx_lm.tuner.utils.linear_to_lora_layers`, generate via `mlx_vlm.generate(...)`. Gemma-3
+  loads natively in `mlx_lm` (use for fast kernel smokes only).
+- The mlx-vlm processor's `apply_chat_template` returns a **BatchEncoding**, not flat ints — coerce.
+- **Reward form:** additive `R + λ·G_spike` is an anti-stall scaffold for *binary* R; on a
+  partial-credit env prefer the **product** `partial_credit · G_spike` (keeps the
+  correct-AND-learnable conjunction).
+- **Overfit-collapse** on small data is real (dev 1.0→0.0). Use lr ~5e-5 and rely on the learning
+  curve, not the endpoint.
+- **Orchestration:** smoke budget must exceed arm guards; per-row try/except in data-gen (one
+  router 500 shouldn't abort the build); retry serve calls; `caffeinate -i` + JSON checkpoints +
+  cheapest-arm-first for overnight runs.
+
+## Kernels (runnable, in `examples/`)
+
+- **`forced_likelihood.py`** — kernel #1: per-token student logp + surprise gap `d_t =
+  logπ(a_max) − logπ(τ_t)` over a forced completion. Validate full-pass == incremental (~0 err).
+  `d_t` is the same-family/concentration meter and the input to `G_spike`.
+- **`kernel2_mlxvlm.py`** — kernel #2: weighted LoRA-SFT on real Gemma-4 via mlx-vlm. `w=1` → plain
+  SFT; `w=σ(κ(logp−γ))` → surprisal gate. Proves the weight update.
+- **`bench8h.py`** — the B/S/O/P arm orchestrator with budget, checkpoints, and learning curves.
+
+## Output Standard
+
+End with: trainable student + loader confirmed (weight update proven); teacher choice; arm × eval
+table (dev + OOD + `d_t`) with learning curves; the distill/pedagogical/climb verdict; saved
+adapter paths; result type (training / heldout / blocked); one recommended next action.
+
+## References
+- [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) — the prompt rung before this.
+- [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md) — hosted RL after.
+- [`../specialize-local-model/SKILL.md`](../specialize-local-model/SKILL.md) — the model ladder.

--- a/skills/local-distillation-lab/SKILL.md
+++ b/skills/local-distillation-lab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-distillation-lab
-description: Use when a developer wants to actually fine-tune / distill a local open model on Apple Silicon MLX — run weight-updating training arms (rejection-sampling SFT, off-policy distillation, on-policy / pedagogical self-distillation) on a captured workload, compare them on a held eval with learning curves, and decide distill-vs-pedagogical-vs-climb. This is the weight-update rung between prompt optimization (optimize-workload/GEPA) and the hosted-RL handoff (prepare-verifier-handoff). Covers the Gemma-4→mlx-vlm loader gotcha, the forced-likelihood + weighted-LoRA kernels, the privileged-teacher choice, and overnight orchestration discipline.
+description: Use when a developer wants to fine-tune or distill a local open model on Apple Silicon MLX, compare weight-update arms on a captured workload, and decide distill-vs-pedagogical-vs-climb before hosted RL.
 metadata:
   understudy:
     mode: interactive

--- a/skills/local-distillation-lab/examples/bench8h.py
+++ b/skills/local-distillation-lab/examples/bench8h.py
@@ -1,0 +1,209 @@
+"""Local pedagogical-distillation bench on REAL Gemma-4 (mlx-vlm) — 8h, all local.
+
+Student = gemma-4-e2b mlx-vlm snapshot (trained via kernel #2 mlx-vlm).
+Teacher / STaR samples via :8081 router. Eval via mlx_vlm.generate.
+Arms B/S/O/P with eval-checkpointed learning curves (sample-efficiency).
+Expanded advisor data (simple train/dev + held-out sales OOD). Budgeted + checkpointed.
+"""
+from __future__ import annotations
+import json, math, os, re, sys, time, traceback, urllib.request
+from pathlib import Path
+import mlx.core as mx, mlx.nn as nn, mlx.optimizers as optim
+from mlx.utils import tree_flatten
+from mlx_vlm import load as vlm_load, generate as vlm_generate
+from mlx_lm.tuner.utils import linear_to_lora_layers
+
+ROOT = Path("/Users/luis/Developer/understudy/testing-environments/AutomationBench")
+EV = ROOT / ".understudy/capture-evidence"
+PED = Path("/Users/luis/Developer/understudy/worktrees/pedagogical-rl/src"); sys.path.insert(0, str(PED))
+from understudy_agent.pedagogical_reward import g_spike, SpikeRewardConfig
+ENDPOINT = "http://127.0.0.1:8081/v1/chat/completions"
+RUN = EV / "bench8h-g4"; RUN.mkdir(parents=True, exist_ok=True)
+SMOKE = "--smoke" in sys.argv
+BUDGET_S = 1000 if SMOKE else int(os.environ.get("BENCH_BUDGET_S", 8 * 3600))
+T0 = time.time(); CFG = SpikeRewardConfig()
+STUDENT = "/Users/luis/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit"
+STUDENT_SERVE = STUDENT
+TEACHER_SERVE = STUDENT  # privileged SELF-teacher (E2B + ICL gold); robust + OPSD/SDFT-faithful
+
+# ---- data: expanded advisor (simple train/dev + held-out sales OOD) ----
+allrows = json.load(open(EV / "advisor-all-domains.json"))
+catalog = json.load(open(EV / "tool-catalog.json"))
+simple = [r for r in allrows if r["domain"] == "simple"]; sales = [r for r in allrows if r["domain"] == "sales"]
+TRAIN, DEV, OOD = simple[:140], simple[140:170], sales[:30]
+if SMOKE: TRAIN, DEV, OOD = simple[:6], simple[140:143], sales[:2]
+apps = {t.split("_")[0] for r in (TRAIN + DEV + OOD) for t in r["gold_tools"]}
+RCAT = [t for t in catalog if t["name"].split("_")[0] in apps]; RNAMES = {t["name"] for t in RCAT}
+CAT = "\n".join(f"- {t['name']}: {t['description']}" for t in RCAT)
+ICL = "\n".join(f'TASK: {r["instruction"][:140]}\nTOOLS: {json.dumps(r["gold_tools"])}' for r in TRAIN[:3])
+
+def log(m):
+    line = f"[{time.strftime('%H:%M:%S')} +{(time.time()-T0)/60:.0f}m] {m}"
+    print(line, flush=True); open(RUN / "progress.log", "a").write(line + "\n")
+def budget_left(): return BUDGET_S - (time.time() - T0)
+
+def sysmsg(icl): return ("You are a tool-retrieval advisor. Return ONLY a JSON array of tool names from "
+                         "the catalog needed for the task (minimal, app must match)."
+                         + (f"\n\nEXAMPLES:\n{ICL}" if icl else "") + f"\n\nCATALOG ({len(RCAT)}):\n{CAT}")
+def msgs_for(instr, icl): return [{"role": "system", "content": sysmsg(icl)},
+                                  {"role": "user", "content": f"TASK: {instr}\nReturn the JSON array."}]
+def parse(txt):
+    m = re.search(r"\[.*?\]", txt, re.S)
+    try: p = [str(x) for x in json.loads(m.group(0))] if m else []
+    except Exception: p = re.findall(r"[a-z0-9_]+_[a-z0-9_]+", txt)
+    return [x for x in p if x in RNAMES]
+def recall(pred, gold): g = set(gold); p = set(pred); return len(p & g) / len(g) if g else 1.0
+
+def serve_gen(model_id, instr, icl=False, temperature=0.0):
+    body = {"model": model_id, "messages": msgs_for(instr, icl), "max_tokens": 80, "temperature": temperature}
+    for attempt in range(3):
+        try:
+            req = urllib.request.Request(ENDPOINT, data=json.dumps(body).encode(), headers={"Content-Type": "application/json"})
+            return json.load(urllib.request.urlopen(req, timeout=180))["choices"][0]["message"]["content"] or ""
+        except Exception:
+            if attempt == 2: raise
+            time.sleep(2)
+
+def chat_ids(tok, messages):
+    enc = tok.apply_chat_template(messages, add_generation_prompt=True)
+    if hasattr(enc, "input_ids"): enc = enc.input_ids
+    elif isinstance(enc, dict): enc = enc["input_ids"]
+    if enc and isinstance(enc[0], (list, tuple)): enc = enc[0]
+    return [int(x) for x in enc]
+def lm_logits(lm, ids):
+    o = lm(ids); return o.logits if hasattr(o, "logits") else (o[0] if isinstance(o, tuple) else o)
+
+def mem_gen(model, proc, instr, icl=False):
+    prompt = proc.tokenizer.apply_chat_template(msgs_for(instr, icl), add_generation_prompt=True, tokenize=False)
+    out = vlm_generate(model, proc, prompt=prompt, max_tokens=80, verbose=False)
+    return out if isinstance(out, str) else getattr(out, "text", str(out))
+def eval_both(model, proc):
+    d = sum(recall(parse(mem_gen(model, proc, r["instruction"])), r["gold_tools"]) for r in DEV) / len(DEV)
+    o = sum(recall(parse(mem_gen(model, proc, r["instruction"])), r["gold_tools"]) for r in OOD) / len(OOD)
+    return {"dev": round(d, 3), "ood": round(o, 3)}
+
+def fresh_student(rank=8, layers=8):
+    model, proc = vlm_load(STUDENT); lm = model.language_model; lm.freeze()
+    try: linear_to_lora_layers(lm, layers, {"rank": rank, "scale": 20.0, "dropout": 0.0})
+    except Exception: linear_to_lora_layers(lm, layers, {"rank": rank, "alpha": 16, "dropout": 0.0})
+    return model, proc, lm
+
+def student_logps(lm, tok, messages, completion):
+    pid = chat_ids(tok, messages); cid = tok.encode(completion, add_special_tokens=False)
+    if not cid: return [], cid
+    logp = nn.log_softmax(lm_logits(lm, mx.array([pid + cid]))[0].astype(mx.float32), axis=-1)
+    ch, dts = [], []
+    for j, t in enumerate(cid):
+        row = logp[len(pid) + j - 1]; c = float(row[t]); ch.append(c); dts.append(float(mx.max(row)) - c)
+    return ch, dts, cid
+
+def train_arm(name, examples, *, chunk=40, max_iters, lr=5e-5):
+    """Train fresh student on examples; eval at iter checkpoints -> learning curve."""
+    model, proc, lm = fresh_student()
+    enc = []
+    for ex in examples:
+        pid = chat_ids(proc.tokenizer, ex["messages"]); cid = proc.tokenizer.encode(ex["completion"], add_special_tokens=False)
+        if not cid: continue
+        w = (ex.get("weights") or [1.0] * len(cid)); enc.append((pid, cid, (w + [1.0] * len(cid))[:len(cid)]))
+    if not enc: return {"error": "no data"}
+    def loss_on(lm, pid, cid, w):
+        logp = nn.log_softmax(lm_logits(lm, mx.array([pid + cid]))[0].astype(mx.float32), axis=-1)
+        P = len(pid); tl = mx.stack([logp[P + j - 1, t] for j, t in enumerate(cid)])
+        wv = mx.array(w); return -(tl * wv).sum() / (wv.sum() + 1e-6)
+    opt = optim.AdamW(learning_rate=lr); lvg = nn.value_and_grad(lm, loss_on)
+    curve = [{"iter": 0, **eval_both(model, proc)}]; it = 0
+    log(f"   [{name}] iter 0: {curve[0]}")
+    while it < max_iters and budget_left() > (40 if SMOKE else 120):
+        for _ in range(chunk):
+            pid, cid, w = enc[it % len(enc)]
+            loss, g = lvg(lm, pid, cid, w); opt.update(lm, g); mx.eval(lm.parameters(), opt.state); it += 1
+            if it >= max_iters: break
+        ev = eval_both(model, proc); curve.append({"iter": it, **ev})
+        log(f"   [{name}] iter {it}: dev={ev['dev']} ood={ev['ood']}")
+    best = max(curve, key=lambda c: c["dev"]) if curve else None
+    return {"curve": curve, "final": curve[-1] if curve else None, "best": best, "n": len(enc)}
+
+results = {"student": STUDENT, "teacher": TEACHER_SERVE, "arms": {}}
+log(f"START bench8h-g4 | budget={BUDGET_S/3600:.1f}h smoke={SMOKE} | rcat={len(RCAT)} train={len(TRAIN)} dev={len(DEV)} ood={len(OOD)}")
+MAXIT = 24 if SMOKE else 560  # ~4 epochs over 140
+
+try:
+    # baseline
+    bm, bp = vlm_load(STUDENT)
+    results["arms"]["B_baseline"] = eval_both(bm, bp); log(f"B baseline {results['arms']['B_baseline']}")
+    del bm; (mx.clear_cache() if hasattr(mx, "clear_cache") else None)
+
+    # build data
+    log("building arm data (STaR via student :8081, teacher via :8081 ICL)")
+    s_ex, t_ex = [], []
+    for r in TRAIN:
+        if budget_left() < (90 if SMOKE else 300): break
+        try:                                  # STaR: student's own passing samples
+            sg = serve_gen(STUDENT_SERVE, r["instruction"], icl=False, temperature=0.7)
+            if recall(parse(sg), r["gold_tools"]) >= 0.999:
+                s_ex.append({"messages": msgs_for(r["instruction"], False), "completion": json.dumps(parse(sg))})
+        except Exception as e: log(f"  STaR gen skip {r['name']}: {str(e)[:60]}")
+        try:                                  # privileged self-teacher (student + ICL gold)
+            tg = serve_gen(STUDENT_SERVE, r["instruction"], icl=True, temperature=0.0)
+            if parse(tg):
+                t_ex.append({"messages": msgs_for(r["instruction"], False), "completion": json.dumps(parse(tg)), "gold": r["gold_tools"]})
+        except Exception as e: log(f"  teacher gen skip {r['name']}: {str(e)[:60]}")
+    log(f"data: STaR={len(s_ex)} teacher={len(t_ex)}")
+    json.dump({"s": s_ex, "t": t_ex}, open(RUN / "arm_data.json", "w"))
+
+    if s_ex and budget_left() > (150 if SMOKE else 600):
+        results["arms"]["S_star"] = train_arm("S", s_ex, max_iters=MAXIT)
+        json.dump(results, open(RUN / "results.json", "w"), indent=2)
+    if t_ex and budget_left() > (150 if SMOKE else 600):
+        results["arms"]["O_offpolicy"] = train_arm("O", [{"messages": d["messages"], "completion": d["completion"]} for d in t_ex], max_iters=MAXIT)
+        json.dump(results, open(RUN / "results.json", "w"), indent=2)
+    if t_ex and budget_left() > (150 if SMOKE else 600):
+        log("scoring arm-P surprisal weights via kernel #1 (fresh student lm)")
+        _, sp, slm = fresh_student()
+        p_ex = []; _dts_all = []
+        for d in t_ex:
+            lps, dts, _ = student_logps(slm, sp.tokenizer, d["messages"], d["completion"])
+            from kernel2_mlxvlm import surprisal_gate
+            _dts_all.extend(dts)
+            p_ex.append({"messages": d["messages"], "completion": d["completion"],
+                         "weights": surprisal_gate(lps) if lps else None})
+        del slm; (mx.clear_cache() if hasattr(mx, "clear_cache") else None)
+        pe = train_arm("P", p_ex, max_iters=MAXIT)
+        pe["teacher_mean_d_t"] = round(sum(_dts_all)/max(len(_dts_all),1), 3)
+        results["arms"]["P_pedagogical"] = pe
+        json.dump(results, open(RUN / "results.json", "w"), indent=2)
+except Exception as e:
+    results["error"] = str(e); log(f"FAILED: {e}\n{traceback.format_exc()[:500]}")
+json.dump(results, open(RUN / "results.json", "w"), indent=2)
+
+# report
+def fin(a): v = results["arms"].get(a, {}); return v.get("final") or v if isinstance(v, dict) else {}
+rows_md = []
+for a in ["B_baseline", "S_star", "O_offpolicy", "P_pedagogical"]:
+    v = results["arms"].get(a, {})
+    f = v.get("final") if isinstance(v, dict) and "final" in v else v
+    dev = f.get("dev", "—") if isinstance(f, dict) else "—"; ood = f.get("ood", "—") if isinstance(f, dict) else "—"
+    rows_md.append(f"| {a} | {dev} | {ood} | {v.get('n','—') if isinstance(v,dict) else '—'} |")
+mins = (time.time() - T0) / 60
+report = f"""# Gemma-4 pedagogical-distillation bench — results
+runtime {mins:.0f}m | budget {BUDGET_S/3600:.1f}h | student gemma-4-e2b (mlx-vlm) | teacher {TEACHER_SERVE}
+reduced catalog {len(RCAT)} tools | train {len(TRAIN)} / dev {len(DEV)} / OOD-sales {len(OOD)}
+
+## Final dev/OOD recall by arm
+| arm | dev | ood | n |
+|---|---|---|---|
+{chr(10).join(rows_md)}
+
+Arms: B baseline · S rejection-sampling SFT · O off-policy distill (ICL teacher) · P pedagogical (surprisal-gated).
+Read: P>O → spike gating helps · O>S → bigger in-family teacher adds signal · OOD col → cross-domain transfer.
+
+## Learning curves
+```json
+{json.dumps({a: results['arms'].get(a, {}).get('curve') for a in ['S_star','O_offpolicy','P_pedagogical']}, indent=1)[:3000]}
+```
+## Next
+Promote winning arm to multi-round on-policy loop; fuse best adapter and serve on :8081; extend to E4B student.
+"""
+open(RUN / "REPORT.md", "w").write(report)
+log(f"DONE {mins:.0f}m -> {RUN/'REPORT.md'}")
+print("\n" + report)

--- a/skills/local-distillation-lab/examples/forced_likelihood.py
+++ b/skills/local-distillation-lab/examples/forced_likelihood.py
@@ -1,0 +1,93 @@
+"""Kernel #1 — local MLX forced-likelihood scorer for Pedagogical RL.
+
+Teacher-forces the STUDENT model over a given trajectory and emits, per
+completion token: chosen logprob, argmax logprob, the paper's surprise gap
+d_t = logπ(a_max) − logπ(τ_t), and the score_table "top-2 gap" (top1 − top2).
+Feeds the existing first-party `pedagogical_reward.g_spike`.
+
+This is the missing executor behind `fullcast_pedagogical_forced_likelihood.py`'s
+`forced_token_logprobs_ref`. Pure-local, no provider calls.
+
+Validation (run as __main__): full-pass gather == incremental teacher-forced
+logp (proves no off-by-one), then prints d_t / top-2 gap / G_spike.
+"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm import load
+
+# import the real first-party reward
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+from understudy_agent.pedagogical_reward import g_spike, SpikeRewardConfig, spike_intensity
+
+
+def forced_token_logprobs(model, prompt_ids: list[int], completion_ids: list[int]) -> list[dict]:
+    """Single forward pass over prompt+completion; gather per-completion-token stats."""
+    ids = mx.array([prompt_ids + completion_ids])
+    logits = model(ids)[0]                      # [T, V]
+    logp = nn.log_softmax(logits, axis=-1)
+    P = len(prompt_ids)
+    out = []
+    for j, tid in enumerate(completion_ids):
+        pos = P + j - 1                         # dist predicting completion token j
+        row = logp[pos]
+        chosen = float(row[tid])
+        amax = float(mx.max(row))
+        # top-2 gap (top1 - top2): mask argmax then take max again
+        arg = int(mx.argmax(row))
+        masked = mx.where(mx.arange(row.shape[0]) == arg, mx.array(-1e9), row)
+        second = float(mx.max(masked))
+        out.append({
+            "token_id": tid, "logp": chosen,
+            "argmax_logp": amax, "d_t": amax - chosen,        # paper surprise gap (>=0)
+            "top2_gap": amax - second,                         # score_table feature
+        })
+    return out
+
+
+def _incremental_logp(model, prompt_ids, completion_ids) -> list[float]:
+    """Reference: feed growing prefixes, read last-position logp of each next token."""
+    out = []
+    for j, tid in enumerate(completion_ids):
+        prefix = prompt_ids + completion_ids[:j]
+        logits = model(mx.array([prefix]))[0]
+        row = nn.log_softmax(logits[-1], axis=-1)
+        out.append(float(row[tid]))
+    return out
+
+
+if __name__ == "__main__":
+    model_id = sys.argv[1] if len(sys.argv) > 1 else "mlx-community/gemma-3-1b-it-4bit"
+    print(f"loading {model_id} ...")
+    model, tok = load(model_id)
+
+    # realistic chat trajectory: a prompt + a model-style completion
+    prompt = tok.apply_chat_template(
+        [{"role": "user", "content": "In one short sentence, what is the capital of France and why is it famous?"}],
+        add_generation_prompt=True,
+    )
+    completion_text = "Paris is the capital of France, famous for the Eiffel Tower and its art and cuisine. zqx"  # 'zqx' = deliberate spike
+    completion = tok.encode(completion_text, add_special_tokens=False)
+
+    t0 = time.time()
+    stats = forced_token_logprobs(model, prompt, completion)
+    dt = time.time() - t0
+
+    # --- validation: full-pass == incremental ---
+    ref = _incremental_logp(model, prompt, completion)
+    maxerr = max(abs(s["logp"] - r) for s, r in zip(stats, ref))
+    print(f"\nVALIDATION full-pass vs incremental: max abs logp err = {maxerr:.2e} "
+          f"-> {'PASS' if maxerr < 1e-2 else 'FAIL'}  ({len(completion)} tokens, {dt*1000:.0f}ms forward)")
+
+    chosen = [s["logp"] for s in stats]
+    cfg = SpikeRewardConfig()
+    gs = g_spike(chosen, cfg)
+    print(f"G_spike(traj) = {gs:.4f} | spike_intensity = {spike_intensity(chosen, cfg):.4f}")
+    print(f"mean top-2 gap = {sum(s['top2_gap'] for s in stats)/len(stats):.4f} | "
+          f"mean d_t = {sum(s['d_t'] for s in stats)/len(stats):.4f} | "
+          f"mean logp = {sum(chosen)/len(chosen):.4f}")
+    print("\nper-token (last 8, watch the injected 'zqx' spike):")
+    for s in stats[-8:]:
+        print(f"  {tok.decode([s['token_id']])!r:14} logp={s['logp']:7.3f}  d_t={s['d_t']:6.3f}  top2_gap={s['top2_gap']:6.3f}")

--- a/skills/local-distillation-lab/examples/kernel2_mlxvlm.py
+++ b/skills/local-distillation-lab/examples/kernel2_mlxvlm.py
@@ -1,0 +1,92 @@
+"""Kernel #2 (mlx-vlm port) — weighted LoRA-SFT on the real Gemma-4 mlx-vlm snapshots.
+
+Loads via mlx_vlm, injects LoRA into model.language_model, runs the surprisal-gated
+weighted-CE loss through the text forward. Proves a real weight update on Gemma-4.
+"""
+from __future__ import annotations
+import math, sys, time
+import mlx.core as mx, mlx.nn as nn, mlx.optimizers as optim
+from mlx.utils import tree_flatten
+from mlx_vlm import load as vlm_load
+
+def surprisal_gate(logps, kappa=1.0, gamma=-4.0):
+    return [1.0 / (1.0 + math.exp(-kappa * (lp - gamma))) for lp in logps]
+
+def _lm_logits(lm, ids):
+    out = lm(ids)
+    return out.logits if hasattr(out, "logits") else (out[0] if isinstance(out, tuple) else out)
+
+def load_g4(path):
+    model, proc = vlm_load(path)
+    tok = getattr(proc, "tokenizer", proc)
+    return model, model.language_model, tok
+
+def chat_ids(tok, prompt):
+    """Return a flat list[int] for a user-turn chat prompt (handles BatchEncoding)."""
+    enc = tok.apply_chat_template([{"role": "user", "content": prompt}], add_generation_prompt=True)
+    if hasattr(enc, "input_ids"): enc = enc.input_ids
+    elif isinstance(enc, dict): enc = enc["input_ids"]
+    if enc and isinstance(enc[0], (list, tuple)): enc = enc[0]
+    return [int(x) for x in enc]
+
+def forced_logps(lm, tok, prompt, completion):
+    """kernel #1 (mlx-vlm): per-token logp of completion under the student LM."""
+    pid = chat_ids(tok, prompt)
+    cid = tok.encode(completion, add_special_tokens=False)
+    if not cid: return [], cid
+    logp = nn.log_softmax(_lm_logits(lm, mx.array([pid + cid]))[0].astype(mx.float32), axis=-1)
+    P = len(pid)
+    return [float(logp[P + j - 1, t]) for j, t in enumerate(cid)], cid
+
+def train_lora_weighted_g4(path, examples, *, iters=24, lr=2e-4, rank=8, num_lora_layers=8, log=print):
+    from mlx_lm.tuner.utils import linear_to_lora_layers, print_trainable_parameters
+    model, lm, tok = load_g4(path)
+    lm.freeze()
+    try: linear_to_lora_layers(lm, num_lora_layers, {"rank": rank, "scale": 20.0, "dropout": 0.0})
+    except Exception: linear_to_lora_layers(lm, num_lora_layers, {"rank": rank, "alpha": 16, "dropout": 0.0})
+    print_trainable_parameters(lm)
+    before = {k: mx.array(v) for k, v in tree_flatten(lm.trainable_parameters())}
+
+    enc = []
+    for ex in examples:
+        pid = chat_ids(tok, ex["prompt"])
+        cid = tok.encode(ex["completion"], add_special_tokens=False)
+        if not cid: continue
+        w = (ex.get("weights") or [1.0] * len(cid))
+        enc.append((pid, cid, (w + [1.0] * len(cid))[:len(cid)]))
+
+    def loss_on(lm, pid, cid, w):
+        logp = nn.log_softmax(_lm_logits(lm, mx.array([pid + cid]))[0].astype(mx.float32), axis=-1)
+        P = len(pid)
+        tl = mx.stack([logp[P + j - 1, t] for j, t in enumerate(cid)])
+        wv = mx.array(w)
+        return -(tl * wv).sum() / (wv.sum() + 1e-6)
+
+    opt = optim.AdamW(learning_rate=lr)
+    lvg = nn.value_and_grad(lm, loss_on)
+    curve = []
+    for it in range(iters):
+        pid, cid, w = enc[it % len(enc)]
+        loss, grads = lvg(lm, pid, cid, w)
+        opt.update(lm, grads); mx.eval(lm.parameters(), opt.state)
+        curve.append(float(loss))
+        if it % max(1, iters // 5) == 0 or it == iters - 1: log(f"   iter {it:3d} loss {float(loss):.4f}")
+    after = {k: v for k, v in tree_flatten(lm.trainable_parameters())}
+    delta = sum(float(mx.abs(after[k] - before[k]).sum()) for k in before)
+    return {"model": model, "lm": lm, "tok": tok, "loss_curve": curve,
+            "loss_drop": curve[0] - curve[-1], "param_delta": delta}
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "/Users/luis/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit"
+    print(f"SMOKE kernel #2 (mlx-vlm) on REAL Gemma-4: {path}")
+    exs = [{"prompt": "TASK: Update Jordan Lee's phone in Salesforce.\nReturn the JSON array.",
+            "completion": '["salesforce_contact_update"]'},
+           {"prompt": "TASK: Create a Salesforce case for the outage.\nReturn the JSON array.",
+            "completion": '["salesforce_case_create"]'},
+           {"prompt": "TASK: Log a note on the SF contact.\nReturn the JSON array.",
+            "completion": '["salesforce_note_create"]'}]
+    t0 = time.time()
+    r = train_lora_weighted_g4(path, exs, iters=20, lr=2e-4)
+    print(f"\nRESULT loss {r['loss_curve'][0]:.3f} -> {r['loss_curve'][-1]:.3f} "
+          f"(drop {r['loss_drop']:+.3f}) | param_delta {r['param_delta']:.4f} | {time.time()-t0:.0f}s")
+    print("GEMMA-4 WEIGHT-UPDATE PROVEN:", "PASS" if r["loss_drop"] > 0.05 and r["param_delta"] > 0 else "INCONCLUSIVE")


### PR DESCRIPTION
## What (draft)

A new worker skill for the **weight-update rung** that's currently missing: `optimize-workload` explicitly does not train; `prepare-verifier-handoff` jumps to hosted RL. This skill runs **real LoRA training arms locally on Apple Silicon** and compares post-training methods on a captured workload.

Drafted from a full dogfood build (Gemma-4 E2B self-distillation bench, end-to-end on an M5 Max).

## Contents

- `SKILL.md` — when-to-use, safety gates, the **B/S/O/P arm taxonomy** (baseline / rejection-sampling SFT / off-policy distillation / pedagogical surprisal-gated), eval-checkpoint learning curves, and the distill-vs-pedagogical-vs-climb decision.
- **Gotchas that cost real time**, esp. the Gemma-4 loader trap: `mlx_lm` can't load the mlx-vlm Gemma-4 conversions (`language_model.` prefix / `k_norm`) → **train via `mlx-vlm 0.6.2` on `model.language_model`**. Plus the BatchEncoding tokenizer trap, additive-vs-product reward, overfit-collapse, and overnight orchestration discipline.
- `examples/` — runnable kernels: `forced_likelihood.py` (kernel #1), `kernel2_mlxvlm.py` (weighted LoRA-SFT on real Gemma-4), `bench8h.py` (arm orchestrator).

## Validated locally

- kernel #1 forced-likelihood: full-pass == incremental, **0.00 err**.
- kernel #2: moves real **Gemma-4 E2B** weights (loss **4.19 → 0.25**, nonzero param-delta).
- Arm orchestrator runs B/S/O/P with learning curves; an 8h run is in progress as of this draft.

## Why draft

Examples carry env-specific paths (model snapshot, venv) and the method set omits a true on-policy-distillation arm (student-rollout + per-token teacher KL) — noted as the next addition. Opening for review of the skill's shape and the Gemma-4 loader guidance before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)