### PR TITLE
Polish: plugin staleness signal, telemetry disclosure, --json discoverability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Understudy Labs"
   },

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ spine
 skills
 doctor
 login
+logout
 status
 projects
 keys
@@ -264,8 +265,17 @@ routes
 setup
 setup-code
 run
+capture-evidence   (alias: understand)
+capture-import
 optimize-workload
+route-decision
+value
+experiments
+next
 ```
+
+Every command accepts the global `--json` flag (before or after the
+subcommand) and emits machine-readable JSON where supported.
 
 `setup-code` is skill-routed. It does not patch files directly; it tells the
 coding agent to use `skills/onboard/setup-code.md` and the matching framework

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -11,6 +11,10 @@ git ls-files
 
 ## Inspect
 
+- versions bumped **together** in `package.json`, `.claude-plugin/plugin.json`,
+  and `.claude-plugin/marketplace.json` on any release that changes the skill
+  catalog or CLI surface — installed plugins have no other staleness signal;
+  `understudy doctor --json` fails if the three drift;
 - no `.understudy/` runtime artifacts;
 - no `.env*`, credentials, tokens, or secret-shaped strings;
 - no private planning docs;

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -14,6 +14,10 @@ Disable telemetry with:
 UNDERSTUDY_TELEMETRY=0
 ```
 
+The CLI discloses this state directly: `understudy login` prints a one-line
+notice on success, and `understudy status` shows a `telemetry` line (and a
+`telemetry_enabled` field under `--json`).
+
 ## Destination
 
 Events are sent to the configured Understudy gateway:
@@ -35,7 +39,7 @@ Allowed fields are categorical or operational:
 
 - event name and event version;
 - anonymous install id from `~/.understudy/telemetry.json`;
-- CLI version placeholder;
+- CLI version (from `package.json`);
 - platform and architecture;
 - org id, project slug, user id, and signup intent id when already known from
   credentials/config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -52,8 +52,13 @@ claude plugin list --json
 ```
 
 Look for `understudy` from the `understudy-skills` marketplace. If it's already
-enabled, stop — report installed and skip to step 4 only if the developer wants
-to update (then `claude plugin marketplace update understudy-skills`).
+enabled, **compare versions before stopping**: installed version (from the list
+output) vs the repo's `$REPO/.claude-plugin/plugin.json` `version`. If the repo
+is newer, the installed catalog is stale (skills may be missing or renamed) —
+run `claude plugin marketplace update understudy-skills`, then
+`claude plugin install understudy@understudy-skills`, then have the developer
+run `/reload-plugins` (step 4). If versions match, report installed-and-current
+and stop.
 
 ### 3. Add the marketplace and install (background-safe)
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -322,6 +322,7 @@ function emitApiKeySuccess(
         api_key_suffix: result.credential.slice(-4),
         gateway_url: result.gateway_url ?? DEFAULT_GATEWAY_URL,
         credentials_path: globalCredentialsPath(),
+        telemetry_enabled: telemetryEnabled(),
       })}\n`,
     );
     return;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -12,6 +12,7 @@ import {
 import { DEFAULT_GATEWAY_URL } from "../config/defaults.js";
 import { isJsonMode, runAction } from "../internal/output.js";
 import {
+  telemetryEnabled,
   trackLoginCompleted,
   trackLoginFailed,
   trackLoginStarted,
@@ -334,4 +335,9 @@ function emitApiKeySuccess(
       `${kleur.gray("key")}      sk_••••${result.credential.slice(-4)}\n` +
       `${kleur.gray("saved")}    ${globalCredentialsPath()}\n`,
   );
+  if (telemetryEnabled()) {
+    process.stdout.write(
+      `${kleur.dim("Signed-in sessions send bounded usage telemetry (docs/telemetry.md); disable with UNDERSTUDY_TELEMETRY=0.")}\n`,
+    );
+  }
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,7 +4,7 @@ import kleur from "kleur";
 import { readCredentials } from "../config/credentials.js";
 import { readProjectConfig } from "../config/index.js";
 import { isJsonMode, runAction } from "../internal/output.js";
-import { trackStatusChecked } from "../internal/telemetry.js";
+import { telemetryEnabled, trackStatusChecked } from "../internal/telemetry.js";
 
 /**
  * `understudy status` — print active org, project, key suffix, and
@@ -103,6 +103,7 @@ export async function runStatus(json = false): Promise<0 | 1> {
         project_slug: config?.project_slug ?? null,
         api_key_suffix: storedApiKey ? storedApiKey.slice(-4) : null,
         gateway_url: gatewayUrl,
+        telemetry_enabled: telemetryEnabled(),
       })}\n`,
     );
     return 0;
@@ -115,6 +116,11 @@ export async function runStatus(json = false): Promise<0 | 1> {
     `${kleur.bold("project_slug")}  ${config?.project_slug ?? kleur.dim("(none)")}`,
     `${kleur.bold("api_key")}       ${storedApiKey ? maskKey(storedApiKey) : kleur.dim("(none)")}`,
     `${kleur.bold("gateway_url")}   ${gatewayUrl ?? kleur.dim("(unknown)")}`,
+    `${kleur.bold("telemetry")}     ${
+      telemetryEnabled()
+        ? `on ${kleur.dim("(bounded usage events; disable with UNDERSTUDY_TELEMETRY=0)")}`
+        : "off"
+    }`,
   ];
 
   process.stdout.write(`${lines.join("\n")}\n`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { registerStatusCommand } from "./commands/status.js";
 import { registerOptimizeWorkloadCommand } from "./commands/optimize-workload.js";
 import { registerWorkloadsCommand } from "./commands/workloads.js";
 import { registerExperimentsCommands, registerNextCommand } from "./commands/experiments.js";
+import { readCliVersion, readManifestVersions } from "./internal/version.js";
 
 export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -42,16 +43,6 @@ type SearchResult = {
 type SearchCandidate = Omit<SearchResult, "score" | "matches"> & {
   text: string;
 };
-
-function readPackageVersion(): string {
-  try {
-    const raw = readFileSync(join(repoRoot, "package.json"), "utf8");
-    const parsed = JSON.parse(raw) as { version?: string };
-    return parsed.version ?? "0.0.0";
-  } catch {
-    return "0.0.0";
-  }
-}
 
 function readSkillSummaries(): SkillSummary[] {
   const skillsRoot = join(repoRoot, "skills");
@@ -208,20 +199,29 @@ function printDoctorJson(): void {
     "vendor/MANIFEST.md",
   ];
   const missing = required.filter((path) => !existsSync(join(repoRoot, path)));
+  // package.json and the plugin manifests must move together: installed
+  // plugins have no other staleness signal, so a skipped bump ships silently.
+  const versions = readManifestVersions();
+  const versionsConsistent =
+    versions.cli !== null &&
+    versions.cli === versions.plugin &&
+    versions.cli === versions.marketplace;
   console.log(
     JSON.stringify(
       {
         repo: "understudy-agent-tools",
         runtime: "node",
         node: process.version,
+        versions,
+        versions_consistent: versionsConsistent,
         missing,
-        ok: missing.length === 0,
+        ok: missing.length === 0 && versionsConsistent,
       },
       null,
       2,
     ),
   );
-  if (missing.length > 0) {
+  if (missing.length > 0 || !versionsConsistent) {
     process.exitCode = 1;
   }
 }
@@ -372,7 +372,7 @@ export function buildProgram(): Command {
   program
     .name("understudy")
     .description("Public Understudy agent tools and skill-library CLI")
-    .version(readPackageVersion())
+    .version(readCliVersion())
     .option("--json", "Emit machine-readable JSON when supported");
 
   program.command("spine").description("Print the public MVP workflow spine").action(printSpine);
@@ -436,8 +436,29 @@ export function buildProgram(): Command {
   registerExperimentsCommands(program);
   registerNextCommand(program);
 
+  annotateGlobalJsonHelp(program);
+
   program.action(printSpine);
   return program;
+}
+
+/**
+ * The global `--json` flag only appears in the program's own help, but
+ * Commander accepts it before or after the subcommand. Surface it in
+ * every subcommand's help so it is discoverable without trial and error;
+ * skip commands that declare their own `--json`.
+ */
+function annotateGlobalJsonHelp(command: Command): void {
+  for (const sub of command.commands) {
+    const hasOwnJson = sub.options.some((option) => option.long === "--json");
+    if (!hasOwnJson) {
+      sub.addHelpText(
+        "after",
+        "\nGlobal options:\n  --json    Emit machine-readable JSON when supported",
+      );
+    }
+    annotateGlobalJsonHelp(sub);
+  }
 }
 
 export async function main(argv = process.argv): Promise<void> {

--- a/src/internal/telemetry.ts
+++ b/src/internal/telemetry.ts
@@ -7,10 +7,10 @@ import { readCredentials } from "../config/credentials.js";
 import { DEFAULT_GATEWAY_URL } from "../config/defaults.js";
 import { readProjectConfig } from "../config/index.js";
 import { globalTelemetryPath } from "../config/paths.js";
+import { readCliVersion } from "./version.js";
 
 const TELEMETRY_TIMEOUT_MS = 3_000;
 const EVENT_VERSION = 1;
-const CLI_VERSION = "0.0.0";
 
 const TelemetryStateSchema = z.object({
   install_id: z.string().min(1),
@@ -165,11 +165,20 @@ export function trackControlPlaneAction(event: ControlPlaneEvent): void {
   });
 }
 
+/**
+ * Whether CLI telemetry is active. Exposed so user-facing surfaces
+ * (`status`, login success) can disclose the current state and the
+ * opt-out, instead of telemetry existing only in docs.
+ */
+export function telemetryEnabled(): boolean {
+  return process.env.UNDERSTUDY_TELEMETRY !== "0";
+}
+
 async function trackCliEvent(
   eventName: string,
   opts: TrackCliEventOpts = {},
 ): Promise<void> {
-  if (process.env.UNDERSTUDY_TELEMETRY === "0") return;
+  if (!telemetryEnabled()) return;
 
   const context = resolveTelemetryContext(opts);
   if (!context) return;
@@ -179,7 +188,7 @@ async function trackCliEvent(
     event_version: EVENT_VERSION,
     install_id: readOrCreateInstallId(),
     created_at_ms: Date.now(),
-    version: CLI_VERSION,
+    version: readCliVersion(),
     properties: sanitizeProperties({
       ...context.properties,
       ...(opts.properties ?? {}),

--- a/src/internal/version.ts
+++ b/src/internal/version.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Compiled to dist/internal/version.js, so the package root is two levels up.
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * The CLI version from package.json. Single source of truth for
+ * `--version`, telemetry payloads, and doctor's version-consistency
+ * check against the plugin manifests.
+ */
+export function readCliVersion(): string {
+  return readManifestVersion(join(packageRoot, "package.json")) ?? "0.0.0";
+}
+
+/**
+ * Versions that must move together on catalog-changing releases.
+ * Installed plugins have no other staleness signal — see
+ * docs/release-checklist.md.
+ */
+export function readManifestVersions(): {
+  cli: string | null;
+  plugin: string | null;
+  marketplace: string | null;
+} {
+  return {
+    cli: readManifestVersion(join(packageRoot, "package.json")),
+    plugin: readManifestVersion(join(packageRoot, ".claude-plugin", "plugin.json")),
+    marketplace: readManifestVersion(
+      join(packageRoot, ".claude-plugin", "marketplace.json"),
+      (parsed) => (parsed as { metadata?: { version?: string } }).metadata?.version,
+    ),
+  };
+}
+
+function readManifestVersion(
+  path: string,
+  pick: (parsed: unknown) => string | undefined = (parsed) =>
+    (parsed as { version?: string }).version,
+): string | null {
+  try {
+    return pick(JSON.parse(readFileSync(path, "utf8"))) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -504,6 +504,30 @@ describe("understudy CLI", () => {
     }
   });
 
+  it("includes telemetry state in login JSON output", () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-login-home-"));
+    try {
+      const result = runWithEnv(
+        [
+          "login",
+          "--json",
+          "--api-key",
+          "sk_test_login_json",
+          "--org",
+          "org_TEST",
+          "--project",
+          "default",
+        ],
+        { HOME: home, USERPROFILE: home, UNDERSTUDY_TELEMETRY: "0" },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.telemetry_enabled, false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("per-org logout preserves top-level credential metadata", () => {
     const home = mkdtempSync(join(tmpdir(), "understudy-logout-home-"));
     try {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -484,6 +484,9 @@ describe("understudy CLI", () => {
     assert.equal(payload.runtime, "node");
     assert.equal(payload.ok, true);
     assert.deepEqual(payload.missing, []);
+    assert.equal(payload.versions_consistent, true);
+    assert.equal(payload.versions.cli, payload.versions.plugin);
+    assert.equal(payload.versions.cli, payload.versions.marketplace);
   });
 
   it("status exits non-zero when local config is malformed", () => {


### PR DESCRIPTION
Mechanical polish pass following a review of the last week of merges (CLI rewrite, installer, plugin packaging, 32→21 skill consolidation).

## Why

The consolidation never reached installed plugins: all three version fields were hard-coded at 0.1.0, so existing installs still expose the pre-consolidation catalog (mlx-arena, specialize-local-model, …) with no signal to update. Separately, two discoverability gaps: the global `--json` flag appeared only in top-level help, and telemetry existed only in docs — nothing in the CLI itself disclosed it.

## What

- **Version staleness signal**: bump `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` together to 0.2.0; new `src/internal/version.ts` is the single source of truth; local `doctor` now reports `versions` + `versions_consistent` and fails on drift; `install-plugin` skill compares installed vs repo version and refreshes when stale; release checklist requires the joint bump on catalog-changing releases.
- **Telemetry disclosure**: `status` shows a `telemetry` line (`telemetry_enabled` under `--json`); `login` prints the opt-out (`UNDERSTUDY_TELEMETRY=0`) once on success; telemetry payload `version` now reads the real package version (was hard-coded `0.0.0`); docs updated.
- **`--json` discoverability**: every subcommand's help now shows the global flag (skipping commands that declare their own).
- **README CLI surface**: list was missing 7 shipped commands (`logout`, `capture-evidence`/`understand` alias, `capture-import`, `route-decision`, `value`, `experiments`, `next`); added a note that `--json` is global.

## Verification

`npm run check` green: build, typecheck, 67/67 tests (incl. new doctor version-consistency assertions), `skills:validate` (21 skills), `package:smoke`.

Deliberately **not** fixed here (working-tree-only files, verified untracked via `.git/info/exclude`): the `/Users/luis` paths in `docs/proposals/examples/*.py`. Skill-content items (distill trigger wording, orchestrator SKILL.md extraction) left for a separate judgment-heavy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->