### PR TITLE
Clarify OpenCode adapter model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 - `understudy doctor` now includes OpenCode adapter version drift checks, the
   installer can launch OpenCode when it is the selected launchable adapter, and
   Cursor adapter install now preserves unexpected existing plugin paths.
+- Clarified that OpenCode support is a native skills/commands adapter, not a
+  JS/TS OpenCode plugin, and documented the symlink/restart behavior.
 
 ## [0.5.0] — 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ through [`.opencode/skills`](.opencode/skills), a symlink to [`skills/`](skills/
 and ships a small [`/understudy-onboard`](.opencode/commands/understudy-onboard.md)
 command.
 
+This is an OpenCode skills/commands adapter, not an OpenCode JS/TS plugin.
+OpenCode plugins are for lifecycle hooks and custom behavior; Understudy only
+needs native skill discovery plus a command that routes into onboarding.
+[`.opencode/adapter.json`](.opencode/adapter.json) is an Understudy
+version/staleness sentinel for release checks, not a manifest consumed by
+OpenCode.
+
 For global local testing from a clone:
 
 ```bash
@@ -247,9 +254,10 @@ Then restart OpenCode or open a new TUI session and run:
 The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
 contains the agent-run install/update/verify flow; ask for platform `opencode`.
 The older [`install-opencode-plugin`](skills/install-opencode-plugin/SKILL.md)
-skill remains as a compatibility shim. This path is local-only: linking the
-skills does not authenticate, upload data, download model weights, or make
-provider calls.
+skill remains as a compatibility shim for the old name. This path is local-only:
+linking the skills does not authenticate, upload data, download model weights,
+or make provider calls. Because symlink targets can live outside the current
+project, OpenCode may ask before reading linked external resources.
 
 To remove Understudy-owned symlinks:
 

--- a/docs/agent-platform-adapters.md
+++ b/docs/agent-platform-adapters.md
@@ -31,7 +31,7 @@ understudy platforms --inspect opencode
 | Claude Code | supported | `.claude-plugin/plugin.json` | Local marketplace plugin discovers `skills/`. |
 | Cursor | supported | `.cursor-plugin/plugin.json` | Local Cursor plugin discovers `skills/` from the plugin root. |
 | Codex | supported | `.codex-plugin/plugin.json` | Local marketplace plugin discovers `skills/`. |
-| OpenCode | supported | `.opencode/skills` | Native OpenCode skills are linked from the shared `skills/` tree. |
+| OpenCode | supported | `.opencode/adapter.json` | Native OpenCode skills and commands are linked from the shared `skills/` tree and `.opencode/commands/`. |
 
 ## Design Rule
 
@@ -39,3 +39,8 @@ Do not copy skills per platform. If a platform needs different packaging, add a
 thin adapter manifest or installer path that points back to the same `skills/`
 directories. Forking skill content creates stale safety gates and inconsistent
 onboarding during the sprint.
+
+OpenCode calls JS/TS hook modules "plugins." Understudy's OpenCode surface is
+not that kind of plugin; it is a native skills/commands adapter. The
+`.opencode/adapter.json` file is only an Understudy version sentinel for
+`understudy doctor` and release checks.

--- a/install.sh
+++ b/install.sh
@@ -757,7 +757,7 @@ link_opencode_path() {
   ln -s "$src" "$dest"
 }
 
-install_opencode_plugin() {
+install_opencode_adapter() {
   if ! should_install_opencode_adapter; then
     say "OpenCode adapter not selected or not detected; skipping OpenCode skill install."
     return 0
@@ -801,7 +801,7 @@ install_agent_adapters() {
   install_claude_plugin
   install_cursor_plugin
   install_codex_plugin
-  install_opencode_plugin
+  install_opencode_adapter
 }
 
 launch_claude_code() {

--- a/skills/install-agent-adapter/reference.md
+++ b/skills/install-agent-adapter/reference.md
@@ -115,6 +115,17 @@ OpenCode loads native `SKILL.md` definitions from project and global skill
 directories. This repo also exposes `.opencode/skills` as a project-level symlink
 to `../skills`.
 
+This is a native OpenCode skills/commands adapter, not an OpenCode JS/TS plugin.
+OpenCode plugins are hook modules for lifecycle events and custom behavior. For
+Understudy, the documented and community-style pattern is simpler: keep one
+durable checkout/package, symlink each `skills/<name>/` directory into
+`~/.config/opencode/skills`, and link a small markdown command into
+`~/.config/opencode/commands`.
+
+The `.opencode/adapter.json` file is not consumed by OpenCode. It is an
+Understudy-owned version/staleness sentinel used by `understudy doctor` and the
+release checklist.
+
 Global install:
 
 ```bash
@@ -149,6 +160,10 @@ Activation:
 Restart OpenCode or open a new TUI session.
 /understudy-onboard
 ```
+
+OpenCode may ask before reading symlink targets outside the current project.
+That is expected; do not bypass the prompt by copying skill content into
+OpenCode config.
 
 Verify:
 

--- a/skills/install-opencode-plugin/SKILL.md
+++ b/skills/install-opencode-plugin/SKILL.md
@@ -13,6 +13,11 @@ metadata:
 This skill is a compatibility shim. The consolidated setup surface is
 [`install-agent-adapter`](../install-agent-adapter/SKILL.md).
 
+The legacy skill name says "plugin" for compatibility with older prompts, but
+the OpenCode implementation is not a JS/TS OpenCode plugin. It is a native
+skills/commands adapter: symlink `SKILL.md` directories into OpenCode's global
+skills directory and link the `/understudy-onboard` markdown command.
+
 ## Procedure
 
 Load `install-agent-adapter` and run it with platform `opencode`.
@@ -43,6 +48,8 @@ weights, start hosted jobs, or make provider calls.
 - Do not overwrite existing non-Understudy OpenCode skills or commands.
 - Do not copy private traces, keys, or `.understudy/` state into OpenCode config.
 - Use symlinks back to this repo's shared `skills/` tree.
+- If OpenCode asks before reading symlinked external resources, let the user
+  make that permission decision; do not copy skill content to bypass it.
 
 ## Resolve CLI
 

--- a/src/agent-platforms.ts
+++ b/src/agent-platforms.ts
@@ -78,8 +78,8 @@ export const agentPlatformAdapters: AgentPlatformAdapter[] = [
     id: "opencode",
     displayName: "OpenCode",
     status: "supported",
-    manifestPath: ".opencode/skills",
-    discovery: "OpenCode native skills discovered from .opencode/skills or ~/.config/opencode/skills",
+    manifestPath: ".opencode/adapter.json",
+    discovery: "OpenCode skills/commands adapter: native skills discovered from .opencode/skills or ~/.config/opencode/skills; command markdown discovered from .opencode/commands or ~/.config/opencode/commands",
     install: [
       'REPO="$(git rev-parse --show-toplevel)"',
       'mkdir -p "$HOME/.config/opencode/skills" "$HOME/.config/opencode/commands"',
@@ -93,8 +93,11 @@ export const agentPlatformAdapters: AgentPlatformAdapter[] = [
     ],
     onboarding: "Run /understudy-onboard, or ask OpenCode: Use the Understudy onboarding skill for this project.",
     notes: [
+      ".opencode/adapter.json is an Understudy version/staleness sentinel, not an OpenCode plugin manifest.",
+      "OpenCode JS/TS plugins are for lifecycle hooks; this adapter intentionally uses native skills and commands.",
       "OpenCode loads SKILL.md definitions natively; no copied skill content or provider calls are required.",
       "The installer links every public skill because OpenCode skill names are global and sibling skill references must stay intact.",
+      "Symlink targets live outside many user projects, so OpenCode may ask before reading linked external resources.",
     ],
   },
 ];

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -122,7 +122,7 @@ async function runSetup(cmd: Command, opts: SetupOpts): Promise<void> {
       `\n${kleur.bold("Next step")}\n` +
       `  Open this repo in Claude Code or another agent that reads .claude/skills/\n` +
       `  and say: ${kleur.cyan('"convert this to Understudy"')}\n\n` +
-      `  For Claude Code, Cursor, Codex, or OpenCode plugin setup, prefer\n` +
+      `  For Claude Code, Cursor, Codex, or OpenCode adapter setup, prefer\n` +
       `  ${kleur.cyan("install.sh --agents ...")} or the ${kleur.cyan("install-agent-adapter")} skill.\n\n` +
       `  The agent will read the skill, detect your SDK, and apply the matching\n` +
       `  recipe end-to-end.\n`,

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -429,7 +429,7 @@ describe("understudy CLI", () => {
     );
     assert.equal(payload.adapters.find((adapter) => adapter.id === "cursor").manifestPath, ".cursor-plugin/plugin.json");
     assert.equal(payload.adapters.find((adapter) => adapter.id === "codex").manifestPath, ".codex-plugin/plugin.json");
-    assert.equal(payload.adapters.find((adapter) => adapter.id === "opencode").manifestPath, ".opencode/skills");
+    assert.equal(payload.adapters.find((adapter) => adapter.id === "opencode").manifestPath, ".opencode/adapter.json");
     assert.equal(payload.adapters.find((adapter) => adapter.id === "codex").status, "supported");
     assert.equal(payload.adapters.find((adapter) => adapter.id === "opencode").status, "supported");
   });
@@ -446,7 +446,8 @@ describe("understudy CLI", () => {
     const result = run(["platforms", "--inspect", "opencode"]);
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /OpenCode/);
-    assert.match(result.stdout, /\.opencode\/skills/);
+    assert.match(result.stdout, /\.opencode\/adapter\.json/);
+    assert.match(result.stdout, /skills\/commands adapter/);
     assert.match(result.stdout, /understudy-onboard/);
   });
 


### PR DESCRIPTION
## Summary
- clarify that OpenCode support is a native skills/commands adapter, not a JS/TS OpenCode plugin
- document the symlink install model, restart behavior, external-resource permission caveat, and adapter.json version-sentinel role
- update the platform registry and CLI tests to expose the OpenCode adapter model accurately

## Validation
- npm run check
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->