### PR TITLE
[codex] Add pedagogical RLM skill bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,9 @@ with `UNDERSTUDY_TELEMETRY=0`.
 
 The skills in [`skills/`](skills/) ship as a Claude Code plugin, declared in
 [`.claude-plugin/`](.claude-plugin/) (`plugin.json` + `marketplace.json`).
-Installing it registers all eleven invocable skills (`understudy`, `onboard`,
-`capture-evidence`, `use-understudy-gateway`, `manage-local-models`,
-`run-local-model-lab`, `optimize-workload`, `optimize-api-workflow`,
-`optimize-agentic-search`, `prepare-verifier-handoff`, `install-plugin`).
+Installing it registers the public invocable skills in [`skills/`](skills/),
+including the `understudy` orchestrator, onboarding, capture/eval, optimization,
+local model, distillation, RLM, and verifier-handoff workers.
 
 From a clone of this repo:
 
@@ -212,12 +211,14 @@ capability worker:
 - `skills/manage-local-models/SKILL.md` (acquire, cache, and explain local open-weight models)
 - `skills/run-local-model-lab/SKILL.md`
 - `skills/specialize-local-model/SKILL.md` (smallest reasonable local rung → Pi head-to-head → gap-driven improvement)
+- `skills/pedagogical-learning/SKILL.md` (privileged-context trajectories that are correct and learnable)
+- `skills/rlm-pedagogical-training/SKILL.md` (stateful RLM/verifiers training surfaces before hosted RL)
+- `skills/local-distillation-lab/SKILL.md` (local Apple Silicon weight-update arms before hosted RL)
 - `skills/prepare-verifier-handoff/SKILL.md`
 
-Everything else stays outside the discovered surface until real usage proves it
-belongs back. See [`skills/README.md`](skills/README.md) for the current
-hierarchy and [`docs/current-functionality.md`](docs/current-functionality.md)
-for the migration ledger.
+See [`skills/README.md`](skills/README.md) for the current hierarchy and
+[`docs/current-functionality.md`](docs/current-functionality.md) for the
+migration ledger.
 
 `prepare-verifier-handoff` is intentionally handoff-only. It is for workloads
 that need a future Understudy verifier/RL-environment release or an external

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -90,6 +90,9 @@ skills/mlx-arena/SKILL.md
 skills/design-simulated-environment/SKILL.md
 skills/recursive-language-model/SKILL.md
 skills/specialize-local-model/SKILL.md
+skills/pedagogical-learning/SKILL.md
+skills/rlm-pedagogical-training/SKILL.md
+skills/local-distillation-lab/SKILL.md
 skills/prepare-verifier-handoff/SKILL.md
 ```
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -37,6 +37,10 @@ const requiredPackageMembers = [
   "cookbook/capture-evidence-node/README.md",
   "cookbook/optimize-eval-input-gepa/eval-input-manifest.json",
   "cookbook/gateway-openai-typescript/src/client.ts",
+  "skills/pedagogical-learning/SKILL.md",
+  "skills/pedagogical-learning/reference.md",
+  "skills/rlm-pedagogical-training/SKILL.md",
+  "skills/rlm-pedagogical-training/reference.md",
 ];
 
 function npmPackFiles() {

--- a/skills/README.md
+++ b/skills/README.md
@@ -58,6 +58,16 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
 - [`compare-model-sweep`](compare-model-sweep/SKILL.md) runs a frozen eval across
   a candidate matrix and writes Pareto-style quality, latency, cost, reliability,
   and caveat artifacts for route decisions.
+- [`pedagogical-learning`](pedagogical-learning/SKILL.md) turns privileged
+  answers, execution feedback, verifier traces, or canonical solutions into
+  local correct-and-learnable trajectory evidence before SFT, GRPO, or hosted RL.
+- [`rlm-pedagogical-training`](rlm-pedagogical-training/SKILL.md) turns a
+  stateful workload into an RLM/verifiers training surface, measures on-policy
+  state coverage and surprise concentration, and decides between local
+  pedagogical SFT, on-policy repair, true pedagogical RL, or verifier handoff.
+- [`local-distillation-lab`](local-distillation-lab/SKILL.md) runs local Apple
+  Silicon weight-update arms for captured workloads: rejection SFT, same-family
+  off-policy distillation, and surprisal-gated pedagogical variants.
 - [`specialize-local-model`](specialize-local-model/SKILL.md) sequences the local
   model product loop: pick the smallest task-reasonable local rung, open it in
   Pi against a frontier model, diagnose the gap, then choose model climb, GEPA,

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -13,10 +13,9 @@ metadata:
 This repo ships its skills as a Claude Code plugin. The manifests live in
 `.claude-plugin/` (`plugin.json` + `marketplace.json`) and the skills live in
 `skills/`. This skill installs/enables that plugin in the developer's Claude
-Code so all eleven skills (`understudy`, `onboard`, `capture-evidence`,
-`use-understudy-gateway`, `manage-local-models`, `run-local-model-lab`,
-`optimize-workload`, `optimize-api-workflow`, `optimize-agentic-search`,
-`prepare-verifier-handoff`, and this `install-plugin` skill) become invocable.
+Code so the public skills become invocable, including the `understudy`
+orchestrator, onboarding, capture/eval, optimization, local model,
+distillation, RLM, and verifier-handoff workers.
 
 The whole flow is local: it adds a **local filesystem marketplace** pointing at
 this repo and installs from it. Nothing uploads, authenticates, or spends.

--- a/skills/local-distillation-lab/examples/bench8h.py
+++ b/skills/local-distillation-lab/examples/bench8h.py
@@ -13,16 +13,18 @@ from mlx.utils import tree_flatten
 from mlx_vlm import load as vlm_load, generate as vlm_generate
 from mlx_lm.tuner.utils import linear_to_lora_layers
 
-ROOT = Path("/Users/luis/Developer/understudy/testing-environments/AutomationBench")
+ROOT = Path(os.environ.get("UNDERSTUDY_AUTOMATIONBENCH_ROOT", ".")).expanduser().resolve()
 EV = ROOT / ".understudy/capture-evidence"
-PED = Path("/Users/luis/Developer/understudy/worktrees/pedagogical-rl/src"); sys.path.insert(0, str(PED))
-from understudy_agent.pedagogical_reward import g_spike, SpikeRewardConfig
-ENDPOINT = "http://127.0.0.1:8081/v1/chat/completions"
-RUN = EV / "bench8h-g4"; RUN.mkdir(parents=True, exist_ok=True)
+ENDPOINT = os.environ.get("UNDERSTUDY_CHAT_ENDPOINT", "http://127.0.0.1:8081/v1/chat/completions")
+RUN = Path(os.environ.get("UNDERSTUDY_DISTILL_RUN_DIR", EV / "bench8h-g4")).expanduser()
+RUN.mkdir(parents=True, exist_ok=True)
 SMOKE = "--smoke" in sys.argv
 BUDGET_S = 1000 if SMOKE else int(os.environ.get("BENCH_BUDGET_S", 8 * 3600))
-T0 = time.time(); CFG = SpikeRewardConfig()
-STUDENT = "/Users/luis/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit"
+T0 = time.time()
+STUDENT = os.environ.get("UNDERSTUDY_MODEL")
+if not STUDENT:
+    print("set UNDERSTUDY_MODEL=/path/to/mlx-vlm-model before running this example")
+    raise SystemExit(2)
 STUDENT_SERVE = STUDENT
 TEACHER_SERVE = STUDENT  # privileged SELF-teacher (E2B + ICL gold); robust + OPSD/SDFT-faithful
 

--- a/skills/local-distillation-lab/examples/forced_likelihood.py
+++ b/skills/local-distillation-lab/examples/forced_likelihood.py
@@ -3,7 +3,7 @@
 Teacher-forces the STUDENT model over a given trajectory and emits, per
 completion token: chosen logprob, argmax logprob, the paper's surprise gap
 d_t = logπ(a_max) − logπ(τ_t), and the score_table "top-2 gap" (top1 − top2).
-Feeds the existing first-party `pedagogical_reward.g_spike`.
+Feeds a small standalone `G_spike` proxy for public smoke testing.
 
 This is the missing executor behind `fullcast_pedagogical_forced_likelihood.py`'s
 `forced_token_logprobs_ref`. Pure-local, no provider calls.
@@ -12,15 +12,28 @@ Validation (run as __main__): full-pass gather == incremental teacher-forced
 logp (proves no off-by-one), then prints d_t / top-2 gap / G_spike.
 """
 from __future__ import annotations
-import sys, time
-from pathlib import Path
+import math, sys, time
 import mlx.core as mx
 import mlx.nn as nn
 from mlx_lm import load
 
-# import the real first-party reward
-sys.path.insert(0, str(Path(__file__).parent / "src"))
-from understudy_agent.pedagogical_reward import g_spike, SpikeRewardConfig, spike_intensity
+class SpikeRewardConfig:
+    """Small standalone spike proxy for this public example."""
+
+    def __init__(self, gamma: float = -4.0, kappa: float = 1.0):
+        self.gamma = gamma
+        self.kappa = kappa
+
+
+def spike_intensity(logps: list[float], cfg: SpikeRewardConfig) -> float:
+    if not logps:
+        return 0.0
+    weights = [1.0 / (1.0 + math.exp(-cfg.kappa * (lp - cfg.gamma))) for lp in logps]
+    return 1.0 - (sum(weights) / len(weights))
+
+
+def g_spike(logps: list[float], cfg: SpikeRewardConfig) -> float:
+    return max(0.0, 1.0 - spike_intensity(logps, cfg))
 
 
 def forced_token_logprobs(model, prompt_ids: list[int], completion_ids: list[int]) -> list[dict]:

--- a/skills/local-distillation-lab/examples/kernel2_mlxvlm.py
+++ b/skills/local-distillation-lab/examples/kernel2_mlxvlm.py
@@ -4,7 +4,7 @@ Loads via mlx_vlm, injects LoRA into model.language_model, runs the surprisal-ga
 weighted-CE loss through the text forward. Proves a real weight update on Gemma-4.
 """
 from __future__ import annotations
-import math, sys, time
+import math, os, sys, time
 import mlx.core as mx, mlx.nn as nn, mlx.optimizers as optim
 from mlx.utils import tree_flatten
 from mlx_vlm import load as vlm_load
@@ -77,7 +77,11 @@ def train_lora_weighted_g4(path, examples, *, iters=24, lr=2e-4, rank=8, num_lor
             "loss_drop": curve[0] - curve[-1], "param_delta": delta}
 
 if __name__ == "__main__":
-    path = sys.argv[1] if len(sys.argv) > 1 else "/Users/luis/.understudy/models/gemma-4-e2b-it-mlx-vlm-4bit"
+    path = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("UNDERSTUDY_MODEL")
+    if not path:
+        print("usage: python kernel2_mlxvlm.py /path/to/mlx-vlm-model")
+        print("or set UNDERSTUDY_MODEL=/path/to/mlx-vlm-model")
+        raise SystemExit(2)
     print(f"SMOKE kernel #2 (mlx-vlm) on REAL Gemma-4: {path}")
     exs = [{"prompt": "TASK: Update Jordan Lee's phone in Salesforce.\nReturn the JSON array.",
             "completion": '["salesforce_contact_update"]'},

--- a/skills/pedagogical-learning/SKILL.md
+++ b/skills/pedagogical-learning/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: pedagogical-learning
+description: Use when a developer has privileged answers, execution feedback, verifier traces, or canonical solutions and wants a local model to learn from trajectories that are both correct and learnable, before moving to SFT, GRPO, or hosted RL.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Pedagogical Learning
+
+Use this worker when privileged information should help **find teachable
+trajectories**, not merely score rollouts after the fact. The goal is to turn a
+weak local model's failures into local evidence about which trajectories are:
+
+- correct under a verifier, answer key, state diff, or execution result;
+- plausible for the current student model to imitate;
+- free of shortcuts, hidden facts, answer-key references, and unsupported jumps.
+
+This is a local evidence and data-selection skill. It may prepare SFT, GRPO, or
+verifier-handoff artifacts, but it does not silently train weights or upload
+data.
+
+## Safety Gates
+
+Default to local, synthetic, redacted, or benchmark-sandbox data. Do not upload
+prompts, traces, completions, labels, datasets, repo paths, or private notes.
+
+Get explicit approval before provider calls, hosted jobs, model downloads,
+weight updates, adapter fusion, publishing artifacts, or running any command that
+can mutate files outside `.understudy/`.
+
+Do not claim "pedagogical RL worked" from prompt-only experiments. Prompt-only
+smokes can prove headroom and scoring shape; they are not policy training. Label
+local SFT as imitation, GRPO as on-policy reward optimization, and hosted RL as a
+handoff.
+
+Do not trust the same weak model as both generator and sole judge for
+learnability. If token-level logprobs are unavailable, use deterministic
+structure checks, an external verifier, or a stronger approved judge, and label
+the score as a proxy.
+
+## When To Use
+
+Use this skill when all of these hold:
+
+- there is privileged context `c`: gold answers, validator output, execution
+  feedback, final-state diffs, oracle tool sets, canonical traces, or policy
+  explanations;
+- the local student model sees only task input `x` at deployment time;
+- blind rollouts from the student have meaningful failure rate or high variance;
+- successful trajectories must be learnable, not just correct by shortcut;
+- the developer wants a rung before hosted RL or broad model climbing.
+
+If the workload is still not understood, route to
+[`../understand-workload/SKILL.md`](../understand-workload/SKILL.md). If there is
+no resettable harness or metric, route to
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md). If prompt GEPA
+is the cheapest live-rollout intervention, route to
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
+
+## Flow
+
+1. **Name the pedagogy contract.** Write down `x`, privileged context `c`,
+   trajectory shape, deploy-time student input, verifier `R`, and what would make
+   a step unsupported. Examples: answer-key-only jumps, hidden tool labels,
+   unexplained final-state edits, brittle chain-of-thought shortcuts, or
+   impossible recovery from a corrupted prefix.
+
+2. **Prove local headroom first.** On a tiny train/dev slice, compare at least
+   three local conditions:
+   - blind student: `x` only;
+   - shortcut teacher: `x + c`, allowed to use the answer key directly;
+   - pedagogical teacher: `x + c`, but required to output steps derivable from
+     `x` alone.
+
+3. **Score correctness and learnability separately.** Correctness comes from the
+   verifier, answer key, or final-state validator. Learnability should prefer
+   teacher-forced student logprobs or surprise-gap scores when available. If not,
+   use deterministic checks such as required step labels, no answer-key
+   references, no hidden facts, no unfinished derivation, and answer plus
+   derivation present. Same-model judge scores are advisory only.
+
+4. **Look for the useful quadrant.** Keep trajectories that are both correct and
+   learnable. Reject answer-key shortcuts even when correct. Reject verbose
+   derivations that time out, omit the final answer, or require facts not visible
+   to the deployed student.
+
+5. **Pick the next rung.**
+   - If a template or route makes the local model correct and learnable, feed it
+     to `optimize-workload` or `recursive-language-model`; no weight update yet.
+   - If correct-and-learnable trajectories can be generated reliably for a flat
+     completion or single-output task, prepare a rejection-sampled SFT dataset
+     for local MLX LoRA. This is the default first weight-update rung because it
+     is simple, local, and easy to verify.
+   - If the task is stateful — tools, documents, code, browser, API state,
+     recursive subcalls, or long context — route to
+     [`../rlm-pedagogical-training/SKILL.md`](../rlm-pedagogical-training/SKILL.md)
+     so the environment and trajectories are represented before weight updates.
+   - If a fast reward exists for generated completions, prepare a GRPO smoke with
+     reward functions for correctness and learnability. Prefer single-output
+     rewards first; multi-step rollout rewards are slower and should usually
+     follow a rejection-SFT proof or a simpler learned advisor surface.
+   - If the reward requires long stateful rollouts, route to
+     `rlm-pedagogical-training` first. Route to `prepare-verifier-handoff` only
+     when local RLM/distillation rungs stall.
+
+6. **Record artifacts locally.** Use an ignored directory such as:
+
+   ```text
+   .understudy/pedagogical-learning/<run-id>/
+     contract.json
+     tasks.jsonl
+     rollouts.jsonl
+     scoring.json
+     selected-trajectories.jsonl
+     next-rung.md
+   ```
+
+## Local MLX Rungs
+
+For Apple Silicon, prefer the smallest working local rung: prompt/template proof,
+then rejection-sampled SFT, then GRPO only when reward calls are cheap. See
+[`reference.md`](reference.md) for the local trainer boundary and adapter
+evidence checklist.
+
+## Output Standard
+
+End with:
+
+- the local model and runtime used;
+- task count and split;
+- blind, shortcut, and pedagogical scores for correctness and learnability;
+- whether learnability was measured by logprobs, deterministic proxy, verifier,
+  or judge;
+- selected trajectory count;
+- next rung: template/GEPA, RLM, rejection SFT, GRPO smoke, or verifier handoff;
+- artifact path under `.understudy/`.

--- a/skills/pedagogical-learning/reference.md
+++ b/skills/pedagogical-learning/reference.md
@@ -1,0 +1,53 @@
+# Pedagogical Learning Reference
+
+## Local MLX Rung Order
+
+For Apple Silicon, prefer the smallest working local rung:
+
+- **Prompt/template proof**: serve the local model and generate blind,
+  shortcut, and pedagogical rollouts. This is the fastest proof of headroom.
+- **Rejection-sampled SFT**: keep only correct-and-learnable trajectories and
+  run local `mlx_lm.lora` after approval. This is imitation, not RL. Evaluate
+  the base model and adapter on the same sealed holdout before claiming the
+  weights improved.
+- **GRPO smoke**: use a reward function that returns correctness and
+  learnability scores per completion. Treat third-party GRPO packages as
+  prototype dependencies until pinned, audited, and smoked in an isolated env.
+  Use this when the reward is cheap enough to run many times locally.
+- **First-party rebuild**: if GRPO becomes core, prefer a narrow reward-runner
+  adapter that consumes Understudy artifacts over vendor-locking a broad
+  training CLI.
+
+## Training Boundary
+
+The public repo may guide local training but should not hide training behind an
+implicit command. Before any SFT, DPO, GRPO, adapter fusion, or model export,
+ask for approval and name the base model, trainer, data path, expected runtime,
+and rollback path.
+
+For a real weight-update claim, record:
+
+- base model path and content/hash identifier;
+- trainer and version, for example `mlx_lm.lora`;
+- train/dev/holdout split hashes;
+- adapter path and whether it has been fused;
+- before/after scores on the same heldout rows;
+- regressions, format drift, latency change, and whether inference still uses
+  only deploy-time input `x`.
+
+## Choosing SFT vs GRPO
+
+Use rejection-sampled SFT first when correct trajectories can be selected from
+rollouts or teacher traces. It is the lowest-complexity proof that the local
+weights can absorb the desired behavior.
+
+Use GRPO when a reward is cheap, deterministic enough, and callable many times
+per prompt. Single-output advisor, retrieval, classification, and formatting
+surfaces are better first GRPO candidates than full multi-step tool rollouts.
+
+For a full agentic rollout, prefer one of these before direct GRPO:
+
+- rejection-SFT from passing trajectories;
+- train a smaller advisor or router surface with a cheap reward;
+- reduce the rollout into scored subdecisions;
+- hand off only when local rungs stall and stateful policy learning is required.

--- a/skills/prepare-verifier-handoff/SKILL.md
+++ b/skills/prepare-verifier-handoff/SKILL.md
@@ -34,6 +34,11 @@ Check these before routing here. Most agentic tool-use work stays local:
   [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md).
 - Offline validator plus train/dev prompt or route optimization is enough? Go to
   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
+- The missing piece is training an RLM policy from local privileged trajectories?
+  Go to
+  [`../rlm-pedagogical-training/SKILL.md`](../rlm-pedagogical-training/SKILL.md)
+  first; this handoff is only for work that still needs external or hosted
+  training.
 - **Only** continue here once the confirmed need is RL / stateful policy
   training that the local rungs cannot satisfy.
 

--- a/skills/recursive-language-model/SKILL.md
+++ b/skills/recursive-language-model/SKILL.md
@@ -72,6 +72,15 @@ remaining gap — feeding the route decision
 local rungs genuinely can't close it,
 [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
 
+## Training Path
+
+When the RLM loop itself is the thing that must improve, route to
+[`../rlm-pedagogical-training/SKILL.md`](../rlm-pedagogical-training/SKILL.md).
+That worker turns the decomposition harness into a verifiers-style training
+surface, separates privileged training context from deploy-time input, and
+decides whether the next rung is local pedagogical SFT, on-policy repair,
+pedagogical RL, or a hosted verifier handoff.
+
 ## Safety Gates
 
 - Run only against the simulated environment or live tools the user approved — never
@@ -84,4 +93,5 @@ local rungs genuinely can't close it,
 - [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md)
 - [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
 - [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md)
+- [`../rlm-pedagogical-training/SKILL.md`](../rlm-pedagogical-training/SKILL.md)
 - [`../mlx-arena/SKILL.md`](../mlx-arena/SKILL.md) — vibe-check the hill-climbed local model vs the frontier.

--- a/skills/rlm-pedagogical-training/SKILL.md
+++ b/skills/rlm-pedagogical-training/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: rlm-pedagogical-training
+description: Use when a developer wants to train or evaluate a Recursive Language Model policy with privileged context, verifiers, Prime Intellect prime-rl, or pedagogical RL. Turns a workload into an RLM/verifiers environment, measures on-policy state coverage and surprise concentration, and decides between local LoRA/distillation, true pedagogical RL, or hosted verifier handoff.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# RLM Pedagogical Training
+
+Use this worker when the unit of learning is a **stateful policy**, not a flat
+completion. The target is an RLM-style loop that learns how to inspect context,
+choose tools, retrieve evidence, call sub-models, and stop with a final answer.
+
+This is the bridge between:
+
+- [`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md):
+  build the decomposition harness;
+- [`../pedagogical-learning/SKILL.md`](../pedagogical-learning/SKILL.md):
+  use privileged context to find correct-and-learnable trajectories;
+- [`../local-distillation-lab/SKILL.md`](../local-distillation-lab/SKILL.md):
+  run local weight-update arms on Apple Silicon;
+- [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md):
+  hand off only when local rungs cannot train the needed policy.
+
+## When To Use
+
+Use this skill when all of these are true:
+
+- the workload has multi-step state: tools, documents, simulated state, code,
+  browser, API calls, recursive sub-questions, or long context;
+- there is privileged context `c`: gold paths, answer keys, execution feedback,
+  final-state diffs, oracle tool/evidence labels, or validator traces;
+- the deploy-time model must run from `x` only, without privileged context;
+- a flat prompt, GEPA pass, or template is not enough, or the user explicitly
+  wants RLM, verifiers, Prime Intellect `prime-rl`, or pedagogical RL.
+
+If the workload is still unclear, route to
+[`../understand-workload/SKILL.md`](../understand-workload/SKILL.md). If no
+validator/splits/baseline exist, route to
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md). If there is no
+stateful policy, stay in
+[`../pedagogical-learning/SKILL.md`](../pedagogical-learning/SKILL.md) or
+[`../local-distillation-lab/SKILL.md`](../local-distillation-lab/SKILL.md).
+
+## Safety Gates
+
+Default to local, synthetic, redacted, or benchmark-sandbox data. Do not upload
+prompts, traces, completions, labels, datasets, repo paths, or private notes.
+
+Get explicit approval before model downloads, provider calls, hosted jobs,
+Prime Intellect training, sandbox execution, adapter fusion, or publishing
+artifacts.
+
+Keep external research repos, generated environments, and private experiment
+artifacts under ignored paths such as `.understudy/`. Do not vendor Python RL
+training frameworks into this public repo without a deliberate architecture
+change.
+
+Do not claim a deploy win from privileged prompts, oracle tools, or train rows.
+Only sealed holdout scores where the deployed student sees `x` only can support
+a product claim.
+
+## Core Claim
+
+Do not claim "pedagogical RL worked" unless a policy was trained with a reward
+that uses both task success and learnability. Local LoRA on teacher traces is
+useful evidence, but it is **off-policy pedagogical SFT**, not true RL.
+
+The stronger claim requires all three:
+
+1. RLM trajectories from a stateful environment.
+2. A reward `R(x,c,tau)` for task success.
+3. A learnability or concentration term such as `G_spike(tau | x)` measured
+   under the current student.
+
+## Flow
+
+1. **Name the RLM contract.** Write:
+   - `x`: deploy-time task input;
+   - `c`: privileged context available only for training/scoring;
+   - `state`: what the RLM can inspect or mutate;
+   - `actions`: inspect, retrieve, tool call, sub-LM call, summarize, answer;
+   - `tau`: the recorded action trajectory;
+   - `R`: deterministic verifier or reward;
+   - `G`: learnability score, preferably surprise-gap / spike concentration.
+
+2. **Choose the smallest learnable subpolicy.** For hard workloads, do not start
+   with final work-product generation. Prefer a subpolicy that has labels and a
+   deterministic scorer: tool selection, evidence retrieval, checklist
+   construction, route choice, state repair, or citation selection.
+
+3. **Build a local `verifiers` shape.** An RLM training row should map to:
+   - prompt/root task in the dataset row;
+   - `info.context` containing documents, state, tool catalog, or file payload;
+   - a correctness function that scores the RLM final answer or final state;
+   - trajectory metrics: iterations, REPL calls, sub-LM calls, final-answer
+     presence, reward, and state deltas.
+
+4. **Run baselines before training.**
+   - Flat local model on the final output.
+   - RLM local model with no privileged context.
+   - Privileged teacher or same-family teacher, labeled as privileged.
+   - Optional frontier teacher only after approval.
+
+5. **Measure concentration.** For teacher or repaired trajectories, compute
+   student forced logprobs and surprise gaps. Report mean `d_t`, max `d_t`, and
+   spike penalty. This answers whether the teacher is giving learnable moves or
+   unsupported jumps.
+
+6. **Pick the training arm honestly.**
+   - **Off-policy pedagogical SFT**: train on correct, low-spike teacher traces.
+     This is the first local rung.
+   - **On-policy repair / DAGGER-style**: sample student RLM trajectories, use
+     privileged context to repair or label them, then train on those states.
+   - **Pedagogical RL**: train a privileged self-teacher with reward
+     `R(x,c,tau) * G_spike(tau | x)`, then assimilate into the student.
+   - **Hosted verifier handoff**: only after local proof shows the policy needs
+     stateful RL beyond the local machine.
+
+7. **Seal holdout before promotion.** The deploy-time candidate must run from
+   `x` only. Privileged context may score or train; it must not be passed at
+   inference.
+
+## Reconcile Parallel Research
+
+When another agent is already running local Gemma/MLX kernels, do not duplicate
+that work. Use this split:
+
+- This skill owns the **environment contract**, RLM trajectory schema,
+  verifier/reward shape, contamination boundary, and train/dev/holdout decision.
+- `local-distillation-lab` owns the **Apple Silicon weight update**: mlx-vlm
+  loader, forced-likelihood kernel, weighted LoRA, B/S/O/P arms, and learning
+  curves.
+- `prepare-verifier-handoff` owns the **external training packet** only after
+  local rungs are insufficient and upload/budget boundaries are approved.
+
+If parallel results conflict, trust sealed-holdout metrics over smoke results,
+and trust deploy-time `x`-only scores over privileged or oracle-tool settings.
+
+## Artifact Contract
+
+Write local artifacts under:
+
+```text
+.understudy/rlm-pedagogical/<run-id>/
+  contract.json
+  dataset-card.json
+  train.jsonl
+  dev.jsonl
+  holdout.jsonl
+  baseline.json
+  trajectories.jsonl
+  concentration.json
+  verifier-env.md
+  training-plan.md
+  claim.json
+```
+
+`claim.json` must say whether the result is:
+
+- `rlm-baseline`;
+- `off-policy-pedagogical-sft`;
+- `on-policy-repair`;
+- `pedagogical-rl-smoke`;
+- `hosted-verifier-handoff`;
+- `blocked`.
+
+## Output Standard
+
+End with:
+
+- the chosen subpolicy and why it is learnable;
+- dataset size and split hashes;
+- local model/runtime;
+- baseline table;
+- concentration metrics;
+- training arm selected and why;
+- whether the result is a local proof, a negative result, or a verifier handoff;
+- artifact path under `.understudy/`.
+
+See [`reference.md`](reference.md) for setup commands and a Prime
+Intellect/RLM bridge checklist.

--- a/skills/rlm-pedagogical-training/reference.md
+++ b/skills/rlm-pedagogical-training/reference.md
@@ -1,0 +1,104 @@
+# RLM Pedagogical Training Reference
+
+This reference keeps setup and evaluation mechanics out of the main skill.
+
+## Local Research Setup
+
+Keep external research repos and generated artifacts out of the public package:
+
+```sh
+mkdir -p .understudy/research
+git clone https://github.com/alexzhang13/rlm.git .understudy/research/rlm
+```
+
+The RLM repo's `training/` directory exposes `rlm.RLM` as a `verifiers`
+environment and is designed to plug into Prime Intellect `prime-rl`. Treat that
+repo as a research dependency until a local smoke proves the workflow belongs in
+Understudy docs or cookbook examples.
+
+Do not vendor RLM, Prime Intellect, or generated Python environments into this
+repo. Public Understudy skills can point to setup commands and artifact shapes;
+product code remains TypeScript-backed unless there is a deliberate architecture
+change.
+
+## Minimal Verifiers Shape
+
+An RLM/verifiers environment needs:
+
+- dataset rows with `prompt` or `root_prompt`;
+- `info.context` containing the inspected corpus, tool catalog, state, or files;
+- a correctness function over final answer, selected tools, retrieved evidence,
+  or final state;
+- metrics for iterations, REPL calls, sub-LM calls, and final-answer presence.
+
+Good first tasks are small and verifiable:
+
+- select the minimal tool set from a fixed catalog;
+- retrieve the required evidence chunks;
+- build a checklist from a fixed policy corpus;
+- choose the next API operation in a simulated workflow;
+- repair a final state to match a deterministic diff.
+
+Avoid starting with broad final-answer generation when the evidence corpus,
+rubric, or judge is incomplete.
+
+## Pedagogical Reward Checklist
+
+For a trajectory `tau`:
+
+1. Score task success with `R(x,c,tau)`.
+2. Teacher-force the same trajectory under the deploy student using `x` only.
+3. Record token logprobs, mean surprise gap, max surprise gap, and spike penalty.
+4. Prefer product rewards when partial credit exists:
+
+   ```text
+   r_ped = partial_credit(x,c,tau) * G_spike(tau | x)
+   ```
+
+5. Use additive reward only as an anti-stall scaffold for binary sparse rewards,
+   and label it as such.
+
+## Baseline Matrix
+
+Run this before any training claim:
+
+| condition | sees privileged context | stateful RLM | trains weights | purpose |
+|---|---:|---:|---:|---|
+| flat local | no | no | no | local floor |
+| RLM local | no | yes | no | harness/decomposition value |
+| privileged teacher | yes | yes | no | upper bound / data source |
+| off-policy pedagogical SFT | train only | yes | yes | first local weight rung |
+| on-policy repair | train only | yes | yes | state-coverage rung |
+| pedagogical RL | train/reward only | yes | yes | true research target |
+
+Only the `x`-only deploy conditions are eligible for product claims.
+
+## Reconciliation Rules
+
+Use these rules when multiple agents are running related experiments:
+
+- RLM skill owns task/environment schema and verifier semantics.
+- Local distillation skill owns mlx-vlm loading, local LoRA, and learning curves.
+- Pedagogical-learning skill owns correct-and-learnable trajectory selection for
+  flat or single-output tasks.
+- Verifier handoff skill owns partner packets and approval gates.
+
+If an external bench script proves a kernel, copy only the general method into a
+skill or cookbook after it passes a small smoke. Do not copy private paths,
+private notes, raw prompts, or local-only failure logs into public docs.
+
+## Negative Result Template
+
+Negative results are valuable and should be recorded:
+
+```text
+Result: negative
+Task: <subpolicy or full task>
+Reason: <missing data / no verifier / local model capability / high spike / no state coverage>
+Evidence: <baseline table or artifact path>
+Next rung: <smaller subpolicy / RLM / same-family teacher / hosted handoff>
+```
+
+For hard legal or long-document work, a negative full-task result usually means
+the next target is an RLM subpolicy such as evidence retrieval or checklist
+construction, not immediate hosted RL.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -149,6 +149,17 @@ Identify the developer's current stage and load exactly one:
   wants to run the same rows across several local, gateway, or frontier models to
   compare quality, latency, cost, and reliability →
   [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md).
+- **Pedagogical learning / privileged-context self-teaching** — the developer has
+  answer keys, execution feedback, verifier traces, oracle tool labels, or
+  canonical solutions and wants the local model to learn from trajectories that
+  are both correct and learnable before SFT, GRPO, or hosted RL →
+  [`../pedagogical-learning/SKILL.md`](../pedagogical-learning/SKILL.md).
+- **RLM pedagogical training / verifiers / Prime RL** — the developer wants to
+  train or evaluate a Recursive Language Model policy over stateful trajectories,
+  use privileged context as training/scoring signal, measure on-policy state
+  coverage or surprise concentration, or prepare a Prime Intellect `verifiers` /
+  `prime-rl` path →
+  [`../rlm-pedagogical-training/SKILL.md`](../rlm-pedagogical-training/SKILL.md).
 - **Local understudy specialization loop** — the developer wants the smallest
   task-reasonable local model opened in Pi and optionally compared against a
   frontier model, then wants the observed gap to drive workload understanding,
@@ -165,14 +176,16 @@ Identify the developer's current stage and load exactly one:
   web search); evaluate, A/B-compare models, or optimize its prompt/route →
   [`../optimize-agentic-search/SKILL.md`](../optimize-agentic-search/SKILL.md)
   (verifiers env, model A/B through the gateway, prompt-GEPA for the cheap model).
-- **RL / stateful-policy training handoff** — local rungs are insufficient and
-  the agent must *learn* multi-step behavior →
+- **RL / stateful-policy training handoff** — local RLM/distillation rungs are
+  insufficient and the agent must *learn* multi-step behavior in external or
+  hosted training →
   [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
 
 Multi-turn or tool-use alone is NOT a handoff: agentic evaluation, API-workflow
 evaluation, A/B, and prompt/route optimization stay local in
-`optimize-agentic-search` or `optimize-api-workflow`. Only RL/policy *training*
-routes to `prepare-verifier-handoff`. When in doubt, route to
+`optimize-agentic-search` or `optimize-api-workflow`. RLM policy training routes
+to `rlm-pedagogical-training` first; only external/hosted RL handoffs route to
+`prepare-verifier-handoff`. When in doubt, route to
 `capture-evidence` — optimizing without a current harness/metric/split/baseline
 creates false progress.
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -260,6 +260,14 @@ describe("understudy CLI", () => {
     assert.match(result.stdout, /use-understudy-gateway/);
   });
 
+  it("lists the pedagogical and local training skills", () => {
+    const result = run(["skills", "--list"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /pedagogical-learning/);
+    assert.match(result.stdout, /rlm-pedagogical-training/);
+    assert.match(result.stdout, /local-distillation-lab/);
+  });
+
   it("searches skills and cookbooks by query", () => {
     const result = run(["skills", "--search", "gateway"]);
     assert.equal(result.status, 0, result.stderr);
@@ -267,10 +275,56 @@ describe("understudy CLI", () => {
     assert.match(result.stdout, /next: understudy skills --inspect use-understudy-gateway/);
   });
 
+  it("searches pedagogical and verifier training surfaces", () => {
+    const pedagogical = run(["skills", "--search", "pedagogical"]);
+    assert.equal(pedagogical.status, 0, pedagogical.stderr);
+    assert.match(pedagogical.stdout, /pedagogical-learning \(skill\)/);
+    assert.match(pedagogical.stdout, /rlm-pedagogical-training \(skill\)/);
+    assert.match(pedagogical.stdout, /next: understudy skills --inspect pedagogical-learning/);
+
+    const verifiers = run(["skills", "--search", "verifiers"]);
+    assert.equal(verifiers.status, 0, verifiers.stderr);
+    assert.match(verifiers.stdout, /rlm-pedagogical-training \(skill\)/);
+    assert.match(verifiers.stdout, /prepare-verifier-handoff \(skill\)/);
+  });
+
   it("inspects one skill", () => {
     const result = run(["skills", "--inspect", "understudy"]);
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /path: skills\/understudy\/SKILL\.md/);
+  });
+
+  it("inspects pedagogical skill descriptions", () => {
+    const pedagogical = run(["skills", "--inspect", "pedagogical-learning"]);
+    assert.equal(pedagogical.status, 0, pedagogical.stderr);
+    assert.match(pedagogical.stdout, /correct and learnable/);
+
+    const rlm = run(["skills", "--inspect", "rlm-pedagogical-training"]);
+    assert.equal(rlm.status, 0, rlm.stderr);
+    assert.match(rlm.stdout, /Recursive Language Model policy/);
+  });
+
+  it("routes local pedagogical and RLM rungs before hosted verifier handoff", () => {
+    const understudySkill = readFileSync("skills/understudy/SKILL.md", "utf8");
+    assert.ok(
+      understudySkill.indexOf("../pedagogical-learning/SKILL.md") <
+        understudySkill.indexOf("../prepare-verifier-handoff/SKILL.md"),
+    );
+    assert.ok(
+      understudySkill.indexOf("../rlm-pedagogical-training/SKILL.md") <
+        understudySkill.indexOf("../prepare-verifier-handoff/SKILL.md"),
+    );
+    assert.match(
+      understudySkill,
+      /RLM policy training routes\s+to `rlm-pedagogical-training` first; only external\/hosted RL handoffs route to\s+`prepare-verifier-handoff`/,
+    );
+
+    const recursiveSkill = readFileSync("skills/recursive-language-model/SKILL.md", "utf8");
+    assert.match(recursiveSkill, /\.\.\/rlm-pedagogical-training\/SKILL\.md/);
+
+    const handoffSkill = readFileSync("skills/prepare-verifier-handoff/SKILL.md", "utf8");
+    assert.match(handoffSkill, /rlm-pedagogical-training\/SKILL\.md/);
+    assert.match(handoffSkill, /only for work that still needs external or hosted\s+training/);
   });
 
   it("runs doctor against the Node package shape", () => {


### PR DESCRIPTION
## Summary

This recovers and bundles a crashed-run skill expansion on top of current `origin/main` after the recent telemetry and installer merges.

- adds `pedagogical-learning` for local privileged-context trajectory selection before SFT, GRPO, or hosted RL
- adds `rlm-pedagogical-training` for stateful RLM/verifiers training surfaces, on-policy coverage, surprise concentration, and handoff decisions
- updates the `understudy`, `recursive-language-model`, `prepare-verifier-handoff`, and skill index routing so local RLM/distillation rungs come before external hosted RL
- cleans the local-distillation examples so public smoke code no longer depends on private local paths or private `understudy_agent` imports
- adds regression coverage for listing/searching/inspecting the new skills, local-before-hosted routing, and package inclusion
- refreshes install/readme/current-functionality docs that still described the old skill count/tree

## Review notes

- Rebased the recovered dirty worktree onto `origin/main` at `2c80a64`, which includes PR #52 (`cli-posthog-telemetry`) and PR #53 (`installer-noninteractive`). The recovered bundle applied without conflicts.
- Fixed one stale docstring in `forced_likelihood.py` that still referred to first-party private reward code after the example was made standalone.
- Verified a fresh Claude Code plugin install in an isolated temp `HOME`; the installed plugin cache contained `pedagogical-learning`, `rlm-pedagogical-training`, and `local-distillation-lab` skill files.

## Validation

- `npm run check` (62 tests, build, typecheck, skills validation, cookbook validation, package smoke)
- `python3 -m py_compile skills/local-distillation-lab/examples/bench8h.py skills/local-distillation-lab/examples/forced_likelihood.py skills/local-distillation-lab/examples/kernel2_mlxvlm.py`
- isolated Claude plugin install smoke:
  - `HOME=$(mktemp -d ...) claude plugin marketplace add "$REPO"`
  - `HOME=$(mktemp -d ...) claude plugin install understudy@understudy-skills`
  - verified installed cache contains the new skill files
- `git diff --check`
