### PR TITLE
Avoid auto-launching OpenCode from installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
   Cursor adapter install now preserves unexpected existing plugin paths.
 - Clarified that OpenCode support is a native skills/commands adapter, not a
   JS/TS OpenCode plugin, and documented the symlink/restart behavior.
+- OpenCode installs now end with a manual TUI handoff instead of auto-launching
+  `opencode` from the curl-piped installer, avoiding Bun/OpenCode TTY failures.
 
 ## [0.5.0] — 2026-06-19
 

--- a/install.sh
+++ b/install.sh
@@ -877,18 +877,7 @@ launch_claude_code() {
   mark_step_done 3
 }
 
-opencode_command() {
-  if need opencode; then
-    command -v opencode
-  elif [ -x "$HOME/.opencode/bin/opencode" ]; then
-    printf '%s\n' "$HOME/.opencode/bin/opencode"
-  else
-    return 1
-  fi
-}
-
 launch_opencode() {
-  local opencode_bin
   if ! should_install_opencode_adapter; then
     say "Skipping OpenCode launch because the OpenCode adapter is not selected or detected."
     mark_step_done 3
@@ -899,28 +888,12 @@ launch_opencode() {
     mark_step_done 3
     return 0
   fi
-  if ! opencode_bin="$(opencode_command)"; then
-    say "OpenCode CLI not found; open OpenCode manually and run /understudy-onboard."
-    mark_step_done 3
-    return 0
-  fi
-  if ! { : </dev/tty >/dev/tty; } 2>/dev/null; then
-    say "No interactive terminal is available for OpenCode."
-    say "Open OpenCode in this directory, then run /understudy-onboard."
-    mark_step_done 3
-    return 0
-  fi
 
   section "Step 3/3 · Open OpenCode"
-  say "OpenCode will open in: $(pwd)"
-  say "Run /understudy-onboard once the TUI loads."
-  say "Launching OpenCode now. Exit OpenCode to return to this shell."
-  log "LAUNCH $opencode_bin"
-  "$opencode_bin" </dev/tty >/dev/tty 2>&1 || {
-    local status="$?"
-    say "OpenCode exited with status $status."
-    return "$status"
-  }
+  say "OpenCode skills and commands are installed."
+  say "Open a fresh OpenCode TUI session in: $(pwd)"
+  say "Then run /understudy-onboard."
+  say "The installer does not auto-launch OpenCode because piped installers cannot reliably hand Bun/OpenCode a stable interactive TTY."
   mark_step_done 3
 }
 

--- a/tests/installer.test.mjs
+++ b/tests/installer.test.mjs
@@ -364,7 +364,7 @@ describe("install.sh", () => {
     assert.equal(existsSync(join(home, ".config", "opencode", "commands", "understudy-onboard.md")), true);
   });
 
-  it("surfaces OpenCode launch instructions when no terminal is available", () => {
+  it("hands off to OpenCode without auto-launching it", () => {
     const script = readFileSync("install.sh", "utf8");
     const home = join(root, "home");
     const bin = join(root, "bin");
@@ -400,11 +400,13 @@ describe("install.sh", () => {
     );
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(result.stdout, /No interactive terminal is available for OpenCode/);
-    assert.match(result.stdout, /Open OpenCode in this directory, then run \/understudy-onboard/);
+    assert.match(result.stdout, /OpenCode skills and commands are installed/);
+    assert.match(result.stdout, /Open a fresh OpenCode TUI session/);
+    assert.match(result.stdout, /Then run \/understudy-onboard/);
+    assert.doesNotMatch(result.stdout, /OpenCode exited with status/);
   });
 
-  it("launches detected OpenCode in auto mode even when Claude Code is disabled", () => {
+  it("hands off to detected OpenCode in auto mode even when Claude Code is disabled", () => {
     const script = readFileSync("install.sh", "utf8");
     const home = join(root, "home");
     const bin = join(root, "bin");
@@ -439,7 +441,8 @@ describe("install.sh", () => {
     );
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(result.stdout, /No interactive terminal is available for OpenCode/);
+    assert.match(result.stdout, /OpenCode skills and commands are installed/);
+    assert.match(result.stdout, /Open a fresh OpenCode TUI session/);
     assert.doesNotMatch(result.stdout, /no other launchable adapter is available/);
   });
 


### PR DESCRIPTION
## Summary
- stop auto-launching OpenCode from the curl-piped installer after linking skills/commands
- replace the fragile Bun/OpenCode TTY handoff with explicit instructions to open a fresh OpenCode TUI and run /understudy-onboard
- update installer tests to cover OpenCode manual handoff in explicit and auto-detected --no-claude paths

## Validation
- npm run check
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->