### PR TITLE
Hygiene review: restore chat tool cap, fix reliability bugs, align skills on -understudy ladder

### DIFF
--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -80,6 +80,7 @@ const CHAT_SIDEKICK_QUICK_WAIT_MS: u64 = 600;
 const CHAT_SIDEKICK_DEFAULT_WAIT_MS: u64 = 1_000;
 const CHAT_SIDEKICK_VERIFICATION_WAIT_MS: u64 = 1_800;
 const BENCHMARK_SIDEKICK_WAIT_MS: u64 = 2_500;
+const MAX_TOOL_ROUNDS: usize = 4;
 const BENCHMARK_MAX_TOOL_ROUNDS: usize = 4;
 const SIDEKICK_MAX_TOOL_ROUNDS: usize = 2;
 const SIDEKICK_MAX_CONTEXT_MESSAGES: usize = 16;
@@ -2404,7 +2405,7 @@ pub async fn chat_stream(
         .build()
         .map_err(|e| e.to_string())?;
 
-    loop {
+    for _round in 0..=MAX_TOOL_ROUNDS {
         prompt_tokens = prompt_tokens.max(approximate_messages_tokens(&outbound_messages));
         let result = stream_chat_once(
             &client,
@@ -2550,6 +2551,34 @@ pub async fn chat_stream(
             }
         }
     }
+
+    let _ = on_event.send(ChatEvent::Error {
+        message: format!("tool call limit reached ({MAX_TOOL_ROUNDS})"),
+    });
+    record_chat_run(
+        &app,
+        ChatRunInput {
+            session_id: session_id.clone(),
+            route: route.clone(),
+            model: model_field,
+            elapsed_ms: Some(started.elapsed().as_millis() as u64),
+            prompt_tokens: Some(prompt_tokens),
+            completion_tokens: Some(completion_tokens),
+            tool_calls: tool_count,
+            sidekick_spawned: sidekick_plan.spawned,
+            gateway_used: route == "cloud",
+            compacted,
+            compaction_reason,
+            context_tokens_before: Some(context_tokens_before),
+            local_mem_gb,
+            gateway_available,
+            gateway_avoided: gateway_available && route != "cloud",
+            status: "tool_limit".to_string(),
+            error: Some(format!("tool call limit reached ({MAX_TOOL_ROUNDS})")),
+        },
+    );
+    let _ = on_event.send(ChatEvent::Done);
+    Ok(())
 }
 
 pub async fn benchmark_local_chat(

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -781,20 +781,26 @@ pub fn get_status(app: AppHandle) -> StatusSnapshot {
 
 #[tauri::command]
 pub fn connect(app: AppHandle) -> Result<(), String> {
-    bin::command("moraine")
+    let status = bin::command("moraine")
         .arg("up")
         .status()
         .map_err(|e| format!("moraine up failed: {e}"))?;
+    if !status.success() {
+        return Err(format!("moraine up exited with {status}"));
+    }
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }
 
 #[tauri::command]
 pub fn disconnect(app: AppHandle) -> Result<(), String> {
-    bin::command("moraine")
+    let status = bin::command("moraine")
         .arg("down")
         .status()
         .map_err(|e| format!("moraine down failed: {e}"))?;
+    if !status.success() {
+        return Err(format!("moraine down exited with {status}"));
+    }
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }
@@ -992,20 +998,26 @@ pub fn install_moraine() -> Result<String, String> {
 
 #[tauri::command]
 pub fn start_moraine(app: AppHandle) -> Result<(), String> {
-    bin::command("moraine")
+    let status = bin::command("moraine")
         .arg("up")
         .status()
         .map_err(|e| format!("moraine up failed: {e}"))?;
+    if !status.success() {
+        return Err(format!("moraine up exited with {status}"));
+    }
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }
 
 #[tauri::command]
 pub fn stop_moraine(app: AppHandle) -> Result<(), String> {
-    bin::command("moraine")
+    let status = bin::command("moraine")
         .arg("down")
         .status()
         .map_err(|e| format!("moraine down failed: {e}"))?;
+    if !status.success() {
+        return Err(format!("moraine down exited with {status}"));
+    }
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -1135,12 +1135,7 @@ impl Db {
 }
 
 fn now_iso() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    format!("1970-01-01T00:00:{secs}Z")
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
 /// Kept so earlier code that calls `db::init` still typechecks during the transition.

--- a/apps/homescreen/src-tauri/src/mcp.rs
+++ b/apps/homescreen/src-tauri/src/mcp.rs
@@ -26,7 +26,7 @@ pub fn call_tool(name: &str, args: Value) -> anyhow::Result<Value> {
                 "jsonrpc": "2.0", "id": 1, "method": "initialize",
                 "params": {
                     "protocolVersion": PROTOCOL_VERSION, "capabilities": {},
-                    "clientInfo": { "name": "understudy-desktop", "version": "0.2.1" }
+                    "clientInfo": { "name": "understudy-desktop", "version": env!("CARGO_PKG_VERSION") }
                 }
             })
         )?;

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -412,7 +412,7 @@ async fn mcp(
             "jsonrpc": "2.0", "id": id,
             "result": {
                 "protocolVersion": "2024-11-05",
-                "serverInfo": { "name": "understudy-desktop", "version": "0.2.1" },
+                "serverInfo": { "name": "understudy-desktop", "version": env!("CARGO_PKG_VERSION") },
                 "capabilities": { "tools": {} }
             }
         }))),
@@ -604,7 +604,7 @@ async fn a2a_card(
     Ok(Json(json!({
         "name": "understudy-desktop",
         "description": "Local Understudy control plane: models, routes, traces, and runtime.",
-        "version": "0.2.1",
+        "version": env!("CARGO_PKG_VERSION"),
         "url": format!("/a2a"),
         "capabilities": { "streaming": false, "tools": true },
         "defaultInputModes": ["text"],

--- a/skills/ladder/serve.py
+++ b/skills/ladder/serve.py
@@ -43,12 +43,12 @@ LOCAL_MODELS = {
     "gemma-4-e2b":   ("mlx_vlm", os.path.join(MODEL_HOME, "gemma-4-e2b-it-qat-mlx-vlm-understudy"), "gemma-4-e2b · thinking", {"temp": 1.0, "top_p": 0.95, "top_k": 64}),
 }
 
+# Static stand-in when the live gateway catalog is unreachable. Keep this list
+# to models the gateway still serves — deprecated ids fail mid-demo. glm-5.1,
+# gemma-4-31b-it, and kimi-k2.6 were removed after their 2026-06-29 deprecation.
 FALLBACK_REMOTE_MODELS = [
     ("glm-5.2", "GLM 5.2"),
     ("minimax-m3", "MiniMax M3"),
-    ("glm-5.1", "GLM 5.1 · deprecates 2026-06-29"),
-    ("gemma-4-31b-it", "Gemma 4 31B · deprecates 2026-06-29"),
-    ("kimi-k2.6", "Kimi K2.6 · deprecates 2026-06-29"),
     ("minimax-m2.7", "MiniMax M2.7"),
     ("nemotron-3-nano", "Nemotron 3 Nano"),
     ("nemotron-3-super", "Nemotron 3 Super"),

--- a/skills/manage-local-models/reference.md
+++ b/skills/manage-local-models/reference.md
@@ -81,12 +81,12 @@ or graduate remote when local quality is the bottleneck.
 | **Gemma 4 E2B QAT (Understudy, g32)** | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-qat-mlx-vlm-understudy` | **Default onboarding rung.** QAT bf16 -> MLX 4-bit `group_size=32`. About 3.6 GB; 4/4 certified (generation, OpenAI-compatible serving, logprobs+top_logprobs, tool_calls) at the prescribed decode (1.0/0.95/k64). Matches-or-beats vanilla BF16 on tool-call fidelity at 2.6x less memory and 2.6x faster decode. Serve with `--top-logprobs-k 20` — see `understudy.serving.json` and `references/serving-manifest.md`. |
 | Gemma 4 E2B 4-bit (vanilla) | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit` | Diagnostic rung (vanilla non-QAT bf16 -> MLX 4-bit). Keep it to isolate "is this a quant artifact?" questions against the QAT default. About 3.3 GB; verified generation, OpenAI-compatible serving, logprobs/top-logprobs. |
 | Gemma 4 E2B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-bf16` | Full-precision diagnostic rung for small-model quality checks. About 9.5 GB. |
-| Gemma 4 E4B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit` | First climb when E2B understands the task but lacks quality. About 4.8 GB; verified signed snapshot delivery. |
+| Gemma 4 E4B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit` | First climb when E2B understands the task but lacks quality. About 4.8 GB; verified signed snapshot delivery. Official target for this tier: `gemma-4-e4b-it-qat-mlx-vlm-understudy` (QAT conversion staged; certification + publication pending) — switch to it once its session URL resolves. |
 | Gemma 4 E4B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-bf16` | Full-precision E4B diagnostic when 4-bit quality looks suspicious. About 15 GB. |
-| Gemma 4 12B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit` | M4/M5 MacBook Pro or high-RAM Air rung when E4B has the right behavior but not enough depth. About 6.3 GB; verified generation plus OpenAI-compatible logprobs/top-logprobs. |
+| Gemma 4 12B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit` | M4/M5 MacBook Pro or high-RAM Air rung when E4B has the right behavior but not enough depth. About 6.3 GB; verified generation plus OpenAI-compatible logprobs/top-logprobs. Official target for this tier: `gemma-4-12b-it-qat-mlx-vlm-understudy` (QAT conversion staged; certification + publication pending). |
 | Gemma 4 12B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16` | Quality/perf profiling rung on larger-memory Macs. About 22 GB; use when quantization may be the bottleneck. |
-| Gemma 4 26B A4B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit` | MoE-style local climb for strong quality with lower active-parameter cost. About 14 GB; verified generation plus logprobs/top-logprobs. |
-| Gemma 4 26B A4B QAT (Understudy) | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-qat-mlx-vlm-understudy` | Certified MLX 4-bit QAT MoE (`group_size=32` + 8-bit routers) from Google's QAT checkpoint. About 16 GB; certified generation, logprobs/top-logprobs, and tool calls. |
+| **Gemma 4 26B A4B QAT (Understudy)** | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-qat-mlx-vlm-understudy` | **Primary MoE-style climb.** Certified MLX 4-bit QAT MoE (`group_size=32` + 8-bit routers) from Google's QAT checkpoint. About 16 GB; certified generation, logprobs/top-logprobs, and tool calls. |
+| Gemma 4 26B A4B 4-bit (vanilla) | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit` | Diagnostic sibling of the QAT rung (and interim pull while the QAT snapshot publication lands). About 14 GB; verified generation plus logprobs/top-logprobs. |
 | Gemma 4 26B A4B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-bf16` | Full-precision MoE high end for 64 GB+ Macs when 4-bit quality is in question. About 52 GB. |
 | Gemma 4 31B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-4bit` | Workstation/high-memory local rung when dense capacity matters. About 17 GB; verified generation plus logprobs/top-logprobs. |
 | Gemma 4 31B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-bf16` | Full-precision dense high end for 96 GB+ Macs. About 62 GB. |
@@ -100,6 +100,12 @@ Cloudflare delivery note: public installation uses stable session endpoints from
 `models.understudylabs.com`. Each session response contains short-lived signed
 per-file URLs; publish the session endpoint, not the expiring object URLs. R2
 remains the durable object source.
+
+Publication check: before promising any pull, hit the session endpoint. A
+response of `{"error":"unknown model"}` means that rung — even a certified
+`-understudy` one — has not been published/registered on the snapshot service
+yet. Fall back to the matching vanilla rung as an interim, say so, and retry
+the official rung later. Never send a user into a dead 404 during onboarding.
 
 CLI snapshot pull:
 
@@ -119,11 +125,15 @@ node scripts/serve-understudy-snapshot.mjs --model gemma-4-e2b-it-qat-mlx-vlm-un
 ```
 
 The pull command writes verified snapshots to `~/.understudy/models/<model-id>` and
-logs to `~/.understudy/agent-tools/logs/model-pull-*.log`. Use
-`gemma-4-e4b-it-mlx-vlm-4bit` for the first quality climb, then
-`gemma-4-e4b-it-mlx-vlm-bf16` or `gemma-4-12b-it-mlx-vlm-bf16` when
-quantization may be the bottleneck. The coding agent should request approval
-with the model id, source, and GB before running it, especially before `--all`.
+logs to `~/.understudy/agent-tools/logs/model-pull-*.log`. The climb order is
+the official `-understudy` ladder: `gemma-4-e2b-it-qat-mlx-vlm-understudy` →
+`gemma-4-e4b-it-qat-mlx-vlm-understudy` (interim until published:
+`gemma-4-e4b-it-mlx-vlm-4bit`) → `gemma-4-12b-it-qat-mlx-vlm-understudy`
+(interim: `gemma-4-12b-it-mlx-vlm-4bit`) →
+`gemma-4-26b-a4b-it-qat-mlx-vlm-understudy`. Reach for a `-bf16` rung only
+when quantization may be the bottleneck. The coding agent should request
+approval with the model id, source, and GB before running it, especially
+before `--all`.
 
 Provenance and smoke test (canonical statement — other skills cross-reference
 this paragraph instead of repeating it): every Understudy Gemma 4 snapshot in

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -70,10 +70,14 @@ and build an opportunity ledger before any code edits or provider calls.
    This caches the first Understudy under
    `~/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy` and logs progress/ETA under
    `~/.understudy/agent-tools/logs/`. If the MLX runtime is missing, the slow
-   step is *install MLX + pull* — get one quick approval, then background it. If
-   the Gemma 4 snapshot URL is unavailable, fall back to
-   `mlx-community/gemma-3-1b-it-4bit` only to preserve the aha moment. Then
-   immediately move on; do not watch the bar.
+   step is *install MLX + pull* — get one quick approval, then background it.
+   **Check the session URL before promising the pull**: if it answers
+   `{"error":"unknown model"}`, the QAT snapshot has not been published to the
+   snapshot service yet — fall back to the published vanilla
+   `gemma-4-e2b-it-mlx-vlm-4bit` (about 3.3 GB, same family and serving stack)
+   and say it is an interim stand-in for the official Understudy rung; only
+   reach for `mlx-community/gemma-3-1b-it-4bit` when disk/RAM is severely
+   constrained. Then immediately move on; do not watch the bar.
 
 2. **Profile the machine (while it downloads).** Detect OS/chip (Apple Silicon
    vs CUDA), RAM / unified memory, free disk. State what fits locally. This is

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -166,14 +166,24 @@ through MLX on Apple Silicon (see
   It is about 3.6 GB on disk, ~3.9 GB peak memory in testing, generated
   locally at about 218 tok/s, and exposes logprobs/top-logprobs through the
   OpenAI-compatible server.
-- **Gemma 4 E4B climb rung** — Understudy-verified `google/gemma-4-e4b-it`,
-  converted with `mlx-vlm 0.6.2` to 4-bit MLX safetensors and served with
-  `mlx_vlm.server`. Snapshot:
-  `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit`.
-  It is about 4.8 GB on disk and is the first quality climb when E2B understands
-  the task but lacks enough capability. Use this Understudy-managed snapshot
-  path for reproducible onboarding (provenance and smoke-test details:
-  [`../manage-local-models/reference.md`](../manage-local-models/reference.md)).
+- **Publication status (check before promising a pull).** The official ladder
+  is the QAT-derived `-understudy` snapshots — they are what Understudy trains,
+  certifies, and stands behind. If
+  `https://models.understudylabs.com/session?model=<id>` answers
+  `{"error":"unknown model"}` for an `-understudy` id, that rung has not been
+  published to the snapshot service yet: fall back to the matching vanilla
+  4-bit snapshot as the *interim* rung, tell the user it is a stand-in, and
+  retry the official rung later. Never let onboarding dead-end on a 404.
+- **Gemma 4 E4B climb rung** — official target:
+  `gemma-4-e4b-it-qat-mlx-vlm-understudy` (QAT weights, MLX 4-bit
+  `group_size=32`, about 5.3 GB), the first quality climb when E2B understands
+  the task but lacks enough capability. Until that snapshot is published and
+  certified, the pullable interim rung is the Understudy-verified vanilla
+  conversion
+  `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit`
+  (about 4.8 GB, `mlx-vlm 0.6.2`, served with `mlx_vlm.server`) — provenance
+  and smoke-test details:
+  [`../manage-local-models/reference.md`](../manage-local-models/reference.md).
 - **Small BF16 diagnostic rungs** — Understudy-verified BF16 conversions of
   `google/gemma-4-e2b-it` and `google/gemma-4-e4b-it`, served with
   `mlx_vlm.server`. Use
@@ -185,18 +195,22 @@ through MLX on Apple Silicon (see
   `models.understudylabs.com/session?model=...` endpoint. It returns a manifest
   with short-lived signed URLs for the actual model files; do not publish the
   expiring per-object URLs directly.
-- **12B local climb rungs** — Understudy-verified `google/gemma-4-12b-it`,
-  converted with `mlx-vlm 0.6.2` and served with `mlx_vlm.server`. Use
+- **12B local climb rungs** — official target:
+  `gemma-4-12b-it-qat-mlx-vlm-understudy` (publication and certification
+  pending). Until it lands, use the Understudy-verified vanilla conversion
   `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit`
   first on high-RAM Apple Silicon; it is about 6.3 GB on disk and verified with
   local generation plus OpenAI-compatible logprobs/top-logprobs. Use
   `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16`
   only for larger-memory quality/perf profiling; it is about 22 GB on disk.
-- **Larger local Gemma rungs** — `gemma-4-26b-a4b-it-mlx-vlm-4bit` is the
-  opinionated MoE-style climb at about 14 GB on disk; `gemma-4-31b-it-mlx-vlm-4bit`
-  is the dense high-memory local rung at about 17 GB. Both use stable
-  `https://models.understudylabs.com/session?model=<id>` endpoints and were
-  verified with chat completions plus logprobs/top-logprobs; see
+- **Larger local Gemma rungs** — the official MoE-style climb is the
+  **certified** `gemma-4-26b-a4b-it-qat-mlx-vlm-understudy` (QAT MLX 4-bit
+  `group_size=32` + 8-bit routers, about 16 GB; certified generation,
+  logprobs/top-logprobs, and tool calls). If its session URL is not yet
+  published, the interim rung is `gemma-4-26b-a4b-it-mlx-vlm-4bit` (about
+  14 GB). `gemma-4-31b-it-mlx-vlm-4bit` is the dense high-memory local rung at
+  about 17 GB. All use stable
+  `https://models.understudylabs.com/session?model=<id>` endpoints; see
   [`../manage-local-models/reference.md`](../manage-local-models/reference.md)
   for the canonical provenance statement and the known-good chat smoke.
 - **DiffusionGemma rungs (specialty, not an onboarding default)** —
@@ -214,10 +228,14 @@ through MLX on Apple Silicon (see
   and served with `mlx_vlm.server`. They are not the default onboarding pull:
   they are large downloads that require explicit approval plus a disk/RAM
   check.
-- **Tiny fallback only** — `mlx-community/gemma-3-1b-it-4bit`, served with
-  `mlx_lm.server`. Dry-run download is about 772 MB and it loads on current
-  `mlx-lm 0.31.3`; use it only when the verified Gemma 4 snapshot is unavailable
-  or disk/RAM is severely constrained.
+- **First-rung fallback order** — if the official
+  `gemma-4-e2b-it-qat-mlx-vlm-understudy` session URL is unavailable, fall back
+  first to the published vanilla
+  `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit`
+  (about 3.3 GB, same family and serving stack — the aha moment survives), and
+  only then to the tiny `mlx-community/gemma-3-1b-it-4bit` (`mlx_lm.server`,
+  about 772 MB, loads on `mlx-lm 0.31.3`) when disk/RAM is severely
+  constrained.
 - **Stock Gemma 4 MLX caveat** — `mlx-community/Gemma4-E2B-IT-Text-int4` and
   `mlx-community/gemma-4-e2b-it-4bit` failed on the tested stack with a Gemma 4
   shared-KV weight/config mismatch. The Understudy snapshot exists to give users

--- a/skills/run-local-model-lab/reference.md
+++ b/skills/run-local-model-lab/reference.md
@@ -50,15 +50,21 @@ llama-server -hf unsloth/gemma-4-E4B-it-GGUF:Q4_K_M --port 8080 --jinja
 
 ```bash
 pip install mlx-vlm                      # or: uv pip install mlx-vlm
-# pull the Understudy-verified snapshot first, then serve OpenAI-compatible
+# pull the official Understudy snapshot first, then serve OpenAI-compatible.
+# The certified QAT `-understudy` rungs are the primary lab models:
 cd /path/to/understudy-agent-tools/skills/manage-local-models
-understudy models pull gemma-4-e4b-it-mlx-vlm-4bit
-python -m mlx_vlm.server --model ~/.understudy/models/gemma-4-e4b-it-mlx-vlm-4bit --port 8080
+understudy models pull gemma-4-e2b-it-qat-mlx-vlm-understudy
+python -m mlx_vlm.server --model ~/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy --port 8080 --top-logprobs-k 20
+# E4B tier: official target gemma-4-e4b-it-qat-mlx-vlm-understudy (pending
+# publication); interim verified rung: gemma-4-e4b-it-mlx-vlm-4bit
 # Nemotron 3 Nano on MLX: mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit
 ```
 
-Use the Understudy snapshot id above when testing E4B in this lab; it is the
-reproducible verified package (provenance and smoke-test details:
+Prefer the `-understudy` suffixed snapshot ids in this lab — they are the
+certified QAT conversions Understudy trains and stands behind (each ships an
+`understudy.serving.json` with the exact serve flags). Fall back to a vanilla
+`-mlx-vlm-4bit` snapshot only when the `-understudy` rung for that tier is not
+yet published (provenance and smoke-test details:
 [`../manage-local-models/reference.md`](../manage-local-models/reference.md)).
 
 (Ollama / LM Studio also serve OpenAI-compatible if a developer already runs one,

--- a/tests/ladder.test.mjs
+++ b/tests/ladder.test.mjs
@@ -41,9 +41,14 @@ describe("ladder model catalog", { skip: !pythonAvailable }, () => {
     assert.equal(models.get("glm-5.2").billed, true);
     assert.equal(models.get("minimax-m3").lane, "gateway");
     assert.equal(models.get("minimax-m3").billed, true);
-    assert.equal(models.get("gemma-4-31b-it").lane, "gateway");
-    assert.match(models.get("gemma-4-31b-it").label, /deprecates 2026-06-29/);
     assert.equal(models.get("nemotron-3-ultra").lane, "gateway");
+    // gateway ids deprecated 2026-06-29 must not be offered as fallbacks
+    for (const retired of ["glm-5.1", "gemma-4-31b-it", "kimi-k2.6"]) {
+      assert.equal(models.has(retired), false, `${retired} should be retired`);
+    }
+    for (const model of payload.models) {
+      assert.doesNotMatch(model.label ?? "", /deprecates/);
+    }
   });
 
   it("can override the remote gateway list with explicit model ids", () => {


### PR DESCRIPTION
## Summary

Fallout from today's code-quality review of the two-day desktop burst plus the onboarding failure investigation.

**Rust (desktop app):**
- Restore `MAX_TOOL_ROUNDS` and the `tool_limit` termination path in `chat_stream` — the 0.2.0 release commit replaced the bounded loop with `loop {}`, leaving the interactive chat loop unbounded when a model keeps emitting tool calls
- Fix `now_iso()` writing malformed timestamps (`1970-01-01T00:00:<epoch-secs>Z`) into every DB row
- Check `moraine up`/`down` exit codes (previously reported success on non-zero exit)
- Version strings from `CARGO_PKG_VERSION` instead of stale hardcoded `0.2.1`

**Skills (root cause of the 2026-07-01 onboarding failure):**
The certified QAT `-understudy` snapshots were never published to models.understudylabs.com (`{"error":"unknown model"}`), while onboard/CLI/app all default to them.
- All model-ladder skills now present the `-understudy` rungs as the official target at every tier
- Added a publication check with an explicit vanilla-4bit interim fallback so onboarding never dead-ends on a 404
- e4b/12b QAT conversions marked certification-pending (no `understudy.serving.json`)
- Dropped gateway models deprecated 2026-06-29 from the ladder fallback catalog

Snapshot publication itself is tracked as a separate running task.

`cargo check --all-targets` clean, `cargo test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->