### PR TITLE
Fix first-run onboarding and model-download failure modes in the desktop app

### DIFF
--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -6,10 +6,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Emitter};
 use tokio::fs;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[derive(Serialize, Clone)]
 pub struct ToolStatus {
@@ -156,7 +157,7 @@ pub async fn download_model(
     fs::create_dir_all(&dest)
         .await
         .map_err(|e| format!("create model dir failed: {e}"))?;
-    let incomplete = dest.join(".understudy-snapshot.incomplete");
+    let incomplete = dest.join(models::INCOMPLETE_MARKER);
     fs::write(&incomplete, format!("model_id={}\n", snapshot.id))
         .await
         .map_err(|e| format!("mark incomplete failed: {e}"))?;
@@ -195,6 +196,17 @@ pub async fn download_model(
     }
 }
 
+/// HTTP client for snapshot downloads. `read_timeout` bounds each socket read
+/// rather than the whole transfer, so a stalled connection errors out instead
+/// of hanging onboarding forever while multi-GB files stay downloadable.
+fn download_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .read_timeout(Duration::from_secs(60))
+        .build()
+        .map_err(|e| format!("http client init failed: {e}"))
+}
+
 async fn download_model_inner(
     snapshot: &SnapshotInfo,
     session_url: &str,
@@ -204,7 +216,10 @@ async fn download_model_inner(
     let _ = on_event.send(DownloadEvent::Log {
         message: format!("requesting signed session for {}", snapshot.id),
     });
-    let manifest: SessionManifest = reqwest::get(session_url)
+    let client = download_client()?;
+    let manifest: SessionManifest = client
+        .get(session_url)
+        .send()
         .await
         .map_err(|e| format!("session request failed: {e}"))?
         .error_for_status()
@@ -216,13 +231,14 @@ async fn download_model_inner(
     files.sort_by(|a, b| file_name(a).cmp(&file_name(b)));
     let mut out = Vec::with_capacity(files.len());
     for file in files {
-        out.push(download_file(dest, file, on_event).await?);
+        out.push(download_file(&client, dest, file, on_event).await?);
     }
     verify_sha256sums(dest).await?;
     Ok(out)
 }
 
 async fn download_file(
+    client: &reqwest::Client,
     dest: &Path,
     file: SessionFile,
     on_event: &Channel<DownloadEvent>,
@@ -239,7 +255,20 @@ async fn download_file(
     }
     let total = file.size_bytes.or(file.size);
     if let Ok(meta) = fs::metadata(&target).await {
-        if total.map(|t| t == meta.len()).unwrap_or(meta.len() > 0) {
+        let size_matches = total.map(|t| t == meta.len()).unwrap_or(meta.len() > 0);
+        // A size match alone can hide a stale or corrupt file; when the
+        // manifest carries a hash, only a hash match counts as cached.
+        let verified = if !size_matches {
+            false
+        } else if let Some(expected) = file.sha256.as_ref() {
+            let _ = on_event.send(DownloadEvent::Log {
+                message: format!("verifying cached {name}"),
+            });
+            sha256_of_file(&target).await.ok().as_deref() == Some(&expected.to_lowercase())
+        } else {
+            true
+        };
+        if verified {
             let _ = on_event.send(DownloadEvent::Log {
                 message: format!("cached {name}"),
             });
@@ -254,7 +283,9 @@ async fn download_file(
     let _ = on_event.send(DownloadEvent::Log {
         message: format!("downloading {name}"),
     });
-    let response = reqwest::get(&file.url)
+    let response = client
+        .get(&file.url)
+        .send()
         .await
         .map_err(|e| format!("download request failed for {name}: {e}"))?
         .error_for_status()
@@ -332,15 +363,30 @@ async fn verify_sha256sums(dest: &Path) -> Result<(), String> {
         }
         let name = raw.trim().trim_start_matches('*').trim_start_matches("./");
         let target = safe_target(dest, name)?;
-        let bytes = fs::read(&target)
+        let actual = sha256_of_file(&target)
             .await
             .map_err(|e| format!("read {name} for SHA256 failed: {e}"))?;
-        let actual = format!("{:x}", Sha256::digest(&bytes));
         if actual != expected.to_lowercase() {
             return Err(format!("sha256 mismatch for {name}"));
         }
     }
     Ok(())
+}
+
+/// Hash a file in fixed-size chunks; weights run 50+ GB and must never be
+/// pulled into memory whole.
+async fn sha256_of_file(path: &Path) -> Result<String, String> {
+    let mut file = fs::File::open(path).await.map_err(|e| e.to_string())?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 4 * 1024 * 1024];
+    loop {
+        let n = file.read(&mut buf).await.map_err(|e| e.to_string())?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn file_name(file: &SessionFile) -> String {

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -35,9 +35,20 @@ pub struct MlxRuntimeStatus {
 pub const MLX_PORT: u16 = 8089;
 pub const LOCAL_BASE_URL: &str = "http://127.0.0.1:8089/v1";
 
+/// Marker dropped at the start of a snapshot download and removed only after
+/// every file has landed and verified. While it exists the snapshot must not
+/// be treated as serveable.
+pub const INCOMPLETE_MARKER: &str = ".understudy-snapshot.incomplete";
+
 fn models_dir() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".understudy").join("models"))
+}
+
+/// A snapshot dir is serveable once config.json exists and the download's
+/// incomplete marker is gone (config.json downloads long before the weights).
+fn snapshot_ready(dir: &Path) -> bool {
+    dir.join("config.json").exists() && !dir.join(INCOMPLETE_MARKER).exists()
 }
 
 /// List every local model snapshot that looks MLX-loadable (has a config.json).
@@ -54,7 +65,7 @@ pub fn list() -> Vec<ModelInfo> {
                 continue;
             }
             let real = std::fs::canonicalize(entry.path()).unwrap_or_else(|_| entry.path());
-            if !real.join("config.json").exists() {
+            if !snapshot_ready(&real) {
                 continue;
             }
             out.push(ModelInfo {
@@ -76,7 +87,7 @@ pub fn snapshots() -> Vec<SnapshotInfo> {
         let Some(dir) = root.as_ref().map(|root| root.join(&row.id)) else {
             continue;
         };
-        row.cached = dir.join("config.json").exists();
+        row.cached = snapshot_ready(&dir);
         row.manifest = dir.join("understudy.serving.json").exists();
         if row.cached {
             row.path = Some(dir.to_string_lossy().into_owned());
@@ -118,4 +129,37 @@ fn dir_size_gb(p: &Path) -> f32 {
         }
     }
     total as f32 / (1024.0 * 1024.0 * 1024.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_snapshot_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "understudy-models-test-{}-{tag}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn snapshot_ready_requires_config_json() {
+        let dir = temp_snapshot_dir("no-config");
+        assert!(!snapshot_ready(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn snapshot_ready_rejects_incomplete_download() {
+        let dir = temp_snapshot_dir("incomplete");
+        std::fs::write(dir.join("config.json"), "{}").unwrap();
+        std::fs::write(dir.join(INCOMPLETE_MARKER), "model_id=x\n").unwrap();
+        assert!(!snapshot_ready(&dir));
+        std::fs::remove_file(dir.join(INCOMPLETE_MARKER)).unwrap();
+        assert!(snapshot_ready(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{Instant, SystemTime};
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -99,6 +99,13 @@ struct ServingServer {
     required_flags: Option<Vec<String>>,
 }
 
+/// Lock with poison recovery: a panic in one holder must not brick every
+/// later status/snapshot call. Slot bookkeeping stays consistent across any
+/// single mutation, so taking the inner value is safe.
+fn locked<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
 fn expand_home(value: &str) -> String {
     if let Some(rest) = value.strip_prefix("~/") {
         if let Some(home) = std::env::var_os("HOME") {
@@ -181,47 +188,28 @@ impl Residency {
     }
 
     fn alloc_id(&self) -> u32 {
-        let mut g = self.next_id.lock().unwrap();
+        let mut g = locked(&self.next_id);
         *g += 1;
         *g
     }
+    /// Hands out the current port and advances, so the first slot on a fresh
+    /// launch binds MLX_PORT itself — the port LOCAL_BASE_URL advertises.
     fn alloc_port(&self) -> u16 {
-        let mut g = self.next_port.lock().unwrap();
+        let mut g = locked(&self.next_port);
+        let port = *g;
         *g += 1;
-        *g
+        port
     }
 
     pub fn snapshot(&self) -> ResidencySnapshot {
-        let inner = self.inner.lock().unwrap();
-        let mut used = 0.0;
-        let slots = inner
-            .iter()
-            .map(|r| {
-                if matches!(r.state, SlotState::Warm) {
-                    used += r.mem_gb;
-                }
-                SlotView {
-                    id: r.id,
-                    model_id: r.model_id.clone(),
-                    state: r.state.as_str().to_string(),
-                    port: r.port,
-                    mem_gb: r.mem_gb,
-                    load_ms: r.load_ms,
-                    thinking: r.thinking,
-                }
-            })
-            .collect();
-        ResidencySnapshot {
-            slots,
-            used_gb: used,
-            usable_gb: self.usable_gb,
-        }
+        let inner = locked(&self.inner);
+        self.snapshot_from(&inner)
     }
 
     /// Add an empty slot; returns its id.
     pub fn add_slot(&self) -> u32 {
         let id = self.alloc_id();
-        self.inner.lock().unwrap().push(Resident {
+        locked(&self.inner).push(Resident {
             id,
             model_id: None,
             model_path: None,
@@ -241,7 +229,7 @@ impl Residency {
             .into_iter()
             .find(|m| m.id == model_id)
             .ok_or_else(|| anyhow::anyhow!("model not found: {model_id}"))?;
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = locked(&self.inner);
         let r = inner
             .iter_mut()
             .find(|r| r.id == slot_id)
@@ -262,7 +250,7 @@ impl Residency {
     }
 
     pub fn set_thinking(&self, slot_id: u32, thinking: bool) -> anyhow::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = locked(&self.inner);
         let r = inner
             .iter_mut()
             .find(|r| r.id == slot_id)
@@ -275,7 +263,7 @@ impl Residency {
     }
 
     pub fn is_warm(&self, slot_id: u32) -> anyhow::Result<bool> {
-        let inner = self.inner.lock().unwrap();
+        let inner = locked(&self.inner);
         let r = inner
             .iter()
             .find(|r| r.id == slot_id)
@@ -284,7 +272,7 @@ impl Residency {
     }
 
     pub fn remove(&self, slot_id: u32) -> anyhow::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = locked(&self.inner);
         if let Some(idx) = inner.iter().position(|r| r.id == slot_id) {
             if let Some(child) = inner[idx].child.as_mut() {
                 let _ = child.kill();
@@ -297,7 +285,7 @@ impl Residency {
 
     /// Resolve a warm slot's endpoint + model path for chat.
     pub fn endpoint(&self, slot_id: u32) -> Option<(u16, String)> {
-        let inner = self.inner.lock().unwrap();
+        let inner = locked(&self.inner);
         inner.iter().find(|r| r.id == slot_id).and_then(|r| {
             if matches!(r.state, SlotState::Warm) {
                 r.port.zip(r.model_path.clone()).map(|(p, path)| (p, path))
@@ -312,7 +300,7 @@ impl Residency {
         &self,
         exclude_slot_id: Option<u32>,
     ) -> Option<(u32, u16, String, String)> {
-        let inner = self.inner.lock().unwrap();
+        let inner = locked(&self.inner);
         let candidates: Vec<_> = inner
             .iter()
             .filter(|r| {
@@ -345,7 +333,7 @@ impl Residency {
     pub fn warm(&self, app: &AppHandle, slot_id: u32) -> anyhow::Result<()> {
         // 1. Validate, reserve a port, flip to Loading (one short-lived borrow).
         let (port, model_id, model_path, mem_gb, thinking) = {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = locked(&self.inner);
             let r = inner
                 .iter_mut()
                 .find(|r| r.id == slot_id)
@@ -376,7 +364,7 @@ impl Residency {
         {
             Ok(child) => child,
             Err(err) => {
-                let mut inner = self.inner.lock().unwrap();
+                let mut inner = locked(&self.inner);
                 if let Some(r) = inner.iter_mut().find(|r| r.id == slot_id) {
                     r.child = None;
                     r.state = SlotState::Error;
@@ -388,7 +376,7 @@ impl Residency {
             }
         };
         {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = locked(&self.inner);
             if let Some(r) = inner.iter_mut().find(|r| r.id == slot_id) {
                 r.child = Some(child);
             }
@@ -401,13 +389,18 @@ impl Residency {
             let ready = wait_ready(port).await;
             let load_ms = started.elapsed().as_millis() as u64;
             let residency = app.state::<Residency>();
-            let mut inner = residency.inner.lock().unwrap();
+            let mut inner = locked(&residency.inner);
             if let Some(r) = inner.iter_mut().find(|r| r.id == slot_id) {
                 if ready {
                     r.state = SlotState::Warm;
                     r.load_ms = Some(load_ms);
                     r.last_used = Instant::now();
-                } else if r.child.is_some() {
+                } else if let Some(mut child) = r.child.take() {
+                    // The server may still be loading weights; kill it so a
+                    // timed-out slot doesn't keep tens of GB resident while
+                    // showing as Error.
+                    let _ = child.kill();
+                    let _ = child.wait();
                     r.state = SlotState::Error;
                 } else {
                     r.state = SlotState::Stopped;
@@ -428,7 +421,7 @@ impl Residency {
     }
 
     pub fn cool(&self, slot_id: u32) -> anyhow::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = locked(&self.inner);
         self.cool_locked(&mut inner, slot_id)
     }
 
@@ -444,10 +437,15 @@ impl Residency {
         Ok(())
     }
 
-    fn used_gb_locked(&self, inner: &Vec<Resident>) -> f32 {
+    /// Memory attributed to slots other than `exclude`: warm slots hold their
+    /// weights and loading slots are about to, so both count against the
+    /// budget — otherwise two models can pass the fit check while one is
+    /// still loading.
+    fn used_gb_locked(&self, inner: &[Resident], exclude: Option<u32>) -> f32 {
         inner
             .iter()
-            .filter(|r| matches!(r.state, SlotState::Warm))
+            .filter(|r| Some(r.id) != exclude)
+            .filter(|r| matches!(r.state, SlotState::Warm | SlotState::Loading))
             .map(|r| r.mem_gb)
             .sum()
     }
@@ -455,8 +453,8 @@ impl Residency {
     /// Evict least-recently-used warm slots (never `slot_id`) until `need_gb` fits.
     fn evict_until_fits(&self, slot_id: u32, need_gb: f32) {
         loop {
-            let mut inner = self.inner.lock().unwrap();
-            if self.used_gb_locked(&inner) + need_gb <= self.usable_gb {
+            let mut inner = locked(&self.inner);
+            if self.used_gb_locked(&inner, Some(slot_id)) + need_gb <= self.usable_gb {
                 return;
             }
             let victim = inner
@@ -473,23 +471,18 @@ impl Residency {
         }
     }
 
-    fn snapshot_from(&self, inner: &Vec<Resident>) -> ResidencySnapshot {
-        let mut used = 0.0;
+    fn snapshot_from(&self, inner: &[Resident]) -> ResidencySnapshot {
+        let used = self.used_gb_locked(inner, None);
         let slots = inner
             .iter()
-            .map(|r| {
-                if matches!(r.state, SlotState::Warm) {
-                    used += r.mem_gb;
-                }
-                SlotView {
-                    id: r.id,
-                    model_id: r.model_id.clone(),
-                    state: r.state.as_str().to_string(),
-                    port: r.port,
-                    mem_gb: r.mem_gb,
-                    load_ms: r.load_ms,
-                    thinking: r.thinking,
-                }
+            .map(|r| SlotView {
+                id: r.id,
+                model_id: r.model_id.clone(),
+                state: r.state.as_str().to_string(),
+                port: r.port,
+                mem_gb: r.mem_gb,
+                load_ms: r.load_ms,
+                thinking: r.thinking,
             })
             .collect();
         ResidencySnapshot {
@@ -501,7 +494,7 @@ impl Residency {
 
     /// Persist the current plan (which slots exist + which should be warm).
     pub fn persist(&self, app: &AppHandle) {
-        let inner = self.inner.lock().unwrap();
+        let inner = locked(&self.inner);
         let rows: Vec<PersistedSlot> = inner
             .iter()
             .enumerate()
@@ -526,13 +519,16 @@ impl Residency {
             return;
         }
         let max_id = rows.iter().map(|r| r.slot_id).max().unwrap_or(0);
-        let max_port = rows
+        // Next allocation hands out this value directly, so start one past
+        // the highest restored port (or at MLX_PORT when none had one).
+        let next_port = rows
             .iter()
             .filter_map(|r| r.port)
             .max()
-            .unwrap_or(MLX_PORT - 1);
+            .map(|p| p + 1)
+            .unwrap_or(MLX_PORT);
         {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = locked(&self.inner);
             for r in &rows {
                 inner.push(Resident {
                     id: r.slot_id,
@@ -547,8 +543,8 @@ impl Residency {
                     child: None,
                 });
             }
-            *self.next_id.lock().unwrap() = max_id;
-            *self.next_port.lock().unwrap() = max_port;
+            *locked(&self.next_id) = max_id;
+            *locked(&self.next_port) = next_port;
         }
         // Re-warm the previously-warm set (best-effort, background).
         for r in rows.into_iter().filter(|r| r.warm) {
@@ -581,3 +577,64 @@ async fn wait_ready(port: u16) -> bool {
 
 #[allow(dead_code)]
 fn _unused(_: SystemTime) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resident(id: u32, state: SlotState, mem_gb: f32) -> Resident {
+        Resident {
+            id,
+            model_id: Some(format!("model-{id}")),
+            model_path: Some(format!("/tmp/model-{id}")),
+            state,
+            port: None,
+            mem_gb,
+            thinking: false,
+            load_ms: None,
+            last_used: Instant::now(),
+            child: None,
+        }
+    }
+
+    #[test]
+    fn first_port_matches_advertised_base_url() {
+        let residency = Residency::new(64);
+        assert_eq!(residency.alloc_port(), MLX_PORT);
+        assert_eq!(residency.alloc_port(), MLX_PORT + 1);
+        assert!(models::LOCAL_BASE_URL.contains(&MLX_PORT.to_string()));
+    }
+
+    #[test]
+    fn loading_slots_count_against_budget() {
+        let residency = Residency::new(64);
+        {
+            let mut inner = locked(&residency.inner);
+            inner.push(resident(1, SlotState::Warm, 16.0));
+            inner.push(resident(2, SlotState::Loading, 16.0));
+            inner.push(resident(3, SlotState::Error, 16.0));
+            inner.push(resident(4, SlotState::Stopped, 16.0));
+        }
+        let inner = locked(&residency.inner);
+        assert_eq!(residency.used_gb_locked(&inner, None), 32.0);
+        // The fit check for a slot must not double-count that slot itself.
+        assert_eq!(residency.used_gb_locked(&inner, Some(2)), 16.0);
+        drop(inner);
+        assert_eq!(residency.snapshot().used_gb, 32.0);
+    }
+
+    #[test]
+    fn poisoned_lock_does_not_brick_snapshots() {
+        let residency = std::sync::Arc::new(Residency::new(64));
+        locked(&residency.inner).push(resident(1, SlotState::Warm, 8.0));
+        let clone = residency.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = clone.inner.lock().unwrap();
+            panic!("poison the residency lock");
+        })
+        .join();
+        let snap = residency.snapshot();
+        assert_eq!(snap.slots.len(), 1);
+        assert_eq!(snap.used_gb, 8.0);
+    }
+}


### PR DESCRIPTION
## What changed

A code review of the desktop app's first-run flow (`apps/homescreen/src-tauri/src`) confirmed seven failure modes around model downloads and warm-slot residency. This PR fixes all of them in `bootstrap.rs`, `models.rs`, and `residency.rs`.

### Download integrity (bootstrap.rs, models.rs)

- **Partial downloads no longer look serveable.** `download_model` already dropped a `.understudy-snapshot.incomplete` marker, but nothing read it — `models::list()`/`snapshots()` gated presence on `config.json`, which downloads long before the safetensors. A new `snapshot_ready()` helper requires `config.json` present *and* the marker absent; the marker filename is now a shared `models::INCOMPLETE_MARKER` constant.
- **Download timeouts.** Both bare `reqwest::get` calls now go through a client with a 20s connect timeout and a 60s `read_timeout` (per socket read, so multi-hour 50 GB transfers still work but a stalled connection errors within a minute and surfaces a `DownloadEvent::Error`).
- **Streamed SHA-256.** `verify_sha256sums` used `fs::read` + `Sha256::digest` on whole files, which OOMs on the 52–62 GB bf16 rungs. A new `sha256_of_file()` hashes in 4 MB chunks.
- **Cached files are hash-verified.** The size-matching cache heuristic now hash-verifies existing files when the manifest carries a `sha256`; a mismatch falls through to re-download. Size-only matching remains for entries with no hash.

### Warm-slot residency (residency.rs)

- **Warm-timeout leak.** When `wait_ready` times out, the spawned mlx server child is now killed and reaped before the slot flips to Error — previously it finished loading later and invisibly held tens of GB. The memory budget now counts Loading slots alongside Warm ones (so two 16 GB models can't pass the fit check concurrently), with the slot being warmed excluded from its own fit check to avoid double-counting.
- **Lock poisoning.** All ~15 `.lock().unwrap()` sites go through a `locked()` helper that recovers via `PoisonError::into_inner`. Note for reviewers: the review suggested erroring like `chat.rs` does, but an error-on-poison would still leave the Status pane failing on every subsequent snapshot; recovery keeps residency functional, and slot bookkeeping has no cross-call invariants poisoning could break.
- **Port mismatch.** `LOCAL_BASE_URL` advertises 8089 but `alloc_port` pre-incremented, so the first slot on a fresh launch bound 8090. `alloc_port` now hands out the current value and post-increments (first slot binds 8089), and `restore` sets `next_port` to one past the highest restored port.

## Tests

Five new unit tests: incomplete-marker gating (models.rs ×2), first-port/base-URL agreement, Loading-counts-in-budget with self-exclusion, and poisoned-lock recovery (residency.rs ×3).

`cargo check`, `cargo test` (8/8), and `cargo fmt` pass; `cargo clippy` warnings went from 25 to 23 (the remaining warnings in touched files pre-date this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->