### PR TITLE
[codex] expand ladder remote model catalog

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Understudy Labs"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-06-19
+
+### Added
+
+- **`ladder` remote model picker.** The ladder now builds remote lanes from the
+  Understudy gateway catalog when org context is available, falls back to the
+  public remote model list, and supports explicit existing model ids via
+  `UNDERSTUDY_LADDER_REMOTE_MODELS` (for example `glm-5.2`). The viewer consumes
+  `/models` as the source of truth instead of hard-coding only `glm-5.1`.
+
+### Changed
+
+- `understudy run` now injects the non-secret `UNDERSTUDY_ORG_ID` when known so
+  local tools can discover org-scoped hosted metadata without reading
+  credentials from disk.
+
 ## [0.4.0] — 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -265,8 +265,9 @@ completes the pending sign-in — so an agent can drive sign-up as two plain
 shell commands. It stores the
 returned `sk_*` in `~/.understudy/credentials.json` with mode `600` and writes a
 repo-local `.understudy/config.json` when the platform returns a default
-project. `run` injects `UNDERSTUDY_API_KEY` and `UNDERSTUDY_GATEWAY_URL` only
-into the child process; do not copy secrets into repo files or chat output.
+project. `run` injects `UNDERSTUDY_API_KEY`, `UNDERSTUDY_GATEWAY_URL`, and the
+non-secret `UNDERSTUDY_ORG_ID` when known into the child process; do not copy
+secrets into repo files or chat output.
 `doctor --hosted` checks credentials, gateway health, projects, keys, models,
 and workloads without provider calls. `gateway probe` is an explicit tiny live
 call and prints request metadata, not the completion text. If you need BYOK for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/skills/ladder/SKILL.md
+++ b/skills/ladder/SKILL.md
@@ -41,10 +41,10 @@ workload, hand off to `run-local-model-lab`.
   `gemma-4-e2b`. If it's missing, pull it with the `manage-local-models` skill
   (`understudy models pull gemma-4-e2b-it-qat-mlx-vlm-understudy`); the server
   prints an actionable error if it's absent.
-- **Frontier lane only:** run `understudy login` once so `understudy run` can
-  inject the gateway key. Without it the frontier lane returns the literal notice
-  `[gateway not configured …]` rather than erroring — don't mistake that for a
-  real run.
+- **Remote lanes only:** run `understudy login` once so `understudy run` can
+  inject the gateway key and org id. Without it a remote lane returns the literal
+  notice `[gateway not configured …]` rather than erroring — don't mistake that
+  for a real run.
 
 Run from the repo root (the path below is relative):
 
@@ -69,8 +69,8 @@ service — though the SSE endpoint is browserless-friendly for an agent.
 - **VS mode** — two models race the same task side by side. Local-vs-local
   serializes on the one GPU; local-vs-gateway runs concurrently.
 
-Frontier (`glm-5.1`) runs go through the Understudy gateway and are **billed** —
-the picker marks that lane and every such run is disclosed.
+Remote runs go through the Understudy gateway and are **billed**. The picker
+marks every gateway-backed lane and every such run is disclosed.
 
 ## What you can actually run ($0 vs billed)
 
@@ -78,12 +78,12 @@ the picker marks that lane and every such run is disclosed.
   watch where it breaks: it passes the easy/medium classify tasks and typically
   fails the hard tool-calling task. That difficulty climb is the free demo and a
   real signal on its own, entirely on your machine.
-- **A side-by-side model-vs-model comparison costs money.** The only frontier
-  lane, `glm-5.1`, is billed, and the "compare two" (VS) button pairs the local
-  model against it by default — so triggering VS bills a gateway run. No *second*
-  free model ships enabled (the local LFM lane is coded but commented out in
-  `serve.py`). So "$0" and "two models side by side" are not both available out
-  of the box: take the free climb, or accept the gateway cost for the race.
+- **A side-by-side model-vs-model comparison usually costs money.** The "compare
+  two" (VS) button pairs the local model against a gateway-backed remote model
+  by default — so triggering VS bills a gateway run. No *second* free model ships
+  enabled (the local LFM lane is coded but commented out in `serve.py`). So "$0"
+  and "two models side by side" are not both available out of the box: take the
+  free climb, or accept the gateway cost for the race.
 
 ## Drive it headlessly
 
@@ -102,10 +102,9 @@ The stream ends with a `done` event carrying the result (`correct`, `response`,
 
 - **Local-first, $0 on the local lane.** The mlx model runs on the developer's
   machine, the server binds `127.0.0.1` only, and nothing is uploaded.
-- **Gateway runs are billed.** The frontier lane (`glm-5.1`) goes through the
-  Understudy gateway and costs money. The picker marks it and every such run is
-  disclosed in the UI — do not route to it without the developer understanding
-  it bills.
+- **Gateway runs are billed.** Remote lanes go through the Understudy gateway and
+  cost money. The picker marks them and every such run is disclosed in the UI —
+  do not route to one without the developer understanding it bills.
 - **Synthetic data only.** The "Larkfield" world is invented; no real customer or
   workload data is involved.
 - **No silent downloads.** The server only *loads* a cached local model from

--- a/skills/ladder/reference.md
+++ b/skills/ladder/reference.md
@@ -40,7 +40,7 @@ specific run or embed a precise view.
 | param | meaning |
 |---|---|
 | `?task=<id>` | task to open: a classify id (`sort-email`, `match-search`) or any tool-task id from the fixtures (e.g. `hard.sla_route`) |
-| `?model=<id>` | model lane for the single pane / VS pane A (`gemma-4-e2b` or `glm-5.1`) |
+| `?model=<id>` | model lane for the single pane / VS pane A (`gemma-4-e2b` or any `/models` remote id such as `glm-5.2`) |
 | `?vs=1` | open in compare-two (VS) mode |
 | `?modelB=<id>` | VS pane B's model (only meaningful with `vs=1`) |
 
@@ -53,12 +53,26 @@ extra wiring. (Both helpers live in the viewer's `<script>`.)
 
 ## Model lanes & tool-call dialects
 
-Two lanes are active; a third is coded but its model line is commented out:
+The local lane is fixed; remote lanes are gateway-backed and discovered at server
+start. If `understudy run` injects `UNDERSTUDY_ORG_ID`, `/models` tries the live
+org catalog first. Without live catalog access it falls back to the checked-in
+public remote ids. For a specific existing remote model that is not in the
+fallback list, launch with:
+
+```sh
+UNDERSTUDY_LADDER_REMOTE_MODELS=glm-5.2 understudy run -- uv run --with mlx-vlm --with mlx-lm python skills/ladder/serve.py
+```
+
+Active local lane plus default fallback remotes:
 
 | id | lane | where |
 |---|---|---|
 | `gemma-4-e2b` | `mlx_vlm` | local default, **$0** |
 | `glm-5.1` | `gateway` | Understudy gateway, **billed** |
+| `gemma-4-31b-it` | `gateway` | Understudy gateway, **billed** |
+| `nemotron-3-nano` | `gateway` | Understudy gateway, **billed** |
+| `nemotron-3-super` | `gateway` | Understudy gateway, **billed** |
+| `nemotron-3-ultra` | `gateway` | Understudy gateway, **billed** |
 | `lfm2.5-8b-a1b` | `mlx_lm` | coded but commented out (uncomment in `serve.py`) |
 
 Each lane speaks its own tool-call dialect against the **one** world + scorer:
@@ -174,10 +188,11 @@ but is otherwise indifferent to it.
   `TOOLS`, and add an OpenAI-shaped entry to `TOOL_SCHEMAS`; then list it in a
   task's `allowed_tools`. Errors must be recoverable — return `{"error": …}`,
   never throw.
-- **New model lane:** add to `serve.py` `MODELS` (`id -> (lane, path, label,
-  sampling)`) and the viewer's `LIVE_MODELS`. A genuinely new tool-call dialect
-  needs a parser + a `LANE_ADAPT` row; an OpenAI-compatible gateway model is just
-  a `gateway` entry.
+- **New model lane:** add a local lane to `serve.py` `LOCAL_MODELS` (`id ->
+  (lane, path, label, sampling)`). Remote OpenAI-compatible gateway models do not
+  need viewer edits: add them to the hosted catalog, the fallback list, or
+  `UNDERSTUDY_LADDER_REMOTE_MODELS`. A genuinely new local tool-call dialect
+  needs a parser + a `LANE_ADAPT` row.
 
 ## Swapping the world (replacing Larkfield with your own domain)
 
@@ -240,7 +255,7 @@ simpler), and it stays a local demo — the path to actual RL is the export in
 - **Reasoning is off by default** in the raw output and switched on per lane
   (gemma `enable_thinking=True`; LFM `<think>`); the server splits the reasoning
   channel from the response before streaming.
-- **Gateway is billed.** Only the `glm-5.1` lane costs money; the picker marks it
+- **Gateway is billed.** Every `gateway` lane costs money; the picker marks it
   and every run is disclosed.
 
 ## Path to RL: exporting to a Verifiers environment

--- a/skills/ladder/serve.py
+++ b/skills/ladder/serve.py
@@ -36,21 +36,92 @@ MODEL_HOME = os.environ.get("UNDERSTUDY_MODEL_HOME") or os.path.expanduser("~/.u
 # Gemma (mlx_vlm): Google's standardized temp 1.0 / top_p 0.95 / top_k 64.
 # Classify runs can expose the reasoning channel; tool-calling uses the
 # snapshot-certified agentic path with thinking disabled.
-MODELS = {
+LOCAL_MODELS = {
     # gemma is our default local model for now. (8b-a1b removed for now -- re-add the
     # line below to restore it; the mlx_lm / LFM tool-calling code is left intact.)
     # "lfm2.5-8b-a1b": ("mlx_lm",  os.path.join(MODEL_HOME, "lfm2.5-8b-a1b-8bit"), "LFM 8B-A1B · thinking", {"temp": 0.2, "top_k": 80, "rep": 1.05}),
     "gemma-4-e2b":   ("mlx_vlm", os.path.join(MODEL_HOME, "gemma-4-e2b-it-qat-mlx-vlm-understudy"), "gemma-4-e2b · thinking", {"temp": 1.0, "top_p": 0.95, "top_k": 64}),
-    # frontier via the Understudy gateway (BILLED). Launch serve.py with `understudy run` so
-    # UNDERSTUDY_API_KEY + UNDERSTUDY_GATEWAY_URL are injected — the raw key is never read from disk.
-    "glm-5.1":       ("gateway", "glm-5.1", "glm-5.1 · frontier", {}),
 }
+
+FALLBACK_REMOTE_MODELS = [
+    ("glm-5.1", "GLM 5.1"),
+    ("gemma-4-31b-it", "Gemma 4 31B"),
+    ("nemotron-3-nano", "Nemotron 3 Nano"),
+    ("nemotron-3-super", "Nemotron 3 Super"),
+    ("nemotron-3-ultra", "Nemotron 3 Ultra"),
+]
+
+
+def _gateway_spec(model_id, label):
+    return ("gateway", model_id, "%s · remote" % label, {})
+
+
+def _fallback_gateway_models():
+    return {mid: _gateway_spec(mid, label) for mid, label in FALLBACK_REMOTE_MODELS}
+
+
+def _configured_gateway_models():
+    raw = os.environ.get("UNDERSTUDY_LADDER_REMOTE_MODELS", "").strip()
+    if not raw:
+        return None
+    out = {}
+    for part in re.split(r"[,;\s]+", raw):
+        mid = part.strip()
+        if mid:
+            out[mid] = _gateway_spec(mid, mid)
+    return out or None
+
+
+def _live_gateway_models():
+    """Best-effort org catalog refresh. Falls back silently when the ladder is
+    launched without org context or while offline; model calls still go through
+    /v1/chat/completions with the selected id."""
+    org_id = os.environ.get("UNDERSTUDY_ORG_ID")
+    api_key = os.environ.get("UNDERSTUDY_API_KEY")
+    gateway_url = os.environ.get("UNDERSTUDY_GATEWAY_URL")
+    if not (org_id and api_key and gateway_url):
+        return None
+    try:
+        import urllib.request
+        req = urllib.request.Request(
+            gateway_url.rstrip("/") + "/admin/v1/orgs/%s/models" % org_id,
+            headers={"Authorization": "Bearer " + api_key, "Accept": "application/json"},
+            method="GET")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        sys.stderr.write("[models] live catalog unavailable: %s: %s\n" % (type(e).__name__, str(e)[:160])); sys.stderr.flush()
+        return None
+    out = {}
+    for item in data.get("models") or []:
+        mid = item.get("id")
+        if not mid:
+            continue
+        label = item.get("display_name") or item.get("name") or mid
+        out[mid] = _gateway_spec(mid, label)
+    return out or None
+
+
+def build_model_catalog():
+    remote = _configured_gateway_models() or _live_gateway_models() or _fallback_gateway_models()
+    out = dict(LOCAL_MODELS)
+    out.update(remote)
+    return out
+
+
+MODELS = build_model_catalog()
+
+
+def model_catalog_payload():
+    return {"models": [
+        {"id": k, "label": v[2], "lane": v[0], "ready": model_loaded(k), "billed": v[0] == "gateway"}
+        for k, v in MODELS.items()]}
 
 # Catalog version stamp. Bump whenever a task row, assertion, scorer, or
 # execution config changes so run results taken against different versions stay
 # comparable (same discipline as the world's scoring contract in env/world.py).
 # Exposed as `tasks_version` on /tasks.
-TASKS_VERSION = "2"
+TASKS_VERSION = "3"
 
 # Classify tasks are DATA, not code -- the same discipline as the tool tasks below.
 # Each row in fixtures/classify_tasks.jsonl is one single-shot classify rung:
@@ -712,8 +783,7 @@ class Handler(BaseHTTPRequestHandler):
                             "tools": t.get("allowed_tools", []), "checks": len(t.get("assertions", []))})
             return self._json({"tasks_version": TASKS_VERSION, "tasks": cat})
         if u.path == "/models":
-            return self._json({"models": [
-                {"id": k, "label": v[2], "lane": v[0], "ready": model_loaded(k)} for k, v in MODELS.items()]})
+            return self._json(model_catalog_payload())
         return self.serve_static(u.path)
 
     def serve_static(self, path):

--- a/skills/ladder/viewer/ladder.climb.html
+++ b/skills/ladder/viewer/ladder.climb.html
@@ -393,8 +393,12 @@
   var idx = 0;
 
   var LIVE_MODELS = [
-    { id: "gemma-4-e2b",   label: "gemma-4-e2b" },
-    { id: "glm-5.1",       label: "glm-5.1 · frontier", billed: true }
+    { id: "gemma-4-e2b", label: "gemma-4-e2b" },
+    { id: "glm-5.1", label: "GLM 5.1 · remote", billed: true },
+    { id: "gemma-4-31b-it", label: "Gemma 4 31B · remote", billed: true },
+    { id: "nemotron-3-nano", label: "Nemotron 3 Nano · remote", billed: true },
+    { id: "nemotron-3-super", label: "Nemotron 3 Super · remote", billed: true },
+    { id: "nemotron-3-ultra", label: "Nemotron 3 Ultra · remote", billed: true }
   ];
   var curModel = "gemma-4-e2b";
   var curModelB = "glm-5.1";        // VS mode: the second model
@@ -411,6 +415,36 @@
   // The server is the single source of truth: classify rungs and tool rungs arrive
   // in one ordered list, and this page frames them identically. Add any task by
   // appending one fixture row on the server -- no edit here.
+  function validModel(id){ return LIVE_MODELS.some(function (m) { return m.id === id; }) ? id : null; }
+  function fallbackRemoteModel(){
+    for (var i = 0; i < LIVE_MODELS.length; i++) if (LIVE_MODELS[i].billed) return LIVE_MODELS[i].id;
+    return LIVE_MODELS[1] ? LIVE_MODELS[1].id : curModel;
+  }
+  function normalizeModels(items){
+    var seen = {}, out = [];
+    (items || []).forEach(function (m) {
+      var id = m && m.id;
+      if (!id || seen[id]) return;
+      seen[id] = true;
+      out.push({
+        id: id,
+        label: m.label || m.display_name || m.name || id,
+        billed: !!(m.billed || m.lane === 'gateway'),
+        lane: m.lane || ''
+      });
+    });
+    return out;
+  }
+  function hydrateModels(){
+    return fetch('/models').then(function (r) { return r.json(); }).then(function (j) {
+      var next = normalizeModels(j.models);
+      if (!next.length) return;
+      LIVE_MODELS = next;
+      if (!validModel(curModel)) curModel = LIVE_MODELS[0].id;
+      if (!validModel(curModelB)) curModelB = fallbackRemoteModel();
+      pickModel(); pickModelB();
+    }).catch(function () { /* keep the fallback model list */ });
+  }
   function humanizeTask(id){ return id.replace(/^hard\./, '').replace(/[-_]/g, ' '); }
   var RAIL_LABELS = {   // friendly rail names; falls back to humanizeTask when absent
     "sort-email": "categorization", "match-search": "classification",
@@ -423,7 +457,7 @@
     return m ? m[1] : (s.length > 90 ? s.slice(0, 88) + '…' : s);
   }
   function hydrate(){
-    return fetch('/tasks').then(function (r) { return r.json(); }).then(function (j) {
+    var tasks = fetch('/tasks').then(function (r) { return r.json(); }).then(function (j) {
       TASKS_VERSION = j.tasks_version || null;
       (j.tasks || []).forEach(function (t) {
         if (t.kind === 'classify') {
@@ -435,6 +469,7 @@
         }
       });
     }).catch(function () { /* server unreachable: TASKS stays empty, the pane keeps its placeholder */ });
+    return Promise.all([hydrateModels(), tasks]);
   }
 
   // ---- pickers: Select dropdowns (one builder, three call sites: model A / hard task / VS model B) ----
@@ -466,6 +501,7 @@
         var on = opt.id(items[i]) === cur;
         if (on) { found = true; valueEl.textContent = opt.text(items[i]); }
         rows[i].classList.toggle('active', on);
+        if (on) wrap.classList.toggle('billed', !!(opt.billed && items[i].billed));
       }
       if (!found) valueEl.textContent = items.length ? opt.text(items[0]) : '\u2014';
     }
@@ -475,7 +511,7 @@
       row.innerHTML = '<span></span>' + PICK_CHECK;
       row.firstChild.textContent = opt.text(it);
       var tip = opt.title && opt.title(it); if (tip) row.title = tip;
-      if (opt.billed && it.billed) { row.title = opt.billed; wrap.classList.add('billed'); }
+      if (opt.billed && it.billed) row.title = opt.billed;
       row.addEventListener('click', function (ev) {
         ev.stopPropagation();
         closeAllPickers();
@@ -672,7 +708,6 @@
 
   // ---- deep links: task + model (+ VS) live in the URL so any view is shareable ----
   function taskIndexForId(id){ for (var i = 0; i < TASKS.length; i++) { if (TASKS[i].id === id) return i; } return -1; }
-  function validModel(id){ return LIVE_MODELS.some(function (m) { return m.id === id; }) ? id : null; }
   function applyQuery(){
     var p = new URLSearchParams(location.search);
     var tid = p.get('task'); if (tid) { var i = taskIndexForId(tid); if (i >= 0) idx = i; }
@@ -738,7 +773,7 @@
   vsBtn.style.display = '';
   applyQuery();                                       // ?model/&vs apply now; task resolves fully post-hydrate
   pickModel();
-  hydrate().then(function () { applyQuery(); buildRail(); if (vsOn) applyVsLayout(); play(); });   // pull catalog, deep-link, run
+  hydrate().then(function () { applyQuery(); pickModel(); pickModelB(); buildRail(); if (vsOn) applyVsLayout(); play(); });   // pull catalogs, deep-link, run
 })();
 </script>
 </body>

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -33,8 +33,8 @@ Do not ask the developer to paste an API key. Use the CLI registration flow and
 let the CLI store credentials outside the repo.
 
 Do not print, commit, or write `sk_*` values into artifacts. `understudy run`
-injects `UNDERSTUDY_API_KEY` and `UNDERSTUDY_GATEWAY_URL` only into the child
-process environment.
+injects `UNDERSTUDY_API_KEY`, `UNDERSTUDY_GATEWAY_URL`, and the non-secret
+`UNDERSTUDY_ORG_ID` when known only into the child process environment.
 
 Do not run provider calls, uploads, hosted jobs, or model downloads without the
 developer approving the exact command, data class, and spend or download bound.

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -65,7 +65,11 @@ async function runWithUnderstudyEnv(
       `${JSON.stringify({
         ok: true,
         command: [bin, ...args],
-        injected: ["UNDERSTUDY_API_KEY", "UNDERSTUDY_GATEWAY_URL"],
+        injected: [
+          "UNDERSTUDY_API_KEY",
+          "UNDERSTUDY_GATEWAY_URL",
+          ...(resolved.orgId ? ["UNDERSTUDY_ORG_ID"] : []),
+        ],
         org_id: resolved.orgId,
         project_slug: resolved.projectSlug,
         source: resolved.source,
@@ -82,6 +86,7 @@ async function runWithUnderstudyEnv(
       ...process.env,
       UNDERSTUDY_API_KEY: resolved.apiKey,
       UNDERSTUDY_GATEWAY_URL: resolved.gatewayUrl,
+      ...(resolved.orgId ? { UNDERSTUDY_ORG_ID: resolved.orgId } : {}),
     },
     stdio: "inherit",
   });

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1253,6 +1253,67 @@ describe("understudy CLI", () => {
     });
   });
 
+  it("injects org context into authenticated child runs", async () => {
+    await withHostedFixture(async ({ home, repo }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const result = await runWithEnvAsync(
+        [
+          "--json",
+          "run",
+          "node",
+          "-e",
+          "console.log(JSON.stringify({api:!!process.env.UNDERSTUDY_API_KEY,gateway:process.env.UNDERSTUDY_GATEWAY_URL,org:process.env.UNDERSTUDY_ORG_ID||null}))",
+        ],
+        env,
+        repo,
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      const runMeta = JSON.parse(result.stderr.trim().split("\n").find((line) => line.startsWith("{")));
+      assert.deepEqual(runMeta.injected, ["UNDERSTUDY_API_KEY", "UNDERSTUDY_GATEWAY_URL", "UNDERSTUDY_ORG_ID"]);
+      assert.equal(runMeta.org_id, "org_1");
+      const childEnv = JSON.parse(result.stdout.trim());
+      assert.equal(childEnv.api, true);
+      assert.match(childEnv.gateway, /^http:\/\/127\.0\.0\.1:/);
+      assert.equal(childEnv.org, "org_1");
+    });
+  });
+
+  it("omits org context from run metadata when no org is configured", async () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-run-env-home-"));
+    const repo = mkdtempSync(join(tmpdir(), "understudy-run-env-repo-"));
+    try {
+      const result = await runWithEnvAsync(
+        [
+          "--json",
+          "run",
+          "node",
+          "-e",
+          "console.log(JSON.stringify({api:!!process.env.UNDERSTUDY_API_KEY,gateway:process.env.UNDERSTUDY_GATEWAY_URL,org:process.env.UNDERSTUDY_ORG_ID||null}))",
+        ],
+        {
+          HOME: home,
+          USERPROFILE: home,
+          UNDERSTUDY_API_KEY: "sk_env_only",
+          UNDERSTUDY_GATEWAY_URL: "https://gateway.example.test",
+        },
+        repo,
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      const runMeta = JSON.parse(result.stderr.trim().split("\n").find((line) => line.startsWith("{")));
+      assert.deepEqual(runMeta.injected, ["UNDERSTUDY_API_KEY", "UNDERSTUDY_GATEWAY_URL"]);
+      assert.equal(runMeta.org_id, null);
+      const childEnv = JSON.parse(result.stdout.trim());
+      assert.equal(childEnv.api, true);
+      assert.equal(childEnv.gateway, "https://gateway.example.test");
+      assert.equal(childEnv.org, null);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it("scans capture/import sources with metadata only and writes a redaction manifest", () =>
     withCaptureFixtureRepo((repo) => {
       const result = run(["capture-import", "scan", "--repo", repo, "--json"]);

--- a/tests/ladder.test.mjs
+++ b/tests/ladder.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+const pythonAvailable = spawnSync("python3", ["--version"], { encoding: "utf8" }).status === 0;
+
+function ladderCatalog(env = {}) {
+  const servePath = resolve("skills/ladder/serve.py");
+  const code = `
+import importlib.util, json, os
+spec = importlib.util.spec_from_file_location("ladder_serve", ${JSON.stringify(servePath)})
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+print(json.dumps(module.model_catalog_payload()))
+`;
+  const result = spawnSync("python3", ["-c", code], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      UNDERSTUDY_TELEMETRY: "0",
+      UNDERSTUDY_API_KEY: "",
+      UNDERSTUDY_GATEWAY_URL: "",
+      UNDERSTUDY_ORG_ID: "",
+      ...env,
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return JSON.parse(result.stdout);
+}
+
+describe("ladder model catalog", { skip: !pythonAvailable }, () => {
+  it("includes multiple gateway-backed remote models by default", () => {
+    const payload = ladderCatalog();
+    const models = new Map(payload.models.map((model) => [model.id, model]));
+
+    assert.equal(models.get("gemma-4-e2b").lane, "mlx_vlm");
+    assert.equal(models.get("gemma-4-e2b").billed, false);
+    assert.equal(models.get("glm-5.1").lane, "gateway");
+    assert.equal(models.get("glm-5.1").billed, true);
+    assert.equal(models.get("gemma-4-31b-it").lane, "gateway");
+    assert.equal(models.get("nemotron-3-ultra").lane, "gateway");
+  });
+
+  it("can override the remote gateway list with explicit model ids", () => {
+    const payload = ladderCatalog({ UNDERSTUDY_LADDER_REMOTE_MODELS: "glm-5.2,nemotron-3-super" });
+    const remoteIds = payload.models.filter((model) => model.lane === "gateway").map((model) => model.id);
+
+    assert.deepEqual(remoteIds, ["glm-5.2", "nemotron-3-super"]);
+    assert.equal(payload.models.find((model) => model.id === "glm-5.2").billed, true);
+  });
+});


### PR DESCRIPTION
## Summary

Expands the ladder so the remote side is no longer hard-coded to GLM 5.1. Remote lanes are gateway-backed: the ladder sends the selected model id, such as `glm-5.2`, to the existing Understudy `/v1/chat/completions` gateway rather than serving that model locally.

## What changed

- `/models` now returns local lanes plus remote gateway lanes.
- Remote lanes come from the live org model catalog when `UNDERSTUDY_ORG_ID` is available, otherwise from the checked-in public fallback list.
- Added `UNDERSTUDY_LADDER_REMOTE_MODELS` for explicit existing model ids, e.g. `glm-5.2,nemotron-3-super`.
- The ladder viewer now hydrates model pickers from `/models` instead of hard-coding only `glm-5.1`.
- `understudy run` now injects non-secret `UNDERSTUDY_ORG_ID` when known so local tools can discover org-scoped metadata without reading credentials from disk.
- Bumped release metadata to `0.5.0` and documented the change.

## Validation

- `npm run check`
- `git diff --check`
- `python3 -m py_compile skills/ladder/serve.py`
- Live ladder smoke: `UNDERSTUDY_LADDER_REMOTE_MODELS="glm-5.2,nemotron-3-super" python3 skills/ladder/serve.py`, then verified `/models` exposes `glm-5.2` as a billed `gateway` lane.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->