### PR TITLE
Add Hermes Agent adapter and bump to 0.6.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,0 +1,6 @@
+{
+  "name": "understudy-hermes-adapter",
+  "version": "0.6.0",
+  "skills": "./skills",
+  "register": "skills.external_dirs in ~/.hermes/config.yaml"
+}

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 Notable, user-facing changes to the Understudy skills + CLI. Versions track the
 plugin: `package.json`, `.claude-plugin/plugin.json`,
 `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`,
-`.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and
-`.opencode/adapter.json` are bumped together on any release that changes the
-skill catalog, CLI surface, or agent-platform adapter surface, because an
-installed plugin has no other
+`.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`,
+`.opencode/adapter.json`, and `.hermes/adapter.json` are bumped together on any
+release that changes the skill catalog, CLI surface, or agent-platform adapter
+surface, because an installed plugin has no other
 staleness signal. After upgrading, reload or enable the plugin in your coding
 agent.
 
@@ -15,8 +15,17 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-22
+
 ### Added
 
+- **Hermes Agent adapter support.** Added a `.hermes/adapter.json` sentinel,
+  registry entry, installer autodetection, and `--agents hermes`. The installer
+  registers the shared `skills/` tree in `skills.external_dirs`
+  (`~/.hermes/config.yaml`) through a durable `~/.understudy/skills` symlink, so
+  Hermes discovers the same `SKILL.md` files natively — no copies, no Python
+  plugin. Config edits are idempotent and back up `config.yaml`; activation is
+  `/reload-skills` (no restart needed).
 - **OpenCode adapter support.** Added native OpenCode skill discovery through
   `.opencode/skills`, a `/understudy-onboard` command, installer autodetection,
   and `--agents opencode`.
@@ -24,12 +33,13 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 ### Changed
 
 - **Unified agent-adapter setup.** Added `install-agent-adapter` as the canonical
-  install/update/verify/uninstall skill for Claude Code, Cursor, Codex, and
-  OpenCode. The older platform-specific install skills now route to it as
+  install/update/verify/uninstall skill for Claude Code, Cursor, Codex, OpenCode,
+  and Hermes Agent. The older platform-specific install skills now route to it as
   compatibility shims.
-- `understudy doctor` now includes OpenCode adapter version drift checks, the
-  installer can launch OpenCode when it is the selected launchable adapter, and
-  Cursor adapter install now preserves unexpected existing plugin paths.
+- `understudy doctor` now includes OpenCode and Hermes adapter version drift
+  checks, the installer can launch OpenCode when it is the selected launchable
+  adapter, and Cursor adapter install now preserves unexpected existing plugin
+  paths.
 - Clarified that OpenCode support is a native skills/commands adapter, not a
   JS/TS OpenCode plugin, and documented the symlink/restart behavior.
 - OpenCode installs now end with a manual TUI handoff instead of auto-launching

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ thin TypeScript/Node: durable shortcuts, auth, artifact checks, and runtime
 wrappers that a coding agent can monitor.
 
 Understudy is agent-platform-neutral at the skill layer. Claude Code, Cursor,
-Codex, and OpenCode share the same [`skills/`](skills/) tree and only differ in a thin
-platform adapter: manifest, install path, reload step, and onboarding
-invocation. The current adapter registry is documented in
+Codex, OpenCode, and Hermes Agent share the same [`skills/`](skills/) tree and only
+differ in a thin platform adapter: manifest, install path, reload step, and
+onboarding invocation. The current adapter registry is documented in
 [`docs/agent-platform-adapters.md`](docs/agent-platform-adapters.md) and exposed
 through `understudy platforms`.
 
@@ -41,7 +41,7 @@ covers the hosted contracts behind them.
 | CLI | `src/` | Thin TypeScript shortcuts for auth, artifact checks, and durable runs. |
 | Skills | `skills/` | MVP progressive-disclosure agent playbooks. |
 | Docs | `docs/` | Public methodology and release-boundary notes. |
-| Platform adapters | `.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `.opencode/`, `.agents/`, `AGENTS.md` | Thin manifests or durable instructions that expose the same skill tree to each coding-agent surface. |
+| Platform adapters | `.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `.opencode/`, `.hermes/`, `.agents/`, `AGENTS.md` | Thin manifests or durable instructions that expose the same skill tree to each coding-agent surface. |
 | Scripts | `scripts/` | Repo hygiene checks, not product CLI code. |
 | Vendor | `vendor/` | Vendored or mirrored compatibility shims, with license metadata. |
 
@@ -58,9 +58,9 @@ curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-too
 ```
 
 This installs the CLI, then asks where to install the local coding-agent plugin:
-Claude Code, Cursor, Codex, OpenCode, all detected agents, or CLI-only. Non-interactive
-installs keep the old script-friendly autodetect behavior. Override the prompt
-with `--agents auto|all|claude-code|cursor|codex|opencode|none`.
+Claude Code, Cursor, Codex, OpenCode, Hermes Agent, all detected agents, or CLI-only.
+Non-interactive installs keep the old script-friendly autodetect behavior. Override
+the prompt with `--agents auto|all|claude-code|cursor|codex|opencode|hermes|none`.
 
 | Agent harness | Default installer behavior | Activation |
 | --- | --- | --- |
@@ -68,6 +68,7 @@ with `--agents auto|all|claude-code|cursor|codex|opencode|none`.
 | Cursor | Autodetected when Cursor is present; links this repo into `~/.cursor/plugins/local/understudy`. | Restart Cursor or run **Developer: Reload Window**, then ask Cursor Agent to use the Understudy onboarding skill. |
 | Codex | Autodetected when `codex` is on `PATH`; registers the local Codex marketplace from `.agents/plugins/marketplace.json`. | Run `/plugins`, choose `understudy-skills`, install or enable `understudy`, then start a new thread if needed. |
 | OpenCode | Autodetected when `opencode` is on `PATH` or OpenCode config/data exists; links the shared skills into `~/.config/opencode/skills`. | Restart OpenCode or open a new TUI session, then run `/understudy-onboard`. |
+| Hermes Agent | Autodetected when `hermes` is on `PATH` or `~/.hermes` exists; registers a stable `~/.understudy/skills` symlink in `skills.external_dirs`. | Run `/reload-skills` (or start a new `hermes` session), then `/onboard` or ask Hermes to use the Understudy onboarding skill. |
 
 If Claude Code is selected, the installer opens Claude Code in the current
 directory. In Claude Code, run:
@@ -251,6 +252,47 @@ Then restart OpenCode or open a new TUI session and run:
 /understudy-onboard
 ```
 
+## Install as Hermes skills
+
+Hermes Agent (Nous Research) loads `SKILL.md` files natively and scans any
+directory listed in `skills.external_dirs` in `~/.hermes/config.yaml`. The shared
+skill tree already ships valid Hermes skills, so the adapter registers the
+directory rather than copying it. To keep the config entry stable across checkout
+or package moves, it registers a durable `~/.understudy/skills` symlink to
+[`skills/`](skills/) — a path indirection, not a fork.
+[`.hermes/adapter.json`](.hermes/adapter.json) is an Understudy version/staleness
+sentinel for release checks, not a manifest consumed by Hermes.
+
+For global local testing from a clone:
+
+```bash
+REPO=/path/to/understudy-agent-tools
+LINK="$HOME/.understudy/skills"
+mkdir -p "$HOME/.understudy"
+[ -e "$LINK" ] || ln -s "$REPO/skills" "$LINK"
+python3 - "${HERMES_HOME:-$HOME/.hermes}/config.yaml" "$LINK" <<'PY'
+import sys, os, yaml
+p, d = sys.argv[1], sys.argv[2]
+c = (yaml.safe_load(open(p)) or {}) if os.path.exists(p) else {}
+s = c.get("skills") if isinstance(c.get("skills"), dict) else {}
+c["skills"] = s
+e = s.get("external_dirs") or []
+e = [e] if isinstance(e, str) else (e if isinstance(e, list) else [])
+if d not in e:
+    e.append(d)
+s["external_dirs"] = e
+os.makedirs(os.path.dirname(p) or ".", exist_ok=True)
+yaml.safe_dump(c, open(p, "w"), sort_keys=False)
+PY
+```
+
+Then, in Hermes, rescan without restarting and start onboarding:
+
+```text
+/reload-skills
+/onboard
+```
+
 The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
 contains the agent-run install/update/verify flow; ask for platform `opencode`.
 The older [`install-opencode-plugin`](skills/install-opencode-plugin/SKILL.md)
@@ -279,8 +321,9 @@ understudy platforms --inspect opencode
 understudy --json platforms
 ```
 
-Claude Code, Cursor, Codex, and OpenCode are supported adapters. All four reuse
-the same `skills/` tree instead of copying platform-specific skill content.
+Claude Code, Cursor, Codex, OpenCode, and Hermes Agent are supported adapters. All
+five reuse the same `skills/` tree instead of copying platform-specific skill
+content.
 
 ## First Commands
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ Then restart OpenCode or open a new TUI session and run:
 /understudy-onboard
 ```
 
+The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
+contains the agent-run install/update/verify flow; ask for platform `opencode`.
+The older [`install-opencode-plugin`](skills/install-opencode-plugin/SKILL.md)
+skill remains as a compatibility shim for the old name. This path is local-only:
+linking the skills does not authenticate, upload data, download model weights,
+or make provider calls. Because symlink targets can live outside the current
+project, OpenCode may ask before reading linked external resources.
+
+To remove Understudy-owned symlinks:
+
+```bash
+find ~/.config/opencode/skills -type l -lname '*/understudy-agent-tools/skills/*' -delete
+rm -f ~/.config/opencode/commands/understudy-onboard.md
+```
+
 ## Install as Hermes skills
 
 Hermes Agent (Nous Research) loads `SKILL.md` files natively and scans any
@@ -294,18 +309,29 @@ Then, in Hermes, rescan without restarting and start onboarding:
 ```
 
 The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
-contains the agent-run install/update/verify flow; ask for platform `opencode`.
-The older [`install-opencode-plugin`](skills/install-opencode-plugin/SKILL.md)
-skill remains as a compatibility shim for the old name. This path is local-only:
-linking the skills does not authenticate, upload data, download model weights,
-or make provider calls. Because symlink targets can live outside the current
-project, OpenCode may ask before reading linked external resources.
+contains the agent-run install/update/verify flow; ask for platform `hermes`.
+This path is local-only: registering the skills does not authenticate, upload
+data, download model weights, or make provider calls. Local `~/.hermes/skills/`
+entries win on name conflicts, so a few generically named skills may be shadowed
+by Hermes bundled skills.
 
-To remove Understudy-owned symlinks:
+To remove the registration, drop the entry from `skills.external_dirs` and the
+symlink:
 
 ```bash
-find ~/.config/opencode/skills -type l -lname '*/understudy-agent-tools/skills/*' -delete
-rm -f ~/.config/opencode/commands/understudy-onboard.md
+CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"
+LINK="$HOME/.understudy/skills"
+python3 - "$CONFIG" "$LINK" <<'PY'
+import sys, os, yaml
+p, d = sys.argv[1], sys.argv[2]
+c = (yaml.safe_load(open(p)) or {}) if os.path.exists(p) else {}
+s = c.get("skills") if isinstance(c.get("skills"), dict) else {}
+e = s.get("external_dirs") or []
+e = [e] if isinstance(e, str) else (e if isinstance(e, list) else [])
+s["external_dirs"] = [x for x in e if x != d]
+yaml.safe_dump(c, open(p, "w"), sort_keys=False)
+PY
+[ -L "$LINK" ] && rm -f "$LINK"
 ```
 
 ## Agent Platform Adapters

--- a/docs/agent-platform-adapters.md
+++ b/docs/agent-platform-adapters.md
@@ -1,9 +1,9 @@
 # Agent Platform Adapters
 
 Understudy should not become separate products for Claude Code, Cursor, Codex,
-and OpenCode. The product is the public skill tree in `skills/`. Platform adapters
-only describe how each coding-agent surface discovers, installs, reloads, and
-starts those skills.
+OpenCode, and Hermes Agent. The product is the public skill tree in `skills/`.
+Platform adapters only describe how each coding-agent surface discovers, installs,
+reloads, and starts those skills.
 
 ## Contract
 
@@ -22,6 +22,7 @@ understudy platforms
 understudy --json platforms
 understudy platforms --inspect cursor
 understudy platforms --inspect opencode
+understudy platforms --inspect hermes
 ```
 
 ## Supported Adapters
@@ -32,6 +33,7 @@ understudy platforms --inspect opencode
 | Cursor | supported | `.cursor-plugin/plugin.json` | Local Cursor plugin discovers `skills/` from the plugin root. |
 | Codex | supported | `.codex-plugin/plugin.json` | Local marketplace plugin discovers `skills/`. |
 | OpenCode | supported | `.opencode/adapter.json` | Native OpenCode skills and commands are linked from the shared `skills/` tree and `.opencode/commands/`. |
+| Hermes Agent | supported | `.hermes/adapter.json` | The shared `skills/` tree is registered in `skills.external_dirs` (`~/.hermes/config.yaml`); Hermes discovers its `SKILL.md` files natively. |
 
 ## Design Rule
 
@@ -44,3 +46,14 @@ OpenCode calls JS/TS hook modules "plugins." Understudy's OpenCode surface is
 not that kind of plugin; it is a native skills/commands adapter. The
 `.opencode/adapter.json` file is only an Understudy version sentinel for
 `understudy doctor` and release checks.
+
+Hermes Agent has its own plugin system (`~/.hermes/plugins/` with `plugin.yaml`
+and Python) and a Skills Hub, but Understudy's Hermes surface uses neither. It
+registers the shared `skills/` tree in `skills.external_dirs` so Hermes scans the
+same `SKILL.md` files the other adapters expose — no copies, no Python plugin.
+To keep the config entry stable across checkout or package moves, the installer
+registers a durable `~/.understudy/skills` symlink (a path indirection to the one
+shared tree, not a fork) and edits `~/.hermes/config.yaml` idempotently with a
+timestamped backup. Hermes rescans in-session via `/reload-skills`, and local
+`~/.hermes/skills/` entries win on name conflicts. The `.hermes/adapter.json`
+file is only an Understudy version sentinel, like the OpenCode one.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -13,14 +13,14 @@ git ls-files
 
 - versions bumped **together** in `package.json`, `.claude-plugin/plugin.json`,
   `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`,
-  `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and
-  `.opencode/adapter.json` on any release that changes the skill catalog or CLI
-  surface — installed adapters have no other staleness signal;
-  `understudy doctor --json` fails if they drift;
+  `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`,
+  `.opencode/adapter.json`, and `.hermes/adapter.json` on any release that changes
+  the skill catalog or CLI surface — installed adapters have no other staleness
+  signal; `understudy doctor --json` fails if they drift;
 - adapter install and onboarding parity checked across Claude Code, Cursor,
-  Codex, and OpenCode: `install.sh --agents ...`, `understudy platforms`, and
-  `skills/install-agent-adapter/reference.md` describe the same supported
-  surfaces, reload steps, and uninstall paths;
+  Codex, OpenCode, and Hermes Agent: `install.sh --agents ...`, `understudy
+  platforms`, and `skills/install-agent-adapter/reference.md` describe the same
+  supported surfaces, reload steps, and uninstall paths;
 - no `.understudy/` runtime artifacts;
 - no `.env*`, credentials, tokens, or secret-shaped strings;
 - no private planning docs;

--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ while [ "$#" -gt 0 ]; do
     --lab) LAB="${2:?missing path}"; shift ;;
     -h|--help)
       cat <<'EOF'
-Usage: install.sh [--yes] [--non-interactive] [--resume] [--from-step N] [--only-step N] [--keep-login] [--agents auto|all|claude-code|cursor|codex|opencode|none] [--no-claude] [--no-launch-agent]
+Usage: install.sh [--yes] [--non-interactive] [--resume] [--from-step N] [--only-step N] [--keep-login] [--agents auto|all|claude-code|cursor|codex|opencode|hermes|none] [--no-claude] [--no-launch-agent]
 
 Installs the Understudy CLI + detected coding-agent skill/plugin surfaces, then
 hands the user back to the selected coding agent when possible. It does not
@@ -66,7 +66,7 @@ Options:
   --only-step N         run only step 1, 2, or 3
   --keep-login          keep an existing sign-in instead of resetting it
   --fresh-login         reset an existing sign-in for agent-first sign-up (default)
-  --agents LIST         agent adapters to install: auto, all, claude-code, cursor, codex, opencode, none
+  --agents LIST         agent adapters to install: auto, all, claude-code, cursor, codex, opencode, hermes, none
                         comma-separated lists are accepted, e.g. claude-code,cursor
   --no-agents           skip all coding-agent plugin installs and launches
   --no-claude           skip Claude Code plugin install and final Claude launch
@@ -89,7 +89,7 @@ Environment overrides:
   UNDERSTUDY_NONINTERACTIVE      set to 1 to use safe defaults without prompting
   UNDERSTUDY_REQUIRE_CONFIRM     set to 1 to fail when no prompt TTY exists
   UNDERSTUDY_KEEP_LOGIN          set to 1 to keep an existing sign-in
-  UNDERSTUDY_AGENT_PLATFORMS     auto, all, claude-code, cursor, codex, opencode, none, or comma list
+  UNDERSTUDY_AGENT_PLATFORMS     auto, all, claude-code, cursor, codex, opencode, hermes, none, or comma list
   UNDERSTUDY_LAUNCH_AGENT       set to 0 to skip opening a coding agent
   UNDERSTUDY_LAUNCH_CLAUDE      set to 0 to skip opening a coding agent
   UNDERSTUDY_CLAUDE_ARGS        optional extra args when launching Claude Code
@@ -272,6 +272,7 @@ configure_resume() {
 normalize_agent_platform() {
   case "$1" in
     claude|claude_code|claudecode) printf '%s\n' "claude-code" ;;
+    hermes|hermes_agent|hermes-agent) printf '%s\n' "hermes" ;;
     cursor|codex|opencode|all|auto|none|claude-code) printf '%s\n' "$1" ;;
     *) printf '%s\n' "$1" ;;
   esac
@@ -285,15 +286,15 @@ validate_agent_platforms() {
     normalized="$(normalize_agent_platform "$token")"
     case "$normalized" in
       auto|all|none) mode="$normalized" ;;
-      claude-code|cursor|codex|opencode) ;;
+      claude-code|cursor|codex|opencode|hermes) ;;
       *)
-        fail_line "Unknown agent adapter '$token'. Use auto, all, claude-code, cursor, codex, opencode, none, or a comma list of explicit adapters."
+        fail_line "Unknown agent adapter '$token'. Use auto, all, claude-code, cursor, codex, opencode, hermes, none, or a comma list of explicit adapters."
         return 1
         ;;
     esac
   done
   if [ "$count" -eq 0 ]; then
-    fail_line "No agent adapter selection provided. Use auto, all, claude-code, cursor, codex, opencode, or none."
+    fail_line "No agent adapter selection provided. Use auto, all, claude-code, cursor, codex, opencode, hermes, or none."
     return 1
   fi
   if [ -n "$mode" ] && [ "$count" -gt 1 ]; then
@@ -332,6 +333,10 @@ detect_opencode() {
     [ -d "$HOME/.config/opencode" ] ||
     [ -d "$HOME/.local/share/opencode" ]
 }
+detect_hermes() {
+  need hermes ||
+    [ -d "${HERMES_HOME:-$HOME/.hermes}" ]
+}
 default_agent_platform() {
   if [ "$NO_CLAUDE" != "1" ] && detect_claude_code; then
     printf '%s\n' "claude-code"
@@ -341,6 +346,8 @@ default_agent_platform() {
     printf '%s\n' "codex"
   elif detect_opencode; then
     printf '%s\n' "opencode"
+  elif detect_hermes; then
+    printf '%s\n' "hermes"
   else
     printf '%s\n' "none"
   fi
@@ -354,6 +361,7 @@ detected_agent_label() {
       cursor) detect_cursor ;;
       codex) detect_codex ;;
       opencode) detect_opencode ;;
+      hermes) detect_hermes ;;
       *) return 1 ;;
     esac
   then
@@ -383,11 +391,12 @@ select_agent_platforms() {
   say "  ${G3}2.${R} $(detected_agent_label "cursor" "Cursor")"
   say "  ${G4}3.${R} $(detected_agent_label "codex" "Codex")"
   say "  ${G5}4.${R} $(detected_agent_label "opencode" "OpenCode")"
-  say "  ${G6}5.${R} All detected coding agents"
-  say "  ${G6}6.${R} CLI only, no coding-agent plugins"
+  say "  ${G6}5.${R} $(detected_agent_label "hermes" "Hermes Agent")"
+  say "  ${G6}6.${R} All detected coding agents"
+  say "  ${G6}7.${R} CLI only, no coding-agent plugins"
   say "Press Enter for: $default."
 
-  if ! printf "  %s?%s Install target %s[1/2/3/4/5/6 or name]%s " "$G4" "$R" "$D" "$R" >/dev/tty 2>/dev/null; then
+  if ! printf "  %s?%s Install target %s[1-7 or name]%s " "$G4" "$R" "$D" "$R" >/dev/tty 2>/dev/null; then
     return 0
   fi
   if ! read -r answer </dev/tty 2>/dev/null; then
@@ -399,8 +408,9 @@ select_agent_platforms() {
     2|cursor) AGENT_PLATFORMS="cursor" ;;
     3|codex) AGENT_PLATFORMS="codex" ;;
     4|opencode|open-code|open_code) AGENT_PLATFORMS="opencode" ;;
-    5|all|auto) AGENT_PLATFORMS="auto" ;;
-    6|none|cli|cli-only|cli_only) AGENT_PLATFORMS="none" ;;
+    5|hermes|hermes-agent|hermes_agent) AGENT_PLATFORMS="hermes" ;;
+    6|all|auto) AGENT_PLATFORMS="auto" ;;
+    7|none|cli|cli-only|cli_only) AGENT_PLATFORMS="none" ;;
     *) AGENT_PLATFORMS="$answer" ;;
   esac
   validate_agent_platforms || exit 2
@@ -433,6 +443,13 @@ should_install_opencode_adapter() {
     auto) detect_opencode; return ;;
   esac
   agent_platform_requested "opencode"
+}
+should_install_hermes_adapter() {
+  case "$(normalize_agent_platform "$AGENT_PLATFORMS")" in
+    none) return 1 ;;
+    auto) detect_hermes; return ;;
+  esac
+  agent_platform_requested "hermes"
 }
 agent_plan_label() {
   case "$(normalize_agent_platform "$AGENT_PLATFORMS")" in
@@ -797,11 +814,146 @@ install_opencode_adapter() {
   say "Then run /understudy-onboard, or ask OpenCode: Use the Understudy onboarding skill for this project."
 }
 
+hermes_config_path() {
+  printf '%s\n' "${HERMES_HOME:-$HOME/.hermes}/config.yaml"
+}
+# Locate a Python interpreter that can parse YAML, used to merge the skills
+# path into an existing Hermes config without guessing its shape. macOS's
+# /usr/bin/python3 only finds PyYAML via HOME-dependent user-site, so we also
+# fall back to Hermes' own bundled venv interpreter, which always ships PyYAML
+# and exists whenever the Hermes adapter is being installed.
+hermes_yaml_python() {
+  local cand hermes_home="${HERMES_HOME:-$HOME/.hermes}"
+  for cand in \
+    python3 \
+    python \
+    "$hermes_home/hermes-agent/venv/bin/python3" \
+    "$hermes_home/hermes-agent/venv/bin/python"; do
+    if command -v "$cand" >/dev/null 2>&1 && "$cand" -c 'import yaml' >/dev/null 2>&1; then
+      printf '%s\n' "$cand"
+      return 0
+    fi
+  done
+  return 1
+}
+# A stable, install-location-independent path that Hermes can keep in its
+# config even if the underlying checkout/package moves. We register this
+# symlink (never a copy — the shared skills/ tree stays the single source of
+# truth); a reinstall just re-points it.
+hermes_stable_skills_link() {
+  printf '%s\n' "$HOME/.understudy/skills"
+}
+# Resolve the path to register in skills.external_dirs: prefer the durable
+# ~/.understudy/skills symlink, falling back to the resolved skills dir if a
+# foreign file already occupies the link. Echoes the path to register.
+hermes_register_dir() {
+  local skills_dir="$1" stable_link current
+  stable_link="$(hermes_stable_skills_link)"
+  mkdir -p "$(dirname "$stable_link")"
+  if [ -L "$stable_link" ]; then
+    current="$(readlink "$stable_link" 2>/dev/null || true)"
+    if [ "$current" = "$skills_dir" ]; then
+      printf '%s\n' "$stable_link"; return 0
+    fi
+    case "$current" in
+      *understudy-agent-tools/skills)
+        rm -f "$stable_link"
+        ln -s "$skills_dir" "$stable_link"
+        printf '%s\n' "$stable_link"; return 0
+        ;;
+      *)
+        warn "An unexpected symlink already exists at $stable_link; registering the resolved skills path instead." >&2
+        printf '%s\n' "$skills_dir"; return 0
+        ;;
+    esac
+  elif [ -e "$stable_link" ]; then
+    warn "A non-symlink path already exists at $stable_link; registering the resolved skills path instead." >&2
+    printf '%s\n' "$skills_dir"; return 0
+  fi
+  ln -s "$skills_dir" "$stable_link"
+  printf '%s\n' "$stable_link"
+}
+
+install_hermes_adapter() {
+  if ! should_install_hermes_adapter; then
+    say "Hermes adapter not selected or not detected; skipping Hermes skill registration."
+    return 0
+  fi
+
+  local repo skills_dir register_dir config py
+  if ! repo="$(resolve_skill_repo)"; then
+    say "Could not find skills/understudy/SKILL.md; skipping Hermes skill registration."
+    return 0
+  fi
+  skills_dir="$repo/skills"
+  register_dir="$(hermes_register_dir "$skills_dir")"
+  config="$(hermes_config_path)"
+
+  say "Registering the Understudy skills with Hermes via $register_dir."
+
+  # Idempotent: Hermes reads skills.external_dirs and skips non-existent or
+  # duplicate paths, so if our path is already present there is nothing to do.
+  # A plain substring check avoids a YAML dependency on the fast path.
+  if [ -f "$config" ] && grep -qF "$register_dir" "$config" 2>/dev/null; then
+    ok "Understudy skills already registered in $config (skills.external_dirs)."
+  elif [ ! -f "$config" ]; then
+    # Fresh Hermes: write a minimal user config. Hermes merges defaults at load
+    # and `hermes config migrate` keeps our block, so this is non-destructive.
+    mkdir -p "$(dirname "$config")"
+    {
+      printf 'skills:\n'
+      printf '  external_dirs:\n'
+      printf '    - %s\n' "$register_dir"
+    } >"$config"
+    ok "Created $config and registered Understudy skills in skills.external_dirs."
+  elif py="$(hermes_yaml_python)"; then
+    cp "$config" "$config.understudy.bak-$(date -u +"%Y%m%dT%H%M%SZ")"
+    if "$py" - "$config" "$register_dir" >>"$LOG_FILE" 2>&1 <<'PY'
+import sys, os, yaml
+
+cfg_path, skills_dir = sys.argv[1], sys.argv[2]
+with open(cfg_path, encoding="utf-8") as f:
+    cfg = yaml.safe_load(f) or {}
+if not isinstance(cfg, dict):
+    cfg = {}
+skills = cfg.get("skills")
+if not isinstance(skills, dict):
+    skills = {}
+    cfg["skills"] = skills
+dirs = skills.get("external_dirs")
+if dirs is None:
+    dirs = []
+elif isinstance(dirs, str):
+    dirs = [dirs]
+elif not isinstance(dirs, list):
+    dirs = []
+if skills_dir not in dirs:
+    dirs.append(skills_dir)
+skills["external_dirs"] = dirs
+with open(cfg_path, "w", encoding="utf-8") as f:
+    yaml.safe_dump(cfg, f, sort_keys=False, default_flow_style=False)
+PY
+    then
+      ok "Registered Understudy skills in $config (skills.external_dirs)."
+    else
+      warn "Could not update $config automatically; continuing with the rest of the install."
+      say "Manual step: add \"$register_dir\" to skills.external_dirs in $config (or run: hermes config edit)."
+    fi
+  else
+    warn "No YAML-capable Python found to edit $config safely; leaving it unchanged."
+    say "Manual step: add \"$register_dir\" to skills.external_dirs in $config (run: hermes config edit)."
+  fi
+
+  say "In Hermes, run /reload-skills (or start a new session) so it rescans skills.external_dirs."
+  say "Then run /onboard, or ask Hermes: Use the Understudy onboarding skill for this project."
+}
+
 install_agent_adapters() {
   install_claude_plugin
   install_cursor_plugin
   install_codex_plugin
   install_opencode_adapter
+  install_hermes_adapter
 }
 
 launch_claude_code() {
@@ -897,8 +1049,30 @@ launch_opencode() {
   mark_step_done 3
 }
 
+launch_hermes() {
+  if ! should_install_hermes_adapter; then
+    say "Skipping Hermes launch because the Hermes adapter is not selected or detected."
+    mark_step_done 3
+    return 0
+  fi
+  if [ "$LAUNCH_CLAUDE" != "1" ]; then
+    say "Skipping coding-agent launch because --no-launch-agent is set."
+    mark_step_done 3
+    return 0
+  fi
+
+  section "Step 3/3 · Open Hermes"
+  say "The Understudy skills are registered in Hermes via skills.external_dirs."
+  say "Start a fresh Hermes session in: $(pwd)"
+  say "  hermes"
+  say "In an already-open session, run /reload-skills to pick them up without restarting."
+  say "Then run /onboard, or ask Hermes: Use the Understudy onboarding skill for this project."
+  say "The installer does not auto-launch Hermes because piped installers cannot reliably hand it a stable interactive TTY."
+  mark_step_done 3
+}
+
 launch_selected_agent() {
-  if [ "$NO_CLAUDE" != "0" ] && ! should_install_opencode_adapter; then
+  if [ "$NO_CLAUDE" != "0" ] && ! should_install_opencode_adapter && ! should_install_hermes_adapter; then
     say "Skipping coding-agent launch because --no-claude is set and no other launchable adapter is available."
     mark_step_done 3
     return 0
@@ -907,6 +1081,8 @@ launch_selected_agent() {
     launch_claude_code
   elif should_install_opencode_adapter; then
     launch_opencode
+  elif should_install_hermes_adapter; then
+    launch_hermes
   else
     say "Skipping coding-agent launch because the selected adapter has no automatic launch path."
     mark_step_done 3
@@ -976,6 +1152,7 @@ say "  Claude Code: run /reload-plugins and then /understudy:onboard."
 say "  Cursor: restart Cursor or run Developer: Reload Window, then ask Cursor Agent to use the Understudy onboarding skill."
 say "  Codex: run /plugins, install or enable understudy, then ask Codex to use the Understudy onboarding skill."
 say "  OpenCode: restart the TUI or open a new session, then run /understudy-onboard."
+say "  Hermes: run /reload-skills in an open session (or start a new hermes session), then run /onboard or ask Hermes to use the Understudy onboarding skill."
 say "That lets the coding agent run the email-code sign-up itself, explain the first local Understudy, and open a terminal of the user's choice when needed."
 if should_run_step 3; then
   launch_selected_agent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {
@@ -15,6 +15,7 @@
     ".cursor-plugin",
     ".opencode",
     "!.opencode/skills",
+    ".hermes",
     "install.sh",
     "dist",
     "skills",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -39,6 +39,7 @@ const requiredPackageMembers = [
   ".cursor-plugin/plugin.json",
   ".opencode/adapter.json",
   ".opencode/commands/understudy-onboard.md",
+  ".hermes/adapter.json",
   "skills/install-agent-adapter/SKILL.md",
   "skills/install-agent-adapter/reference.md",
   "skills/local-distillation-lab/SKILL.md",

--- a/skills/install-agent-adapter/SKILL.md
+++ b/skills/install-agent-adapter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install-agent-adapter
-description: Use when a developer wants to install, enable, update, reinstall, remove, or verify Understudy in a coding agent - "install Understudy", "add the Understudy skills", "make Claude/Cursor/Codex/OpenCode see the skills". Chooses the requested agent platform and routes to the local install, reload, onboarding, and uninstall steps.
+description: Use when a developer wants to install, enable, update, reinstall, remove, or verify Understudy in a coding agent - "install Understudy", "add the Understudy skills", "make Claude/Cursor/Codex/OpenCode/Hermes see the skills". Chooses the requested agent platform and routes to the local install, reload, onboarding, and uninstall steps.
 metadata:
   understudy:
     mode: automatic
@@ -11,8 +11,8 @@ metadata:
 # Install the Understudy Agent Adapter
 
 Understudy is agent-platform-neutral at the skill layer. The product is the
-shared `skills/` tree; Claude Code, Cursor, Codex, and OpenCode only differ in
-how they discover and reload those skills.
+shared `skills/` tree; Claude Code, Cursor, Codex, OpenCode, and Hermes Agent only
+differ in how they discover and reload those skills.
 
 Use this skill for setup, refresh, verification, uninstall, or "why can't my
 agent see Understudy?" requests. Keep the workflow local-first and pick the
@@ -29,9 +29,11 @@ command -v claude || true
 command -v cursor || true
 command -v codex || true
 command -v opencode || true
+command -v hermes || true
 test -d "$HOME/.cursor" && echo cursor-config
 test -d "$HOME/.config/opencode" && echo opencode-config
 test -d "$HOME/.local/share/opencode" && echo opencode-data
+test -d "$HOME/.hermes" && echo hermes-config
 ```
 
 Platform details live in [`reference.md`](reference.md):
@@ -43,6 +45,8 @@ Platform details live in [`reference.md`](reference.md):
   `/plugins`.
 - OpenCode: link the shared skills into `~/.config/opencode/skills`, then restart
   or open a new TUI session.
+- Hermes Agent: register a stable `~/.understudy/skills` symlink in
+  `skills.external_dirs` (`~/.hermes/config.yaml`), then run `/reload-skills`.
 
 ## Procedure
 
@@ -72,6 +76,13 @@ For OpenCode, the convenience command is:
 
 ```text
 /understudy-onboard
+```
+
+For Hermes, rescan in-session and start onboarding:
+
+```text
+/reload-skills
+/onboard
 ```
 
 ## Safety Gates

--- a/skills/install-agent-adapter/reference.md
+++ b/skills/install-agent-adapter/reference.md
@@ -178,3 +178,100 @@ Uninstall Understudy-owned symlinks:
 find "$HOME/.config/opencode/skills" -type l -lname '*/understudy-agent-tools/skills/*' -delete
 rm -f "$HOME/.config/opencode/commands/understudy-onboard.md"
 ```
+
+## Hermes Agent
+
+Hermes Agent (Nous Research) discovers native `SKILL.md` skills from
+`~/.hermes/skills/` and from any directory listed in `skills.external_dirs` in
+`~/.hermes/config.yaml`. The shared `skills/` tree already ships valid Hermes
+skills (Hermes reads `name`/`description`; the extra `metadata.understudy.*` is
+ignored), so the adapter just registers the directory — no copies and no Hermes
+plugin. (It does register through a stable `~/.understudy/skills` symlink for
+path durability, but that points at the one shared tree; it is not a fork.)
+
+This is not a Hermes plugin (`~/.hermes/plugins/` with `plugin.yaml` + Python)
+and not a Skills Hub install. The `.hermes/adapter.json` file is not consumed by
+Hermes; it is an Understudy-owned version/staleness sentinel for
+`understudy doctor` and the release checklist.
+
+Register through a stable symlink, not the raw checkout path. The installer
+points a durable `~/.understudy/skills` symlink at the resolved `skills/` tree
+and registers that symlink, so the Hermes config entry survives checkout or
+package moves (a reinstall just re-points the link — never a copy).
+`skills.external_dirs` accepts a string or a list, expands `~` and `${VAR}`,
+`.resolve()`s symlinks, and silently skips paths that do not exist. The edit is
+idempotent and backs up the config first:
+
+```bash
+REPO="$(cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && pwd)"
+ls "$REPO/skills/understudy/SKILL.md"
+LINK="$HOME/.understudy/skills"
+mkdir -p "$HOME/.understudy"
+[ -e "$LINK" ] || ln -s "$REPO/skills" "$LINK"
+CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"
+[ -f "$CONFIG" ] && cp "$CONFIG" "$CONFIG.understudy.bak-$(date -u +%Y%m%dT%H%M%SZ)"
+python3 - "$CONFIG" "$LINK" <<'PY'
+import sys, os, yaml
+cfg_path, skills_dir = sys.argv[1], sys.argv[2]
+cfg = (yaml.safe_load(open(cfg_path)) or {}) if os.path.exists(cfg_path) else {}
+cfg = cfg if isinstance(cfg, dict) else {}
+skills = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
+cfg["skills"] = skills
+dirs = skills.get("external_dirs") or []
+dirs = [dirs] if isinstance(dirs, str) else (dirs if isinstance(dirs, list) else [])
+if skills_dir not in dirs:
+    dirs.append(skills_dir)
+skills["external_dirs"] = dirs
+os.makedirs(os.path.dirname(cfg_path) or ".", exist_ok=True)
+yaml.safe_dump(cfg, open(cfg_path, "w"), sort_keys=False)
+PY
+```
+
+If no YAML-capable `python3` is available, edit `~/.hermes/config.yaml` by hand
+(or run `hermes config edit`) and add `~/.understudy/skills` under
+`skills.external_dirs`. Do not use `hermes config set skills.external_dirs <path>`
+on a config that already has entries — it overwrites the list instead of
+appending.
+
+Activation — Hermes rescans `skills.external_dirs` in-session, no restart needed:
+
+```text
+/reload-skills
+/onboard
+```
+
+Then, if you prefer natural language, ask Hermes:
+
+```text
+Use the Understudy onboarding skill for this project.
+```
+
+A few generically named skills (e.g. `onboard`, `review`) may be shadowed by
+Hermes bundled skills of the same name, since local `~/.hermes/skills/` wins on
+conflicts; the Understudy-specific skills are unique and unaffected.
+
+Verify:
+
+```bash
+ls -l "$HOME/.understudy/skills"          # symlink -> the resolved skills/ tree
+hermes config show | grep -A4 'external_dirs'
+hermes skills list | grep -i understudy
+```
+
+Uninstall — remove the entry from `skills.external_dirs`, then drop the symlink:
+
+```bash
+CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"
+LINK="$HOME/.understudy/skills"
+python3 - "$CONFIG" "$LINK" <<'PY'
+import sys, os, yaml
+cfg_path, skills_dir = sys.argv[1], sys.argv[2]
+cfg = (yaml.safe_load(open(cfg_path)) or {}) if os.path.exists(cfg_path) else {}
+skills = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
+dirs = skills.get("external_dirs") or []
+dirs = [dirs] if isinstance(dirs, str) else (dirs if isinstance(dirs, list) else [])
+skills["external_dirs"] = [x for x in dirs if x != skills_dir]
+yaml.safe_dump(cfg, open(cfg_path, "w"), sort_keys=False)
+PY
+[ -L "$LINK" ] && rm -f "$LINK"
+```

--- a/src/agent-platforms.ts
+++ b/src/agent-platforms.ts
@@ -100,6 +100,36 @@ export const agentPlatformAdapters: AgentPlatformAdapter[] = [
       "Symlink targets live outside many user projects, so OpenCode may ask before reading linked external resources.",
     ],
   },
+  {
+    id: "hermes",
+    displayName: "Hermes Agent",
+    status: "supported",
+    manifestPath: ".hermes/adapter.json",
+    discovery:
+      "Hermes Agent registers a durable ~/.understudy/skills symlink (to the shared skills/ tree) in skills.external_dirs (~/.hermes/config.yaml); it discovers SKILL.md skills natively alongside ~/.hermes/skills, with local skills winning on name conflicts",
+    install: [
+      'REPO="$(git rev-parse --show-toplevel)"',
+      'LINK="$HOME/.understudy/skills"',
+      'CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"',
+      'mkdir -p "$HOME/.understudy"; [ -e "$LINK" ] || ln -s "$REPO/skills" "$LINK"',
+      `python3 -c "import sys,os,yaml;p,d=sys.argv[1],sys.argv[2];c=(yaml.safe_load(open(p)) or {}) if os.path.exists(p) else {};c=c if isinstance(c,dict) else {};s=c.get('skills') if isinstance(c.get('skills'),dict) else {};c['skills']=s;e=s.get('external_dirs') or [];e=[e] if isinstance(e,str) else (e if isinstance(e,list) else []);(d in e) or e.append(d);s['external_dirs']=e;os.makedirs(os.path.dirname(p) or '.',exist_ok=True);yaml.safe_dump(c,open(p,'w'),sort_keys=False)" "$CONFIG" "$LINK"`,
+    ],
+    reload: "Run /reload-skills in Hermes (or start a new `hermes` session) to rescan skills.external_dirs.",
+    uninstall: [
+      'CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"',
+      'LINK="$HOME/.understudy/skills"',
+      `python3 -c "import sys,os,yaml;p,d=sys.argv[1],sys.argv[2];c=(yaml.safe_load(open(p)) or {}) if os.path.exists(p) else {};s=c.get('skills') if isinstance(c.get('skills'),dict) else {};e=s.get('external_dirs') or [];e=[e] if isinstance(e,str) else (e if isinstance(e,list) else []);s['external_dirs']=[x for x in e if x!=d];yaml.safe_dump(c,open(p,'w'),sort_keys=False)" "$CONFIG" "$LINK"`,
+      '[ -L "$LINK" ] && rm -f "$LINK"',
+    ],
+    onboarding: "In Hermes run /onboard, or ask Hermes: Use the Understudy onboarding skill for this project.",
+    notes: [
+      ".hermes/adapter.json is an Understudy version/staleness sentinel, not a Hermes plugin manifest.",
+      "Hermes discovers SKILL.md skills natively; registering skills/ via skills.external_dirs needs no copies and keeps the shared tree as the single source of truth.",
+      "The installer registers a stable ~/.understudy/skills symlink so the config entry survives checkout/package moves; a reinstall just re-points the link. external_dirs expands ~ and ${VAR} and silently skips missing paths.",
+      "Edits to ~/.hermes/config.yaml are idempotent and back up the file first; /reload-skills rescans without a restart.",
+      "Local ~/.hermes/skills entries win on name conflicts, so a few generically named skills may be shadowed by Hermes bundled skills.",
+    ],
+  },
 ];
 
 export function findAgentPlatformAdapter(id: string): AgentPlatformAdapter | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,7 +235,8 @@ function printDoctorJson(): void {
     versions.cli === versions.cursorPlugin &&
     versions.cli === versions.codexPlugin &&
     versions.cli === versions.codexMarketplace &&
-    versions.cli === versions.opencodeAdapter;
+    versions.cli === versions.opencodeAdapter &&
+    versions.cli === versions.hermesAdapter;
   console.log(
     JSON.stringify(
       {

--- a/src/internal/version.ts
+++ b/src/internal/version.ts
@@ -27,6 +27,7 @@ export function readManifestVersions(): {
   codexPlugin: string | null;
   codexMarketplace: string | null;
   opencodeAdapter: string | null;
+  hermesAdapter: string | null;
 } {
   return {
     cli: readManifestVersion(join(packageRoot, "package.json")),
@@ -42,6 +43,7 @@ export function readManifestVersions(): {
       (parsed) => (parsed as { metadata?: { version?: string } }).metadata?.version,
     ),
     opencodeAdapter: readManifestVersion(join(packageRoot, ".opencode", "adapter.json")),
+    hermesAdapter: readManifestVersion(join(packageRoot, ".hermes", "adapter.json")),
   };
 }
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -425,13 +425,15 @@ describe("understudy CLI", () => {
     const payload = JSON.parse(result.stdout);
     assert.deepEqual(
       payload.adapters.map((adapter) => adapter.id),
-      ["claude-code", "cursor", "codex", "opencode"],
+      ["claude-code", "cursor", "codex", "opencode", "hermes"],
     );
     assert.equal(payload.adapters.find((adapter) => adapter.id === "cursor").manifestPath, ".cursor-plugin/plugin.json");
     assert.equal(payload.adapters.find((adapter) => adapter.id === "codex").manifestPath, ".codex-plugin/plugin.json");
     assert.equal(payload.adapters.find((adapter) => adapter.id === "opencode").manifestPath, ".opencode/adapter.json");
+    assert.equal(payload.adapters.find((adapter) => adapter.id === "hermes").manifestPath, ".hermes/adapter.json");
     assert.equal(payload.adapters.find((adapter) => adapter.id === "codex").status, "supported");
     assert.equal(payload.adapters.find((adapter) => adapter.id === "opencode").status, "supported");
+    assert.equal(payload.adapters.find((adapter) => adapter.id === "hermes").status, "supported");
   });
 
   it("inspects one agent platform adapter", () => {
@@ -449,6 +451,15 @@ describe("understudy CLI", () => {
     assert.match(result.stdout, /\.opencode\/adapter\.json/);
     assert.match(result.stdout, /skills\/commands adapter/);
     assert.match(result.stdout, /understudy-onboard/);
+  });
+
+  it("inspects the Hermes platform adapter", () => {
+    const result = run(["platforms", "--inspect", "hermes"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Hermes Agent/);
+    assert.match(result.stdout, /\.hermes\/adapter\.json/);
+    assert.match(result.stdout, /external_dirs/);
+    assert.match(result.stdout, /\/onboard/);
   });
 
   it("lists the pedagogical and local training skills", () => {
@@ -529,6 +540,7 @@ describe("understudy CLI", () => {
     assert.equal(payload.versions.cli, payload.versions.codexPlugin);
     assert.equal(payload.versions.cli, payload.versions.codexMarketplace);
     assert.equal(payload.versions.cli, payload.versions.opencodeAdapter);
+    assert.equal(payload.versions.cli, payload.versions.hermesAdapter);
   });
 
   it("status exits non-zero when local config is malformed", () => {

--- a/tests/installer.test.mjs
+++ b/tests/installer.test.mjs
@@ -446,6 +446,52 @@ describe("install.sh", () => {
     assert.doesNotMatch(result.stdout, /no other launchable adapter is available/);
   });
 
+  it("registers the Hermes skills tree through a stable symlink when explicitly requested", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const hermesHome = join(home, ".hermes");
+    const config = join(hermesHome, "config.yaml");
+    const stableLink = join(home, ".understudy", "skills");
+    const realSkills = join(process.cwd(), "skills");
+    const env = {
+      ...process.env,
+      CI: "1",
+      HOME: home,
+      HERMES_HOME: hermesHome,
+      UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+    };
+    const args = [
+      "-s",
+      "--",
+      "--non-interactive",
+      "--only-step",
+      "2",
+      "--agents",
+      "hermes",
+      "--no-launch-claude",
+      "--lab",
+      join(root, "lab"),
+    ];
+
+    const first = spawnSync("bash", args, { cwd: process.cwd(), input: script, encoding: "utf8", env });
+    assert.equal(first.status, 0, first.stderr || first.stdout);
+    assert.match(first.stdout, /registered Understudy skills in skills\.external_dirs/);
+    // A durable ~/.understudy/skills symlink points at the resolved skills tree.
+    assert.equal(readlinkSync(stableLink), realSkills);
+    // The config registers the stable symlink path, not the resolved checkout path.
+    assert.equal(existsSync(config), true);
+    const written = readFileSync(config, "utf8");
+    assert.match(written, /external_dirs/);
+    assert.ok(written.includes(stableLink), `expected ${config} to list ${stableLink}`);
+
+    // A second run is idempotent: the path is already present, so nothing changes.
+    const second = spawnSync("bash", args, { cwd: process.cwd(), input: script, encoding: "utf8", env });
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    assert.match(second.stdout, /already registered in .*config\.yaml/);
+    const after = readFileSync(config, "utf8");
+    assert.equal((after.match(new RegExp(stableLink.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length, 1);
+  });
+
   it("autodetects available agent adapters by default", () => {
     const script = readFileSync("install.sh", "utf8");
     const home = join(root, "home");
@@ -480,6 +526,8 @@ describe("install.sh", () => {
           ...process.env,
           CI: "1",
           HOME: home,
+          // Isolate from any real ~/.hermes so autodetection never edits it.
+          HERMES_HOME: join(home, ".hermes"),
           PATH: `${bin}:${process.env.PATH}`,
           UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
         },
@@ -506,6 +554,7 @@ describe("install.sh", () => {
     assert.match(script, /All detected coding agents/);
     assert.match(script, /CLI only, no coding-agent plugins/);
     assert.match(script, /OpenCode/);
+    assert.match(script, /Hermes Agent/);
   });
 
   it("continues when Codex marketplace registration cannot be refreshed", () => {
@@ -602,6 +651,7 @@ describe("install.sh", () => {
     assert.match(result.stdout, /Cursor adapter not selected or not detected/);
     assert.match(result.stdout, /Codex adapter not selected or not detected/);
     assert.match(result.stdout, /OpenCode adapter not selected or not detected/);
+    assert.match(result.stdout, /Hermes adapter not selected or not detected/);
     assert.equal(existsSync(join(home, ".cursor", "plugins", "local", "understudy")), false);
   });
 });


### PR DESCRIPTION
## What

Adds **Hermes Agent** (Nous Research) as a supported agent-platform adapter, alongside Claude Code, Cursor, Codex, and OpenCode. Bumps all adapter manifests + CLI to **0.6.0** (this release also covers the previously-unreleased OpenCode adapter work).

## How it works

Hermes discovers `SKILL.md` skills natively, so the adapter is a thin registration shim — **no copies, no Python plugin, no fork of the skill tree**:

- Registers the shared `skills/` tree in `skills.external_dirs` (`~/.hermes/config.yaml`) through a durable `~/.understudy/skills` symlink, so the config entry survives checkout/package moves (a reinstall just re-points the link).
- Config edits are **idempotent** and back up `config.yaml` first. The YAML merge uses PyYAML, falling back to **Hermes' own bundled venv Python** because macOS system `python3` only finds PyYAML via HOME-dependent user-site.
- Activation is `/reload-skills` — Hermes rescans in-session, no restart.

## Changes

- New `.hermes/adapter.json` sentinel + `agent-platforms.ts` registry entry
- `install.sh`: `detect_hermes`, `--agents hermes`, interactive menu, idempotent config registration, launch handoff
- `understudy doctor` version-consistency now covers `.hermes/adapter.json`
- README / `docs/agent-platform-adapters.md` / `install-agent-adapter` SKILL+reference / release-checklist updated for Hermes
- Tests: detection, stable-symlink registration, idempotency

## Verification

- `npm run check` green: build, typecheck, **95/95 tests**, 26 skills validated, package smoke (incl. `.hermes`)
- `understudy doctor` → `ok: true`, all 8 manifests consistent at `0.6.0`
- End-to-end dry-runs (throwaway HOME) on **fresh** and **existing** Hermes configs — other `external_dirs`/keys preserved, backup created, symlink correct. No writes to any real `~/.hermes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->