### PR TITLE
Link hosted-contract docs (docs.understudylabs.com) from README and gateway-touching skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Registration is not required for that loop. Hosted gateway access is available
 after `understudy login`; browser, channel, daemon, and desktop-runtime
 commands remain outside this public CLI until intentionally extracted.
 
+The hosted surface this CLI consumes is documented at
+[docs.understudylabs.com](https://docs.understudylabs.com) — see
+[open-source/agent-tools](https://docs.understudylabs.com/open-source/agent-tools)
+for how this repo fits the platform and
+[open-source/cli](https://docs.understudylabs.com/open-source/cli) for the
+command-level CLI reference. The skills here stay local-first; the docs site
+covers the hosted contracts behind them.
+
 ## Shape
 
 | Spine | Path | Purpose |
@@ -175,6 +183,16 @@ Understudy model IDs and display names only. `routes set/clear` writes
 control-plane route config, so the application keeps calling the normal gateway
 while a percentage of traffic goes to the selected Understudy model and the
 rest remains passthrough/frontier.
+
+The hosted contracts behind these commands are documented on the docs site: the
+[control-plane API](https://docs.understudylabs.com/reference/control-plane)
+(what `workloads`, `routes`, and `captures` call), the
+[routing](https://docs.understudylabs.com/concepts/routing) and
+[capture](https://docs.understudylabs.com/concepts/capture) semantics, the
+gateway [request headers](https://docs.understudylabs.com/reference/request-headers)
+and [response headers](https://docs.understudylabs.com/reference/response-headers),
+and the [CLI command reference](https://docs.understudylabs.com/open-source/cli)
+for every command in the journey above.
 
 If the coding agent has an approved native email connector, it may complete the
 email-code prompt by reading the fresh Understudy sign-in email directly. The

--- a/skills/onboard/anthropic-typescript.md
+++ b/skills/onboard/anthropic-typescript.md
@@ -77,6 +77,10 @@ Key points:
 - Preserve every other field the constructor already had (`timeout`,
   `maxRetries`, custom `fetch`, etc.). They're orthogonal to gateway
   routing.
+- The full gateway header contract is documented at
+  [reference/request-headers](https://docs.understudylabs.com/reference/request-headers)
+  and
+  [reference/response-headers](https://docs.understudylabs.com/reference/response-headers).
 
 ## What doesn't need to change
 

--- a/skills/onboard/mastra-typescript.md
+++ b/skills/onboard/mastra-typescript.md
@@ -129,6 +129,10 @@ Key points:
 - Do not delete `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from `.env` or
   deployment config. The provider reads them at runtime to forward on
   `x-understudy-upstream-key`.
+- The full gateway header contract is documented at
+  [reference/request-headers](https://docs.understudylabs.com/reference/request-headers)
+  and
+  [reference/response-headers](https://docs.understudylabs.com/reference/response-headers).
 
 ## What doesn't need to change
 

--- a/skills/onboard/openai-typescript.md
+++ b/skills/onboard/openai-typescript.md
@@ -64,6 +64,10 @@ Key points:
   OpenAI key. **Do not delete or rename `OPENAI_API_KEY`** anywhere — the
   patch reads it at runtime to forward to `api.openai.com`.
 - Preserve any other constructor fields the user had.
+- The full gateway header contract is documented at
+  [reference/request-headers](https://docs.understudylabs.com/reference/request-headers)
+  and
+  [reference/response-headers](https://docs.understudylabs.com/reference/response-headers).
 
 ## What doesn't need to change
 

--- a/skills/onboard/universal-typescript.md
+++ b/skills/onboard/universal-typescript.md
@@ -115,6 +115,12 @@ The header machinery varies by client. Common forms:
   (Python)
 - Raw `fetch`: add to the `headers` object on the request
 
+The full gateway header contract — every request header the gateway
+reads and every response header it adds — is documented at
+[reference/request-headers](https://docs.understudylabs.com/reference/request-headers)
+and
+[reference/response-headers](https://docs.understudylabs.com/reference/response-headers).
+
 ## Worked examples
 
 ### Vercel AI SDK with OpenAI

--- a/skills/ramp-and-verify/SKILL.md
+++ b/skills/ramp-and-verify/SKILL.md
@@ -37,7 +37,8 @@ node dist/bin.js status --json
 - **Disclose capture-on-by-default.** Setting a model route enables request
   capture for that workload unless capture is explicitly disabled — tell the
   developer this before the first route write and confirm the capture setting
-  they want.
+  they want. The hosted capture behavior is documented at
+  [docs.understudylabs.com/concepts/capture](https://docs.understudylabs.com/concepts/capture).
 - **Snapshot before every change.** The CLI writes a route snapshot before
   route writes; verify it exists so `routes rollback` has something to restore.
 - **No savings claim without a claim packet.** Measured routed-vs-passthrough
@@ -67,7 +68,9 @@ node dist/bin.js status --json
 
 Default tiers: **5% → 25% → 100%** (note: `routes set` defaults `--traffic-pct`
 to 10 when not specified, so pass `--traffic-pct 5` explicitly for the first
-tier). At each tier:
+tier). The dial's hosted split semantics are documented at
+[docs.understudylabs.com/concepts/routing](https://docs.understudylabs.com/concepts/routing).
+At each tier:
 
 1. `understudy routes set <workload> --project <p> --model-id <id>
    --traffic-pct <pct>` — after approval.
@@ -116,3 +119,8 @@ recommended next action.
   frozen-eval verdict required by the pre-ramp gate.
 - [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) — the
   claim-packet contract for any measured savings statement.
+- Hosted contracts on the docs site —
+  [routing](https://docs.understudylabs.com/concepts/routing),
+  [capture](https://docs.understudylabs.com/concepts/capture), and the
+  [control-plane API](https://docs.understudylabs.com/reference/control-plane)
+  behind `routes set/rollback/clear` and `captures list`.

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -122,7 +122,8 @@ comparing a workload's quality and cost across the split.
    ```
 
    Clearing the route (`--clear` in place of the model/traffic flags) returns the
-   workload to full passthrough.
+   workload to full passthrough. The hosted split semantics are documented at
+   [docs.understudylabs.com/concepts/routing](https://docs.understudylabs.com/concepts/routing).
 
 3. Run the eval through the gateway so the routed model serves its share. Any
    local command works; an eval harness like a verifiers `vf-eval` run is typical.
@@ -153,6 +154,13 @@ End with:
 - [`references/frontier-keys.md`](references/frontier-keys.md) — the BYO
   `.env`-keys vs ZDR-gateway vs skip decision, the allowlisted env vars, the
   secret-to-remote-infra recipe, and the installer mapping.
+- Hosted contracts on the docs site —
+  [routing semantics](https://docs.understudylabs.com/concepts/routing),
+  [capture](https://docs.understudylabs.com/concepts/capture), the
+  [control-plane API](https://docs.understudylabs.com/reference/control-plane)
+  behind `workloads`/`routes`/`captures`, and the gateway
+  [request headers](https://docs.understudylabs.com/reference/request-headers) /
+  [response headers](https://docs.understudylabs.com/reference/response-headers).
 
 Domain depth in [`reference.md`](reference.md):
 

--- a/skills/use-understudy-gateway/reference.md
+++ b/skills/use-understudy-gateway/reference.md
@@ -35,11 +35,17 @@ anything that the developer has not approved.
    that leaves the application code untouched:
    - *Gateway already in place* — enable gateway trace capture for the workload
      so calls are recorded as they pass through. The app keeps calling the same
-     base URL.
+     base URL. Hosted capture semantics (what is recorded, defaults, redaction)
+     are documented at
+     [docs.understudylabs.com/concepts/capture](https://docs.understudylabs.com/concepts/capture).
    - *Provider SDK direct* — point the existing client's base URL at the gateway
      (an OpenAI-compatible base URL plus the injected key from
      `understudy run`), so the SDK, request shape, and response shape are
-     unchanged and only the endpoint moves.
+     unchanged and only the endpoint moves. The gateway's header contract is
+     documented at
+     [reference/request-headers](https://docs.understudylabs.com/reference/request-headers)
+     and
+     [reference/response-headers](https://docs.understudylabs.com/reference/response-headers).
    - *Restricted / offline* — when the environment is local-only or hosted
      capture is disallowed (for example a ZDR constraint, see
      [`../understudy/reference.md`](../understudy/reference.md) → Constraints),
@@ -96,7 +102,12 @@ rules below apply to every upload, spend, credential, deploy, or route change.
    ```
 
    See [`SKILL.md`](SKILL.md) → A/B model routing for the full split mechanics
-   and the managed-frontier prerequisite for a frontier comparison.
+   and the managed-frontier prerequisite for a frontier comparison. The hosted
+   side of this contract is documented at
+   [concepts/routing](https://docs.understudylabs.com/concepts/routing) (split
+   semantics) and
+   [reference/control-plane](https://docs.understudylabs.com/reference/control-plane)
+   (the API the workloads route commands call).
 4. **Local-only mode: write a deployment artifact instead of routing.** When no
    hosted route is allowed, write the chosen route to a local deployment artifact
    / `understudy.yaml` (model id, traffic intent, prompt/parser version, baseline


### PR DESCRIPTION
## What

The understudy-platform monorepo now has a public docs site (docs.understudylabs.com) documenting the hosted surface this repo's CLI consumes. This PR links those pages from everywhere this repo explains hosted-gateway contracts inline:

- **README** — intro now points to `/open-source/agent-tools` and `/open-source/cli`; the **First Auth Journey** section maps its commands to the control-plane API reference, routing/capture concepts, request/response header references, and the CLI command reference.
- **use-understudy-gateway** (SKILL.md + reference.md) — routing split semantics, capture semantics, header contract, and the control-plane API linked at the steps that use them, plus a docs entry in References.
- **ramp-and-verify** — capture-on-by-default gate links `/concepts/capture`; the traffic-dial ladder links `/concepts/routing`; docs entry in References.
- **onboard recipes** (anthropic / openai / mastra / universal TypeScript) — each `x-understudy-upstream-key` explanation links `/reference/request-headers` and `/reference/response-headers`.

Local-first framing is unchanged — the links are for the hosted contracts, not a replacement for skill content. `plan-hosted-run` deliberately untouched (its "routing" is GPU-provider selection, not gateway traffic routing).

## Verification

- `npm run skills:validate` — ok 21 public skills
- `node scripts/public-safety.mjs` — exit 0
- Markdown-only change; build/typecheck unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->