### PR TITLE
add multi-agent plugin adapters

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "understudy-skills",
+  "metadata": {
+    "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
+    "version": "0.4.0"
+  },
+  "plugins": [
+    {
+      "name": "understudy",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Understudy",
+        "description": "Improve LLM apps from traces: capture evidence, build evals, optimize, compare models, and route through Understudy."
+      }
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "understudy",
+  "version": "0.4.0",
+  "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
+  "skills": "./skills/"
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "understudy",
+  "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
+  "version": "0.4.0",
+  "author": {
+    "name": "Understudy Labs"
+  },
+  "keywords": ["understudy", "llm", "evals", "optimization", "gepa", "routing", "traces", "cost", "latency"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,41 @@
 # Changelog
 
 Notable, user-facing changes to the Understudy skills + CLI. Versions track the
-plugin: `package.json`, `.claude-plugin/plugin.json`, and
-`.claude-plugin/marketplace.json` are bumped together on any release that changes
-the skill catalog or CLI surface, because an installed plugin has no other
-staleness signal. After upgrading, run `/reload-plugins`.
+plugin: `package.json`, `.claude-plugin/plugin.json`,
+`.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, and `.agents/plugins/marketplace.json` are bumped
+together on any release that changes the skill catalog, CLI surface, or
+agent-platform adapter surface, because an installed plugin has no other
+staleness signal. After upgrading, reload or enable the plugin in your coding
+agent.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/); this project
 uses semantic-ish versioning (minor = new skill or new capability, patch = fixes).
 
 ## [Unreleased]
+
+## [0.4.0] — 2026-06-19
+
+### Added
+
+- **Multi-agent plugin adapters.** Added a shared adapter registry and
+  `understudy platforms` so Claude Code, Cursor, and Codex can expose the same
+  `skills/` tree without platform-specific forks.
+- **Cursor plugin support.** Added `.cursor-plugin/plugin.json`, an
+  `install-cursor-plugin` skill, installer autodetect/linking into
+  `~/.cursor/plugins/local/understudy`, and README/docs activation guidance.
+- **Codex plugin support.** Added `.codex-plugin/plugin.json`, a local Codex
+  marketplace at `.agents/plugins/marketplace.json`, an `install-codex-plugin`
+  skill, installer marketplace registration, and `/plugins` activation
+  guidance.
+
+### Changed
+
+- `install.sh` now supports `--agents auto|all|claude-code|cursor|codex|none`
+  and `UNDERSTUDY_AGENT_PLATFORMS` so the curl installer can autodetect or
+  explicitly target multiple coding-agent harnesses.
+- `understudy doctor` now checks version consistency across Claude Code,
+  Cursor, and Codex plugin metadata.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ optimization planning, gateway handoff, and agent-led implementation. The CLI is
 thin TypeScript/Node: durable shortcuts, auth, artifact checks, and runtime
 wrappers that a coding agent can monitor.
 
+Understudy is agent-platform-neutral at the skill layer. Claude Code, Cursor,
+and Codex share the same [`skills/`](skills/) tree and only differ in a thin
+platform adapter: manifest, install path, reload step, and onboarding
+invocation. The current adapter registry is documented in
+[`docs/agent-platform-adapters.md`](docs/agent-platform-adapters.md) and exposed
+through `understudy platforms`.
+
 The OSS MVP loop is local-first and skill-led:
 
 ```text
@@ -34,6 +41,7 @@ covers the hosted contracts behind them.
 | CLI | `src/` | Thin TypeScript shortcuts for auth, artifact checks, and durable runs. |
 | Skills | `skills/` | MVP progressive-disclosure agent playbooks. |
 | Docs | `docs/` | Public methodology and release-boundary notes. |
+| Platform adapters | `.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `.agents/`, `AGENTS.md` | Thin manifests or durable instructions that expose the same skill tree to each coding-agent surface. |
 | Scripts | `scripts/` | Repo hygiene checks, not product CLI code. |
 | Vendor | `vendor/` | Vendored or mirrored compatibility shims, with license metadata. |
 
@@ -49,9 +57,20 @@ Fast first-run installer:
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash
 ```
 
-This installs the CLI, installs or refreshes the Claude Code plugin when
-`claude` is available, then opens Claude Code in the current directory. In
-Claude Code, run:
+This installs the CLI, autodetects available coding-agent adapters, and installs
+or refreshes the matching local plugin surfaces. Today that means Claude Code
+when `claude` is available, Cursor when Cursor is present, and Codex when the
+`codex` CLI is available. Override the
+default with `--agents auto|all|claude-code|cursor|codex|none`.
+
+| Agent harness | Default installer behavior | Activation |
+| --- | --- | --- |
+| Claude Code | Autodetected when `claude` is on `PATH`; installs the local Claude plugin. | Run `/reload-plugins`, then `/understudy:onboard`. |
+| Cursor | Autodetected when Cursor is present; links this repo into `~/.cursor/plugins/local/understudy`. | Restart Cursor or run **Developer: Reload Window**, then ask Cursor Agent to use the Understudy onboarding skill. |
+| Codex | Autodetected when `codex` is on `PATH`; registers the local Codex marketplace from `.agents/plugins/marketplace.json`. | Run `/plugins`, choose `understudy-skills`, install or enable `understudy`, then start a new thread if needed. |
+
+If Claude Code is selected, the installer opens Claude Code in the current
+directory. In Claude Code, run:
 
 ```text
 /reload-plugins
@@ -139,12 +158,83 @@ claude plugin marketplace remove understudy-skills
 
 — and nothing outside Claude Code's plugin registry is touched.
 
+## Install as a Cursor plugin
+
+The same skills also ship as a Cursor plugin, declared in
+[`.cursor-plugin/plugin.json`](.cursor-plugin/plugin.json). Cursor discovers
+the repo's existing [`skills/`](skills/) tree from the plugin root, so there is
+no Cursor-specific fork of the playbooks.
+
+For local testing from a clone:
+
+```bash
+mkdir -p ~/.cursor/plugins/local
+ln -s /path/to/understudy-agent-tools ~/.cursor/plugins/local/understudy
+```
+
+Then restart Cursor or run **Developer: Reload Window**. In Cursor Settings ->
+Rules, the Understudy skills should appear under Agent Decides. To remove it:
+
+```bash
+rm -f ~/.cursor/plugins/local/understudy
+```
+
+The [`install-cursor-plugin`](skills/install-cursor-plugin/SKILL.md) skill
+contains the agent-run install/update/verify flow. This path is local-only:
+adding the plugin does not authenticate, upload data, download model weights, or
+make provider calls.
+
+## Install as a Codex plugin
+
+The same skills ship as a Codex plugin, declared in
+[`.codex-plugin/plugin.json`](.codex-plugin/plugin.json) and exposed through the
+repo marketplace at [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
+The plugin points at the repo's existing [`skills/`](skills/) tree.
+
+From a clone of this repo:
+
+```bash
+codex plugin marketplace add /path/to/understudy-agent-tools
+```
+
+Then open Codex, run `/plugins`, choose the `understudy-skills` marketplace, and
+install or enable the `understudy` plugin. The
+[`install-codex-plugin`](skills/install-codex-plugin/SKILL.md) skill contains
+the agent-run registration/verify flow. This path is local-only: registering the
+marketplace does not authenticate, upload data, download model weights, or make
+provider calls.
+
+To remove the marketplace registration:
+
+```bash
+codex plugin marketplace remove understudy-skills
+```
+
+`AGENTS.md` remains repo guidance for Codex, but the Codex plugin is the reusable
+distribution unit for the skills.
+
+## Agent Platform Adapters
+
+Use the platform registry to see the current install/reload surface across
+agent clients:
+
+```bash
+understudy platforms
+understudy platforms --inspect claude-code
+understudy platforms --inspect cursor
+understudy --json platforms
+```
+
+Claude Code, Cursor, and Codex are supported adapters. All three reuse the same
+`skills/` tree instead of copying platform-specific skill content.
+
 ## First Commands
 
 ```bash
 understudy spine
 understudy skills --list
 understudy skills --search gateway
+understudy platforms
 understudy doctor
 ```
 
@@ -231,7 +321,8 @@ conservative claims.
 capability worker per intent. The workers are grouped by journey stage; deeper
 playbooks live in each skill's `references/` directory:
 
-- **Setup & first run** — install-plugin, onboard, ladder (the onboarding "climb")
+- **Setup & first run** — install-plugin, install-cursor-plugin,
+  install-codex-plugin, onboard, ladder (the onboarding "climb")
 - **Understand & capture** — understand-workload, ingest-traces (incl. the
   capture-directory profiler), capture-evidence (incl. the public-benchmark
   on-ramp), design-simulated-environment
@@ -272,6 +363,7 @@ The TypeScript CLI currently owns the public tools surface:
 
 ```text
 spine
+platforms
 skills
 doctor
 login

--- a/docs/agent-platform-adapters.md
+++ b/docs/agent-platform-adapters.md
@@ -1,0 +1,39 @@
+# Agent Platform Adapters
+
+Understudy should not become three separate products for Claude Code, Cursor,
+and Codex. The product is the public skill tree in `skills/`. Platform adapters
+only describe how each coding-agent surface discovers, installs, reloads, and
+starts those skills.
+
+## Contract
+
+Each adapter answers the same questions:
+
+- where the platform manifest or durable instruction file lives
+- how the platform discovers `skills/`
+- what local install command, if any, is safe to run
+- what activation step the user must perform in that agent UI
+- how to uninstall or reverse the local registration
+
+The CLI registry is `src/agent-platforms.ts`; inspect it with:
+
+```bash
+understudy platforms
+understudy --json platforms
+understudy platforms --inspect cursor
+```
+
+## Supported Adapters
+
+| Platform | Status | Manifest | Discovery |
+| --- | --- | --- | --- |
+| Claude Code | supported | `.claude-plugin/plugin.json` | Local marketplace plugin discovers `skills/`. |
+| Cursor | supported | `.cursor-plugin/plugin.json` | Local Cursor plugin discovers `skills/` from the plugin root. |
+| Codex | supported | `.codex-plugin/plugin.json` | Local marketplace plugin discovers `skills/`. |
+
+## Design Rule
+
+Do not copy skills per platform. If a platform needs different packaging, add a
+thin adapter manifest or installer path that points back to the same `skills/`
+directories. Forking skill content creates stale safety gates and inconsistent
+onboarding during the sprint.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install Understudy agent tools and hand the user back to Claude Code skills.
+# Install Understudy agent tools and hand the user back to an agent skill surface.
 set -euo pipefail
 
 LAB="${UNDERSTUDY_LAB:-$HOME/.understudy/agent-tools}"
@@ -13,6 +13,7 @@ LAUNCH_CLAUDE="${UNDERSTUDY_LAUNCH_CLAUDE:-1}"
 CLAUDE_PERMISSION_MODE="${UNDERSTUDY_CLAUDE_PERMISSION_MODE:-auto}"
 USER_PROMPT_OVERRIDE="${UNDERSTUDY_INITIAL_CLAUDE_PROMPT:-}"
 INITIAL_CLAUDE_PROMPT=""
+AGENT_PLATFORMS="${UNDERSTUDY_AGENT_PLATFORMS:-auto}"
 KEEP_LOGIN="${UNDERSTUDY_KEEP_LOGIN:-0}"
 NO_CLAUDE=0
 START_STEP=1
@@ -28,6 +29,8 @@ while [ "$#" -gt 0 ]; do
     --non-interactive|--noninteractive|--no-input) NONINTERACTIVE=1 ;;
     --require-confirm) REQUIRE_CONFIRM=1 ;;
     --no-claude) NO_CLAUDE=1 ;;
+    --agents|--agent) AGENT_PLATFORMS="${2:?missing agent platform list}"; shift ;;
+    --no-agents) AGENT_PLATFORMS="none"; NO_CLAUDE=1; LAUNCH_CLAUDE=0 ;;
     --no-launch-claude) LAUNCH_CLAUDE=0 ;;
     --launch-claude) LAUNCH_CLAUDE=1 ;;
     --keep-login) KEEP_LOGIN=1 ;;
@@ -38,14 +41,13 @@ while [ "$#" -gt 0 ]; do
     --lab) LAB="${2:?missing path}"; shift ;;
     -h|--help)
       cat <<'EOF'
-Usage: install.sh [--yes] [--non-interactive] [--resume] [--from-step N] [--only-step N] [--keep-login] [--no-claude] [--no-launch-claude]
+Usage: install.sh [--yes] [--non-interactive] [--resume] [--from-step N] [--only-step N] [--keep-login] [--agents auto|all|claude-code|cursor|codex|none] [--no-claude] [--no-launch-claude]
 
-Installs the Understudy CLI + Claude Code skill/plugin surface, then hands the
-user back to Claude Code, where the coding agent runs the agent-first sign-up
-(email one-time code through `understudy login`) and onboarding. It does not
-download model weights, start MLX, launch the ladder server, or make
-frontier calls. Those are guided by the /understudy:onboard skill after the
-user is in their coding agent.
+Installs the Understudy CLI + detected coding-agent skill/plugin surfaces, then
+hands the user back to the selected coding agent when possible. It does not
+download model weights, start MLX, launch the ladder server, or make frontier
+calls. Those are guided by the Understudy onboarding skill after the user is in
+their coding agent.
 
 If you are already signed in, the installer signs you out by default so the
 agent-first sign-up can be experienced (or demoed) from scratch. Only the
@@ -62,6 +64,9 @@ Options:
   --only-step N         run only step 1, 2, or 3
   --keep-login          keep an existing sign-in instead of resetting it
   --fresh-login         reset an existing sign-in for agent-first sign-up (default)
+  --agents LIST         agent adapters to install: auto, all, claude-code, cursor, codex, none
+                        comma-separated lists are accepted, e.g. claude-code,cursor
+  --no-agents           skip all coding-agent plugin installs and launches
   --no-claude           skip Claude Code plugin install and final Claude launch
   --no-launch-claude    install plugin but do not open Claude Code at the end
   --launch-claude       open Claude Code at the end (default)
@@ -80,6 +85,7 @@ Environment overrides:
   UNDERSTUDY_NONINTERACTIVE      set to 1 to use safe defaults without prompting
   UNDERSTUDY_REQUIRE_CONFIRM     set to 1 to fail when no prompt TTY exists
   UNDERSTUDY_KEEP_LOGIN          set to 1 to keep an existing sign-in
+  UNDERSTUDY_AGENT_PLATFORMS     auto, all, claude-code, cursor, codex, none, or comma list
   UNDERSTUDY_LAUNCH_CLAUDE      set to 0 to skip opening Claude Code
   UNDERSTUDY_CLAUDE_ARGS        optional extra args when launching Claude Code
   UNDERSTUDY_CLAUDE_PERMISSION_MODE Claude Code permission mode, default auto
@@ -258,6 +264,93 @@ configure_resume() {
     say "Resuming from step $START_STEP based on $STATE_DIR/last-step"
   fi
 }
+normalize_agent_platform() {
+  case "$1" in
+    claude|claude_code|claudecode) printf '%s\n' "claude-code" ;;
+    cursor|codex|all|auto|none|claude-code) printf '%s\n' "$1" ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+validate_agent_platforms() {
+  local token normalized count mode
+  count=0
+  mode=""
+  for token in $(printf '%s\n' "$AGENT_PLATFORMS" | tr ',;' '  '); do
+    count=$((count + 1))
+    normalized="$(normalize_agent_platform "$token")"
+    case "$normalized" in
+      auto|all|none) mode="$normalized" ;;
+      claude-code|cursor|codex) ;;
+      *)
+        fail_line "Unknown agent adapter '$token'. Use auto, all, claude-code, cursor, codex, none, or a comma list of explicit adapters."
+        return 1
+        ;;
+    esac
+  done
+  if [ "$count" -eq 0 ]; then
+    fail_line "No agent adapter selection provided. Use auto, all, claude-code, cursor, codex, or none."
+    return 1
+  fi
+  if [ -n "$mode" ] && [ "$count" -gt 1 ]; then
+    fail_line "Agent adapter mode '$mode' cannot be combined with other values. Use '$mode' alone, or use a comma list like claude-code,cursor."
+    return 1
+  fi
+}
+agent_platform_requested() {
+  local wanted token normalized
+  wanted="$(normalize_agent_platform "$1")"
+  for token in $(printf '%s\n' "$AGENT_PLATFORMS" | tr ',;' '  '); do
+    normalized="$(normalize_agent_platform "$token")"
+    case "$normalized" in
+      all) return 0 ;;
+      none|auto) ;;
+      "$wanted") return 0 ;;
+    esac
+  done
+  return 1
+}
+detect_claude_code() {
+  need claude
+}
+detect_cursor() {
+  need cursor ||
+    [ -d "$HOME/.cursor" ] ||
+    [ -d "/Applications/Cursor.app" ] ||
+    [ -d "$HOME/Applications/Cursor.app" ]
+}
+detect_codex() {
+  need codex
+}
+should_install_claude_adapter() {
+  [ "$NO_CLAUDE" = "1" ] && return 1
+  case "$(normalize_agent_platform "$AGENT_PLATFORMS")" in
+    none) return 1 ;;
+    auto) detect_claude_code; return ;;
+  esac
+  agent_platform_requested "claude-code"
+}
+should_install_cursor_adapter() {
+  case "$(normalize_agent_platform "$AGENT_PLATFORMS")" in
+    none) return 1 ;;
+    auto) detect_cursor; return ;;
+  esac
+  agent_platform_requested "cursor"
+}
+should_install_codex_adapter() {
+  case "$(normalize_agent_platform "$AGENT_PLATFORMS")" in
+    none) return 1 ;;
+    auto) detect_codex; return ;;
+  esac
+  agent_platform_requested "codex"
+}
+agent_plan_label() {
+  case "$(normalize_agent_platform "$AGENT_PLATFORMS")" in
+    auto) printf '%s\n' "Autodetect and install available agent adapters." ;;
+    none) printf '%s\n' "Skip coding-agent plugin adapters." ;;
+    all) printf '%s\n' "Install all supported agent adapters." ;;
+    *) printf '%s\n' "Install requested agent adapter(s): $AGENT_PLATFORMS." ;;
+  esac
+}
 confirm() {
   local answer
   [ "$YES" = "1" ] && return 0
@@ -407,20 +500,33 @@ compose_initial_prompt() {
   fi
 }
 
-install_claude_plugin() {
-  [ "$NO_CLAUDE" = "1" ] && return 0
+resolve_plugin_repo() {
+  local manifest_dir="$1" repo="$PKG_DIR"
+  if [ ! -f "$repo/$manifest_dir/plugin.json" ]; then
+    repo="$(cd "$(dirname "$0")" && pwd)"
+  fi
+  if [ ! -f "$repo/$manifest_dir/plugin.json" ]; then
+    repo="$(pwd)"
+  fi
+  if [ ! -f "$repo/$manifest_dir/plugin.json" ]; then
+    return 1
+  fi
+  printf '%s\n' "$repo"
+}
 
+install_claude_plugin() {
+  if ! should_install_claude_adapter; then
+    say "Claude Code adapter not selected or not detected; skipping Claude Code plugin install."
+    return 0
+  fi
   if ! need claude; then
     say "Claude Code CLI not found; skipping plugin install."
     say "Later, from a checkout, run: claude plugin marketplace add <repo> && claude plugin install understudy@understudy-skills"
     return 0
   fi
 
-  local repo="$PKG_DIR"
-  if [ ! -f "$repo/.claude-plugin/plugin.json" ]; then
-    repo="$(cd "$(dirname "$0")" && pwd)"
-  fi
-  if [ ! -f "$repo/.claude-plugin/plugin.json" ]; then
+  local repo
+  if ! repo="$(resolve_plugin_repo ".claude-plugin")"; then
     say "Could not find .claude-plugin/plugin.json; skipping Claude Code plugin install."
     return 0
   fi
@@ -437,10 +543,79 @@ install_claude_plugin() {
   say "Then type /understudy:onboard so the agent can guide the first local Understudy."
 }
 
+install_cursor_plugin() {
+  if ! should_install_cursor_adapter; then
+    say "Cursor adapter not selected or not detected; skipping Cursor plugin install."
+    return 0
+  fi
+
+  local repo dest
+  if ! repo="$(resolve_plugin_repo ".cursor-plugin")"; then
+    say "Could not find .cursor-plugin/plugin.json; skipping Cursor plugin install."
+    return 0
+  fi
+
+  dest="$HOME/.cursor/plugins/local/understudy"
+  say "Installing the Understudy Cursor plugin from $repo."
+  mkdir -p "$(dirname "$dest")"
+  if [ -L "$dest" ] && [ "$(readlink "$dest" 2>/dev/null || true)" = "$repo" ]; then
+    ok "Understudy Cursor plugin already points at $repo."
+  else
+    rm -rf "$dest"
+    ln -s "$repo" "$dest"
+    ok "Understudy Cursor plugin linked at $dest."
+  fi
+  say "In Cursor, restart the app or run Developer: Reload Window."
+  say "Then ask Cursor Agent: Use the Understudy onboarding skill for this project."
+}
+
+install_codex_plugin() {
+  if ! should_install_codex_adapter; then
+    say "Codex adapter not selected or not detected; skipping Codex marketplace registration."
+    return 0
+  fi
+  if ! need codex; then
+    say "Codex CLI not found; skipping Codex marketplace registration."
+    say "Later, from a checkout, run: codex plugin marketplace add <repo>"
+    return 0
+  fi
+
+  local repo
+  if ! repo="$(resolve_plugin_repo ".codex-plugin")"; then
+    say "Could not find .codex-plugin/plugin.json; skipping Codex marketplace registration."
+    return 0
+  fi
+  if [ ! -f "$repo/.agents/plugins/marketplace.json" ]; then
+    say "Could not find .agents/plugins/marketplace.json; skipping Codex marketplace registration."
+    return 0
+  fi
+
+  say "Registering the Understudy Codex marketplace from $repo."
+  if codex plugin marketplace add "$repo" >>"$LOG_FILE" 2>&1; then
+    ok "Understudy Codex marketplace registered."
+  else
+    say "Codex marketplace add failed; trying marketplace refresh."
+    run_logged "Refresh the Understudy Codex marketplace" codex plugin marketplace upgrade understudy-skills
+  fi
+  say "In Codex, run /plugins, choose the understudy-skills marketplace, and install or enable the understudy plugin."
+  say "Then ask Codex: Use the Understudy onboarding skill for this project."
+}
+
+install_agent_adapters() {
+  install_claude_plugin
+  install_cursor_plugin
+  install_codex_plugin
+}
+
 launch_claude_code() {
   local claude_log
   if [ "$NO_CLAUDE" != "0" ]; then
     say "Skipping Claude Code launch because --no-claude is set."
+    mark_step_done 3
+    return 0
+  fi
+  if ! should_install_claude_adapter; then
+    say "Skipping Claude Code launch because the Claude Code adapter is not selected or detected."
     mark_step_done 3
     return 0
   fi
@@ -510,6 +685,7 @@ need npm || {
   exit 1
 }
 
+validate_agent_platforms || exit 2
 configure_resume
 
 banner
@@ -529,12 +705,12 @@ if [ "$KEEP_LOGIN" = "1" ]; then
 else
   say "  ${G3}·${R}  Reset any existing sign-in so the agent-first sign-up starts fresh (backup kept; --keep-login skips)."
 fi
-say "  ${G4}2.${R} Install or refresh the Claude Code skills when Claude Code is available."
-say "  ${G5}3.${R} Open Claude Code here — the agent signs you up by email code, then onboards you."
+say "  ${G4}2.${R} $(agent_plan_label)"
+say "  ${G5}3.${R} Open Claude Code here when the Claude Code adapter is selected — otherwise finish with reload instructions."
 say ""
 say "Default install does not download weights, start MLX, launch the ladder server, or make frontier calls."
-say "Those actions happen later through /understudy:onboard, where the coding agent can coach the user and ask consent."
-say "This installer writes only under $LAB, $HOME/.understudy, the global npm prefix, and Claude Code plugin state when enabled."
+say "Those actions happen later through the Understudy onboarding skill, where the coding agent can coach the user and ask consent."
+say "This installer writes only under $LAB, $HOME/.understudy, the global npm prefix, and selected coding-agent plugin state."
 confirm "Continue with this Understudy installation?" || exit 1
 
 PKG_DIR="$(npm root -g)/@understudylabs/understudy-agent-tools"
@@ -551,19 +727,19 @@ fi
 prepare_agent_first_signin
 
 if should_run_step 2; then
-  section "Step 2/3 · Install the Claude Code skills"
-  install_claude_plugin
+  section "Step 2/3 · Install agent adapters"
+  install_agent_adapters
   mark_step_done 2
 else
-  say "Skipping step 2/3: install the Claude Code skills."
+  say "Skipping step 2/3: install agent adapters."
 fi
 
 compose_initial_prompt
 
 section "Where this goes next"
-say "The installer is done. The next experience belongs inside Claude Code:"
-say "  The launched Claude Code session receives the sign-up + onboarding prompt automatically."
-say "  If you continue in an already-open Claude Code session instead, run /reload-plugins and then /understudy:onboard."
+say "The installer is done. The next experience belongs inside your coding agent:"
+say "  Claude Code: run /reload-plugins and then /understudy:onboard."
+say "  Cursor: restart Cursor or run Developer: Reload Window, then ask Cursor Agent to use the Understudy onboarding skill."
 say "That lets the coding agent run the email-code sign-up itself, explain the first local Understudy, and open a terminal of the user's choice when needed."
 if should_run_step 3; then
   launch_claude_code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {
@@ -9,7 +9,10 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
+    ".agents",
     ".claude-plugin",
+    ".codex-plugin",
+    ".cursor-plugin",
     "install.sh",
     "dist",
     "skills",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -33,6 +33,9 @@ const forbiddenMemberParts = [
 ];
 
 const requiredPackageMembers = [
+  ".agents/plugins/marketplace.json",
+  ".codex-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
   "skills/local-distillation-lab/SKILL.md",
   "skills/local-distillation-lab/references/pedagogical-arm.md",
   "skills/recursive-language-model/SKILL.md",

--- a/skills/README.md
+++ b/skills/README.md
@@ -24,6 +24,13 @@ group it belongs to.
   verifies the Understudy skills as a Claude Code plugin via the
   non-interactive `claude plugin` CLI, then surfaces the one `/reload-plugins`
   activation step.
+- [`install-cursor-plugin`](install-cursor-plugin/SKILL.md) installs, refreshes,
+  verifies, or removes the same Understudy skills as a local Cursor plugin by
+  symlinking this repo into `~/.cursor/plugins/local/understudy`, then surfaces
+  the Cursor reload step.
+- [`install-codex-plugin`](install-codex-plugin/SKILL.md) registers, refreshes,
+  verifies, or removes the same Understudy skills as a local Codex marketplace
+  plugin, then surfaces the `/plugins` install/enable step.
 - [`onboard`](onboard/SKILL.md) is the engaging first-run experience: it
   backgrounds a small American open-model download while it profiles the machine,
   detects ML tooling, interviews the user, and writes a durable

--- a/skills/install-codex-plugin/SKILL.md
+++ b/skills/install-codex-plugin/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: install-codex-plugin
+description: Use when a developer wants to install, enable, update, reinstall, or verify the Understudy skills as a Codex plugin - "install Understudy in Codex", "add the Codex plugin", "make Codex see the Understudy skills". Registers the local Codex marketplace and tells the developer how to install or enable it from Codex.
+metadata:
+  understudy:
+    mode: automatic
+    safety: local-first
+    cli_required: false
+---
+
+# Install the Understudy Codex plugin
+
+This repo ships the public skills as a Codex plugin. The plugin manifest lives in
+`.codex-plugin/plugin.json`, and the repo marketplace lives in
+`.agents/plugins/marketplace.json`. The plugin points at the existing `skills/`
+tree; do not copy or fork the skills for Codex.
+
+The local flow registers this repo as a Codex marketplace. Codex's plugin
+browser owns the final install/enable step.
+
+## Key facts
+
+- `codex plugin marketplace add <repo-root>` registers the local marketplace.
+- The plugin browser is where the developer installs or toggles the plugin.
+- Codex should be restarted after marketplace or plugin changes if the plugin
+  does not appear immediately.
+- The plugin reuses the same `skills/` tree as Claude Code and Cursor.
+
+## Procedure
+
+### 1. Find the repo root
+
+```bash
+REPO="$(cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && pwd)"
+ls "$REPO/.codex-plugin/plugin.json" "$REPO/.agents/plugins/marketplace.json" "$REPO/skills/understudy/SKILL.md"
+```
+
+### 2. Register the local marketplace
+
+```bash
+codex plugin marketplace add "$REPO"
+```
+
+If the marketplace is already registered, refresh it:
+
+```bash
+codex plugin marketplace upgrade understudy-skills
+```
+
+### 3. Install or enable in Codex
+
+Open Codex and run:
+
+```text
+/plugins
+```
+
+Choose the `understudy-skills` marketplace, open the `understudy` plugin, and
+install or enable it. Start a new Codex thread if the new skills do not appear.
+
+### 4. Start onboarding
+
+In Codex, ask:
+
+```text
+Use the Understudy onboarding skill for this project.
+```
+
+The agent should route into `understudy` or `onboard`, profile the machine, and
+guide any model download, ladder climb, or frontier comparison with explicit
+consent.
+
+## Uninstall
+
+From Codex, open `/plugins` and uninstall the `understudy` plugin. To remove the
+local marketplace registration:
+
+```bash
+codex plugin marketplace remove understudy-skills
+```
+
+## Safety Gates
+
+Local-first and free: registering the marketplace makes no provider calls,
+uploads, spend, or credential changes. Do not require Understudy login, provider
+keys, or hosted access for this skill.
+
+- Do not edit `~/.codex/config.toml` by hand unless the `codex plugin`
+  marketplace command is unavailable and the user explicitly asks for manual
+  setup.
+- Do not copy private traces, keys, local `.understudy/` runtime state, or user
+  data into the plugin directory.
+- Do not claim the plugin was installed if only the marketplace was registered.
+
+## Resolve CLI
+
+Use `codex plugin marketplace add` when the `codex` CLI is available. If the CLI
+is missing, show the manual marketplace path and the `/plugins` activation step.
+
+## Output Standard
+
+End with whether the Codex marketplace was already present / just registered /
+refreshed / shown for manual run; the `/plugins` install step; the next
+onboarding prompt; and the marketplace removal command.

--- a/skills/install-cursor-plugin/SKILL.md
+++ b/skills/install-cursor-plugin/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: install-cursor-plugin
+description: Use when a developer wants to install, enable, update, reinstall, or verify the Understudy skills as a Cursor plugin - "install Understudy in Cursor", "add the Cursor plugin", "make Cursor see the Understudy skills". Creates or refreshes a local Cursor plugin symlink and tells the developer how to reload Cursor.
+metadata:
+  understudy:
+    mode: automatic
+    safety: local-first
+    cli_required: false
+---
+
+# Install the Understudy Cursor plugin
+
+This repo ships the same public skills as a Cursor plugin. The manifest lives in
+`.cursor-plugin/plugin.json`, and Cursor discovers the `skills/` directory from
+the plugin root. The local install path is a symlink from this checkout into
+`~/.cursor/plugins/local/understudy`.
+
+The flow is local: it does not upload, authenticate, spend, download models, or
+make provider calls.
+
+## Key facts
+
+- Cursor loads local plugins from `~/.cursor/plugins/local/<plugin-name>`.
+- For fast iteration, symlink this repo instead of copying it.
+- After install or update, the developer must restart Cursor or run
+  **Developer: Reload Window**. The agent cannot reload the user's Cursor UI.
+- The plugin reuses the repo's existing `skills/` tree. Do not fork or copy the
+  skills into a Cursor-only directory unless Cursor's plugin format changes.
+
+## Procedure
+
+### 1. Find the repo root
+
+Resolve the directory that contains `.cursor-plugin/plugin.json`:
+
+```bash
+REPO="$(cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && pwd)"
+ls "$REPO/.cursor-plugin/plugin.json" "$REPO/skills/understudy/SKILL.md"
+```
+
+### 2. Install or refresh the local Cursor plugin
+
+```bash
+mkdir -p "$HOME/.cursor/plugins/local"
+rm -rf "$HOME/.cursor/plugins/local/understudy"
+ln -s "$REPO" "$HOME/.cursor/plugins/local/understudy"
+```
+
+Use `rm -rf` only for the known local plugin path above. Do not remove any other
+Cursor plugin directory.
+
+### 3. Activate in Cursor
+
+Tell the developer to restart Cursor or run:
+
+```text
+Developer: Reload Window
+```
+
+Then verify in Cursor Settings -> Rules that the Understudy skills appear in the
+Agent Decides section.
+
+### 4. Start onboarding
+
+In Cursor Agent chat, ask for:
+
+```text
+Use the Understudy onboarding skill for this project.
+```
+
+The agent should route into `understudy` or `onboard`, profile the machine, and
+guide any model download, ladder climb, or frontier comparison with explicit
+consent.
+
+## Uninstall
+
+```bash
+rm -f "$HOME/.cursor/plugins/local/understudy"
+```
+
+Then restart Cursor or run **Developer: Reload Window**.
+
+## Safety Gates
+
+Local-first and free: adding the symlink makes no provider calls, uploads,
+spend, or credential changes. Do not require Understudy login, provider keys, or
+hosted access for this skill.
+
+- Confirm before overwriting anything except the exact
+  `~/.cursor/plugins/local/understudy` symlink/directory.
+- Do not edit Cursor's internal settings databases or user settings by hand.
+- Do not copy private traces, keys, local `.understudy/` runtime state, or user
+  data into the plugin directory.
+
+## Resolve CLI
+
+No Understudy CLI command is required. Use shell only to create the local plugin
+symlink. If `git` is unavailable, use the current working directory only after
+confirming it contains `.cursor-plugin/plugin.json`.
+
+## Output Standard
+
+End with whether the Cursor plugin was already present / just installed /
+refreshed / shown for manual run; the reload step (`Developer: Reload Window` or
+restart Cursor); the next onboarding prompt; and the uninstall command.

--- a/src/agent-platforms.ts
+++ b/src/agent-platforms.ts
@@ -1,0 +1,81 @@
+export type AgentPlatformStatus = "supported" | "planned";
+
+export type AgentPlatformAdapter = {
+  id: string;
+  displayName: string;
+  status: AgentPlatformStatus;
+  manifestPath: string;
+  discovery: string;
+  install: string[];
+  reload: string;
+  uninstall: string[];
+  onboarding: string;
+  notes: string[];
+};
+
+export const agentPlatformAdapters: AgentPlatformAdapter[] = [
+  {
+    id: "claude-code",
+    displayName: "Claude Code",
+    status: "supported",
+    manifestPath: ".claude-plugin/plugin.json",
+    discovery: "Claude Code local marketplace plugin with skills discovered from skills/",
+    install: [
+      'REPO="$(git rev-parse --show-toplevel)"',
+      'claude plugin marketplace add "$REPO"',
+      "claude plugin install understudy@understudy-skills",
+    ],
+    reload: "Run /reload-plugins in Claude Code.",
+    uninstall: [
+      "claude plugin uninstall understudy@understudy-skills",
+      "claude plugin marketplace remove understudy-skills",
+    ],
+    onboarding: "Run /understudy:onboard.",
+    notes: [
+      "Best current default for guided onboarding.",
+      "The agent cannot run Claude slash commands; the developer runs reload and onboarding.",
+    ],
+  },
+  {
+    id: "cursor",
+    displayName: "Cursor",
+    status: "supported",
+    manifestPath: ".cursor-plugin/plugin.json",
+    discovery: "Cursor local plugin with skills discovered from skills/ at the plugin root",
+    install: [
+      'REPO="$(git rev-parse --show-toplevel)"',
+      'mkdir -p "$HOME/.cursor/plugins/local"',
+      'rm -rf "$HOME/.cursor/plugins/local/understudy"',
+      'ln -s "$REPO" "$HOME/.cursor/plugins/local/understudy"',
+    ],
+    reload: "Restart Cursor or run Developer: Reload Window.",
+    uninstall: ['rm -f "$HOME/.cursor/plugins/local/understudy"'],
+    onboarding: "Ask Cursor Agent: Use the Understudy onboarding skill for this project.",
+    notes: [
+      "Uses Cursor's local plugin loader rather than a VSIX wrapper.",
+      "A future VS Code/Cursor extension can call Cursor's plugin path API against the same plugin directory.",
+    ],
+  },
+  {
+    id: "codex",
+    displayName: "Codex",
+    status: "supported",
+    manifestPath: ".codex-plugin/plugin.json",
+    discovery: "Codex local marketplace plugin with skills discovered from skills/",
+    install: [
+      'REPO="$(git rev-parse --show-toplevel)"',
+      'codex plugin marketplace add "$REPO"',
+    ],
+    reload: "Open /plugins in Codex, install or enable the understudy plugin, then start a new thread if needed.",
+    uninstall: ["codex plugin marketplace remove understudy-skills"],
+    onboarding: "Ask Codex: Use the Understudy onboarding skill for this project.",
+    notes: [
+      "The CLI registers the marketplace; the Codex plugin browser owns final install/enable.",
+      "AGENTS.md remains repo guidance, but the plugin is the reusable distribution unit.",
+    ],
+  },
+];
+
+export function findAgentPlatformAdapter(id: string): AgentPlatformAdapter | undefined {
+  return agentPlatformAdapters.find((adapter) => adapter.id === id);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { runUnderstandCheck, runUnderstandWorkloadCard } from "./understand.js";
 import { buildWorkloadCard, previewCaptureImport, scanCaptureImport } from "./capture-import.js";
 import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
+import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
 import { registerCapturesCommand } from "./commands/captures.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
 import { registerGatewayCommand } from "./commands/gateway.js";
@@ -189,6 +190,31 @@ function printSpine(): void {
   console.log("4. skills/use-understudy-gateway/SKILL.md runs authenticated gateway workflows when approved.");
 }
 
+function printPlatforms(json: boolean, inspect?: string): void {
+  let adapters: AgentPlatformAdapter[];
+  if (inspect) {
+    const adapter = findAgentPlatformAdapter(inspect);
+    if (!adapter) {
+      throw new Error(`Unknown agent platform adapter: ${inspect}`);
+    }
+    adapters = [adapter];
+  } else {
+    adapters = agentPlatformAdapters;
+  }
+  if (json) {
+    printJson({ adapters });
+    return;
+  }
+  console.log("Understudy agent platform adapters:");
+  for (const adapter of adapters) {
+    console.log(`- ${adapter.id} (${adapter.status})`);
+    console.log(`  ${adapter.displayName}: ${adapter.discovery}`);
+    console.log(`  manifest: ${adapter.manifestPath}`);
+    console.log(`  reload: ${adapter.reload}`);
+    console.log(`  onboarding: ${adapter.onboarding}`);
+  }
+}
+
 function printDoctorJson(): void {
   const required = [
     "README.md",
@@ -205,7 +231,10 @@ function printDoctorJson(): void {
   const versionsConsistent =
     versions.cli !== null &&
     versions.cli === versions.plugin &&
-    versions.cli === versions.marketplace;
+    versions.cli === versions.marketplace &&
+    versions.cli === versions.cursorPlugin &&
+    versions.cli === versions.codexPlugin &&
+    versions.cli === versions.codexMarketplace;
   console.log(
     JSON.stringify(
       {
@@ -376,6 +405,14 @@ export function buildProgram(): Command {
     .option("--json", "Emit machine-readable JSON when supported");
 
   program.command("spine").description("Print the public MVP workflow spine").action(printSpine);
+
+  program
+    .command("platforms")
+    .description("List agent platform adapters for Claude Code, Cursor, and Codex")
+    .option("--inspect <id>", "Inspect one platform adapter")
+    .action((options: { inspect?: string }) => {
+      printPlatforms(commandJsonEnabled(program, {}), options.inspect);
+    });
 
   const skills = program.command("skills").description("List and inspect public skills");
   skills.option("--list", "List public MVP skills");

--- a/src/internal/version.ts
+++ b/src/internal/version.ts
@@ -23,12 +23,21 @@ export function readManifestVersions(): {
   cli: string | null;
   plugin: string | null;
   marketplace: string | null;
+  cursorPlugin: string | null;
+  codexPlugin: string | null;
+  codexMarketplace: string | null;
 } {
   return {
     cli: readManifestVersion(join(packageRoot, "package.json")),
     plugin: readManifestVersion(join(packageRoot, ".claude-plugin", "plugin.json")),
     marketplace: readManifestVersion(
       join(packageRoot, ".claude-plugin", "marketplace.json"),
+      (parsed) => (parsed as { metadata?: { version?: string } }).metadata?.version,
+    ),
+    cursorPlugin: readManifestVersion(join(packageRoot, ".cursor-plugin", "plugin.json")),
+    codexPlugin: readManifestVersion(join(packageRoot, ".codex-plugin", "plugin.json")),
+    codexMarketplace: readManifestVersion(
+      join(packageRoot, ".agents", "plugins", "marketplace.json"),
       (parsed) => (parsed as { metadata?: { version?: string } }).metadata?.version,
     ),
   };

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -419,6 +419,27 @@ describe("understudy CLI", () => {
     assert.match(result.stdout, /use-understudy-gateway/);
   });
 
+  it("lists agent platform adapters", () => {
+    const result = run(["--json", "platforms"]);
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.deepEqual(
+      payload.adapters.map((adapter) => adapter.id),
+      ["claude-code", "cursor", "codex"],
+    );
+    assert.equal(payload.adapters.find((adapter) => adapter.id === "cursor").manifestPath, ".cursor-plugin/plugin.json");
+    assert.equal(payload.adapters.find((adapter) => adapter.id === "codex").manifestPath, ".codex-plugin/plugin.json");
+    assert.equal(payload.adapters.find((adapter) => adapter.id === "codex").status, "supported");
+  });
+
+  it("inspects one agent platform adapter", () => {
+    const result = run(["platforms", "--inspect", "cursor"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Cursor/);
+    assert.match(result.stdout, /\.cursor-plugin\/plugin\.json/);
+    assert.match(result.stdout, /Developer: Reload Window/);
+  });
+
   it("lists the pedagogical and local training skills", () => {
     const result = run(["skills", "--list"]);
     assert.equal(result.status, 0, result.stderr);
@@ -493,6 +514,9 @@ describe("understudy CLI", () => {
     assert.equal(payload.versions_consistent, true);
     assert.equal(payload.versions.cli, payload.versions.plugin);
     assert.equal(payload.versions.cli, payload.versions.marketplace);
+    assert.equal(payload.versions.cli, payload.versions.cursorPlugin);
+    assert.equal(payload.versions.cli, payload.versions.codexPlugin);
+    assert.equal(payload.versions.cli, payload.versions.codexMarketplace);
   });
 
   it("status exits non-zero when local config is malformed", () => {

--- a/tests/installer.test.mjs
+++ b/tests/installer.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -167,5 +167,177 @@ describe("install.sh", () => {
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.equal(existsSync(join(understudyDir, "credentials.json")), true);
+  });
+
+  it("installs the Cursor adapter when explicitly requested", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const result = spawnSync(
+      "bash",
+      [
+        "-s",
+        "--",
+        "--non-interactive",
+        "--only-step",
+        "2",
+        "--agents",
+        "cursor",
+        "--no-launch-claude",
+        "--lab",
+        join(root, "lab"),
+      ],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Understudy Cursor plugin linked/);
+    assert.equal(existsSync(join(home, ".cursor", "plugins", "local", "understudy")), true);
+  });
+
+  it("registers the Codex marketplace when explicitly requested", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const bin = join(root, "bin");
+    const calls = join(root, "codex-calls.txt");
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(
+      join(bin, "codex"),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${calls}"\nexit 0\n`,
+    );
+    chmodSync(join(bin, "codex"), 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-s",
+        "--",
+        "--non-interactive",
+        "--only-step",
+        "2",
+        "--agents",
+        "codex",
+        "--no-launch-claude",
+        "--lab",
+        join(root, "lab"),
+      ],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          PATH: `${bin}:${process.env.PATH}`,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Understudy Codex marketplace registered/);
+    assert.match(readFileSync(calls, "utf8"), /plugin marketplace add /);
+  });
+
+  it("autodetects available agent adapters by default", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const bin = join(root, "bin");
+    const calls = join(root, "agent-calls.txt");
+    mkdirSync(join(home, ".cursor"), { recursive: true });
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(
+      join(bin, "claude"),
+      `#!/usr/bin/env bash\nprintf 'claude %s\\n' "$*" >> "${calls}"\nif [ "$*" = "plugin list --json" ]; then printf '[]\\n'; fi\nexit 0\n`,
+    );
+    writeFileSync(
+      join(bin, "codex"),
+      `#!/usr/bin/env bash\nprintf 'codex %s\\n' "$*" >> "${calls}"\nexit 0\n`,
+    );
+    chmodSync(join(bin, "claude"), 0o755);
+    chmodSync(join(bin, "codex"), 0o755);
+
+    const result = spawnSync(
+      "bash",
+      ["-s", "--", "--non-interactive", "--only-step", "2", "--no-launch-claude", "--lab", join(root, "lab")],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          PATH: `${bin}:${process.env.PATH}`,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Understudy plugin installed/);
+    assert.match(result.stdout, /Understudy Cursor plugin linked/);
+    assert.match(result.stdout, /Understudy Codex marketplace registered/);
+    const callsText = readFileSync(calls, "utf8");
+    assert.match(callsText, /claude plugin marketplace add /);
+    assert.match(callsText, /claude plugin install understudy@understudy-skills/);
+    assert.match(callsText, /codex plugin marketplace add /);
+  });
+
+  it("rejects ambiguous mixed agent adapter modes", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const result = spawnSync(
+      "bash",
+      ["-s", "--", "--non-interactive", "--only-step", "2", "--agents", "auto,cursor", "--lab", join(root, "lab")],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 2);
+    assert.match(result.stdout, /cannot be combined/);
+  });
+
+  it("skips agent adapters with --no-agents", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const result = spawnSync(
+      "bash",
+      ["-s", "--", "--non-interactive", "--only-step", "2", "--no-agents", "--lab", join(root, "lab")],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Claude Code adapter not selected or not detected/);
+    assert.match(result.stdout, /Cursor adapter not selected or not detected/);
+    assert.match(result.stdout, /Codex adapter not selected or not detected/);
+    assert.equal(existsSync(join(home, ".cursor", "plugins", "local", "understudy")), false);
   });
 });


### PR DESCRIPTION
## Summary

Adds a shared agent-platform adapter layer so the same Understudy skill tree can be exposed through Claude Code, Cursor, and Codex without forking playbooks.

## What changed

- Added Cursor and Codex plugin manifests plus a Codex local marketplace file.
- Added `understudy platforms` to inspect supported agent harnesses and install/reload guidance.
- Updated `install.sh` with `--agents auto|all|claude-code|cursor|codex|none`, autodetection, Cursor local plugin linking, and Codex marketplace registration.
- Added install skills and docs for Cursor/Codex adapter setup.
- Extended package smoke/version checks and installer/CLI tests for the new adapter surface.

## Impact

The curl installer now defaults to autodetecting available agent harnesses: Claude Code when `claude` is available, Cursor when present, and Codex when `codex` is available. Codex registration is noninteractive, while final install/enable still happens in Codex via `/plugins`.

## Validation

- `npm run check`
- `git diff --check`
- `understudy platforms`
- `understudy --json platforms`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->