### PR TITLE
[codex] docs: align skill index with managed catalog

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -29,8 +29,8 @@ group it belongs to.
   detects ML tooling, interviews the user, and writes a durable
   `~/.understudy/profile.json` so every later skill meets the user where they are.
   (Profile schema, interview bank, and tooling map in its
-  [`reference.md`](onboard/reference.md).) The BYO-keys vs ZDR-gateway choice it
-  needs lives in
+  [`reference.md`](onboard/reference.md).) The managed-catalog vs BYO-keys
+  frontier choice it needs lives in
   [`use-understudy-gateway/references/frontier-keys.md`](use-understudy-gateway/references/frontier-keys.md).
 - [`ladder`](ladder/SKILL.md) is the no-data front door: a small local web UI that
   watches a local model and a frontier model attempt the same task side by side —
@@ -182,7 +182,7 @@ shows headroom, no hosted RL until the local arms plateau.
 - [`use-understudy-gateway`](use-understudy-gateway/SKILL.md) handles
   authenticated gateway inference, project/key readiness, public model listing,
   workload route percentages, `understudy run`, and monitored durable CLI
-  execution. The local-provider-keys vs ZDR-gateway decision (with all
+  execution. The managed-catalog vs BYO provider-key decision (with all
   key-safety rules) is in
   [`references/frontier-keys.md`](use-understudy-gateway/references/frontier-keys.md).
 - [`ramp-and-verify`](ramp-and-verify/SKILL.md) owns the last mile after a


### PR DESCRIPTION
## Summary

- Updates the skill index to use the managed-catalog vs BYO provider-key framing.
- Keeps the index consistent with the already-merged gateway/frontier access skill docs.

## Review notes

- I first reviewed `yolo/managed-frontier-skills`; GitHub reports its PR (#91) is already merged, and opening a PR from that stale branch would regress newer `main` changes.
- This follow-up branch is based on current `origin/main` and contains only the README consistency fix.

## Validation

- `npm run skills:validate`
- `npm run check`
- `git diff --check`