### PR TITLE
skills: distill-classifier, ingest-traces, ramp-and-verify (+ five fold-ins)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -22,6 +22,11 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   harness/environment, confirms the metric and validator, freezes splits, and
   reruns the incumbent baseline. (Discovery + capture/import folded into its
   [`reference.md`](capture-evidence/reference.md).)
+- [`ingest-traces`](ingest-traces/SKILL.md) is the front door for developers
+  who arrive with data instead of a harness: it turns existing production
+  traces (an object-store bucket, provider log exports, or a gateway capture
+  export) into local, redacted, deterministically classified and frozen
+  evaluation slices that `capture-evidence` and the optimizers consume.
 - [`walkthrough-public-benchmark-ladder`](walkthrough-public-benchmark-ladder/SKILL.md)
   runs the improvement loop against public long-horizon agent benchmarks such as
   Zapier AutomationBench and Harvey LAB. It keeps public harnesses upstream and
@@ -47,6 +52,12 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   authenticated gateway inference, project/key readiness, public model listing,
   workload route percentages, `understudy run`, and monitored durable CLI
   execution.
+- [`ramp-and-verify`](ramp-and-verify/SKILL.md) owns the last mile after a
+  route decision: pre-ramp repeat-replay stability gates, a staged traffic
+  ladder (5% → 25% → 100%) on the gateway dial with explicit approval per
+  tier, routed-vs-passthrough verification from captures at each step,
+  rollback triggers, and the measured before/after that feeds the claim
+  packet.
 - [`choose-frontier-keys`](choose-frontier-keys/SKILL.md) handles the first-run
   choice between BYO provider keys from the current shell or a local `.env`, the
   Understudy ZDR gateway route, or skipping remote frontier calls. It asks
@@ -78,6 +89,13 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   stateful workload into an RLM/verifiers training surface, measures on-policy
   state coverage and surprise concentration, and decides between local
   pedagogical SFT, on-policy repair, true pedagogical RL, or verifier handoff.
+- [`distill-classifier`](distill-classifier/SKILL.md) replaces an expensive
+  frontier model on a classification workload (binary, multi-class,
+  multi-label, structured extraction) with a fine-tuned open-weight student:
+  multi-teacher majority-vote labeling, failure-directed SFT data, the
+  confound ablations that keep the lift honest, and a four-way
+  promote/shadow/collect/stop verdict. (Quantified findings and defaults in
+  its [`reference.md`](distill-classifier/reference.md).)
 - [`local-distillation-lab`](local-distillation-lab/SKILL.md) runs local Apple
   Silicon weight-update arms for captured workloads: rejection SFT, same-family
   off-policy distillation, and surprisal-gated pedagogical variants.

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -60,6 +60,15 @@ comparison.
    tokens, cost/task, run seconds, errors, empty responses, and caveats. If
    per-task latency is unavailable, use run-level duration and say so.
 
+   **Pairwise option.** When the workload has no programmatic metric
+   (open-ended generation), score quality as a pairwise preference against the
+   incumbent instead of an absolute rubric: same row, two outputs, an LLM
+   judge picks A/B/tie — run **twice with the order swapped** and count a win
+   only when both passes agree. Report the debiased win-rate with N. Dry-run
+   the judge on a few rows first, budget-gate the live judge like any provider
+   spend, and keep judge-scored quality as its own column — never silently
+   blended with a programmatic metric.
+
 6. **Compute the frontier.** A candidate is dominated when another candidate has
    equal or better quality and equal or lower cost and latency, with no worse
    error rate or safety result. Write `pareto.json` with dominated reasons.

--- a/skills/compare-trajectories/SKILL.md
+++ b/skills/compare-trajectories/SKILL.md
@@ -117,6 +117,17 @@ not here. They compose: behavioral verdict here, learnability cut there.
    warm-start count, and the RL-shaped verdict to
    `.understudy/trajectory-diffs/<timestamp>/`.
 
+## Repeat-replay stability
+
+A single run per model can mistake sampling noise for a behavioral gap. Before
+classifying gaps — and always before a candidate graduates toward live traffic
+— re-run the candidate on the same frozen rows N times (default 3): all repeats
+match → stable; some → borderline; none → stochastic (exclude from gap
+classification and the warm-start yield). Above ~5% unstable, fix decoding
+(temperature, seed) or downgrade verdicts to directional-only. The dispositions
+feed the pre-ramp gate in [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md)
+(stable → serve, borderline → shadow, stochastic → incumbent fallback).
+
 ## Output Standard
 
 End with the diff path and: the two run ids + harness/tool-access mode;

--- a/skills/compare-trajectories/reference.md
+++ b/skills/compare-trajectories/reference.md
@@ -1,0 +1,37 @@
+# Compare Trajectories — reference
+
+Loaded on demand from `SKILL.md`.
+
+## Repeat-replay stability — full procedure
+
+The section in `SKILL.md` gives the rule; this is the working detail.
+
+1. **Choose N.** Default 3 full re-runs of the candidate on the same frozen
+   rows, same harness, same decoding settings. Raise N only when the per-run
+   cost is trivial; below N=3 the borderline bucket is meaningless.
+2. **Bucket per task** by comparing the scored outcome (and, for tool-call
+   workloads, the tool-call sequence) across runs:
+   - **all-repeats-match** — deterministic for this workload's purposes.
+   - **some-match** — borderline; investigate before trusting any verdict
+     that depends on this row.
+   - **none-match** — a stochastic pocket; exclude from gap classification
+     and from the warm-start yield, and record it by id.
+3. **Gate.** Report `unstable / total`. Above ~5%, stop: lower temperature,
+   pin seeds where the runtime honors them, or re-check the harness for
+   nondeterministic state. Until fixed, every gap verdict is directional only.
+4. **Dispositions for ramping.** Each row's bucket maps to a serving
+   disposition consumed by `ramp-and-verify`'s pre-ramp gate:
+   - stable → eligible to serve;
+   - borderline → **shadow** (send to candidate for observation, serve the
+     incumbent's answer);
+   - stochastic → **fallback** (route to incumbent), or
+     **requires-fresh-traffic** when there is too little history to judge.
+5. **Re-check in production.** After a route ramp, repeat the procedure on a
+   sample of really-routed rows; if instability is materially above the
+   pre-ramp measurement, the lab measurement did not transfer — escalate to
+   the rollback triggers in
+   [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md).
+
+The same replay loop, run once against the **incumbent**, is also the cheapest
+way to learn whether the baseline itself is stable — an unstable incumbent
+changes what "regression" means in the outcome-delta matrix.

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -89,6 +89,23 @@ criteria (recall / precision / policy — not just cost/speed).
    ([`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md))
    and the route decision ([`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md)).
 
+## Validator quality gates
+
+Two checks beyond the scripted oracle, before any model score is trusted:
+
+- **Strict-vs-dense divergence.** Score every run with both the strict
+  pass/fail and the partial-credit axes. When strict reads 0 while partial
+  credit is high across many rows, the strict reward is underestimating real
+  behavior — and as a training signal it would yield constant all-fail groups
+  with no gradient. Confirmed by Understudy: 2026-05-18 (internal — strict
+  pass-rate materially under-read measured behavior on a multi-step workload).
+- **Reward-hacking sentinels.** Plant runs the validator must reject: an
+  empty/no-op trajectory, a plausible-but-wrong-values write, and a
+  metric-gaming run (e.g. writing every record to inflate recall). Each must
+  score near 0 — the precision and forbidden-write axes are what keep recall
+  un-gameable. A validator that hasn't rejected a sentinel has not been
+  tested.
+
 ## Running it as a real `verifiers` env
 
 One env, many uses: the *same* `verifiers` Environment serves eval, RL training,

--- a/skills/distill-classifier/SKILL.md
+++ b/skills/distill-classifier/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: distill-classifier
+description: Use when a developer wants to replace an expensive frontier model on a classification workload (binary, multi-class, multi-label, or structured extraction) with a fine-tuned open-weight student — "distill this classifier", "can a small model do this tagging job", "the frontier labels these for $X, make it cheaper", "consensus-label my data". Multi-teacher majority-vote labeling, failure-directed SFT data, and a four-way promote/shadow/collect/stop verdict.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Distill Classifier
+
+Most production LLM calls are not agents — they are classifiers: tag, route,
+score, extract. This worker replaces a frontier classifier with a fine-tuned
+open-weight student using **teacher-as-labeler hard-label distillation**: an
+ensemble of teachers votes labels onto unlabeled rows, the student trains on the
+consensus, and a gated verdict decides whether it ships. It does not cover
+reasoning or tool-calling workloads — for those use
+[`../compare-trajectories/SKILL.md`](../compare-trajectories/SKILL.md) and the
+training rungs it feeds.
+
+## Decision Gate
+
+Right move when the task is **knowledge-bound classification** (domain label
+boundaries, not instruction-following), call volume justifies a ~$5–15
+experiment, and either the teacher's logits are closed (hard labels are all you
+can get) or several teachers are available. Wrong move when prompt optimization
+hasn't been tried — run [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md)
+(GEPA) first; it has moved classifiers +8pp accuracy with no weight update, and
+SFT is only warranted after it plateaus against a **measured baseline**.
+
+## Safety Gates
+
+- Do not upload source files, prompts, traces, labels, or datasets unless the
+  developer explicitly approves that exact action in the current thread.
+  Teacher-labeling calls send rows to providers — name the row count and get
+  approval before the sweep.
+- Frozen splits before any labeling: train/dev/holdout from
+  [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md), with a
+  leakage check across splits. Teachers label **train only**; dev is for
+  checkpoints; holdout is scored once, at the end.
+- Never report accuracy on imbalanced classes — macro-F1 and per-class recall
+  are the promotion metrics; accuracy hides class collapse.
+- Run the confound ablations (see `reference.md`) before attributing any lift
+  to training.
+
+## Flow
+
+1. **Baseline the teachers.** Score ≥2 (prefer 3) frontier/strong models on a
+   balanced labeled sample (≥200 rows/class). Record per-model macro-F1 and
+   per-class recall. Pick the **N best** teachers — mean teacher quality
+   predicts student quality; teacher *diversity* does not (confirmed null, see
+   `reference.md`).
+2. **Try the no-weight rung.** GEPA on train rows only. If macro-F1 lands
+   within ~3pp of the best-teacher ceiling, stop — ship the prompt.
+3. **Consensus-label train.** Each teacher labels every train row; majority
+   vote per row (per *label* for multi-label). Keep ≥80% of rows: **volume
+   beats purity** — strict confidence filtering measurably hurts (−8pp
+   macro-F1 in the controlled comparison). Set the split-vote rows aside as
+   the disagreement set.
+4. **Build a failure-directed corpus.** Run the student zero-shot on train;
+   build the SFT set as roughly 60–70% student-miss rows (consensus label the
+   student got wrong) plus 30–40% unanimous correct rows balancing the
+   minority class to ~50/50. Targeting residual failures beats a larger
+   clean-unanimous corpus.
+5. **LoRA SFT.** One epoch, conservative LR, and **LoRA rank ≥64** — r32 and
+   below cannot override the base model's class prior and collapses minority
+   recall (the single most load-bearing hyperparameter measured; details in
+   `reference.md`). Train locally via
+   [`../local-distillation-lab/SKILL.md`](../local-distillation-lab/SKILL.md)
+   or export the JSONL for a hosted SFT job (approval-gated; size it with
+   [`../estimate-run-cost/SKILL.md`](../estimate-run-cost/SKILL.md)).
+6. **Validate, then verdict.** On dev: macro-F1 vs best teacher, per-class
+   recall ≥50% everywhere, schema-validity 100% for structured output. Then
+   one holdout pass and a four-way verdict:
+   - **PROMOTE** — beats the bar at ≤ the cost target → route it
+     ([`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)).
+   - **SHADOW-TEST** — passes overall but a critical class is marginal.
+   - **COLLECT-MORE-DATA** — holdout too thin (<~120 rows) to decide.
+   - **STOP** — far below bar after GEPA *and* SFT; do not iterate
+     hyperparameters more than twice — the ceiling is the data or the task.
+7. **Escalation (optional).** If the student plateaus exactly on the
+   disagreement set and an open teacher with logits is available, soft-target
+   distillation on that boundary slice is the next rung (measured +7.9pp on
+   ambiguous classes; see `reference.md`).
+
+## Output Standard
+
+End with: the frozen split ids and row counts; the teacher panel with
+per-teacher macro-F1; the consensus yield and disagreement-set size; the SFT
+corpus composition (failure-directed mix, balance ratio, LoRA rank); the dev
+and one-shot holdout table (macro-F1, per-class recall, schema validity,
+cost/call vs incumbent); the confound ablations run; the four-way verdict; the
+result type (dry-run, validation, heldout); and the one recommended next
+command or handoff.
+
+## References
+
+- [`reference.md`](reference.md) — quantified findings (dated), the three
+  confounds with prevention, corpus/training defaults, and the verdict
+  thresholds.
+- [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) — the
+  cheaper no-weight rung; always first.
+- [`../local-distillation-lab/SKILL.md`](../local-distillation-lab/SKILL.md) —
+  local training arms and the weight-update proof discipline.
+- [`../curate-trajectories/SKILL.md`](../curate-trajectories/SKILL.md) — split
+  hygiene for the labeled selections.
+- [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md) —
+  Pareto framing once a student candidate exists.

--- a/skills/distill-classifier/reference.md
+++ b/skills/distill-classifier/reference.md
@@ -1,0 +1,83 @@
+# Distill Classifier — reference
+
+Loaded on demand from `SKILL.md`. Quantified findings are dated, internal, and
+anonymized (`workload-NNN`); re-verify anything load-bearing on your own
+workload before promoting.
+
+## Quantified findings
+
+- **Consensus student beats every individual teacher.** A 30B-class open
+  student trained on ~21K consensus-labeled rows reached 87.5% macro-F1 vs
+  78.1% for the best single teacher; minority-class recall rose from 37–48%
+  (teachers) to 90% (student). Training cost ≈ $0.55; whole experiment < $10.
+  Confirmed by Understudy: 2026-05-29 (internal workload-001).
+- **Teacher quality predicts; diversity does not.** Mean teacher F1 correlates
+  with student F1 (ρ = 0.68, p < 0.001); teacher disagreement does not
+  (ρ = −0.38, n.s.). Pick the N best teachers, not the most-disagreeing.
+  Confirmed by Understudy: 2026-05-29.
+- **Volume beats purity.** Confidence-filtering the consensus set to the top
+  50% scored 77.0% macro-F1; keeping ~80% scored 85.0%; keeping all rows
+  scored 84.5%. Consensus filtering is not load-bearing — keep ≥80% of rows.
+  Confirmed by Understudy: 2026-05-29 (internal workload-003).
+- **Failure-directed beats clean-unanimous.** A ~6.9K-row corpus targeting
+  rows the student already missed outperformed a ~13K-row clean-unanimous
+  corpus on the residual failures. Confirmed by Understudy: 2026-05-14
+  (internal workload-003).
+- **GEPA first.** Prompt optimization alone moved an 8B student +8.4 accuracy
+  points and +21.7pp minority-class recall with no weight update. Confirmed by
+  Understudy: 2026-05-14 (internal workload-003).
+- **Dataset elbow.** ~3K–7K consensus rows reaches ≈95% of the 20K-row score;
+  ≥10K recommended before a promotion verdict. Confirmed by Understudy:
+  2026-05-29.
+- **Transfers across shapes.** Per-label majority vote works for multi-label
+  (public GoEmotions: 4B student beat all three teachers by +1.8pp) and
+  structured extraction (public CoNLL-2003: schema-valid at a few percent of
+  teacher cost). Confirmed by Understudy: 2026-05-29.
+- **Soft-target escalation.** Per-token KL distillation focused on the
+  teacher-disagreement slice added +7.9pp on ambiguous classes after
+  hard-label SFT plateaued — at the cost of slight regression on unanimous
+  rows. Needs an open teacher with logits. Confirmed by Understudy:
+  2026-05-29.
+
+## Confounds — run these ablations before claiming a lift
+
+1. **JSON-prefill confound.** On structured-output tasks, forcing the response
+   frame (a JSON prefill) on the *untrained* base model can reproduce nearly
+   the entire SFT "lift" (96.7% of it, in the measured case — Confirmed by
+   Understudy: 2026-05-06). Four arms before any claim: base / base+prefill /
+   SFT / SFT+prefill. Also state `max_tokens` — a tight cap suffocates the
+   untrained arms and biases the comparison.
+2. **Class-prior collapse.** LoRA r32 on imbalanced data drove minority recall
+   to 18.6% while accuracy looked fine; r64 trained a healthy boundary
+   (macro-F1 0.567 → 0.811, the largest single effect in the ablation —
+   Confirmed by Understudy: 2026-05-29, internal workload-001). Prevention,
+   in order: rank ≥64; balance to ~50/50; watch macro-F1 and per-class
+   recall, never accuracy.
+3. **Over-filtering.** See "volume beats purity" above — treat the consensus
+   audit as a debugging surface, not a training-data gate.
+
+## Defaults
+
+| Knob | Default | Note |
+|---|---|---|
+| Teachers | 3, picked by F1 | 2 acceptable; 5+ rarely pays |
+| Consensus keep-rate | ≥80% of rows | per-label vote for multi-label |
+| Corpus mix | ~60–70% student-miss + balanced unanimous | minority ≈ 50/50 |
+| LoRA rank | ≥64 | the load-bearing knob |
+| Epochs / LR | 1 / ~2e-5 | watch the dev curve, not the endpoint |
+| Promotion metrics | macro-F1, per-class recall ≥50%, schema validity 100% | holdout scored once |
+| Verdict floor | STOP below ~70% primary after GEPA + SFT | ≤2 hyperparameter retries |
+
+## SFT row shape
+
+```jsonl
+{"messages": [
+  {"role": "system", "content": "<system prompt with the label schema>"},
+  {"role": "user", "content": "<row content> Classify as: <label options>"},
+  {"role": "assistant", "content": "{\"label\": \"<consensus label>\"}"}
+], "metadata": {"consensus_count": 3, "source": "hard-slice", "difficulty": "high"}}
+```
+
+Keep `metadata.source` so the corpus mix is auditable, and keep the export
+under `.understudy/distill-classifier/<workload>/` until the developer
+approves a hosted handoff.

--- a/skills/estimate-run-cost/SKILL.md
+++ b/skills/estimate-run-cost/SKILL.md
@@ -88,6 +88,17 @@ in [`reference.md`](reference.md); the methodology is here.
    thousands of rollouts, slow for millions. Compute the wall-clock and let the
    developer judge if the time is acceptable.
 
+**Cache tokens are their own line item.** Multi-turn/agentic workloads re-send
+the growing context every turn, and with provider prompt caching most of those
+tokens bill at cache-read/cache-write rates, not the base input rate. On
+long-context workloads, cache-read tokens can exceed fresh input tokens by more
+than 10× — an estimate priced entirely at the base input rate is wrong in
+either direction. Pull the cache fields from measured usage
+(`cache_read`/`cache_creation` or `cached_tokens`) and price each class at the
+provider's current cached rates, cited with source + date like every other
+dollar figure. Confirmed by Understudy: 2026-05-22 (internal workload-002 —
+cache-read tokens >10× fresh input tokens on a long-context agentic loop).
+
 ### Decide
 
 Present **local vs cloud side by side**: wall-clock and dollars for each, with the

--- a/skills/ingest-traces/SKILL.md
+++ b/skills/ingest-traces/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: ingest-traces
+description: Use when a developer already has production LLM traces somewhere — an object-store bucket (R2/S3), provider log exports, or an Understudy gateway capture export — and wants them turned into local, redacted, deterministically split evaluation artifacts. "ingest my traces", "I have a bucket of captures", "turn these logs into an eval set", "get my production calls into the harness". The front door for users who arrive with data instead of a harness.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Ingest Traces
+
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) assumes a local
+harness can be attached and run. Many workloads arrive the other way around:
+the traces already exist — in an object-store bucket, a provider log export,
+or an Understudy gateway capture export — and the job is to get them into
+local evidence artifacts without leaking anything. This worker does that
+transformation: source → deterministic classification → frozen slices →
+redacted manifests, all on the local machine.
+
+## Safety Gates
+
+- **Raw bodies never leave the source files.** Manifests reference traces by
+  path/key and carry counts, schemas, and hashes — never prompt text,
+  completions, or tool payloads. Downstream tools fetch bodies from disk at
+  runtime.
+- **No identifiers in artifacts.** Bucket names, org/account ids, and customer
+  identifiers stay in local credentials/config; manifests use relative keys
+  only. Every manifest records `privacy.local_only: true` and
+  `privacy.upload_performed: false`, and is itself review-gated before any
+  external reference.
+- Downloading from a customer-controlled bucket is a read of customer data —
+  confirm the developer is authorized for that source before pulling, and
+  keep the pulled files under `.understudy/` (gitignored).
+- Do not upload source files, prompts, traces, outputs, or datasets unless the
+  developer explicitly approves that exact action in the current thread.
+
+## Intake
+
+Identify the source shape first:
+
+- **Object-store bucket** (R2/S3-compatible): list keys with the developer's
+  existing tooling (`aws s3`, `rclone`, `wrangler`); pull to a local staging
+  dir.
+- **Provider log export**: JSONL/CSV of historical calls.
+- **Understudy capture export**: gateway capture files (`captures export`, or
+  a platform bulk export). Captures may carry either `workload_id` or the
+  older `placement_id` — read both.
+
+Then confirm with the developer which workload(s) the traces should map to,
+and what the unit of one "task" is (one request? one conversation?).
+
+## Flow
+
+1. **Classify deterministically.** Bucket every trace into workload groups by
+   content-based rules, never hand-picking: match on stable markers in the
+   request (a system-prompt heading, a template name, an endpoint). Record the
+   exact pattern used per group so the classification is auditable and
+   re-runnable.
+2. **Filter to the replayable unit.** Keep the calls that constitute the task
+   (e.g. single-turn extraction calls with a completed stop reason); drop
+   scaffolding (sub-agent spawns, retries, health probes). The lossless
+   conversation history (`request.messages` or equivalent) is the canonical
+   replay surface — record that invariant in the manifest; never evaluate
+   against a lossy projection.
+3. **Slice and freeze.** Per workload group, cut a dev set and a disjoint
+   held-out set, choosing for shape diversity (size, tool mix, turn count),
+   and freeze each as a list of relative keys with a hash. A frozen slice is
+   never edited mid-experiment. Register the splits with
+   [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) so its
+   split/baseline contract owns them from here.
+4. **Emit manifests.** Per slice: row count, token-count distribution,
+   tool-call name/sequence distribution, the classification pattern, the
+   freeze hash, and the privacy block — plus an eval-input manifest (rows
+   keyed by a stable `input_id`, expected outputs/tool-calls where the trace
+   contains them) that `optimize-workload` adapters and
+   [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md) can
+   consume directly.
+5. **Hand off.** Fleet-level cost/taxonomy questions →
+   [`../profile-captures/SKILL.md`](../profile-captures/SKILL.md). "What is
+   this workload actually doing?" →
+   [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md).
+   Harness attachment, metric, and baseline →
+   [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md).
+
+## Output Standard
+
+End with: the source shape and trace count pulled (staging path, not bucket
+identity); the workload groups with their classification patterns and counts;
+the frozen slice names, sizes, and hashes; the manifest paths written under
+`.understudy/ingest-traces/`; the privacy assertions (local-only, no raw
+bodies in manifests, review required before upload); and the recommended next
+skill for this workload.
+
+## References
+
+- [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) — owns the
+  metric/validator/baseline contract the frozen slices feed.
+- [`../profile-captures/SKILL.md`](../profile-captures/SKILL.md) — fleet-level
+  cost and call-type taxonomy over the same capture set.
+- [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) —
+  decomposes one ingested workload before model comparison.
+- [`../curate-trajectories/SKILL.md`](../curate-trajectories/SKILL.md) — split
+  provenance and leak-blocking once selections are made.

--- a/skills/ramp-and-verify/SKILL.md
+++ b/skills/ramp-and-verify/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: ramp-and-verify
+description: Use after a route decision exists and a candidate model must take live traffic safely — "ramp this route", "move 25% of traffic to the new model", "did the route change regress anything", "roll this back", "prove the savings are real". Pre-ramp stability gates, a staged traffic ladder through the Understudy gateway dial, routed-vs-passthrough verification from captures at each step, and explicit rollback triggers.
+metadata:
+  understudy:
+    mode: production
+    safety: approval-required
+    cli_required: true
+---
+
+# Ramp and Verify
+
+Every successful journey through this library ends the same way: a candidate
+won on a frozen eval and a route decision says ship it. This worker owns the
+**last mile** — taking that candidate from 0% to 100% of live traffic on the
+gateway dial without trusting a single lab number, and producing the measured
+before/after that makes any savings statement honest. It starts where
+[`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md) and
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)
+stop.
+
+## Resolve CLI
+
+Prefer the installed `understudy` binary. If it is unavailable inside a repo
+checkout, run through the package script:
+
+```sh
+npm run build
+node dist/bin.js status --json
+```
+
+## Safety Gates
+
+- **Every traffic change is an explicit, approved action.** Name the workload,
+  the model id, the old and new percentage, and get approval in the current
+  thread before each `routes set`. Never ramp two tiers in one step.
+- **Disclose capture-on-by-default.** Setting a model route enables request
+  capture for that workload unless capture is explicitly disabled — tell the
+  developer this before the first route write and confirm the capture setting
+  they want.
+- **Snapshot before every change.** The CLI writes a route snapshot before
+  route writes; verify it exists so `routes rollback` has something to restore.
+- **No savings claim without a claim packet.** Measured routed-vs-passthrough
+  deltas go into the evidence contract from
+  [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) (`claim.json`);
+  a tier that "looks cheaper" is not a claim.
+- Captures contain raw request/response bodies. Read them through the CLI's
+  redacted, metadata-first views; full payload export is opt-in, file-only,
+  and approval-gated.
+
+## Pre-ramp gates (all must pass)
+
+1. **Frozen-eval verdict exists** — a sweep/optimization result on frozen
+   splits with the incumbent baseline recorded.
+2. **Repeat-replay stability.** Re-run the candidate on the frozen rows N
+   times (default 3) and bucket each row: all-repeats-match / some / none
+   (the procedure lives in
+   [`../compare-trajectories/SKILL.md`](../compare-trajectories/SKILL.md)).
+   Rows that never repeat are stochastic pockets — assign each a disposition:
+   **fallback** (route to incumbent), **shadow** (observe, don't serve), or
+   **requires-fresh-traffic**. Stop if >~5% of rows are unstable.
+3. **Fallback exists.** The non-routed remainder passes through to the
+   incumbent by construction; confirm the workload's passthrough path works
+   (`gateway probe`) before sending anything to the candidate.
+
+## The ladder
+
+Default tiers: **5% → 25% → 100%** (5 is also the platform's default split on
+a fresh route). At each tier:
+
+1. `understudy routes set <workload> --project <p> --model-id <id>
+   --traffic-pct <pct>` — after approval.
+2. **Soak.** Hold the tier for an agreed window (hours at 5%, a day at 25%)
+   while traffic accumulates.
+3. **Verify from captures.** Pull the window's captures (metadata-first) and
+   compare routed vs passthrough on the same period: error/status-code rate,
+   latency distribution, schema/parse validity of outputs, and token/cost per
+   call. The routed cohort must hold the lab quality bar on whatever the
+   workload's validator can score from captures.
+4. **Spot-check determinism.** Re-run a small sample of routed rows against
+   the candidate; if repeats disagree materially more than the pre-ramp
+   measurement, stop the ramp and re-diagnose.
+5. **Advance or roll back.** Advance only when the tier window is clean.
+   Rollback triggers — any one fires `understudy routes rollback` (or
+   `routes clear`) immediately: error rate or schema-validity regression vs
+   passthrough, tail-latency regression beyond the agreed bound, instability
+   above the pre-ramp measurement, or the developer's call. After a rollback,
+   do not re-ramp until the root cause is fixed and the pre-ramp gates pass
+   again on a fresh eval.
+
+## After 100%
+
+Keep the incumbent reachable (snapshot retained, rollback tested) for an
+agreed observation window. Then assemble the before/after: incumbent baseline
+vs routed steady-state on quality-from-captures, latency, and cost/call —
+into the claim packet. That packet, not the ramp log, is what any cost or
+quality statement cites.
+
+## Output Standard
+
+End with: the workload/project/model ids and the tier history (pct, window,
+verdict per tier); the pre-ramp gate results (stability fraction, disposition
+counts); per-tier routed-vs-passthrough table (errors, latency, validity,
+cost/call); any rollbacks and their trigger; the current route state and
+snapshot path; result type (live); and the claim-packet status with the one
+recommended next action.
+
+## References
+
+- [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) —
+  route/capture command surface and auth readiness.
+- [`../compare-trajectories/SKILL.md`](../compare-trajectories/SKILL.md) —
+  repeat-replay stability procedure and dispositions.
+- [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md) — the
+  frozen-eval verdict required by the pre-ramp gate.
+- [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) — the
+  claim-packet contract for any measured savings statement.

--- a/skills/recursive-language-model/SKILL.md
+++ b/skills/recursive-language-model/SKILL.md
@@ -55,6 +55,18 @@ so the small model has a real, scorable place to run the whole case.
 5. **Stop** when the model writes its answer/observations or hits a step budget;
    score the final state with the environment's validator.
 
+## Pattern: structured intermediate artifacts
+
+When the task is long-horizon synthesis (drafting, analysis, multi-document
+work) rather than tool routing, have the loop emit **explicit intermediate
+artifacts** — a structured plan, an extracted-facts table, a checklist the
+deliverable must satisfy — and make later steps consume only those artifacts,
+not free-form scratchpad prose. Each artifact is checkable (schema, required
+keys) at the step that produces it, so errors surface mid-loop instead of in
+the final deliverable. The gap this closes is large: Confirmed by Understudy:
+2026-06-03 (internal long-horizon benchmark — a structured-artifact workflow
+scored 57/59 where a raw free-form RLM loop scored 3/59 with the same models).
+
 ## What to measure (what's possible)
 
 - **Decomposition factor** — small-model steps ÷ the teacher's steps to reach the


### PR DESCRIPTION
## What

Completes the skill library at both ends of the journey — **data in** and **savings out** — and adds the one workload shape it was missing, while folding proven internal findings into five existing workers instead of multiplying skills.

### Three new skills

| Skill | Job it fills | Grounded in |
|---|---|---|
| `distill-classifier` | Plain classification (tag/route/score/extract) — the most common cheap-win workload shape; the library was agentic-skewed | Confirmed consensus-distillation playbooks: multi-teacher majority vote, failure-directed SFT corpora, LoRA-rank and confound findings, four-way promote/shadow/collect/stop verdict (quantified, dated findings in its `reference.md`) |
| `ingest-traces` | Users who arrive with data instead of a harness — bucket/log/capture-export → local, redacted, deterministically frozen eval slices feeding `capture-evidence` | The production trace-ETL workflow (deterministic classification, frozen key-list slices, paths-only manifests, local-only privacy assertions) |
| `ramp-and-verify` | The last mile no skill owned: route decision → 5→25→100 traffic ladder on the gateway dial → routed-vs-passthrough verification per tier → rollback or claim packet | Promotion-gate and repeat-replay practice; aligned with current platform behavior (traffic-pct dial, **capture-on-by-default disclosure on route set**, snapshot/rollback) |

### Five fold-ins

- `estimate-run-cost` — cache tokens as their own line item (cache reads can exceed fresh input >10× on long-context agentic loops).
- `design-simulated-environment` — validator quality gates: strict-vs-dense divergence check + reward-hacking sentinels.
- `compare-model-sweep` — position-debiased pairwise-judge option for metric-less workloads.
- `recursive-language-model` — structured-intermediate-artifacts pattern (57/59 vs 3/59 on an internal long-horizon benchmark, same models).
- `compare-trajectories` — repeat-replay stability section + new `reference.md` with the full procedure and the serve/shadow/fallback dispositions that feed `ramp-and-verify`.

All internal findings are anonymized (`workload-NNN`, dated "Confirmed by Understudy" entries) per the extraction discipline — no customer names, traces, or identifiers.

## Notes for reviewers

- `skills/README.md` gains three entries in the existing flat list. The in-flight `workload-012-multi-turn-rl-skills` branch restructures that index into grouped sections and adds orchestrator routes — reconciliation happens there when it lands; this PR deliberately does not touch `skills/understudy/SKILL.md` to avoid conflicting.
- `ramp-and-verify` intentionally discloses that setting a model route enables capture by default (platform behavior as of capture envelope v4 / capture-on-by-default).

## Validation

`npm run check` green: build, typecheck, CLI tests, `ok 32 public skill(s)`, golden-path validate, package smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->