### PR TITLE
skills: fix skills:validate warnings on the RL-handoff bundle

### DIFF
--- a/skills/author-rl-env/SKILL.md
+++ b/skills/author-rl-env/SKILL.md
@@ -153,11 +153,10 @@ holdout gate. Each is a gate, not a suggestion.
 
 ## Running example
 
-AutomationBench `simple`/`api` endpoint-discovery, local Gemma-4-E2B served via
-the MLX router at `:8081`, frozen seed-7 splits (train 18 / dev 6 / holdout 6).
-The sim backend (endpoint catalog + state + final-state validator) is re-exposed
-behind `reset`/`step`; reward = the existing fractional final-state score, with
-optional "correct app before mutation" shaping under the reward-hacking guard.
+AutomationBench `simple`/`api` endpoint-discovery — the sim backend is re-exposed
+behind `reset`/`step`, reward = the fractional final-state score. The concrete
+wiring (which sim primitives to call), the verified determinism caveat, and the
+replay-conformance recipe are in [`reference.md`](reference.md).
 
 ## Output Standard
 
@@ -177,6 +176,7 @@ End with:
 
 ## References
 
+- [`reference.md`](reference.md) — obs/action contract recovery, the worked AutomationBench wiring, the determinism caveat, and the replay-conformance recipe.
 - [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md) — builds the batch-scored sim env this skill inverts.
 - [`../curate-trajectories/SKILL.md`](../curate-trajectories/SKILL.md) — supplies the decontaminated, holdout-free RL train pool.
 - [`../optimize-api-workflow/SKILL.md`](../optimize-api-workflow/SKILL.md) — the API-workflow final-state validator and metric axes that become the reward.

--- a/skills/author-rl-env/reference.md
+++ b/skills/author-rl-env/reference.md
@@ -1,0 +1,61 @@
+# author-rl-env — reference
+
+Supplementary detail for [`SKILL.md`](SKILL.md): how the obs/action contract is
+recovered, a worked wiring against a real sim, the determinism caveat, and the
+replay-conformance recipe. Load this only when actually building the wrapper.
+
+## Recovering the obs/action contract from recorded trajectories
+
+The batch sim env's per-task export already encodes everything the step API
+needs, so the contract is *recovered*, not invented:
+
+- **obs** = the `messages` list (system + user + prior tool results) plus the
+  tool catalog.
+- **action** = one assistant message carrying `tool_calls`.
+- **tool result** = a message appended after the action is applied.
+- **terminal reward** = the existing fractional `score`.
+
+Watch the on-disk encoding: real exports store each `tool_calls` entry as a
+**JSON-encoded string**, and inside it `arguments` is itself a JSON string —
+double-decode (`json.loads` twice) when reconstructing actions. The stable task
+id lives in the `name` field; `id` is only a 1-based enumeration index.
+
+## Worked wiring — AutomationBench `simple`/`api`
+
+Verified integration map (reuse the sim's own primitives; do not rebuild):
+
+- The episode loop is **not** in the workload repo — it lives in the vendored
+  `verifiers` library (`MultiTurnEnv.rollout`). Factor *that* out; the trainer
+  owns the policy.
+- `WorldState(**info["initial_state"])` — the per-task sim state. It is
+  instantiated per task with no module-level globals, so parallel rollouts are
+  already isolation-safe. The `initial_state` IS the seed (there is no RNG seed).
+- `api_fetch(world=..., method, url, params, body)` — the state mutator (one
+  step). `api_search(query, top_k)` is read-only discovery.
+- `partial_credit(state)` — the reward (fractional final-state score), with the
+  anti-free-credit logic already built in.
+- Task definition: dataset row keyed by `task`; its `info` is a JSON string with
+  `initial_state` / `assertions`. Set `AUTOMATIONBENCH_STRICT_ASSERTIONS=0` so a
+  buggy assertion yields reward 0 instead of crashing the rollout.
+
+## Determinism caveat (verified, not hypothetical)
+
+`WorldState()` stamps a wall-clock `gmail.internal_date` at construction time. Two
+resets therefore differ on a field no task touches and no assertion reads. Across
+all 200 recorded trajectories this wrapper reproduced the **score 200/200**, but
+full `end_state` equality was **0/200** — entirely from that timestamp, i.e.
+reward fidelity, not state divergence. Pin such constructor defaults to the
+seed/initial_state, or project them out before comparing state.
+
+## Replay-conformance recipe
+
+1. `reset` a fresh sim from `initial_state`.
+2. Recover the action sequence from `messages[].tool_calls` (double-decode).
+3. Apply each action through `step()` (api_fetch mutates; api_search is inert).
+4. **Hard-assert** reproduced `score` == recorded `score` — this is the
+   conformance signal (it is exactly what the trainer optimizes).
+5. **Soft-check** `end_state` equality *modulo* the volatile default fields from
+   step 4 of the SKILL Flow; raw full-dump equality will spuriously fail.
+
+A score that fails to round-trip means the inversion changed semantics — fix the
+wrapper, not the fixture.

--- a/skills/author-rl-env/reference.md
+++ b/skills/author-rl-env/reference.md
@@ -47,6 +47,15 @@ full `end_state` equality was **0/200** — entirely from that timestamp, i.e.
 reward fidelity, not state divergence. Pin such constructor defaults to the
 seed/initial_state, or project them out before comparing state.
 
+## Running-example specifics
+
+The grounding workload: AutomationBench `simple`/`api` endpoint-discovery, with
+local **Gemma-4-E2B** served via the MLX router at `:8081`, and frozen **seed-7
+splits (train 18 / dev 6 / holdout 6)**. The sim backend (endpoint catalog +
+state + final-state validator) is re-exposed behind `reset`/`step`; reward = the
+fractional final-state score, with optional **"correct app before mutation"
+shaping** under the reward-hacking guard (SKILL Flow step 5).
+
 ## Replay-conformance recipe
 
 1. `reset` a fresh sim from `initial_state`.
@@ -55,7 +64,8 @@ seed/initial_state, or project them out before comparing state.
 4. **Hard-assert** reproduced `score` == recorded `score` — this is the
    conformance signal (it is exactly what the trainer optimizes).
 5. **Soft-check** `end_state` equality *modulo* the volatile default fields from
-   step 4 of the SKILL Flow; raw full-dump equality will spuriously fail.
+   step 3 of the SKILL Flow ("Make reset(task, seed) deterministic"); raw
+   full-dump equality will spuriously fail.
 
 A score that fails to round-trip means the inversion changed semantics — fix the
 wrapper, not the fixture.

--- a/skills/compare-trajectories/SKILL.md
+++ b/skills/compare-trajectories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compare-trajectories
-description: Use when a developer needs to know HOW two model runs differ behaviorally on the same tasks — not just THAT one scores higher. Per-task, per-step trajectory diffing between two runs that classifies the capability gap as persistence/recovery, knowledge, or format/parsing, and counts warm-start examples. "why does the bigger model pass these", "is this gap RL-shaped", "diff these two trajectory runs", "where do the trajectories diverge", "what would distillation buy me". Complements compare-model-sweep (scalars) with behavior.
+description: Use when you need to know HOW two model runs differ behaviorally on the same tasks, not just THAT one scores higher — per-task trajectory diffing that classifies the gap as persistence/recovery, knowledge, or format/parsing. "why does the bigger model pass these", "is this gap RL-shaped", "diff these two trajectory runs", "where do the trajectories diverge", "what would distillation buy me". The behavioral complement to compare-model-sweep.
 metadata:
   understudy:
     mode: interactive

--- a/skills/curate-trajectories/SKILL.md
+++ b/skills/curate-trajectories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: curate-trajectories
-description: Use to turn loose per-task trajectory JSONs (Lilac export or a local rollout corpus) into a queryable, provenance-tracked, contamination-safe dataset — "curate my trajectories", "which rollouts are train-safe", "exclude the holdout rows before RL", "is this distill pool contaminated", "make a hash-stamped selection", "stop hand-filtering trajectories in bash". Indexes runs with provenance, tags each row with its frozen split from capture-evidence, and hard-blocks any selection that leaks dev/holdout into a train/RL/distill pool.
+description: Use to turn loose per-task trajectory JSONs (a Lilac export or local rollout corpus) into a queryable, provenance-tracked, contamination-safe dataset that hard-blocks any selection leaking frozen dev/holdout into a train/RL/distill pool. "curate my trajectories", "which rollouts are train-safe", "exclude the holdout rows before RL", "is this distill pool contaminated", "make a hash-stamped selection", "stop hand-filtering trajectories in bash".
 metadata:
   understudy:
     mode: interactive

--- a/skills/package-verifier-env/SKILL.md
+++ b/skills/package-verifier-env/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-verifier-env
-description: Use after prepare-verifier-handoff confirms a stateful-RL need and author-rl-env has produced a conformant reset/step/score env, to package that env locally into a Prime Intellect Verifiers-compatible module, run a trainer-free conformance check, and build the frozen-holdout return-eval that makes a partner-trained policy comparable to the pre-RL baseline. "Package my env for verifiers", "make this RL-trainable for the partner", "prep the return-eval round-trip", "is my verifier env conformant". Packages locally only — does not run hosted training or upload.
+description: Use after prepare-verifier-handoff confirms a stateful-RL need and author-rl-env produced a conformant reset/step env, to package that env locally into a Prime Intellect Verifiers-compatible module, run a trainer-free conformance check, and build the frozen-holdout return-eval. "package my env for verifiers", "make this RL-trainable for the partner", "prep the return-eval round-trip", "is my verifier env conformant". Packages locally only — never trains or uploads.
 metadata:
   understudy:
     mode: interactive


### PR DESCRIPTION
Follow-up to #54. I'd validated #54 with a hand-rolled lint instead of the repo's `scripts/validate-public-skills.mjs`, which flags two rules I missed:

- **Descriptions must be activation-only (<512 chars).** `compare-trajectories` (530), `curate-trajectories` (534), and `package-verifier-env` (564) were over. Trimmed to 444 / 448 / 469 — kept the trigger phrases, cut the explanatory tails.
- **Skills >150 lines need a `reference.md`.** `author-rl-env` is 187 lines. Added `reference.md` (the idiomatic progressive-disclosure fix, matching the pedagogical skills) holding the deeper detail: obs/action contract recovery, the worked AutomationBench wiring (`WorldState`/`api_fetch`/`partial_credit`), the verified determinism caveat (`gmail.internal_date` → score 200/200 but full `end_state` 0/200), and the replay-conformance recipe. Slimmed the SKILL's running example to point at it.

`node scripts/validate-public-skills.mjs --repo` now exits clean with zero warnings for the four RL skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->