### PR TITLE
feat: add check-routing-health skill for self-service diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ live in each skill's `references/` directory:
 | **Optimize** | optimize-workload, optimize-agentic-workload (read-only search loops and state-mutating API workflows) |
 | **Train locally** | curate-trajectories, distill-classifier, local-distillation-lab (incl. the pedagogical arm) |
 | **RL handoff** | prepare-verifier-handoff (decide → author env → package → hand off) |
-| **Gateway & routing** | use-understudy-gateway (incl. the frontier-keys decision), ramp-and-verify |
+| **Gateway & routing** | use-understudy-gateway (incl. the frontier-keys decision), ramp-and-verify, check-routing-health (self-service diagnostics) |
 
 [`skills/README.md`](skills/README.md) is the authoritative index with
 per-skill descriptions — keep it in sync when adding skills. See

--- a/skills/README.md
+++ b/skills/README.md
@@ -211,6 +211,11 @@ shows headroom, no hosted RL until the local arms plateau.
   tier, routed-vs-passthrough verification from captures at each step,
   rollback triggers, and the measured before/after that feeds the claim
   packet.
+- [`check-routing-health`](check-routing-health/SKILL.md) is the read-only
+  self-service diagnostics worker: calls the hosted reporting endpoints
+  (routing-status, provider-health, compact status) to answer "which
+  workloads are routed", "are there provider errors", and "is this us?" —
+  without asking the team. Uses the developer's existing `sk_*` key.
 
 ## Public Safety
 

--- a/skills/check-routing-health/SKILL.md
+++ b/skills/check-routing-health/SKILL.md
@@ -53,7 +53,9 @@ node dist/bin.js status --json
    understudy status --json
    ```
 
-   Extract `org_id` and `project_slug` from the output. If not signed in, route
+   Extract `org_id` and `project_slug` from the output. Resolve the project
+   slug to a project id via `understudy projects list --json` if needed — the
+   API path requires the `proj_...` id, not the slug. If not signed in, route
    to [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
 
 2. For a quick overview, call the compact status endpoint:
@@ -61,7 +63,7 @@ node dist/bin.js status --json
    ```sh
    understudy run -- curl -s \
      -H "Authorization: Bearer \$UNDERSTUDY_API_KEY" \
-     "https://api.understudylabs.com/admin/v1/orgs/\$UNDERSTUDY_ORG_ID/projects/$PROJECT_ID/status?window=30m"
+     "https://api.understudylabs.com/admin/v1/orgs/\$UNDERSTUDY_ORG_ID/projects/<project-id>/status?window=30m"
    ```
 
 3. Print the `lines` array first — it is the dense human-readable summary.

--- a/skills/check-routing-health/SKILL.md
+++ b/skills/check-routing-health/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: check-routing-health
+description: Use when a developer asks "is Understudy causing my errors", "which workloads are routed", "is my provider healthy", "are there 500s on staging", "what's our error rate", "check provider health", or wants self-service diagnostics without asking the team. Reads the hosted reporting endpoints with the developer's sk_* key.
+metadata:
+  understudy:
+    mode: interactive
+    safety: read-only
+    cli_required: true
+---
+
+# Check Routing Health
+
+Use this worker when the developer wants to know whether Understudy routing is
+causing errors, which workloads are routed, or what the current provider health
+looks like. These are read-only hosted endpoints that answer "is this us?"
+without asking the team.
+
+Checked against existing skills: `use-understudy-gateway` owns auth, routing
+setup, and route writes; `ramp-and-verify` owns production traffic changes.
+This skill owns read-only diagnostic queries against the reporting surface and
+does not write routes or change traffic.
+
+## Safety Gates
+
+These endpoints are read-only and carry no side effects. They do not change
+routes, traffic percentages, or provider configuration. Do not print the full
+`sk_*` key in output — mask it to the last 4 characters. Use `understudy run`
+to inject credentials into child processes instead of pasting keys into shell
+commands.
+
+## Prerequisites
+
+The developer must be signed in (`understudy status --json` shows
+`signed_in: true`) and have a project configured. If not, route to
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) for
+auth setup first.
+
+## Resolve CLI
+
+Prefer the installed `understudy` binary. If it is unavailable inside a repo
+checkout, run through the package script:
+
+```sh
+npm run build
+node dist/bin.js status --json
+```
+
+## Flow
+
+1. Confirm auth and project:
+
+   ```sh
+   understudy status --json
+   ```
+
+   Extract `org_id` and `project_slug` from the output. If not signed in, route
+   to [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+
+2. For a quick overview, call the compact status endpoint:
+
+   ```sh
+   understudy run -- curl -s \
+     -H "Authorization: Bearer \$UNDERSTUDY_API_KEY" \
+     "https://api.understudylabs.com/admin/v1/orgs/\$UNDERSTUDY_ORG_ID/projects/$PROJECT_ID/status?window=30m"
+   ```
+
+3. Print the `lines` array first — it is the dense human-readable summary.
+
+4. If the developer needs details, call the individual endpoints
+   (`routing-status`, `provider-health`) — see [`reference.md`](reference.md).
+
+5. If `example_request_ids` are present, offer to look them up:
+
+   ```sh
+   understudy captures get <request-id> --project <project>
+   ```
+
+6. Interpret the results:
+   - `error_5xx_rate` above ~2% is worth investigating.
+   - Non-zero `timeout_count` or `fallback_count` indicates upstream instability.
+   - `passthrough` workloads with errors are provider-side, not Understudy-caused.
+   - `understudy` or `primary` workloads with errors may be route-related — check
+     `provider_label` and `model` to identify the upstream.
+
+7. If issues are found and the developer wants to roll back, route to
+   [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md) or clear the
+   route immediately with `understudy routes clear <workload> --project <project>`.
+
+## Output Standard
+
+End with:
+
+- project/org context (without revealing the full key);
+- compact status lines or the specific diagnostic answer;
+- whether any workloads show elevated error rates;
+- the window queried and when the data was generated;
+- recommended next action (investigate a request ID, adjust the window, roll
+  back a route, or confirm healthy).
+
+## References
+
+- [`reference.md`](reference.md) — endpoint details, response shapes, field
+  descriptions, and the individual routing-status and provider-health surfaces.
+- [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) —
+  auth setup, route writes, and gateway inference.
+- [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md) — production
+  ramp/rollback when diagnostics reveal a problem.

--- a/skills/check-routing-health/reference.md
+++ b/skills/check-routing-health/reference.md
@@ -120,14 +120,14 @@ The endpoints accept a standard `Authorization: Bearer sk_*` header. Use
 ```sh
 understudy run -- curl -s \
   -H "Authorization: Bearer \$UNDERSTUDY_API_KEY" \
-  "https://api.understudylabs.com/admin/v1/orgs/\$UNDERSTUDY_ORG_ID/projects/$PROJECT_ID/routing-status"
+  "https://api.understudylabs.com/admin/v1/orgs/\$UNDERSTUDY_ORG_ID/projects/<project-id>/routing-status"
 ```
 
 Or call directly with the key from `~/.understudy/credentials.json`:
 
 ```sh
 curl -s -H "Authorization: Bearer $UNDERSTUDY_API_KEY" \
-  "https://api.understudylabs.com/admin/v1/orgs/$ORG_ID/projects/$PROJECT_ID/provider-health?window=1h"
+  "https://api.understudylabs.com/admin/v1/orgs/$ORG_ID/projects/<project-id>/provider-health?window=1h"
 ```
 
 ## Error responses

--- a/skills/check-routing-health/reference.md
+++ b/skills/check-routing-health/reference.md
@@ -1,0 +1,140 @@
+# Check Routing Health — Reference
+
+Endpoint details and response shapes for the three self-service reporting
+endpoints. Full hosted reference at
+[docs.understudylabs.com/reference/control-plane/reporting](https://docs.understudylabs.com/reference/control-plane/reporting).
+
+All three are `GET` requests authenticated with the developer's `sk_*` key at
+`https://api.understudylabs.com/admin/v1/orgs/:org_id/projects/:project_id/...`.
+
+## Routing status
+
+```
+GET .../routing-status
+```
+
+Returns per-workload routing topology: which workloads route through Understudy,
+at what traffic percentage, which provider and model are active, and when the
+route was last changed.
+
+```jsonc
+{
+  "project_id": "proj_...",
+  "workloads": [
+    {
+      "workload_id": "usp_...",
+      "display_name": "chat",
+      "environment": null,
+      "route_mode": "understudy",       // "primary" | "understudy" | "passthrough"
+      "active_traffic_pct": 30,
+      "provider_label": "fireworks",
+      "model": "llama-3.3-70b",
+      "updated_at": "2026-06-30T00:00:00Z"
+    }
+  ],
+  "workload_count": 2,
+  "generated_at": "2026-06-30T18:30:00.000Z"
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `route_mode` | `primary` — 100% routed. `understudy` — 1–99% canary. `passthrough` — BYO, no routing. |
+| `active_traffic_pct` | 0–100. Percentage of matching requests routed to the managed model. |
+| `provider_label` | Public upstream provider name (e.g. fireworks, anthropic). null when passthrough. |
+| `model` | Catalog model id the route targets. null when passthrough. |
+
+## Provider health
+
+```
+GET .../provider-health?window=30m
+```
+
+Returns recent error and health metrics aggregated by provider, workload, and
+model.
+
+| Param | Default | Details |
+|---|---|---|
+| `window` | `30m` | Lookback window. Accepts `30m`, `1h`, `6h`, up to `24h`. |
+
+```jsonc
+{
+  "project_id": "proj_...",
+  "window": "30m",
+  "window_start": "2026-06-30T18:00:00.000Z",
+  "window_end": "2026-06-30T18:30:00.000Z",
+  "total_requests": 1200,
+  "total_errors": 11,
+  "providers": [
+    {
+      "provider": "anthropic",
+      "workload": "chat",
+      "model": "claude-haiku-4-5",
+      "request_count": 600,
+      "error_5xx_count": 11,
+      "error_5xx_rate": 0.0183,
+      "timeout_count": 2,
+      "fallback_count": 8,
+      "last_failing_at": "2026-06-30T18:28:12.000Z",
+      "example_request_ids": [
+        "0190a7c2-7e11-7cc3-a312-9f1b22d40e88",
+        "0190a7c2-8a22-7cc3-b413-1a2c33e51f99"
+      ]
+    }
+  ],
+  "generated_at": "2026-06-30T18:30:00.000Z"
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `error_5xx_rate` | error_5xx_count / request_count, rounded to four decimal places. |
+| `timeout_count` | Requests where the upstream timed out and triggered a fallback. |
+| `fallback_count` | Total requests that fell back to an alternative route for any reason. |
+| `example_request_ids` | Up to 5 request IDs from failing requests in the window. Look up via [captures](https://docs.understudylabs.com/reference/control-plane/captures) or `x-understudy-request-id` in logs. |
+
+## Compact status
+
+```
+GET .../status?window=30m
+```
+
+Combines routing topology and provider health into human-readable `lines` plus
+the full structured data. The `lines` array is the quick answer:
+
+```text
+chat: 30% routed through Understudy / fireworks (llama-3.3-70b)
+  Last 30m: 11 provider 500s, 1.83% error rate
+automation: passthrough (BYO)
+```
+
+The nested `routing` and `health` objects carry the same data as the individual
+endpoints. The optional `?window=` param works the same as on provider-health
+(default `30m`, max `24h`).
+
+## Calling without the CLI
+
+The endpoints accept a standard `Authorization: Bearer sk_*` header. Use
+`understudy run` to inject credentials from the CLI's credential store:
+
+```sh
+understudy run -- curl -s \
+  -H "Authorization: Bearer \$UNDERSTUDY_API_KEY" \
+  "https://api.understudylabs.com/admin/v1/orgs/\$UNDERSTUDY_ORG_ID/projects/$PROJECT_ID/routing-status"
+```
+
+Or call directly with the key from `~/.understudy/credentials.json`:
+
+```sh
+curl -s -H "Authorization: Bearer $UNDERSTUDY_API_KEY" \
+  "https://api.understudylabs.com/admin/v1/orgs/$ORG_ID/projects/$PROJECT_ID/provider-health?window=1h"
+```
+
+## Error responses
+
+| Status | Type | When |
+|---|---|---|
+| 400 | `invalid_request_error` | Invalid `window` param (not a recognized duration or exceeds 24h). |
+| 401 | `authentication_error` | Missing or invalid `sk_*` key. |
+| 404 | `not_found_error` | Project not found or does not belong to the caller's org. |
+| 500 | `internal_error` | ClickHouse or D1 query failure; retry after a moment. |

--- a/skills/ramp-and-verify/SKILL.md
+++ b/skills/ramp-and-verify/SKILL.md
@@ -81,11 +81,22 @@ At each tier:
    --traffic-pct <pct>` — after approval.
 2. **Soak.** Hold the tier for an agreed window (hours at 5%, a day at 25%)
    while traffic accumulates.
-3. **Verify from captures.** Pull the window's captures (metadata-first) and
-   compare routed vs passthrough on the same period: error/status-code rate,
-   latency distribution, schema/parse validity of outputs, and token/cost per
-   call. The routed cohort must hold the lab quality bar on whatever the
-   workload's validator can score from captures.
+3. **Verify from reporting + captures.** Check the reporting endpoints first
+   for a fast aggregate view:
+
+   ```
+   GET .../provider-health?window=<soak-window>
+   GET .../status?window=<soak-window>
+   ```
+
+   ([docs](https://docs.understudylabs.com/reference/control-plane/reporting))
+   Use
+   [`../check-routing-health/SKILL.md`](../check-routing-health/SKILL.md)
+   for the full diagnostic flow. Then pull the window's captures
+   (metadata-first) and compare routed vs passthrough on the same period:
+   error/status-code rate, latency distribution, schema/parse validity of
+   outputs, and token/cost per call. The routed cohort must hold the lab
+   quality bar on whatever the workload's validator can score from captures.
 4. **Spot-check determinism.** Re-run a small sample of routed rows against
    the candidate; if repeats disagree materially more than the pre-ramp
    measurement, stop the ramp and re-diagnose.
@@ -124,8 +135,13 @@ recommended next action.
   frozen-eval verdict required by the pre-ramp gate.
 - [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) — the
   claim-packet contract for any measured savings statement.
+- [`../check-routing-health/SKILL.md`](../check-routing-health/SKILL.md) —
+  read-only diagnostics from the reporting endpoints (routing-status,
+  provider-health, compact status).
 - Hosted contracts on the docs site —
   [routing](https://docs.understudylabs.com/concepts/routing),
-  [capture](https://docs.understudylabs.com/concepts/capture), and the
+  [capture](https://docs.understudylabs.com/concepts/capture),
+  [reporting & health](https://docs.understudylabs.com/reference/control-plane/reporting),
+  and the
   [control-plane API](https://docs.understudylabs.com/reference/control-plane)
   behind `routes set/rollback/clear` and `captures list`.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -166,6 +166,11 @@ Identify the developer's current stage and load exactly one:
   "did the route change regress anything", "roll this back", "prove the
   savings are real" →
   [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md).
+- **Routing diagnostics / provider health** — the developer asks "is
+  Understudy causing my errors", "which workloads are routed", "check
+  provider health", "are there 500s", "what's our error rate", or wants
+  self-service diagnostics without asking the team →
+  [`../check-routing-health/SKILL.md`](../check-routing-health/SKILL.md).
 - **Share savings / leaderboard receipt** — the developer wants to share how
   much money they saved, submit an anonymous lower-Anthropic-bill result, or
   send metrics back for the coming leaderboard →

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -232,6 +232,15 @@ comparing a workload's quality and cost across the split.
    requests error. For keyless accounts, use the **keyless catalog sweep** recipe
    first, then route only after choosing a candidate.
 
+## Diagnostics
+
+When the developer asks whether the gateway is causing errors, wants to check
+provider health, or asks "is this us?", route to
+[`../check-routing-health/SKILL.md`](../check-routing-health/SKILL.md). That
+worker calls the read-only reporting endpoints (routing-status, provider-health,
+compact status) and interprets the results. The full endpoint reference is at
+[docs.understudylabs.com/reference/control-plane/reporting](https://docs.understudylabs.com/reference/control-plane/reporting).
+
 ## Output Standard
 
 End with:
@@ -252,7 +261,9 @@ End with:
   [routing semantics](https://docs.understudylabs.com/concepts/routing),
   [capture](https://docs.understudylabs.com/concepts/capture), the
   [control-plane API](https://docs.understudylabs.com/reference/control-plane)
-  behind `workloads`/`routes`/`captures`, and the gateway
+  behind `workloads`/`routes`/`captures`,
+  [reporting & health](https://docs.understudylabs.com/reference/control-plane/reporting)
+  for self-service diagnostics, and the gateway
   [request headers](https://docs.understudylabs.com/reference/request-headers) /
   [response headers](https://docs.understudylabs.com/reference/response-headers).
 


### PR DESCRIPTION
## Summary

New `check-routing-health` skill that teaches agents how to call the three self-service reporting endpoints shipped in understudylabs/understudy-platform#326 — so developers (like Isabelle) and their agents can answer "is this us?" without asking the team.

**New skill:** `skills/check-routing-health/`
- `SKILL.md` — flow: confirm auth → resolve project id → call compact status → interpret `lines` → drill into individual endpoints → look up failing request IDs via captures → recommend rollback if needed
- `reference.md` — full endpoint reference with response shapes, field descriptions, error codes, and curl examples for `routing-status`, `provider-health`, and `status`

**Updated skills:**
- `understudy/SKILL.md` — added "Routing diagnostics / provider health" route entry for intents like "is Understudy causing my errors", "check provider health"
- `use-understudy-gateway/SKILL.md` — added Diagnostics section routing to the new skill + reporting docs link in References
- `ramp-and-verify/SKILL.md` — verify step now checks reporting endpoints for aggregate view before capture-level comparison + reference link

Docs reference: [docs.understudylabs.com/reference/control-plane/reporting](https://docs.understudylabs.com/reference/control-plane/reporting)

Link to Devin session: https://app.devin.ai/sessions/9eac14e0d3fa467d8589090dd095cda1
Requested by: @lluisinthedesert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->