### PR TITLE
cli: move workload reads/writes to /admin/v1 for sk_* key sessions

### DIFF
--- a/src/commands/workloads.ts
+++ b/src/commands/workloads.ts
@@ -109,7 +109,7 @@ async function runCreate(cmd: Command, name: string, opts: CreateOpts): Promise<
   const captureEnabled = Boolean(opts.capture);
   const res = await request(
     {
-      url: `/customer/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads`,
+      url: `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads`,
       orgId: project.auth.orgId,
       method: "POST",
       body: { name, capture_enabled: captureEnabled },
@@ -159,7 +159,7 @@ async function runUpdate(cmd: Command, workloadValue: string, opts: UpdateOpts):
 
   const res = await request(
     {
-      url: `/customer/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads/${encodeURIComponent(workload.id)}`,
+      url: `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads/${encodeURIComponent(workload.id)}`,
       orgId: project.auth.orgId,
       method: "PATCH",
       body,

--- a/src/internal/workloads.ts
+++ b/src/internal/workloads.ts
@@ -40,7 +40,7 @@ export type RouteResponse = z.infer<typeof RouteResponseSchema>;
 export async function listWorkloads(project: ResolvedProject): Promise<Workload[]> {
   const res = await request(
     {
-      url: `/customer/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads`,
+      url: `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads`,
       orgId: project.auth.orgId,
     },
     ListWorkloadsResponseSchema,

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -10,6 +10,12 @@ import { describe, it } from "node:test";
 const cli = ["node", resolve("dist/bin.js")];
 const uvAvailable = spawnSync("uv", ["--version"], { encoding: "utf8" }).status === 0;
 
+// Ambient Understudy credentials (a developer's shell, a CI secret) must not
+// leak into spawned CLIs — fixtures provide their own.
+const baseEnv = { ...process.env };
+delete baseEnv.UNDERSTUDY_API_KEY;
+delete baseEnv.UNDERSTUDY_GATEWAY_URL;
+
 function run(args) {
   return spawnSync(cli[0], [cli[1], ...args], {
     cwd: process.cwd(),
@@ -22,7 +28,7 @@ function runWithHome(args, home, cwd = process.cwd()) {
     cwd,
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...baseEnv,
       HOME: home,
       USERPROFILE: home,
     },
@@ -34,7 +40,7 @@ function runWithEnv(args, env, cwd = process.cwd()) {
     cwd,
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...baseEnv,
       UNDERSTUDY_TELEMETRY: "0",
       ...env,
     },
@@ -46,7 +52,7 @@ function runWithEnvAsync(args, env, cwd = process.cwd()) {
     const child = spawn(cli[0], [cli[1], ...args], {
       cwd,
       env: {
-        ...process.env,
+        ...baseEnv,
         UNDERSTUDY_TELEMETRY: "0",
         ...env,
       },
@@ -136,13 +142,13 @@ async function withHostedFixture(fn) {
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects") return send(200, { projects: state.projects, cursor: null });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/api_keys") return send(200, { keys: [{ id: "key_1", name: "default", obfuscated_value: "sk_...test", last_used_at: null, permissions: [], created_at: "2026-06-01T00:00:00Z" }] });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/models") return send(200, { models: [{ id: "glm-5.1", display_name: "GLM 5.1", capabilities: ["chat"], context_window: 128000 }] });
-    if (req.method === "GET" && url.pathname === "/customer/v1/orgs/org_1/projects/proj_1/workloads") return send(200, { workloads: state.workloads, cursor: null });
-    if (req.method === "POST" && url.pathname === "/customer/v1/orgs/org_1/projects/proj_1/workloads") {
+    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads") return send(200, { workloads: state.workloads, cursor: null });
+    if (req.method === "POST" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads") {
       const workload = { id: `usp_${body.name}`, project_id: "proj_1", name: body.name, capture_enabled: Boolean(body.capture_enabled), route_model_id: null, route_traffic_pct: null, is_default: false, created_at: "2026-06-07T00:00:00Z" };
       state.workloads.push(workload);
       return send(200, workload);
     }
-    const workloadPatch = url.pathname.match(/^\/customer\/v1\/orgs\/org_1\/projects\/proj_1\/workloads\/([^/]+)$/);
+    const workloadPatch = url.pathname.match(/^\/admin\/v1\/orgs\/org_1\/projects\/proj_1\/workloads\/([^/]+)$/);
     if (req.method === "PATCH" && workloadPatch) {
       const workload = state.workloads.find((entry) => entry.id === workloadPatch[1]);
       if (!workload) return send(404, { message: "missing" });
@@ -974,7 +980,7 @@ describe("understudy CLI", () => {
     assert.match(route.stdout, /--clear/);
   });
 
-  it("runs hosted workload lifecycle commands against the customer API", async () => {
+  it("runs hosted workload lifecycle commands against the admin API", async () => {
     await withHostedFixture(async ({ home, repo, requests }) => {
       const env = { HOME: home, USERPROFILE: home };
 
@@ -990,7 +996,7 @@ describe("understudy CLI", () => {
       assert.equal(create.status, 0, create.stderr);
       assert.match(create.stdout, /Created workload support_triage/);
       assert.equal(requests.at(-1).method, "POST");
-      assert.equal(requests.at(-1).path, "/customer/v1/orgs/org_1/projects/proj_1/workloads");
+      assert.equal(requests.at(-1).path, "/admin/v1/orgs/org_1/projects/proj_1/workloads");
       assert.deepEqual(requests.at(-1).body, { name: "support_triage", capture_enabled: true });
 
       const show = await runWithEnvAsync(["--json", "workloads", "show", "support_triage"], env, repo);

--- a/tests/login-command-telemetry.test.mjs
+++ b/tests/login-command-telemetry.test.mjs
@@ -14,6 +14,8 @@ describe("login command telemetry", () => {
   let previousHome;
   let previousUserProfile;
   let previousTelemetry;
+  let previousApiKey;
+  let previousGatewayUrl;
   let previousFetch;
   let previousStdoutWrite;
   let previousExitCode;
@@ -23,12 +25,18 @@ describe("login command telemetry", () => {
     previousHome = process.env.HOME;
     previousUserProfile = process.env.USERPROFILE;
     previousTelemetry = process.env.UNDERSTUDY_TELEMETRY;
+    previousApiKey = process.env.UNDERSTUDY_API_KEY;
+    previousGatewayUrl = process.env.UNDERSTUDY_GATEWAY_URL;
     previousFetch = globalThis.fetch;
     previousStdoutWrite = process.stdout.write;
     previousExitCode = process.exitCode;
     process.env.HOME = root;
     process.env.USERPROFILE = root;
     delete process.env.UNDERSTUDY_TELEMETRY;
+    // Ambient credentials (a developer's shell, a CI secret) change which
+    // telemetry the login path emits — keep the test hermetic.
+    delete process.env.UNDERSTUDY_API_KEY;
+    delete process.env.UNDERSTUDY_GATEWAY_URL;
     process.exitCode = undefined;
     process.stdout.write = () => true;
   });
@@ -40,6 +48,10 @@ describe("login command telemetry", () => {
     else process.env.USERPROFILE = previousUserProfile;
     if (previousTelemetry === undefined) delete process.env.UNDERSTUDY_TELEMETRY;
     else process.env.UNDERSTUDY_TELEMETRY = previousTelemetry;
+    if (previousApiKey === undefined) delete process.env.UNDERSTUDY_API_KEY;
+    else process.env.UNDERSTUDY_API_KEY = previousApiKey;
+    if (previousGatewayUrl === undefined) delete process.env.UNDERSTUDY_GATEWAY_URL;
+    else process.env.UNDERSTUDY_GATEWAY_URL = previousGatewayUrl;
     globalThis.fetch = previousFetch;
     process.stdout.write = previousStdoutWrite;
     process.exitCode = previousExitCode;


### PR DESCRIPTION
## Summary

Every `workloads` subcommand that read state (`list`, `show`, name→id resolution inside `update`/`route`/`captures`) and the `doctor --hosted` workloads check failed for `sk_*`-key sessions with:

> This endpoint only accepts WorkOS AuthKit access tokens. Use /admin/v1 for legacy CLI-key flows.

`/customer/v1` rejects `sk_*` keys by design. This points `workloads list/create/update` at the same `/admin/v1` org/project surface the `route` and `captures` calls already use. The missing server-side GETs are added in the companion PR on understudylabs/understudy-platform (same branch name) — `workloads list/show` keeps failing (404 instead of 401) until that deploys; `create`/`update` work against production today.

Also makes the test suite hermetic to ambient credentials: an `UNDERSTUDY_API_KEY` exported in the shell (e.g. baked into a remote-execution environment) leaked into spawned CLI fixtures and the in-process login-telemetry test, flipping six tests red and printing gateway-probe output that contained the real key. Test runners now strip `UNDERSTUDY_API_KEY` / `UNDERSTUDY_GATEWAY_URL` before spawning, and the telemetry test clears/restores them around each case.

## Testing

- `npm run check` → build, typecheck, 67/67 tests, skills validation, package smoke all green
- Verified the failure mode against production with a fresh `sk_*` key before the change, and that `create`/`route` already succeed on `/admin/v1`

https://claude.ai/code/session_01Vd3e4NUxRe4tjVmnhE3qN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vd3e4NUxRe4tjVmnhE3qN2)_