### PR TITLE
Installer glow-up + agent-native two-phase login for demoable agent-first sign-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ understudy doctor
 The first hosted journey is intentionally narrow:
 
 ```bash
-understudy login --email you@company.com
+understudy login --email you@company.com   # emails a one-time code
+understudy login --code 123456             # completes sign-in (non-TTY shells)
 understudy doctor --hosted
 understudy workloads list
 understudy workloads create classify --capture
@@ -159,7 +160,11 @@ understudy routes show classify --project rehearsal
 understudy routes clear classify --project rehearsal
 ```
 
-`login --email` uses the Understudy email-code registration flow. It stores the
+`login --email` uses the Understudy email-code registration flow. In an
+interactive terminal it prompts for the code inline; in a non-TTY shell (a
+coding agent, a script) it sends the code and exits, and `login --code`
+completes the pending sign-in — so an agent can drive sign-up as two plain
+shell commands. It stores the
 returned `sk_*` in `~/.understudy/credentials.json` with mode `600` and writes a
 repo-local `.understudy/config.json` when the platform returns a default
 project. `run` injects `UNDERSTUDY_API_KEY` and `UNDERSTUDY_GATEWAY_URL` only

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,9 @@ STATE_DIR="${UNDERSTUDY_INSTALL_STATE_DIR:-$LAB/install-state}"
 INSTALLER_COMMIT="${UNDERSTUDY_INSTALLER_COMMIT:-unknown}"
 LAUNCH_CLAUDE="${UNDERSTUDY_LAUNCH_CLAUDE:-1}"
 CLAUDE_PERMISSION_MODE="${UNDERSTUDY_CLAUDE_PERMISSION_MODE:-auto}"
-INITIAL_CLAUDE_PROMPT="${UNDERSTUDY_INITIAL_CLAUDE_PROMPT:-Use the Understudy onboarding skill for this project now. Guide me through getting my first local Understudy, choosing my terminal/tmux/Pi handoff, and after the first local-vs-frontier duel, help me pick a real problem or find local data so we can try to make the Understudy beat the frontier on that task slice.}"
+USER_PROMPT_OVERRIDE="${UNDERSTUDY_INITIAL_CLAUDE_PROMPT:-}"
+INITIAL_CLAUDE_PROMPT=""
+KEEP_LOGIN="${UNDERSTUDY_KEEP_LOGIN:-0}"
 NO_CLAUDE=0
 START_STEP=1
 ONLY_STEP=""
@@ -28,18 +30,28 @@ while [ "$#" -gt 0 ]; do
     --no-claude) NO_CLAUDE=1 ;;
     --no-launch-claude) LAUNCH_CLAUDE=0 ;;
     --launch-claude) LAUNCH_CLAUDE=1 ;;
+    --keep-login) KEEP_LOGIN=1 ;;
+    --fresh-login) KEEP_LOGIN=0 ;;
     --from-step) START_STEP="${2:?missing step number}"; shift ;;
     --only-step) ONLY_STEP="${2:?missing step number}"; shift ;;
     --resume) RESUME=1 ;;
     --lab) LAB="${2:?missing path}"; shift ;;
     -h|--help)
       cat <<'EOF'
-Usage: install.sh [--yes] [--non-interactive] [--resume] [--from-step N] [--only-step N] [--no-claude] [--no-launch-claude]
+Usage: install.sh [--yes] [--non-interactive] [--resume] [--from-step N] [--only-step N] [--keep-login] [--no-claude] [--no-launch-claude]
 
 Installs the Understudy CLI + Claude Code skill/plugin surface, then hands the
-user back to Claude Code. It does not download model weights, start MLX, install
-Pi, launch tmux/iTerm, or make frontier calls. Those are guided by the
-/understudy:onboard skill after the user is in their coding agent.
+user back to Claude Code, where the coding agent runs the agent-first sign-up
+(email one-time code through `understudy login`) and onboarding. It does not
+download model weights, start MLX, install Pi, launch tmux/iTerm, or make
+frontier calls. Those are guided by the /understudy:onboard skill after the
+user is in their coding agent.
+
+If you are already signed in, the installer signs you out by default so the
+agent-first sign-up can be experienced (or demoed) from scratch. Only the
+login state is touched — profile, models, and history under ~/.understudy are
+preserved, and the old credentials file is kept as a timestamped backup.
+Pass --keep-login to keep the existing sign-in.
 
 Options:
   --yes                 approve the installer prompt
@@ -48,6 +60,8 @@ Options:
   --resume              continue from the next unfinished install step
   --from-step N         start from step 1, 2, or 3
   --only-step N         run only step 1, 2, or 3
+  --keep-login          keep an existing sign-in instead of resetting it
+  --fresh-login         reset an existing sign-in for agent-first sign-up (default)
   --no-claude           skip Claude Code plugin install and final Claude launch
   --no-launch-claude    install plugin but do not open Claude Code at the end
   --launch-claude       open Claude Code at the end (default)
@@ -65,10 +79,12 @@ Environment overrides:
   UNDERSTUDY_INSTALL_PACKAGE     optional npm package spec override
   UNDERSTUDY_NONINTERACTIVE      set to 1 to use safe defaults without prompting
   UNDERSTUDY_REQUIRE_CONFIRM     set to 1 to fail when no prompt TTY exists
+  UNDERSTUDY_KEEP_LOGIN          set to 1 to keep an existing sign-in
   UNDERSTUDY_LAUNCH_CLAUDE      set to 0 to skip opening Claude Code
   UNDERSTUDY_CLAUDE_ARGS        optional extra args when launching Claude Code
   UNDERSTUDY_CLAUDE_PERMISSION_MODE Claude Code permission mode, default auto
   UNDERSTUDY_INITIAL_CLAUDE_PROMPT initial prompt passed to Claude Code
+  NO_COLOR                      disable all installer styling
 EOF
       exit 0
       ;;
@@ -81,22 +97,127 @@ LOG_DIR="${UNDERSTUDY_INSTALL_LOG_DIR:-$LAB/logs}"
 LOG_FILE="${UNDERSTUDY_INSTALL_LOG_FILE:-$LOG_DIR/install-$(date -u +"%Y%m%dT%H%M%SZ").log}"
 mkdir -p "$LOG_DIR"
 
+# ── presentation ─────────────────────────────────────────────────────
+# Fancy output needs a TTY on stdout; pipes, CI, and dumb terminals get
+# the plain `understudy <message>` lines so logs and tests stay stable.
+FANCY=0
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-dumb}" != "dumb" ]; then
+  FANCY=1
+fi
+
+if [ "$FANCY" = "1" ]; then
+  R=$'\033[0m' B=$'\033[1m' D=$'\033[2m'
+  case "${COLORTERM:-}" in
+    *truecolor*|*24bit*)
+      # stage-light gradient: indigo -> cyan -> spring green
+      G1=$'\033[38;2;139;132;250m' G2=$'\033[38;2;120;156;250m'
+      G3=$'\033[38;2;97;181;246m'  G4=$'\033[38;2;72;204;231m'
+      G5=$'\033[38;2;56;222;205m'  G6=$'\033[38;2;72;235;170m'
+      ;;
+    *)
+      G1=$'\033[38;5;105m' G2=$'\033[38;5;111m' G3=$'\033[38;5;75m'
+      G4=$'\033[38;5;44m'  G5=$'\033[38;5;43m'  G6=$'\033[38;5;48m'
+      ;;
+  esac
+  AC="$G3" OKC=$'\033[38;5;42m' WARNC=$'\033[33m' ERRC=$'\033[31m'
+  trap 'printf "\033[?25h" 2>/dev/null || true' EXIT
+else
+  R="" B="" D="" G1="" G2="" G3="" G4="" G5="" G6=""
+  AC="" OKC="" WARNC="" ERRC=""
+fi
+
 log() { printf '%s %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*" >>"$LOG_FILE"; }
 say() {
-  printf '\033[1munderstudy\033[0m %s\n' "$*"
+  if [ "$FANCY" = "1" ]; then
+    printf '  %s│%s %s\n' "$D" "$R" "$*"
+  else
+    printf '\033[1munderstudy\033[0m %s\n' "$*"
+  fi
+  log "$*"
+}
+ok() {
+  if [ "$FANCY" = "1" ]; then
+    printf '  %s✓%s %s\n' "$OKC" "$R" "$*"
+  else
+    printf '\033[1munderstudy\033[0m %s\n' "$*"
+  fi
+  log "$*"
+}
+warn() {
+  if [ "$FANCY" = "1" ]; then
+    printf '  %s!%s %s\n' "$WARNC" "$R" "$*"
+  else
+    printf '\033[1munderstudy\033[0m %s\n' "$*"
+  fi
+  log "$*"
+}
+fail_line() {
+  if [ "$FANCY" = "1" ]; then
+    printf '  %s✗%s %s\n' "$ERRC" "$R" "$*"
+  else
+    printf '\033[1munderstudy\033[0m %s\n' "$*"
+  fi
   log "$*"
 }
 section() {
-  printf '\n\033[1munderstudy\033[0m %s\n' "$*"
+  if [ "$FANCY" = "1" ]; then
+    # bash 3.2 (macOS default) counts bytes, not characters, in ${#var}
+    # and substring expansion — measure with wc -m and build the rule
+    # character by character so multibyte titles stay valid UTF-8.
+    local title="$*" len n pad=""
+    len=$(printf '%s' "$title" | wc -m)
+    n=$((54 - len))
+    [ "$n" -lt 2 ] && n=2
+    while [ "$n" -gt 0 ]; do pad="$pad─"; n=$((n - 1)); done
+    printf '\n  %s──%s %s%s%s %s%s%s\n' "$AC" "$R" "$B" "$title" "$R" "$AC" "$pad" "$R"
+  else
+    printf '\n\033[1munderstudy\033[0m %s\n' "$*"
+  fi
   log "$*"
 }
-run_logged() {
-  log "RUN $*"
-  if "$@" >>"$LOG_FILE" 2>&1; then
+banner() {
+  if [ "$FANCY" != "1" ]; then
     return 0
   fi
-  local status="$?"
-  say "Command failed: $*"
+  printf '\n'
+  printf '  %s%s%s\n' "$G1" '                   __               __            __' "$R"
+  printf '  %s%s%s\n' "$G2" '  __  ______  ____/ /__  __________/ /___  ______/ /_  __' "$R"
+  printf '  %s%s%s\n' "$G3" ' / / / / __ \/ __  / _ \/ ___/ ___/ __/ / / / __  / / / /' "$R"
+  printf '  %s%s%s\n' "$G4" '/ /_/ / / / / /_/ /  __/ /  (__  ) /_/ /_/ / /_/ / /_/ /' "$R"
+  printf '  %s%s%s\n' "$G5" '\__,_/_/ /_/\__,_/\___/_/  /____/\__/\__,_/\__,_/\__, /' "$R"
+  printf '  %s%s%s\n' "$G6" '                                                /____/' "$R"
+  printf '\n  %severy frontier model deserves an understudy%s\n' "$D" "$R"
+}
+# run_logged <label> <command...> — run quietly into the install log,
+# with a live spinner on a TTY and a plain line everywhere else.
+run_logged() {
+  local label="$1"
+  shift
+  log "RUN $*"
+  local status=0
+  if [ "$FANCY" = "1" ]; then
+    local frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏) i=0 start=$SECONDS
+    "$@" >>"$LOG_FILE" 2>&1 &
+    local pid=$!
+    printf '\033[?25l'
+    while kill -0 "$pid" 2>/dev/null; do
+      printf '\r  %s%s%s %s %s%ss%s ' "$AC" "${frames[$((i % 10))]}" "$R" "$label" "$D" "$((SECONDS - start))" "$R"
+      i=$((i + 1))
+      sleep 0.1
+    done
+    wait "$pid" || status=$?
+    printf '\r\033[2K\033[?25h'
+    if [ "$status" = "0" ]; then
+      ok "$label ${D}($((SECONDS - start))s)${R}"
+      return 0
+    fi
+  else
+    if "$@" >>"$LOG_FILE" 2>&1; then
+      return 0
+    fi
+    status="$?"
+  fi
+  fail_line "Command failed: $*"
   say "See install log: $LOG_FILE"
   tail -40 "$LOG_FILE" >&2 || true
   return "$status"
@@ -153,7 +274,7 @@ confirm() {
     say "Confirmation is required; rerun in a terminal or pass --yes / --non-interactive."
     return 1
   fi
-  if ! printf "%s [y/N] " "$1" >/dev/tty 2>/dev/null; then
+  if ! printf "  %s?%s %s %s[y/N]%s " "$G4" "$R" "$1" "$D" "$R" >/dev/tty 2>/dev/null; then
     say "No interactive terminal is available for prompts."
     say "Confirmation is required; rerun in a terminal or pass --yes / --non-interactive."
     return 1
@@ -198,7 +319,7 @@ install_understudy_package() {
 
   if [ -n "$INSTALL_PACKAGE" ]; then
     say "Installing Understudy package from $INSTALL_PACKAGE"
-    run_logged npm install -g "$INSTALL_PACKAGE"
+    run_logged "Install Understudy package" npm install -g "$INSTALL_PACKAGE"
     return 0
   fi
 
@@ -210,14 +331,78 @@ install_understudy_package() {
   say "Installing Understudy package from $INSTALL_REPO_URL#$INSTALL_REF"
   rm -rf "$INSTALL_SOURCE_DIR"
   mkdir -p "$(dirname "$INSTALL_SOURCE_DIR")"
-  run_logged git clone --depth 1 --branch "$INSTALL_REF" "$INSTALL_REPO_URL" "$INSTALL_SOURCE_DIR"
+  run_logged "Download Understudy ($INSTALL_REF)" git clone --depth 1 --branch "$INSTALL_REF" "$INSTALL_REPO_URL" "$INSTALL_SOURCE_DIR"
   package_commit="$(git -C "$INSTALL_SOURCE_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
   say "Understudy package commit: $package_commit"
   mkdir -p "$STATE_DIR"
   printf '%s\n' "$package_commit" >"$STATE_DIR/package-commit"
-  run_logged npm install --prefix "$INSTALL_SOURCE_DIR" --ignore-scripts
-  run_logged npm run --prefix "$INSTALL_SOURCE_DIR" build
-  run_logged npm install -g --ignore-scripts "$INSTALL_SOURCE_DIR"
+  run_logged "Install dependencies" npm install --prefix "$INSTALL_SOURCE_DIR" --ignore-scripts
+  run_logged "Build the CLI" npm run --prefix "$INSTALL_SOURCE_DIR" build
+  run_logged "Link the understudy command" npm install -g --ignore-scripts "$INSTALL_SOURCE_DIR"
+}
+
+# ── agent-first sign-in ──────────────────────────────────────────────
+# The sign-up itself belongs to the coding agent (`understudy login`
+# sends an email code; `understudy login --code` finishes). The
+# installer only resets login state so that experience starts from
+# scratch — everything else under ~/.understudy is preserved.
+CREDENTIALS_FILE="$HOME/.understudy/credentials.json"
+KNOWN_EMAIL=""
+
+credentials_email() {
+  need node || return 0
+  node -e 'try{const c=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));if(c.email)process.stdout.write(c.email)}catch(e){}' "$CREDENTIALS_FILE" 2>/dev/null || true
+}
+
+prepare_agent_first_signin() {
+  [ -n "$ONLY_STEP" ] && return 0
+  section "Prepare the agent-first sign-in."
+  if [ -f "$CREDENTIALS_FILE" ]; then
+    KNOWN_EMAIL="$(credentials_email)"
+    if [ "$KEEP_LOGIN" = "1" ]; then
+      say "Keeping the existing Understudy sign-in (--keep-login)."
+      return 0
+    fi
+    local backup
+    backup="$HOME/.understudy/credentials.json.bak-$(date -u +"%Y%m%dT%H%M%SZ")"
+    mv "$CREDENTIALS_FILE" "$backup"
+    rm -f "$HOME/.understudy/login-pending.json"
+    if [ -n "$KNOWN_EMAIL" ]; then
+      ok "Signed out $KNOWN_EMAIL so the agent can run the sign-up from scratch."
+    else
+      ok "Signed out so the agent can run the sign-up from scratch."
+    fi
+    say "Only the login state was reset; profile, models, and history under ~/.understudy are untouched."
+    say "Credentials backup: $backup"
+    say "Restore it without re-signing in: mv \"$backup\" \"$CREDENTIALS_FILE\""
+    say "Keep the sign-in next time with --keep-login."
+  else
+    say "No existing sign-in found; the coding agent will run the first sign-up."
+  fi
+  if [ -z "$KNOWN_EMAIL" ]; then
+    KNOWN_EMAIL="$(git config --get user.email 2>/dev/null || true)"
+  fi
+}
+
+compose_initial_prompt() {
+  if [ -n "$USER_PROMPT_OVERRIDE" ]; then
+    INITIAL_CLAUDE_PROMPT="$USER_PROMPT_OVERRIDE"
+    return 0
+  fi
+  local signup="" email_clause
+  if [ ! -f "$CREDENTIALS_FILE" ]; then
+    if [ -n "$KNOWN_EMAIL" ]; then
+      email_clause="run \`understudy login --email $KNOWN_EMAIL\`"
+    else
+      email_clause="ask me for my email, then run \`understudy login --email <my-email>\`"
+    fi
+    signup="Start with the agent-first Understudy sign-up: check \`understudy status --json\`, and if signed_in is false, $email_clause — it emails me a one-time code and exits. Ask me for the code from my inbox (or fetch it yourself if you have email access, reading only the Understudy sign-in email), finish with \`understudy login --code <code>\`, and confirm with \`understudy status --json\`. Then "
+  fi
+  if [ -n "$signup" ]; then
+    INITIAL_CLAUDE_PROMPT="${signup}use the Understudy onboarding skill for this project. Guide me through getting my first local Understudy, choosing my terminal/tmux/Pi handoff, and after the first local-vs-frontier duel, help me pick a real problem or find local data so we can try to make the Understudy beat the frontier on that task slice."
+  else
+    INITIAL_CLAUDE_PROMPT="Use the Understudy onboarding skill for this project now. Guide me through getting my first local Understudy, choosing my terminal/tmux/Pi handoff, and after the first local-vs-frontier duel, help me pick a real problem or find local data so we can try to make the Understudy beat the frontier on that task slice."
+  fi
 }
 
 install_claude_plugin() {
@@ -240,11 +425,11 @@ install_claude_plugin() {
 
   say "Installing the Understudy Claude Code plugin from $repo."
   if claude plugin list --json 2>/dev/null | grep -q 'understudy@understudy-skills'; then
-    say "Understudy plugin already appears installed."
+    ok "Understudy plugin already appears installed."
   else
-    claude plugin marketplace add "$repo" >/dev/null
-    claude plugin install understudy@understudy-skills >/dev/null
-    say "Understudy plugin installed."
+    run_logged "Register the plugin marketplace" claude plugin marketplace add "$repo"
+    run_logged "Install the Understudy plugin" claude plugin install understudy@understudy-skills
+    ok "Understudy plugin installed."
   fi
   say "In Claude Code, type /reload-plugins once to activate the skills."
   say "Then type /understudy:onboard so the agent can guide the first local Understudy."
@@ -274,12 +459,12 @@ launch_claude_code() {
     return 0
   fi
 
-  section "Step 3/3: open Claude Code."
+  section "Step 3/3 · Open Claude Code"
   say "Claude Code will open in: $(pwd)"
   say "The Understudy plugin will be loaded for this launch with --plugin-dir."
   say "Claude Code permission mode: $CLAUDE_PERMISSION_MODE."
   say "Claude Code will receive the first prompt automatically:"
-  say "  $INITIAL_CLAUDE_PROMPT"
+  say "  ${D}$INITIAL_CLAUDE_PROMPT${R}"
   say "If you open a separate existing Claude Code session later, run /reload-plugins there once."
   say "Launching Claude Code now. Exit Claude to return to this shell."
   claude_log="$LOG_DIR/claude-$(date -u +"%Y%m%dT%H%M%SZ").log"
@@ -325,16 +510,25 @@ need npm || {
 
 configure_resume
 
-section "Welcome. We are going to install Understudy for your coding agent."
-say "Install log: $LOG_FILE"
-say "Installer script commit: $INSTALLER_COMMIT"
-say "Install source ref: $INSTALL_REF"
+banner
+if [ "$FANCY" = "1" ]; then
+  section "Welcome"
+else
+  section "Welcome. We are going to install Understudy for your coding agent."
+fi
 say "This installer bootstraps the CLI and Claude Code skills, then drops you back into your coding agent."
+say "Source: $INSTALL_REPO_URL#$INSTALL_REF ${D}(installer commit: $INSTALLER_COMMIT)${R}"
+say "Install log: $LOG_FILE"
 say ""
-say "Install plan:"
-say "  1. Download and install the Understudy CLI from $INSTALL_REPO_URL#$INSTALL_REF."
-say "  2. Install or refresh the Claude Code skills when Claude Code is available."
-say "  3. Open Claude Code in this directory and show the next slash commands."
+say "${B}Install plan${R}"
+say "  ${G2}1.${R} Install the Understudy CLI."
+if [ "$KEEP_LOGIN" = "1" ]; then
+  say "  ${G3}·${R}  Keep the existing Understudy sign-in (--keep-login)."
+else
+  say "  ${G3}·${R}  Reset any existing sign-in so the agent-first sign-up starts fresh (backup kept; --keep-login skips)."
+fi
+say "  ${G4}2.${R} Install or refresh the Claude Code skills when Claude Code is available."
+say "  ${G5}3.${R} Open Claude Code here — the agent signs you up by email code, then onboards you."
 say ""
 say "Default install does not download weights, start MLX, install Pi, launch tmux/iTerm, or make frontier calls."
 say "Those actions happen later through /understudy:onboard, where the coding agent can coach the user and ask consent."
@@ -344,7 +538,7 @@ confirm "Continue with this Understudy installation?" || exit 1
 PKG_DIR="$(npm root -g)/@understudylabs/understudy-agent-tools"
 
 if should_run_step 1; then
-  section "Step 1/3: install the CLI."
+  section "Step 1/3 · Install the CLI"
   install_understudy_package
   PKG_DIR="$(npm root -g)/@understudylabs/understudy-agent-tools"
   mark_step_done 1
@@ -352,19 +546,23 @@ else
   say "Skipping step 1/3: install the CLI."
 fi
 
+prepare_agent_first_signin
+
 if should_run_step 2; then
-  section "Step 2/3: install the Claude Code skills."
+  section "Step 2/3 · Install the Claude Code skills"
   install_claude_plugin
   mark_step_done 2
 else
   say "Skipping step 2/3: install the Claude Code skills."
 fi
 
-section "Where this goes next."
+compose_initial_prompt
+
+section "Where this goes next"
 say "The installer is done. The next experience belongs inside Claude Code:"
-say "  The launched Claude Code session receives an Understudy onboarding prompt automatically."
+say "  The launched Claude Code session receives the sign-up + onboarding prompt automatically."
 say "  If you continue in an already-open Claude Code session instead, run /reload-plugins and then /understudy:onboard."
-say "That lets the coding agent explain the first local Understudy, open a terminal of the user's choice when needed, and run the same commands itself when appropriate."
+say "That lets the coding agent run the email-code sign-up itself, explain the first local Understudy, and open a terminal of the user's choice when needed."
 if should_run_step 3; then
   launch_claude_code
 else

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -77,20 +77,29 @@ node dist/bin.js status --json
    understudy status --json
    ```
 
-2. If not signed in, register/sign in with the email-code flow:
+2. If not signed in, register/sign in with the two-phase email-code flow:
 
    ```sh
-   understudy login --email <developer-email>
+   understudy login --email <developer-email>   # emails a one-time code, then exits
+   understudy login --code <one-time-code>      # completes the sign-in
    ```
+
+   In a non-TTY shell (an agent's shell) the first command sends the code and
+   exits with instructions; the pending claim is saved under
+   `~/.understudy/login-pending.json`, so no interactive prompt has to be held
+   open — no tmux or expect tricks. In an interactive terminal the same command
+   prompts for the code inline instead. Codes expire after about 10 minutes;
+   rerun `--email` to send a fresh one.
 
    This creates or finds the developer's Understudy account, retrieves an API
    key through the CLI, and stores it outside the repo. The key is used for
    authenticated gateway inference, project/key management, and remote model
    routes. Do not ask the developer to paste the key.
 
-   An agent with an approved native email connector may search narrowly for the
-   fresh sign-in email and enter the one-time code into the waiting CLI prompt.
-   Do not print or persist the code.
+   Ask the developer to read the one-time code from their inbox. An agent with
+   an approved native email connector may instead search narrowly for the fresh
+   Understudy sign-in email and pass the code to `understudy login --code`. Read
+   only that email, and do not persist the code anywhere else.
 
 3. Confirm project/key readiness:
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,3 +1,13 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
 import { input } from "@inquirer/prompts";
 import { Command } from "commander";
 import kleur from "kleur";
@@ -7,6 +17,7 @@ import { writeProjectConfig } from "../config/index.js";
 import { readCredentials, writeCredentials } from "../config/credentials.js";
 import {
   globalCredentialsPath,
+  globalLoginPendingPath,
   PROJECT_CONFIG_DIR,
 } from "../config/paths.js";
 import { DEFAULT_GATEWAY_URL } from "../config/defaults.js";
@@ -20,6 +31,8 @@ import {
 
 interface LoginOpts {
   email?: string;
+  code?: string;
+  sendCode?: boolean;
   apiKey?: string;
   org?: string;
   project?: string;
@@ -62,11 +75,40 @@ const AgentClaimResponseSchema = z.object({
 
 type AgentClaimResponse = z.infer<typeof AgentClaimResponseSchema>;
 
+/**
+ * In-flight email-code sign-in, persisted at
+ * `~/.understudy/login-pending.json` (mode 600 — the claim token is
+ * sensitive). Written when a code is sent, consumed by
+ * `understudy login --code <code>`, removed on success. This is what
+ * lets a coding agent drive sign-in as two plain shell commands
+ * instead of holding an interactive prompt open.
+ */
+const PendingLoginSchema = z.object({
+  email: z.string().email(),
+  gateway_url: z.string().url(),
+  claim_token: z.string().min(1),
+  complete_url: z.string().url(),
+  signup_intent_id: z.string().optional(),
+  sent_at: z.string(),
+});
+
+type PendingLogin = z.infer<typeof PendingLoginSchema>;
+
 export function registerLoginCommand(program: Command): void {
   program
     .command("login")
-    .description("Sign in or register with Understudy.")
+    .description(
+      "Sign in or register with Understudy. `--email` sends a one-time code; in a non-interactive shell, finish with `understudy login --code <code>`.",
+    )
     .option("--email <email>", "Use the auth.md email code registration flow.")
+    .option(
+      "--send-code",
+      "Send the one-time code and exit without prompting; finish with `understudy login --code <code>`.",
+    )
+    .option(
+      "--code <code>",
+      "Complete a pending email sign-in with the one-time code from the inbox.",
+    )
     .option(
       "--api-key <key>",
       "Non-interactive escape hatch: save this sk_* directly. Requires --org and --project.",
@@ -96,16 +138,33 @@ async function runLogin(opts: LoginOpts, json: boolean): Promise<void> {
   const gatewayUrl =
     opts.gatewayUrl ?? process.env.UNDERSTUDY_GATEWAY_URL ?? DEFAULT_GATEWAY_URL;
 
+  if (opts.code) {
+    await completePendingLogin(opts.code, json);
+    return;
+  }
+
+  if (opts.sendCode && !opts.email) {
+    throw new Error("--send-code requires --email <email>.");
+  }
+
   if (opts.email) {
     const signupIntentId = opts.signupIntentId ?? signupIntentFromEnv();
+    // Without a TTY (an agent's shell, a script) the inline code prompt
+    // cannot work — degrade to send-and-exit so the caller can finish
+    // with `understudy login --code <code>`.
+    const sendOnly = Boolean(opts.sendCode) || !process.stdin.isTTY;
     await trackLoginStarted({ mode: "auth.md", gatewayUrl, signupIntentId });
     try {
       const result = await runAuthMdLogin(
         opts.email,
         gatewayUrl,
         json,
+        sendOnly,
         signupIntentId,
       );
+      if (!result) {
+        return; // code sent; completion happens via `login --code`
+      }
       saveApiKeyResult(result, gatewayUrl, signupIntentId);
       emitApiKeySuccess(result, json, "auth.md");
       await trackLoginCompleted({
@@ -155,7 +214,7 @@ async function runLogin(opts: LoginOpts, json: boolean): Promise<void> {
   }
 
   throw new Error(
-    "Run `understudy login --email <email>` to sign in with an email code.",
+    "Run `understudy login --email <email>` to send a one-time code, then `understudy login --code <code>` to finish.",
   );
 }
 
@@ -187,8 +246,9 @@ async function runAuthMdLogin(
   email: string,
   gatewayUrl: string,
   json: boolean,
+  sendOnly: boolean,
   signupIntentId?: string,
-): Promise<AgentClaimResponse> {
+): Promise<AgentClaimResponse | null> {
   const metadata = await fetchAuthMdMetadata(gatewayUrl);
   const register = await postJson(metadata.agent_auth.register_uri, {
     type: "identity_assertion",
@@ -198,6 +258,28 @@ async function runAuthMdLogin(
     ...(signupIntentId ? { signup_intent_id: signupIntentId } : {}),
   });
   const reg = AgentRegisterResponseSchema.parse(register);
+  const completeUrl = resolveClaimCompleteUrl(
+    reg.claim_url,
+    metadata.agent_auth.claim_uri,
+    metadata.agent_auth.register_uri,
+  );
+
+  // Persist the claim so the sign-in survives this process: an agent
+  // (or an interrupted prompt) finishes with `understudy login --code`.
+  const pending: PendingLogin = {
+    email,
+    gateway_url: gatewayUrl,
+    claim_token: reg.claim_token,
+    complete_url: completeUrl,
+    ...(signupIntentId ? { signup_intent_id: signupIntentId } : {}),
+    sent_at: new Date().toISOString(),
+  };
+  writePendingLogin(pending);
+
+  if (sendOnly) {
+    emitCodeSent(pending, json);
+    return null;
+  }
 
   if (!json) {
     process.stdout.write(
@@ -206,16 +288,104 @@ async function runAuthMdLogin(
   }
   const code = await input({ message: "One-time code:" });
 
-  const completeUrl = resolveClaimCompleteUrl(
-    reg.claim_url,
-    metadata.agent_auth.claim_uri,
-    metadata.agent_auth.register_uri,
-  );
   const claim = await postJson(completeUrl, {
     claim_token: reg.claim_token,
     code,
   });
-  return AgentClaimResponseSchema.parse(claim);
+  const result = AgentClaimResponseSchema.parse(claim);
+  clearPendingLogin();
+  return result;
+}
+
+/**
+ * Phase two of the email-code flow: `understudy login --code <code>`.
+ * Reads the pending claim written by phase one, completes it, saves
+ * credentials, and clears the pending file. The pending file is kept
+ * on failure so a mistyped code can simply be retried.
+ */
+async function completePendingLogin(code: string, json: boolean): Promise<void> {
+  const pending = readPendingLogin();
+  if (!pending) {
+    throw new Error(
+      "No pending sign-in found. Run `understudy login --email <email>` first to send a one-time code.",
+    );
+  }
+  try {
+    const claim = await postJson(pending.complete_url, {
+      claim_token: pending.claim_token,
+      code: code.trim(),
+    });
+    const result = AgentClaimResponseSchema.parse(claim);
+    saveApiKeyResult(result, pending.gateway_url, pending.signup_intent_id);
+    clearPendingLogin();
+    emitApiKeySuccess(result, json, "auth.md");
+    await trackLoginCompleted({
+      apiKey: result.credential,
+      gatewayUrl: result.gateway_url ?? pending.gateway_url,
+      mode: "auth.md",
+      orgId: result.org_id ?? result.organization_id ?? null,
+      userId: result.user_id ?? null,
+      signupIntentId: pending.signup_intent_id ?? null,
+    });
+  } catch (err) {
+    await trackLoginFailed({
+      mode: "auth.md",
+      gatewayUrl: pending.gateway_url,
+      signupIntentId: pending.signup_intent_id,
+      errorKind: loginErrorKind(err),
+    });
+    if (err instanceof Error) {
+      err.message += ` If the code expired (about 10 minutes), run \`understudy login --email ${pending.email}\` to send a fresh one.`;
+    }
+    throw err;
+  }
+}
+
+function writePendingLogin(pending: PendingLogin): void {
+  const path = globalLoginPendingPath();
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, `${JSON.stringify(pending, null, 2)}\n`, {
+    encoding: "utf8",
+  });
+  chmodSync(path, 0o600);
+}
+
+function readPendingLogin(): PendingLogin | null {
+  const path = globalLoginPendingPath();
+  if (!existsSync(path)) {
+    return null;
+  }
+  return PendingLoginSchema.parse(JSON.parse(readFileSync(path, "utf8")));
+}
+
+function clearPendingLogin(): void {
+  const path = globalLoginPendingPath();
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}
+
+function emitCodeSent(pending: PendingLogin, json: boolean): void {
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify({
+        ok: true,
+        pending: true,
+        code_sent_to: pending.email,
+        gateway_url: pending.gateway_url,
+        complete_with: "understudy login --code <code>",
+        expires_in_minutes: 10,
+        pending_path: globalLoginPendingPath(),
+      })}\n`,
+    );
+    return;
+  }
+  process.stdout.write(
+    `${kleur.green("✓")} One-time code sent to ${kleur.bold(pending.email)}\n` +
+      `  Get the code from the inbox, then finish with:\n` +
+      `    ${kleur.cyan("understudy login --code <code>")}\n` +
+      `  ${kleur.dim("The code expires in about 10 minutes.")}\n`,
+  );
 }
 
 async function fetchAuthMdMetadata(gatewayUrl: string) {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -25,6 +25,12 @@ export const GLOBAL_CREDENTIALS_FILE = "credentials.json";
 export const GLOBAL_TELEMETRY_FILE = "telemetry.json";
 
 /**
+ * In-flight email-code sign-in state. Written when a one-time code is
+ * sent, consumed by `understudy login --code`, removed on success.
+ */
+export const GLOBAL_LOGIN_PENDING_FILE = "login-pending.json";
+
+/**
  * Walk upward from `startDir` looking for the nearest directory that
  * contains a `.understudy/` folder. If none exists, fall back to
  * `startDir` itself.
@@ -64,4 +70,8 @@ export function globalCredentialsPath(): string {
 
 export function globalTelemetryPath(): string {
   return join(globalConfigDir(), GLOBAL_TELEMETRY_FILE);
+}
+
+export function globalLoginPendingPath(): string {
+  return join(globalConfigDir(), GLOBAL_LOGIN_PENDING_FILE);
 }

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1236,3 +1236,136 @@ describe("understudy CLI", () => {
       assert.equal(packet.constraints.data_class, "source-metadata-only");
     }));
 });
+
+describe("two-phase email login", () => {
+  function startFakeAuthGateway() {
+    const state = { registers: 0, claims: [] };
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        const base = `http://127.0.0.1:${server.address().port}`;
+        if (req.method === "GET" && req.url === "/.well-known/oauth-authorization-server") {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({
+            agent_auth: {
+              register_uri: `${base}/agent/auth/register`,
+              claim_uri: `${base}/agent/auth/claim`,
+            },
+          }));
+          return;
+        }
+        if (req.method === "POST" && req.url === "/agent/auth/register") {
+          state.registers += 1;
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({
+            registration_id: "reg_1",
+            claim_token: "ct_test_token",
+            claim_url: "/agent/auth/claim/complete",
+          }));
+          return;
+        }
+        if (req.method === "POST" && req.url === "/agent/auth/claim/complete") {
+          const payload = JSON.parse(body);
+          state.claims.push(payload);
+          if (payload.claim_token !== "ct_test_token" || payload.code !== "424242") {
+            res.writeHead(400, { "content-type": "application/json" });
+            res.end(JSON.stringify({ message: "Invalid or expired code." }));
+            return;
+          }
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({
+            credential_type: "api_key",
+            credential: "sk_test_two_phase",
+            org_id: "org_TWOPHASE",
+            email: "agent@example.com",
+            default_project: { slug: "default" },
+          }));
+          return;
+        }
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ message: `unexpected ${req.method} ${req.url}` }));
+      });
+    });
+    return new Promise((resolveServer) => {
+      server.listen(0, "127.0.0.1", () => resolveServer({ server, state }));
+    });
+  }
+
+  it("sends a code with --send-code, retries a bad code, completes with --code", async () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-two-phase-"));
+    const { server, state } = await startFakeAuthGateway();
+    const gatewayUrl = `http://127.0.0.1:${server.address().port}`;
+    try {
+      const env = { HOME: home, USERPROFILE: home };
+
+      const sent = await runWithEnvAsync(
+        ["login", "--email", "agent@example.com", "--send-code", "--gateway-url", gatewayUrl, "--json"],
+        env,
+      );
+      assert.equal(sent.status, 0, sent.stderr);
+      const sentPayload = JSON.parse(sent.stdout);
+      assert.equal(sentPayload.pending, true);
+      assert.equal(sentPayload.code_sent_to, "agent@example.com");
+      assert.match(sentPayload.complete_with, /understudy login --code/);
+      const pendingPath = join(home, ".understudy", "login-pending.json");
+      const pending = JSON.parse(readFileSync(pendingPath, "utf8"));
+      assert.equal(pending.claim_token, "ct_test_token");
+      assert.equal(state.registers, 1);
+
+      const wrong = await runWithEnvAsync(["login", "--code", "111111", "--json"], env);
+      assert.equal(wrong.status, 1);
+      assert.match(wrong.stderr, /Invalid or expired code/);
+      assert.match(wrong.stderr, /login --email agent@example.com/);
+      // a mistyped code keeps the pending claim so the user can retry
+      assert.equal(JSON.parse(readFileSync(pendingPath, "utf8")).claim_token, "ct_test_token");
+
+      const done = await runWithEnvAsync(["login", "--code", "424242", "--json"], env);
+      assert.equal(done.status, 0, done.stderr);
+      const donePayload = JSON.parse(done.stdout);
+      assert.equal(donePayload.ok, true);
+      assert.equal(donePayload.org_id, "org_TWOPHASE");
+      const creds = JSON.parse(readFileSync(join(home, ".understudy", "credentials.json"), "utf8"));
+      assert.equal(creds.api_key, "sk_test_two_phase");
+      assert.equal(creds.email, "agent@example.com");
+      assert.throws(() => readFileSync(pendingPath));
+    } finally {
+      server.close();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("degrades --email to send-and-exit when stdin is not a TTY", async () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-two-phase-notty-"));
+    const { server } = await startFakeAuthGateway();
+    const gatewayUrl = `http://127.0.0.1:${server.address().port}`;
+    try {
+      const result = await runWithEnvAsync(
+        ["login", "--email", "agent@example.com", "--gateway-url", gatewayUrl],
+        { HOME: home, USERPROFILE: home },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /One-time code sent to/);
+      assert.match(result.stdout, /understudy login --code/);
+    } finally {
+      server.close();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("fails clearly when completing with no pending sign-in", () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-two-phase-none-"));
+    try {
+      const result = runWithEnv(["login", "--code", "424242"], {
+        HOME: home,
+        USERPROFILE: home,
+      });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /No pending sign-in found/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/installer.test.mjs
+++ b/tests/installer.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -77,5 +77,95 @@ describe("install.sh", () => {
 
     assert.equal(result.status, 1);
     assert.match(result.stdout, /Confirmation is required/);
+  });
+
+  it("resets an existing sign-in by default, preserving everything else", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const understudyDir = join(home, ".understudy");
+    mkdirSync(understudyDir, { recursive: true });
+    writeFileSync(
+      join(understudyDir, "credentials.json"),
+      `${JSON.stringify({ api_key: "sk_demo", gateway_url: "https://api.understudylabs.com", email: "demo@example.com", orgs: {} })}\n`,
+    );
+    writeFileSync(join(understudyDir, "profile.json"), '{"keep":"me"}\n');
+    const result = spawnSync(
+      "bash",
+      ["-s", "--", "--non-interactive", "--from-step", "3", "--no-claude", "--lab", join(root, "lab")],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Signed out demo@example\.com/);
+    assert.equal(existsSync(join(understudyDir, "credentials.json")), false);
+    const backups = readdirSync(understudyDir).filter((name) => name.startsWith("credentials.json.bak-"));
+    assert.equal(backups.length, 1);
+    assert.equal(readFileSync(join(understudyDir, "profile.json"), "utf8"), '{"keep":"me"}\n');
+  });
+
+  it("keeps the sign-in with --keep-login", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const understudyDir = join(home, ".understudy");
+    mkdirSync(understudyDir, { recursive: true });
+    writeFileSync(
+      join(understudyDir, "credentials.json"),
+      `${JSON.stringify({ api_key: "sk_demo", gateway_url: "https://api.understudylabs.com", email: "demo@example.com", orgs: {} })}\n`,
+    );
+    const result = spawnSync(
+      "bash",
+      ["-s", "--", "--non-interactive", "--keep-login", "--from-step", "3", "--no-claude", "--lab", join(root, "lab")],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Keeping the existing Understudy sign-in/);
+    assert.equal(existsSync(join(understudyDir, "credentials.json")), true);
+  });
+
+  it("leaves login state alone when running a single step", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const understudyDir = join(home, ".understudy");
+    mkdirSync(understudyDir, { recursive: true });
+    writeFileSync(join(understudyDir, "credentials.json"), '{"api_key":"sk_demo","orgs":{}}\n');
+    const result = spawnSync(
+      "bash",
+      ["-s", "--", "--non-interactive", "--only-step", "3", "--no-claude", "--lab", join(root, "lab")],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(existsSync(join(understudyDir, "credentials.json")), true);
   });
 });


### PR DESCRIPTION
## What

**Cooler installer.** On a TTY, `install.sh` now shows a gradient ASCII banner, ruled section headers, live spinners with elapsed time on every long step, and ✓/✗ result lines (truecolor/256-color auto-detected). Pipes, CI, `NO_COLOR`, and dumb terminals get the exact previous plain output, so logs and tests are unchanged. Built for macOS bash 3.2 (byte-based string ops — rules are constructed char-by-char to stay valid UTF-8).

**Demo-ready agent-first sign-up by default.** After the CLI installs, a "Prepare the agent-first sign-in" phase runs: if already signed in, `credentials.json` is *moved* to a timestamped backup (restore command printed); profile, models, and history under `~/.understudy` are untouched. The signed-out email is remembered and baked into the launch prompt, so the opened Claude Code session signs the user up first, then onboards. `--keep-login` / `UNDERSTUDY_KEEP_LOGIN=1` opt out; `--only-step` never touches login state. Re-demo fast with `install.sh --from-step 3`.

**Agent-native two-phase login.** `understudy login --email <email>` with no TTY (or with `--send-code`) sends the one-time code, persists the pending claim to `~/.understudy/login-pending.json` (mode 600), and exits with instructions; `understudy login --code <code>` completes it. Each phase is a plain exiting command, so a coding agent drives sign-up natively — no tmux capture-pane workaround. Interactive terminals keep the inline prompt. Mistyped codes are retryable (pending claim kept); expired codes get a resend hint.

Docs: `use-understudy-gateway` skill and README updated to the two-phase flow.

## Tests

- `npm run check`: 74/74 pass, 21 skills validate, package smoke OK.
- New: fake-gateway send → wrong-code retry → complete cycle; non-TTY degradation of `--email`; clear error when completing with no pending sign-in; installer reset/keep-login/only-step coverage.
- Manual: fancy-mode run under `script(1)` verified banner, aligned UTF-8 rules, spinner success/failure status propagation, and that the reset preserves `profile.json` while backing up credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->