### PR TITLE
[codex] Ignore GitHub noreply installer emails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -569,11 +569,30 @@ credentials_email() {
   node -e 'try{const c=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));if(c.email)process.stdout.write(c.email)}catch(e){}' "$CREDENTIALS_FILE" 2>/dev/null || true
 }
 
+is_github_noreply_email() {
+  case "${1:-}" in
+    *@users.noreply.github.com|*@noreply.github.com|noreply@github.com) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+remember_known_email() {
+  local candidate="${1:-}" source_label="${2:-email source}"
+  [ -z "$candidate" ] && return 0
+  if is_github_noreply_email "$candidate"; then
+    say "Ignoring GitHub noreply email from $source_label; the agent will ask for a real sign-in email."
+    return 0
+  fi
+  KNOWN_EMAIL="$candidate"
+}
+
 prepare_agent_first_signin() {
+  local existing_email=""
   [ -n "$ONLY_STEP" ] && return 0
   section "Prepare the agent-first sign-in."
   if [ -f "$CREDENTIALS_FILE" ]; then
-    KNOWN_EMAIL="$(credentials_email)"
+    existing_email="$(credentials_email)"
+    remember_known_email "$existing_email" "existing Understudy credentials"
     if [ "$KEEP_LOGIN" = "1" ]; then
       say "Keeping the existing Understudy sign-in (--keep-login)."
       return 0
@@ -584,6 +603,8 @@ prepare_agent_first_signin() {
     rm -f "$HOME/.understudy/login-pending.json"
     if [ -n "$KNOWN_EMAIL" ]; then
       ok "Signed out $KNOWN_EMAIL so the agent can run the sign-up from scratch."
+    elif [ -n "$existing_email" ]; then
+      ok "Signed out the existing Understudy sign-in so the agent can run the sign-up from scratch."
     else
       ok "Signed out so the agent can run the sign-up from scratch."
     fi
@@ -595,7 +616,7 @@ prepare_agent_first_signin() {
     say "No existing sign-in found; the coding agent will run the first sign-up."
   fi
   if [ -z "$KNOWN_EMAIL" ]; then
-    KNOWN_EMAIL="$(git config --get user.email 2>/dev/null || true)"
+    remember_known_email "$(git config --get user.email 2>/dev/null || true)" "git config user.email"
   fi
 }
 

--- a/tests/installer.test.mjs
+++ b/tests/installer.test.mjs
@@ -126,6 +126,95 @@ describe("install.sh", () => {
     assert.equal(readFileSync(join(understudyDir, "profile.json"), "utf8"), '{"keep":"me"}\n');
   });
 
+  it("does not reuse a GitHub noreply email from existing credentials", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const understudyDir = join(home, ".understudy");
+    mkdirSync(understudyDir, { recursive: true });
+    writeFileSync(
+      join(understudyDir, "credentials.json"),
+      `${JSON.stringify({
+        api_key: "sk_demo",
+        gateway_url: "https://api.understudylabs.com",
+        email: "166242911+lluisinthedesert@users.noreply.github.com",
+        orgs: {},
+      })}\n`,
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-s",
+        "--",
+        "--non-interactive",
+        "--from-step",
+        "3",
+        "--no-claude",
+        "--agents",
+        "none",
+        "--lab",
+        join(root, "lab"),
+      ],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Ignoring GitHub noreply email from existing Understudy credentials/);
+    assert.match(result.stdout, /Signed out the existing Understudy sign-in/);
+    assert.doesNotMatch(result.stdout, /users\.noreply\.github\.com/);
+  });
+
+  it("does not seed the launch prompt from a GitHub noreply git email", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      join(home, ".gitconfig"),
+      "[user]\n\temail = 166242911+lluisinthedesert@users.noreply.github.com\n",
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-s",
+        "--",
+        "--non-interactive",
+        "--from-step",
+        "3",
+        "--no-claude",
+        "--agents",
+        "none",
+        "--lab",
+        join(root, "lab"),
+      ],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Ignoring GitHub noreply email from git config user\.email/);
+    assert.doesNotMatch(result.stdout, /users\.noreply\.github\.com/);
+  });
+
   it("keeps the sign-in with --keep-login", () => {
     const script = readFileSync("install.sh", "utf8");
     const home = join(root, "home");


### PR DESCRIPTION
## Summary
- ignore GitHub noreply addresses when seeding the installer sign-in prompt
- avoid echoing noreply addresses from backed-up credentials
- add installer regressions for credentials and git config fallback

## Validation
- node --test tests/installer.test.mjs
- git diff --check
- npm run check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->