### PR TITLE
docs: register the ladder skill in the indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ conservative claims.
 capability worker per intent. The workers are grouped by journey stage; deeper
 playbooks live in each skill's `references/` directory:
 
-- **Setup & first run** — install-plugin, onboard
+- **Setup & first run** — install-plugin, onboard, ladder (the onboarding "climb")
 - **Understand & capture** — understand-workload, ingest-traces (incl. the
   capture-directory profiler), capture-evidence (incl. the public-benchmark
   on-ramp), design-simulated-environment

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,6 +32,13 @@ group it belongs to.
   [`reference.md`](onboard/reference.md).) The BYO-keys vs ZDR-gateway choice it
   needs lives in
   [`use-understudy-gateway/references/frontier-keys.md`](use-understudy-gateway/references/frontier-keys.md).
+- [`ladder`](ladder/SKILL.md) is the no-data front door: a small local web UI that
+  watches a local model and a frontier model attempt the same task side by side —
+  live reasoning, real tool calls, strict scoring — so a new user sees the
+  local-vs-frontier difference before they have any of their own traces. It is the
+  onboarding "climb"; reach for `compare-model-sweep` once you have your own eval.
+  (Architecture, the tool-call dialects, adding/swapping tasks, and the demo→RL
+  export path in its [`reference.md`](ladder/reference.md).)
 
 ## Understand & Capture
 


### PR DESCRIPTION
Closes the discoverability gap: the `ladder` skill shipped (#80–#86) but was never added to either human-facing index, violating the catalog growth rule in AGENTS.md.

- `README.md` Skill Tree → Setup & first run: install-plugin, onboard, ladder.
- `skills/README.md` → a `ladder` bullet in Setup & First Run, with the no-data-front-door framing and a pointer to its `reference.md`.

Doc-only. `npm run check` green (22 skills validated, package smoke).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->