### PR TITLE
docs: authoritative grouped skill index + structure cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ docs/skill-comparison-audit.md
 
 # local scratch (checklists, notes) — never shipped
 .scratch/
+
+# local staging for external snapshots / incoming worktrees — never shipped
+_incoming/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,6 @@ Read these before extraction, release, or public docs work:
 - [`docs/telemetry.md`](docs/telemetry.md)
 - [`docs/oss-release-boundary.md`](docs/oss-release-boundary.md)
 - [`docs/release-checklist.md`](docs/release-checklist.md)
-- [`docs/pr-review.md`](docs/pr-review.md)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -205,22 +205,26 @@ conservative claims.
 ## Skill Tree
 
 `skills/understudy/SKILL.md` is the public entrypoint. It routes to exactly one
-capability worker:
+capability worker per intent. The workers are grouped by journey stage:
 
-- `skills/onboard/SKILL.md` (first-run: profiles the machine + user, backgrounds a small model)
-- `skills/walkthrough-public-benchmark-ladder/SKILL.md` (public benchmark golden path)
-- `skills/capture-evidence/SKILL.md`
-- `skills/optimize-workload/SKILL.md`
-- `skills/use-understudy-gateway/SKILL.md`
-- `skills/manage-local-models/SKILL.md` (acquire, cache, and explain local open-weight models)
-- `skills/run-local-model-lab/SKILL.md`
-- `skills/specialize-local-model/SKILL.md` (smallest reasonable local rung → Pi head-to-head → gap-driven improvement)
-- `skills/pedagogical-learning/SKILL.md` (privileged-context trajectories that are correct and learnable)
-- `skills/rlm-pedagogical-training/SKILL.md` (stateful RLM/verifiers training surfaces before hosted RL)
-- `skills/local-distillation-lab/SKILL.md` (local Apple Silicon weight-update arms before hosted RL)
-- `skills/prepare-verifier-handoff/SKILL.md`
+- **Setup & first run** — install-plugin, onboard, choose-frontier-keys,
+  walkthrough-public-benchmark-ladder
+- **Understand & capture** — understand-workload, profile-captures,
+  ingest-traces, capture-evidence, design-simulated-environment
+- **Local models** — manage-local-models, run-local-model-lab, mlx-arena,
+  specialize-local-model, recursive-language-model
+- **Compare & diagnose** — compare-model-sweep, compare-trajectories
+- **Cost & providers** — estimate-run-cost, choose-cloud-provider
+- **Optimize** — optimize-workload, optimize-api-workflow,
+  optimize-agentic-search
+- **Train locally** — pedagogical-learning, curate-trajectories,
+  distill-classifier, local-distillation-lab, rlm-pedagogical-training
+- **RL environment & handoff** — author-rl-env, package-verifier-env,
+  prepare-verifier-handoff
+- **Gateway & routing** — use-understudy-gateway, ramp-and-verify
 
-See [`skills/README.md`](skills/README.md) for the current hierarchy and
+[`skills/README.md`](skills/README.md) is the authoritative index with
+per-skill descriptions — keep it in sync when adding skills. See
 [`docs/current-functionality.md`](docs/current-functionality.md) for the
 migration ledger.
 
@@ -231,8 +235,10 @@ Prime Intellect Verifiers is the current preferred referral for that rung.
 
 Optimizer implementation stays upstream. Do not vendor GEPA or add the full
 private runtime as a dependency. The implementation contract is documented in
-[`docs/optimize-workload-contract.md`](docs/optimize-workload-contract.md).
-The TypeScript-to-`uv` Python bridge pattern is documented in
+[`docs/optimize-workload-contract.md`](docs/optimize-workload-contract.md),
+the evidence-ladder methodology behind it in
+[`docs/methodology-framework.md`](docs/methodology-framework.md). The
+TypeScript-to-`uv` Python bridge pattern is documented in
 [`docs/uv-python-bridge.md`](docs/uv-python-bridge.md).
 
 ## CLI Surface

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -90,47 +90,14 @@ messages, completions, traces, or secret values.
 
 ## What Is Skill-Led Now
 
-The public workflow now lives in the MVP skill tree:
-
-```text
-skills/understudy/SKILL.md
-skills/onboard/SKILL.md
-skills/capture-evidence/SKILL.md
-skills/optimize-workload/SKILL.md
-skills/use-understudy-gateway/SKILL.md
-skills/manage-local-models/SKILL.md
-skills/run-local-model-lab/SKILL.md
-skills/mlx-arena/SKILL.md
-skills/design-simulated-environment/SKILL.md
-skills/recursive-language-model/SKILL.md
-skills/specialize-local-model/SKILL.md
-skills/pedagogical-learning/SKILL.md
-skills/rlm-pedagogical-training/SKILL.md
-skills/local-distillation-lab/SKILL.md
-skills/prepare-verifier-handoff/SKILL.md
-```
+The public workflow now lives in the skill tree. The authoritative,
+per-skill index — grouped by journey stage (setup, understand/capture, local
+models, compare/diagnose, cost/providers, optimize, train, RL handoff,
+gateway/routing) — is [`skills/README.md`](../skills/README.md). This ledger
+does not duplicate that list.
 
 Agents should use those skills to inspect local artifacts and guide users, but
 they should not claim that removed Python commands still exist.
-
-`onboard` is the engaging first-run experience (machine + user profiling,
-interview, durable `~/.understudy/profile.json`); it backgrounds a small
-open-model download per the engagement doctrine in
-`docs/engagement-and-pacing.md` and hands off to `understudy`.
-`manage-local-models` acquires, caches, and explains local open-weight models
-(Gemma 4, Nemotron 3) — distinct from `run-local-model-lab`, which evaluates a
-local model against a frozen workload.
-
-`specialize-local-model` sequences the local-understudy product loop: pick the
-smallest task-reasonable local model, open it in the Pi/MLX arena against a
-frontier model, diagnose the gap, then choose model climb, simulated
-environment, GEPA/prompt optimization, RLM decomposition, hybrid route, or
-remote-only.
-
-`prepare-verifier-handoff` is a future-release stub, not an executable CLI
-surface. It helps agents recognize workloads that need stateful RL
-verifier/environment training, preserve the local evidence packet, and refer to
-Prime Intellect Verifiers as the current preferred external path.
 
 `use-understudy-gateway` includes the public model-routing workflow. Agents can
 list routeable Understudy model IDs without supplier/provider details, run

--- a/skills/README.md
+++ b/skills/README.md
@@ -5,63 +5,64 @@ workloads. Use progressive disclosure: start with the entrypoint, then load one
 worker only when the developer's intent requires it. The CLI handles durable
 execution; skills tell the agent what to inspect, gate, monitor, and report.
 
+This file is the authoritative index. The root README and
+`docs/current-functionality.md` point here instead of keeping their own lists;
+when you add a skill, register it here in the group it belongs to.
+
 ## Entry Point
 
 - [`understudy`](understudy/SKILL.md) — orchestrator. Routes the journey to the
   right capability worker.
 
-## Capability Skills
+## Setup & First Run
 
+- [`install-plugin`](install-plugin/SKILL.md) installs, enables, updates, or
+  verifies the Understudy skills as a Claude Code plugin via the
+  non-interactive `claude plugin` CLI, then surfaces the one `/reload-plugins`
+  activation step.
 - [`onboard`](onboard/SKILL.md) is the engaging first-run experience: it
   backgrounds a small American open-model download while it profiles the machine,
   detects ML tooling, interviews the user, and writes a durable
   `~/.understudy/profile.json` so every later skill meets the user where they are.
   (Profile schema, interview bank, and tooling map in its
   [`reference.md`](onboard/reference.md).)
-- [`capture-evidence`](capture-evidence/SKILL.md) attaches the local
-  harness/environment, confirms the metric and validator, freezes splits, and
-  reruns the incumbent baseline. (Discovery + capture/import folded into its
-  [`reference.md`](capture-evidence/reference.md).)
-- [`ingest-traces`](ingest-traces/SKILL.md) is the front door for developers
-  who arrive with data instead of a harness: it turns existing production
-  traces (an object-store bucket, provider log exports, or a gateway capture
-  export) into local, redacted, deterministically classified and frozen
-  evaluation slices that `capture-evidence` and the optimizers consume.
+- [`choose-frontier-keys`](choose-frontier-keys/SKILL.md) handles the first-run
+  choice between BYO provider keys from the current shell or a local `.env`, the
+  Understudy ZDR gateway route, or skipping remote frontier calls. It asks
+  before reading `.env` values and never prints or stores secrets.
 - [`walkthrough-public-benchmark-ladder`](walkthrough-public-benchmark-ladder/SKILL.md)
   runs the improvement loop against public long-horizon agent benchmarks such as
   Zapier AutomationBench and Harvey LAB. It keeps public harnesses upstream and
   maps their outputs into Understudy capture, split, baseline, optimization, and
   conservative-claim artifacts.
-- [`optimize-api-workflow`](optimize-api-workflow/SKILL.md) evaluates and
-  optimizes cross-application REST/API workflow agents with seeded state, fixed
-  API schemas, policy docs, request logs, final-state validators, and
-  side-effect safety before any RL handoff. (Artifact schemas, harness mapping,
-  A/B procedure, and GEPA bridge in its
-  [`reference.md`](optimize-api-workflow/reference.md).)
-- [`optimize-workload`](optimize-workload/SKILL.md) refuses stale
-  artifacts, preserves train/dev/holdout boundaries, writes dry-run proof
-  packets, and requires `claim.json` before public claims. (Evaluate, optimize,
-  and decide folded into its [`reference.md`](optimize-workload/reference.md).)
-- [`optimize-agentic-search`](optimize-agentic-search/SKILL.md) evaluates and
-  optimizes agentic / tool-use workloads (multi-turn tool-calling loops such as
-  agentic search): holds tools fixed, A/B-tests the policy model on quality,
-  latency, and cost through the gateway, and routes prompt tuning to
-  `optimize-workload` — before any RL handoff. (Verifier-env→artifact bridge and
-  determinism notes in its [`reference.md`](optimize-agentic-search/reference.md).)
-- [`use-understudy-gateway`](use-understudy-gateway/SKILL.md) handles
-  authenticated gateway inference, project/key readiness, public model listing,
-  workload route percentages, `understudy run`, and monitored durable CLI
-  execution.
-- [`ramp-and-verify`](ramp-and-verify/SKILL.md) owns the last mile after a
-  route decision: pre-ramp repeat-replay stability gates, a staged traffic
-  ladder (5% → 25% → 100%) on the gateway dial with explicit approval per
-  tier, routed-vs-passthrough verification from captures at each step,
-  rollback triggers, and the measured before/after that feeds the claim
-  packet.
-- [`choose-frontier-keys`](choose-frontier-keys/SKILL.md) handles the first-run
-  choice between BYO provider keys from the current shell or a local `.env`, the
-  Understudy ZDR gateway route, or skipping remote frontier calls. It asks
-  before reading `.env` values and never prints or stores secrets.
+
+## Understand & Capture
+
+- [`understand-workload`](understand-workload/SKILL.md) decomposes and explains
+  a captured prompt or trace — purpose, data shape, tool catalog, token cost,
+  success criteria — before any model comparison or vibe-check questions are
+  written.
+- [`profile-captures`](profile-captures/SKILL.md) is the fleet-level sibling:
+  it aggregates a directory of gateway captures into a cost and call-type
+  taxonomy and flags the call types that are candidates for open-weight
+  takeover.
+- [`ingest-traces`](ingest-traces/SKILL.md) is the front door for developers
+  who arrive with data instead of a harness: it turns existing production
+  traces (an object-store bucket, provider log exports, or a gateway capture
+  export) into local, redacted, deterministically classified and frozen
+  evaluation slices that `capture-evidence` and the optimizers consume.
+- [`capture-evidence`](capture-evidence/SKILL.md) attaches the local
+  harness/environment, confirms the metric and validator, freezes splits, and
+  reruns the incumbent baseline. (Discovery + capture/import folded into its
+  [`reference.md`](capture-evidence/reference.md).)
+- [`design-simulated-environment`](design-simulated-environment/SKILL.md)
+  builds a seeded, synthetic, scorable environment (AutomationBench /
+  verifiers style) plus final-state validator so any candidate model can run a
+  captured agentic workload end-to-end and be judged on outcome — a recorded
+  replay cannot host a different model's trajectory.
+
+## Local Models
+
 - [`manage-local-models`](manage-local-models/SKILL.md) acquires, caches,
   organizes, and explains local open-weight models (Gemma 4, Nemotron 3): where
   weights come from and live, formats/quantization, gated weights and HF tokens,
@@ -71,6 +72,25 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
 - [`run-local-model-lab`](run-local-model-lab/SKILL.md) evaluates local or
   workstation-hosted models against the same frozen workload/eval, keeps model
   downloads behind approval, and compares local, hybrid, and remote routes.
+- [`mlx-arena`](mlx-arena/SKILL.md) runs a frontier model against an
+  opinionated local Understudy on Apple Silicon, blind, then hill-climbs the
+  local model toward it — the vibe-check entry point before a frozen-eval lab
+  run.
+- [`specialize-local-model`](specialize-local-model/SKILL.md) sequences the local
+  model product loop: pick the smallest task-reasonable local rung, open it in
+  Pi against a frontier model, diagnose the gap, then choose model climb, GEPA,
+  simulated environment, RLM decomposition, hybrid route, or remote-only.
+- [`recursive-language-model`](recursive-language-model/SKILL.md) makes a
+  small/local model take over an agentic task a frontier model one-shots by
+  decomposing it into bounded steps with flat context behind the incumbent's
+  existing call contract, and measures what is possible.
+
+## Compare & Diagnose
+
+The diagnostic ladder runs scalar → trajectory → token → tool-call: sweep
+first (is there a gap?), trajectories next (which tasks, what kind of gap?),
+logprobs (which tokens?), and tool-trace forensics (why did this call fail?).
+
 - [`compare-model-sweep`](compare-model-sweep/SKILL.md) runs a frozen eval across
   a candidate matrix and writes Pareto-style quality, latency, cost, reliability,
   and caveat artifacts for route decisions.
@@ -84,14 +104,53 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   holdout caveats. Its token-logprob lens
   ([`references/logprob-lens.md`](compare-trajectories/references/logprob-lens.md))
   covers same-row, same-family token-confidence comparison when logprob
-  sidecars exist.
+  sidecars exist; tool-call forensics for a single failing run live in
+  [`understand-workload/references/tool-trace-forensics.md`](understand-workload/references/tool-trace-forensics.md).
+
+## Cost & Providers
+
+- [`estimate-run-cost`](estimate-run-cost/SKILL.md) estimates wall-clock and
+  dollar cost before spend for fine-tuning, RL training, batch inference, and RL
+  trajectory generation across local Apple Silicon, cloud GPU, and serverless
+  paths.
+- [`choose-cloud-provider`](choose-cloud-provider/SKILL.md) maps hosted job
+  shape to provider fit across Azure, GCP, Prime Intellect, Fireworks, Together
+  AI, and Lilac, with live-pricing and provenance caveats in its reference.
+
+## Optimize
+
+- [`optimize-workload`](optimize-workload/SKILL.md) refuses stale
+  artifacts, preserves train/dev/holdout boundaries, writes dry-run proof
+  packets, and requires `claim.json` before public claims. (Evaluate, optimize,
+  and decide folded into its [`reference.md`](optimize-workload/reference.md).)
+- [`optimize-api-workflow`](optimize-api-workflow/SKILL.md) evaluates and
+  optimizes cross-application REST/API workflow agents with seeded state, fixed
+  API schemas, policy docs, request logs, final-state validators, and
+  side-effect safety before any RL handoff. (Artifact schemas, harness mapping,
+  A/B procedure, and GEPA bridge in its
+  [`reference.md`](optimize-api-workflow/reference.md).)
+- [`optimize-agentic-search`](optimize-agentic-search/SKILL.md) evaluates and
+  optimizes agentic / tool-use workloads (multi-turn tool-calling loops such as
+  agentic search): holds tools fixed, A/B-tests the policy model on quality,
+  latency, and cost through the gateway, and routes prompt tuning to
+  `optimize-workload` — before any RL handoff. (Verifier-env→artifact bridge and
+  determinism notes in its [`reference.md`](optimize-agentic-search/reference.md).)
+
+## Train Locally
+
+The training rungs are ordered: no weight updates until pedagogical evidence
+shows headroom, no hosted RL until the local arms plateau.
+
 - [`pedagogical-learning`](pedagogical-learning/SKILL.md) turns privileged
   answers, execution feedback, verifier traces, or canonical solutions into
   local correct-and-learnable trajectory evidence before SFT, GRPO, or hosted RL.
-- [`rlm-pedagogical-training`](rlm-pedagogical-training/SKILL.md) turns a
-  stateful workload into an RLM/verifiers training surface, measures on-policy
-  state coverage and surprise concentration, and decides between local
-  pedagogical SFT, on-policy repair, true pedagogical RL, or verifier handoff.
+- [`curate-trajectories`](curate-trajectories/SKILL.md) treats a trajectory
+  dataset as a first-class, queryable, provenance-tracked artifact: it indexes run
+  JSONs (or a Lilac export) with per-row provenance, tags each row with its frozen
+  split from `capture-evidence`, and resolves hand-filtering into named,
+  hash-stamped selections. Its core value is split hygiene — it hard-blocks any
+  train/RL/distill selection that leaks frozen dev/holdout rows and emits a
+  contamination report.
 - [`distill-classifier`](distill-classifier/SKILL.md) replaces an expensive
   frontier model on a classification workload (binary, multi-class,
   multi-label, structured extraction) with a fine-tuned open-weight student:
@@ -102,17 +161,18 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
 - [`local-distillation-lab`](local-distillation-lab/SKILL.md) runs local Apple
   Silicon weight-update arms for captured workloads: rejection SFT, same-family
   off-policy distillation, and surprisal-gated pedagogical variants.
-- [`specialize-local-model`](specialize-local-model/SKILL.md) sequences the local
-  model product loop: pick the smallest task-reasonable local rung, open it in
-  Pi against a frontier model, diagnose the gap, then choose model climb, GEPA,
-  simulated environment, RLM decomposition, hybrid route, or remote-only.
-- [`curate-trajectories`](curate-trajectories/SKILL.md) treats a trajectory
-  dataset as a first-class, queryable, provenance-tracked artifact: it indexes run
-  JSONs (or a Lilac export) with per-row provenance, tags each row with its frozen
-  split from `capture-evidence`, and resolves hand-filtering into named,
-  hash-stamped selections. Its core value is split hygiene — it hard-blocks any
-  train/RL/distill selection that leaks frozen dev/holdout rows and emits a
-  contamination report.
+- [`rlm-pedagogical-training`](rlm-pedagogical-training/SKILL.md) turns a
+  stateful workload into an RLM/verifiers training surface, measures on-policy
+  state coverage and surprise concentration, and decides between local
+  pedagogical SFT, on-policy repair, true pedagogical RL, or verifier handoff.
+
+## RL Environment & Handoff
+
+The escalation chain is mechanical: `design-simulated-environment` (batch
+runner) → `author-rl-env` (stateful step-API MDP) → `package-verifier-env`
+(Verifiers module + conformance) → `prepare-verifier-handoff` (partner
+referral).
+
 - [`author-rl-env`](author-rl-env/SKILL.md) inverts a batch-scored simulated
   environment into a stateful step-API MDP (`reset`/`step`) an external RL trainer
   can drive: factors the agent loop out, isolates per-rollout state, makes
@@ -131,13 +191,19 @@ execution; skills tell the agent what to inspect, gate, monitor, and report.
   future-release stub for stateful RL verifier/environment handoffs. It does not
   execute training; it prepares evidence and actively refers suitable workloads
   to Prime Intellect Verifiers.
-- [`estimate-run-cost`](estimate-run-cost/SKILL.md) estimates wall-clock and
-  dollar cost before spend for fine-tuning, RL training, batch inference, and RL
-  trajectory generation across local Apple Silicon, cloud GPU, and serverless
-  paths.
-- [`choose-cloud-provider`](choose-cloud-provider/SKILL.md) maps hosted job
-  shape to provider fit across Azure, GCP, Prime Intellect, Fireworks, Together
-  AI, and Lilac, with live-pricing and provenance caveats in its reference.
+
+## Gateway & Routing
+
+- [`use-understudy-gateway`](use-understudy-gateway/SKILL.md) handles
+  authenticated gateway inference, project/key readiness, public model listing,
+  workload route percentages, `understudy run`, and monitored durable CLI
+  execution.
+- [`ramp-and-verify`](ramp-and-verify/SKILL.md) owns the last mile after a
+  route decision: pre-ramp repeat-replay stability gates, a staged traffic
+  ladder (5% → 25% → 100%) on the gateway dial with explicit approval per
+  tier, routed-vs-passthrough verification from captures at each step,
+  rollback triggers, and the measured before/after that feeds the claim
+  packet.
 
 ## Public Safety
 


### PR DESCRIPTION
## What

(Replaces #66, which GitHub auto-closed when its stacked base branch was deleted on #65's merge. Same content, rebased onto main.)

Makes `skills/README.md` the single authoritative skill index and fixes the documentation drift around it:

- **Grouped index**: the flat 30-entry list becomes nine journey-stage groups (setup → understand/capture → local models → compare/diagnose → cost/providers → optimize → train locally → RL handoff → gateway/routing), with short notes on how the chains relate (the scalar→trajectory→token→tool-call diagnostic ladder, the ordered training rungs, the mechanical RL escalation chain). All 32 skills indexed — including six that existed on disk but were never listed (`install-plugin`, `understand-workload`, `profile-captures`, `mlx-arena`, `recursive-language-model`, `design-simulated-environment`).
- **Root README**: the Skill Tree section now shows the groups and defers to `skills/README.md` instead of maintaining its own 11-item stale copy; links the previously orphaned `docs/methodology-framework.md`.
- **`docs/current-functionality.md`**: drops its own (third, stale) skill list for a pointer.
- **Small fixes**: dead `docs/pr-review.md` link removed from AGENTS.md; `_incoming/` gitignored.

## Validation

`npm run check` green: build, typecheck, CLI tests, `ok 32 public skill(s)`, golden-path validate, package smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->