### PR TITLE
Polish capture onboarding flow

### DIFF
--- a/apps/homescreen/app/components/CapturePane.tsx
+++ b/apps/homescreen/app/components/CapturePane.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Persona } from "@/components/ai-elements/persona";
+import { PauseIcon, PlayIcon, ShieldCheckIcon } from "lucide-react";
 
 type CaptureStep = {
   id: string;
@@ -11,6 +12,8 @@ type CaptureStep = {
   cli: string;
   diagram: "baseline" | "gateway" | "learning" | "scorecard" | "replace";
   status: string;
+  route: string;
+  artifact: string;
 };
 
 const STEPS: CaptureStep[] = [
@@ -22,6 +25,8 @@ const STEPS: CaptureStep[] = [
     cli: "understudy capture inspect",
     diagram: "baseline",
     status: "read-only",
+    route: "Your app → Anthropic",
+    artifact: "No behavior change",
   },
   {
     id: "insert",
@@ -31,6 +36,8 @@ const STEPS: CaptureStep[] = [
     cli: "understudy gateway install --provider anthropic",
     diagram: "gateway",
     status: "same model",
+    route: "Your app → Understudy → Anthropic",
+    artifact: "Local traces begin",
   },
   {
     id: "learn",
@@ -40,6 +47,8 @@ const STEPS: CaptureStep[] = [
     cli: "understudy traces build-eval && understudy lab run",
     diagram: "learning",
     status: "offline loop",
+    route: "Teacher traffic → eval rows",
+    artifact: "Candidate learns",
   },
   {
     id: "score",
@@ -49,15 +58,19 @@ const STEPS: CaptureStep[] = [
     cli: "understudy eval compare --candidate understudy-fast",
     diagram: "scorecard",
     status: "promotion gate",
+    route: "Candidate vs teacher",
+    artifact: "Scorecard decides",
   },
   {
     id: "replace",
     label: "Replace",
     title: "Swap calls and start the next loop",
-    body: "Once the candidate passes, Understudy replaces the route. The old provider path becomes the teacher for the next smaller, faster model.",
+    body: "Once the candidate passes, Understudy serves the app. Anthropic moves out of the hot path, and the new live traces start training the next Understudy candidate.",
     cli: "understudy route promote --candidate understudy-fast",
     diagram: "replace",
     status: "continuous",
+    route: "Your app → Understudy live",
+    artifact: "Next candidate training",
   },
 ];
 
@@ -79,24 +92,40 @@ export function CapturePane() {
     <>
       <div className="pane-head">
         <h1 className="pane-title">Capture</h1>
-        <p className="pane-sub">Install the gateway, collect traces, prove a better local route, then repeat.</p>
+        <p className="pane-sub">Capture production-shaped traces, build a scorecard, and replace expensive calls only after the candidate proves itself.</p>
       </div>
 
       <div className="pane-body capture-pane">
         <div className="card capture-hero">
           <div className="capture-hero-copy">
+            <span className="capture-eyebrow">Gateway replacement loop</span>
             <div className="card-title">{step.title}</div>
             <div className="card-sub">{step.body}</div>
           </div>
           <div className="capture-actions">
             <span className="svc-state">{step.status}</span>
-            <button className="btn" type="button" onClick={() => setPlaying((value) => !value)}>
+            <button className="btn icon-label" type="button" onClick={() => setPlaying((value) => !value)}>
+              {playing ? <PauseIcon size={15} /> : <PlayIcon size={15} />}
               {playing ? "Pause" : "Play"}
             </button>
           </div>
         </div>
 
         <div className="card capture-stage-card">
+          <div className="capture-route-strip">
+            <div>
+              <span>Route</span>
+              <strong>{step.route}</strong>
+            </div>
+            <div>
+              <span>Artifact</span>
+              <strong>{step.artifact}</strong>
+            </div>
+            <div>
+              <span>Privacy</span>
+              <strong><ShieldCheckIcon size={14} /> local-first</strong>
+            </div>
+          </div>
           <CaptureFlow state={step.diagram} />
           <div className="capture-progress">
             <span style={{ width: `${progress}%` }} />
@@ -124,10 +153,10 @@ export function CapturePane() {
         <div className="card capture-cli-card">
           <div className="card-row">
             <div>
-              <div className="card-title">What the CLI teaches</div>
-              <div className="card-sub">Each step maps to an agent-visible action and an auditable local artifact.</div>
+              <div className="card-title">Agent-visible install path</div>
+              <div className="card-sub">The CLI changes endpoints, records the local evidence, and leaves a report agents can inspect.</div>
             </div>
-            <span className="svc-state">demo script</span>
+            <span className="svc-state">replayable</span>
           </div>
           <pre className="capture-cli">{step.cli}</pre>
           <div className="capture-artifacts">
@@ -150,32 +179,42 @@ function CaptureFlow({ state }: { state: CaptureStep["diagram"] }) {
 
   return (
     <div className={`capture-flow ${state}`}>
+      <div className="capture-stage-label source">live workload</div>
+      <div className="capture-stage-label provider">{replaced ? "teacher" : "provider"}</div>
       <FlowNode kind="site" title="Your app" subtitle="Website / agent" />
       <div className="flow-lane app-to-provider">
         <FlowPackets count={gatewayOn ? 3 : 4} />
       </div>
-      {gatewayOn && <FlowNode kind="gateway" title="Understudy" subtitle="Gateway + trace tap" />}
+      {gatewayOn && <FlowNode kind={replaced ? "live" : "gateway"} title="Understudy" subtitle={replaced ? "serving app calls" : "Gateway + trace tap"} />}
       <div className="flow-lane gateway-to-provider">
         <FlowPackets count={gatewayOn ? 2 : 0} />
       </div>
-      <FlowNode kind={replaced ? "retired" : "anthropic"} title={replaced ? "Teacher" : "Anthropic"} subtitle={replaced ? "fallback + labels" : "current route"} />
+      <FlowNode kind={replaced ? "retired" : "anthropic"} title={replaced ? "Anthropic" : "Anthropic"} subtitle={replaced ? "replaced teacher" : "current route"} />
 
       <div className="capture-trace-stream" aria-hidden="true">
-        <span />
-        <span />
-        <span />
-        <span />
+        <span>prompt</span>
+        <span>tools</span>
+        <span>outcome</span>
+        <span>latency</span>
       </div>
 
       <div className={"capture-learner" + (learning ? " active" : "")}>
         <Persona state={learning ? "thinking" : "idle"} variant="halo" />
         <div>
-          <strong>{replaced ? "Understudy live" : "Understudy candidate"}</strong>
-          <span>{learning ? "learning from captured traces" : "waiting for traces"}</span>
+          <strong>{replaced ? "Next Understudy" : "Understudy candidate"}</strong>
+          <span>{replaced ? "training from replacement traffic" : learning ? "learning from captured traces" : "waiting for traces"}</span>
         </div>
       </div>
 
+      {replaced && (
+        <div className="capture-replacement-badge">
+          <strong>Understudy replaced Anthropic</strong>
+          <span>new traces feed the next candidate</span>
+        </div>
+      )}
+
       <div className={"capture-scorecard" + (scorecard ? " active" : "")}>
+        <div className="scorecard-title">Promotion scorecard</div>
         <ScoreRow label="Quality" value={scorecard ? 92 : 46} pass={scorecard} />
         <ScoreRow label="Latency" value={scorecard ? 81 : 35} pass={scorecard} />
         <ScoreRow label="Cost" value={scorecard ? 88 : 28} pass={scorecard} />

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -302,15 +302,20 @@ select,
   display: grid;
   place-items: center;
   justify-self: center;
+  box-sizing: border-box;
   width: 256px;
   height: 256px;
+  overflow: hidden;
   border-radius: 18px;
   background: #f7f5ef;
   padding: 12px;
 }
 .qr-code-frame canvas {
-  width: 232px;
-  height: 232px;
+  display: block;
+  width: 232px !important;
+  height: 232px !important;
+  max-width: 100%;
+  max-height: 100%;
 }
 .qr-url {
   overflow: hidden;
@@ -768,15 +773,58 @@ select,
   min-width: 0;
   max-width: 680px;
 }
+.capture-eyebrow {
+  display: inline-flex;
+  margin-bottom: 8px;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
 .capture-actions {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
 }
+.icon-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
 .capture-stage-card {
   padding: 0;
   overflow: hidden;
+}
+.capture-route-strip {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr .8fr;
+  gap: 1px;
+  border-bottom: 1px solid var(--border);
+  background: var(--border);
+}
+.capture-route-strip > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 13px 16px;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+}
+.capture-route-strip span {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.capture-route-strip strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
 }
 .capture-flow {
   position: relative;
@@ -811,6 +859,12 @@ select,
   grid-column: 3;
   grid-row: 1;
 }
+.flow-node.live {
+  grid-column: 3;
+  grid-row: 1;
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: color-mix(in srgb, var(--accent) 13%, var(--surface));
+}
 .flow-node.anthropic,
 .flow-node.retired {
   grid-column: 5;
@@ -843,6 +897,11 @@ select,
   background: color-mix(in srgb, var(--accent) 28%, var(--surface-2));
   color: #fff;
 }
+.flow-node.live .flow-node-icon {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 0 22px color-mix(in srgb, var(--accent) 28%, transparent);
+}
 .flow-provider-mark {
   display: grid;
   place-items: center;
@@ -867,7 +926,12 @@ select,
   fill: #d8c7ad;
 }
 .flow-node.retired {
-  opacity: .62;
+  opacity: .5;
+  filter: grayscale(.4);
+}
+.capture-flow.replace .gateway-to-provider {
+  opacity: .28;
+  background: linear-gradient(90deg, var(--border), var(--border));
 }
 .flow-node strong {
   color: var(--text);
@@ -939,11 +1003,16 @@ select,
   position: absolute;
   left: 50%;
   top: 0;
-  width: 58px;
+  display: grid;
+  place-items: center;
+  width: 64px;
   height: 18px;
   border: 1px solid var(--border);
   border-radius: 5px;
   background: color-mix(in srgb, var(--surface-2) 92%, transparent);
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 9px;
   transform: translateX(-50%);
   animation: trace-drop 2.8s ease-in-out infinite;
 }
@@ -1014,6 +1083,11 @@ select,
   opacity: 1;
   transform: translateY(0);
 }
+.scorecard-title {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+}
 .score-row {
   display: grid;
   grid-template-columns: 58px 1fr 52px;
@@ -1040,6 +1114,28 @@ select,
   color: var(--text-2);
   font-weight: 500;
   text-align: right;
+}
+.capture-replacement-badge {
+  position: absolute;
+  z-index: 4;
+  left: 28px;
+  bottom: 28px;
+  display: grid;
+  gap: 4px;
+  width: 238px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border));
+  border-radius: var(--r-card);
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  box-shadow: 0 14px 50px rgba(0, 0, 0, .24);
+}
+.capture-replacement-badge strong {
+  color: var(--text);
+  font-size: 12px;
+}
+.capture-replacement-badge span {
+  color: var(--text-3);
+  font-size: 11px;
 }
 .capture-progress {
   height: 4px;
@@ -1429,6 +1525,9 @@ select,
   .evals-actions {
     justify-content: start;
   }
+  .capture-route-strip {
+    grid-template-columns: 1fr;
+  }
   .capture-flow {
     grid-template-columns: 1fr;
     grid-template-rows: repeat(5, auto);
@@ -1444,6 +1543,7 @@ select,
   }
   .flow-node.site,
   .flow-node.gateway,
+  .flow-node.live,
   .flow-node.anthropic,
   .flow-node.retired {
     grid-column: 1;
@@ -1459,7 +1559,9 @@ select,
     to { transform: translateY(44px) rotate(180deg); opacity: 0; }
   }
   .capture-trace-stream,
-  .capture-scorecard {
+  .capture-scorecard,
+  .capture-replacement-badge,
+  .capture-stage-label {
     display: none;
   }
   .capture-learner {


### PR DESCRIPTION
## Summary
- clarify the Capture onboarding story around gateway insertion, scorecard promotion, and replacement
- show Understudy serving after replacement while the next Understudy candidate trains from new traces
- fix QR modal canvas alignment inside its frame

## Verification
- npm run build
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->