### PR TITLE
From Research-side of house: fold learnings into RL-signal, verifiers-env, and key-handling skills

### DIFF
--- a/skills/choose-frontier-keys/SKILL.md
+++ b/skills/choose-frontier-keys/SKILL.md
@@ -68,6 +68,27 @@ frontier routes:
    `.understudy/frontier-choice.json` or
    `~/.understudy/agent-tools/install-state/frontier-choice`.
 
+## Pushing a secret to remote infra
+
+When a run needs a key on a remote box (a training GPU), or a firewall / IAM
+change, the agent is correctly blocked from writing secrets to remote machines or
+mutating cloud security — and pasting a key into a command leaks it into
+transcripts / process args. Instead, hand the user a one-liner they run themselves
+(`!`-prefixed so the result is visible), reading the secret from a local source and
+piping it over SSH stdin so the value is never printed:
+
+```bash
+KEY=$(security find-internet-password -s <service> -w)   # or a parsed local .env / keychain
+printf 'export NAME=%s\n' "$KEY" \
+  | gcloud compute ssh BOX --command 'umask 077; cat > ~/.run_env; echo "wrote $(wc -c < ~/.run_env) bytes"'
+```
+
+Same shape for security changes the agent shouldn't make directly — generate the
+exact command, let the user run it:
+`gcloud compute firewall-rules update …`,
+`gcloud storage buckets add-iam-policy-binding …`,
+`modal secret create …`. Report only byte counts / success, never the value.
+
 ## Installer Mapping
 
 The public installer exposes the same choice:

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -98,6 +98,27 @@ experimentation" — Prime Intellect, https://www.primeintellect.ai/blog/environ
 That's why building it well — and validating it cheaply via eval *before* any GPU —
 pays off across all of them.
 
+**Four LEGO blocks (dataset · parser · rubric · rollout).** A `verifiers` env snaps
+together from four independently-swappable pieces (Will Brown / Prime Intellect):
+
+- **Dataset** — the tasks: `prompt` + gold `answer` + per-example `info`.
+- **Rollout** — the harness / the "world": tools, turn budget, how state flows.
+- **Parser** — turns raw model output into actions/answer (tool-call extraction,
+  final-answer pull).
+- **Rubric** — the reward: scoring function(s) + weights. The metric, not the trajectory.
+
+The payoff is the seams — swap one brick, keep the rest: swap the **dataset** → new
+task; swap the model in the **rollout** → model comparison on the *same* harness;
+add a **rubric** function → reward something new; change the **consumer** → the same
+env runs as eval, RL training, or synthetic-data gen (one env, many uses). This is
+why the env is the durable asset and the trainer/model are swap-in bricks — how a
+run can change model (e.g. Gemma-4 → Nemotron-3) or trainer (eval → prime-rl)
+*without rebuilding the env*.
+
+Caveat: the bricks look independent, but the **parser must match the model** (and
+the trainer's renderer must too) — that's the seam that breaks on a new model arch.
+When you swap the model brick, re-check the parser/renderer.
+
 When the env is built as an actual `verifiers` Environment (the form
 [`author-rl-env`](../author-rl-env/SKILL.md) / `package-verifier-env` consume),
 these API facts save real trial — verified against the `verifiers` library v0.1.14

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -91,11 +91,17 @@ criteria (recall / precision / policy — not just cost/speed).
 
 ## Running it as a real `verifiers` env
 
+One env, many uses: the *same* `verifiers` Environment serves eval, RL training,
+synthetic-data generation, and agent-harness experimentation ("playgrounds for RL
+training, evaluation benchmarking, synthetic data generation, and agent-harness
+experimentation" — Prime Intellect, https://www.primeintellect.ai/blog/environments).
+That's why building it well — and validating it cheaply via eval *before* any GPU —
+pays off across all of them.
+
 When the env is built as an actual `verifiers` Environment (the form
 [`author-rl-env`](../author-rl-env/SKILL.md) / `package-verifier-env` consume),
-these API facts save real trial — verified against the `verifiers` library
-v0.1.14 (Prime Intellect / `willccbb/verifiers`; APIs move, so re-check the
-pinned version):
+these API facts save real trial — verified against the `verifiers` library v0.1.14
+(https://github.com/PrimeIntellect-ai/verifiers ; APIs move, re-check the pin):
 
 - `vf.ToolEnv(tools=[fns], max_turns=, **kwargs)` — `dataset`, `rubric`,
   `system_prompt` pass through `**kwargs` to `MultiTurnEnv`; tools are plain

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -93,7 +93,9 @@ criteria (recall / precision / policy — not just cost/speed).
 
 When the env is built as an actual `verifiers` Environment (the form
 [`author-rl-env`](../author-rl-env/SKILL.md) / `package-verifier-env` consume),
-these API facts (verifiers 0.1.14) save real trial:
+these API facts save real trial — verified against the `verifiers` library
+v0.1.14 (Prime Intellect / `willccbb/verifiers`; APIs move, so re-check the
+pinned version):
 
 - `vf.ToolEnv(tools=[fns], max_turns=, **kwargs)` — `dataset`, `rubric`,
   `system_prompt` pass through `**kwargs` to `MultiTurnEnv`; tools are plain

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -89,6 +89,32 @@ criteria (recall / precision / policy — not just cost/speed).
    ([`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md))
    and the route decision ([`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md)).
 
+## Running it as a real `verifiers` env
+
+When the env is built as an actual `verifiers` Environment (the form
+[`author-rl-env`](../author-rl-env/SKILL.md) / `package-verifier-env` consume),
+these API facts (verifiers 0.1.14) save real trial:
+
+- `vf.ToolEnv(tools=[fns], max_turns=, **kwargs)` — `dataset`, `rubric`,
+  `system_prompt` pass through `**kwargs` to `MultiTurnEnv`; tools are plain
+  functions (type hints + docstring → auto tool schema).
+- **Tools are stateless** — a tool gets only its JSON args, not the dataset row.
+  For per-example scoping (each task targets a different account/inbox), subclass
+  ToolEnv and override `env_response(messages, state)` to set a **contextvar** from
+  `state["info"]` before `super().env_response(...)`; tools read the contextvar
+  (concurrency-safe across parallel rollouts).
+- Dataset rows: `question` + `answer` + `info` (dict); verifiers derives `prompt`
+  and `example_id`. Final answer = last assistant message with text (no submit
+  tool; the episode ends when the model stops calling tools).
+- Rubric: `vf.Rubric(funcs=[...], weights=[...])`; reward funcs take kwargs
+  `(prompt, completion, answer, state, ...)` — pull what you need by name.
+- Eval: `env.evaluate` is a **coroutine** — use `evaluate_sync` for blocking calls,
+  and pass a verifiers **`ClientConfig`** (a raw `openai.OpenAI` raises
+  "Unsupported client type"): `ClientConfig(client_type="openai_chat_completions",
+  api_key_var="<ENV_VAR_NAME>", api_base_url="<…/v1>")` — `api_key_var` is the
+  env-var *name* (default `PRIME_API_KEY`). Pointed at the Understudy gateway this
+  runs a full rollout+reward eval on CPU for pennies — strong pre-GPU validation.
+
 ## Output Standard
 
 End with: the seeded fixtures and gold set; the tool classes simulated; the

--- a/skills/design-simulated-environment/reference.md
+++ b/skills/design-simulated-environment/reference.md
@@ -1,0 +1,48 @@
+# Design Simulated Environment Reference
+
+This reference backs the long-form implementation notes in `SKILL.md`.
+
+## `verifiers` Environment Notes
+
+The same `verifiers` environment can serve eval, RL training, synthetic-data
+generation, and agent-harness experimentation. Build it well once, validate it
+cheaply with eval before any GPU run, then reuse the environment across trainer
+and model swaps.
+
+Useful implementation shape:
+
+- Dataset: tasks with `prompt`, gold `answer`, and per-example `info`.
+- Rollout: the simulated world, tools, turn budget, and state flow.
+- Parser: raw model output to tool actions or final answer.
+- Rubric: reward functions and weights. The metric is final-state quality, not
+  trajectory matching.
+
+These pieces are independently swappable, but parser and renderer compatibility
+must be rechecked when changing model families. That is the failure mode this
+skill is meant to catch before a hosted RL run.
+
+## API Facts To Recheck
+
+These details were verified against `verifiers` v0.1.14 and should be rechecked
+when the dependency pin changes:
+
+- `vf.ToolEnv(tools=[...], max_turns=, **kwargs)` passes `dataset`, `rubric`,
+  and `system_prompt` through to `MultiTurnEnv`.
+- Tool functions are stateless. For per-example scoping, subclass `ToolEnv`,
+  override `env_response(messages, state)`, set a context variable from
+  `state["info"]`, then call `super().env_response(...)`.
+- Dataset rows use `question`, `answer`, and `info`; `verifiers` derives the
+  prompt and example id.
+- `vf.Rubric(funcs=[...], weights=[...])` reward functions can take named
+  kwargs such as `prompt`, `completion`, `answer`, and `state`.
+- `env.evaluate` is async. Use `evaluate_sync` for blocking calls and pass a
+  `ClientConfig`; do not pass a raw client object.
+
+## Sources
+
+- Prime Intellect Environments Hub:
+  https://www.primeintellect.ai/blog/environments
+- `verifiers` source project:
+  https://github.com/PrimeIntellect-ai/verifiers
+- Will Brown / Prime Intellect environment framing:
+  https://github.com/willccbb/verifiers

--- a/skills/rlm-pedagogical-training/SKILL.md
+++ b/skills/rlm-pedagogical-training/SKILL.md
@@ -174,16 +174,20 @@ switch trainers.
 Original papers (theory):
 
 - GRPO / within-group advantage normalization — Shao et al., *DeepSeekMath*,
-  arXiv:2402.03300; DeepSeek-AI, *DeepSeek-R1*, arXiv:2501.12948.
+  https://arxiv.org/abs/2402.03300 ; DeepSeek-AI, *DeepSeek-R1*,
+  https://arxiv.org/abs/2501.12948
 - Reward shape governs learnability — Ng, Harada & Russell, *Policy Invariance
-  Under Reward Transformations*, ICML 1999.
-- Delayed/sudden-jump dynamics — Power et al., *Grokking*, arXiv:2201.02177.
+  Under Reward Transformations* (ICML 1999), https://dl.acm.org/doi/10.5555/645528.657613
+- Delayed/sudden-jump dynamics — Power et al., *Grokking*,
+  https://arxiv.org/abs/2201.02177
 
 Source projects (engineering facts — renderer/registry/GRPO support, env API):
 
-- Prime Intellect `prime-rl` and its `renderers` lib; vLLM model registry.
-- Public reproduction on this task: OpenPipe ART·E blog
-  (`openpipe.ai/blog/art-e-mail-agent`).
+- Prime Intellect `prime-rl` — https://github.com/PrimeIntellect-ai/prime-rl ;
+  `renderers` — https://github.com/PrimeIntellect-ai/renderers ;
+  vLLM model registry — https://github.com/vllm-project/vllm
+- Public reproduction on this task: OpenPipe ART·E blog —
+  https://openpipe.ai/blog/art-e-mail-agent
 
 Confirmed internally by Understudy: 2026-04-29 (workload-010) and 2026-06-07
 (ART·E Qwen-14B recreation).

--- a/skills/rlm-pedagogical-training/SKILL.md
+++ b/skills/rlm-pedagogical-training/SKILL.md
@@ -124,6 +124,50 @@ The stronger claim requires all three:
    `x` only. Privileged context may score or train; it must not be passed at
    inference.
 
+## Reading the training signal
+
+Read the signal before and during a GRPO / prime-rl run — do not just wait.
+
+**Predict gradual vs flat-then-jump from reward variance.** GRPO normalizes each
+rollout's advantage *within its group* — subtract the group mean, divide by the
+group std (DeepSeekMath, arXiv:2402.03300; DeepSeek-R1, arXiv:2501.12948). A group
+whose rollouts all score the same has advantage ≈ 0 and contributes **no
+gradient**, so **group reward-variance is the learning signal**:
+
+- High variance from step 1 (most groups mixed success/failure; prime-rl/ART
+  `groups_trainable` healthy) → expect a **gradual, noisy climb** with plateaus.
+- Near-zero variance (sparse reward — most groups all-fail or all-pass) → expect
+  **flat until a lucky success** (grokking-like; cf. arXiv:2201.02177). Fix the
+  reward shape (denser / shaped signal) rather than waiting it out.
+
+Check `groups_trainable` / per-group reward std over the first ~5 steps to set
+expectations before forecasting an ETA.
+
+**Read smoothed reward + a periodic held-out mini-eval, not per-step reward.**
+Per-step train reward is noisy; trust a moving average plus a small held-out eval
+every N steps (the ART·E recipe evaluated every 30). Timeline heuristic when
+variance is healthy: first drift ~step 30–50, clear trend ~step 100, gains across
+epochs.
+
+**Confirmed by Understudy:** 2026-04-29 (understudy-knowledge workload-010 —
+verifiers-shaped reward moved GRPO 0.025→0.1 where action-level reward did not);
+2026-06-07 (ART·E Qwen-14B recreation — `groups_trainable` held 4–11/12 from step 1
+→ gradual climb exactly as the variance predicts). Public reproduction: OpenPipe
+ART·E blog.
+
+**Trainer/model fit check (before picking prime-rl vs Unsloth/TRL).** A model
+*loading* is not support. For multi-turn tool-use RL on a specific model, confirm
+the trainer has, for that model: (1) a **renderer** for correct multi-turn
+tokenization — prime-rl's `renderers` lib; no per-model renderer falls back to
+`DefaultRenderer` → token drift, flagged lossy / ~3x-cost for multi-turn; (2) the
+model in the trainer/inference **registry** (e.g. vLLM `VLM_REGISTRY`); (3)
+**merged GRPO** support, not just SFT or an open PR. Field check 2026-06: prime-rl
+ships renderers for Qwen / GLM / MiniMax / DeepSeek / Kimi / Nemotron / GPT-OSS but
+**not Gemma** (no merged Gemma-4 GRPO; `gemma4` absent from registry; grad-norm
+blowup) → Gemma-4 multi-turn GRPO belongs on Unsloth/TRL, while Nemotron-3 is
+first-class on prime-rl. Match the model to the trainer that has all three, or
+switch trainers.
+
 ## Reconcile Parallel Research
 
 When another agent is already running local Gemma/MLX kernels, do not duplicate

--- a/skills/rlm-pedagogical-training/SKILL.md
+++ b/skills/rlm-pedagogical-training/SKILL.md
@@ -150,7 +150,7 @@ every N steps (the ART·E recipe evaluated every 30). Timeline heuristic when
 variance is healthy: first drift ~step 30–50, clear trend ~step 100, gains across
 epochs.
 
-**Confirmed by Understudy:** 2026-04-29 (understudy-knowledge workload-010 —
+**Confirmed by Understudy:** 2026-04-29 (internal synthetic workload —
 verifiers-shaped reward moved GRPO 0.025→0.1 where action-level reward did not);
 2026-06-07 (ART·E Qwen-14B recreation — `groups_trainable` held 4–11/12 from step 1
 → gradual climb exactly as the variance predicts). Public reproduction: OpenPipe

--- a/skills/rlm-pedagogical-training/SKILL.md
+++ b/skills/rlm-pedagogical-training/SKILL.md
@@ -138,7 +138,8 @@ gradient**, so **group reward-variance is the learning signal**:
   `groups_trainable` healthy) → expect a **gradual, noisy climb** with plateaus.
 - Near-zero variance (sparse reward — most groups all-fail or all-pass) → expect
   **flat until a lucky success** (grokking-like; cf. arXiv:2201.02177). Fix the
-  reward shape (denser / shaped signal) rather than waiting it out.
+  reward shape (denser / shaped signal) rather than waiting it out — reward shape
+  governs what is learnable (Ng, Harada & Russell, ICML 1999).
 
 Check `groups_trainable` / per-group reward std over the first ~5 steps to set
 expectations before forecasting an ETA.
@@ -167,6 +168,25 @@ ships renderers for Qwen / GLM / MiniMax / DeepSeek / Kimi / Nemotron / GPT-OSS 
 blowup) → Gemma-4 multi-turn GRPO belongs on Unsloth/TRL, while Nemotron-3 is
 first-class on prime-rl. Match the model to the trainer that has all three, or
 switch trainers.
+
+### References for this section
+
+Original papers (theory):
+
+- GRPO / within-group advantage normalization — Shao et al., *DeepSeekMath*,
+  arXiv:2402.03300; DeepSeek-AI, *DeepSeek-R1*, arXiv:2501.12948.
+- Reward shape governs learnability — Ng, Harada & Russell, *Policy Invariance
+  Under Reward Transformations*, ICML 1999.
+- Delayed/sudden-jump dynamics — Power et al., *Grokking*, arXiv:2201.02177.
+
+Source projects (engineering facts — renderer/registry/GRPO support, env API):
+
+- Prime Intellect `prime-rl` and its `renderers` lib; vLLM model registry.
+- Public reproduction on this task: OpenPipe ART·E blog
+  (`openpipe.ai/blog/art-e-mail-agent`).
+
+Confirmed internally by Understudy: 2026-04-29 (workload-010) and 2026-06-07
+(ART·E Qwen-14B recreation).
 
 ## Reconcile Parallel Research
 


### PR DESCRIPTION
## What
Adds a **"Reading the training signal"** section to `rlm-pedagogical-training/SKILL.md` — teaching an agent to *read* a GRPO/prime-rl run instead of waiting:

1. **Predict gradual vs flat-then-jump from group reward-variance.** GRPO normalizes advantage *within each group* (DeepSeekMath [2402.03300], DeepSeek-R1 [2501.12948]) → a group with zero reward-variance contributes no gradient. So `groups_trainable` / per-group std *is* the learning signal: high variance → gradual climb; near-zero → flat-until-lucky (grokking-like [2201.02177]).
2. **Read smoothed reward + periodic held-out mini-eval**, not per-step reward; timeline heuristic.
3. **Trainer/model fit check** (renderer + registry + merged-GRPO) — the check that caught the **Gemma-4-on-prime-rl** wall (no Gemma renderer → multi-turn token drift; no merged GRPO). Nemotron-3 is first-class; Gemma-4 belongs on Unsloth/TRL.

## Why it's grounded
Public theory + public reproduction (OpenPipe ART·E blog) + **dated Understudy confirmations** (2026-04-29 workload-010; 2026-06-07 ART·E Qwen-14B recreation, `groups_trainable` 4–11/12 from step 1 → gradual climb as predicted).

## Source
Distilled from the ART·E recreation end-to-end (see `SKILL_GAPS.notes.md` #7/#7b/#7c).

## Coordination
- Edits `SKILL.md` only (not `reference.md`) to avoid conflict with #60 (legacy-cookbook removal touches that reference.md).
- Cost/timing + cloud-provider learnings from the same run are being folded into **#62** (`estimate-run-cost` / `choose-cloud-provider`) via review comments, since those skills live on #62's branch, not main.
- No conflict with the in-flight Gemma-4 investigation (no open PR there yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->