### PR TITLE
[codex] skills: prefer managed frontier catalog

### DIFF
--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -41,10 +41,14 @@ comparison.
    and budget.
    Write it to `.understudy/model-sweeps/<timestamp>/sweep-plan.json`.
 
-2. **Normalize candidate routes.** Include each model id, endpoint/base URL,
-   loader/runtime, local-vs-remote boundary, max tokens, reasoning effort,
-   pricing basis, and whether the model is cached or requires download.
+2. **Normalize candidate routes.** Include each model id, route type
+   (`local`, `understudy-managed-catalog`, `understudy-routed`,
+   `byo-provider`, or `hosted-other`), endpoint/base URL, loader/runtime,
+   local-vs-remote boundary, max tokens, reasoning effort, pricing basis, and
+   whether the model is cached or requires download.
 
+   For remote Understudy candidates, run `understudy models list --json`;
+   prefer managed-catalog ids unless BYO provider-direct behavior is required.
 3. **Run a smoke row first.** Each candidate must complete one row without
    connection errors, empty responses, or bad model aliases. For local MLX, prefer
    verified filesystem paths or Understudy snapshot aliases over arbitrary
@@ -56,9 +60,14 @@ comparison.
    `.understudy/model-sweeps/<timestamp>/candidate-runs/<candidate>/`.
 
 5. **Summarize at the same grain.** Build `summary.csv` with candidate, route,
-   model family, tool-access mode, task count, pass rate, partial credit, total
-   tokens, cost/task, run seconds, errors, empty responses, and caveats. If
-   per-task latency is unavailable, use run-level duration and say so.
+   route type, requested model, effective model, model family, tool-access mode,
+   task count, pass rate, partial credit, total tokens, cost/task, run seconds,
+   errors, empty responses, and caveats. If per-task latency is unavailable, use
+   run-level duration and say so.
+
+   For Understudy gateway runs, capture `x-understudy-mode`,
+   `x-understudy-route`, and `x-understudy-effective-model`; exclude rows where
+   requested and effective model disagree unless that is the test.
 
    **Caching parity.** Cost columns must state each candidate's caching basis.
    If the incumbent runs cache-warmed in production (e.g. a cached primer),
@@ -101,6 +110,10 @@ Use the workload harness's JSON exports directly. Keep the command concrete in
   --tool-access "$TOOL_ACCESS" \
   --export-json ".understudy/model-sweeps/$RUN/candidate-runs/$ID/results.json"
 ```
+
+For keyless managed-catalog sweeps, use one cleared/no-route workload and vary
+only request-body `model`. Do not use a traffic split unless the non-routed
+passthrough share has a managed provider credential or BYO key.
 
 For API-workflow sweeps, keep tool-access interpretation explicit:
 

--- a/skills/optimize-agentic-workload/SKILL.md
+++ b/skills/optimize-agentic-workload/SKILL.md
@@ -150,10 +150,11 @@ single-output optimization does not need a tool environment.
    List public model options, route the project workload to a chosen model,
    then run the frozen harness through the gateway with `understudy run`.
    Compare quality vs latency vs cost (vs side-effect safety) across candidates
-   and pick the model you would ship. Prerequisite: an A/B split sends only the
-   routed share to the chosen model; the non-routed share needs a configured
-   managed frontier fallback so untouched traffic still completes. Clear a
-   route with `--clear`. Routing detail lives in
+   and pick the model you would ship. For keyless accounts, prefer a
+   managed-catalog sweep on a cleared/no-route workload before traffic-split
+   A/B. Prerequisite for a traffic split: the non-routed passthrough share
+   needs a configured managed provider credential or BYO key so untouched
+   traffic still completes. Clear a route with `--clear`. Routing detail lives in
    [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
    For state-mutating workflows, A/B is often simpler: run the same harness
    rows twice with only the model changed (see the reference).

--- a/skills/optimize-agentic-workload/references/read-only-search.md
+++ b/skills/optimize-agentic-workload/references/read-only-search.md
@@ -210,10 +210,11 @@ The main lever is swapping the policy model with tools held fixed. Procedure:
    ```
 
 **A/B fallback prerequisite (generic).** A traffic split sends only the routed
-share to the chosen model; the remainder must still complete. That non-routed
-share needs a configured managed frontier fallback so untouched traffic keeps
-working during the experiment. Configure it through the normal gateway/project
-setup in
+share to the chosen model; the remainder must still complete. For keyless
+accounts, run a managed-catalog sweep on a cleared/no-route workload first. Use
+a traffic split only when the non-routed passthrough share has a configured
+managed provider credential or BYO key, so untouched traffic keeps working
+during the experiment. Configure it through the normal gateway/project setup in
 [`../../use-understudy-gateway/SKILL.md`](../../use-understudy-gateway/SKILL.md);
 this skill does not describe the internal plumbing.
 

--- a/skills/run-local-model-lab/references/blind-arena.md
+++ b/skills/run-local-model-lab/references/blind-arena.md
@@ -172,7 +172,7 @@ only on reveal; if fallback happened, the reveal names the actual route used.
 
 Before a first-run duel, route through the frontier-keys decision in
 [`../../use-understudy-gateway/references/frontier-keys.md`](../../use-understudy-gateway/references/frontier-keys.md):
-BYO `.env` keys, the Understudy ZDR gateway route, or local-only skip.
+the Understudy managed catalog, BYO `.env` keys, or local-only skip.
 
 ## Hill-climb routing
 

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -140,9 +140,9 @@ Identify the developer's current stage and load exactly one:
   gateway trace capture, project/key management, model A/B via route traffic %,
   `understudy run`, or registering an improved route →
   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
-- **Frontier key choice** — a local-vs-frontier comparison, installer, or agent
-  run needs to decide between BYO `.env` provider keys, the Understudy ZDR
-  gateway route, or skipping remote frontier calls →
+- **Frontier access choice** — a local-vs-frontier comparison, installer, or
+  agent run needs to decide between the Understudy managed catalog, BYO `.env`
+  provider keys, or skipping remote frontier calls →
   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)
   and its frontier-keys lens (`references/frontier-keys.md`).
 - **Production ramp / rollback** — a route decision exists and live traffic
@@ -230,8 +230,9 @@ orchestrator owns the ladder — sequence workers, don't reimplement them:
    never evaluate `*-assistant` drafter checkpoints as standalone candidates.
    Use [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md) and
    [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
-2. **Optional frontier head-to-head** for calibration — the blind-arena
-   protocol in
+2. **Optional frontier head-to-head** for calibration — prefer the Understudy
+   managed catalog when the frontier id is listed, so the comparison uses one
+   gateway key and no provider key handling. Use the blind-arena protocol in
    [`../run-local-model-lab/references/blind-arena.md`](../run-local-model-lab/references/blind-arena.md).
    Preference is a gap signal, never a claim.
 3. **Freeze the eval** (`capture-evidence`; for workflow/tool tasks,

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -19,13 +19,13 @@ explicitly asks for Understudy inference, gateway routing, project/key
 management, workload route configuration, hosted execution, or authenticated
 gateway routing.
 
-**Choosing between local provider keys and the gateway route?** When an
-onboarding step, installer, or local-vs-frontier comparison needs a remote
-frontier model, run the decision in
-[`references/frontier-keys.md`](references/frontier-keys.md) first — BYO
-shell/`.env` keys vs the Understudy ZDR gateway vs local-only skip. It keeps
-secrets local, asks before reading `.env` values, and records the choice
-without printing keys.
+**Choosing frontier access?** When an onboarding step, installer, or
+local-vs-frontier comparison needs a remote frontier model, run the decision in
+[`references/frontier-keys.md`](references/frontier-keys.md) first. Default to
+the Understudy managed catalog when the requested model is available there; use
+BYO shell/`.env` keys only for unsupported models, provider-specific account
+needs, or an explicit developer preference. It keeps secrets local, asks before
+reading `.env` values, and records the choice without printing keys.
 
 ## Safety Gates
 
@@ -108,11 +108,11 @@ node dist/bin.js status --json
    understudy keys list --json
    ```
 
-4. For frontier-vs-Understudy A/B routing, list public model IDs and set a
-   bounded workload route — see the **A/B model routing** recipe below for the
-   commands and the split mechanics. The agent must not expose or ask for
-   supplier/provider details; the app keeps calling the normal gateway path while
-   the control-plane route decides the split.
+4. For frontier-vs-Understudy comparison, list public model IDs first. If the
+   account is keyless for frontier providers, prefer the **keyless catalog
+   sweep** recipe below: clear the workload route and vary the request-body
+   `model`. Use traffic-split A/B only after confirming the non-routed
+   passthrough share has a managed provider credential or BYO key.
 
 5. Run the local command through the gateway wrapper only after approval:
 
@@ -123,6 +123,43 @@ node dist/bin.js status --json
 6. Monitor the command output and local artifacts. For optimization work, route
    back to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) once
    the run has produced candidate/proof evidence.
+
+## Keyless catalog sweep
+
+Use this recipe for the fastest frontier/open-weight comparison when the
+developer does not have, or does not want to use, provider keys. The same
+Understudy key can request supported Anthropic, OpenAI, and open-weight catalog
+models by public id.
+
+1. Discover public model options:
+
+   ```sh
+   understudy models list --json
+   ```
+
+2. Ensure the eval workload has **no route configured**. A route dialed to 0%
+   still counts as configured and prevents request-time catalog resolution.
+
+   ```sh
+   understudy workloads route <workload-id> --project-id <project-id> --clear
+   ```
+
+3. Run the frozen eval once per catalog model by changing only the request-body
+   `model` value. Send `x-understudy-project` and `x-understudy-workload` on
+   every request so the run does not accidentally use the org default workload.
+
+4. Record the legibility headers for every row: `x-understudy-mode`,
+   `x-understudy-route`, and `x-understudy-effective-model`. Treat rows where the
+   requested model and effective model disagree as invalid for model comparison.
+
+5. Unknown ids for a keyless managed org return a clean catalog-miss 404 with
+   available alternatives. Do not expect arbitrary frontier names to passthrough
+   unless the org has its own managed provider key or the request supplies BYO
+   credentials.
+
+6. Bound the run by row count, max tokens, and wall-clock time. New accounts get
+   prepaid credit and async suspension, not a synchronous per-request spend
+   reservation.
 
 ## A/B model routing
 
@@ -149,11 +186,12 @@ comparing a workload's quality and cost across the split.
    **Eval shortcut — request-time catalog resolution.** On a workload with **no
    route configured** (never routed, or explicitly `--clear`ed — a route dialed
    to 0% still counts as configured and stays passthrough), a request for any
-   active catalog id (`"model": "glm-5.1"`) is served from managed supply with
-   no per-model setup; unknown ids fall through to passthrough, where the URL
-   shape picks the provider (`/v1/chat/completions` → OpenAI) and the provider
-   returns its own 404. So a model sweep needs exactly one unrouted workload and
-   can iterate over catalog ids in the request body.
+   active catalog id (`"model": "glm-5.1"`, `"model": "gpt-5.5"`, or another
+   listed id) is served from managed supply with no per-model setup. For a
+   keyless managed org, unknown ids return a clean catalog-miss 404 with
+   available alternatives instead of falling through to unpriced provider
+   passthrough. So a model sweep needs exactly one unrouted workload and can
+   iterate over listed catalog ids in the request body.
 
    **Selecting the workload per request.** The gateway resolves which workload's
    route serves a request from two optional headers: `x-understudy-project`
@@ -189,9 +227,10 @@ comparing a workload's quality and cost across the split.
 
 4. Prerequisite for a frontier comparison. For the split to compare the routed
    model against a frontier model, the non-routed (passthrough) share must have a
-   configured managed frontier; without it those requests error. This is usually
-   account setup, not a per-run flag, so confirm it before starting an A/B —
-   otherwise only the routed share returns results.
+   configured managed provider key or BYO key; the managed catalog only resolves
+   on no-route workloads. Without passthrough credentials, those non-routed
+   requests error. For keyless accounts, use the **keyless catalog sweep** recipe
+   first, then route only after choosing a candidate.
 
 ## Output Standard
 
@@ -206,8 +245,8 @@ End with:
 
 ## References
 
-- [`references/frontier-keys.md`](references/frontier-keys.md) — the BYO
-  `.env`-keys vs ZDR-gateway vs skip decision, the allowlisted env vars, the
+- [`references/frontier-keys.md`](references/frontier-keys.md) — managed catalog
+  vs BYO `.env` keys vs skip, the allowlisted env vars, the
   secret-to-remote-infra recipe, and the installer mapping.
 - Hosted contracts on the docs site —
   [routing semantics](https://docs.understudylabs.com/concepts/routing),

--- a/skills/use-understudy-gateway/references/frontier-keys.md
+++ b/skills/use-understudy-gateway/references/frontier-keys.md
@@ -1,14 +1,22 @@
-# Frontier keys — local provider keys vs the gateway route
+# Frontier access — managed catalog vs local provider keys
 
 Use this lens before any local-vs-frontier duel, gateway A/B, or first-run
-installer step that needs a remote frontier model. The user must choose one of
-three frontier routes:
+installer step that needs a remote frontier model. Default to the managed
+catalog when the model is available there: it uses the developer's Understudy
+account key, keeps provider keys out of the local project, and lets the same
+gateway run compare frontier and open-weight candidates.
 
-1. **BYO local key from shell or `.env`** — use an existing OpenAI, Anthropic,
+The user may still choose one of three frontier routes:
+
+1. **Understudy managed catalog** — use the developer's Understudy
+   account/gateway route, with no local provider key read by the installer or
+   agent. This is the default for supported Anthropic, OpenAI, and open-weight
+   catalog models.
+2. **BYO local key from shell or `.env`** — use an existing OpenAI, Anthropic,
    or OpenAI-compatible AI-gateway key already exported in the shell or stored
-   on the developer's machine.
-2. **Understudy ZDR gateway** — use the developer's Understudy account/gateway
-   route, with no local provider key read by the installer or agent.
+   on the developer's machine. Use this only when the requested model is not in
+   the catalog, the developer needs a provider-specific feature or account, or
+   they explicitly prefer provider-direct traffic.
 3. **Skip** — run local-only now and defer the remote frontier comparison.
 
 ## Safety gates
@@ -22,13 +30,17 @@ three frontier routes:
   `FRONTIER_API_KEY`, `AI_GATEWAY_API_KEY`, `OPENAI_BASE_URL`,
   `FRONTIER_BASE_URL`, `AI_GATEWAY_BASE_URL`, `OPENAI_MODEL`,
   `ANTHROPIC_MODEL`, `FRONTIER_MODEL`, `AI_GATEWAY_MODEL`.
-- If the user chooses Understudy ZDR, clear local provider-key env vars for the
-  duel and set `UNDERSTUDY_FALLBACK_MODEL=gpt-5.5` unless they choose another
-  public Understudy model.
+- If the user chooses the managed catalog, clear local provider-key env vars for
+  the duel and set `UNDERSTUDY_FALLBACK_MODEL=gpt-5.5` unless they choose another
+  public Understudy model from `understudy models list --json`.
 - If the user chooses BYO, state that the key stays local but the selected
   upstream provider receives the prompts used in the comparison.
-- If the user chooses ZDR, state that no local provider key is read and the
-  comparison goes through the Understudy gateway route.
+- If the user chooses the managed catalog, state that no local provider key is
+  read and the comparison goes through the Understudy gateway route.
+- Do not describe the signup credit as a hard synchronous spend cap. New
+  accounts get prepaid credit and the gateway enforces suspension from the
+  async billing state; agents should still set a row count, max-token, and
+  wall-clock budget for every remote comparison.
 - **Watch for the silent-bypass failure.** If a provider key is pasted directly
   into the app's own config (its provider stack, `.env`, or client setup),
   that traffic goes straight to the provider and never touches the gateway —
@@ -41,28 +53,34 @@ three frontier routes:
 ## Flow
 
 1. Explain the decision in one sentence:
-   "The local model stays on your Mac; the right-side frontier can use either
-   an already-exported/local `.env` provider key or Understudy's ZDR gateway."
-2. Ask which route they want: BYO shell/`.env`, Understudy ZDR, or skip.
-3. For BYO, first check whether allowed key variables are already present in the
-   shell. If yes, use them without reading `.env` files.
-4. If no shell key is present, ask for permission to inspect local `.env` files in the current
-   project directory for known variable names.
-5. Detect candidate files without printing values:
-   ```bash
-   find . -maxdepth 2 -type f \( -name '.env' -o -name '.env.*' \) \
-     -not -path './node_modules/*' -not -path './.git/*'
-   ```
-6. If a candidate is found, import only the allowlisted variables for the child
-   process. Do not `source` arbitrary `.env` shell. Use a parser that ignores all
-   other lines.
-7. For ZDR, verify the user has an Understudy login when possible:
+   "The local model stays on your Mac; the right-side frontier should use the
+   Understudy managed catalog when available, with BYO provider keys only for
+   unsupported models or provider-specific needs."
+2. Ask which route they want: managed catalog, BYO shell/`.env`, or skip. Lead
+   with managed catalog unless the user's stated model is not catalogued.
+3. For managed catalog, verify the user has an Understudy login and a priceable
+   model id:
    ```bash
    understudy status --json
    understudy models list --json
    ```
    If not signed in, ask them to run `understudy login` or skip the remote duel.
-8. Record the choice locally without secrets, for example:
+4. For keyless managed-catalog comparisons, use an unrouted workload and vary
+   the request-body `model`. Unknown model ids get a clean catalog-miss 404
+   rather than falling through to arbitrary provider passthrough.
+5. For BYO, first check whether allowed key variables are already present in the
+   shell. If yes, use them without reading `.env` files.
+6. If no shell key is present, ask for permission to inspect local `.env` files in the current
+   project directory for known variable names.
+7. Detect candidate files without printing values:
+   ```bash
+   find . -maxdepth 2 -type f \( -name '.env' -o -name '.env.*' \) \
+     -not -path './node_modules/*' -not -path './.git/*'
+   ```
+8. If a candidate is found, import only the allowlisted variables for the child
+   process. Do not `source` arbitrary `.env` shell. Use a parser that ignores all
+   other lines.
+9. Record the choice locally without secrets, for example:
    `.understudy/frontier-choice.json` or
    `~/.understudy/agent-tools/install-state/frontier-choice`.
 
@@ -102,6 +120,11 @@ UNDERSTUDY_FRONTIER_KEY_MODE=zdr \
   curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | sh
 ```
 
+`zdr` is the legacy installer flag name for the managed-catalog path. In agent
+conversation, call the choice `managed catalog` so users understand the product
+behavior: no local provider key, catalog-priced models through the Understudy
+gateway.
+
 The installer stores logs under `~/.understudy/agent-tools/logs` and the
 frontier choice under `~/.understudy/agent-tools/install-state/frontier-choice`.
 It does not store secret values in that choice file.
@@ -110,8 +133,8 @@ It does not store secret values in that choice file.
 
 End with:
 
-- selected frontier route: `byo`, `zdr`, or `skip`
+- selected frontier route: `managed`, `byo`, or `skip`
 - whether shell env or a `.env` file was used, by path only for `.env`
-- which model will be used for ZDR, default `gpt-5.5`
+- which catalog model will be used for managed frontier, default `gpt-5.5`
 - reminder that keys were not printed or committed
 - exact command to rerun with the same choice


### PR DESCRIPTION
## Summary

- Make the managed catalog the default frontier path in gateway/frontier-access skill guidance.
- Add a keyless catalog sweep recipe for cleared/no-route workloads and request-body model iteration.
- Update model sweep and agentic optimization skills to record effective-model headers and avoid traffic-split A/B unless passthrough credentials exist.

## Why

Managed frontier catalog support means agents no longer need to steer users toward provider keys just to get frontier baselines. These skill updates make the fast path explicit while preserving BYO for unsupported models or provider-direct needs.

## Validation

- npm run check
- git diff --check
