### PR TITLE
docs: refresh Lilac model catalog knowledge

### DIFF
--- a/skills/ladder/reference.md
+++ b/skills/ladder/reference.md
@@ -68,8 +68,12 @@ Active local lane plus default fallback remotes:
 | id | lane | where |
 |---|---|---|
 | `gemma-4-e2b` | `mlx_vlm` | local default, **$0** |
-| `glm-5.1` | `gateway` | Understudy gateway, **billed** |
-| `gemma-4-31b-it` | `gateway` | Understudy gateway, **billed** |
+| `glm-5.2` | `gateway` | Understudy gateway, **billed** |
+| `minimax-m3` | `gateway` | Understudy gateway, **billed** |
+| `glm-5.1` | `gateway` | Understudy gateway, **billed**; Lilac deprecates 2026-06-29 |
+| `gemma-4-31b-it` | `gateway` | Understudy gateway, **billed**; Lilac deprecates 2026-06-29 |
+| `kimi-k2.6` | `gateway` | Understudy gateway, **billed**; Lilac deprecates 2026-06-29 |
+| `minimax-m2.7` | `gateway` | Understudy gateway, **billed** |
 | `nemotron-3-nano` | `gateway` | Understudy gateway, **billed** |
 | `nemotron-3-super` | `gateway` | Understudy gateway, **billed** |
 | `nemotron-3-ultra` | `gateway` | Understudy gateway, **billed** |

--- a/skills/ladder/serve.py
+++ b/skills/ladder/serve.py
@@ -44,8 +44,12 @@ LOCAL_MODELS = {
 }
 
 FALLBACK_REMOTE_MODELS = [
-    ("glm-5.1", "GLM 5.1"),
-    ("gemma-4-31b-it", "Gemma 4 31B"),
+    ("glm-5.2", "GLM 5.2"),
+    ("minimax-m3", "MiniMax M3"),
+    ("glm-5.1", "GLM 5.1 · deprecates 2026-06-29"),
+    ("gemma-4-31b-it", "Gemma 4 31B · deprecates 2026-06-29"),
+    ("kimi-k2.6", "Kimi K2.6 · deprecates 2026-06-29"),
+    ("minimax-m2.7", "MiniMax M2.7"),
     ("nemotron-3-nano", "Nemotron 3 Nano"),
     ("nemotron-3-super", "Nemotron 3 Super"),
     ("nemotron-3-ultra", "Nemotron 3 Ultra"),

--- a/skills/ladder/viewer/ladder.climb.html
+++ b/skills/ladder/viewer/ladder.climb.html
@@ -394,8 +394,12 @@
 
   var LIVE_MODELS = [
     { id: "gemma-4-e2b", label: "gemma-4-e2b" },
-    { id: "glm-5.1", label: "GLM 5.1 · remote", billed: true },
-    { id: "gemma-4-31b-it", label: "Gemma 4 31B · remote", billed: true },
+    { id: "glm-5.2", label: "GLM 5.2 · remote", billed: true },
+    { id: "minimax-m3", label: "MiniMax M3 · remote", billed: true },
+    { id: "glm-5.1", label: "GLM 5.1 · deprecates 2026-06-29", billed: true },
+    { id: "gemma-4-31b-it", label: "Gemma 4 31B · deprecates 2026-06-29", billed: true },
+    { id: "kimi-k2.6", label: "Kimi K2.6 · deprecates 2026-06-29", billed: true },
+    { id: "minimax-m2.7", label: "MiniMax M2.7 · remote", billed: true },
     { id: "nemotron-3-nano", label: "Nemotron 3 Nano · remote", billed: true },
     { id: "nemotron-3-super", label: "Nemotron 3 Super · remote", billed: true },
     { id: "nemotron-3-ultra", label: "Nemotron 3 Ultra · remote", billed: true }

--- a/skills/plan-hosted-run/references/cost-estimation.md
+++ b/skills/plan-hosted-run/references/cost-estimation.md
@@ -141,9 +141,11 @@ on-demand / $0.94 spot.
   Qwen2.5-7B Turbo $0.30/$0.30 · Gemma 4 31B $0.39/$0.97. Dedicated H100 $6.49/hr.
 - **Fireworks:** ≤16B tier ~$0.20 · >16B tier ~$0.90. On-demand H100 $7.00/hr. LoRA
   SFT $0.50/1M tok (≤16B).
-- **Lilac (getlilac):** Gemma 4 31B $0.11/$0.35 · Kimi K2.6 $0.70/$3.50 · GLM 5.1
-  $0.90/$3.00 (verify input-vs-cache split live). Batch/concurrency is not publicly
-  documented; treat it as a probe path until confirmed.
+- **Lilac (getlilac):** GLM 5.2 $0.90/$3.00 (cache $0.27) · MiniMax M3
+  $0.28/$1.10 (cache $0.05) · Gemma 4 31B $0.11/$0.35 · Kimi K2.6
+  $0.70/$3.50. Kimi K2.6, GLM 5.1, and Gemma 4 are marked deprecating
+  2026-06-29 on the Lilac page. Batch/concurrency is not publicly documented;
+  treat it as a probe path until confirmed.
 
 Sources: together.ai/pricing ; fireworks.ai/pricing ; getlilac.com.
 **Drift flag:** Together's live rates rose vs older blog citations ($0.88→$1.04 for

--- a/skills/plan-hosted-run/references/providers.md
+++ b/skills/plan-hosted-run/references/providers.md
@@ -188,16 +188,20 @@ Databricks (March 2024)** — different entity, do not conflate.
 base-URL swap, prepaid). Routes inference to **idle enterprise GPUs already powered on**
 (clusters typically run 30–50% utilized), passing the savings to per-token price.
 
-**Models hosted, with on-site pricing [V]** (confirm input-vs-cache split live — [U]):
+**Models hosted, with on-site pricing [V]** (snapshot 2026-06-23; confirm live before
+large runs):
 
-| Model | Precision | $/M input | $/M output |
-|---|---|---|---|
-| Gemma 4 (31B) | BF16 | $0.11 | $0.35 |
-| MiniMax M2.7 | FP8 | $0.30 | $1.20 |
-| Kimi K2.6 | INT4 | $0.70* | $3.50 |
-| GLM 5.1 | FP8 | $0.90* | $3.00 |
+| Model | Provider id | Precision | Context | $/M input | $/M output | $/M cache | Status |
+|---|---|---|---:|---:|---:|---:|---|
+| GLM 5.2 | `zai-org/glm-5.2` | FP8/NVFP4 | 524.3K | $0.90 | $3.00 | $0.27 | current |
+| MiniMax M3 | `minimaxai/minimax-m3` | — | 1.0M | $0.28 | $1.10 | $0.05 | current |
+| MiniMax M2.7 | `minimaxai/minimax-m2.7` | FP8 | 204.8K | $0.30 | $1.20 | $0.055 | legacy |
+| Kimi K2.6 | `moonshotai/kimi-k2.6` | INT4 | 262.1K | $0.70 | $3.50 | $0.20 | deprecates 2026-06-29 |
+| GLM 5.1 | `zai-org/glm-5.1` | FP8/NVFP4 | 202.8K | $0.90 | $3.00 | $0.27 | deprecates 2026-06-29 |
+| Gemma 4 (31B) | `google/gemma-4-31b-it` | FP8 | 262.1K | $0.11 | $0.35 | — | deprecates 2026-06-29 |
 
-\* a second source listed lower input + a separate cache rate — verify on the live page.
+GLM/Kimi/Gemma/MiniMax advertise tools + reasoning. Gemma and MiniMax M3 also
+advertise image/video input on the current Lilac page.
 
 **Batch / trajectory throughput [U — NOT FOUND]:** as of 2026-06-07 the public inference
 docs (quickstart) document **no** batch API, async endpoint, or rpm/concurrency limits

--- a/tests/ladder.test.mjs
+++ b/tests/ladder.test.mjs
@@ -37,9 +37,12 @@ describe("ladder model catalog", { skip: !pythonAvailable }, () => {
 
     assert.equal(models.get("gemma-4-e2b").lane, "mlx_vlm");
     assert.equal(models.get("gemma-4-e2b").billed, false);
-    assert.equal(models.get("glm-5.1").lane, "gateway");
-    assert.equal(models.get("glm-5.1").billed, true);
+    assert.equal(models.get("glm-5.2").lane, "gateway");
+    assert.equal(models.get("glm-5.2").billed, true);
+    assert.equal(models.get("minimax-m3").lane, "gateway");
+    assert.equal(models.get("minimax-m3").billed, true);
     assert.equal(models.get("gemma-4-31b-it").lane, "gateway");
+    assert.match(models.get("gemma-4-31b-it").label, /deprecates 2026-06-29/);
     assert.equal(models.get("nemotron-3-ultra").lane, "gateway");
   });
 


### PR DESCRIPTION
## Summary
- update ladder fallback remote models with GLM 5.2, MiniMax M3, Kimi K2.6, and MiniMax M2.7
- mark Lilac models deprecating on 2026-06-29 in ladder/docs
- refresh hosted-run Lilac pricing/context notes from the June 23 snapshot

## Validation
- npm test -- --run tests/ladder.test.mjs
- npm run check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->