### PR TITLE
Boundary cleanup: remove internal provenance/coordination notes, fix two factual claims

### DIFF
--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -97,8 +97,8 @@ Two checks beyond the scripted oracle, before any model score is trusted:
   pass/fail and the partial-credit axes. When strict reads 0 while partial
   credit is high across many rows, the strict reward is underestimating real
   behavior — and as a training signal it would yield constant all-fail groups
-  with no gradient. Confirmed by Understudy: 2026-05-18 (internal — strict
-  pass-rate materially under-read measured behavior on a multi-step workload).
+  with no gradient. Measured on an internal synthetic workload, 2026-05-18
+  (strict pass-rate materially under-read behavior on a multi-step workload).
 - **Reward-hacking sentinels.** Plant runs the validator must reject: an
   empty/no-op trajectory, a plausible-but-wrong-values write, and a
   metric-gaming run (e.g. writing every record to inflate recall). Each must

--- a/skills/distill-classifier/reference.md
+++ b/skills/distill-classifier/reference.md
@@ -1,8 +1,8 @@
 # Distill Classifier — reference
 
-Loaded on demand from `SKILL.md`. Quantified findings are dated, internal, and
-anonymized (`workload-NNN`); re-verify anything load-bearing on your own
-workload before promoting.
+Loaded on demand from `SKILL.md`. Quantified findings are dated and were
+measured on internal synthetic workloads; re-verify anything load-bearing on
+your own workload before promoting.
 
 ## Quantified findings
 
@@ -10,47 +10,47 @@ workload before promoting.
   student trained on ~21K consensus-labeled rows reached 87.5% macro-F1 vs
   78.1% for the best single teacher; minority-class recall rose from 37–48%
   (teachers) to 90% (student). Training cost ≈ $0.55; whole experiment < $10.
-  Confirmed by Understudy: 2026-05-29 (internal workload-001).
+  Measured on an internal synthetic workload, 2026-05-29.
 - **Teacher quality predicts; diversity does not.** Mean teacher F1 correlates
   with student F1 (ρ = 0.68, p < 0.001); teacher disagreement does not
   (ρ = −0.38, n.s.). Pick the N best teachers, not the most-disagreeing.
-  Confirmed by Understudy: 2026-05-29.
+  Measured on an internal synthetic workload, 2026-05-29.
 - **Volume beats purity.** Confidence-filtering the consensus set to the top
   50% scored 77.0% macro-F1; keeping ~80% scored 85.0%; keeping all rows
   scored 84.5%. Consensus filtering is not load-bearing — keep ≥80% of rows.
-  Confirmed by Understudy: 2026-05-29 (internal workload-003).
+  Measured on an internal synthetic workload, 2026-05-29.
 - **Failure-directed beats clean-unanimous.** A ~6.9K-row corpus targeting
   rows the student already missed outperformed a ~13K-row clean-unanimous
-  corpus on the residual failures. Confirmed by Understudy: 2026-05-14
-  (internal workload-003).
+  corpus on the residual failures. Measured on an internal synthetic
+  workload, 2026-05-14.
 - **GEPA first.** Prompt optimization alone moved an 8B student +8.4 accuracy
-  points and +21.7pp minority-class recall with no weight update. Confirmed by
-  Understudy: 2026-05-14 (internal workload-003).
+  points and +21.7pp minority-class recall with no weight update. Measured on
+  an internal synthetic workload, 2026-05-14.
 - **Dataset elbow.** ~3K–7K consensus rows reaches ≈95% of the 20K-row score;
-  ≥10K recommended before a promotion verdict. Confirmed by Understudy:
-  2026-05-29.
+  ≥10K recommended before a promotion verdict. Measured on an internal
+  synthetic workload, 2026-05-29.
 - **Transfers across shapes.** Per-label majority vote works for multi-label
   (public GoEmotions: 4B student beat all three teachers by +1.8pp) and
   structured extraction (public CoNLL-2003: schema-valid at a few percent of
-  teacher cost). Confirmed by Understudy: 2026-05-29.
+  teacher cost). Measured 2026-05-29.
 - **Soft-target escalation.** Per-token KL distillation focused on the
   teacher-disagreement slice added +7.9pp on ambiguous classes after
   hard-label SFT plateaued — at the cost of slight regression on unanimous
-  rows. Needs an open teacher with logits. Confirmed by Understudy:
-  2026-05-29.
+  rows. Needs an open teacher with logits. Measured on an internal synthetic
+  workload, 2026-05-29.
 
 ## Confounds — run these ablations before claiming a lift
 
 1. **JSON-prefill confound.** On structured-output tasks, forcing the response
    frame (a JSON prefill) on the *untrained* base model can reproduce nearly
-   the entire SFT "lift" (96.7% of it, in the measured case — Confirmed by
-   Understudy: 2026-05-06). Four arms before any claim: base / base+prefill /
-   SFT / SFT+prefill. Also state `max_tokens` — a tight cap suffocates the
-   untrained arms and biases the comparison.
+   the entire SFT "lift" (96.7% of it, in the measured case — measured on an
+   internal synthetic workload, 2026-05-06). Four arms before any claim:
+   base / base+prefill / SFT / SFT+prefill. Also state `max_tokens` — a tight
+   cap suffocates the untrained arms and biases the comparison.
 2. **Class-prior collapse.** LoRA r32 on imbalanced data drove minority recall
    to 18.6% while accuracy looked fine; r64 trained a healthy boundary
    (macro-F1 0.567 → 0.811, the largest single effect in the ablation —
-   Confirmed by Understudy: 2026-05-29, internal workload-001). Prevention,
+   measured on an internal synthetic workload, 2026-05-29). Prevention,
    in order: rank ≥64; balance to ~50/50; watch macro-F1 and per-class
    recall, never accuracy.
 3. **Over-filtering.** See "volume beats purity" above — treat the consensus

--- a/skills/estimate-run-cost/SKILL.md
+++ b/skills/estimate-run-cost/SKILL.md
@@ -96,8 +96,8 @@ than 10× — an estimate priced entirely at the base input rate is wrong in
 either direction. Pull the cache fields from measured usage
 (`cache_read`/`cache_creation` or `cached_tokens`) and price each class at the
 provider's current cached rates, cited with source + date like every other
-dollar figure. Confirmed by Understudy: 2026-05-22 (internal workload-002 —
-cache-read tokens >10× fresh input tokens on a long-context agentic loop).
+dollar figure. Measured on an internal synthetic workload, 2026-05-22
+(cache-read tokens >10× fresh input tokens on a long-context agentic loop).
 
 ### Decide
 

--- a/skills/ingest-traces/SKILL.md
+++ b/skills/ingest-traces/SKILL.md
@@ -43,9 +43,14 @@ Identify the source shape first:
   existing tooling (`aws s3`, `rclone`, `wrangler`); pull to a local staging
   dir.
 - **Provider log export**: JSONL/CSV of historical calls.
-- **Understudy capture export**: gateway capture files (`captures export`, or
-  a platform bulk export). Captures may carry either `workload_id` or the
-  older `placement_id` — read both.
+- **Understudy capture export**: gateway capture files. Note the access
+  limits: `captures export <request-id>` exports **one request at a time**,
+  writes metadata only unless run with `--include-payload --yes` (payloads may
+  contain prompts/completions), and platform-side bulk export requires
+  elevated platform-administrator access — plan on per-request exports or ask
+  your platform administrator for a bulk dump.
+  Captures may carry either `workload_id` or the older `placement_id` — read
+  both.
 
 Then confirm with the developer which workload(s) the traces should map to,
 and what the unit of one "task" is (one request? one conversation?).

--- a/skills/ramp-and-verify/SKILL.md
+++ b/skills/ramp-and-verify/SKILL.md
@@ -65,8 +65,9 @@ node dist/bin.js status --json
 
 ## The ladder
 
-Default tiers: **5% → 25% → 100%** (5 is also the platform's default split on
-a fresh route). At each tier:
+Default tiers: **5% → 25% → 100%** (note: `routes set` defaults `--traffic-pct`
+to 10 when not specified, so pass `--traffic-pct 5` explicitly for the first
+tier). At each tier:
 
 1. `understudy routes set <workload> --project <p> --model-id <id>
    --traffic-pct <pct>` — after approval.

--- a/skills/recursive-language-model/SKILL.md
+++ b/skills/recursive-language-model/SKILL.md
@@ -63,9 +63,9 @@ artifacts** — a structured plan, an extracted-facts table, a checklist the
 deliverable must satisfy — and make later steps consume only those artifacts,
 not free-form scratchpad prose. Each artifact is checkable (schema, required
 keys) at the step that produces it, so errors surface mid-loop instead of in
-the final deliverable. The gap this closes is large: Confirmed by Understudy:
-2026-06-03 (internal long-horizon benchmark — a structured-artifact workflow
-scored 57/59 where a raw free-form RLM loop scored 3/59 with the same models).
+the final deliverable. The gap this closes is large: measured on an internal
+long-horizon benchmark, 2026-06-03, a structured-artifact workflow scored
+57/59 where a raw free-form RLM loop scored 3/59 with the same models.
 
 ## What to measure (what's possible)
 

--- a/skills/rlm-pedagogical-training/SKILL.md
+++ b/skills/rlm-pedagogical-training/SKILL.md
@@ -145,6 +145,8 @@ Read the signal before and during a GRPO / prime-rl run — do not just wait.
 - **Read smoothed reward + a periodic held-out mini-eval, not per-step
   reward.** Timeline heuristic when variance is healthy: first drift
   ~step 30–50, clear trend ~step 100, gains across epochs.
+- **When results conflict, trust sealed-holdout metrics over smoke results.**
+  A quick smoke run never overrides a measured holdout eval.
 - **Trainer/model fit check (before picking prime-rl vs Unsloth/TRL).** A model
   *loading* is not support. For multi-turn tool-use RL, confirm the trainer
   has, for that model: a multi-turn **renderer**, the model in the

--- a/skills/rlm-pedagogical-training/SKILL.md
+++ b/skills/rlm-pedagogical-training/SKILL.md
@@ -14,6 +14,13 @@ Use this worker when the unit of learning is a **stateful policy**, not a flat
 completion. The target is an RLM-style loop that learns how to inspect context,
 choose tools, retrieve evidence, call sub-models, and stop with a final answer.
 
+**Not for** environment mechanics or partner packaging: this skill owns the
+learnability decision and the training-arm choice;
+[`../author-rl-env/SKILL.md`](../author-rl-env/SKILL.md) owns building the
+`reset`/`step` environment once RL is the chosen arm, and
+[`../package-verifier-env/SKILL.md`](../package-verifier-env/SKILL.md) owns
+packaging that env for a partner.
+
 This is the bridge between:
 
 - [`../recursive-language-model/SKILL.md`](../recursive-language-model/SKILL.md):
@@ -128,93 +135,25 @@ The stronger claim requires all three:
 
 Read the signal before and during a GRPO / prime-rl run — do not just wait.
 
-**Predict gradual vs flat-then-jump from reward variance.** GRPO normalizes each
-rollout's advantage *within its group* — subtract the group mean, divide by the
-group std (DeepSeekMath, arXiv:2402.03300; DeepSeek-R1, arXiv:2501.12948). A group
-whose rollouts all score the same has advantage ≈ 0 and contributes **no
-gradient**, so **group reward-variance is the learning signal**:
+- **Group reward-variance is the learning signal.** GRPO normalizes each
+  rollout's advantage within its group, so a group whose rollouts all score the
+  same contributes no gradient. Check `groups_trainable` / per-group reward std
+  over the first ~5 steps before forecasting an ETA: healthy variance from
+  step 1 predicts a gradual, noisy climb with plateaus; near-zero variance
+  (most groups all-fail or all-pass) predicts flat-until-a-lucky-success — fix
+  the reward shape (denser / shaped signal) rather than waiting it out.
+- **Read smoothed reward + a periodic held-out mini-eval, not per-step
+  reward.** Timeline heuristic when variance is healthy: first drift
+  ~step 30–50, clear trend ~step 100, gains across epochs.
+- **Trainer/model fit check (before picking prime-rl vs Unsloth/TRL).** A model
+  *loading* is not support. For multi-turn tool-use RL, confirm the trainer
+  has, for that model: a multi-turn **renderer**, the model in the
+  trainer/inference **registry**, and **merged GRPO** support — or switch
+  trainers.
 
-- High variance from step 1 (most groups mixed success/failure; prime-rl/ART
-  `groups_trainable` healthy) → expect a **gradual, noisy climb** with plateaus.
-- Near-zero variance (sparse reward — most groups all-fail or all-pass) → expect
-  **flat until a lucky success** (grokking-like; cf. arXiv:2201.02177). Fix the
-  reward shape (denser / shaped signal) rather than waiting it out — reward shape
-  governs what is learnable (Ng, Harada & Russell, ICML 1999).
-
-Check `groups_trainable` / per-group reward std over the first ~5 steps to set
-expectations before forecasting an ETA.
-
-**Read smoothed reward + a periodic held-out mini-eval, not per-step reward.**
-Per-step train reward is noisy; trust a moving average plus a small held-out eval
-every N steps (the ART·E recipe evaluated every 30). Timeline heuristic when
-variance is healthy: first drift ~step 30–50, clear trend ~step 100, gains across
-epochs.
-
-**Confirmed by Understudy:** 2026-04-29 (internal synthetic workload —
-verifiers-shaped reward moved GRPO 0.025→0.1 where action-level reward did not);
-2026-06-07 (ART·E Qwen-14B recreation — `groups_trainable` held 4–11/12 from step 1
-→ gradual climb exactly as the variance predicts). Public reproduction: OpenPipe
-ART·E blog.
-
-**Trainer/model fit check (before picking prime-rl vs Unsloth/TRL).** A model
-*loading* is not support. For multi-turn tool-use RL on a specific model, confirm
-the trainer has, for that model: (1) a **renderer** for correct multi-turn
-tokenization — prime-rl's `renderers` lib; no per-model renderer falls back to
-`DefaultRenderer` → token drift, flagged lossy / ~3x-cost for multi-turn; (2) the
-model in the trainer/inference **registry** (e.g. vLLM `VLM_REGISTRY`); (3)
-**merged GRPO** support, not just SFT or an open PR. Field check 2026-06: prime-rl
-ships renderers for Qwen / GLM / MiniMax / DeepSeek / Kimi / Nemotron / GPT-OSS but
-**not Gemma** (no merged Gemma-4 GRPO; `gemma4` absent from registry; grad-norm
-blowup) → Gemma-4 multi-turn GRPO belongs on Unsloth/TRL, while Nemotron-3 is
-first-class on prime-rl. Match the model to the trainer that has all three, or
-switch trainers.
-
-### References for this section
-
-Original papers (theory):
-
-- GRPO / within-group advantage normalization — Shao et al., *DeepSeekMath*,
-  https://arxiv.org/abs/2402.03300 ; DeepSeek-AI, *DeepSeek-R1*,
-  https://arxiv.org/abs/2501.12948
-- Reward shape governs learnability — Ng, Harada & Russell, *Policy Invariance
-  Under Reward Transformations* (ICML 1999), https://dl.acm.org/doi/10.5555/645528.657613
-- Delayed/sudden-jump dynamics — Power et al., *Grokking*,
-  https://arxiv.org/abs/2201.02177
-
-Source projects (engineering facts — renderer/registry/GRPO support, env API):
-
-- Prime Intellect `prime-rl` — https://github.com/PrimeIntellect-ai/prime-rl ;
-  `renderers` — https://github.com/PrimeIntellect-ai/renderers ;
-  vLLM model registry — https://github.com/vllm-project/vllm
-- Public reproduction on this task: OpenPipe ART·E blog —
-  https://openpipe.ai/blog/art-e-mail-agent
-
-Confirmed internally by Understudy: 2026-04-29 (workload-010) and 2026-06-07
-(ART·E Qwen-14B recreation).
-
-## Reconcile Parallel Research
-
-When another agent is already running local Gemma/MLX kernels, do not duplicate
-that work. Use this split:
-
-- This skill owns the **learnability decision**: RLM trajectory schema,
-  verifier/reward shape, surprise concentration, contamination boundary, and the
-  arm choice (pedagogical SFT vs on-policy repair vs RL vs handoff).
-- [`author-rl-env`](../author-rl-env/SKILL.md) owns the **environment mechanics**
-  once RL is the chosen arm: inverting a batch sim into a `reset`/`step` MDP,
-  per-rollout state isolation, deterministic reset, and replay-conformance. Decide
-  the arm here; build the step-API env there. Don't re-specify the reset/step
-  contract in this skill.
-- [`package-verifier-env`](../package-verifier-env/SKILL.md) owns **packaging that
-  env for the partner** plus the frozen-holdout return-eval.
-- `local-distillation-lab` owns the **Apple Silicon weight update**: mlx-vlm
-  loader, forced-likelihood kernel, weighted LoRA, B/S/O/P arms, and learning
-  curves.
-- `prepare-verifier-handoff` owns the **external training packet** only after
-  local rungs are insufficient and upload/budget boundaries are approved.
-
-If parallel results conflict, trust sealed-holdout metrics over smoke results,
-and trust deploy-time `x`-only scores over privileged or oracle-tool settings.
+Citations (GRPO, grokking, reward shaping), the measured confirmations, and the
+per-trainer support details are in
+[`reference.md`](reference.md#reading-the-training-signal--background-and-references).
 
 ## Artifact Contract
 

--- a/skills/rlm-pedagogical-training/reference.md
+++ b/skills/rlm-pedagogical-training/reference.md
@@ -73,6 +73,51 @@ Run this before any training claim:
 
 Only the `x`-only deploy conditions are eligible for product claims.
 
+## Reading the training signal — background and references
+
+Background for the "Reading the training signal" section of the skill.
+
+**Why group reward-variance is the learning signal.** GRPO normalizes each
+rollout's advantage *within its group* — subtract the group mean, divide by the
+group std (DeepSeekMath, arXiv:2402.03300; DeepSeek-R1, arXiv:2501.12948). A
+group whose rollouts all score the same has advantage ≈ 0 and contributes no
+gradient. Near-zero variance under a sparse reward produces flat-then-jump
+dynamics (grokking-like; cf. arXiv:2201.02177); reward shape governs what is
+learnable (Ng, Harada & Russell, ICML 1999). Per-step train reward is noisy;
+trust a moving average plus a small held-out eval every N steps (the ART·E
+recipe evaluated every 30).
+
+Measured on an internal synthetic workload, 2026-04-29 (a verifiers-shaped
+reward moved GRPO 0.025→0.1 where action-level reward did not), and on an
+ART·E Qwen-14B recreation, 2026-06-07 (`groups_trainable` held 4–11/12 from
+step 1 → gradual climb exactly as the variance predicts). Public reproduction:
+OpenPipe ART·E blog.
+
+**Trainer/model fit details.** Renderer: prime-rl's `renderers` lib handles
+multi-turn tokenization; a model with no per-model renderer falls back to
+`DefaultRenderer` → token drift, flagged lossy / ~3x-cost for multi-turn.
+Registry: the model must be in the trainer/inference registry (e.g. vLLM
+`VLM_REGISTRY`). GRPO: merged support, not just SFT or an open PR. Field check
+2026-06: prime-rl ships renderers for Qwen / GLM / MiniMax / DeepSeek / Kimi /
+Nemotron / GPT-OSS but **not Gemma** (no merged Gemma-4 GRPO; `gemma4` absent
+from registry; grad-norm blowup) → Gemma-4 multi-turn GRPO belongs on
+Unsloth/TRL, while Nemotron-3 is first-class on prime-rl.
+
+References:
+
+- GRPO / within-group advantage normalization — Shao et al., *DeepSeekMath*,
+  https://arxiv.org/abs/2402.03300 ; DeepSeek-AI, *DeepSeek-R1*,
+  https://arxiv.org/abs/2501.12948
+- Reward shape governs learnability — Ng, Harada & Russell, *Policy Invariance
+  Under Reward Transformations* (ICML 1999), https://dl.acm.org/doi/10.5555/645528.657613
+- Delayed/sudden-jump dynamics — Power et al., *Grokking*,
+  https://arxiv.org/abs/2201.02177
+- Prime Intellect `prime-rl` — https://github.com/PrimeIntellect-ai/prime-rl ;
+  `renderers` — https://github.com/PrimeIntellect-ai/renderers ;
+  vLLM model registry — https://github.com/vllm-project/vllm
+- Public reproduction on this task: OpenPipe ART·E blog —
+  https://openpipe.ai/blog/art-e-mail-agent
+
 ## Reconciliation Rules
 
 Use these rules when multiple agents are running related experiments:


### PR DESCRIPTION
Public/private-boundary cleanup per quality review. No behavioral guidance or quantified findings were removed — only provenance tags reworded and two factual claims corrected.

- **Reworded internal provenance tags repo-wide.** All "Confirmed by Understudy: <date> (internal workload-NNN)" tags (rlm-pedagogical-training, estimate-run-cost, distill-classifier reference, design-simulated-environment, recursive-language-model) now read "Measured on an internal synthetic workload, <same date>." Every finding and number kept; no workload-NNN identifiers remain anywhere.
- **Deleted the "Reconcile Parallel Research" section** from rlm-pedagogical-training/SKILL.md (internal team-coordination state). The useful ownership split is distilled into one "Not for" line in the intro pointing at author-rl-env and package-verifier-env.
- **Trimmed rlm-pedagogical-training/SKILL.md toward the worker norm** (261 → 200 lines) by moving the literature-review portion of "Reading the training signal" (GRPO/grokking/reward-shaping citations, trainer support matrix) into reference.md. The exact heading "Reading the training signal" stays in SKILL.md with the operational core plus a pointer to reference.md.
- **Fixed the traffic-split contradiction** in ramp-and-verify/SKILL.md: `routes set` defaults `--traffic-pct` to 10 (src/commands/routes.ts), not 5. The 5% → 25% → 100% ramp tiers stay as the recommendation, with a note to pass `--traffic-pct 5` explicitly.
- **Caveated the export path** in ingest-traces/SKILL.md: `captures export` is per-request, payloads only behind `--include-payload --yes`, and platform bulk export requires elevated platform-administrator access.

`npm run check` passes (67 tests, 32 public skills validated, package smoke ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->