### PR TITLE
onboard: drop arena.sh, serve the QAT default from the manifest

### DIFF
--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -99,23 +99,26 @@ work — do not re-run the full interview. Only first-timers get the full flow.
    If `~/.understudy/companion.json` points at a dead pid, clear it and record
    the stale pid in the card.
 
-6. **Land the quick win: show the local Understudy exists.** Once the snapshot is cached, follow
-   the blind-arena playbook in
-   [`../run-local-model-lab/references/blind-arena.md`](../run-local-model-lab/references/blind-arena.md).
-   Coach the user to open a
-   terminal of their choice and attach to the tmux session, or launch it from the
-   agent if they ask. Use:
+6. **Land the quick win: show the local Understudy exists.** Once the snapshot is
+   cached, serve it from the manifest so the launcher, required flags, and
+   prescribed decode are all enforced — not hand-specified. Route through
+   [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md) and run
+   the skill-owned serve helper:
     ```bash
-    FIRST_REPO="$HOME/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy" \
-      skills/run-local-model-lab/scripts/arena.sh first
+    node scripts/serve-understudy-snapshot.mjs --model gemma-4-e2b-it-qat-mlx-vlm-understudy --exec
     ```
-   The pane says their first local Understudy is ready and opens Pi on verified
-   Gemma 4 E2B. Have them try one real prompt only to prove local inference is
-   real and inspectable. If Pi is not installed, run one local generation and print:
-   `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`. Briefly
-   teach the idea: an open-weight model is downloadable weights you run yourself;
-   local is free and ZDR-safe; you iterate small and local, then *graduate* to a
-   larger model in the same family via the gateway when you need the quality.
+   Resolve the script relative to the `manage-local-models` skill directory. It
+   reads the artifact's `understudy.serving.json` and spawns the MLX server on
+   `http://127.0.0.1:8094/v1` with the exact flags (e.g. `--top-logprobs-k 20`)
+   and the prescribed decode exported; drop `--exec` to print the command for
+   review first. Then prove local inference is real and inspectable with one
+   generation against that endpoint (or point Pi at it:
+   `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`). Record the
+   live runtime facts — endpoint, `served_by`, model path — in the agent card
+   (step 5). Briefly teach the idea: an open-weight model is downloadable
+   weights you run yourself; local is free and ZDR-safe; you iterate small and
+   local, then *graduate* to a larger model in the same family via the gateway
+   when you need the quality.
 
 7. **Profile the user's real workload.** The main path after the local proof is
    not a model duel. Ask the user for a codebase, trace folder, dataset, eval
@@ -132,14 +135,11 @@ work — do not re-run the full interview. Only first-timers get the full flow.
    user needs to feel the quality gap, calibrate taste, or get buy-in. It is a
    side quest, not the default evidence path. If the user wants it, follow the
    local specialization sequencing in the
-   [`understudy`](../understudy/SKILL.md) orchestrator's routing section and
-   run:
-    ```bash
-    LEFT_REPO="$HOME/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy" \
-      skills/run-local-model-lab/scripts/arena.sh play
-    ```
-   Otherwise keep going through workload understanding, capture evidence, and
-   local evaluation against the actual task slice.
+   [`understudy`](../understudy/SKILL.md) orchestrator's routing section, which
+   hands off to [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md)
+   for the blind local-vs-frontier protocol. Otherwise keep going through
+   workload understanding, capture evidence, and local evaluation against the
+   actual task slice.
 
 9. **Route onward.** Hand to the [`understudy`](../understudy/SKILL.md)
    orchestrator for the improvement loop;

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -94,8 +94,9 @@ profile. Never put secrets, prompts, outputs, or customer data in it.
 }
 ```
 
-Refresh this card during onboarding, whenever `arena.sh first|play|up` serves a
-model, and whenever a companion process starts. If `~/.understudy/companion.json`
+Refresh this card during onboarding, whenever
+`serve-understudy-snapshot.mjs` serves a model, and whenever a companion process
+starts. If `~/.understudy/companion.json`
 contains a dead pid, clear that pid in the companion state file and record it as
 `stale_pid` in the card. A later agent should be able to answer the user's
 runtime question from this card first, using health checks only to refresh stale

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -67,15 +67,15 @@ profile. Never put secrets, prompts, outputs, or customer data in it.
   "understudy": {
     "model": "/Users/me/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy",
     "name": "Gemma 4 E2B",
-    "endpoint": "http://127.0.0.1:8081/v1",
-    "health_url": "http://127.0.0.1:8081/v1/models",
+    "endpoint": "http://127.0.0.1:8094/v1",
+    "health_url": "http://127.0.0.1:8094/v1/models",
     "healthy": true,
     "served_by": "mlx_vlm.server",
     "runtime": "mlx_vlm",
     "provider": "mlx-gemma4-e2b",
-    "tmux_session": "mlx-arena-first",
-    "logs": "~/.understudy/agent-tools/.understudy/local-model-lab/arena/logs",
-    "how_to_talk": "curl -s http://127.0.0.1:8081/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"/Users/me/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello from my local Understudy.\"}],\"max_tokens\":128}'"
+    "tmux_session": null,
+    "logs": null,
+    "how_to_talk": "curl -s http://127.0.0.1:8094/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"/Users/me/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello from my local Understudy.\"}],\"max_tokens\":128}'"
   },
   "companion": {
     "alive": false,


### PR DESCRIPTION
## Summary

Finishes the move off `arena.sh` in onboarding. PR #90 shipped the manifest-driven `serve-understudy-snapshot.mjs` and made `gemma-4-e2b-it-qat-mlx-vlm-understudy` the default rung, but onboarding still launched the quick-win and the optional duel through `arena.sh`. This PR repoints both at the new serve helper.

## Changes

- **`skills/onboard/SKILL.md` step 6 (quick win)** — replaced `arena.sh first` + the blind-arena tmux flow with:
  ```bash
  node scripts/serve-understudy-snapshot.mjs --model gemma-4-e2b-it-qat-mlx-vlm-understudy --exec
  ```
  which reads the artifact's `understudy.serving.json` and spawns the MLX server on `http://127.0.0.1:8094/v1` with the exact flags (e.g. `--top-logprobs-k 20`) and prescribed decode. Local inference is then proven with one generation against that endpoint.
- **`skills/onboard/SKILL.md` step 8 (optional head-to-head)** — dropped the `arena.sh play` block. The frontier-vs-local duel stays as a side quest, routed through the `understudy` orchestrator and `run-local-model-lab`'s blind-arena protocol.
- **`skills/onboard/reference.md`** — the agent-card refresh trigger now reads `serve-understudy-snapshot.mjs` instead of `arena.sh first|play|up`.

## Why

`arena.sh` was a heavy launcher (two-pane tmux, side-by-side servers) for a first-run "prove local inference is real" moment. The manifest-driven serve helper does the one thing onboarding needs — serve the certified QAT default with correct flags — with no arena scaffolding, which is the shorter onboarding we want now that the QAT model is the default.

## Verification

- `npm run skills:validate` → `ok 22 public skill(s)`
- `git diff --check` → clean
- `rg "arena" skills/onboard` → no `arena.sh` invocations remain (see follow-up)
- Full `npm run check` not run in this worktree (no `node_modules`); change is docs-only (two `.md` files), so `tsc`/tests are unaffected.

## Follow-up (out of scope)

The agent-card JSON example in `skills/onboard/reference.md` still shows `"tmux_session": "mlx-arena-first"` and an arena logs path. Left alone per the scoped cut; worth a follow-up to align the example with the serve-helper runtime (`:8094`, no tmux session).