### PR TITLE
Fix Fusion benchmark scoring, event correlation, and dry-run pollution

### DIFF
--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -1704,7 +1704,7 @@ fn prompt_excerpt(prompt: &str) -> String {
     format!("{}…", &trimmed[..end])
 }
 
-fn approximate_token_count(text: &str) -> u64 {
+pub(crate) fn approximate_token_count(text: &str) -> u64 {
     text.split_whitespace().count() as u64
 }
 

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -552,6 +552,9 @@ fn avg(values: &[f64]) -> Option<f64> {
     }
 }
 
+/// Scores a benchmark row against its rubric. Returns `None` when the
+/// (task, mode) pair has no rubric — such rows stay unscored so averages and
+/// best-mode selection only consider rubric-covered combinations.
 fn fusion_benchmark_score(
     task_id: &str,
     mode: &str,
@@ -560,58 +563,33 @@ fn fusion_benchmark_score(
     sidekick_runs: u64,
     status: &str,
     content: &str,
-) -> f64 {
+) -> Option<f64> {
+    let passed = match (task_id, mode) {
+        ("long-context-routing" | "frontier-upgrade-trigger", "sidekick-routing") => {
+            effective_route == "gateway" && !policy_sidekick
+        }
+        ("judgment-boundary", "sidekick-routing") => !policy_sidekick && sidekick_runs == 0,
+        (
+            "repo-search-summary"
+            | "runtime-status-check"
+            | "repo-open-grounding"
+            | "mcp-surface-check"
+            | "skill-lookup"
+            | "automationbench-api-discovery"
+            | "automationbench-state-verification"
+            | "automationbench-tool-risk"
+            | "automationbench-cost-latency",
+            "sidekick-routing",
+        ) => effective_route == "local" && policy_sidekick,
+        ("automationbench-domain-routing", "sidekick-routing") => {
+            !policy_sidekick && (effective_route == "local" || effective_route == "gateway")
+        }
+        _ => return None,
+    };
     if status != "ok" || content.trim().is_empty() {
-        return 0.0;
+        return Some(0.0);
     }
-    match task_id {
-        "long-context-routing" if mode == "sidekick-routing" => {
-            if effective_route == "gateway" && !policy_sidekick {
-                1.0
-            } else {
-                0.0
-            }
-        }
-        "frontier-upgrade-trigger" if mode == "sidekick-routing" => {
-            if effective_route == "gateway" && !policy_sidekick {
-                1.0
-            } else {
-                0.0
-            }
-        }
-        "judgment-boundary" if mode == "sidekick-routing" => {
-            if !policy_sidekick && sidekick_runs == 0 {
-                1.0
-            } else {
-                0.0
-            }
-        }
-        "repo-search-summary"
-        | "runtime-status-check"
-        | "repo-open-grounding"
-        | "mcp-surface-check"
-        | "skill-lookup"
-        | "automationbench-api-discovery"
-        | "automationbench-state-verification"
-        | "automationbench-tool-risk"
-        | "automationbench-cost-latency"
-            if mode == "sidekick-routing" =>
-        {
-            if effective_route == "local" && policy_sidekick {
-                1.0
-            } else {
-                0.0
-            }
-        }
-        "automationbench-domain-routing" if mode == "sidekick-routing" => {
-            if !policy_sidekick && (effective_route == "local" || effective_route == "gateway") {
-                1.0
-            } else {
-                0.0
-            }
-        }
-        _ => 1.0,
-    }
+    Some(if passed { 1.0 } else { 0.0 })
 }
 
 fn prompt_excerpt(prompt: &str) -> String {
@@ -1268,6 +1246,17 @@ pub fn fusion_route_recommendation(
     app: AppHandle,
     request: FusionRouteRecommendationRequest,
 ) -> FusionRouteRecommendation {
+    fusion_route_recommendation_with_persist(app, request, true)
+}
+
+/// `persist_decision: false` computes the recommendation without recording a
+/// fusion_route_decisions row — used by benchmark dry runs so planning never
+/// pollutes exported routing evidence.
+pub fn fusion_route_recommendation_with_persist(
+    app: AppHandle,
+    request: FusionRouteRecommendationRequest,
+    persist_decision: bool,
+) -> FusionRouteRecommendation {
     let snapshot = residency(&app).snapshot();
     let active_slot = request.active_slot_id.and_then(|slot_id| {
         snapshot
@@ -1555,6 +1544,9 @@ pub fn fusion_route_recommendation(
         sidekick_ready,
         gateway_ready,
     };
+    if !persist_decision {
+        return recommendation;
+    }
     let _ = app
         .state::<crate::db::Db>()
         .record_fusion_route_decision(&FusionRouteDecisionInput {
@@ -1573,7 +1565,7 @@ pub fn fusion_route_recommendation(
             local_ready: recommendation.local_ready,
             sidekick_ready: recommendation.sidekick_ready,
             gateway_ready: recommendation.gateway_ready,
-            prompt_tokens: prompt.split_whitespace().count() as u64,
+            prompt_tokens: crate::chat::approximate_token_count(prompt),
             local_mem_gb: (local_mem_gb > 0.0).then_some(local_mem_gb),
         });
     recommendation
@@ -2076,7 +2068,7 @@ pub async fn run_fusion_benchmark(
     app: AppHandle,
     request: RunFusionBenchmarkRequest,
 ) -> Result<FusionBenchmarkRun, String> {
-    run_fusion_benchmark_inner(app, request, None, None).await
+    run_fusion_benchmark_inner(app, request, None, None, None).await
 }
 
 async fn run_fusion_benchmark_inner(
@@ -2084,12 +2076,16 @@ async fn run_fusion_benchmark_inner(
     request: RunFusionBenchmarkRequest,
     candidate_label: Option<&str>,
     on_event: Option<&Channel<FusionEvalEvent>>,
+    event_run_id: Option<&str>,
 ) -> Result<FusionBenchmarkRun, String> {
     let matrix = fusion_benchmark_matrix();
     let run_id = request.run_id.unwrap_or_else(default_fusion_run_id);
     if run_id.trim().is_empty() {
         return Err("run_id is required".to_string());
     }
+    // Matrix runs persist rows under a candidate-suffixed run id but emit
+    // events under the parent run id so the frontend can correlate them.
+    let event_run_id = event_run_id.unwrap_or(&run_id).to_string();
     let candidate = request
         .candidate
         .unwrap_or_else(|| "local-main".to_string());
@@ -2168,7 +2164,7 @@ async fn run_fusion_benchmark_inner(
         for mode in &requested_modes {
             let recommendation =
                 (mode == "sidekick-routing" && candidate != "gateway-glm").then(|| {
-                    fusion_route_recommendation(
+                    fusion_route_recommendation_with_persist(
                         app.clone(),
                         FusionRouteRecommendationRequest {
                             prompt: task.prompt.to_string(),
@@ -2176,6 +2172,7 @@ async fn run_fusion_benchmark_inner(
                             active_slot_id: main_slot_id,
                             session_id: Some(run_id.clone()),
                         },
+                        !dry_run,
                     )
                 });
             let effective_route = recommendation
@@ -2222,7 +2219,7 @@ async fn run_fusion_benchmark_inner(
             };
             if let Some(on_event) = on_event {
                 let _ = on_event.send(FusionEvalEvent::RowStarted {
-                    run_id: run_id.clone(),
+                    run_id: event_run_id.clone(),
                     candidate: candidate_label.unwrap_or(&candidate).to_string(),
                     task_id: task.id.to_string(),
                     mode: mode.clone(),
@@ -2278,6 +2275,15 @@ async fn run_fusion_benchmark_inner(
                 let result = match result {
                     Ok(result) => result,
                     Err(err) => {
+                        let error_score = fusion_benchmark_score(
+                            task.id,
+                            mode,
+                            effective_route,
+                            policy_sidekick,
+                            sidekick_run_count,
+                            "error",
+                            "",
+                        );
                         app.state::<crate::db::Db>()
                             .record_fusion_benchmark(&FusionBenchmarkInput {
                                 run_id: run_id.clone(),
@@ -2285,17 +2291,18 @@ async fn run_fusion_benchmark_inner(
                                 mode: mode.clone(),
                                 model: effective_model.clone(),
                                 elapsed_ms: None,
-                                prompt_tokens: Some(task.prompt.split_whitespace().count() as u64),
+                                // Token columns hold approximate token counts from
+                                // executed calls; rows that never executed stay None
+                                // so unit-mismatched word counts don't skew averages.
+                                prompt_tokens: None,
                                 completion_tokens: None,
                                 sidekick_runs: sidekick_run_count,
                                 sidekick_tool_calls,
                                 gateway_used: effective_route == "gateway",
                                 compacted: false,
-                                context_tokens_before: Some(
-                                    task.prompt.split_whitespace().count() as u64
-                                ),
+                                context_tokens_before: None,
                                 local_mem_gb: effective_local_mem_gb,
-                                score: Some(0.0),
+                                score: error_score,
                                 status: "error".to_string(),
                                 notes: Some(format!(
                                     "error:{}; status=error; policy_reason={}; error={}",
@@ -2307,14 +2314,14 @@ async fn run_fusion_benchmark_inner(
                             .map_err(|e| e.to_string())?;
                         if let Some(on_event) = on_event {
                             let _ = on_event.send(FusionEvalEvent::RowFinished {
-                                run_id: run_id.clone(),
+                                run_id: event_run_id.clone(),
                                 candidate: candidate_label.unwrap_or(&candidate).to_string(),
                                 task_id: task.id.to_string(),
                                 mode: mode.clone(),
                                 route: effective_route.to_string(),
                                 model: effective_model.clone(),
                                 status: "error".to_string(),
-                                score: Some(0.0),
+                                score: error_score,
                                 elapsed_ms: None,
                                 sidekick_runs: sidekick_run_count,
                                 sidekick_tool_calls,
@@ -2330,7 +2337,7 @@ async fn run_fusion_benchmark_inner(
                         continue;
                     }
                 };
-                let score = Some(fusion_benchmark_score(
+                let score = fusion_benchmark_score(
                     task.id,
                     mode,
                     effective_route,
@@ -2338,7 +2345,7 @@ async fn run_fusion_benchmark_inner(
                     sidekick_run_count,
                     &result.status,
                     &result.content,
-                ));
+                );
                 app.state::<crate::db::Db>()
                     .record_fusion_benchmark(&FusionBenchmarkInput {
                         run_id: run_id.clone(),
@@ -2369,7 +2376,7 @@ async fn run_fusion_benchmark_inner(
                     .map_err(|e| e.to_string())?;
                 if let Some(on_event) = on_event {
                     let _ = on_event.send(FusionEvalEvent::RowFinished {
-                        run_id: run_id.clone(),
+                        run_id: event_run_id.clone(),
                         candidate: candidate_label.unwrap_or(&candidate).to_string(),
                         task_id: task.id.to_string(),
                         mode: mode.clone(),
@@ -2392,13 +2399,15 @@ async fn run_fusion_benchmark_inner(
                         mode: mode.clone(),
                         model: effective_model.clone(),
                         elapsed_ms: None,
-                        prompt_tokens: Some(task.prompt.split_whitespace().count() as u64),
+                        // Non-executed rows keep token columns None; see the error
+                        // path above.
+                        prompt_tokens: None,
                         completion_tokens: None,
                         sidekick_runs: 0,
                         sidekick_tool_calls: 0,
                         gateway_used: effective_route == "gateway",
                         compacted: false,
-                        context_tokens_before: Some(task.prompt.split_whitespace().count() as u64),
+                        context_tokens_before: None,
                         local_mem_gb: effective_local_mem_gb,
                         score: None,
                         status: "skipped".to_string(),
@@ -2408,7 +2417,7 @@ async fn run_fusion_benchmark_inner(
                 recorded_skips += 1;
                 if let Some(on_event) = on_event {
                     let _ = on_event.send(FusionEvalEvent::RowFinished {
-                        run_id: run_id.clone(),
+                        run_id: event_run_id.clone(),
                         candidate: candidate_label.unwrap_or(&candidate).to_string(),
                         task_id: task.id.to_string(),
                         mode: mode.clone(),
@@ -2426,7 +2435,7 @@ async fn run_fusion_benchmark_inner(
             } else if dry_run {
                 if let Some(on_event) = on_event {
                     let _ = on_event.send(FusionEvalEvent::RowFinished {
-                        run_id: run_id.clone(),
+                        run_id: event_run_id.clone(),
                         candidate: candidate_label.unwrap_or(&candidate).to_string(),
                         task_id: task.id.to_string(),
                         mode: mode.clone(),
@@ -2481,59 +2490,7 @@ pub async fn run_fusion_benchmark_matrix(
     app: AppHandle,
     request: RunFusionBenchmarkMatrixRequest,
 ) -> Result<FusionBenchmarkMatrixRun, String> {
-    let run_id = request.run_id.unwrap_or_else(default_fusion_run_id);
-    if run_id.trim().is_empty() {
-        return Err("run_id is required".to_string());
-    }
-    let suite = request.suite.unwrap_or_else(|| "full-matrix".to_string());
-    let candidates = request.candidates.unwrap_or_else(|| {
-        vec![
-            "gateway-glm".to_string(),
-            "local-main".to_string(),
-            "local-fast".to_string(),
-        ]
-    });
-    for candidate in &candidates {
-        if !valid_fusion_candidate(candidate) {
-            return Err(format!("unknown Fusion benchmark candidate: {candidate}"));
-        }
-    }
-    let dry_run = request.dry_run.unwrap_or(true);
-    let mut runs = vec![];
-    let mut rows = 0u64;
-    let mut recorded_skips = 0u64;
-    for candidate in candidates {
-        let candidate_run_id = format!("{run_id}-{candidate}");
-        let run = run_fusion_benchmark_inner(
-            app.clone(),
-            RunFusionBenchmarkRequest {
-                run_id: Some(candidate_run_id),
-                suite: Some(suite.clone()),
-                candidate: Some(candidate.clone()),
-                route: None,
-                modes: request.modes.clone(),
-                task_ids: request.task_ids.clone(),
-                model: None,
-                dry_run: Some(dry_run),
-                record_skips: request.record_skips,
-            },
-            Some(&candidate),
-            None,
-        )
-        .await?;
-        rows += run.rows.len() as u64;
-        recorded_skips += run.recorded_skips;
-        runs.push(FusionBenchmarkCandidateRun { candidate, run });
-    }
-    Ok(FusionBenchmarkMatrixRun {
-        schema_version: "understudy.fusion_benchmark_matrix_run.v1",
-        run_id,
-        suite,
-        dry_run,
-        candidates: runs,
-        rows,
-        recorded_skips,
-    })
+    run_fusion_benchmark_matrix_impl(app, request, None).await
 }
 
 #[tauri::command]
@@ -2541,6 +2498,14 @@ pub async fn run_fusion_benchmark_matrix_live(
     app: AppHandle,
     request: RunFusionBenchmarkMatrixRequest,
     on_event: Channel<FusionEvalEvent>,
+) -> Result<FusionBenchmarkMatrixRun, String> {
+    run_fusion_benchmark_matrix_impl(app, request, Some(&on_event)).await
+}
+
+async fn run_fusion_benchmark_matrix_impl(
+    app: AppHandle,
+    request: RunFusionBenchmarkMatrixRequest,
+    on_event: Option<&Channel<FusionEvalEvent>>,
 ) -> Result<FusionBenchmarkMatrixRun, String> {
     let run_id = request.run_id.unwrap_or_else(default_fusion_run_id);
     if run_id.trim().is_empty() {
@@ -2559,27 +2524,36 @@ pub async fn run_fusion_benchmark_matrix_live(
             return Err(format!("unknown Fusion benchmark candidate: {candidate}"));
         }
     }
-    let dry_run = request.dry_run.unwrap_or(false);
-    let (suite_modes, suite_tasks) = fusion_benchmark_suite(Some(&suite))?;
-    let requested_modes = request.modes.clone().unwrap_or(suite_modes);
-    let requested_tasks = request.task_ids.clone().unwrap_or(suite_tasks);
-    let planned_rows = (candidates.len() * requested_modes.len() * requested_tasks.len()) as u64;
-    let _ = on_event.send(FusionEvalEvent::RunStarted {
-        run_id: run_id.clone(),
-        suite: suite.clone(),
-        candidates: candidates.clone(),
-        rows: planned_rows,
-    });
+    // Planning is the safe default; callers must opt into spending tokens.
+    let dry_run = request.dry_run.unwrap_or(true);
+    if let Some(on_event) = on_event {
+        let (suite_modes, suite_tasks) = fusion_benchmark_suite(Some(&suite))?;
+        let mode_count = request.modes.as_ref().map_or(suite_modes.len(), Vec::len);
+        let task_count = request
+            .task_ids
+            .as_ref()
+            .map_or(suite_tasks.len(), Vec::len);
+        let _ = on_event.send(FusionEvalEvent::RunStarted {
+            run_id: run_id.clone(),
+            suite: suite.clone(),
+            candidates: candidates.clone(),
+            rows: (candidates.len() * mode_count * task_count) as u64,
+        });
+    }
 
     let mut runs = vec![];
     let mut rows = 0u64;
     let mut recorded_skips = 0u64;
     for candidate in candidates {
+        // Result rows persist under the candidate-suffixed run id; every
+        // emitted event carries the parent run_id plus the candidate field.
         let candidate_run_id = format!("{run_id}-{candidate}");
-        let _ = on_event.send(FusionEvalEvent::CandidateStarted {
-            run_id: candidate_run_id.clone(),
-            candidate: candidate.clone(),
-        });
+        if let Some(on_event) = on_event {
+            let _ = on_event.send(FusionEvalEvent::CandidateStarted {
+                run_id: run_id.clone(),
+                candidate: candidate.clone(),
+            });
+        }
         let run = match run_fusion_benchmark_inner(
             app.clone(),
             RunFusionBenchmarkRequest {
@@ -2594,39 +2568,52 @@ pub async fn run_fusion_benchmark_matrix_live(
                 record_skips: request.record_skips,
             },
             Some(&candidate),
-            Some(&on_event),
+            on_event,
+            Some(&run_id),
         )
         .await
         {
             Ok(run) => run,
             Err(err) => {
-                let _ = on_event.send(FusionEvalEvent::Error {
-                    run_id: candidate_run_id,
-                    message: err.clone(),
-                });
+                if let Some(on_event) = on_event {
+                    let _ = on_event.send(FusionEvalEvent::Error {
+                        run_id: run_id.clone(),
+                        message: format!("candidate {candidate}: {err}"),
+                    });
+                }
                 return Err(err);
             }
         };
         rows += run.rows.len() as u64;
         recorded_skips += run.recorded_skips;
-        let _ = on_event.send(FusionEvalEvent::CandidateFinished {
-            run_id: run.run_id.clone(),
-            candidate: candidate.clone(),
-            rows: run.rows.len() as u64,
-        });
+        if let Some(on_event) = on_event {
+            let _ = on_event.send(FusionEvalEvent::CandidateFinished {
+                run_id: run_id.clone(),
+                candidate: candidate.clone(),
+                rows: run.rows.len() as u64,
+            });
+        }
         runs.push(FusionBenchmarkCandidateRun { candidate, run });
     }
-    let avg_score = fusion_benchmark_run_summary(app.clone(), Some(200))
-        .ok()
-        .and_then(|summary| summary.runs.into_iter().find(|run| run.run_id == run_id))
-        .and_then(|run| run.avg_score);
-    let _ = on_event.send(FusionEvalEvent::RunFinished {
-        run_id: run_id.clone(),
-        suite: suite.clone(),
-        rows,
-        recorded_skips,
-        avg_score,
-    });
+    if let Some(on_event) = on_event {
+        // Recorded rows live under the candidate-suffixed run ids, so
+        // aggregate scores across all of this run's candidates.
+        let score_values: Vec<f64> = app
+            .state::<crate::db::Db>()
+            .list_fusion_benchmarks(500)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|row| runs.iter().any(|c| c.run.run_id == row.run_id))
+            .filter_map(|row| row.score)
+            .collect();
+        let _ = on_event.send(FusionEvalEvent::RunFinished {
+            run_id: run_id.clone(),
+            suite: suite.clone(),
+            rows,
+            recorded_skips,
+            avg_score: avg(&score_values),
+        });
+    }
     Ok(FusionBenchmarkMatrixRun {
         schema_version: "understudy.fusion_benchmark_matrix_run.v1",
         run_id,
@@ -2805,4 +2792,184 @@ pub fn set_setting(app: AppHandle, key: String, value: String) -> Result<(), Str
 #[tauri::command]
 pub fn server_info(app: AppHandle) -> Option<Value> {
     crate::server::info(&app).map(|(base, token)| json!({ "base_url": base, "token": token }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fusion_benchmark_score;
+
+    #[test]
+    fn score_is_none_without_rubric() {
+        for mode in ["main-only", "sidekick-advisory", "sidekick-parallel"] {
+            assert_eq!(
+                fusion_benchmark_score("repo-search-summary", mode, "local", true, 1, "ok", "out"),
+                None,
+            );
+        }
+        assert_eq!(
+            fusion_benchmark_score(
+                "unknown-task",
+                "sidekick-routing",
+                "local",
+                true,
+                1,
+                "ok",
+                "out"
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn rubric_rows_score_zero_on_error_or_empty_output() {
+        assert_eq!(
+            fusion_benchmark_score(
+                "repo-search-summary",
+                "sidekick-routing",
+                "local",
+                true,
+                1,
+                "error",
+                "out",
+            ),
+            Some(0.0),
+        );
+        assert_eq!(
+            fusion_benchmark_score(
+                "repo-search-summary",
+                "sidekick-routing",
+                "local",
+                true,
+                1,
+                "ok",
+                "  \n",
+            ),
+            Some(0.0),
+        );
+        // Rows without a rubric stay unscored even when they fail.
+        assert_eq!(
+            fusion_benchmark_score(
+                "repo-search-summary",
+                "main-only",
+                "local",
+                false,
+                0,
+                "error",
+                ""
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn mechanical_tasks_reward_local_sidekick_delegation() {
+        assert_eq!(
+            fusion_benchmark_score(
+                "repo-search-summary",
+                "sidekick-routing",
+                "local",
+                true,
+                1,
+                "ok",
+                "out",
+            ),
+            Some(1.0),
+        );
+        assert_eq!(
+            fusion_benchmark_score(
+                "repo-search-summary",
+                "sidekick-routing",
+                "gateway",
+                false,
+                0,
+                "ok",
+                "out",
+            ),
+            Some(0.0),
+        );
+    }
+
+    #[test]
+    fn frontier_tasks_reward_gateway_without_sidekick() {
+        assert_eq!(
+            fusion_benchmark_score(
+                "long-context-routing",
+                "sidekick-routing",
+                "gateway",
+                false,
+                0,
+                "ok",
+                "out",
+            ),
+            Some(1.0),
+        );
+        assert_eq!(
+            fusion_benchmark_score(
+                "frontier-upgrade-trigger",
+                "sidekick-routing",
+                "local",
+                true,
+                1,
+                "ok",
+                "out",
+            ),
+            Some(0.0),
+        );
+    }
+
+    #[test]
+    fn judgment_boundary_rewards_main_keeping_the_task() {
+        assert_eq!(
+            fusion_benchmark_score(
+                "judgment-boundary",
+                "sidekick-routing",
+                "local",
+                false,
+                0,
+                "ok",
+                "out",
+            ),
+            Some(1.0),
+        );
+        assert_eq!(
+            fusion_benchmark_score(
+                "judgment-boundary",
+                "sidekick-routing",
+                "local",
+                false,
+                2,
+                "ok",
+                "out",
+            ),
+            Some(0.0),
+        );
+    }
+
+    #[test]
+    fn domain_routing_rewards_either_route_without_sidekick() {
+        assert_eq!(
+            fusion_benchmark_score(
+                "automationbench-domain-routing",
+                "sidekick-routing",
+                "gateway",
+                false,
+                0,
+                "ok",
+                "out",
+            ),
+            Some(1.0),
+        );
+        assert_eq!(
+            fusion_benchmark_score(
+                "automationbench-domain-routing",
+                "sidekick-routing",
+                "local",
+                true,
+                1,
+                "ok",
+                "out",
+            ),
+            Some(0.0),
+        );
+    }
 }


### PR DESCRIPTION
## What changed

Six correctness fixes in the desktop Fusion benchmark pipeline (`apps/homescreen/src-tauri/src/commands.rs`), from a code review of the scoring/matrix code:

1. **Scoring no longer defaults to perfect.** `fusion_benchmark_score` returns `Option<f64>`: `None` for (task, mode) pairs without a rubric, `Some(0.0)` for rubric-covered rows that errored or produced empty output, otherwise the rubric result. Previously every uncovered pair scored `1.0` for any non-empty output, so `main-only`/`sidekick-advisory`/`sidekick-parallel` always looked perfect and `best_mode` systematically crowned main-only. Averages (`avg_score`) now cover scored rows only, and the error-recording path uses the rubric instead of hardcoding `Some(0.0)`.
2. **`RunFinished.avg_score` was always null.** Matrix rows persist under `{run_id}-{candidate}`, but the final event looked up the parent `run_id` in the run summary, which never matched. It now aggregates scores directly from the DB across this run's candidate-suffixed run ids.
3. **Consistent event run_id.** All `FusionEvalEvent`s now carry the parent `run_id`, with the existing `candidate` field identifying the sub-run (previously RunStarted used the parent id while CandidateStarted/CandidateFinished used the suffixed id). DB rows still persist under the candidate-suffixed id. `Error` events prefix the failing candidate in the message since that variant has no candidate field.
4. **No more mixed units in token columns.** Error/skip rows stored whitespace word counts of the prompt while executed rows stored approximate token counts, skewing `avg_total_tokens`, `avg_context_tokens_before`, and `speed_index`. Non-executed rows now store `None`; the route-decision row reuses the shared `crate::chat::approximate_token_count` estimator (made `pub(crate)`).
5. **Dry runs no longer pollute routing evidence.** New `fusion_route_recommendation_with_persist` takes a persist flag; the tauri command, HTTP endpoint, and chat pipeline keep persisting, but the benchmark path passes `!dry_run`, so planning a matrix no longer writes synthetic `fusion_route_decisions` rows that later export as production routing evidence.
6. **Unified matrix executors and dry_run defaults.** `run_fusion_benchmark_matrix` and `run_fusion_benchmark_matrix_live` are now thin wrappers around a single `run_fusion_benchmark_matrix_impl(app, request, Option<&Channel>)`, and both default `dry_run` to `true` (previously the live variant defaulted to `false`, so the same JSON body planned in one and spent tokens in the other).

## Reviewer notes

- **Frontend compatibility:** event shapes are unchanged; `TrainingPane.tsx` keys live rows by `candidate:task:mode` and always passes `dry_run` explicitly, so no frontend change is needed. Anyone calling the live command without `dry_run` now gets a plan instead of a token spend (the safe direction).
- **Signal side effect:** the `sidekick_benchmark_score` routing signal averages `sidekick-parallel` scores, which were all fake 1.0s; new rows in that mode are unscored, so the `sidekick_benchmark_low` trigger (needs ≥4 scored rows) stops firing on synthetic data.
- **Historical data:** rows recorded under the old scorer keep their fake 1.0 scores; only new runs get corrected scoring, so old and new run summaries aren't directly comparable.

## Verification

- `cargo check`: clean
- `cargo clippy`: no new warnings (same 23 pre-existing before/after)
- `cargo fmt --check`: clean
- `cargo test`: 9/9 passing, including 6 new unit tests for the scorer (rubric coverage, error/empty-output zeroing, and each rubric family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->