### PR TITLE
Fold first-external-user learnings into four workers

### DIFF
--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -83,7 +83,15 @@ enough provenance for another agent to repeat the step without guessing.
      feedback is the assertion or diff that failed.
    - `schema` (e.g. Zod/JSON-schema `safeParse`) — keep `schema_pass` separate
      from `quality_pass`; a valid-shape, valid-enum output must not be failed
-     merely for not matching a teacher trace verbatim.
+     merely for not matching a teacher trace verbatim. Two grounding checks a
+     shape-only schema misses, both observed in real workloads: (a) **verbatim
+     evidence** — when a field claims to quote a source (transcript, doc,
+     log), verify the quote appears verbatim in the source; smaller open
+     models hallucinate correctly-formatted quotes; (b) **conditional
+     requireds** — when an optional signal (date, flag, risk) is present, its
+     evidence subfield must be present too; models that include the signal but
+     drop its evidence are the dominant residual failure and usually
+     prompt-fixable.
    - `rubric` — a confirmed criteria list (each criterion: id, description,
      review type); auto-generated rubrics need human approval.
    - `llm-judge` — must debias position with a swapped two-pass score

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -66,7 +66,10 @@ comparison.
    equivalent cache layer (a different provider or gateway can't share the
    incumbent's cache pool), measure it uncached and label it — what you
    measured is what they'd pay. Note that batching or longer cache TTLs shift
-   absolute costs on the cached side but should not change the ratios.
+   absolute costs on the cached side but should not change the ratios. To
+   structure the harness itself for cache hits (and avoid the
+   parallel-fan-out all-miss trap), see
+   [`optimize-workload/references/prompt-cache-optimization.md`](../optimize-workload/references/prompt-cache-optimization.md).
 
    **Pairwise option.** When the workload has no programmatic metric
    (open-ended generation), score quality as a pairwise preference against the

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -60,6 +60,14 @@ comparison.
    tokens, cost/task, run seconds, errors, empty responses, and caveats. If
    per-task latency is unavailable, use run-level duration and say so.
 
+   **Caching parity.** Cost columns must state each candidate's caching basis.
+   If the incumbent runs cache-warmed in production (e.g. a cached primer),
+   measure same-provider candidates cache-warmed too; when a candidate has no
+   equivalent cache layer (a different provider or gateway can't share the
+   incumbent's cache pool), measure it uncached and label it — what you
+   measured is what they'd pay. Note that batching or longer cache TTLs shift
+   absolute costs on the cached side but should not change the ratios.
+
    **Pairwise option.** When the workload has no programmatic metric
    (open-ended generation), score quality as a pairwise preference against the
    incumbent instead of an absolute rubric: same row, two outputs, an LLM
@@ -102,3 +110,24 @@ For API-workflow sweeps, keep tool-access interpretation explicit:
 End with the sweep path, candidate count, split size, quality/cost/latency axes,
 which candidates are on the frontier, which are dominated, and the recommended
 next action.
+
+When the sweep informs a real route decision, also write the report as a
+**decision memo** the developer can paste to their team unedited:
+
+- a results table: candidate, pass rate against the production validator,
+  total cost, cost per unit of work the business counts (per deal, per ticket,
+  per call — not per token), and the cost ratio vs the incumbent;
+- caching basis per row (see step 5) and any other comparability caveats;
+- where the residual failures cluster, as named patterns with the cheapest fix
+  per pattern (prompt line, decode/format fix, decomposition, route fallback);
+- a staged recommendation: the drop-in safe swap, the parallel pilot, and the
+  cheap iteration, rather than one all-or-nothing verdict;
+- a scope line: what fraction of the workload's total LLM cost this step
+  represents, and what's next if the approach extends;
+- one headline the finance owner can multiply by volume ("saves ~$X per
+  <unit>; multiply by monthly volume").
+
+If the verdict supports changing production traffic, hand off to
+[`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md): add the provider,
+set the route, and ramp staged traffic gated by the same production validator
+the sweep used.

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -93,7 +93,11 @@ validator kinds in [`reference.md`](reference.md):
    basis, cost basis if available, and failure taxonomy.
 3. Select the cheapest intervention that matches the observed failure mode:
    prompt repair, parser/schema repair, context trimming, route change,
-   candidate model comparison, or GEPA. Pick the cheapest *target* that matches
+   candidate model comparison, or GEPA. When the complaint is cost (not
+   quality) and inputs dominate the bill, check prompt-cache structure first —
+   it's often the cheapest lever of all:
+   [`references/prompt-cache-optimization.md`](references/prompt-cache-optimization.md).
+   Pick the cheapest *target* that matches
    the failure too — see [`reference.md`](reference.md) → Optimization-Target
    Menu for the full list. For an agentic workload, treat latency
    and cost per rollout as first-class objectives alongside the rubric score —

--- a/skills/optimize-workload/references/prompt-cache-optimization.md
+++ b/skills/optimize-workload/references/prompt-cache-optimization.md
@@ -1,0 +1,107 @@
+# Prompt-cache optimization — cut input cost without touching the model
+
+Use this lens when an incumbent's bill is input-token-heavy (shared primer,
+long system prompt, growing agentic context, per-row repeated instructions) or
+when a harness's measured cost looks higher than the same workload in
+production. Cache structure is usually the cheapest lever available — check it
+**before** proposing a model swap, because a cache-blind comparison misprices
+every candidate (see the caching-parity rule in
+[`compare-model-sweep`](../../compare-model-sweep/SKILL.md)).
+
+Mechanics, multipliers, and minimums below are from the Anthropic prompt-caching
+and cache-diagnostics docs, fetched 2026-06-09. They are provider-specific —
+re-verify before quoting, and treat other providers separately (OpenAI caches
+long shared prefixes automatically with no markers; vLLM/SGLang do server-side
+prefix caching for local serving; the same structure rules pay off on all of
+them).
+
+## Measure before changing anything
+
+Pull the cache fields from real response usage:
+
+- `cache_read_input_tokens` — served from cache (~0.1× base input price)
+- `cache_creation_input_tokens` — written to cache (1.25× for 5-min TTL, 2× for 1-hour)
+- `input_tokens` — the uncached remainder only (full price)
+
+Total prompt = the sum of all three. Two checks:
+
+1. **Hit rate**: `cache_read / (cache_read + cache_creation + input)` across a
+   sample of real calls. A workload with a shared primer and near-zero reads
+   has broken structure — that's the finding.
+2. **Don't misread `input_tokens`**: if an agent ran for hours but
+   `input_tokens` shows 4K, the rest was cached — check the sum, not one field.
+
+## Structure rules
+
+Caching is a **prefix match**: one changed byte invalidates everything after
+it. Render order is `tools` → `system` → `messages`.
+
+- **Stable content first.** Frozen system prompt and deterministic tool list
+  before anything per-session; per-row/per-turn content last, after the final
+  breakpoint. Never interpolate timestamps, UUIDs, user IDs, or mode flags
+  into the system prompt — inject them later in `messages`.
+- **Byte-stable means deterministic.** Sort JSON keys, fix tool ordering,
+  don't shuffle few-shot examples per request.
+- **Breakpoints** (`cache_control: {type: "ephemeral"}`): max 4 per request;
+  place at stability boundaries (end of shared portion, not end of prompt).
+  Top-level `cache_control` auto-places on the last cacheable block — fine for
+  simple cases.
+- **Minimum cacheable prefix is model-dependent** (roughly 512–4096 tokens
+  depending on model and platform). Shorter prefixes *silently* don't cache —
+  no error, just `cache_creation_input_tokens: 0`.
+- Tool-definition or model changes invalidate everything; `tool_choice`,
+  thinking toggles, and images invalidate only the messages tier — the
+  tools+system cache survives them.
+
+## Diagnose misses instead of guessing
+
+If the hit rate is low and the prefix "looks" stable, use **cache diagnostics**
+(beta, Claude API only, header `cache-diagnosis-2026-04-07`): pass the previous
+response's `id` as `diagnostics.previous_message_id` and the API reports the
+first divergence as a `cache_miss_reason` — `model_changed`, `system_changed`,
+`tools_changed`, or `messages_changed` (plus an estimate of how many input
+tokens fell after the divergence). Read it together with usage:
+
+| diagnostics | cache_read | Meaning |
+|---|---|---|
+| null | high | Working as intended |
+| null | low/zero | Requests match but the entry expired — shorten gaps or use 1h TTL |
+| `*_changed` | low/zero | Your bug — fix the named divergence |
+
+Fix the earliest divergence first; later ones may be hidden behind it.
+
+## Harness traps (where evals silently pay full price)
+
+- **Concurrent fan-out all-misses.** A cache entry is readable only after the
+  first response starts streaming. A sweep that fires 24 rows in parallel pays
+  full price on all 24. Warm with one row, await the first streamed token,
+  then fan out the rest.
+- **Interleaving candidates busts the cache.** Caches are model-scoped. Run
+  all rows for one candidate grouped together within the TTL, not round-robin
+  across candidates.
+- **Per-candidate prompt edits must stay out of the shared prefix** or the
+  comparison loses both cache and parity.
+- **LLM-judge and fork calls** (scoring, summarization, repair) must reuse the
+  parent call's `system`/`tools`/model verbatim and append at the end —
+  a rebuilt prefix misses the parent's cache entirely.
+- **Long agentic turns**: a breakpoint only looks back 20 content blocks for a
+  prior entry. Turns that add more than 20 blocks (many tool_use/tool_result
+  pairs) need an intermediate breakpoint every ~15 blocks.
+
+## TTL economics
+
+- 5-min TTL: write 1.25×, read 0.1× — breaks even at two requests. Refreshes
+  free on every hit, so steady traffic keeps itself warm.
+- 1-hour TTL (`ttl: "1h"`): write 2× — needs ≥3 reads to pay off. Use for
+  bursty/slow loops with gaps longer than 5 minutes (overnight batches,
+  human-in-the-loop reviews).
+- Batch rows so gaps stay under the TTL; for user-facing first-request
+  latency, pre-warm with a `max_tokens: 0` request against the shared prefix.
+
+## Output standard
+
+Report: measured hit rate before/after, the specific invalidator(s) found
+(quote the diagnostics `cache_miss_reason` or the offending prompt-builder
+line), and the cost delta per the workload's unit of work — same
+cost-per-deal/-ticket framing as the compare-model-sweep decision memo. State
+the caching basis of any number you carry into a model comparison.

--- a/skills/plan-hosted-run/SKILL.md
+++ b/skills/plan-hosted-run/SKILL.md
@@ -121,6 +121,8 @@ either direction. Pull the cache fields from measured usage
 provider's current cached rates, cited with source + date like every other
 dollar figure. Measured on an internal synthetic workload, 2026-05-22
 (cache-read tokens >10× fresh input tokens on a long-context agentic loop).
+To *improve* a workload's hit rate rather than just price it, see
+[`optimize-workload/references/prompt-cache-optimization.md`](../optimize-workload/references/prompt-cache-optimization.md).
 
 ### Decide local vs cloud
 

--- a/skills/recursive-language-model/references/pedagogical-training.md
+++ b/skills/recursive-language-model/references/pedagogical-training.md
@@ -13,12 +13,13 @@ This reference applies them to stateful trajectories and adds what is
 RLM-specific: the verifiers environment shape, the baseline matrix, surprise
 concentration, the training-arm choice, and how to read a live training run.
 
-**Not for** environment mechanics or partner packaging: this skill owns the
-learnability decision and the training-arm choice;
-[`../author-rl-env/SKILL.md`](../author-rl-env/SKILL.md) owns building the
-`reset`/`step` environment once RL is the chosen arm, and
-[`../package-verifier-env/SKILL.md`](../package-verifier-env/SKILL.md) owns
-packaging that env for a partner.
+**Not for** environment mechanics or partner packaging: this reference owns
+the learnability decision and the training-arm choice;
+[`prepare-verifier-handoff`](../../prepare-verifier-handoff/SKILL.md) owns the
+rest — building the `reset`/`step` environment once RL is the chosen arm
+([`references/stage-1-author-env.md`](../../prepare-verifier-handoff/references/stage-1-author-env.md))
+and packaging that env for a partner
+([`references/stage-2-package-env.md`](../../prepare-verifier-handoff/references/stage-2-package-env.md)).
 
 This is the bridge between:
 

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -138,6 +138,11 @@ Identify the developer's current stage and load exactly one:
   gateway route, or skipping remote frontier calls →
   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)
   and its frontier-keys lens (`references/frontier-keys.md`).
+- **Production ramp / rollback** — a route decision exists and live traffic
+  must move safely: "ramp this route", "move 25% of traffic to the new model",
+  "did the route change regress anything", "roll this back", "prove the
+  savings are real" →
+  [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md).
 - **Acquire / cache / organize local models** — download a model, see what's
   already cached, free up model disk, pick which Gemma/Nemotron to pull, or
   explain how open weights work →

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -149,7 +149,11 @@ Identify the developer's current stage and load exactly one:
 - **Multi-model sweep / Pareto comparison** — the developer has a frozen eval and
   wants to run the same rows across several local, gateway, or frontier models to
   compare quality, latency, cost, and reliability →
-  [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md).
+  [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md). When the
+  sweep verdict supports changing production traffic, don't stop at the report —
+  the answer to "how do I get this running in prod?" is
+  [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md) (add provider →
+  set route → staged ramp gated by the production validator).
 - **Token-level logprob comparison** — the developer has two same-family eval
   runs with stored logprob sidecars and wants to see the exact moment a smaller,
   quantized, or weaker model diverged from a larger/full-precision sibling on

--- a/skills/use-understudy-gateway/references/frontier-keys.md
+++ b/skills/use-understudy-gateway/references/frontier-keys.md
@@ -29,6 +29,14 @@ three frontier routes:
   upstream provider receives the prompts used in the comparison.
 - If the user chooses ZDR, state that no local provider key is read and the
   comparison goes through the Understudy gateway route.
+- **Watch for the silent-bypass failure.** If a provider key is pasted directly
+  into the app's own config (its provider stack, `.env`, or client setup),
+  that traffic goes straight to the provider and never touches the gateway —
+  no capture, no routing, and any "gateway vs frontier" comparison is silently
+  measuring the wrong path. This has happened in real onboarding. Before
+  trusting a comparison run, verify the requests actually arrived:
+  `understudy captures list` (or `understudy status --json`) should show them;
+  if it doesn't, find the direct-wired key before re-running.
 
 ## Flow
 


### PR DESCRIPTION
## What

Four additive edits (+51/−2, all markdown) encoding what the first external user session and its follow-up results validated. No new skills — per the AGENTS.md catalog growth rule, findings land in the skills that own the intent.

- **compare-model-sweep**: caching-parity rule for cost columns (cache-warmed vs uncached must be labeled; ratios vs absolutes); a **decision-memo output standard** — results table with cost per business unit of work, named failure patterns with cheapest fix each, staged recommendation (safe swap / parallel pilot / cheap iteration), scope line, and a finance headline. This is the report shape that landed with a real buyer.
- **understudy router**: after a sweep verdict, route the "how do I get this running in prod?" question to **ramp-and-verify** — the exact question the first user asked and the catalog didn't answer on its own.
- **use-understudy-gateway/frontier-keys**: the silent-bypass failure mode — a provider key pasted directly into the app's config routes traffic off-gateway with no capture (happened live in onboarding); adds a verify-in-captures step before trusting comparison runs.
- **capture-evidence**: two grounding checks shape-only schema validators miss — verbatim evidence quotes (open models hallucinate well-formatted quotes) and conditional-required evidence subfields (the dominant residual failure pattern, usually prompt-fixable).

## Validation

`npm run check` green: 67/67 tests, ok 21 public skill(s), package smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->