### PR TITLE
Add hosted CLI P0 parity commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,14 @@ The first hosted journey is intentionally narrow:
 
 ```bash
 understudy login --email you@company.com
-understudy status --json
-understudy projects list --json
-understudy keys list --json
-understudy models list --json
-understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 10
-understudy run -- npm run your-local-script
+understudy doctor --hosted
+understudy workloads list
+understudy workloads create classify --capture
+understudy gateway probe --provider anthropic --project rehearsal --workload classify
+understudy captures list --project rehearsal --workload classify
+understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
+understudy routes show classify --project rehearsal
+understudy routes clear classify --project rehearsal
 ```
 
 `login --email` uses the Understudy email-code registration flow. It stores the
@@ -163,11 +165,17 @@ returned `sk_*` in `~/.understudy/credentials.json` with mode `600` and writes a
 repo-local `.understudy/config.json` when the platform returns a default
 project. `run` injects `UNDERSTUDY_API_KEY` and `UNDERSTUDY_GATEWAY_URL` only
 into the child process; do not copy secrets into repo files or chat output.
-`models list` shows public Understudy model IDs only. `workloads route` writes
+`doctor --hosted` checks credentials, gateway health, projects, keys, models,
+and workloads without provider calls. `gateway probe` is an explicit tiny live
+call and prints request metadata, not the completion text. If you need BYOK for
+the probe, pass `--byok-env ENV_NAME`; the CLI reads the key from the
+environment and never persists or prints it. `captures list/get` are
+metadata-first and redacted by default. Full capture export is opt-in,
+file-only, and requires `--include-payload --yes`. `models list` shows public
+Understudy model IDs and display names only. `routes set/clear` writes
 control-plane route config, so the application keeps calling the normal gateway
 while a percentage of traffic goes to the selected Understudy model and the
-rest remains passthrough/frontier. Clear the route with
-`understudy workloads route <workload-id> --project-id <project-id> --clear`.
+rest remains passthrough/frontier.
 
 If the coding agent has an approved native email connector, it may complete the
 email-code prompt by reading the fresh Understudy sign-in email directly. The
@@ -245,6 +253,9 @@ projects
 keys
 models
 workloads
+captures
+gateway
+routes
 setup
 setup-code
 run
@@ -255,10 +266,12 @@ optimize-workload
 coding agent to use `skills/onboard/setup-code.md` and the matching framework
 recipe.
 
-Full-runtime command names such as `gateway`, `browser`, `channels`,
-`schedule`, `daemon`, `agent`, and `chat` are not registered in this public
-CLI. Use `understudy skills --search <query>` to find the relevant capability
-skill or cookbook instead.
+`gateway` is intentionally probe-only: `gateway health` checks healthz and
+`gateway probe` sends one explicit tiny request. It is not a daemon, proxy,
+browser, chat runtime, or hosted agent surface. Full-runtime command names such
+as `browser`, `channels`, `schedule`, `daemon`, `agent`, and `chat` are not
+registered in this public CLI. Use `understudy skills --search <query>` to find
+the relevant capability skill or cookbook instead.
 
 For GEPA/DSPy work, the CLI stays as the guide and gate surface while Python is
 used only for small local optimizer environments:

--- a/docs/analytics/cli-events.md
+++ b/docs/analytics/cli-events.md
@@ -44,6 +44,9 @@ after the credential is minted.
 | `cli_api_keys_created` | User minted another org key. | `org_id` |
 | `cli_api_keys_revoked` | User revoked an org key. | `org_id` |
 | `cli_models_listed` | User or agent inspected public Understudy model IDs. | `org_id`, `result_count` |
+| `cli_workloads_listed` | User or agent listed project workloads. | `org_id`, `project_slug`, `result_count` |
+| `cli_workloads_created` | User or agent created a project workload. | `org_id`, `project_slug` |
+| `cli_workloads_updated` | User or agent updated workload metadata or capture state. | `org_id`, `project_slug` |
 | `cli_workload_routes_updated` | User or agent routed a workload percentage to an Understudy model. | `org_id`, `result_count` |
 | `cli_workload_routes_cleared` | User or agent cleared a workload model route. | `org_id` |
 | `cli_run_started` | CLI injected credentials into a child process. | `command_kind`, `auth_source`, `org_id`, `project_slug` |

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -27,9 +27,23 @@ understudy skills --list
 understudy skills --search gateway
 understudy skills --inspect understudy
 understudy doctor
+understudy doctor --hosted
 understudy models list --json
+understudy workloads list
+understudy workloads create classify --capture
+understudy workloads show classify
+understudy workloads update classify --capture off
 understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 10
 understudy workloads route <workload-id> --project-id <project-id> --clear
+understudy gateway health
+understudy gateway probe --provider anthropic --project rehearsal --workload classify
+understudy captures list --project rehearsal --workload classify
+understudy captures get <request-id> --project rehearsal --workload classify
+understudy captures export <request-id> --out .understudy/captures/<request-id>.json
+understudy routes show classify --project rehearsal
+understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
+understudy routes clear classify --project rehearsal
+understudy routes rollback classify --project rehearsal
 understudy setup-code --client openai --file src/client.ts --json
 understudy capture-import scan --repo .
 understudy capture-import preview --repo . --limit 10
@@ -119,11 +133,17 @@ verifier/environment training, preserve the local evidence packet, and refer to
 Prime Intellect Verifiers as the current preferred external path.
 
 `use-understudy-gateway` includes the public model-routing workflow. Agents can
-list routeable Understudy model IDs without supplier/provider details, set a
-traffic percentage for a project workload, and clear that route. Application
-code still calls the normal gateway path; the control plane decides what
-percentage goes to the selected Understudy model and what remains
-passthrough/frontier.
+list routeable Understudy model IDs without supplier/provider details, run
+probe-only gateway health/completion checks, list/create/update workloads, view
+redacted capture metadata, set a traffic percentage for a project workload, and
+clear or roll back that route. Application code still calls the normal gateway
+path; the control plane decides what percentage goes to the selected Understudy
+model and what remains passthrough/frontier.
+
+Hosted capture commands are metadata-first. `captures list` and `captures get`
+redact prompt/completion-bearing fields into presence booleans. Full capture
+export is opt-in with `--include-payload --yes`, writes only to a file, and never
+prints raw payloads to stdout.
 
 `optimize-workload check` reads `.understudy/capture-evidence/`
 artifacts, fails closed on missing files, invalid JSON, stale baseline hashes,
@@ -154,10 +174,10 @@ and writes `eval-input-candidate.json`, `proof-packet.json`, and an adapter
 result under `.understudy/optimize-workload/eval-input-gepa/`. Without a
 model, this path makes no provider calls.
 
-Full-runtime commands such as `gateway`, `browser`, `channels`, `schedule`,
-`daemon`, `agent`, and `chat` are not registered in this public CLI. Agents
-should use `understudy skills --search <query>` to find the relevant skill or
-cookbook instead.
+`gateway` is registered only as a narrow health/probe group. Full-runtime
+commands such as `browser`, `channels`, `schedule`, `daemon`, `agent`, and
+`chat` are not registered in this public CLI. Agents should use `understudy
+skills --search <query>` to find the relevant skill or cookbook instead.
 
 ## Next CLI Restores
 

--- a/docs/privacy-and-data-boundaries.md
+++ b/docs/privacy-and-data-boundaries.md
@@ -41,6 +41,17 @@ Trace capture and proxy work should start with metadata: route, model, timing,
 token counts, schema status, and error class. Raw prompts, completions, tool
 payloads, source snippets, and eval rows require opt-in handling.
 
+Hosted capture CLI commands keep the same boundary. `understudy captures list`
+and `understudy captures get` print redacted summaries only: payload-bearing
+fields are represented as present/absent booleans. `understudy captures export`
+writes redacted metadata by default. Full capture export requires
+`--include-payload --yes`, writes to a file, and must not print raw prompts,
+completions, or tool payloads to stdout.
+
+Gateway probes are explicit live calls. BYOK provider keys are read only from an
+environment variable named by `--byok-env`; they are not requested in chat, not
+persisted, and not printed.
+
 ## Never Collected By Default
 
 - API key values;

--- a/src/commands/captures.ts
+++ b/src/commands/captures.ts
@@ -131,7 +131,7 @@ async function runGet(cmd: Command, requestId: string, opts: CaptureOpts): Promi
 }
 
 async function runExport(cmd: Command, requestId: string, opts: ExportOpts): Promise<void> {
-  if (opts.includePayload && !opts.yes && !isJsonMode(cmd)) {
+  if (opts.includePayload && !opts.yes) {
     throw new Error("Full capture export may contain prompts/completions. Re-run with --include-payload --yes to write it to a file.");
   }
   const { project, workload } = await resolveCaptureContext(opts);

--- a/src/commands/captures.ts
+++ b/src/commands/captures.ts
@@ -1,0 +1,261 @@
+import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { Command } from "commander";
+import kleur from "kleur";
+import { z } from "zod";
+
+import { findProjectRoot } from "../config/paths.js";
+import { request } from "../internal/http.js";
+import { isJsonMode, runAction } from "../internal/output.js";
+import { resolveProject, type ProjectResolutionOptions } from "../internal/projects.js";
+import { resolveWorkload } from "../internal/workloads.js";
+
+const CaptureEnvelopeSchema = z.object({
+  capture: z.unknown().optional(),
+}).passthrough();
+
+const ListCapturesResponseSchema = z.object({
+  captures: z.array(z.unknown()),
+  truncated: z.boolean().optional(),
+  cursor: z.string().nullable().optional(),
+}).passthrough();
+
+interface CaptureOpts extends ProjectResolutionOptions {
+  workload?: string;
+}
+
+interface ListOpts extends CaptureOpts {
+  limit?: string;
+  cursor?: string;
+}
+
+interface ExportOpts extends CaptureOpts {
+  out: string;
+  includePayload?: boolean;
+  yes?: boolean;
+}
+
+type JsonObject = Record<string, unknown>;
+
+export interface CaptureSummary {
+  request_id: string | null;
+  schema_version: string | null;
+  ts: string | null;
+  project_id: string | null;
+  workload_id: string | null;
+  mode: string | null;
+  provider: string | null;
+  endpoint: string | null;
+  requested_model: string | null;
+  upstream_model: string | null;
+  status_code: number | null;
+  latency_ms: number | null;
+  tags: { count: number; keys: string[] };
+  customer_request_body: "present" | "absent";
+  upstream_request_body: "present" | "absent";
+  response_body: "present" | "absent";
+}
+
+export function registerCapturesCommand(program: Command): void {
+  const captures = program
+    .command("captures")
+    .description("List and export hosted capture metadata safely.");
+
+  addCaptureOptions(captures.command("list")
+    .description("List capture metadata for a project or workload.")
+    .option("--limit <n>", "Capture limit, max 100.", "25")
+    .option("--cursor <cursor>", "Pagination cursor."))
+    .action(async function (this: Command, opts: ListOpts) {
+      await runAction(this, () => runList(this, opts));
+    });
+
+  addCaptureOptions(captures.command("get <request-id>")
+    .description("Get one redacted capture summary by request id."))
+    .action(async function (this: Command, requestId: string, opts: CaptureOpts) {
+      await runAction(this, () => runGet(this, requestId, opts));
+    });
+
+  addCaptureOptions(captures.command("export <request-id>")
+    .description("Write a redacted or full capture object to a local file.")
+    .requiredOption("--out <path>", "Output file or directory.")
+    .option("--include-payload", "Write the full capture object, including prompt/completion payloads.")
+    .option("--yes", "Confirm full payload export without prompting."))
+    .action(async function (this: Command, requestId: string, opts: ExportOpts) {
+      await runAction(this, () => runExport(this, requestId, opts));
+    });
+}
+
+function addCaptureOptions(command: Command): Command {
+  return command
+    .option("--project-id <id>", "Project id from `understudy projects list --json`.")
+    .option("--project <slug>", "Project slug to resolve to an id.")
+    .option("--workload <name-or-id>", "Optional workload name or id.")
+    .option("--org <id>", "Org id to use (default: local config or only org in credentials).");
+}
+
+async function runList(cmd: Command, opts: ListOpts): Promise<void> {
+  const limit = parseLimit(opts.limit);
+  const { project, workload } = await resolveCaptureContext(opts);
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (opts.cursor) params.set("cursor", opts.cursor);
+  const base = workload
+    ? `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads/${encodeURIComponent(workload.id)}/captures`
+    : `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/captures`;
+  const res = await request(
+    { url: `${base}?${params.toString()}`, orgId: project.auth.orgId },
+    ListCapturesResponseSchema,
+  );
+  const summaries = res.data.captures.map(summarizeCapture);
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify({
+      project_id: project.projectId,
+      workload_id: workload?.id ?? null,
+      captures: summaries,
+      truncated: Boolean(res.data.truncated),
+      cursor: res.data.cursor ?? null,
+    })}\n`);
+    return;
+  }
+  printCaptureTable(summaries);
+}
+
+async function runGet(cmd: Command, requestId: string, opts: CaptureOpts): Promise<void> {
+  const { project, workload } = await resolveCaptureContext(opts);
+  const capture = await fetchCapture(project.auth.orgId, project.projectId, requestId, workload?.id);
+  const summary = summarizeCapture(capture);
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify({ project_id: project.projectId, workload_id: workload?.id ?? null, capture: summary })}\n`);
+    return;
+  }
+  printCaptureBlock(summary);
+}
+
+async function runExport(cmd: Command, requestId: string, opts: ExportOpts): Promise<void> {
+  if (opts.includePayload && !opts.yes && !isJsonMode(cmd)) {
+    throw new Error("Full capture export may contain prompts/completions. Re-run with --include-payload --yes to write it to a file.");
+  }
+  const { project, workload } = await resolveCaptureContext(opts);
+  const capture = await fetchCapture(project.auth.orgId, project.projectId, requestId, workload?.id);
+  const outputPath = resolveOutputPath(opts.out, requestId);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const value = opts.includePayload ? capture : summarizeCapture(capture);
+  writeFileSync(outputPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+
+  const payload = {
+    ok: true,
+    output: outputPath,
+    include_payload: Boolean(opts.includePayload),
+    warning: opts.includePayload ? "file may contain prompts, completions, or tool payloads" : null,
+  };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stdout.write(`${kleur.green("✓")} Wrote capture export: ${outputPath}\n`);
+  if (opts.includePayload) {
+    process.stdout.write(`${kleur.yellow("warning")}: file may contain prompts, completions, or tool payloads\n`);
+  }
+}
+
+async function resolveCaptureContext(opts: CaptureOpts) {
+  const project = await resolveProject(opts);
+  const workload = opts.workload ? await resolveWorkload(project, opts.workload) : null;
+  return { project, workload };
+}
+
+async function fetchCapture(orgId: string, projectId: string, requestId: string, workloadId?: string): Promise<unknown> {
+  const base = workloadId
+    ? `/admin/v1/orgs/${orgId}/projects/${encodeURIComponent(projectId)}/workloads/${encodeURIComponent(workloadId)}/captures/${encodeURIComponent(requestId)}`
+    : `/admin/v1/orgs/${orgId}/projects/${encodeURIComponent(projectId)}/captures/${encodeURIComponent(requestId)}`;
+  const res = await request({ url: base, orgId }, CaptureEnvelopeSchema);
+  return res.data.capture ?? res.data;
+}
+
+export function summarizeCapture(input: unknown): CaptureSummary {
+  const capture = isObject(input) ? input : {};
+  const tags = isObject(capture.tags) ? capture.tags : {};
+  return {
+    request_id: stringField(capture, "request_id"),
+    schema_version: stringField(capture, "schema_version"),
+    ts: stringField(capture, "ts") ?? stringField(capture, "created_at"),
+    project_id: stringField(capture, "project_id"),
+    workload_id: stringField(capture, "workload_id") ?? stringField(capture, "placement_id"),
+    mode: stringField(capture, "mode"),
+    provider: stringField(capture, "provider"),
+    endpoint: stringField(capture, "endpoint"),
+    requested_model: stringField(capture, "requested_model") ?? stringField(capture, "model"),
+    upstream_model: stringField(capture, "upstream_model"),
+    status_code: numberField(capture, "status_code"),
+    latency_ms: numberField(capture, "latency_ms"),
+    tags: { count: Object.keys(tags).length, keys: Object.keys(tags).sort() },
+    customer_request_body: present(capture.customer_request_body),
+    upstream_request_body: present(capture.upstream_request_body),
+    response_body: present(capture.response_body),
+  };
+}
+
+function parseLimit(value: string | undefined): number {
+  const parsed = Number(value ?? "25");
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100) {
+    throw new Error(`Expected --limit between 1 and 100, got: ${value}`);
+  }
+  return parsed;
+}
+
+function resolveOutputPath(out: string, requestId: string): string {
+  if (existsSync(out) && statSync(out).isDirectory()) {
+    return join(out, ".understudy", "captures", `${requestId}.json`);
+  }
+  if (out.endsWith("/") || out.endsWith("\\")) {
+    return join(out, ".understudy", "captures", `${requestId}.json`);
+  }
+  return out || join(findProjectRoot(), ".understudy", "captures", `${requestId}.json`);
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(obj: JsonObject, key: string): string | null {
+  const value = obj[key];
+  return typeof value === "string" ? value : null;
+}
+
+function numberField(obj: JsonObject, key: string): number | null {
+  const value = obj[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function present(value: unknown): "present" | "absent" {
+  return value === undefined || value === null ? "absent" : "present";
+}
+
+function printCaptureTable(captures: CaptureSummary[]): void {
+  if (captures.length === 0) {
+    process.stdout.write(`${kleur.gray("No captures found.")}\n`);
+    return;
+  }
+  const rows = captures.map((capture) => ({
+    request_id: capture.request_id ?? "",
+    uploaded: capture.ts ?? "",
+    size: "",
+    key: capture.request_id ? capture.request_id.slice(-8) : "",
+  }));
+  const headers = ["request_id", "uploaded", "size", "key"];
+  const widths = headers.map((h) => Math.max(h.length, ...rows.map((r) => r[h as keyof typeof r].length)));
+  const pad = (s: string, w: number) => s + " ".repeat(w - s.length);
+  process.stdout.write(`${headers.map((h, i) => kleur.bold(pad(h, widths[i]!))).join("  ")}\n`);
+  for (const row of rows) {
+    process.stdout.write(`${headers.map((h, i) => pad(row[h as keyof typeof row], widths[i]!)).join("  ")}\n`);
+  }
+}
+
+function printCaptureBlock(capture: CaptureSummary): void {
+  for (const [key, value] of Object.entries(capture)) {
+    if (key === "tags") {
+      process.stdout.write(`${kleur.bold(key)} ${capture.tags.count} (${capture.tags.keys.join(",")})\n`);
+    } else {
+      process.stdout.write(`${kleur.bold(key)} ${String(value)}\n`);
+    }
+  }
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,145 @@
+import { Command } from "commander";
+import kleur from "kleur";
+import { z } from "zod";
+
+import { readCredentials } from "../config/credentials.js";
+import { readProjectConfig } from "../config/index.js";
+import { request, resolveAuth } from "../internal/http.js";
+import { isJsonMode, runAction } from "../internal/output.js";
+import { listProjects, resolveProject } from "../internal/projects.js";
+import { listWorkloads } from "../internal/workloads.js";
+
+const ListKeysResponseSchema = z.object({ keys: z.array(z.unknown()) }).passthrough();
+const ListModelsResponseSchema = z.object({ models: z.array(z.unknown()) }).passthrough();
+
+interface DoctorOpts {
+  hosted?: boolean;
+  probe?: boolean;
+  org?: string;
+  projectId?: string;
+  project?: string;
+}
+
+type Check = { name: string; ok: boolean; detail?: string };
+
+export function registerDoctorCommand(program: Command, runLocalDoctor: () => void): void {
+  program
+    .command("doctor")
+    .description("Run local repository diagnostics or hosted readiness checks.")
+    .option("--json", "Output JSON")
+    .option("--hosted", "Check hosted Understudy readiness without provider calls.")
+    .option("--probe", "After hosted checks pass, run one explicit tiny gateway probe.")
+    .option("--project-id <id>", "Project id for hosted checks.")
+    .option("--project <slug>", "Project slug for hosted checks.")
+    .option("--org <id>", "Org id to use.")
+    .action(async function (this: Command, opts: DoctorOpts) {
+      if (!opts.hosted) {
+        runLocalDoctor();
+        return;
+      }
+      await runAction(this, () => runHostedDoctor(this, opts));
+    });
+}
+
+async function runHostedDoctor(cmd: Command, opts: DoctorOpts): Promise<void> {
+  const checks: Check[] = [];
+  let nextCommand = "understudy login --email you@company.com";
+  let auth: ReturnType<typeof resolveAuth> | null = null;
+
+  try {
+    readCredentials();
+    auth = resolveAuth(opts.org ?? readProjectConfig()?.org_id);
+    checks.push({ name: "credentials", ok: true });
+  } catch (error) {
+    checks.push({ name: "credentials", ok: false, detail: message(error) });
+    return finish(cmd, checks, nextCommand);
+  }
+
+  await check("gateway health", checks, async () => {
+    const res = await fetch(`${auth!.gatewayUrl.replace(/\/+$/, "")}/healthz`, { headers: { accept: "application/json" } });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+  });
+
+  await check("projects", checks, async () => {
+    const projects = await listProjects(auth!);
+    if (projects.length === 0) {
+      throw new Error("no projects");
+    }
+  });
+
+  let projectResolved: Awaited<ReturnType<typeof resolveProject>> | null = null;
+  await check("project selection", checks, async () => {
+    projectResolved = await resolveProject({ org: opts.org, projectId: opts.projectId, project: opts.project });
+  });
+
+  await check("keys", checks, async () => {
+    await request({ url: `/admin/v1/orgs/${auth!.orgId}/api_keys`, orgId: auth!.orgId }, ListKeysResponseSchema);
+  });
+
+  await check("models", checks, async () => {
+    await request({ url: `/admin/v1/orgs/${auth!.orgId}/models`, orgId: auth!.orgId }, ListModelsResponseSchema);
+  });
+
+  await check("workloads", checks, async () => {
+    if (!projectResolved) throw new Error("project not resolved");
+    await listWorkloads(projectResolved);
+  });
+
+  const resolvedForNext = projectResolved as Awaited<ReturnType<typeof resolveProject>> | null;
+  const projectLabel = resolvedForNext?.projectSlug ?? resolvedForNext?.projectId ?? "rehearsal";
+  nextCommand = `understudy gateway probe --provider anthropic --project ${projectLabel}`;
+
+  if (opts.probe && checks.every((entry) => entry.ok)) {
+    await check("gateway probe", checks, async () => {
+      const res = await fetch(`${auth!.gatewayUrl.replace(/\/+$/, "")}/v1/messages`, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "x-api-key": auth!.token,
+          "anthropic-version": "2023-06-01",
+          ...(resolvedForNext?.projectSlug ? { "x-understudy-project": resolvedForNext.projectSlug } : {}),
+        },
+        body: JSON.stringify({
+          model: "claude-3-5-haiku-latest",
+          max_tokens: 8,
+          messages: [{ role: "user", content: "Reply with the single word ok." }],
+        }),
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+    });
+  }
+
+  finish(cmd, checks, nextCommand);
+}
+
+async function check(name: string, checks: Check[], fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+    checks.push({ name, ok: true });
+  } catch (error) {
+    checks.push({ name, ok: false, detail: message(error) });
+  }
+}
+
+function finish(cmd: Command, checks: Check[], nextCommand: string): void {
+  const ok = checks.every((entry) => entry.ok);
+  const payload = { ok, hosted: true, checks, next_command: nextCommand };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+  } else {
+    process.stdout.write(`${kleur.bold("hosted doctor")}\n`);
+    for (const entry of checks) {
+      const mark = entry.ok ? kleur.green("✓") : kleur.red("✗");
+      process.stdout.write(`${mark} ${entry.name}${entry.detail ? ` — ${entry.detail}` : ""}\n`);
+    }
+    process.stdout.write(`next: ${nextCommand}\n`);
+  }
+  if (!ok) {
+    process.exitCode = 1;
+  }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/commands/gateway.ts
+++ b/src/commands/gateway.ts
@@ -1,0 +1,204 @@
+import { Command } from "commander";
+import kleur from "kleur";
+
+import { DEFAULT_GATEWAY_URL } from "../config/defaults.js";
+import { readCredentials } from "../config/credentials.js";
+import { resolveAuth } from "../internal/http.js";
+import { isJsonMode, runAction } from "../internal/output.js";
+
+interface HealthOpts {
+  gatewayUrl?: string;
+}
+
+interface ProbeOpts {
+  provider: "anthropic" | "openai";
+  model?: string;
+  project?: string;
+  workload?: string;
+  byokEnv?: string;
+  stream?: boolean;
+  maxTokens?: string;
+  tag?: string[];
+  org?: string;
+}
+
+export function registerGatewayCommand(program: Command): void {
+  const gateway = program
+    .command("gateway")
+    .description("Run narrow Understudy gateway health and probe checks.");
+
+  gateway
+    .command("health")
+    .description("Check gateway health without provider calls.")
+    .option("--gateway-url <url>", "Gateway URL override.")
+    .action(async function (this: Command, opts: HealthOpts) {
+      await runAction(this, () => runHealth(this, opts));
+    });
+
+  gateway
+    .command("probe")
+    .description("Run one explicit tiny gateway completion probe.")
+    .requiredOption("--provider <anthropic|openai>", "Provider-compatible API shape to probe.")
+    .option("--model <id>", "Requested model id.")
+    .option("--project <slug>", "Project slug header.")
+    .option("--workload <name>", "Workload name header.")
+    .option("--byok-env <ENV_NAME>", "Read upstream provider key from this environment variable.")
+    .option("--stream", "Request a streaming response.")
+    .option("--max-tokens <n>", "Maximum output tokens.", "8")
+    .option("--tag <key=value>", "Flat string tag; may be repeated.", collectTag, [])
+    .option("--org <id>", "Org id to use (default: local config or only org in credentials).")
+    .action(async function (this: Command, opts: ProbeOpts) {
+      await runAction(this, () => runProbe(this, opts));
+    });
+}
+
+async function runHealth(cmd: Command, opts: HealthOpts): Promise<void> {
+  const gatewayUrl = resolveGatewayUrl(opts.gatewayUrl);
+  const url = `${gatewayUrl.replace(/\/+$/, "")}/healthz`;
+  const started = Date.now();
+  let status = 0;
+  let ok = false;
+  try {
+    const res = await fetch(url, { headers: { accept: "application/json" } });
+    status = res.status;
+    ok = res.ok;
+  } catch {
+    ok = false;
+  }
+  const payload = { ok, gateway_url: gatewayUrl, status, latency_ms: Date.now() - started };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stdout.write(`ok ${ok ? "yes" : "no"}\n`);
+  process.stdout.write(`gateway_url ${gatewayUrl}\n`);
+  process.stdout.write(`status ${status || "unreachable"}\n`);
+}
+
+async function runProbe(cmd: Command, opts: ProbeOpts): Promise<void> {
+  if (opts.provider !== "anthropic" && opts.provider !== "openai") {
+    throw new Error("Expected --provider anthropic|openai.");
+  }
+  const auth = resolveAuth(opts.org);
+  const endpoint = opts.provider === "anthropic" ? "/v1/messages" : "/v1/chat/completions";
+  const url = `${auth.gatewayUrl.replace(/\/+$/, "")}${endpoint}`;
+  const maxTokens = parseMaxTokens(opts.maxTokens);
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/json",
+  };
+  if (opts.provider === "anthropic") {
+    headers["x-api-key"] = auth.token;
+    headers["anthropic-version"] = "2023-06-01";
+  } else {
+    headers.authorization = `Bearer ${auth.token}`;
+  }
+  if (opts.project) headers["x-understudy-project"] = opts.project;
+  if (opts.workload) headers["x-understudy-workload"] = opts.workload;
+  const tags = parseTags(opts.tag ?? []);
+  if (Object.keys(tags).length > 0) {
+    headers["x-understudy-tags"] = JSON.stringify(tags);
+  }
+  if (opts.byokEnv) {
+    const upstreamKey = process.env[opts.byokEnv];
+    if (!upstreamKey) {
+      throw new Error(`Environment variable ${opts.byokEnv} is not set.`);
+    }
+    headers["x-understudy-upstream-key"] = upstreamKey;
+  }
+
+  const body = opts.provider === "anthropic"
+    ? {
+        model: opts.model ?? "claude-3-5-haiku-latest",
+        max_tokens: maxTokens,
+        stream: Boolean(opts.stream),
+        messages: [{ role: "user", content: "Reply with the single word ok." }],
+      }
+    : {
+        model: opts.model ?? "gpt-4o-mini",
+        max_tokens: maxTokens,
+        stream: Boolean(opts.stream),
+        messages: [{ role: "user", content: "Reply with the single word ok." }],
+      };
+
+  const started = Date.now();
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const latencyMs = Date.now() - started;
+  const text = await res.text();
+  const requestId = res.headers.get("x-understudy-request-id");
+  const payload = {
+    ok: res.ok,
+    status: res.status,
+    provider: opts.provider,
+    endpoint,
+    requested_model: opts.model ?? body.model,
+    request_id: requestId,
+    latency_ms: latencyMs,
+    project: opts.project ?? null,
+    workload: opts.workload ?? null,
+    byok: Boolean(opts.byokEnv),
+    response_kind: opts.stream ? "stream" : responseKind(text),
+  };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stdout.write(`status ${res.status}\n`);
+  process.stdout.write(`provider ${opts.provider}\n`);
+  process.stdout.write(`endpoint ${endpoint}\n`);
+  process.stdout.write(`requested_model ${payload.requested_model}\n`);
+  process.stdout.write(`project ${payload.project ?? "(none)"}\n`);
+  process.stdout.write(`workload ${payload.workload ?? "(none)"}\n`);
+  process.stdout.write(`request_id ${requestId ?? "(none)"}\n`);
+  process.stdout.write(`latency_ms ${latencyMs}\n`);
+  process.stdout.write(`${res.ok ? kleur.green("response received") : kleur.red("response failed")}\n`);
+}
+
+function resolveGatewayUrl(override?: string): string {
+  if (override) return override;
+  const credentials = readCredentials();
+  return credentials?.gateway_url ?? process.env.UNDERSTUDY_GATEWAY_URL ?? DEFAULT_GATEWAY_URL;
+}
+
+function parseMaxTokens(value: string | undefined): number {
+  const parsed = Number(value ?? "8");
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 64) {
+    throw new Error(`Expected --max-tokens between 1 and 64, got: ${value}`);
+  }
+  return parsed;
+}
+
+function collectTag(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
+}
+
+function parseTags(values: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of values) {
+    const index = entry.indexOf("=");
+    if (index <= 0) {
+      throw new Error(`Expected --tag key=value, got: ${entry}`);
+    }
+    const key = entry.slice(0, index);
+    const value = entry.slice(index + 1);
+    if (!/^[a-zA-Z0-9_.:-]{1,64}$/.test(key)) {
+      throw new Error(`Invalid tag key: ${key}`);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function responseKind(text: string): "json" | "stream" {
+  try {
+    JSON.parse(text);
+    return "json";
+  } catch {
+    return "stream";
+  }
+}

--- a/src/commands/gateway.ts
+++ b/src/commands/gateway.ts
@@ -66,6 +66,7 @@ async function runHealth(cmd: Command, opts: HealthOpts): Promise<void> {
     ok = false;
   }
   const payload = { ok, gateway_url: gatewayUrl, status, latency_ms: Date.now() - started };
+  if (!ok) process.exitCode = 1;
   if (isJsonMode(cmd)) {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
     return;
@@ -143,6 +144,7 @@ async function runProbe(cmd: Command, opts: ProbeOpts): Promise<void> {
     byok: Boolean(opts.byokEnv),
     response_kind: opts.stream ? "stream" : responseKind(text),
   };
+  if (!res.ok) process.exitCode = 1;
   if (isJsonMode(cmd)) {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
     return;

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -8,6 +8,7 @@ import { trackControlPlaneAction } from "../internal/telemetry.js";
 
 const PublicModelSchema = z.object({
   id: z.string(),
+  display_name: z.string().optional(),
   name: z.string().optional(),
   description: z.string().optional(),
   capabilities: z.array(z.string()).optional(),
@@ -61,7 +62,7 @@ async function runList(cmd: Command, opts: OrgOpt): Promise<void> {
 
   const rows = res.data.models.map((model) => ({
     id: model.id,
-    name: model.name ?? "",
+    name: model.display_name ?? model.name ?? "",
     capabilities: model.capabilities?.join(",") ?? "",
     context_window: model.context_window == null ? "" : String(model.context_window),
   }));

--- a/src/commands/routes.ts
+++ b/src/commands/routes.ts
@@ -1,0 +1,232 @@
+import { existsSync, readFileSync } from "node:fs";
+import { Command } from "commander";
+import kleur from "kleur";
+
+import { isJsonMode, runAction } from "../internal/output.js";
+import { resolveProject, type ProjectResolutionOptions } from "../internal/projects.js";
+import {
+  listWorkloads,
+  parseTrafficPct,
+  readRouteSnapshot,
+  resolveWorkload,
+  setWorkloadRoute,
+  writeRouteSnapshot,
+  type Workload,
+} from "../internal/workloads.js";
+
+interface RouteOpts extends ProjectResolutionOptions {}
+
+interface SetOpts extends RouteOpts {
+  modelId: string;
+  trafficPct?: string;
+}
+
+interface PromoteOpts extends RouteOpts {
+  from: string;
+  workload?: string;
+  modelId?: string;
+  trafficPct?: string;
+  yes?: boolean;
+}
+
+export function registerRoutesCommand(program: Command): void {
+  const routes = program
+    .command("routes")
+    .description("Inspect, set, clear, promote, and rollback hosted workload routes.");
+
+  addProjectOptions(routes.command("show <workload>")
+    .description("Show the current hosted route for a workload."))
+    .action(async function (this: Command, workload: string, opts: RouteOpts) {
+      await runAction(this, () => runShow(this, workload, opts));
+    });
+
+  addProjectOptions(routes.command("set <workload>")
+    .description("Route a small traffic percentage to an Understudy model.")
+    .requiredOption("--model-id <id>", "Public Understudy model id.")
+    .option("--traffic-pct <0-100>", "Traffic percentage.", "10"))
+    .action(async function (this: Command, workload: string, opts: SetOpts) {
+      await runAction(this, () => runSet(this, workload, opts));
+    });
+
+  addProjectOptions(routes.command("clear <workload>")
+    .description("Clear a hosted route and return to passthrough."))
+    .action(async function (this: Command, workload: string, opts: RouteOpts) {
+      await runAction(this, () => runClear(this, workload, opts));
+    });
+
+  addProjectOptions(routes.command("rollback <workload>")
+    .description("Restore the last route snapshot, or clear when no snapshot exists."))
+    .action(async function (this: Command, workload: string, opts: RouteOpts) {
+      await runAction(this, () => runRollback(this, workload, opts));
+    });
+
+  addProjectOptions(routes.command("promote")
+    .description("Promote a hosted-ready route-decision packet.")
+    .requiredOption("--from <path>", "Route decision packet JSON.")
+    .option("--workload <name-or-id>", "Workload name or id when the packet lacks hosted ids.")
+    .option("--model-id <id>", "Model id when the packet lacks hosted ids.")
+    .option("--traffic-pct <0-100>", "Traffic percentage override.")
+    .option("--yes", "Confirm hosted traffic mutation."))
+    .action(async function (this: Command, opts: PromoteOpts) {
+      await runAction(this, () => runPromote(this, opts));
+    });
+}
+
+function addProjectOptions(command: Command): Command {
+  return command
+    .option("--project-id <id>", "Project id from `understudy projects list --json`.")
+    .option("--project <slug>", "Project slug to resolve to an id.")
+    .option("--org <id>", "Org id to use (default: local config or only org in credentials).");
+}
+
+async function runShow(cmd: Command, workloadValue: string, opts: RouteOpts): Promise<void> {
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkloadWithState(project, workloadValue);
+  const payload = routePayload(project.projectId, workload);
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  printRoute(payload);
+}
+
+async function runSet(cmd: Command, workloadValue: string, opts: SetOpts): Promise<void> {
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkloadWithState(project, workloadValue);
+  const trafficPct = parseTrafficPct(opts.trafficPct, 10);
+  const snapshotPath = writeRouteSnapshot(project, workload);
+  const result = await setWorkloadRoute(project, workload, { model_id: opts.modelId, route_traffic_pct: trafficPct });
+  const payload = { ok: true, workload_id: workload.id, workload_name: workload.name, model_id: result.route_model_id ?? result.model_id ?? opts.modelId, route_traffic_pct: result.route_traffic_pct ?? trafficPct, snapshot_path: snapshotPath };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stdout.write(`${kleur.green("✓")} Route set for ${workload.name} (${workload.id})\n`);
+  process.stdout.write(`route: ${payload.model_id} at ${payload.route_traffic_pct}%\n`);
+  process.stdout.write(`${kleur.gray("Inference calls keep using the normal Understudy gateway path.")}\n`);
+}
+
+async function runClear(cmd: Command, workloadValue: string, opts: RouteOpts): Promise<void> {
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkloadWithState(project, workloadValue);
+  const snapshotPath = writeRouteSnapshot(project, workload);
+  await setWorkloadRoute(project, workload, { model_id: null });
+  const payload = { ok: true, workload_id: workload.id, workload_name: workload.name, model_id: null, route_traffic_pct: 0, snapshot_path: snapshotPath };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stdout.write(`${kleur.green("✓")} Cleared route for ${workload.name} (${workload.id})\n`);
+  process.stdout.write("route: passthrough\n");
+}
+
+async function runRollback(cmd: Command, workloadValue: string, opts: RouteOpts): Promise<void> {
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkloadWithState(project, workloadValue);
+  const snapshot = readRouteSnapshot(project.projectId, workload.id);
+  const previous = snapshot?.previous ?? { route_model_id: null, route_traffic_pct: null };
+  const body = previous.route_model_id
+    ? { model_id: previous.route_model_id, route_traffic_pct: previous.route_traffic_pct ?? 10 }
+    : { model_id: null };
+  const result = await setWorkloadRoute(project, workload, body);
+  const payload = {
+    ok: true,
+    restored_from_snapshot: Boolean(snapshot),
+    workload_id: workload.id,
+    workload_name: workload.name,
+    model_id: result.route_model_id ?? result.model_id ?? body.model_id,
+    route_traffic_pct: result.route_traffic_pct ?? ("route_traffic_pct" in body ? body.route_traffic_pct : 0),
+  };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  if (!snapshot) {
+    process.stdout.write(`${kleur.yellow("no snapshot")} cleared route for ${workload.name} (${workload.id})\n`);
+    return;
+  }
+  process.stdout.write(`${kleur.green("✓")} Rolled back route for ${workload.name} (${workload.id})\n`);
+}
+
+async function runPromote(cmd: Command, opts: PromoteOpts): Promise<void> {
+  const packet = readPacket(opts.from);
+  const decision = stringValue(packet.decision);
+  if (decision === "evaluate-first" || decision === "local-only") {
+    throw new Error("Route packet is evaluate-first, not hosted-promotion-ready. Run local evaluation or pass explicit route inputs after review.");
+  }
+  const project = await resolveProject({
+    org: opts.org,
+    projectId: opts.projectId ?? stringValue(packet.project_id),
+    project: opts.project ?? stringValue(packet.project_slug),
+  });
+  const workloadValue = opts.workload ?? stringValue(packet.workload_id) ?? stringValue(packet.workload_name);
+  const modelId = opts.modelId ?? stringValue(packet.model_id) ?? stringValue(packet.route_model_id);
+  if (!workloadValue || !modelId) {
+    throw new Error("Packet lacks hosted workload/model fields. Pass --workload and --model-id after reviewing the packet.");
+  }
+  if (!opts.yes) {
+    throw new Error("Promoting a route mutates hosted traffic. Re-run with --yes after reviewing the packet.");
+  }
+  const workload = await resolveWorkloadWithState(project, workloadValue);
+  const trafficPct = parseTrafficPct(opts.trafficPct ?? numberValue(packet.route_traffic_pct), 10);
+  const snapshotPath = writeRouteSnapshot(project, workload);
+  const result = await setWorkloadRoute(project, workload, { model_id: modelId, route_traffic_pct: trafficPct });
+  const payload = { ok: true, workload_id: workload.id, workload_name: workload.name, model_id: result.route_model_id ?? result.model_id ?? modelId, route_traffic_pct: result.route_traffic_pct ?? trafficPct, snapshot_path: snapshotPath };
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stdout.write(`${kleur.green("✓")} Promoted route for ${workload.name} (${workload.id})\n`);
+  process.stdout.write(`route: ${payload.model_id} at ${payload.route_traffic_pct}%\n`);
+}
+
+async function resolveWorkloadWithState(project: Awaited<ReturnType<typeof resolveProject>>, value: string): Promise<Workload> {
+  if (!value.startsWith("usp_")) {
+    return resolveWorkload(project, value);
+  }
+  const workloads = await listWorkloads(project);
+  return workloads.find((candidate) => candidate.id === value) ?? resolveWorkload(project, value);
+}
+
+function routePayload(projectId: string, workload: Workload) {
+  return {
+    project_id: projectId,
+    workload_id: workload.id,
+    workload_name: workload.name,
+    route_model_id: workload.route_model_id ?? null,
+    route_traffic_pct: workload.route_traffic_pct ?? 0,
+    capture_enabled: Boolean(workload.capture_enabled),
+    is_default: Boolean(workload.is_default),
+  };
+}
+
+function printRoute(payload: ReturnType<typeof routePayload>): void {
+  process.stdout.write(`workload: ${payload.workload_name} (${payload.workload_id})\n`);
+  if (payload.route_model_id) {
+    process.stdout.write(`route: ${payload.route_model_id} at ${payload.route_traffic_pct}%\n`);
+    process.stdout.write(`passthrough: ${100 - payload.route_traffic_pct}%\n`);
+  } else {
+    process.stdout.write("route: passthrough\n");
+  }
+  process.stdout.write(`capture_enabled: ${payload.capture_enabled ? "true" : "false"}\n`);
+  process.stdout.write(`is_default: ${payload.is_default ? "true" : "false"}\n`);
+}
+
+function readPacket(path: string): Record<string, unknown> {
+  if (!existsSync(path)) {
+    throw new Error(`Route decision packet not found: ${path}`);
+  }
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Route decision packet must be a JSON object.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): string | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : undefined;
+}

--- a/src/commands/routes.ts
+++ b/src/commands/routes.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import kleur from "kleur";
 
 import { isJsonMode, runAction } from "../internal/output.js";
+import { trackControlPlaneAction } from "../internal/telemetry.js";
 import { resolveProject, type ProjectResolutionOptions } from "../internal/projects.js";
 import {
   listWorkloads,
@@ -96,6 +97,7 @@ async function runSet(cmd: Command, workloadValue: string, opts: SetOpts): Promi
   const trafficPct = parseTrafficPct(opts.trafficPct, 10);
   const snapshotPath = writeRouteSnapshot(project, workload);
   const result = await setWorkloadRoute(project, workload, { model_id: opts.modelId, route_traffic_pct: trafficPct });
+  trackControlPlaneAction({ resource: "workload_routes", action: "updated", orgId: project.auth.orgId, projectSlug: project.projectSlug, resultCount: 1 });
   const payload = { ok: true, workload_id: workload.id, workload_name: workload.name, model_id: result.route_model_id ?? result.model_id ?? opts.modelId, route_traffic_pct: result.route_traffic_pct ?? trafficPct, snapshot_path: snapshotPath };
   if (isJsonMode(cmd)) {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
@@ -111,6 +113,7 @@ async function runClear(cmd: Command, workloadValue: string, opts: RouteOpts): P
   const workload = await resolveWorkloadWithState(project, workloadValue);
   const snapshotPath = writeRouteSnapshot(project, workload);
   await setWorkloadRoute(project, workload, { model_id: null });
+  trackControlPlaneAction({ resource: "workload_routes", action: "cleared", orgId: project.auth.orgId, projectSlug: project.projectSlug, resultCount: 0 });
   const payload = { ok: true, workload_id: workload.id, workload_name: workload.name, model_id: null, route_traffic_pct: 0, snapshot_path: snapshotPath };
   if (isJsonMode(cmd)) {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
@@ -129,6 +132,7 @@ async function runRollback(cmd: Command, workloadValue: string, opts: RouteOpts)
     ? { model_id: previous.route_model_id, route_traffic_pct: previous.route_traffic_pct ?? 10 }
     : { model_id: null };
   const result = await setWorkloadRoute(project, workload, body);
+  trackControlPlaneAction({ resource: "workload_routes", action: previous.route_model_id ? "updated" : "cleared", orgId: project.auth.orgId, projectSlug: project.projectSlug, resultCount: previous.route_model_id ? 1 : 0 });
   const payload = {
     ok: true,
     restored_from_snapshot: Boolean(snapshot),
@@ -171,6 +175,7 @@ async function runPromote(cmd: Command, opts: PromoteOpts): Promise<void> {
   const trafficPct = parseTrafficPct(opts.trafficPct ?? numberValue(packet.route_traffic_pct), 10);
   const snapshotPath = writeRouteSnapshot(project, workload);
   const result = await setWorkloadRoute(project, workload, { model_id: modelId, route_traffic_pct: trafficPct });
+  trackControlPlaneAction({ resource: "workload_routes", action: "updated", orgId: project.auth.orgId, projectSlug: project.projectSlug, resultCount: 1 });
   const payload = { ok: true, workload_id: workload.id, workload_name: workload.name, model_id: result.route_model_id ?? result.model_id ?? modelId, route_traffic_pct: result.route_traffic_pct ?? trafficPct, snapshot_path: snapshotPath };
   if (isJsonMode(cmd)) {
     process.stdout.write(`${JSON.stringify(payload)}\n`);

--- a/src/commands/workloads.ts
+++ b/src/commands/workloads.ts
@@ -1,24 +1,35 @@
 import { Command } from "commander";
 import kleur from "kleur";
-import { z } from "zod";
 
-import { request, resolveAuth } from "../internal/http.js";
+import { request } from "../internal/http.js";
 import { isJsonMode, runAction } from "../internal/output.js";
+import { resolveProject, type ProjectResolutionOptions } from "../internal/projects.js";
 import { trackControlPlaneAction } from "../internal/telemetry.js";
+import {
+  listWorkloads,
+  parseTrafficPct,
+  resolveWorkload,
+  setWorkloadRoute,
+  WorkloadSchema,
+  WORKLOAD_NAME_PATTERN,
+  type Workload,
+} from "../internal/workloads.js";
 
-const RouteResponseSchema = z.object({
-  workload_id: z.string().optional(),
-  project_id: z.string().optional(),
-  model_id: z.string().nullable().optional(),
-  route_traffic_pct: z.number().nullable().optional(),
-}).passthrough();
+const CreateWorkloadResponseSchema = WorkloadSchema;
+const UpdateWorkloadResponseSchema = WorkloadSchema;
 
-interface OrgOpt {
-  org?: string;
+interface WorkloadOpts extends ProjectResolutionOptions {}
+
+interface CreateOpts extends WorkloadOpts {
+  capture?: boolean;
 }
 
-interface RouteOpts extends OrgOpt {
-  projectId: string;
+interface UpdateOpts extends WorkloadOpts {
+  name?: string;
+  capture?: "on" | "off";
+}
+
+interface RouteOpts extends WorkloadOpts {
   modelId?: string;
   trafficPct?: string;
   clear?: boolean;
@@ -29,72 +40,223 @@ export function registerWorkloadsCommand(program: Command): void {
     .command("workloads")
     .description("Manage project workload route configuration.");
 
-  workloads
-    .command("route <workload-id>")
+  addProjectOptions(workloads.command("list")
+    .description("List workloads in a project."))
+    .action(async function (this: Command, opts: WorkloadOpts) {
+      await runAction(this, () => runList(this, opts));
+    });
+
+  addProjectOptions(workloads.command("create <name>")
+    .description("Create a workload in a project.")
+    .option("--capture", "Enable hosted capture for this workload.")
+    .option("--no-capture", "Disable hosted capture for this workload."))
+    .action(async function (this: Command, name: string, opts: CreateOpts) {
+      await runAction(this, () => runCreate(this, name, opts));
+    });
+
+  addProjectOptions(workloads.command("show <workload>")
+    .description("Show one workload by id or name."))
+    .action(async function (this: Command, workload: string, opts: WorkloadOpts) {
+      await runAction(this, () => runShow(this, workload, opts));
+    });
+
+  addProjectOptions(workloads.command("update <workload>")
+    .description("Update workload name or capture setting.")
+    .option("--name <name>", "New workload name.")
+    .option("--capture <on|off>", "Turn hosted capture on or off."))
+    .action(async function (this: Command, workload: string, opts: UpdateOpts) {
+      await runAction(this, () => runUpdate(this, workload, opts));
+    });
+
+  addProjectOptions(workloads.command("route <workload>")
     .description("Set or clear an Understudy model traffic route for a workload.")
-    .requiredOption("--project-id <id>", "Project id from `understudy projects list --json`.")
     .option("--model-id <id>", "Public Understudy model id from `understudy models list`.")
     .option("--traffic-pct <0-100>", "Percent of traffic to send to the selected Understudy model.", "10")
-    .option("--clear", "Clear the Understudy model route and return to passthrough/frontier.")
-    .option("--org <id>", "Org id to use (default: only org in credentials).")
-    .action(async function (this: Command, workloadId: string, opts: RouteOpts) {
-      await runAction(this, () => runRoute(this, workloadId, opts));
+    .option("--clear", "Clear the Understudy model route and return to passthrough/frontier."))
+    .action(async function (this: Command, workload: string, opts: RouteOpts) {
+      await runAction(this, () => runRoute(this, workload, opts));
     });
 }
 
-async function runRoute(cmd: Command, workloadId: string, opts: RouteOpts): Promise<void> {
-  if (!workloadId) {
-    throw new Error("workload-id is required.");
-  }
-  if (opts.clear && opts.modelId) {
-    throw new Error("Use either --clear or --model-id, not both.");
-  }
-  if (!opts.clear && !opts.modelId) {
-    throw new Error("Pass --model-id <id> to set a route or --clear to remove it.");
-  }
+function addProjectOptions(command: Command): Command {
+  return command
+    .option("--project-id <id>", "Project id from `understudy projects list --json`.")
+    .option("--project <slug>", "Project slug to resolve to an id.")
+    .option("--org <id>", "Org id to use (default: local config or only org in credentials).");
+}
 
-  const auth = resolveAuth(opts.org);
-  const body = opts.clear
-    ? { model_id: null }
-    : {
-        model_id: opts.modelId,
-        route_traffic_pct: parseTrafficPct(opts.trafficPct ?? "10"),
-      };
+async function runList(cmd: Command, opts: WorkloadOpts): Promise<void> {
+  const project = await resolveProject(opts);
+  const workloads = await listWorkloads(project);
+  trackControlPlaneAction({
+    resource: "workloads",
+    action: "listed",
+    orgId: project.auth.orgId,
+    projectSlug: project.projectSlug,
+    resultCount: workloads.length,
+  });
+
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify({ project_id: project.projectId, project_slug: project.projectSlug, workloads })}\n`);
+    return;
+  }
+  printWorkloadTable(workloads);
+}
+
+async function runCreate(cmd: Command, name: string, opts: CreateOpts): Promise<void> {
+  validateWorkloadName(name);
+  const project = await resolveProject(opts);
+  const captureEnabled = Boolean(opts.capture);
   const res = await request(
     {
-      url: `/admin/v1/orgs/${auth.orgId}/projects/${encodeURIComponent(opts.projectId)}/workloads/${encodeURIComponent(workloadId)}/route`,
-      orgId: auth.orgId,
-      method: "PUT",
-      body,
+      url: `/customer/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads`,
+      orgId: project.auth.orgId,
+      method: "POST",
+      body: { name, capture_enabled: captureEnabled },
     },
-    RouteResponseSchema,
+    CreateWorkloadResponseSchema,
   );
   trackControlPlaneAction({
-    resource: "workload_routes",
-    action: opts.clear ? "cleared" : "updated",
-    orgId: auth.orgId,
-    resultCount: opts.clear ? 0 : 1,
+    resource: "workloads",
+    action: "created",
+    orgId: project.auth.orgId,
+    projectSlug: project.projectSlug,
   });
 
   if (isJsonMode(cmd)) {
     process.stdout.write(`${JSON.stringify(res.data)}\n`);
     return;
   }
+  process.stdout.write(`${kleur.green("✓")} Created workload ${kleur.bold(res.data.name)} (${res.data.id})\n`);
+  process.stdout.write(`capture: ${res.data.capture_enabled ? "on" : "off"}\n`);
+  process.stdout.write(`next: understudy gateway probe --provider anthropic --project ${project.projectSlug ?? project.projectId} --workload ${res.data.name}\n`);
+}
 
-  if (opts.clear) {
-    process.stdout.write(`${kleur.green("✓")} Cleared route for workload ${kleur.bold(workloadId)}\n`);
+async function runShow(cmd: Command, workloadValue: string, opts: WorkloadOpts): Promise<void> {
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkload(project, workloadValue);
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify({ project_id: project.projectId, workload })}\n`);
     return;
   }
-  process.stdout.write(
-    `${kleur.green("✓")} Routed ${kleur.bold(`${body.route_traffic_pct}%`)} of workload ${kleur.bold(workloadId)} to ${kleur.bold(String(body.model_id))}\n`,
+  printWorkloadBlock(project.projectId, workload);
+}
+
+async function runUpdate(cmd: Command, workloadValue: string, opts: UpdateOpts): Promise<void> {
+  if (!opts.name && !opts.capture) {
+    throw new Error("Pass --name <name> and/or --capture on|off.");
+  }
+  if (opts.name) validateWorkloadName(opts.name);
+  if (opts.capture && opts.capture !== "on" && opts.capture !== "off") {
+    throw new Error("Expected --capture on|off.");
+  }
+
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkload(project, workloadValue);
+  const body: Record<string, unknown> = {};
+  if (opts.name) body.name = opts.name;
+  if (opts.capture) body.capture_enabled = opts.capture === "on";
+
+  const res = await request(
+    {
+      url: `/customer/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads/${encodeURIComponent(workload.id)}`,
+      orgId: project.auth.orgId,
+      method: "PATCH",
+      body,
+    },
+    UpdateWorkloadResponseSchema,
   );
+  trackControlPlaneAction({
+    resource: "workloads",
+    action: "updated",
+    orgId: project.auth.orgId,
+    projectSlug: project.projectSlug,
+  });
+
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(res.data)}\n`);
+    return;
+  }
+  process.stdout.write(`${kleur.green("✓")} Updated workload ${kleur.bold(res.data.name)} (${res.data.id})\n`);
+  process.stdout.write(`capture: ${res.data.capture_enabled ? "on" : "off"}\n`);
+}
+
+async function runRoute(cmd: Command, workloadValue: string, opts: RouteOpts): Promise<void> {
+  if (opts.clear && opts.modelId) {
+    throw new Error("Use either --clear or --model-id, not both.");
+  }
+  if (!opts.clear && !opts.modelId) {
+    throw new Error("Pass --model-id <id> to set a route or --clear to remove it.");
+  }
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkload(project, workloadValue);
+  const body = opts.clear
+    ? { model_id: null }
+    : { model_id: opts.modelId!, route_traffic_pct: parseTrafficPct(opts.trafficPct, 10) };
+  const result = await setWorkloadRoute(project, workload, body);
+  trackControlPlaneAction({
+    resource: "workload_routes",
+    action: opts.clear ? "cleared" : "updated",
+    orgId: project.auth.orgId,
+    projectSlug: project.projectSlug,
+    resultCount: opts.clear ? 0 : 1,
+  });
+
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify({ ...result, workload_id: workload.id, workload_name: workload.name })}\n`);
+    return;
+  }
+  printRouteResult(opts.clear, workload, result.route_model_id ?? result.model_id ?? body.model_id, result.route_traffic_pct ?? body.route_traffic_pct ?? null);
+}
+
+function validateWorkloadName(name: string): void {
+  if (!WORKLOAD_NAME_PATTERN.test(name)) {
+    throw new Error(`Invalid workload name "${name}". Must match /^[a-z0-9][a-z0-9_-]{0,62}$/.`);
+  }
+}
+
+function printWorkloadTable(workloads: Workload[]): void {
+  if (workloads.length === 0) {
+    process.stdout.write(`${kleur.gray("No workloads in this project.")} Run ${kleur.cyan("understudy workloads create <name>")} to create one.\n`);
+    return;
+  }
+  const rows = workloads.map((w) => ({
+    id: w.id,
+    name: w.name,
+    capture: w.capture_enabled ? "on" : "off",
+    route_model: w.route_model_id ?? "passthrough",
+    traffic_pct: w.route_traffic_pct == null ? "" : String(w.route_traffic_pct),
+    default: w.is_default ? "yes" : "",
+    created_at: w.created_at ?? "",
+  }));
+  printRows(rows, ["id", "name", "capture", "route_model", "traffic_pct", "default", "created_at"]);
+}
+
+function printWorkloadBlock(projectId: string, workload: Workload): void {
+  process.stdout.write(`${kleur.bold("workload")}       ${workload.name}\n`);
+  process.stdout.write(`${kleur.bold("id")}             ${workload.id}\n`);
+  process.stdout.write(`${kleur.bold("project_id")}     ${workload.project_id ?? projectId}\n`);
+  process.stdout.write(`${kleur.bold("capture_enabled")} ${workload.capture_enabled ? "true" : "false"}\n`);
+  process.stdout.write(`${kleur.bold("route_model_id")} ${workload.route_model_id ?? "passthrough"}\n`);
+  process.stdout.write(`${kleur.bold("route_traffic_pct")} ${workload.route_traffic_pct ?? 0}\n`);
+  process.stdout.write(`${kleur.bold("is_default")}     ${workload.is_default ? "true" : "false"}\n`);
+}
+
+function printRouteResult(clear: boolean | undefined, workload: Workload, modelId: string | null | undefined, trafficPct: number | null): void {
+  if (clear) {
+    process.stdout.write(`${kleur.green("✓")} Cleared route for workload ${kleur.bold(workload.name)} (${workload.id})\n`);
+    process.stdout.write(`route: passthrough\n`);
+    return;
+  }
+  process.stdout.write(`${kleur.green("✓")} Routed ${kleur.bold(`${trafficPct ?? 10}%`)} of workload ${kleur.bold(workload.name)} (${workload.id}) to ${kleur.bold(String(modelId))}\n`);
   process.stdout.write(`${kleur.gray("Inference calls keep using the normal Understudy gateway path.")}\n`);
 }
 
-function parseTrafficPct(value: string): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
-    throw new Error(`Expected --traffic-pct between 0 and 100, got: ${value}`);
+function printRows(rows: Array<Record<string, string>>, headers: string[]): void {
+  const widths = headers.map((h) => Math.max(h.length, ...rows.map((r) => r[h]!.length)));
+  const pad = (s: string, w: number) => s + " ".repeat(w - s.length);
+  process.stdout.write(`${headers.map((h, i) => kleur.bold(pad(h, widths[i]!))).join("  ")}\n`);
+  for (const row of rows) {
+    process.stdout.write(`${headers.map((h, i) => pad(row[h]!, widths[i]!)).join("  ")}\n`);
   }
-  return parsed;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,15 @@ import { runUnderstandCheck, runUnderstandWorkloadCard } from "./understand.js";
 import { buildWorkloadCard, previewCaptureImport, scanCaptureImport } from "./capture-import.js";
 import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
+import { registerCapturesCommand } from "./commands/captures.js";
+import { registerDoctorCommand } from "./commands/doctor.js";
+import { registerGatewayCommand } from "./commands/gateway.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerLoginCommand } from "./commands/login.js";
 import { registerLogoutCommand } from "./commands/logout.js";
 import { registerModelsCommand } from "./commands/models.js";
 import { registerProjectsCommand } from "./commands/projects.js";
+import { registerRoutesCommand } from "./commands/routes.js";
 import { registerRunCommand } from "./commands/run.js";
 import { registerSetupCodeCommand } from "./commands/setup-code.js";
 import { registerSetupCommand } from "./commands/setup.js";
@@ -394,7 +398,7 @@ export function buildProgram(): Command {
     printSkillList();
   });
 
-  program.command("doctor").description("Run local repository diagnostics").option("--json", "Output JSON").action(printDoctorJson);
+  registerDoctorCommand(program, printDoctorJson);
 
   registerLoginCommand(program);
   registerLogoutCommand(program);
@@ -403,6 +407,9 @@ export function buildProgram(): Command {
   registerModelsCommand(program);
   registerProjectsCommand(program);
   registerWorkloadsCommand(program);
+  registerCapturesCommand(program);
+  registerGatewayCommand(program);
+  registerRoutesCommand(program);
   registerSetupCommand(program);
   registerSetupCodeCommand(program);
   registerRunCommand(program);

--- a/src/internal/projects.ts
+++ b/src/internal/projects.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+import { readProjectConfig } from "../config/index.js";
+import { request, resolveAuth, type ResolvedAuth } from "./http.js";
+
+export const ProjectSchema = z.object({
+  id: z.string(),
+  org_id: z.string().optional(),
+  slug: z.string(),
+  name: z.string().optional(),
+  created_at: z.string().optional(),
+  settings: z.string().optional(),
+  deleted_at: z.string().nullable().optional(),
+}).passthrough();
+
+const ListProjectsResponseSchema = z.object({
+  projects: z.array(ProjectSchema),
+  cursor: z.string().nullable().optional(),
+}).passthrough();
+
+export type Project = z.infer<typeof ProjectSchema>;
+
+export interface ProjectResolutionOptions {
+  org?: string;
+  projectId?: string;
+  project?: string;
+}
+
+export interface ResolvedProject {
+  auth: ResolvedAuth;
+  projectId: string;
+  projectSlug: string | null;
+  project: Project | null;
+}
+
+export async function listProjects(auth: ResolvedAuth): Promise<Project[]> {
+  const projects: Project[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const url: string = cursor
+      ? `/admin/v1/orgs/${auth.orgId}/projects?cursor=${encodeURIComponent(cursor)}`
+      : `/admin/v1/orgs/${auth.orgId}/projects`;
+    const res: Awaited<ReturnType<typeof request<z.infer<typeof ListProjectsResponseSchema>>>> = await request({ url, orgId: auth.orgId }, ListProjectsResponseSchema);
+    projects.push(...res.data.projects);
+    cursor = res.data.cursor ?? null;
+    if (!cursor) break;
+  }
+  return projects;
+}
+
+export async function resolveProject(opts: ProjectResolutionOptions): Promise<ResolvedProject> {
+  const config = readProjectConfig();
+  const auth = resolveAuth(opts.org ?? config?.org_id);
+
+  if (opts.projectId) {
+    return {
+      auth,
+      projectId: opts.projectId,
+      projectSlug: null,
+      project: null,
+    };
+  }
+
+  const slug = opts.project ?? config?.project_slug;
+  if (!slug) {
+    throw new Error("No project selected. Run `understudy projects list` or pass --project-id.");
+  }
+
+  const projects = await listProjects(auth);
+  const project = projects.find((candidate) => candidate.slug === slug);
+  if (!project) {
+    throw new Error(`No project with slug "${slug}" in org ${auth.orgId}. Run \`understudy projects list\` to see what's available.`);
+  }
+
+  return {
+    auth,
+    projectId: project.id,
+    projectSlug: project.slug,
+    project,
+  };
+}

--- a/src/internal/telemetry.ts
+++ b/src/internal/telemetry.ts
@@ -66,7 +66,7 @@ interface StatusCheckedEvent {
 }
 
 interface ControlPlaneEvent {
-  resource: "api_keys" | "projects" | "models" | "workload_routes";
+  resource: "api_keys" | "projects" | "models" | "workloads" | "workload_routes";
   action: "listed" | "created" | "revoked" | "switched" | "deleted" | "updated" | "cleared";
   orgId: string | null;
   projectSlug?: string | null;

--- a/src/internal/workloads.ts
+++ b/src/internal/workloads.ts
@@ -1,0 +1,143 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { z } from "zod";
+
+import { findProjectRoot } from "../config/paths.js";
+import { request } from "./http.js";
+import { type ResolvedProject } from "./projects.js";
+
+export const WORKLOAD_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/;
+
+export const WorkloadSchema = z.object({
+  id: z.string(),
+  project_id: z.string().optional(),
+  name: z.string(),
+  capture_enabled: z.boolean().optional(),
+  route_model_id: z.string().nullable().optional(),
+  route_traffic_pct: z.number().nullable().optional(),
+  route_deployment_id: z.string().nullable().optional(),
+  is_default: z.boolean().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+}).passthrough();
+
+const ListWorkloadsResponseSchema = z.object({
+  workloads: z.array(WorkloadSchema),
+  cursor: z.string().nullable().optional(),
+}).passthrough();
+
+const RouteResponseSchema = z.object({
+  workload_id: z.string().optional(),
+  project_id: z.string().optional(),
+  model_id: z.string().nullable().optional(),
+  route_model_id: z.string().nullable().optional(),
+  route_traffic_pct: z.number().nullable().optional(),
+}).passthrough();
+
+export type Workload = z.infer<typeof WorkloadSchema>;
+export type RouteResponse = z.infer<typeof RouteResponseSchema>;
+
+export async function listWorkloads(project: ResolvedProject): Promise<Workload[]> {
+  const res = await request(
+    {
+      url: `/customer/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads`,
+      orgId: project.auth.orgId,
+    },
+    ListWorkloadsResponseSchema,
+  );
+  return res.data.workloads;
+}
+
+export async function resolveWorkload(project: ResolvedProject, value: string): Promise<Workload> {
+  if (!value) {
+    throw new Error("workload is required.");
+  }
+  if (value.startsWith("usp_")) {
+    return {
+      id: value,
+      project_id: project.projectId,
+      name: value,
+    };
+  }
+  const workloads = await listWorkloads(project);
+  const workload = workloads.find((candidate) => candidate.name === value);
+  if (!workload) {
+    const projectLabel = project.projectSlug ?? project.projectId;
+    throw new Error(`No workload named ${value} in project ${projectLabel}. Run \`understudy workloads list\` or create it.`);
+  }
+  return workload;
+}
+
+export async function setWorkloadRoute(
+  project: ResolvedProject,
+  workload: Workload,
+  body: { model_id: string | null; route_traffic_pct?: number },
+): Promise<RouteResponse> {
+  const res = await request(
+    {
+      url: `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads/${encodeURIComponent(workload.id)}/route`,
+      orgId: project.auth.orgId,
+      method: "PUT",
+      body,
+    },
+    RouteResponseSchema,
+  );
+  return res.data;
+}
+
+export interface RouteSnapshot {
+  schema_version: "understudy.route_snapshot.v1";
+  org_id: string;
+  project_id: string;
+  workload_id: string;
+  workload_name: string | null;
+  previous: {
+    route_model_id: string | null;
+    route_traffic_pct: number | null;
+  };
+  created_at: string;
+}
+
+export function routeSnapshotPath(projectId: string, workloadId: string): string {
+  return join(findProjectRoot(), ".understudy", "routes", projectId, workloadId, "last-route.json");
+}
+
+export function writeRouteSnapshot(project: ResolvedProject, workload: Workload): string {
+  const path = routeSnapshotPath(project.projectId, workload.id);
+  const snapshot: RouteSnapshot = {
+    schema_version: "understudy.route_snapshot.v1",
+    org_id: project.auth.orgId,
+    project_id: project.projectId,
+    workload_id: workload.id,
+    workload_name: workload.name ?? null,
+    previous: {
+      route_model_id: workload.route_model_id ?? null,
+      route_traffic_pct: workload.route_traffic_pct ?? null,
+    },
+    created_at: new Date().toISOString(),
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+  return path;
+}
+
+export function readRouteSnapshot(projectId: string, workloadId: string): RouteSnapshot | null {
+  const path = routeSnapshotPath(projectId, workloadId);
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as RouteSnapshot;
+    if (parsed.schema_version !== "understudy.route_snapshot.v1") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function parseTrafficPct(value: string | number | undefined, fallback = 10): number {
+  const parsed = value === undefined ? fallback : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+    throw new Error(`Expected --traffic-pct between 0 and 100, got: ${String(value)}`);
+  }
+  return parsed;
+}

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1041,6 +1041,11 @@ describe("understudy CLI", () => {
       assert.equal(full.status, 0, full.stderr);
       assert.doesNotMatch(full.stdout, /SECRET_PROMPT|SECRET_COMPLETION/);
       assert.match(readFileSync(fullPath, "utf8"), /SECRET_PROMPT/);
+
+      // --json must NOT bypass the --yes confirmation for full payload export.
+      const blockedJson = await runWithEnvAsync(["--json", "captures", "export", "req_123", "--out", join(repo, "full-json.json"), "--include-payload"], env, repo);
+      assert.notEqual(blockedJson.status, 0, "json mode must still require --yes for payload export");
+      assert.match(blockedJson.stderr, /may contain prompts\/completions/);
     });
   });
 
@@ -1069,6 +1074,11 @@ describe("understudy CLI", () => {
       const openaiRequest = requests.at(-1);
       assert.equal(openaiRequest.path, "/v1/chat/completions");
       assert.equal(openaiRequest.headers.authorization, "Bearer sk_test_hosted");
+
+      // An unreachable gateway must surface a non-zero exit code (scriptability).
+      const healthDown = await runWithEnvAsync(["--json", "gateway", "health", "--gateway-url", "http://127.0.0.1:1"], env, repo);
+      assert.notEqual(healthDown.status, 0, "gateway health must exit non-zero when unreachable");
+      assert.equal(JSON.parse(healthDown.stdout).ok, false);
     });
   });
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, it } from "node:test";
@@ -26,6 +27,158 @@ function runWithHome(args, home, cwd = process.cwd()) {
       USERPROFILE: home,
     },
   });
+}
+
+function runWithEnv(args, env, cwd = process.cwd()) {
+  return spawnSync(cli[0], [cli[1], ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      UNDERSTUDY_TELEMETRY: "0",
+      ...env,
+    },
+  });
+}
+
+function runWithEnvAsync(args, env, cwd = process.cwd()) {
+  return new Promise((resolve) => {
+    const child = spawn(cli[0], [cli[1], ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        UNDERSTUDY_TELEMETRY: "0",
+        ...env,
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+function writeHostedConfig({ home, repo, gatewayUrl }) {
+  mkdirSync(join(home, ".understudy"), { recursive: true });
+  writeFileSync(
+    join(home, ".understudy", "credentials.json"),
+    `${JSON.stringify({
+      api_key: "sk_test_hosted",
+      gateway_url: gatewayUrl,
+      orgs: {
+        org_1: {
+          api_key: "sk_test_org",
+          gateway_url: gatewayUrl,
+        },
+      },
+    }, null, 2)}\n`,
+  );
+  mkdirSync(join(repo, ".understudy"), { recursive: true });
+  writeFileSync(
+    join(repo, ".understudy", "config.json"),
+    `${JSON.stringify({ org_id: "org_1", project_slug: "rehearsal" }, null, 2)}\n`,
+  );
+}
+
+async function withHostedFixture(fn) {
+  const requests = [];
+  const state = {
+    projects: [{ id: "proj_1", org_id: "org_1", slug: "rehearsal", name: "Rehearsal", created_at: "2026-06-01T00:00:00Z", settings: "{}", deleted_at: null }],
+    workloads: [
+      { id: "usp_main", project_id: "proj_1", name: "main", capture_enabled: true, route_model_id: null, route_traffic_pct: null, is_default: true, created_at: "2026-06-01T00:00:00Z" },
+      { id: "usp_classify", project_id: "proj_1", name: "classify", capture_enabled: false, route_model_id: "glm-5.1", route_traffic_pct: 10, is_default: false, created_at: "2026-06-02T00:00:00Z" },
+    ],
+    captures: [
+      {
+        request_id: "req_123",
+        schema_version: "understudy.capture.v1",
+        ts: "2026-06-07T00:00:00Z",
+        project_id: "proj_1",
+        workload_id: "usp_classify",
+        mode: "gateway",
+        provider: "anthropic",
+        endpoint: "/v1/messages",
+        requested_model: "claude-test",
+        upstream_model: "claude-test-upstream",
+        status_code: 200,
+        latency_ms: 42,
+        tags: { env: "test" },
+        customer_request_body: { messages: [{ role: "user", content: "SECRET_PROMPT" }] },
+        upstream_request_body: { messages: [{ role: "user", content: "SECRET_PROMPT" }] },
+        response_body: { content: "SECRET_COMPLETION" },
+      },
+    ],
+  };
+
+  const server = createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const bodyText = Buffer.concat(chunks).toString("utf8");
+    const body = bodyText ? JSON.parse(bodyText) : null;
+    const url = new URL(req.url, "http://127.0.0.1");
+    requests.push({ method: req.method, path: url.pathname, search: url.search, headers: req.headers, body });
+
+    const send = (status, value, headers = {}) => {
+      res.writeHead(status, { "content-type": "application/json", ...headers });
+      res.end(JSON.stringify(value));
+    };
+
+    if (req.method === "GET" && url.pathname === "/healthz") return send(200, { ok: true });
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects") return send(200, { projects: state.projects, cursor: null });
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/api_keys") return send(200, { keys: [{ id: "key_1", name: "default", obfuscated_value: "sk_...test", last_used_at: null, permissions: [], created_at: "2026-06-01T00:00:00Z" }] });
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/models") return send(200, { models: [{ id: "glm-5.1", display_name: "GLM 5.1", capabilities: ["chat"], context_window: 128000 }] });
+    if (req.method === "GET" && url.pathname === "/customer/v1/orgs/org_1/projects/proj_1/workloads") return send(200, { workloads: state.workloads, cursor: null });
+    if (req.method === "POST" && url.pathname === "/customer/v1/orgs/org_1/projects/proj_1/workloads") {
+      const workload = { id: `usp_${body.name}`, project_id: "proj_1", name: body.name, capture_enabled: Boolean(body.capture_enabled), route_model_id: null, route_traffic_pct: null, is_default: false, created_at: "2026-06-07T00:00:00Z" };
+      state.workloads.push(workload);
+      return send(200, workload);
+    }
+    const workloadPatch = url.pathname.match(/^\/customer\/v1\/orgs\/org_1\/projects\/proj_1\/workloads\/([^/]+)$/);
+    if (req.method === "PATCH" && workloadPatch) {
+      const workload = state.workloads.find((entry) => entry.id === workloadPatch[1]);
+      if (!workload) return send(404, { message: "missing" });
+      if (body.name) workload.name = body.name;
+      if (typeof body.capture_enabled === "boolean") workload.capture_enabled = body.capture_enabled;
+      return send(200, workload);
+    }
+    const routePut = url.pathname.match(/^\/admin\/v1\/orgs\/org_1\/projects\/proj_1\/workloads\/([^/]+)\/route$/);
+    if (req.method === "PUT" && routePut) {
+      const workload = state.workloads.find((entry) => entry.id === routePut[1]);
+      if (!workload) return send(404, { message: "missing" });
+      workload.route_model_id = body.model_id;
+      workload.route_traffic_pct = body.model_id === null ? null : body.route_traffic_pct;
+      return send(200, { workload_id: workload.id, project_id: "proj_1", model_id: body.model_id, route_model_id: body.model_id, route_traffic_pct: workload.route_traffic_pct });
+    }
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/captures") return send(200, { captures: state.captures, truncated: false, cursor: null });
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify/captures") return send(200, { captures: state.captures, truncated: false, cursor: null });
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/captures/req_123") return send(200, { capture: state.captures[0] });
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify/captures/req_123") return send(200, { capture: state.captures[0] });
+    if (req.method === "POST" && (url.pathname === "/v1/messages" || url.pathname === "/v1/chat/completions")) return send(200, { ok: true, content: "SECRET_COMPLETION" }, { "x-understudy-request-id": "req_probe" });
+    return send(404, { message: `${req.method} ${url.pathname}` });
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const gatewayUrl = `http://127.0.0.1:${address.port}`;
+  const home = mkdtempSync(join(tmpdir(), "understudy-hosted-home-"));
+  const repo = mkdtempSync(join(tmpdir(), "understudy-hosted-repo-"));
+  try {
+    writeHostedConfig({ home, repo, gatewayUrl });
+    return await fn({ gatewayUrl, home, repo, requests, state });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
 }
 
 function withFixtureRepo(fn) {
@@ -813,12 +966,157 @@ describe("understudy CLI", () => {
     assert.equal(root.status, 0, root.stderr);
     assert.match(root.stdout, /models/);
     assert.match(root.stdout, /workloads/);
+    assert.match(root.stdout, /captures/);
+    assert.match(root.stdout, /gateway/);
+    assert.match(root.stdout, /routes/);
 
     const route = run(["workloads", "route", "--help"]);
     assert.equal(route.status, 0, route.stderr);
     assert.match(route.stdout, /--model-id/);
     assert.match(route.stdout, /--traffic-pct/);
     assert.match(route.stdout, /--clear/);
+  });
+
+  it("runs hosted workload lifecycle commands against the customer API", async () => {
+    await withHostedFixture(async ({ home, repo, requests }) => {
+      const env = { HOME: home, USERPROFILE: home };
+
+      const list = await runWithEnvAsync(["--json", "workloads", "list"], env, repo);
+      assert.equal(list.status, 0, list.stderr);
+      assert.equal(JSON.parse(list.stdout).workloads.length, 2);
+
+      const listByProjectId = await runWithEnvAsync(["--json", "workloads", "list", "--project-id", "proj_1"], env, repo);
+      assert.equal(listByProjectId.status, 0, listByProjectId.stderr);
+      assert.equal(JSON.parse(listByProjectId.stdout).project_id, "proj_1");
+
+      const create = await runWithEnvAsync(["workloads", "create", "support_triage", "--capture", "--project", "rehearsal"], env, repo);
+      assert.equal(create.status, 0, create.stderr);
+      assert.match(create.stdout, /Created workload support_triage/);
+      assert.equal(requests.at(-1).method, "POST");
+      assert.equal(requests.at(-1).path, "/customer/v1/orgs/org_1/projects/proj_1/workloads");
+      assert.deepEqual(requests.at(-1).body, { name: "support_triage", capture_enabled: true });
+
+      const show = await runWithEnvAsync(["--json", "workloads", "show", "support_triage"], env, repo);
+      assert.equal(show.status, 0, show.stderr);
+      assert.equal(JSON.parse(show.stdout).workload.id, "usp_support_triage");
+
+      const update = await runWithEnvAsync(["workloads", "update", "support_triage", "--capture", "off"], env, repo);
+      assert.equal(update.status, 0, update.stderr);
+      assert.equal(requests.at(-1).method, "PATCH");
+      assert.deepEqual(requests.at(-1).body, { capture_enabled: false });
+
+      const route = await runWithEnvAsync(["--json", "workloads", "route", "support_triage", "--model-id", "glm-5.1", "--traffic-pct", "10"], env, repo);
+      assert.equal(route.status, 0, route.stderr);
+      assert.equal(JSON.parse(route.stdout).route_traffic_pct, 10);
+      assert.equal(requests.at(-1).method, "PUT");
+      assert.equal(requests.at(-1).path, "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_support_triage/route");
+      assert.deepEqual(requests.at(-1).body, { model_id: "glm-5.1", route_traffic_pct: 10 });
+    });
+  });
+
+  it("redacts capture payloads by default and writes full payloads only to files", async () => {
+    await withHostedFixture(async ({ home, repo }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const list = await runWithEnvAsync(["--json", "captures", "list", "--workload", "classify"], env, repo);
+      assert.equal(list.status, 0, list.stderr);
+      assert.match(list.stdout, /req_123/);
+      assert.doesNotMatch(list.stdout, /SECRET_PROMPT|SECRET_COMPLETION/);
+      assert.equal(JSON.parse(list.stdout).captures[0].customer_request_body, "present");
+
+      const get = await runWithEnvAsync(["--json", "captures", "get", "req_123"], env, repo);
+      assert.equal(get.status, 0, get.stderr);
+      assert.doesNotMatch(get.stdout, /SECRET_PROMPT|SECRET_COMPLETION/);
+
+      const blocked = await runWithEnvAsync(["captures", "export", "req_123", "--out", join(repo, "full.json"), "--include-payload"], env, repo);
+      assert.notEqual(blocked.status, 0);
+      assert.match(blocked.stderr, /may contain prompts\/completions/);
+
+      const redactedPath = join(repo, "redacted.json");
+      const redacted = await runWithEnvAsync(["captures", "export", "req_123", "--out", redactedPath], env, repo);
+      assert.equal(redacted.status, 0, redacted.stderr);
+      assert.doesNotMatch(readFileSync(redactedPath, "utf8"), /SECRET_PROMPT|SECRET_COMPLETION/);
+
+      const fullPath = join(repo, "full.json");
+      const full = await runWithEnvAsync(["captures", "export", "req_123", "--out", fullPath, "--include-payload", "--yes"], env, repo);
+      assert.equal(full.status, 0, full.stderr);
+      assert.doesNotMatch(full.stdout, /SECRET_PROMPT|SECRET_COMPLETION/);
+      assert.match(readFileSync(fullPath, "utf8"), /SECRET_PROMPT/);
+    });
+  });
+
+  it("runs gateway health and probes without printing secrets", async () => {
+    await withHostedFixture(async ({ home, repo, gatewayUrl, requests }) => {
+      const env = { HOME: home, USERPROFILE: home, UPSTREAM_TEST_KEY: "provider_secret_value" };
+      const health = await runWithEnvAsync(["--json", "gateway", "health", "--gateway-url", gatewayUrl], env, repo);
+      assert.equal(health.status, 0, health.stderr);
+      assert.equal(JSON.parse(health.stdout).ok, true);
+
+      const anthropic = await runWithEnvAsync(["--json", "gateway", "probe", "--provider", "anthropic", "--project", "rehearsal", "--workload", "classify", "--tag", "env=test", "--byok-env", "UPSTREAM_TEST_KEY"], env, repo);
+      assert.equal(anthropic.status, 0, anthropic.stderr);
+      const anthropicPayload = JSON.parse(anthropic.stdout);
+      assert.equal(anthropicPayload.request_id, "req_probe");
+      assert.doesNotMatch(anthropic.stdout + anthropic.stderr, /sk_test|provider_secret_value|SECRET_COMPLETION/);
+      const anthropicRequest = requests.at(-1);
+      assert.equal(anthropicRequest.path, "/v1/messages");
+      assert.equal(anthropicRequest.headers["x-api-key"], "sk_test_hosted");
+      assert.equal(anthropicRequest.headers["x-understudy-upstream-key"], "provider_secret_value");
+      assert.equal(anthropicRequest.headers["x-understudy-project"], "rehearsal");
+      assert.equal(anthropicRequest.headers["x-understudy-workload"], "classify");
+      assert.equal(anthropicRequest.headers["x-understudy-tags"], "{\"env\":\"test\"}");
+
+      const openai = await runWithEnvAsync(["--json", "gateway", "probe", "--provider", "openai"], env, repo);
+      assert.equal(openai.status, 0, openai.stderr);
+      const openaiRequest = requests.at(-1);
+      assert.equal(openaiRequest.path, "/v1/chat/completions");
+      assert.equal(openaiRequest.headers.authorization, "Bearer sk_test_hosted");
+    });
+  });
+
+  it("shows, sets, clears, and rolls back hosted routes", async () => {
+    await withHostedFixture(async ({ home, repo, requests }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const show = await runWithEnvAsync(["--json", "routes", "show", "classify"], env, repo);
+      assert.equal(show.status, 0, show.stderr);
+      assert.equal(JSON.parse(show.stdout).route_model_id, "glm-5.1");
+
+      const set = await runWithEnvAsync(["--json", "routes", "set", "classify", "--model-id", "glm-5.2", "--traffic-pct", "20"], env, repo);
+      assert.equal(set.status, 0, set.stderr);
+      assert.equal(JSON.parse(set.stdout).route_traffic_pct, 20);
+      assert.deepEqual(requests.at(-1).body, { model_id: "glm-5.2", route_traffic_pct: 20 });
+
+      const clear = await runWithEnvAsync(["--json", "routes", "clear", "classify"], env, repo);
+      assert.equal(clear.status, 0, clear.stderr);
+      assert.deepEqual(requests.at(-1).body, { model_id: null });
+
+      const rollback = await runWithEnvAsync(["--json", "routes", "rollback", "classify"], env, repo);
+      assert.equal(rollback.status, 0, rollback.stderr);
+      assert.equal(JSON.parse(rollback.stdout).model_id, "glm-5.2");
+
+      const packetPath = join(repo, "route-decision.json");
+      writeFileSync(packetPath, JSON.stringify({ schema_version: "understudy.route_decision_packet.v1", decision: "evaluate-first" }));
+      const promote = await runWithEnvAsync(["routes", "promote", "--from", packetPath, "--yes"], env, repo);
+      assert.notEqual(promote.status, 0);
+      assert.match(promote.stderr, /evaluate-first/);
+    });
+  });
+
+  it("runs hosted doctor and renders model display_name", async () => {
+    await withHostedFixture(async ({ home, repo }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const doctor = await runWithEnvAsync(["--json", "doctor", "--hosted"], env, repo);
+      assert.equal(doctor.status, 0, doctor.stderr);
+      const payload = JSON.parse(doctor.stdout);
+      assert.equal(payload.ok, true);
+      assert.deepEqual(payload.checks.map((entry) => entry.name), ["credentials", "gateway health", "projects", "project selection", "keys", "models", "workloads"]);
+
+      const probeDoctor = await runWithEnvAsync(["--json", "doctor", "--hosted", "--probe"], env, repo);
+      assert.equal(probeDoctor.status, 0, probeDoctor.stderr);
+      assert.equal(JSON.parse(probeDoctor.stdout).checks.at(-1).name, "gateway probe");
+
+      const models = await runWithEnvAsync(["models", "list"], env, repo);
+      assert.equal(models.status, 0, models.stderr);
+      assert.match(models.stdout, /GLM 5\.1/);
+    });
   });
 
   it("scans capture/import sources with metadata only and writes a redaction manifest", () =>


### PR DESCRIPTION
Supersedes #56, which auto-closed when its base branch (`yolo/pedagogical-rlm-skill-bundle`, the #55 stack) was deleted on merge. This is the same work rebased onto `main` (just the CLI commit, no #55 content) with the review findings fixed.

## What it adds
Hosted CLI P0 parity commands: `captures`, `doctor --hosted`, `gateway` (health/probe), `routes` (show/set/clear/promote/rollback), expanded `workloads`, plus `src/internal/{projects,workloads}.ts` and docs (`cli-events.md`, `privacy-and-data-boundaries.md`).

## Review findings addressed (from the #56 code review)
- **Blocker — data boundary:** `captures export --include-payload` bypassed the `--yes` confirmation under `--json`, writing full prompts/completions to disk without confirmation. Now required in **all** modes. Test added (`--json --include-payload` without `--yes` is rejected).
- **Should-fix — telemetry:** `routes set/clear/promote/rollback` now emit `cli_workload_routes_updated/_cleared`, matching `workloads route` (the documented events were undercounting).
- **Should-fix — exit codes:** `gateway health`/`probe` now exit non-zero on failure (were returning 0 on an unreachable gateway / non-2xx probe). Test added.

## Validation
`npm run check` green locally: build, typecheck, **67 tests pass**, skills:validate (26 skills), cookbook:validate, package:smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->