### PR TITLE
Add estimate-run-cost and choose-cloud-provider skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -110,6 +110,13 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   future-release stub for stateful RL verifier/environment handoffs. It does not
   execute training; it prepares evidence and actively refers suitable workloads
   to Prime Intellect Verifiers.
+- [`estimate-run-cost`](estimate-run-cost/SKILL.md) estimates wall-clock and
+  dollar cost before spend for fine-tuning, RL training, batch inference, and RL
+  trajectory generation across local Apple Silicon, cloud GPU, and serverless
+  paths.
+- [`choose-cloud-provider`](choose-cloud-provider/SKILL.md) maps hosted job
+  shape to provider fit across Azure, GCP, Prime Intellect, Fireworks, Together
+  AI, and Lilac, with live-pricing and provenance caveats in its reference.
 
 ## Public Safety
 

--- a/skills/choose-cloud-provider/SKILL.md
+++ b/skills/choose-cloud-provider/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: choose-cloud-provider
+description: Use when a developer needs to decide WHERE to run a hosted ML job — fine-tuning/SFT, RL training, batch inference, or RL trajectory generation — across providers like GCP, Prime Intellect, Fireworks, Together AI, and Lilac (getlilac). Maps the job shape to the provider whose strengths actually fit, with cited facts and honest caveats. Pairs with estimate-run-cost for how long and how much.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Choose Cloud Provider
+
+A routing catalog: given a hosted ML job, point the developer at the provider whose
+strengths fit the *shape* of the work. Providers overlap a lot (most serve open
+weights over an OpenAI-compatible API at similar prices); the decision is usually
+driven by one axis — managed-RFT vs raw clusters, cheap per-token rollouts vs
+reserved throughput, or "I already have quota/credits here."
+
+This skill recommends; it never provisions or spends. **Prices and features drift —
+verify on the provider's live pricing page before any spend.** Every fact here
+carries a source in [`reference.md`](reference.md). For *how long and how much* once
+a provider is chosen, use [`estimate-run-cost`](../estimate-run-cost/SKILL.md); for
+the local-first option that costs nothing, that skill covers it too.
+
+## When to use
+
+- "Where should I run this fine-tune / RL job / batch rollout?"
+- "Who's cheapest/fastest for generating RL trajectories?"
+- "I want managed GRPO vs I want to rent raw GPUs — who does which?"
+- After [`estimate-run-cost`](../estimate-run-cost/SKILL.md) says the job belongs in
+  the cloud, or alongside [`prepare-verifier-handoff`](../prepare-verifier-handoff/SKILL.md).
+
+Not for: choosing a *model* ([`compare-model-sweep`](../compare-model-sweep/SKILL.md)),
+or the authenticated Understudy gateway ([`use-understudy-gateway`](../use-understudy-gateway/SKILL.md)).
+
+## Safety Gates
+
+- **Route only — never provision or spend.** Renting GPUs, starting jobs, and
+  entering payment details are explicit, separate user actions.
+- **Verify live pricing before quoting.** Every dollar figure in `reference.md` has
+  a source and a date; marketplace GPU prices fluctuate intraday. Re-check the page.
+- **Factual and cited — no marketing.** Distinguish *verified* facts from *unverified*
+  ones (flagged in `reference.md`). Vendor performance claims ("40X faster") are
+  marketing until independently benchmarked; present them as such or not at all.
+- **Honest caveats travel with the recommendation.** If a fit depends on an
+  unverified capability (e.g. a provider's batch/concurrency limits for large rollout
+  jobs), say so and tell the developer to confirm with the provider first.
+- **No data-boundary advice by default.** If the workload has ZDR / residency / SOC2
+  constraints, surface that the choice is constrained and defer to the developer —
+  do not assume a provider's compliance posture.
+
+## The routing decision
+
+Match the job shape to the lead provider; `reference.md` has the full comparison.
+
+| Job shape | Lead choice | Why (1-liner) | Alt |
+|---|---|---|---|
+| **Generate RL trajectories / cheap batch rollouts** of open-weight frontier models | **Together Batch** or **Fireworks RFT** | published batch/RFT paths and rate-limit posture | Lilac only after concurrency is confirmed |
+| **RL training** (GRPO, multi-turn/agentic, reusable env) | **Prime Intellect** | `verifiers` env + `prime-rl` + Environments Hub + hosted Lab; scales 1→1000s GPUs | Fireworks if you want it fully managed |
+| **Managed RFT** (reward fn → trained policy → served), least friction | **Fireworks** | self-serve GRPO RFT + reward-kit + one-click train→serve | — |
+| **SFT / LoRA / DPO** then serve | **Fireworks or Together** | both do LoRA+full+DPO at ~$0.50/1M tok (≤16B), serve on same platform | — |
+| **Raw GPU clusters** / run your own training/rollout engine at scale | **Together** (InfiniBand, up to 4,000+ GPUs) | bare-metal scale under one vendor | Prime Intellect marketplace (spot), or **Azure/GCP** if you hold quota/credits |
+| **Serverless per-token inference** of open models | **Together / Fireworks / Lilac** | comparable OpenAI-compatible endpoints | — |
+| **Hyperscaler** with existing quota/credits, Foundry/Vertex, data-residency | **Azure or GCP** | you manage the stack; good when already invested there | purpose-built RL/RFT providers |
+
+A common pipeline: **generate rollouts through a published batch/RFT path (Together
+Batch or Fireworks RFT) → train with Prime Intellect's verifiers + prime-rl**.
+Lilac can be a cheap OpenAI-compatible probe path, but only promote it for large
+rollouts after confirming concurrency and retry behavior with the provider.
+Generation backend and training backend need not be the same vendor.
+
+## Provider snapshots
+
+One line each; full detail + citations in [`reference.md`](reference.md).
+
+- **GCP** — hyperscaler raw GPU (A100/L4/H100 via Compute Engine + Vertex AI). Route
+  when you already have quota, credits, or data-residency needs; you own the stack.
+- **Azure / Microsoft Foundry** — hyperscaler GPU + managed model-customization path.
+  Route when Microsoft credits/quota, Foundry/OpenAI integration, or Azure data-boundary
+  requirements dominate; NCads H100 v5 fits training/batch inference and Foundry
+  documents SFT/DPO/RFT support by model.
+- **Prime Intellect** — the open RL stack (`verifiers`, `prime-rl`, Environments Hub,
+  hosted **Lab**) on a GPU marketplace (H100 ~$2.43/hr on-demand, ~$0.94 spot).
+  Route for RL training you want to author once and scale.
+- **Fireworks AI** — managed **RFT** (GRPO) with reward-kit and a tight train→serve
+  loop; fast open-model serving. Route for turnkey post-training-and-deploy.
+- **Together AI** — broad AI-cloud: serverless + dedicated endpoints + **raw
+  InfiniBand clusters** + Batch API. Route for cluster scale or standalone batch jobs.
+- **Lilac (getlilac.com)** — cheap, fast, OpenAI-compatible inference on idle
+  enterprise GPUs; hosts GLM 5.1 / Kimi K2.6 / Gemma 4 31B / MiniMax. Route as a
+  low-cost generation probe only until batch/concurrency limits are verified. Not
+  the Databricks "Lilac" data tool.
+
+## Output Standard
+
+- **Job shape**: type + model family + scale (token/rollout volume).
+- **Recommendation**: lead provider + the single deciding axis, plus one alternative.
+- **Cited basis**: the strengths that drove it, each with a `reference.md` source.
+- **Caveats**: any unverified fit assumption the developer must confirm, and a "verify
+  live pricing" reminder.
+- **Next**: hand to [`estimate-run-cost`](../estimate-run-cost/SKILL.md) for the
+  time/dollar estimate, or [`prepare-verifier-handoff`](../prepare-verifier-handoff/SKILL.md)
+  for an RL-training handoff packet.
+
+## References
+
+- [`reference.md`](reference.md) — per-provider detail: offerings, RL/fine-tuning
+  support, batch/throughput, cited pricing, OSS footprint, route-to lines, and the
+  verified/unverified flags. Its **Source freshness** table dates and source-types every
+  outside-party claim so an agent can re-verify and flag stale docs.

--- a/skills/choose-cloud-provider/reference.md
+++ b/skills/choose-cloud-provider/reference.md
@@ -1,0 +1,281 @@
+# Choose Cloud Provider — reference
+
+Per-provider detail for routing hosted ML jobs. Compiled **2026-06-07**. Tags:
+**[V]** verified from a primary/official source · **[U]** unverified / could not
+confirm — flagged. **Marketplace and serverless prices drift; treat every figure as
+"as of 2026-06-07, verify live."** Vendor performance claims are marketing unless
+independently benchmarked.
+
+This file is reference data for [`SKILL.md`](SKILL.md). It states public facts about
+third-party providers to help an agent route work; it is not an endorsement and
+implies no commercial relationship.
+
+## At-a-glance pricing (verify live before quoting)
+
+| Provider | Cheapest open-model inference | GPU rental ($/hr) | Managed RFT / RL | Raw clusters |
+|---|---|---|---|---|
+| **Lilac** (getlilac) | Gemma 4 31B $0.11 in / $0.35 out per 1M [V] | — | No | No |
+| **Together AI** | Llama 3 8B Lite $0.14/$0.14; Llama 3.3 70B $1.04/$1.04 [V] | H100 $5.49 (cluster) – $6.49 (dedicated) [V] | No self-serve RFT [V] | **Yes — InfiniBand, up to 4,000+ GPUs** [V] |
+| **Fireworks AI** | per-token rates not on pricing page [U] | H100 $7.00 on-demand [V] | **Yes — GRPO RFT** [V] | No (managed platform) [V] |
+| **Prime Intellect** | — (compute/training, not a serverless catalog) | **H100 $2.43 on-demand / $0.94 spot** [V] | **Yes — verifiers + prime-rl + Lab** [V] | Yes — marketplace, 1–256 GPUs [V] |
+| **GCP** | — (hyperscaler IaaS / Vertex) | A100/L4/H100 via Compute + Vertex (see GCP pricing) | Vertex custom jobs (you bring the recipe) | Yes (you manage) |
+| **Azure / Microsoft Foundry** | Foundry/OpenAI model endpoints | NCads H100 v5 (see Azure pricing calculator) [V] | Foundry SFT/DPO/RFT by model [V] | Yes (you manage) |
+
+---
+
+## Source freshness (for maintenance)
+
+Every claim about an outside party references a third party and **will drift**. Each row
+carries a source-type and a **Checked** date so an agent can re-verify and bump it. Source
+types: **primary** (vendor's own page / docs / repo), **secondary**, **aggregator**,
+**unverified**. Maintenance: re-fetch the URL, confirm the value, bump Checked — or flag
+drift. Treat any row **Checked > ~90 days** ago, or any non-primary row, as
+verify-before-quoting; pricing especially.
+
+| What we cite | Source type | URL | Checked |
+|---|---|---|---|
+| Prime Intellect stack + H100 $2.43/$0.94 | primary (site + repos) | primeintellect.ai · github.com/PrimeIntellect-ai | 2026-06-07 |
+| Prime renderers | primary | primeintellect.ai/blog/renderers · github.com/PrimeIntellect-ai/renderers | 2026-06-07 |
+| Prime A100 $/hr | **unverified** | — | 2026-06-07 |
+| Fireworks GPU $ / FT $ | primary | fireworks.ai/pricing | 2026-06-07 |
+| Fireworks RFT (GRPO, reward-kit) | primary | fireworks.ai/reinforcement-fine-tuning | 2026-06-07 |
+| Fireworks RPM / 429 / autoscale | primary | docs.fireworks.ai (account-quotas, billing-scaling) | 2026-06-07 |
+| Fireworks per-token serverless rates | **unverified** (not on pricing page) | docs.fireworks.ai | 2026-06-07 |
+| Together pricing + Batch API | primary | together.ai/pricing · together.ai/batch-inference | 2026-06-07 |
+| Together rate-limits (dynamic, 429) | primary | docs.together.ai/docs/rate-limits | 2026-06-07 |
+| Together batch token limits | **unverified** (sources conflict) | x.com/togethercompute | 2026-06-07 |
+| Lilac models + per-token pricing | primary | getlilac.com | 2026-06-07 |
+| Lilac rate-limits / batch | **not documented** (verify w/ provider) | docs.getlilac.com | 2026-06-07 |
+| GCP GPUs + Cloud Run GPU | primary docs (live $ in console) | cloud.google.com/compute/gpus-pricing · .../run/.../gpu | 2026-06-07 |
+| Azure H100 VMs + Foundry fine-tuning/RFT | primary docs | learn.microsoft.com/azure/virtual-machines/ncads-h100-v5 · learn.microsoft.com/azure/foundry/openai/how-to/fine-tuning | 2026-06-08 |
+| Lilac↔Databricks name collision | primary | ycombinator.com/companies/lilac · databricks.com/blog | 2026-06-07 |
+
+## Prime Intellect — primeintellect.ai
+
+**Core offering [V]:** "The Open Stack for Self-Improving Agents." On-demand GPU
+**marketplace** aggregating GPUs across 50+ providers (1–256 GPUs, SLURM/K8s,
+InfiniBand), plus Liquid Reserved Clusters. Full post-training stack: **Lab** (hosted
+RL training), **Verifiers** (OSS RL-environment library), **Prime-RL** (large-scale
+async RL), **Environments Hub** (2,500+ open RL environments), Hosted Evaluations,
+and Deployments (inference with LoRA adapters).
+
+**RL story (the differentiator) [V]:**
+- **Verifiers** (MIT) — build an RL **environment** = dataset + harness (tools /
+  sandboxes / context mgmt) + reward/rubric, distributed as pip wheels. Native to the
+  Environments Hub; integrates with prime-rl and hosted training. Includes a minimal
+  `vf.RLTrainer` and plugs into other RL stacks.
+- **Prime-RL** — open framework for large-scale **asynchronous** RL; single-node →
+  1000+ GPUs; first-class **multi-turn / tool-use (agentic) RL**; covers synthetic
+  data → SFT → RL → eval.
+- **Lab** — hosted RL training without managing clusters.
+- **Renderers** [V] — a Python library that makes model chat templates programmable
+  objects, solving **tokenization drift** (re-rendered samples retokenize differently,
+  e.g. `false`→`False`) and preserving **multi-turn prefix continuity** via
+  `bridge_to_next_turn` (extends prior sampled tokens verbatim instead of re-rendering
+  history). Reports ~3× packing savings and clean loss-mask construction; used by both
+  `verifiers` (parsing) and `prime-rl` (token-native training). Directly relevant to
+  agentic/multi-turn RL correctness. (primeintellect.ai/blog/renderers)
+- Model-family agnostic; config examples reference Qwen (e.g. `Qwen3-30B-A3B`). A
+  GRPO-on-small-Qwen/Gemma job fits the verifiers + prime-rl path. [V] (An explicit
+  end-to-end GRPO-on-small-Gemma doc was **not** found — [U].)
+
+**Pricing [V/U]:** on-site tiles show **H100 $2.43/hr on-demand, $0.94/hr spot**; H200
+single-node $0.47–$1.99/hr; B300 $4.99/hr. A secondary "H100 $1.49 / A100 $0.79" did
+**not** match the site — do not quote; **A100/hr unconfirmed [U]**. Marketplace prices
+fluctuate.
+
+**OSS [V]:** verifiers (MIT) + prime-rl (open); open-weight **INTELLECT-1/2/3** models
+(INTELLECT-2 = first model trained via globally distributed RL; INTELLECT-3 = 106B MoE,
+~12B active, MIT, 131K ctx).
+
+**Route to Prime Intellect when** you need to *train* (not just infer) — especially
+multi-turn/agentic RL or GRPO — and want a reusable, open environment spec that scales
+from one GPU to a cluster, with an option to offload to a hosted Lab.
+
+Sources: https://www.primeintellect.ai/ · https://github.com/PrimeIntellect-ai/verifiers
+· https://github.com/PrimeIntellect-ai/prime-rl · https://github.com/PrimeIntellect-ai/renderers
+· https://www.primeintellect.ai/blog/renderers · https://www.primeintellect.ai/blog/environments
+· https://docs.primeintellect.ai/guides/rl-training · https://docs.primeintellect.ai/hosted-training/what-is-lab
+· https://docs.primeintellect.ai/verifiers/overview · https://huggingface.co/PrimeIntellect/INTELLECT-3
+
+---
+
+## Fireworks AI — fireworks.ai
+
+**Core offering [V]:** low-latency serverless + per-GPU-second dedicated deployments +
+fine-tuning + **managed reinforcement fine-tuning (RFT)**. It is a managed platform,
+**not** a raw GPU-cluster IaaS.
+
+**Fine-tuning / RL [V]:** LoRA + full-param SFT, DPO, and **self-serve GRPO-based RFT**
+(GA Nov 2025): define a reward/evaluator, run multi-turn agent rollouts in your own
+environment, train via GRPO, one-click deploy. Delta-compressed checkpoints (~98%
+smaller), sub-minute hot-loading. Base families: Llama, Qwen 2.5/3, Phi 3/4,
+DeepSeek V3/R1, Kimi K2. **Trajectory generation is built into the RFT training loop** —
+the integrated path when rollouts feed straight into training.
+
+**Pricing [V]:** on-demand GPU/hr **H100 $7.00 · H200 $7.00 · B200 $10.00 · B300 $12.00**
+(RFT billed per-GPU-second at the same rate). Fine-tuning per 1M training tokens (≤16B):
+LoRA SFT **$0.50** / LoRA DPO $1.00 / Full SFT $1.00 / Full DPO $2.00 (higher tiers up to
+>300B). Batch & cached input = 50% of serverless. **Per-token serverless rates are not on
+the pricing page** (deferred to docs) — [U].
+
+**Scaling / quotas [V]:** on-demand deployments **autoscale to 0 when idle**, bill **per
+GPU-second**, and throughput "scales with GPU allocation" (default 8 A100/H100, 100 LoRAs).
+Documented account limits: **6,000 RPM** account-wide fixed ceiling with credits (**10 RPM**
+without), and on on-demand an HTTP **429** "typically means deployment saturation (GPUs
+busy)," not a TPM-tier cap. Size for *effective* sustained throughput, not peak, when
+planning large rollout jobs (see `estimate-run-cost`
+[`reference.md`](../estimate-run-cost/reference.md) §3d).
+Sources: https://docs.fireworks.ai/faq/deployment/ondemand/billing-scaling (autoscale/billing)
+· https://docs.fireworks.ai/guides/quotas_usage/account-quotas (RPM ceiling + 429 meaning)
+
+**OSS [V]:** OpenAI-compatible API; open **Reward-kit** (reward/evaluator framework),
+`firectl` CLI, Firefunction models on HF.
+
+**Route to Fireworks when** you want to fine-tune *and* RL-train an open model with a
+reward function and serve it on the same platform — the closed RFT→serving loop with
+the least assembly.
+
+Sources: https://fireworks.ai/pricing · https://fireworks.ai/reinforcement-fine-tuning
+· https://fireworks.ai/blog/fireworks-rft · https://docs.fireworks.ai/fine-tuning/reinforcement-fine-tuning-models
+· https://docs.fireworks.ai/tools-sdks/openai-compatibility
+
+---
+
+## Together AI — together.ai
+
+**Core offering [V]:** broad AI-native cloud — serverless (per-token) + dedicated
+endpoints + **raw InfiniBand GPU clusters (8 → 4,000+ GPUs)** + a **Batch API**. LoRA +
+full SFT + DPO/preference fine-tuning that serves on a dedicated endpoint.
+
+**RL [V/U]:** **No self-serve RFT/GRPO product.** RL presence is research/infra: a
+"distribution-aware speculative decoding (DAS)" result (~April 2026) claiming up to 50%
+faster RL rollouts, plus PyTorch RL on rented clusters — you assemble the RL stack. A
+secondary note claimed GRPO/DPO on 70B needs ≥2×H100 — [U].
+
+**Batch / trajectory generation [V/U]:** **Batch API** at ~50% off serverless, separate
+rate-limit pool, up to **50,000 requests/batch**, 24h window, marketed for synthetic
+data + evals. Per-model enqueued-token limits cited inconsistently (10M/model vs 30B) —
+[U]. Best for a **standalone large rollout/synthetic-data job decoupled from training**,
+or run your own engine on raw clusters.
+
+**Pricing [V]:** serverless per 1M tok (in/out) — Llama 3 8B Lite $0.14/$0.14 · Llama 3.3
+70B $1.04/$1.04 · Gemma 4 31B $0.39/$0.97 · Qwen 2.5 7B Turbo $0.30/$0.30. Dedicated H100
+$6.49/hr; clusters on-demand H100 $5.49 (reserved $4.99). FT per 1M tok ≤16B SFT $0.48 /
+DPO $0.54. Some catalog variant names looked like scraping drift — [U].
+
+**OSS [V]:** OpenAI-compatible; large open-weight catalog; open **together-cookbook**;
+strong research publishing (FlashAttention lineage, DAS).
+
+**Route to Together when** you need breadth of compute under one roof — serverless +
+dedicated + raw clusters — to run your own training/rollout engine at scale, or a
+standalone large-batch trajectory job, often at a slightly lower GPU-hour price.
+
+Sources: https://www.together.ai/pricing · https://www.together.ai/batch-inference
+· https://docs.together.ai/docs/batch-inference · https://www.together.ai/fine-tuning
+· https://github.com/togethercomputer/together-cookbook
+
+---
+
+## Lilac — getlilac.com  (NOT the Databricks "Lilac" data tool)
+
+**Disambiguation [V]:** two unrelated companies share the name. **getlilac.com** (YC
+Summer 2025, founded 2025) is the **serverless inference provider** described here.
+**lilacml.com** is an open-source unstructured-data-curation tool **acquired by
+Databricks (March 2024)** — different entity, do not conflate.
+
+**Core offering [V]:** OpenAI-compatible inference API (`api.getlilac.com`, drop-in
+base-URL swap, prepaid). Routes inference to **idle enterprise GPUs already powered on**
+(clusters typically run 30–50% utilized), passing the savings to per-token price.
+
+**Models hosted, with on-site pricing [V]** (confirm input-vs-cache split live — [U]):
+
+| Model | Precision | $/M input | $/M output |
+|---|---|---|---|
+| Gemma 4 (31B) | BF16 | $0.11 | $0.35 |
+| MiniMax M2.7 | FP8 | $0.30 | $1.20 |
+| Kimi K2.6 | INT4 | $0.70* | $3.50 |
+| GLM 5.1 | FP8 | $0.90* | $3.00 |
+
+\* a second source listed lower input + a separate cache rate — verify on the live page.
+
+**Batch / trajectory throughput [U — NOT FOUND]:** as of 2026-06-07 the public inference
+docs (quickstart) document **no** batch API, async endpoint, or rpm/concurrency limits
+(verified by reading the docs). The trajectory-generation use case is **inferred** (fan
+out parallel chat-completion calls against a cheap OpenAI-compatible endpoint), **not an
+advertised feature**. **Confirm concurrency limits with the provider before a large
+rollout job** and design for retries/backoff on overload. (By contrast, Fireworks and
+Together publish concrete rate limits — see their entries above.)
+
+**OSS [V]:** getlilac/lilac is itself open-source (connect compute from any source);
+hosts open-weight families (GLM, Kimi/Moonshot, Gemma, MiniMax).
+
+**Route to Lilac when** you need cheap, fast, OpenAI-compatible inference of open-weight
+frontier models for a **small probe** or latency/cost comparison, and $/token matters
+more than guaranteed reserved throughput. Do **not** make it the default high-volume
+trajectory path until the provider confirms batch/concurrency support and retry/backoff
+behavior.
+
+Sources: https://getlilac.com/ · https://docs.getlilac.com/inference/quickstart
+· https://www.ycombinator.com/companies/lilac · https://github.com/getlilac/lilac
+
+---
+
+## GCP — cloud.google.com
+
+**Core offering:** hyperscaler IaaS — raw GPUs (A100-40GB/80GB, L4, H100) via Compute
+Engine, and managed training/serving via **Vertex AI** custom jobs and endpoints. You
+own the stack (drivers, orchestration, the RL/SFT framework); there is no turnkey RFT
+product. GPU availability is **per-region quota** and often must be requested; spot
+(preemptible) classes are cheaper but interruptible. For bursty inference / trajectory
+generation without managing VMs, **Cloud Run GPU** offers serverless GPU containers that
+scale to zero (https://docs.cloud.google.com/run/docs/configuring/services/gpu).
+
+**Route to GCP when** you already hold quota, credits, or have data-residency / Vertex
+integration needs, and are comfortable managing the training stack yourself — versus a
+purpose-built RL platform (Prime Intellect) or managed RFT (Fireworks).
+
+Pricing varies by region/commitment; quote from the live GCP pricing pages
+(https://cloud.google.com/compute/gpus-pricing , https://cloud.google.com/vertex-ai/pricing)
+rather than a cached number.
+
+---
+
+## Azure / Microsoft Foundry — azure.microsoft.com / learn.microsoft.com
+
+**Core offering [V]:** hyperscaler GPUs via Azure Virtual Machines plus managed model
+customization through Microsoft Foundry / Azure OpenAI. Azure NCads H100 v5 VMs are
+documented for Applied AI training and batch inference workloads, with 1× or 2×
+NVIDIA H100 NVL GPUs (94 GB each) and up to 640 GiB system memory.
+
+**Fine-tuning / RFT [V]:** Microsoft Foundry documents SFT, DPO, and RFT support by
+model. Current docs list SFT/DPO across GPT-4o/GPT-4.1 families, RFT for selected
+reasoning/frontier models, and several open-source models for SFT in Foundry. Access,
+regions, model availability, and deployment permissions are quota/RBAC-gated, so verify
+the specific subscription and region before planning a run.
+
+**Route to Azure when** Microsoft credits, quota, enterprise/data-boundary constraints,
+or existing Foundry/OpenAI integration dominate the decision. Treat it like GCP for raw
+GPU work: good if you already have quota/credits and can manage the stack, weaker as a
+default than Prime/Fireworks when you want a purpose-built RL/RFT workflow.
+
+Pricing varies by region, VM family, commitment, and credits. Quote from the live Azure
+pricing calculator or portal before spend.
+
+Sources: https://learn.microsoft.com/azure/virtual-machines/ncads-h100-v5
+· https://learn.microsoft.com/azure/foundry/openai/how-to/fine-tuning
+· https://devblogs.microsoft.com/foundry/whats-new-in-foundry-finetune-april-2026/
+
+---
+
+## Putting it together — the RL pipeline pattern
+
+1. **Generate rollouts / trajectories** cheaply: Together Batch for published batch
+   semantics, Fireworks when rollouts feed directly into managed RFT, or Lilac only
+   after provider-confirmed concurrency for the target volume.
+2. **Train** (GRPO / agentic RL): Prime Intellect (verifiers + prime-rl/Lab) or
+   Fireworks managed RFT.
+3. **Serve** the result: Fireworks/Together (managed) or your own GCP/cluster endpoint.
+
+Generation, training, and serving can each live on a different vendor — pick per stage
+by the strengths above, and always re-verify pricing before committing spend.

--- a/skills/estimate-run-cost/SKILL.md
+++ b/skills/estimate-run-cost/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: estimate-run-cost
+description: Use when a developer asks how long an ML job will take and what it will cost — fine-tuning/SFT, RL training, batch inference, or RL trajectory generation — comparing local Apple-Silicon (MLX) against cloud GPU and serverless. Produces a wall-clock + dollar estimate and a local-vs-cloud recommendation before any spend. Pairs with choose-cloud-provider for where to run it.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Estimate Run Cost
+
+Answer two questions before a developer spends anything: **how long will this run,
+and what will it cost** — local (Apple Silicon / MLX) versus cloud (rented GPU or
+serverless). The goal is a defensible back-of-envelope with explicit assumptions,
+not a precise quote. Always show the inputs and the arithmetic so the estimate can
+be checked and re-run when a number changes.
+
+This skill estimates and recommends. It never provisions, rents, or spends — that
+is always an explicit, separate user action. For *where* to run a job once the
+numbers point to cloud, hand off to
+[`choose-cloud-provider`](../choose-cloud-provider/SKILL.md).
+
+## When to use
+
+- "How long will fine-tuning / SFT / an RL run take on my Mac vs a rented GPU?"
+- "What will it cost to generate N RL trajectories?" (policy rollouts at scale)
+- "Is this cheaper to run locally or in the cloud?"
+- Before any [`prepare-verifier-handoff`](../prepare-verifier-handoff/SKILL.md) or
+  remote run, to size the spend.
+
+Not for: choosing a model (see [`compare-model-sweep`](../compare-model-sweep/SKILL.md)),
+or running the job itself.
+
+## Safety Gates
+
+- **Estimate only — never spend.** This skill does not rent GPUs, start jobs, or
+  call paid APIs. Provisioning and spending are separate, explicit user actions.
+- **Label every number.** Mark each input as *measured* (benchmarked on this
+  machine / quoted from a live price page) or *assumed* (rule-of-thumb). An
+  estimate built on assumptions must say so.
+- **Prefer a measured local datapoint** over a generic benchmark when the hardware
+  is available: a 2-minute throughput probe (tokens/sec on the actual machine)
+  beats a number from someone else's M-series. See `reference.md`.
+- **No silent staleness.** Cloud prices and serverless rates drift; cite the source
+  and date of every dollar figure, and flag when a cited number may be out of date.
+- **Range, not false precision.** Report a low/high band, not a single number, and
+  name the dominant uncertainty (usually MFU for training, throughput for rollouts).
+
+## Inputs to gather
+
+Ask only for what the job type needs:
+
+- **Job type**: SFT/LoRA, full fine-tune, RL (GRPO/DPO), batch inference, or RL
+  trajectory generation.
+- **Model**: parameter count N and quant (sets memory + per-token compute).
+- **Data size**: training tokens D (≈ examples × avg tokens × epochs), or for
+  inference/rollouts: num_prompts × rollouts × avg output tokens.
+- **Hardware on hand**: chip + unified memory (local), or target GPU (cloud). The
+  Understudy profile at `~/.understudy/profile.json` often has the local machine.
+
+## The estimate
+
+Two engines, picked by job type. Full constants, benchmarks, and cited prices live
+in [`reference.md`](reference.md); the methodology is here.
+
+### Compute-bound work (training / fine-tuning)
+
+1. **FLOPs** ≈ `6 × N × D` (forward+backward; the standard 6ND approximation —
+   `reference.md` cites the origin). LoRA reduces the *trainable* params but the
+   forward/backward still flows through the full model, so use full N for wall-clock.
+2. **Wall-clock** ≈ `FLOPs / (GPU_peak_FLOPS × MFU)`. Use realized MFU ~0.3–0.5,
+   not peak. State the GPU's BF16 dense FLOPS from `reference.md`.
+3. **Local (MLX)** has no published MFU; instead use a measured tokens/sec from
+   `mlx_lm.lora` (or the probe) and `wall-clock ≈ D / throughput`.
+4. **Cost** = `wall-clock_hours × $/GPU-hour` (cloud) or **$0** (local, already-owned).
+
+### Throughput-bound work (inference / RL trajectory generation)
+
+1. **Total output tokens** = `num_prompts × rollouts × avg_output_tokens` (+ input
+   tokens if a per-token rate charges for them).
+2. **Serverless** cost = `total_tokens × $/token` (from a provider price page). Fast
+   to start, no idle cost, but per-token adds up at scale.
+3. **Rented deployment** cost = `(total_tokens / sustained_throughput) × $/GPU-hour`.
+   Wins above a crossover volume because you amortize a flat hourly rate. `reference.md`
+   shows how to find the crossover.
+4. **Local (MLX)** cost = **$0** but bounded by one machine's tokens/sec — fine for
+   thousands of rollouts, slow for millions. Compute the wall-clock and let the
+   developer judge if the time is acceptable.
+
+### Decide
+
+Present **local vs cloud side by side**: wall-clock and dollars for each, with the
+band and the dominant assumption. Recommend local when it's free and the wall-clock
+is tolerable; recommend cloud when local wall-clock is the blocker (typical for RL
+training and large-scale rollouts — see the Understudy local-SFT / cloud-RL split).
+When the answer is cloud, hand to [`choose-cloud-provider`](../choose-cloud-provider/SKILL.md).
+
+## Output Standard
+
+A short estimate block the developer can audit:
+
+- **Job**: type, N, D (or token volume), hardware.
+- **Local**: wall-clock band, $0, and whether the time is tolerable.
+- **Cloud**: wall-clock band, $ band, on which GPU/provider, with cited $/hr or $/token.
+- **Assumptions**: every *assumed* input, MFU/throughput used, and source+date of each price.
+- **Recommendation**: local / cloud / hybrid, plus the single number that would
+  most change the answer if re-measured.
+
+## References
+
+- [`reference.md`](reference.md) — cited GPU FLOPS, $/GPU-hour and $/token tables,
+  MLX/Apple-Silicon throughput benchmarks, the 6ND + MFU derivation, the
+  serverless-vs-rented crossover, and a worked RL-trajectory example. Its **Source
+  freshness** table dates and source-types every outside-party number so an agent can
+  re-verify and flag stale docs.
+- [`choose-cloud-provider`](../choose-cloud-provider/SKILL.md) — where to run cloud work.

--- a/skills/estimate-run-cost/reference.md
+++ b/skills/estimate-run-cost/reference.md
@@ -1,0 +1,228 @@
+# Estimate Run Cost — reference
+
+Cited numbers and worked math for [`SKILL.md`](SKILL.md). Compiled **2026-06-07**.
+Tags: **[MEASURED]** real benchmark / live rate · **[SPEC]** vendor datasheet ·
+**[ESTIMATE]** rule-of-thumb. **Cloud and per-token prices drift monthly — re-fetch
+the live pricing page before quoting.** Where an aggregator disagreed with a vendor's
+own page, the vendor page wins.
+
+## Re-verify here (don't hard-code prices)
+
+- https://cloud.google.com/compute/gpus-pricing · https://www.runpod.io/pricing
+  · https://azure.microsoft.com/pricing/calculator/ · https://www.primeintellect.ai/
+  · https://www.runpod.io/pricing · https://lambda.ai/pricing · https://www.together.ai/pricing
+  · https://fireworks.ai/pricing · https://getlilac.com/
+- Apple-Silicon throughput: https://github.com/ggml-org/llama.cpp/discussions/4167
+  · LoRA: https://github.com/ml-explore/mlx-examples/blob/main/lora/README.md
+
+---
+
+## Source freshness (for maintenance)
+
+Every figure below references an outside party and **will drift**. Each row carries a
+source-type and a **Checked** date so an agent can re-verify and bump it. Source types:
+**primary** (vendor's own page / datasheet / first-party repo), **aggregator** (third-party
+price tracker), **blog** (third-party write-up). Treat any row **Checked > ~90 days** ago,
+or any **aggregator/blog** row, as verify-before-quoting. To maintain: re-fetch the URL,
+confirm the value, bump Checked — or flag drift.
+
+| What we cite | Source type | URL | Checked |
+|---|---|---|---|
+| Apple-Silicon decode tok/s (§1a) | primary (community bench) | github.com/ggml-org/llama.cpp/discussions/4167 | 2026-06-07 |
+| MLX-specific tok/s (§1a) | blog | sitepoint.com/local-llms-apple-silicon-mac-2026 | 2026-06-07 |
+| MLX LoRA train tok/s (§1b) | primary | github.com/ml-explore/mlx-examples (lora/README) | 2026-06-07 |
+| GCP GPU $/hr (§2a) | **aggregator** (primary page JS-rendered) | gpucost.org/provider/gcp → verify cloud.google.com/compute/gpus-pricing | 2026-06-07 |
+| GCP Cloud Run GPU (§2a) | primary | docs.cloud.google.com/run/docs/configuring/services/gpu | 2026-06-08 |
+| Azure H100 VM / Foundry pricing (§2a) | primary docs + live calculator | learn.microsoft.com/azure/virtual-machines/ncads-h100-v5 · azure.microsoft.com/pricing/calculator | 2026-06-08 |
+| RunPod / Lambda $/hr (§2b) | primary | runpod.io/pricing · lambda.ai/pricing | 2026-06-07 |
+| CoreWeave $/hr (§2b) | secondary | coreweave.com/pricing | 2026-06-07 |
+| Marketplace spot floors (§2b) | **aggregator** | spheron.network · aimultiple.com/gpu-marketplace | 2026-06-07 |
+| Prime Intellect H100 $/hr (§2b) | primary | primeintellect.ai | 2026-06-07 |
+| Together serverless/GPU $ (§2c) | primary | together.ai/pricing | 2026-06-07 |
+| Fireworks GPU $ / FT $ (§2c) | primary | fireworks.ai/pricing | 2026-06-07 |
+| Fireworks per-token tiers (§2c) | secondary | tokenmix.ai + fireworks docs | 2026-06-07 |
+| Lilac model $ (§2c) | primary | getlilac.com | 2026-06-07 |
+| Lilac batch/concurrency (§3d) | **not documented** | docs.getlilac.com | 2026-06-07 |
+| Fireworks RPM / 429 (§3d) | primary | docs.fireworks.ai/guides/quotas_usage/account-quotas | 2026-06-07 |
+| Together rate-limits (§3d) | primary | docs.together.ai/docs/rate-limits | 2026-06-07 |
+| NVIDIA H100/A100 FLOPS (§3b) | primary (datasheet) | nvidia.com H100/A100 datasheets | 2026-06-07 |
+| 6ND / MFU method (§3a) | primary (papers) | arxiv.org/abs/2203.15556 | 2026-06-07 |
+
+## 1. Local — Apple Silicon / MLX
+
+### 1a. Inference decode throughput (tok/s) [MEASURED]
+
+llama.cpp Apple-Silicon thread, **LLaMA-7B Q4_0**, text-generation (decode):
+
+| Chip (GPU cores) | tok/s decode |
+|---|---|
+| M1 Max (32) | 61 |
+| M2 Max (38) | 66 |
+| M3 Max (40) | 66 |
+| M4 Max (40) | 83 |
+| M2 Ultra (76) | 94 |
+| M3 Ultra (80) | 92 |
+
+Prefill ≫ decode (M4 Max ~886 tok/s prefill @512-batch vs 83 decode). MLX is ~20–87%
+faster than llama.cpp for sub-14B generation; Llama-8B 4-bit ~72 tok/s on M3 Max; tiny
+3B models can exceed ~1,100 tok/s on M4 Max (bandwidth-bound).
+Sources: github.com/ggml-org/llama.cpp/discussions/4167 ; sitepoint.com/local-llms-apple-silicon-mac-2026
+
+> **M5 flag:** M5-generation numbers are **not yet** in the canonical benchmark table.
+> Treat any M5 throughput as **unverified** — run a probe (below) instead of assuming.
+
+### 1b. LoRA/QLoRA fine-tuning throughput [MEASURED]
+
+`mlx-examples` LoRA (Llama-7B, WikiSQL): **~475 tok/s on M2 Ultra**, **~250 tok/s on
+M1 Max (32GB)**; reference run 1000 iters, val loss 2.659→1.230. Use these as the
+anchor, not looser blog estimates. Apple-Silicon training is far below an H100 — plan
+**hours-to-days** for non-trivial datasets.
+Source: github.com/ml-explore/mlx-examples/blob/main/lora/README.md
+
+### 1c. Memory rule of thumb [ESTIMATE]
+
+- **Model GB ≈ N(B params) × bytes/param**; bytes/param = 2.0 (BF16), 1.0 (8-bit),
+  ~0.5 (4-bit). A 7–8B model ≈ 14–16 GB BF16, ~8 GB int8, **~4–5 GB 4-bit**.
+- **QLoRA** 7B ≈ ~7 GB (4-bit base + adapter) vs ~14 GB plain LoRA.
+- **Unified-memory ceiling:** weights + KV-cache + activations + OS must fit. Keep the
+  model under ~60–70% of RAM. 16 GB runs a 4-bit 7–8B; ~128 GB to QLoRA up to ~70B.
+
+### 1d. The 2-minute local probe (beats any generic number)
+
+Measure tok/s on the actual machine before estimating: serve the target model with
+`mlx_lm.server`, send a fixed prompt, divide generated tokens by elapsed seconds. Use
+that as the local throughput in §3. For training, run ~50 `mlx_lm.lora` iters and read
+the reported tok/s.
+
+---
+
+## 2. Cloud pricing ($/GPU-hour) [MEASURED — snapshots, verify live]
+
+### 2a. Hyperscalers — GCP / Azure (VMs may bill more than GPU component)
+
+**GCP** [aggregator, checked 2026-06-07]:
+
+| GPU | On-demand | Spot |
+|---|---|---|
+| H100 80GB (A3) | $9.80 | $2.25 |
+| A100 80GB (A2) | $3.93 | $1.57 |
+| A100 40GB (A2) | $2.93 | $1.15 |
+| L4 (G2) | $0.56 | $0.22 |
+
+Source: gpucost.org/provider/gcp — cross-check cloud.google.com/compute/gpus-pricing.
+GCP often bills the whole VM (e.g. a3-highgpu-1g ≈ $11/hr incl. host).
+For serverless managed-container inference, Cloud Run GPU supports GPU services that
+scale to zero; verify live region/GPU availability and pricing before using it for
+rollouts.
+
+**Azure / Microsoft Foundry** [primary docs, checked 2026-06-08]:
+NCads H100 v5 VMs are documented for Applied AI training and batch inference workloads
+with 1× or 2× NVIDIA H100 NVL GPUs (94 GB each). Pricing is region/subscription/credit
+dependent; quote from the live Azure pricing calculator or portal, not this document.
+Foundry/OpenAI fine-tuning and RFT costs depend on model, region, and access tier.
+
+### 2b. GPU-rental marketplaces (most volatile category)
+
+| GPU | RunPod (community) | Lambda | CoreWeave | Marketplace spot floor |
+|---|---|---|---|---|
+| H100 SXM | $3.29 | $4.29 (→$3.99 @8×) | ~$4.25 PCIe | ~$1.03 |
+| A100 80GB | $1.49 | $1.99 | ~$2.21 PCIe | ~$0.60 |
+| A100 40GB | — | $1.99 | — | — |
+| L40S 48GB | $0.86 | — | — | — |
+
+Sources: runpod.io/pricing ; lambda.ai/pricing ; coreweave.com/pricing ;
+spheron.network/blog/gpu-cloud-pricing-comparison-2026 ; primeintellect.ai.
+Spot floors are best-case, not guaranteed. Prime Intellect on-site: H100 $2.43
+on-demand / $0.94 spot.
+
+### 2c. Serverless per-token (per 1M tokens, in/out) [MEASURED]
+
+- **Together:** Llama-3.3-70B $1.04/$1.04 · Llama-3.x-8B Lite $0.14/$0.14 ·
+  Qwen2.5-7B Turbo $0.30/$0.30 · Gemma 4 31B $0.39/$0.97. Dedicated H100 $6.49/hr.
+- **Fireworks:** ≤16B tier ~$0.20 · >16B tier ~$0.90. On-demand H100 $7.00/hr. LoRA
+  SFT $0.50/1M tok (≤16B).
+- **Lilac (getlilac):** Gemma 4 31B $0.11/$0.35 · Kimi K2.6 $0.70/$3.50 · GLM 5.1
+  $0.90/$3.00 (verify input-vs-cache split live). Batch/concurrency is not publicly
+  documented; treat it as a probe path until confirmed.
+
+Sources: together.ai/pricing ; fireworks.ai/pricing ; getlilac.com.
+**Drift flag:** Together's live rates rose vs older blog citations ($0.88→$1.04 for
+70B) — use the live page.
+
+---
+
+## 3. Methodology (the math)
+
+### 3a. Training compute — the 6ND rule [ESTIMATE]
+
+**C ≈ 6 × N × D** FLOPs (N params, D tokens; 2 fwd + 4 bwd FLOPs/param/token). Origin:
+Kaplan et al. 2020; Chinchilla (Hoffmann 2022) adds compute-optimal D/N ≈ 20.
+LoRA reduces *trainable* params but fwd/bwd still flow through full N — use full N for
+wall-clock. Sources: arxiv.org/abs/2203.15556 ; en.wikipedia.org/wiki/Neural_scaling_law
+
+**Wall-clock:** `time = (6 × N × D) / (num_GPUs × peak_FLOPS × MFU)`.
+
+### 3b. Realistic GPU FLOPS [SPEC] — use *dense*, halve marketing sparse
+
+| GPU | BF16 dense | (2:4 sparse marketing) |
+|---|---|---|
+| H100 SXM5 | **989 TFLOPS** | 1,979 |
+| H100 PCIe | 756 TFLOPS | 1,513 |
+| A100 40/80GB | **312 TFLOPS** | 624 |
+
+Sources: NVIDIA H100/A100 datasheets. **MFU (Model FLOPs Utilization)** = achieved ÷
+peak; realistic **0.3–0.5** (Llama-3.1 ~38–43% on H100; 8B on A100 ~31%). After MFU,
+an H100 realizes ~300–500 dense TFLOPS — "about half of marketing."
+Sources: medium.com/better-ml/using-model-flops-utilization-mfu-7b17de07faec
+
+### 3c. Inference → wall-clock → $
+
+- **Wall-clock** = `total_tokens / throughput_tok_s` (local: §1a/probe; cloud: deployment benchmark).
+- **Serverless $** = `(in_tok × $/M_in + out_tok × $/M_out) / 1e6` (§2c).
+- **Rented GPU $** = `(total_tokens / throughput_tok_s / 3600) × $/GPU-hr` (§2a/2b).
+
+### 3d. RL trajectory generation + the crossover [ESTIMATE]
+
+`total_tokens = num_prompts × rollouts × avg_tokens_per_trajectory`.
+
+- **Serverless** = `total_tokens × per-token-rate` — wins for small/bursty jobs (no idle, no warmup).
+- **Rented deployment** = `(total_tokens / sustained_throughput) × $/GPU-hr` — wins
+  only when you keep the box highly utilized. Break-even where
+  `per-token-rate × throughput_tok_s × 3600 ≈ $/GPU-hr`.
+
+> **Effective ≠ peak throughput.** Providers publish request rate limits and return
+> **429** when exceeded, so a large rollout rarely sustains headline tok/s. Documented
+> examples (verify live): **Fireworks** caps account-wide requests at **6,000 RPM**
+> (10 RPM without credits) and returns 429 on deployment saturation
+> (https://docs.fireworks.ai/guides/quotas_usage/account-quotas); **Together** uses
+> **dynamic** per-model limits — read the `x-ratelimit-reset` header and pace ~1 RPS
+> rather than bursting (https://docs.together.ai/docs/rate-limits). Estimate with
+> *effective* throughput, add retries/backoff, and **shard across jobs rather than
+> cranking per-job concurrency**.
+
+**Worked example.** Together Llama-8B serverless ≈ $0.14/M = $1.4e-7/token. A RunPod
+H100 at ~$3.29/hr (§2b) serving Llama-8B at ~2,500 tok/s sustained →
+$3.29 / (2500 × 3600) ≈ **$3.7e-7/token** — *more* than serverless, because serverless
+batches across tenants. The rented box wins only if you sustain higher batched
+throughput, need a model/quant no serverless host offers, or run enormous sustained
+volume. **Always compute both with the deployment's *measured* throughput — don't
+assume the rented GPU is cheaper.**
+
+---
+
+## 4. Worked local-vs-cloud examples
+
+**SFT cold-start, ~4B model, 1k long trajectories (~8k tok each), 3 epochs (D≈24M tok):**
+- Local M-series (LoRA ~250–475 tok/s [MEASURED §1b]): 24e6 / 350 ≈ **~19 hr, $0** —
+  overnight, free, but slow. (M5 throughput unverified — probe to confirm.)
+- Cloud A100-80GB spot ($1.57/hr GCP [§2a], down to ~$0.60 marketplace floor [§2b]):
+  same job far faster; even at 10× the local tok/s, ~2 hr × ~$1.57 ≈ **~$3**. The trade
+  is dollars-for-hours.
+
+**Generate 50k RL trajectories, ~2k tok each (D≈100M tok):**
+- Serverless Llama-8B @ $0.14/M: 100 × $0.14 ≈ **~$14**, no infra.
+- Cheap open-weight via Lilac Gemma 4 31B @ $0.11/$0.35: dominated by output tokens.
+- Local M-series @ ~80 tok/s decode: 100e6 / 80 ≈ ~347 hr — **impractical** for this volume.
+
+Pattern: **SFT → local is the free, tolerable-time path; large-scale generation and RL
+training → cloud**, matching the Understudy local-SFT / cloud-RL split.


### PR DESCRIPTION
## What

Two OSS skills for deciding **where** to run hosted ML work and **how long / how much** it'll take.

### `estimate-run-cost`
Wall-clock + dollar estimates for SFT, RL training, batch inference, and RL trajectory generation — **local Apple Silicon (MLX) vs cloud GPU/serverless**. Estimate-only; never provisions or spends. `reference.md` carries cited GPU FLOPS (dense, not marketing-sparse), `$/GPU-hour` and `$/token` tables, MLX throughput benchmarks, the `6ND` + MFU training math, and the serverless-vs-rented crossover with a worked example showing the rented GPU often *loses* to serverless batching.

### `choose-cloud-provider`
A routing catalog mapping job shape → provider strength: **GCP, Prime Intellect, Fireworks, Together AI, Lilac (getlilac)**. Each gets a "route to X when…" line and a verify-live-pricing gate. Resolves the **getlilac.com vs Databricks-"Lilac"** name collision; surfaces the decisive axes (managed RFT vs raw clusters vs cheap per-token rollouts) and the generate-on-one / train-on-another pipeline.

## Provenance discipline
- **Every third-party claim is doc-cited or explicitly flagged.** Rate-limit/429 behavior is backed by the providers' own quota docs (Fireworks account-quotas: 6,000 RPM ceiling, 429 = deployment saturation; Together rate-limits: dynamic per-model, `x-ratelimit-reset`) — no anecdotes.
- **Dated `Source freshness` table** in each `reference.md`: every outside-party fact carries a source-type (primary / secondary / aggregator / blog / unverified), its URL, and a `Checked: 2026-06-07` date, with a convention for an agent to re-verify and flag drift.
- **Primary-vs-aggregator audit:** GCP per-GPU pricing marked `[aggregator]` (primary page is JS-rendered, won't extract), spot floors `[aggregator]`, CoreWeave `[secondary]`, Fireworks per-token tiers `[unverified]`; vendor pages / NVIDIA datasheets / mlx-examples / llama.cpp bench labeled `[primary]`.

## Checks
- `npm run check` green: build, typecheck, 67/67 tests, `skills:validate` (28 skills), cookbook, package smoke. CI `gates` ✅.
- Public-safety scan clean — no private terms; examples reference only public provider docs.

## Commits
1. Add the two skills.
2. Back rate-limit/429 claims with provider docs, not anecdote.
3. Add dated source-freshness tables + primary/aggregator audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)