### PR TITLE
Release v0.3.0: bump plugin version + CHANGELOG (deliver ladder + recent skills to existing installs)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Understudy Labs"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+Notable, user-facing changes to the Understudy skills + CLI. Versions track the
+plugin: `package.json`, `.claude-plugin/plugin.json`, and
+`.claude-plugin/marketplace.json` are bumped together on any release that changes
+the skill catalog or CLI surface, because an installed plugin has no other
+staleness signal. After upgrading, run `/reload-plugins`.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/); this project
+uses semantic-ish versioning (minor = new skill or new capability, patch = fixes).
+
+## [0.3.0] — 2026-06-16
+
+### Added
+
+- **`ladder` skill** — a local web UI for an immediate local-vs-frontier model
+  comparison (the onboarding "climb"): a local mlx model and a frontier gateway
+  model run the same task with live thinking + tool-call traces, scored against a
+  synthetic world. Skill catalog goes from 21 to 22. (Existing installs need this
+  release to pick it up — see the note at the top.)
+- **`ingest-traces`** gained a LOTUS semantic-triage reference and orchestrator
+  routing for developers who already have production traces.
+
+### Changed
+
+- **`recursive-language-model`** now measures the decomposition *process*, not
+  just the outcome.
+- Folded June-2026 local-model + gateway benchmark learnings into the
+  `run-local-model-lab`, `manage-local-models`, and gateway-touching skills.
+- **Gateway inference always streams** across the skills, recipes, and CLI (the
+  edge cuts long non-streaming calls), so frontier and routed runs are reliable.
+- Installer glow-up with an agent-native two-phase login for a demoable,
+  agent-first sign-up; `install.sh` bash 3.2 fix.
+- CLI workload admin commands (`list`/`create`/`update`) moved to `/admin/v1`;
+  hosted-contract docs linked from the README and gateway-touching skills.
+
+## [0.2.0] — 2026-06-11
+
+### Added
+
+- **Plugin staleness signal** so updates actually reach existing installs:
+  `install-plugin` compares the installed version against the repo's
+  `plugin.json`, `understudy doctor` fails if the three version files drift, and
+  the release checklist requires the joint bump.
+- Telemetry disclosure in the CLI (`status` shows a telemetry line; login prints
+  the opt-out once) and a global `--json` flag surfaced in every subcommand.
+
+### Changed
+
+- Consolidated the skill catalog from 32 to 21 focused skills.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/skills/install-plugin/SKILL.md
+++ b/skills/install-plugin/SKILL.md
@@ -57,8 +57,9 @@ output) vs the repo's `$REPO/.claude-plugin/plugin.json` `version`. If the repo
 is newer, the installed catalog is stale (skills may be missing or renamed) —
 run `claude plugin marketplace update understudy-skills`, then
 `claude plugin install understudy@understudy-skills`, then have the developer
-run `/reload-plugins` (step 4). If versions match, report installed-and-current
-and stop.
+run `/reload-plugins` (step 4). On a stale upgrade, also surface the
+`$REPO/CHANGELOG.md` entries newer than the installed version (what's new, not
+just a bumped number). If versions match, report installed-and-current and stop.
 
 ### 3. Add the marketplace and install (background-safe)
 
@@ -142,7 +143,7 @@ repo-local skills.
 
 ## Output Standard
 
-End with: whether the plugin was already installed / just installed / shown for
-manual run; the exact activation step (`/reload-plugins`); an explicit
-restart-or-not statement (not needed); the next onboarding command
-(`/understudy:onboard`); and the verification result.
+End with: whether the plugin was already installed / just installed / refreshed
+from a stale version (+ a one-line "what's new") / shown for manual run; the
+activation step (`/reload-plugins`); a restart-or-not statement (not needed); the
+next onboarding command (`/understudy:onboard`); and the verification result.


### PR DESCRIPTION
## Why

Installed Understudy plugins have **no native "update available" notification** —
Claude Code doesn't push update banners for third-party marketplaces, and
auto-update defaults off for them. The *only* staleness signal is the plugin
**version**: `claude plugin update` reports "already at the latest version" unless
the version string is bumped, regardless of new commits. This is exactly the
failure [#73](https://github.com/understudylabs/understudy-agent-tools/pull/73)
was created to prevent ("the 32→21 consolidation never reached existing installs").

The **`ladder`** skill ([#80](https://github.com/understudylabs/understudy-agent-tools/pull/80))
and **seven** other PRs have landed since `0.2.0` **without a version bump**, so
they're currently stranded for anyone already installed. This release ships the
bump so they actually arrive.

## What

- **Joint version bump `0.2.0 → 0.3.0`** in `package.json`,
  `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` — required by
  [docs/release-checklist.md](docs/release-checklist.md) on any release that
  changes the skill catalog; `understudy doctor` (`versions_consistent`) and a
  test enforce that the three never drift.
- **New `CHANGELOG.md`** (Keep a Changelog). `0.3.0` headlines the new `ladder`
  skill (catalog 21 → 22) plus the other changes since `0.2.0`; a `0.2.0` baseline
  is included.
- **`install-plugin` surfaces "what's new":** on a stale upgrade it now reads the
  `CHANGELOG.md` entries newer than the installed version and tells the developer
  what they're getting — not just a bumped number.

## How users get updates (documented for context)

There is no proactive push for third-party plugins. The supported flow, already
wrapped by the `install-plugin` skill (which compares installed-vs-repo version):

```
claude plugin marketplace update understudy-skills
claude plugin update understudy@understudy-skills   # now sees 0.3.0
/reload-plugins
```

A user can opt into Claude Code's native marketplace auto-update for a
post-startup "reloaded plugins" prompt; a fully *proactive* "new skills available"
notification would require a SessionStart hook (out of scope here).

## Verification

`npm run check` green: build + typecheck + **74/74 tests** (incl. the
`versions_consistent` assertion) + `skills:validate` (ok 22 skills) +
`package:smoke`. `understudy doctor --json` → `versions_consistent: true, ok: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->