### PR TITLE
fix: strip FORCE_COLOR from test env to prevent ANSI regex failures

### DIFF
--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -12,9 +12,13 @@ const uvAvailable = spawnSync("uv", ["--version"], { encoding: "utf8" }).status 
 
 // Ambient Understudy credentials (a developer's shell, a CI secret) must not
 // leak into spawned CLIs — fixtures provide their own.
+// FORCE_COLOR (set by actions/setup-node and npm in TTY contexts) must also be
+// stripped so kleur in child processes falls back to isTTY detection and does
+// not emit ANSI codes into piped stdout that break regex assertions.
 const baseEnv = { ...process.env };
 delete baseEnv.UNDERSTUDY_API_KEY;
 delete baseEnv.UNDERSTUDY_GATEWAY_URL;
+delete baseEnv.FORCE_COLOR;
 
 function run(args) {
   return spawnSync(cli[0], [cli[1], ...args], {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -24,6 +24,7 @@ function run(args) {
   return spawnSync(cli[0], [cli[1], ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
+    env: baseEnv,
   });
 }
 


### PR DESCRIPTION
## Summary

`actions/setup-node@v4` exports `FORCE_COLOR=3` into CI. The test harness spreads `process.env` into `baseEnv` and deletes credential vars, but `FORCE_COLOR` was not stripped — so kleur in child processes emits ANSI bold codes (`\x1b[1m…\x1b[22m`) around workload names even though stdout is piped. Regex assertions like `/Created workload support_triage/` then fail.

```diff
 delete baseEnv.UNDERSTUDY_API_KEY;
 delete baseEnv.UNDERSTUDY_GATEWAY_URL;
+delete baseEnv.FORCE_COLOR;

 function run(args) {
   return spawnSync(cli[0], [cli[1], ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
+    env: baseEnv,
   });
 }
```

`run()` previously omitted `env` entirely, inheriting raw `process.env` and bypassing `baseEnv` — so neither `FORCE_COLOR` nor the credential deletions applied to its ~51 call sites. Now all four helpers (`run`, `runWithHome`, `runWithEnv`, `runWithEnvAsync`) use `baseEnv`.

Link to Devin session: https://app.devin.ai/sessions/89077ee405664538844813fdaf3516b5
Requested by: @lluisinthedesert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->