### PR TITLE
Fix installer noninteractive prompt handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,10 +17,14 @@ START_STEP=1
 ONLY_STEP=""
 RESUME=0
 YES=0
+NONINTERACTIVE="${UNDERSTUDY_NONINTERACTIVE:-${CI:-0}}"
+REQUIRE_CONFIRM="${UNDERSTUDY_REQUIRE_CONFIRM:-0}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -y|--yes) YES=1 ;;
+    --non-interactive|--noninteractive|--no-input) NONINTERACTIVE=1 ;;
+    --require-confirm) REQUIRE_CONFIRM=1 ;;
     --no-claude) NO_CLAUDE=1 ;;
     --no-launch-claude) LAUNCH_CLAUDE=0 ;;
     --launch-claude) LAUNCH_CLAUDE=1 ;;
@@ -30,7 +34,7 @@ while [ "$#" -gt 0 ]; do
     --lab) LAB="${2:?missing path}"; shift ;;
     -h|--help)
       cat <<'EOF'
-Usage: install.sh [--yes] [--resume] [--from-step N] [--only-step N] [--no-claude] [--no-launch-claude]
+Usage: install.sh [--yes] [--non-interactive] [--resume] [--from-step N] [--only-step N] [--no-claude] [--no-launch-claude]
 
 Installs the Understudy CLI + Claude Code skill/plugin surface, then hands the
 user back to Claude Code. It does not download model weights, start MLX, install
@@ -39,6 +43,8 @@ Pi, launch tmux/iTerm, or make frontier calls. Those are guided by the
 
 Options:
   --yes                 approve the installer prompt
+  --non-interactive     use safe defaults without prompting
+  --require-confirm     fail instead of using defaults when no prompt TTY exists
   --resume              continue from the next unfinished install step
   --from-step N         start from step 1, 2, or 3
   --only-step N         run only step 1, 2, or 3
@@ -57,6 +63,8 @@ Environment overrides:
   UNDERSTUDY_INSTALL_LOG_FILE    exact install log path
   UNDERSTUDY_INSTALLER_COMMIT    optional script commit label when caller knows it
   UNDERSTUDY_INSTALL_PACKAGE     optional npm package spec override
+  UNDERSTUDY_NONINTERACTIVE      set to 1 to use safe defaults without prompting
+  UNDERSTUDY_REQUIRE_CONFIRM     set to 1 to fail when no prompt TTY exists
   UNDERSTUDY_LAUNCH_CLAUDE      set to 0 to skip opening Claude Code
   UNDERSTUDY_CLAUDE_ARGS        optional extra args when launching Claude Code
   UNDERSTUDY_CLAUDE_PERMISSION_MODE Claude Code permission mode, default auto
@@ -128,14 +136,33 @@ configure_resume() {
   fi
 }
 confirm() {
+  local answer
   [ "$YES" = "1" ] && return 0
-  if [ ! -r /dev/tty ]; then
-    say "This install is running without an interactive terminal for prompts."
-    say "Rerun with --yes to approve, for example: curl -fsSL .../install.sh | bash -s -- --yes"
+  case "$NONINTERACTIVE" in
+    1|true|TRUE|yes|YES|on|ON)
+      if [ "$REQUIRE_CONFIRM" = "1" ]; then
+        say "Confirmation is required but running non-interactively; rerun in a terminal or pass --yes."
+        return 1
+      fi
+      say "Running non-interactively; using installer defaults."
+      return 0
+      ;;
+  esac
+  if [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; then
+    say "No interactive terminal is available for prompts."
+    say "Confirmation is required; rerun in a terminal or pass --yes / --non-interactive."
     return 1
   fi
-  printf "%s [y/N] " "$1" >/dev/tty
-  read -r answer </dev/tty
+  if ! printf "%s [y/N] " "$1" >/dev/tty 2>/dev/null; then
+    say "No interactive terminal is available for prompts."
+    say "Confirmation is required; rerun in a terminal or pass --yes / --non-interactive."
+    return 1
+  fi
+  if ! read -r answer </dev/tty 2>/dev/null; then
+    say "No interactive terminal input is available."
+    say "Confirmation is required; rerun in a terminal or pass --yes / --non-interactive."
+    return 1
+  fi
   case "$answer" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
 }
 

--- a/tests/installer.test.mjs
+++ b/tests/installer.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+let root;
+
+describe("install.sh", () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "understudy-installer-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("runs from a pipe when noninteractive mode is explicit", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const lab = join(root, "lab");
+    const result = spawnSync(
+      "bash",
+      [
+        "-s",
+        "--",
+        "--non-interactive",
+        "--only-step",
+        "3",
+        "--no-claude",
+        "--lab",
+        lab,
+      ],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Running non-interactively/);
+    assert.match(result.stdout, /Skipping Claude Code launch because --no-claude is set/);
+  });
+
+  it("lets require-confirm override noninteractive mode", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const result = spawnSync(
+      "bash",
+      [
+        "-s",
+        "--",
+        "--non-interactive",
+        "--require-confirm",
+        "--only-step",
+        "3",
+        "--no-claude",
+        "--lab",
+        join(root, "lab"),
+      ],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Confirmation is required/);
+  });
+});


### PR DESCRIPTION
## Summary
- let the installer proceed with safe defaults when no prompt TTY is available
- add explicit --non-interactive / --no-input and UNDERSTUDY_NONINTERACTIVE controls
- add --require-confirm / UNDERSTUDY_REQUIRE_CONFIRM for strict prompt-required runs
- harden /dev/tty prompt handling so failed tty writes/reads do not trip set -u
- add regression coverage for piped installer execution

## Root Cause
Coding-agent invocations such as `curl .../install.sh | bash` can run without a usable /dev/tty. The installer only checked file readability before writing to /dev/tty, so macOS could still fail with `Device not configured`; with `set -u`, the unset prompt answer then aborted the script.

## Validation
- node --test tests/installer.test.mjs
- npm run check
- git diff --check
- smoke: `cat install.sh | bash -s -- --yes --only-step 3 --no-claude --lab <tmp>`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->