### PR TITLE
Fix desktop persistence concurrency and sidekick transcript bugs

### DIFF
--- a/apps/homescreen/src-tauri/src/aa.rs
+++ b/apps/homescreen/src-tauri/src/aa.rs
@@ -83,7 +83,7 @@ pub async fn models(db: &Db) -> Result<Vec<AaModel>> {
 }
 
 fn cache_path(db: &Db) -> std::path::PathBuf {
-    db.0.join("aa_cache.json")
+    db.data_dir().join("aa_cache.json")
 }
 
 fn read_cache(db: &Db) -> Option<Vec<AaModel>> {

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Manager, State};
@@ -90,10 +90,67 @@ const CHAT_COMPACTION_TOKEN_THRESHOLD: u64 = 12_000;
 const CHAT_RECENT_CONTEXT_MESSAGES: usize = 12;
 const CHAT_COMPACTED_CONTEXT_PREFIX: &str = "Chat compacted context:";
 
-static SIDEKICK_SESSIONS: OnceLock<Mutex<HashMap<String, Vec<Value>>>> = OnceLock::new();
+const SIDEKICK_SESSION_CACHE_MAX: usize = 32;
 
-fn sidekick_sessions() -> &'static Mutex<HashMap<String, Vec<Value>>> {
-    SIDEKICK_SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+/// In-memory transcript cache, bounded by evicting the least-recently-used
+/// session key; evicted sessions reload from SQLite on next use.
+#[derive(Default)]
+struct SidekickSessionCache {
+    tick: u64,
+    entries: HashMap<String, (u64, Vec<Value>)>,
+}
+
+impl SidekickSessionCache {
+    fn get(&mut self, key: &str) -> Option<Vec<Value>> {
+        self.tick += 1;
+        let tick = self.tick;
+        self.entries.get_mut(key).map(|entry| {
+            entry.0 = tick;
+            entry.1.clone()
+        })
+    }
+
+    fn insert(&mut self, key: &str, messages: Vec<Value>) {
+        self.tick += 1;
+        self.entries.insert(key.to_string(), (self.tick, messages));
+        while self.entries.len() > SIDEKICK_SESSION_CACHE_MAX {
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, (tick, _))| *tick)
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+    }
+}
+
+static SIDEKICK_SESSIONS: OnceLock<Mutex<SidekickSessionCache>> = OnceLock::new();
+
+fn sidekick_sessions() -> &'static Mutex<SidekickSessionCache> {
+    SIDEKICK_SESSIONS.get_or_init(|| Mutex::new(SidekickSessionCache::default()))
+}
+
+type SessionLockMap = HashMap<String, Arc<tokio::sync::Mutex<()>>>;
+
+static SIDEKICK_SESSION_LOCKS: OnceLock<Mutex<SessionLockMap>> = OnceLock::new();
+
+/// Per-session-key async lock so a parallel sidekick and an inline
+/// delegate_to_sidekick call can't interleave load -> HTTP rounds -> save and
+/// overwrite each other's transcript.
+fn sidekick_session_lock(key: &str) -> Result<Arc<tokio::sync::Mutex<()>>, String> {
+    let mut locks = SIDEKICK_SESSION_LOCKS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .map_err(|_| "sidekick session lock map poisoned".to_string())?;
+    if locks.len() > SIDEKICK_SESSION_CACHE_MAX {
+        // Only drop locks nobody holds; an in-flight holder keeps its Arc, and
+        // recreating a held key's lock would break mutual exclusion.
+        locks.retain(|_, lock| Arc::strong_count(lock) > 1);
+    }
+    Ok(locks.entry(key.to_string()).or_default().clone())
 }
 
 fn initial_sidekick_messages(profile: &SidekickProfile) -> Vec<Value> {
@@ -109,11 +166,11 @@ fn load_sidekick_messages(
     profile: &SidekickProfile,
 ) -> Result<Vec<Value>, String> {
     {
-        let sessions = sidekick_sessions()
+        let mut sessions = sidekick_sessions()
             .lock()
             .map_err(|_| "sidekick session lock poisoned".to_string())?;
         if let Some(messages) = sessions.get(key) {
-            return Ok(messages.clone());
+            return Ok(messages);
         }
     }
     let messages = app
@@ -128,7 +185,7 @@ fn load_sidekick_messages(
         let mut sessions = sidekick_sessions()
             .lock()
             .map_err(|_| "sidekick session lock poisoned".to_string())?;
-        sessions.insert(key.to_string(), messages.clone());
+        sessions.insert(key, messages.clone());
     }
     Ok(messages)
 }
@@ -148,7 +205,7 @@ fn save_sidekick_messages(
     let mut sessions = sidekick_sessions()
         .lock()
         .map_err(|_| "sidekick session lock poisoned".to_string())?;
-    sessions.insert(key.to_string(), messages.to_vec());
+    sessions.insert(key, messages.to_vec());
     Ok(())
 }
 
@@ -237,9 +294,21 @@ fn compact_sidekick_messages(messages: Vec<Value>) -> Vec<Value> {
         }
     }
 
-    let recent_start = non_system
+    let mut recent_start = non_system
         .len()
         .saturating_sub(SIDEKICK_RECENT_CONTEXT_MESSAGES);
+    // Never cut between an assistant tool_calls message and its tool replies:
+    // a transcript starting with orphaned tool messages is rejected by
+    // OpenAI-compatible servers on every later turn. Walk back to include the
+    // assistant message that issued the calls.
+    while recent_start > 0
+        && non_system[recent_start]
+            .get("role")
+            .and_then(|v| v.as_str())
+            == Some("tool")
+    {
+        recent_start -= 1;
+    }
     let older = &non_system[..recent_start];
     let recent = non_system[recent_start..].to_vec();
     let mut prior_memory = vec![];
@@ -631,7 +700,10 @@ async fn delegate_to_sidekick(
     let profile = sidekick_profile();
     let started = Instant::now();
     let db = app.state::<crate::db::Db>();
-    let _ = db.record_sidekick_event(session_id, mode, "started", &task);
+    log_db_write(
+        "record_sidekick_event(started)",
+        db.record_sidekick_event(session_id, mode, "started", &task),
+    );
     let result = match call_sidekick_model(
         app,
         port,
@@ -646,38 +718,50 @@ async fn delegate_to_sidekick(
     {
         Ok(result) => result,
         Err(err) => {
-            let _ = db.record_sidekick_event(session_id, mode, "error", &err);
+            log_db_write(
+                "record_sidekick_event(error)",
+                db.record_sidekick_event(session_id, mode, "error", &err),
+            );
             return Err(err);
         }
     };
     let elapsed_ms = started.elapsed().as_millis() as u64;
     let escalate = result.tool_limited || result.content.contains("ESCALATE_TO_MAIN");
-    let _ = db.record_sidekick_run(
-        session_id,
-        mode,
-        &task,
-        Some(&model_id),
-        Some(&result.content),
-        Some(elapsed_ms),
-        result.tool_calls as u64,
-        result.session_messages as u64,
-        escalate,
-    );
-    if result.tool_limited {
-        let _ = db.record_sidekick_event(
+    log_db_write(
+        "record_sidekick_run",
+        db.record_sidekick_run(
             session_id,
             mode,
-            "tool_limit",
-            "sidekick reached bounded tool limit; main should continue or upgrade",
+            &task,
+            Some(&model_id),
+            Some(&result.content),
+            Some(elapsed_ms),
+            result.tool_calls as u64,
+            result.session_messages as u64,
+            escalate,
+        ),
+    );
+    if result.tool_limited {
+        log_db_write(
+            "record_sidekick_event(tool_limit)",
+            db.record_sidekick_event(
+                session_id,
+                mode,
+                "tool_limit",
+                "sidekick reached bounded tool limit; main should continue or upgrade",
+            ),
         );
     }
-    let _ = db.record_sidekick_event(
-        session_id,
-        mode,
-        "finished",
-        &format!(
-            "{}ms · {} tools · {} ctx",
-            elapsed_ms, result.tool_calls, result.session_messages
+    log_db_write(
+        "record_sidekick_event(finished)",
+        db.record_sidekick_event(
+            session_id,
+            mode,
+            "finished",
+            &format!(
+                "{}ms · {} tools · {} ctx",
+                elapsed_ms, result.tool_calls, result.session_messages
+            ),
         ),
     );
     Ok(json!({
@@ -1344,6 +1428,11 @@ async fn call_sidekick_model(
         "Task:\n{task}\n\nContext:\n{context}\n\nExpected output:\n{expected_output}\n\nReturn only the useful result for the main model."
     );
     let key = format!("{session_id}:{model_path}");
+    // Hold the per-session-key lock across the whole load -> tool rounds ->
+    // save span; concurrent callers on the same key would otherwise clobber
+    // each other's transcript with a stale load.
+    let session_lock = sidekick_session_lock(&key)?;
+    let _session_guard = session_lock.lock().await;
     let mut messages = load_sidekick_messages(app, &key, profile)?;
     messages.push(json!({ "role": "user", "content": user }));
 
@@ -1429,6 +1518,12 @@ async fn call_sidekick_model(
         }
     }
 
+    if tool_limited {
+        // Keep the saved transcript consistent with what the caller received:
+        // without this, the session keeps the model's real tool-calling
+        // message while the caller got the synthetic ESCALATE_TO_MAIN string.
+        messages.push(json!({ "role": "assistant", "content": final_content }));
+    }
     if messages.len() > SIDEKICK_MAX_CONTEXT_MESSAGES {
         messages = compact_sidekick_messages(messages);
     }
@@ -1775,8 +1870,19 @@ fn compact_chat_messages(messages: Vec<Value>) -> (Vec<Value>, Option<String>, u
     )
 }
 
+/// Routing metrics and sidekick accounting feed later route decisions, so a
+/// dropped write must at least be visible in the logs.
+fn log_db_write<T>(context: &str, result: anyhow::Result<T>) {
+    if let Err(err) = result {
+        eprintln!("understudy db: {context} failed: {err:#}");
+    }
+}
+
 fn record_chat_run(app: &AppHandle, input: ChatRunInput) {
-    let _ = app.state::<crate::db::Db>().record_chat_run(&input);
+    log_db_write(
+        "record_chat_run",
+        app.state::<crate::db::Db>().record_chat_run(&input),
+    );
 }
 
 fn local_resident_mem_gb(app: &AppHandle) -> Option<f64> {
@@ -1818,11 +1924,14 @@ fn record_compaction_route_decision(
         "{} · {} tokens · recommend {} ({})",
         compaction_reason, context_tokens_before, recommendation.route, recommendation.reason
     );
-    let _ = app.state::<crate::db::Db>().record_sidekick_event(
-        session_id,
-        "routing",
-        "compaction_boundary",
-        &detail,
+    log_db_write(
+        "record_sidekick_event(compaction_boundary)",
+        app.state::<crate::db::Db>().record_sidekick_event(
+            session_id,
+            "routing",
+            "compaction_boundary",
+            &detail,
+        ),
     );
     if let Some(on_event) = on_event {
         let _ = on_event.send(ChatEvent::SidekickEvent {
@@ -1873,11 +1982,14 @@ fn apply_dynamic_chat_route(
             "{} -> {} · {} ({})",
             route, next_route, recommendation.policy_class, recommendation.reason
         );
-        let _ = app.state::<crate::db::Db>().record_sidekick_event(
-            session_id,
-            "routing",
-            "route_applied",
-            &detail,
+        log_db_write(
+            "record_sidekick_event(route_applied)",
+            app.state::<crate::db::Db>().record_sidekick_event(
+                session_id,
+                "routing",
+                "route_applied",
+                &detail,
+            ),
         );
         let _ = on_event.send(ChatEvent::SidekickEvent {
             mode: "routing".to_string(),
@@ -2080,12 +2192,15 @@ fn maybe_spawn_parallel_sidekick(
     let db = app.state::<crate::db::Db>();
     let prompt = latest_user_message(messages).map(str::trim).unwrap_or("");
     let record_decision = |eligible: bool, reason: &'static str| {
-        let _ = db.record_sidekick_decision(
-            session_id,
-            route,
-            &prompt_excerpt(prompt),
-            eligible,
-            reason,
+        log_db_write(
+            "record_sidekick_decision",
+            db.record_sidekick_decision(
+                session_id,
+                route,
+                &prompt_excerpt(prompt),
+                eligible,
+                reason,
+            ),
         );
     };
     if route != "local" {
@@ -2127,7 +2242,10 @@ fn maybe_spawn_parallel_sidekick(
         "expected_output": "Return compact findings, uncertainty, and ESCALATE_TO_MAIN only if the request requires main-agent judgment."
     });
     let detail = format!("{} · wait_ms={}", decision.reason, decision.wait_ms);
-    let _ = db.record_sidekick_event(session_id, "parallel", "queued", &detail);
+    log_db_write(
+        "record_sidekick_event(queued)",
+        db.record_sidekick_event(session_id, "parallel", "queued", &detail),
+    );
     if let Some(on_event) = on_event {
         let _ = on_event.send(ChatEvent::SidekickEvent {
             mode: "parallel".to_string(),
@@ -2155,17 +2273,24 @@ fn maybe_spawn_parallel_sidekick(
     }
 }
 
-fn consume_sidekick_handoffs(app: &AppHandle, session_id: &str) -> Vec<Value> {
-    let Ok(rows) = app
+/// Claim pending handoffs; returns the injected context messages plus the
+/// claimed row ids so a failed turn can hand them back.
+fn consume_sidekick_handoffs(app: &AppHandle, session_id: &str) -> (Vec<Value>, Vec<u64>) {
+    let rows = match app
         .state::<crate::db::Db>()
         .consume_sidekick_handoffs(session_id, 2)
-    else {
-        return vec![];
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            eprintln!("understudy db: consume_sidekick_handoffs failed: {err:#}");
+            return (vec![], vec![]);
+        }
     };
     if rows.is_empty() {
-        return vec![];
+        return (vec![], vec![]);
     }
 
+    let ids: Vec<u64> = rows.iter().map(|row| row.id).collect();
     let mut body = String::from(
         "Background sidekick findings from prior parallel work. Treat these as advisory context, not final judgment. Use them only if relevant.\n",
     );
@@ -2190,7 +2315,7 @@ fn consume_sidekick_handoffs(app: &AppHandle, session_id: &str) -> Vec<Value> {
         body.push('\n');
     }
 
-    vec![json!({ "role": "system", "content": body })]
+    (vec![json!({ "role": "system", "content": body })], ids)
 }
 
 fn sidekick_progress_context(app: &AppHandle, session_id: &str, wait_ms: u64) -> Vec<Value> {
@@ -2224,7 +2349,7 @@ async fn wait_for_sidekick_handoffs(
     spawned: bool,
     wait_ms: u64,
     on_event: Option<&Channel<ChatEvent>>,
-) -> Vec<Value> {
+) -> (Vec<Value>, Vec<u64>) {
     if !spawned {
         return consume_sidekick_handoffs(app, session_id);
     }
@@ -2239,13 +2364,16 @@ async fn wait_for_sidekick_handoffs(
     let interval_ms = 250;
     let attempts = (wait_ms / interval_ms).max(1);
     for attempt in 0..attempts {
-        let handoffs = consume_sidekick_handoffs(app, session_id);
+        let (handoffs, handoff_ids) = consume_sidekick_handoffs(app, session_id);
         if !handoffs.is_empty() {
-            let _ = app.state::<crate::db::Db>().record_sidekick_event(
-                session_id,
-                "parallel",
-                "handoff_ready",
-                &format!("attempt={attempt}"),
+            log_db_write(
+                "record_sidekick_event(handoff_ready)",
+                app.state::<crate::db::Db>().record_sidekick_event(
+                    session_id,
+                    "parallel",
+                    "handoff_ready",
+                    &format!("attempt={attempt}"),
+                ),
             );
             if let Some(on_event) = on_event {
                 let _ = on_event.send(ChatEvent::SidekickEvent {
@@ -2254,16 +2382,19 @@ async fn wait_for_sidekick_handoffs(
                     detail: format!("attempt={attempt}"),
                 });
             }
-            return handoffs;
+            return (handoffs, handoff_ids);
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
 
-    let _ = app.state::<crate::db::Db>().record_sidekick_event(
-        session_id,
-        "parallel",
-        "handoff_deferred",
-        &format!("main continued after {wait_ms}ms"),
+    log_db_write(
+        "record_sidekick_event(handoff_deferred)",
+        app.state::<crate::db::Db>().record_sidekick_event(
+            session_id,
+            "parallel",
+            "handoff_deferred",
+            &format!("main continued after {wait_ms}ms"),
+        ),
     );
     if let Some(on_event) = on_event {
         let _ = on_event.send(ChatEvent::SidekickEvent {
@@ -2272,7 +2403,7 @@ async fn wait_for_sidekick_handoffs(
             detail: format!("main continued after {wait_ms}ms"),
         });
     }
-    sidekick_progress_context(app, session_id, wait_ms)
+    (sidekick_progress_context(app, session_id, wait_ms), vec![])
 }
 
 /// Stream a chat completion. `route` is "local" (MLX :8089) or "cloud" (gateway).
@@ -2327,16 +2458,15 @@ pub async fn chat_stream(
         "role": "system",
         "content": system_prompt_for(&model_field),
     })];
-    outbound_messages.extend(
-        wait_for_sidekick_handoffs(
-            &app,
-            &session_id,
-            sidekick_plan.spawned,
-            sidekick_plan.wait_ms,
-            Some(&on_event),
-        )
-        .await,
-    );
+    let (handoff_messages, handoff_ids) = wait_for_sidekick_handoffs(
+        &app,
+        &session_id,
+        sidekick_plan.spawned,
+        sidekick_plan.wait_ms,
+        Some(&on_event),
+    )
+    .await;
+    outbound_messages.extend(handoff_messages);
     outbound_messages.extend(
         messages
             .iter()
@@ -2385,11 +2515,14 @@ pub async fn chat_stream(
                     "local -> cloud · compaction_boundary ({reason}, {} tokens)",
                     context_tokens_before
                 );
-                let _ = app.state::<crate::db::Db>().record_sidekick_event(
-                    &session_id,
-                    "routing",
-                    "compaction_route_applied",
-                    &detail,
+                log_db_write(
+                    "record_sidekick_event(compaction_route_applied)",
+                    app.state::<crate::db::Db>().record_sidekick_event(
+                        &session_id,
+                        "routing",
+                        "compaction_route_applied",
+                        &detail,
+                    ),
                 );
                 let _ = on_event.send(ChatEvent::SidekickEvent {
                     mode: "routing".to_string(),
@@ -2439,6 +2572,14 @@ pub async fn chat_stream(
                     error: Some(error),
                 },
             );
+            // The turn failed before the model could use the findings; hand
+            // the claimed handoffs back so the next turn can retry them.
+            if let Err(err) = app
+                .state::<crate::db::Db>()
+                .unconsume_sidekick_handoffs(&handoff_ids)
+            {
+                eprintln!("understudy db: unconsume_sidekick_handoffs failed: {err:#}");
+            }
             let _ = on_event.send(ChatEvent::Done);
             return Ok(());
         }
@@ -2536,11 +2677,14 @@ pub async fn chat_stream(
                     "local -> cloud · mid_session_tool_depth ({} tool calls)",
                     tool_count
                 );
-                let _ = app.state::<crate::db::Db>().record_sidekick_event(
-                    &session_id,
-                    "routing",
-                    "mid_session_route_applied",
-                    &detail,
+                log_db_write(
+                    "record_sidekick_event(mid_session_route_applied)",
+                    app.state::<crate::db::Db>().record_sidekick_event(
+                        &session_id,
+                        "routing",
+                        "mid_session_route_applied",
+                        &detail,
+                    ),
                 );
                 let _ = on_event.send(ChatEvent::SidekickEvent {
                     mode: "routing".to_string(),
@@ -2591,7 +2735,8 @@ pub async fn benchmark_local_chat(
             BENCHMARK_SIDEKICK_WAIT_MS,
             None,
         )
-        .await,
+        .await
+        .0,
     );
     outbound_messages.push(json!({ "role": "user", "content": prompt }));
     let (mut outbound_messages, compaction_reason, context_tokens_before) =
@@ -2708,7 +2853,7 @@ pub async fn benchmark_gateway_chat(
         "role": "system",
         "content": system_prompt_for(model_field),
     })];
-    outbound_messages.extend(consume_sidekick_handoffs(app, session_id));
+    outbound_messages.extend(consume_sidekick_handoffs(app, session_id).0);
     outbound_messages.push(json!({ "role": "user", "content": prompt }));
     let (mut outbound_messages, compaction_reason, context_tokens_before) =
         compact_chat_messages(outbound_messages);
@@ -3060,6 +3205,55 @@ mod tests {
 
     fn feedback(useful: u64, misses: u64) -> SidekickFeedbackSummary {
         SidekickFeedbackSummary { useful, misses }
+    }
+
+    #[test]
+    fn sidekick_compaction_never_orphans_tool_replies() {
+        let mut messages = vec![json!({"role": "system", "content": "sys"})];
+        for i in 0..9 {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            messages.push(json!({"role": role, "content": format!("turn {i}")}));
+        }
+        // Tool replies placed to straddle the default recent-messages cut.
+        messages.push(json!({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_1", "type": "function",
+                            "function": {"name": "repo_search", "arguments": "{}"}}],
+        }));
+        messages.push(json!({"role": "tool", "tool_call_id": "call_1", "content": "result a"}));
+        messages.push(json!({"role": "tool", "tool_call_id": "call_1", "content": "result b"}));
+        for i in 0..8 {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            messages.push(json!({"role": role, "content": format!("late turn {i}")}));
+        }
+
+        let compacted = compact_sidekick_messages(messages);
+        let first_kept = compacted
+            .iter()
+            .find(|m| m.get("role").and_then(|v| v.as_str()) != Some("system"))
+            .expect("compaction keeps recent messages");
+        assert_eq!(
+            first_kept.get("role").and_then(|v| v.as_str()),
+            Some("assistant")
+        );
+        assert!(
+            first_kept.get("tool_calls").is_some(),
+            "recent slice must start at the assistant tool_calls message, not an orphaned tool reply"
+        );
+    }
+
+    #[test]
+    fn sidekick_session_cache_is_bounded() {
+        let mut cache = SidekickSessionCache::default();
+        for i in 0..(SIDEKICK_SESSION_CACHE_MAX + 8) {
+            cache.insert(&format!("key-{i}"), vec![]);
+        }
+        assert_eq!(cache.entries.len(), SIDEKICK_SESSION_CACHE_MAX);
+        assert!(cache.get("key-0").is_none(), "oldest entries are evicted");
+        assert!(cache
+            .get(&format!("key-{}", SIDEKICK_SESSION_CACHE_MAX + 7))
+            .is_some());
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -83,6 +83,7 @@ const BENCHMARK_SIDEKICK_WAIT_MS: u64 = 2_500;
 const MAX_TOOL_ROUNDS: usize = 4;
 const BENCHMARK_MAX_TOOL_ROUNDS: usize = 4;
 const SIDEKICK_MAX_TOOL_ROUNDS: usize = 2;
+const SIDEKICK_REQUEST_TIMEOUT_SECS: u64 = 120;
 const SIDEKICK_MAX_CONTEXT_MESSAGES: usize = 16;
 const SIDEKICK_RECENT_CONTEXT_MESSAGES: usize = 10;
 const SIDEKICK_FILE_READ_LIMIT: usize = 48 * 1024;
@@ -1437,7 +1438,12 @@ async fn call_sidekick_model(
     let mut messages = load_sidekick_messages(app, &key, profile)?;
     messages.push(json!({ "role": "user", "content": user }));
 
-    let client = reqwest::Client::new();
+    // This client runs while the per-session-key lock is held; the request
+    // timeout is what keeps a stalled local server from wedging the key forever.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(SIDEKICK_REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("sidekick client failed: {e}"))?;
     let mut tool_count = 0usize;
     let mut final_content = String::new();
     let mut tool_limited = false;
@@ -2721,6 +2727,14 @@ pub async fn chat_stream(
             error: Some(format!("tool call limit reached ({MAX_TOOL_ROUNDS})")),
         },
     );
+    // The turn hit the tool limit; hand the claimed handoffs back so the next
+    // turn can retry them, matching the in-loop error path.
+    if let Err(err) = app
+        .state::<crate::db::Db>()
+        .unconsume_sidekick_handoffs(&handoff_ids)
+    {
+        eprintln!("understudy db: unconsume_sidekick_handoffs failed: {err:#}");
+    }
     let _ = on_event.send(ChatEvent::Done);
     Ok(())
 }

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -1,7 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
 
 use anyhow::Result;
-use rusqlite::Connection;
+use rusqlite::{Connection, TransactionBehavior};
 use serde::Serialize;
 
 use crate::residency::PersistedSlot;
@@ -203,14 +205,45 @@ pub struct SidekickFeedbackSummary {
 
 /// App-owned SQLite store, under the macOS app-data dir. Profile, credentials,
 /// and the model cache continue to live under `~/.understudy/`.
-pub struct Db(pub std::path::PathBuf);
+///
+/// A single connection is shared behind a mutex: chat turns, parallel
+/// sidekicks, and Fusion benchmark runs all write concurrently, and per-call
+/// connections raced each other on schema setup and left readers seeing
+/// half-applied writes. WAL + busy_timeout cover any other process holding
+/// the file.
+pub struct Db {
+    data_dir: PathBuf,
+    conn: Mutex<Connection>,
+}
 
 impl Db {
-    fn conn(&self) -> Result<Connection> {
-        std::fs::create_dir_all(&self.0).ok();
-        let conn = Connection::open(self.0.join("understudy.db"))?;
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS residency (
+    pub fn open(data_dir: PathBuf) -> Result<Self> {
+        std::fs::create_dir_all(&data_dir)?;
+        let conn = Connection::open(data_dir.join("understudy.db"))?;
+        conn.busy_timeout(Duration::from_millis(5_000))?;
+        conn.query_row("PRAGMA journal_mode=WAL", [], |_| Ok(()))?;
+        migrate(&conn)?;
+        Ok(Self {
+            data_dir,
+            conn: Mutex::new(conn),
+        })
+    }
+
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    fn conn(&self) -> Result<MutexGuard<'_, Connection>> {
+        self.conn
+            .lock()
+            .map_err(|_| anyhow::anyhow!("db connection lock poisoned"))
+    }
+}
+
+/// Run schema setup + column migrations once at startup.
+fn migrate(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS residency (
                 slot_id     INTEGER PRIMARY KEY,
                 model_id    TEXT,
                 model_path  TEXT,
@@ -343,74 +376,45 @@ impl Db {
                 memory      TEXT,
                 updated_at  TEXT NOT NULL
             );",
-        )?;
-        let _ = conn.execute(
-            "ALTER TABLE residency ADD COLUMN thinking INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute("ALTER TABLE sidekick_runs ADD COLUMN content TEXT", []);
-        let _ = conn.execute(
-            "ALTER TABLE sidekick_runs ADD COLUMN consumed INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE chat_runs ADD COLUMN compacted INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE chat_runs ADD COLUMN compaction_reason TEXT",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE chat_runs ADD COLUMN context_tokens_before INTEGER",
-            [],
-        );
-        let _ = conn.execute("ALTER TABLE chat_runs ADD COLUMN local_mem_gb REAL", []);
-        let _ = conn.execute(
-            "ALTER TABLE chat_runs ADD COLUMN gateway_available INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE chat_runs ADD COLUMN gateway_avoided INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE fusion_benchmarks ADD COLUMN compacted INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE fusion_benchmarks ADD COLUMN context_tokens_before INTEGER",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE fusion_benchmarks ADD COLUMN local_mem_gb REAL",
-            [],
-        );
-        let _ = conn.execute("ALTER TABLE fusion_benchmarks ADD COLUMN status TEXT", []);
-        let _ = conn.execute(
-            "ALTER TABLE sidekick_sessions ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE sidekick_sessions ADD COLUMN compacted_count INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute("ALTER TABLE sidekick_sessions ADD COLUMN memory TEXT", []);
-        let _ = conn.execute(
-            "ALTER TABLE fusion_route_decisions ADD COLUMN policy_class TEXT NOT NULL DEFAULT 'unknown'",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE fusion_route_decisions ADD COLUMN signals TEXT",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE fusion_route_decisions ADD COLUMN upgrade_sidekick INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        Ok(conn)
+    )?;
+    const ALTERS: &[&str] = &[
+        "ALTER TABLE residency ADD COLUMN thinking INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE sidekick_runs ADD COLUMN content TEXT",
+        "ALTER TABLE sidekick_runs ADD COLUMN consumed INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE chat_runs ADD COLUMN compacted INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE chat_runs ADD COLUMN compaction_reason TEXT",
+        "ALTER TABLE chat_runs ADD COLUMN context_tokens_before INTEGER",
+        "ALTER TABLE chat_runs ADD COLUMN local_mem_gb REAL",
+        "ALTER TABLE chat_runs ADD COLUMN gateway_available INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE chat_runs ADD COLUMN gateway_avoided INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE fusion_benchmarks ADD COLUMN compacted INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE fusion_benchmarks ADD COLUMN context_tokens_before INTEGER",
+        "ALTER TABLE fusion_benchmarks ADD COLUMN local_mem_gb REAL",
+        "ALTER TABLE fusion_benchmarks ADD COLUMN status TEXT",
+        "ALTER TABLE sidekick_sessions ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE sidekick_sessions ADD COLUMN compacted_count INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE sidekick_sessions ADD COLUMN memory TEXT",
+        "ALTER TABLE fusion_route_decisions ADD COLUMN policy_class TEXT NOT NULL DEFAULT 'unknown'",
+        "ALTER TABLE fusion_route_decisions ADD COLUMN signals TEXT",
+        "ALTER TABLE fusion_route_decisions ADD COLUMN upgrade_sidekick INTEGER NOT NULL DEFAULT 0",
+    ];
+    for sql in ALTERS {
+        apply_alter(conn, sql)?;
     }
+    Ok(())
+}
 
+/// Apply a column-add migration; a duplicate column just means the migration
+/// already ran, anything else is a real failure.
+fn apply_alter(conn: &Connection, sql: &str) -> Result<()> {
+    match conn.execute(sql, []) {
+        Ok(_) => Ok(()),
+        Err(err) if err.to_string().contains("duplicate column name") => Ok(()),
+        Err(err) => Err(anyhow::anyhow!("migration failed ({sql}): {err}")),
+    }
+}
+
+impl Db {
     pub fn save_residency(&self, slots: &[PersistedSlot]) -> Result<()> {
         let conn = self.conn()?;
         conn.execute("DELETE FROM residency", [])?;
@@ -861,13 +865,18 @@ impl Db {
         })
     }
 
+    /// Atomically claim unconsumed handoffs: the SELECT and the consumed=1
+    /// marks commit together so concurrent consumers can't double-inject the
+    /// same handoff. A failed turn should hand claims back via
+    /// [`Db::unconsume_sidekick_handoffs`].
     pub fn consume_sidekick_handoffs(
         &self,
         session_id: &str,
         limit: u32,
     ) -> Result<Vec<SidekickRunRow>> {
-        let conn = self.conn()?;
-        let mut stmt = conn.prepare(
+        let mut conn = self.conn()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let mut stmt = tx.prepare(
             "SELECT id, session_id, mode, task, model, content, elapsed_ms, tool_calls, session_messages, escalated, accepted, consumed, run_at
              FROM sidekick_runs
              WHERE session_id=?1 AND mode='parallel' AND consumed=0 AND content IS NOT NULL
@@ -896,13 +905,32 @@ impl Db {
         let out = rows
             .collect::<rusqlite::Result<Vec<_>>>()
             .map_err(anyhow::Error::from)?;
+        drop(stmt);
         for row in &out {
-            conn.execute(
+            tx.execute(
                 "UPDATE sidekick_runs SET consumed=1 WHERE id=?1",
                 [row.id as i64],
             )?;
         }
+        tx.commit()?;
         Ok(out)
+    }
+
+    /// Hand claimed handoffs back (turn failed before the findings were used).
+    pub fn unconsume_sidekick_handoffs(&self, ids: &[u64]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        for id in ids {
+            tx.execute(
+                "UPDATE sidekick_runs SET consumed=0 WHERE id=?1",
+                [*id as i64],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
     }
 
     pub fn record_sidekick_decision(

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -1171,3 +1171,91 @@ fn now_iso() -> String {
 pub fn init(_data_dir: &Path) -> Result<()> {
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_db(tag: &str) -> (PathBuf, Db) {
+        let dir =
+            std::env::temp_dir().join(format!("understudy-db-test-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let db = Db::open(dir.clone()).expect("open temp db");
+        (dir, db)
+    }
+
+    #[test]
+    fn open_is_idempotent_on_existing_database() {
+        let (dir, db) = temp_db("reopen");
+        db.setting_set("k", "v").unwrap();
+        drop(db);
+        // Second open replays the CREATE batch + ALTERs against the existing
+        // file: duplicate columns must be tolerated, data preserved.
+        let db = Db::open(dir.clone()).expect("re-open existing db");
+        assert_eq!(db.setting_get("k").as_deref(), Some("v"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn concurrent_consumers_never_double_claim_handoffs() {
+        let (dir, db) = temp_db("claim");
+        let db = std::sync::Arc::new(db);
+        for i in 0..8 {
+            db.record_sidekick_run(
+                "s",
+                "parallel",
+                &format!("task {i}"),
+                Some("model"),
+                Some("finding"),
+                Some(5),
+                1,
+                3,
+                false,
+            )
+            .unwrap();
+        }
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let db = db.clone();
+                std::thread::spawn(move || {
+                    let mut claimed = vec![];
+                    loop {
+                        let rows = db.consume_sidekick_handoffs("s", 5).unwrap();
+                        if rows.is_empty() {
+                            break;
+                        }
+                        claimed.extend(rows.into_iter().map(|row| row.id));
+                    }
+                    claimed
+                })
+            })
+            .collect();
+        let mut all: Vec<u64> = handles
+            .into_iter()
+            .flat_map(|handle| handle.join().unwrap())
+            .collect();
+        all.sort_unstable();
+        let claims = all.len();
+        all.dedup();
+        assert_eq!(claims, all.len(), "a handoff was claimed by two consumers");
+        assert_eq!(all.len(), 8, "every handoff is claimed exactly once");
+
+        // Handing claims back makes them consumable again (failed-turn path).
+        db.unconsume_sidekick_handoffs(&all).unwrap();
+        assert_eq!(db.consume_sidekick_handoffs("s", 5).unwrap().len(), 5);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[ignore = "set UNDERSTUDY_TEST_DB_DIR to a COPY of a real app-data dir"]
+    fn open_real_database_copy() {
+        let dir = std::env::var("UNDERSTUDY_TEST_DB_DIR").expect("UNDERSTUDY_TEST_DB_DIR set");
+        let db = Db::open(PathBuf::from(dir)).expect("open real db copy");
+        db.list_chat_runs(5).unwrap();
+        db.list_sidekick_runs(5).unwrap();
+        db.list_fusion_benchmarks(5).unwrap();
+        db.list_sidekick_session_summaries(5).unwrap();
+        db.load_residency().unwrap();
+    }
+}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -35,7 +35,8 @@ pub fn run() {
             let machine = metrics::detect_machine();
             let residency = residency::Residency::new(machine.memory_gb);
 
-            app.manage(db::Db(data_dir));
+            let db = db::Db::open(data_dir).expect("understudy database opened");
+            app.manage(db);
             app.manage(metrics::MetricsReader::new());
             app.manage(machine);
             app.manage(residency);

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -412,9 +412,12 @@ impl Residency {
             // Persist + benchmark record.
             if ready {
                 residency.persist(&app);
-                let _ = app
+                if let Err(err) = app
                     .state::<Db>()
-                    .record_benchmark(&model_id, None, mem_gb, Some(load_ms));
+                    .record_benchmark(&model_id, None, mem_gb, Some(load_ms))
+                {
+                    eprintln!("understudy db: record_benchmark failed: {err:#}");
+                }
             }
         });
         Ok(())

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -516,7 +516,9 @@ impl Residency {
                 ordinal: i as u32,
             })
             .collect();
-        let _ = app.state::<Db>().save_residency(&rows);
+        if let Err(err) = app.state::<Db>().save_residency(&rows) {
+            eprintln!("understudy db: save_residency failed: {err:#}");
+        }
     }
 
     /// On launch, rebuild slots from the persisted plan and re-warm the warm set.

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -89,7 +89,9 @@ pub fn start(app: AppHandle) {
         Some(t) => t,
         None => {
             let t = gen_token();
-            let _ = db.setting_set(TOKEN_KEY, &t);
+            if let Err(err) = db.setting_set(TOKEN_KEY, &t) {
+                eprintln!("understudy db: persisting server token failed: {err:#}");
+            }
             t
         }
     };


### PR DESCRIPTION
## Summary

A code review confirmed the desktop app's SQLite layer was unsafe under the concurrency the sidekick/Fusion features introduced. This PR fixes the persistence layer in `apps/homescreen/src-tauri` plus two sidekick transcript bugs found in the same pass.

### Persistence (`db.rs`)
- **Single shared connection** behind a `Mutex<Connection>` instead of opening a fresh connection (and replaying the full CREATE TABLE batch + ~19 ALTER migrations) on every call. `Db::open()` runs once at startup with `journal_mode=WAL` and a 5s `busy_timeout`.
- **Migrations distinguish "duplicate column" (expected) from real failures** — real ALTER errors now propagate instead of being swallowed by `let _ =`.
- **`consume_sidekick_handoffs` is transactional** (IMMEDIATE): the SELECT and `consumed=1` marks commit atomically, so concurrent consumers can't double-inject the same handoff.
- **Ack-on-failure**: new `unconsume_sidekick_handoffs` hands claims back when a chat turn errors before the model uses the findings, so a failed turn no longer permanently loses them.

### Concurrency in `chat.rs`
- **Per-session-key tokio locks** around `call_sidekick_model`'s load → HTTP rounds → save span, fixing the lost-update race between a parallel sidekick and an inline `delegate_to_sidekick` in the same turn. The lock map only evicts locks nobody holds.
- **`SIDEKICK_SESSIONS` cache is bounded** (LRU, 32 keys; evicted sessions reload from SQLite).
- **DB write failures are logged** — every `let _ = db.record_*` in chat.rs (plus `save_residency` and the server-token write) now reports to stderr so routing metrics can't go quietly incomplete.

### Sidekick transcript bugs
- **Compaction no longer cuts between an assistant `tool_calls` message and its tool replies** — the old slice could persist a malformed transcript that OpenAI-compatible servers reject on every later turn. The cut now walks back to the tool-call pair boundary.
- **Tool-limit rounds save what the caller saw** — the synthetic `ESCALATE_TO_MAIN` message is appended to the persisted session so it matches the returned content.

## Testing
- `cargo check` clean; `cargo clippy --all-targets` has the identical 25 pre-existing warnings before and after (verified by stashing).
- `cargo test`: 5/5 pass, including two new regression tests (`sidekick_compaction_never_orphans_tool_replies`, `sidekick_session_cache_is_bounded`).

## Notes
- Pre-existing sessions already saved with orphaned tool messages stay broken until re-compacted or cleared; the fix prevents new ones.
- `now_iso()` still writes `1970-01-01T00:00:<epoch-secs>Z` pseudo-timestamps — left out of scope for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->