### PR TITLE
ladder: drop the dead save-play alias

### DIFF
--- a/skills/ladder/SKILL.md
+++ b/skills/ladder/SKILL.md
@@ -95,7 +95,7 @@ curl -N 'http://localhost:8011/run?task=sort-email&model=gemma-4-e2b'
 
 The stream ends with a `done` event carrying the result (`correct`, `response`,
 `tok_s` for the classify rungs; `strict` / `dense` / `passes` for the hard rung).
-`GET /tasks` lists task ids (`sort-email`, `match-search`, `save-play`); `GET
+`GET /tasks` lists task ids (`sort-email`, `match-search`, `hard.sla_route`); `GET
 /models` lists the lanes.
 
 ## Safety Gates

--- a/skills/ladder/serve.py
+++ b/skills/ladder/serve.py
@@ -75,9 +75,7 @@ def classify_tasks():
 # Tool-calling tasks are DATA, not code: they live in fixtures/hard/tool_tasks.jsonl
 # and load through env/world.py. EVERY task there runs through the same agent loop
 # with no per-task server code -- add a JSONL row and it is immediately live and
-# scored. The viewer's friendly "save-play" id aliases one fixture task; every other
-# task is addressed by its real fixture id (e.g. hard.sla_route).
-TASK_ALIASES = {"save-play": "hard.renewal_save_route"}
+# scored. Every task is addressed by its real fixture id (e.g. hard.sla_route).
 _TOOL_TASKS = None
 
 def tool_tasks():
@@ -89,10 +87,9 @@ def tool_tasks():
     return _TOOL_TASKS
 
 def resolve_task(task):
-    """Map a requested task id (or alias) to a real tool-task id, or None if it
-    isn't a tool task (then it's a single-shot classify task or unknown)."""
-    real = TASK_ALIASES.get(task, task)
-    return real if real in tool_tasks() else None
+    """Map a requested task id to a real tool-task id, or None if it isn't a tool
+    task (then it's a single-shot classify task or unknown)."""
+    return task if task in tool_tasks() else None
 
 _loaded = {}
 _lock = threading.Lock()


### PR DESCRIPTION
Housekeeping. `save-play` was the pre-flatten hard placeholder; after data-driven tasks (#86) it aliased `hard.renewal_save_route` but appears in no task list — dead weight.

- Removed `TASK_ALIASES` + the alias indirection in `resolve_task` (`?task=save-play` now returns 400 like any unknown id).
- Fixed the stale id in `SKILL.md`'s `/tasks` example (`save-play` → `hard.sla_route`).

Verified: `serve.py` compiles; restarted server — `/tasks` returns 5 tasks + `tasks_version:1`; `?task=save-play` → 400; `?task=sort-email` → 200. `npm run check` green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->