### PR TITLE
Extract Fusion route policy into one module and fix routing bugs

### DIFF
--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -9,8 +9,12 @@ use std::time::{Duration, Instant};
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Manager, State};
 
-use crate::db::{ChatRunInput, SidekickFeedbackSummary};
+use crate::db::ChatRunInput;
 use crate::residency::Residency;
+use crate::route_policy::{
+    self, CHAT_RUNS_SIGNAL_WINDOW, FUSION_BENCHMARK_SIGNAL_WINDOW, GATEWAY_CHAT_MODEL,
+    SIDEKICK_FEEDBACK_SIGNAL_WINDOW, SIDEKICK_RUNS_SIGNAL_WINDOW, TOOL_DEPTH_ESCALATION_CALLS,
+};
 
 /// Frontend-facing stream events. Tagged so JS can switch on `msg.type`.
 #[derive(Serialize, Clone)]
@@ -76,9 +80,6 @@ const CHAT_MAX_TOKENS: u32 = 8192;
 const BENCHMARK_MAX_TOKENS: u32 = 384;
 const CHAT_THINKING_BUDGET: u32 = 2048;
 const BENCHMARK_THINKING_BUDGET: u32 = 0;
-const CHAT_SIDEKICK_QUICK_WAIT_MS: u64 = 600;
-const CHAT_SIDEKICK_DEFAULT_WAIT_MS: u64 = 1_000;
-const CHAT_SIDEKICK_VERIFICATION_WAIT_MS: u64 = 1_800;
 const BENCHMARK_SIDEKICK_WAIT_MS: u64 = 2_500;
 const MAX_TOOL_ROUNDS: usize = 4;
 const BENCHMARK_MAX_TOOL_ROUNDS: usize = 4;
@@ -1753,45 +1754,10 @@ fn latest_user_message(messages: &[ChatMsg]) -> Option<&str> {
         .map(|m| m.content.as_str())
 }
 
-struct SidekickRoutingDecision {
-    eligible: bool,
-    reason: &'static str,
-    wait_ms: u64,
-}
-
 #[derive(Clone, Copy)]
 struct ParallelSidekickPlan {
     spawned: bool,
     wait_ms: u64,
-}
-
-fn sidekick_ineligible(reason: &'static str) -> SidekickRoutingDecision {
-    SidekickRoutingDecision {
-        eligible: false,
-        reason,
-        wait_ms: 0,
-    }
-}
-
-fn sidekick_eligible(reason: &'static str, wait_ms: u64) -> SidekickRoutingDecision {
-    SidekickRoutingDecision {
-        eligible: true,
-        reason,
-        wait_ms,
-    }
-}
-
-#[derive(Default)]
-struct SidekickRoutingSignals {
-    feedback_rows: u64,
-    useful_rate: Option<f64>,
-    handoff_rate: Option<f64>,
-    escalation_rate: Option<f64>,
-    sidekick_rows: u64,
-    sidekick_benchmark_rows: u64,
-    sidekick_benchmark_score: Option<f64>,
-    avg_local_elapsed_ms: Option<f64>,
-    avg_sidekick_elapsed_ms: Option<f64>,
 }
 
 fn prompt_excerpt(prompt: &str) -> String {
@@ -1904,6 +1870,102 @@ fn local_resident_mem_gb(app: &AppHandle) -> Option<f64> {
     (mem > 0.0).then_some(mem)
 }
 
+/// Route name + endpoint + auth + model of a live chat turn, kept together
+/// so they can never drift apart across a mid-turn switch.
+struct RouteBinding {
+    route: String,
+    url: String,
+    bearer: Option<String>,
+    model_field: String,
+}
+
+fn cloud_route_binding() -> Option<RouteBinding> {
+    let (base, key) = credentials()?;
+    Some(RouteBinding {
+        route: "cloud".to_string(),
+        url: format!("{}/v1/chat/completions", base.trim_end_matches('/')),
+        bearer: Some(key),
+        model_field: GATEWAY_CHAT_MODEL.to_string(),
+    })
+}
+
+fn local_route_binding(
+    route: &str,
+    mgr: &Residency,
+    slot_id: Option<u32>,
+) -> Result<RouteBinding, String> {
+    // A specific warm slot must be selected; each slot is its own mlx_vlm
+    // process on its own port, keyed by the model's local path.
+    let sid = slot_id.ok_or_else(|| "no local slot selected".to_string())?;
+    let (port, path) = mgr
+        .endpoint(sid)
+        .ok_or_else(|| "selected slot is not warm".to_string())?;
+    Ok(RouteBinding {
+        route: route.to_string(),
+        url: format!("http://127.0.0.1:{port}/v1/chat/completions"),
+        bearer: None,
+        model_field: path,
+    })
+}
+
+fn fusion_routing_enabled(app: &AppHandle) -> bool {
+    app.state::<crate::db::Db>()
+        .setting_get("fusion.routing")
+        .as_deref()
+        != Some("off")
+}
+
+fn emit_routing_event(
+    app: &AppHandle,
+    session_id: &str,
+    stage: &str,
+    detail: &str,
+    on_event: Option<&Channel<ChatEvent>>,
+) {
+    log_db_write(
+        "record_sidekick_event(routing)",
+        app.state::<crate::db::Db>()
+            .record_sidekick_event(session_id, "routing", stage, detail),
+    );
+    if let Some(on_event) = on_event {
+        let _ = on_event.send(ChatEvent::SidekickEvent {
+            mode: "routing".to_string(),
+            stage: stage.to_string(),
+            detail: detail.to_string(),
+        });
+    }
+}
+
+/// The single local→cloud switch used at every escalation point of a live
+/// turn: rebinds the endpoint, refreshes the system prompt for the gateway
+/// model, and records the applied route in the audit trail. Returns false
+/// (and changes nothing) when routing is off or the gateway is unavailable.
+fn switch_route_to_cloud(
+    app: &AppHandle,
+    session_id: &str,
+    binding: &mut RouteBinding,
+    outbound_messages: &mut [Value],
+    stage: &str,
+    detail: &str,
+    on_event: Option<&Channel<ChatEvent>>,
+) -> bool {
+    if !fusion_routing_enabled(app) {
+        return false;
+    }
+    let Some(cloud) = cloud_route_binding() else {
+        return false;
+    };
+    *binding = cloud;
+    if let Some(system) = outbound_messages
+        .iter_mut()
+        .find(|message| message.get("role").and_then(|v| v.as_str()) == Some("system"))
+    {
+        system["content"] = json!(system_prompt_for(&binding.model_field));
+    }
+    emit_routing_event(app, session_id, stage, detail, on_event);
+    true
+}
+
 fn record_compaction_route_decision(
     app: &AppHandle,
     session_id: &str,
@@ -1913,10 +1975,10 @@ fn record_compaction_route_decision(
     compaction_reason: &str,
     context_tokens_before: u64,
     on_event: Option<&Channel<ChatEvent>>,
-) {
+) -> Option<crate::commands::FusionRouteRecommendation> {
     let prompt = latest_user_message(messages).unwrap_or("").trim();
     if prompt.is_empty() {
-        return;
+        return None;
     }
     let recommendation = crate::commands::fusion_route_recommendation(
         app.clone(),
@@ -1931,22 +1993,8 @@ fn record_compaction_route_decision(
         "{} · {} tokens · recommend {} ({})",
         compaction_reason, context_tokens_before, recommendation.route, recommendation.reason
     );
-    log_db_write(
-        "record_sidekick_event(compaction_boundary)",
-        app.state::<crate::db::Db>().record_sidekick_event(
-            session_id,
-            "routing",
-            "compaction_boundary",
-            &detail,
-        ),
-    );
-    if let Some(on_event) = on_event {
-        let _ = on_event.send(ChatEvent::SidekickEvent {
-            mode: "routing".to_string(),
-            stage: "compaction_boundary".to_string(),
-            detail,
-        });
-    }
+    emit_routing_event(app, session_id, "compaction_boundary", &detail, on_event);
+    Some(recommendation)
 }
 
 fn apply_dynamic_chat_route(
@@ -1957,12 +2005,7 @@ fn apply_dynamic_chat_route(
     messages: &[ChatMsg],
     on_event: &Channel<ChatEvent>,
 ) -> String {
-    if app
-        .state::<crate::db::Db>()
-        .setting_get("fusion.routing")
-        .as_deref()
-        == Some("off")
-    {
+    if !fusion_routing_enabled(app) {
         return route.to_string();
     }
     let prompt = latest_user_message(messages).unwrap_or("").trim();
@@ -1989,20 +2032,7 @@ fn apply_dynamic_chat_route(
             "{} -> {} · {} ({})",
             route, next_route, recommendation.policy_class, recommendation.reason
         );
-        log_db_write(
-            "record_sidekick_event(route_applied)",
-            app.state::<crate::db::Db>().record_sidekick_event(
-                session_id,
-                "routing",
-                "route_applied",
-                &detail,
-            ),
-        );
-        let _ = on_event.send(ChatEvent::SidekickEvent {
-            mode: "routing".to_string(),
-            stage: "route_applied".to_string(),
-            detail,
-        });
+        emit_routing_event(app, session_id, "route_applied", &detail, Some(on_event));
     }
     next_route.to_string()
 }
@@ -2023,13 +2053,16 @@ fn benchmark_finalize_prompt(reasoning: &str) -> Value {
     })
 }
 
-fn sidekick_routing_signals(app: &AppHandle) -> SidekickRoutingSignals {
-    let Ok(rows) = app.state::<crate::db::Db>().list_sidekick_runs(30) else {
-        return SidekickRoutingSignals::default();
+fn sidekick_routing_signals(app: &AppHandle) -> route_policy::SidekickRoutingSignals {
+    let Ok(rows) = app
+        .state::<crate::db::Db>()
+        .list_sidekick_runs(SIDEKICK_RUNS_SIGNAL_WINDOW)
+    else {
+        return route_policy::SidekickRoutingSignals::default();
     };
     let total = rows.len() as u64;
     if total == 0 {
-        return SidekickRoutingSignals::default();
+        return route_policy::SidekickRoutingSignals::default();
     }
 
     let useful = rows.iter().filter(|row| row.accepted == Some(true)).count() as u64;
@@ -2042,7 +2075,7 @@ fn sidekick_routing_signals(app: &AppHandle) -> SidekickRoutingSignals {
     let escalated = rows.iter().filter(|row| row.escalated).count() as u64;
     let chat_rows = app
         .state::<crate::db::Db>()
-        .list_chat_runs(60)
+        .list_chat_runs(CHAT_RUNS_SIGNAL_WINDOW)
         .unwrap_or_default();
     let local_elapsed: Vec<f64> = chat_rows
         .iter()
@@ -2056,14 +2089,15 @@ fn sidekick_routing_signals(app: &AppHandle) -> SidekickRoutingSignals {
         .collect();
     let benchmark_rows = app
         .state::<crate::db::Db>()
-        .list_fusion_benchmarks(40)
+        .list_fusion_benchmarks(FUSION_BENCHMARK_SIGNAL_WINDOW)
         .unwrap_or_default();
     let sidekick_scores: Vec<f64> = benchmark_rows
         .iter()
         .filter(|row| row.mode == "sidekick-parallel")
         .filter_map(|row| row.score)
         .collect();
-    SidekickRoutingSignals {
+    route_policy::SidekickRoutingSignals {
+        rows: total,
         feedback_rows,
         useful_rate: (feedback_rows > 0).then_some(useful as f64 / feedback_rows as f64),
         handoff_rate: Some(consumed as f64 / total as f64),
@@ -2082,106 +2116,6 @@ fn avg_f64(values: &[f64]) -> Option<f64> {
     } else {
         Some(values.iter().sum::<f64>() / values.len() as f64)
     }
-}
-
-fn route_parallel_sidekick(
-    prompt: &str,
-    feedback: SidekickFeedbackSummary,
-    signals: SidekickRoutingSignals,
-) -> SidekickRoutingDecision {
-    let lower = prompt.to_lowercase();
-    let delegate_terms = [
-        "check",
-        "review",
-        "inspect",
-        "search",
-        "summarize",
-        "open",
-        "ground",
-        "grounding",
-        "read",
-        "locate",
-        "verify",
-        "compare",
-        "find",
-        "trace",
-        "status",
-        "models",
-        "what's left",
-        "whats left",
-        "reminder",
-    ];
-    let judgment_terms = [
-        "decide",
-        "should we",
-        "what should",
-        "strategy",
-        "plan",
-        "architect",
-        "tradeoff",
-        "judgment",
-    ];
-    if judgment_terms.iter().any(|needle| lower.contains(needle)) {
-        return sidekick_ineligible("main_keeps_judgment");
-    }
-    if signals.feedback_rows >= 5 && signals.useful_rate.is_some_and(|rate| rate < 0.25) {
-        return sidekick_ineligible("metrics_low_usefulness");
-    }
-    if signals
-        .escalation_rate
-        .is_some_and(|rate| signals.feedback_rows >= 3 && rate > 0.6)
-    {
-        return sidekick_ineligible("metrics_high_escalation");
-    }
-    if signals.sidekick_rows >= 3
-        && matches!(
-            (signals.avg_sidekick_elapsed_ms, signals.avg_local_elapsed_ms),
-            (Some(sidekick_ms), Some(local_ms)) if local_ms > 0.0 && sidekick_ms > local_ms * 1.75
-        )
-    {
-        return sidekick_ineligible("metrics_sidekick_latency_high");
-    }
-    if signals.sidekick_benchmark_rows >= 4
-        && signals
-            .sidekick_benchmark_score
-            .is_some_and(|score| score < 0.5)
-    {
-        return sidekick_ineligible("benchmark_sidekick_score_low");
-    }
-    let mechanical = delegate_terms
-        .iter()
-        .find(|needle| lower.contains(**needle))
-        .copied();
-    if let Some(term) = mechanical {
-        if signals
-            .handoff_rate
-            .is_some_and(|rate| signals.feedback_rows >= 3 && rate < 0.2)
-        {
-            return sidekick_ineligible("metrics_low_handoff");
-        }
-        if feedback.misses >= 3 && feedback.misses > feedback.useful.saturating_mul(2) {
-            return sidekick_ineligible("feedback_recent_misses");
-        }
-        let (reason, wait_ms) = match term {
-            "search" | "find" | "trace" => ("mechanical_search", CHAT_SIDEKICK_DEFAULT_WAIT_MS),
-            "check" | "verify" | "inspect" | "review" => {
-                ("verification", CHAT_SIDEKICK_VERIFICATION_WAIT_MS)
-            }
-            "summarize" | "reminder" | "what's left" | "whats left" => {
-                ("summary", CHAT_SIDEKICK_QUICK_WAIT_MS)
-            }
-            "status" | "models" | "compare" => ("runtime_inspection", CHAT_SIDEKICK_QUICK_WAIT_MS),
-            _ => ("eligible", CHAT_SIDEKICK_DEFAULT_WAIT_MS),
-        };
-        return sidekick_eligible(reason, wait_ms);
-    }
-    if feedback.useful >= 3 && feedback.useful >= feedback.misses.saturating_mul(2).max(1) {
-        return sidekick_eligible("feedback_positive_prior", CHAT_SIDEKICK_DEFAULT_WAIT_MS);
-    }
-    if signals.feedback_rows >= 5 && signals.useful_rate.is_some_and(|rate| rate >= 0.75) {
-        return sidekick_eligible("metrics_success_prior", CHAT_SIDEKICK_DEFAULT_WAIT_MS);
-    }
-    sidekick_ineligible("no_mechanical_subtask")
 }
 
 fn maybe_spawn_parallel_sidekick(
@@ -2234,9 +2168,11 @@ fn maybe_spawn_parallel_sidekick(
         record_decision(false, "no_warm_sidekick");
         return no_spawn;
     }
-    let feedback = db.sidekick_feedback_summary(20).unwrap_or_default();
+    let feedback = db
+        .sidekick_feedback_summary(SIDEKICK_FEEDBACK_SIGNAL_WINDOW)
+        .unwrap_or_default();
     let signals = sidekick_routing_signals(app);
-    let decision = route_parallel_sidekick(prompt, feedback, signals);
+    let decision = route_policy::route_parallel_sidekick(prompt, feedback, signals);
     record_decision(decision.eligible, decision.reason);
     if !decision.eligible {
         return no_spawn;
@@ -2427,8 +2363,7 @@ pub async fn chat_stream(
 ) -> Result<(), String> {
     let started = Instant::now();
     let session_id = session_id.unwrap_or_else(|| "default".to_string());
-    let mut route =
-        apply_dynamic_chat_route(&app, &session_id, &route, slot_id, &messages, &on_event);
+    let route = apply_dynamic_chat_route(&app, &session_id, &route, slot_id, &messages, &on_event);
     let sidekick_plan = maybe_spawn_parallel_sidekick(
         &app,
         &route,
@@ -2437,33 +2372,14 @@ pub async fn chat_stream(
         &messages,
         Some(&on_event),
     );
-    let (mut url, mut bearer, mut model_field) = match route.as_str() {
-        "cloud" => {
-            let (base, key) = credentials().ok_or_else(|| "not signed in".to_string())?;
-            (
-                format!("{}/v1/chat/completions", base.trim_end_matches('/')),
-                Some(key),
-                "glm-5.2".to_string(),
-            )
-        }
-        _ => {
-            // A specific warm slot must be selected; each slot is its own mlx_vlm
-            // process on its own port, keyed by the model's local path.
-            let sid = slot_id.ok_or_else(|| "no local slot selected".to_string())?;
-            let (port, path) = mgr
-                .endpoint(sid)
-                .ok_or_else(|| "selected slot is not warm".to_string())?;
-            (
-                format!("http://127.0.0.1:{port}/v1/chat/completions"),
-                None,
-                path,
-            )
-        }
+    let mut binding = match route.as_str() {
+        "cloud" => cloud_route_binding().ok_or_else(|| "not signed in".to_string())?,
+        _ => local_route_binding(&route, &mgr, slot_id)?,
     };
 
     let mut outbound_messages = vec![json!({
         "role": "system",
-        "content": system_prompt_for(&model_field),
+        "content": system_prompt_for(&binding.model_field),
     })];
     let (handoff_messages, handoff_ids) = wait_for_sidekick_handoffs(
         &app,
@@ -2490,53 +2406,36 @@ pub async fn chat_stream(
     let gateway_available = credentials().is_some();
     let local_mem_gb = local_resident_mem_gb(&app);
     if let Some(reason) = compaction_reason.as_deref() {
-        record_compaction_route_decision(
+        let recommendation = record_compaction_route_decision(
             &app,
             &session_id,
-            &route,
+            &binding.route,
             slot_id,
             &messages,
             reason,
             context_tokens_before,
             Some(&on_event),
         );
-        if route == "local"
-            && app
-                .state::<crate::db::Db>()
-                .setting_get("fusion.routing")
-                .as_deref()
-                != Some("off")
+        // Only switch when the recorded recommendation actually says gateway,
+        // so the audit trail and the applied route cannot disagree.
+        if binding.route == "local"
+            && recommendation
+                .as_ref()
+                .is_some_and(|rec| rec.route == "gateway" && rec.gateway_ready)
         {
-            if let Some((base, key)) = credentials() {
-                route = "cloud".to_string();
-                url = format!("{}/v1/chat/completions", base.trim_end_matches('/'));
-                bearer = Some(key);
-                model_field = "glm-5.2".to_string();
-                if let Some(system) = outbound_messages
-                    .iter_mut()
-                    .find(|message| message.get("role").and_then(|v| v.as_str()) == Some("system"))
-                {
-                    system["content"] = json!(system_prompt_for(&model_field));
-                }
-                let detail = format!(
-                    "local -> cloud · compaction_boundary ({reason}, {} tokens)",
-                    context_tokens_before
-                );
-                log_db_write(
-                    "record_sidekick_event(compaction_route_applied)",
-                    app.state::<crate::db::Db>().record_sidekick_event(
-                        &session_id,
-                        "routing",
-                        "compaction_route_applied",
-                        &detail,
-                    ),
-                );
-                let _ = on_event.send(ChatEvent::SidekickEvent {
-                    mode: "routing".to_string(),
-                    stage: "compaction_route_applied".to_string(),
-                    detail,
-                });
-            }
+            let detail = format!(
+                "local -> cloud · compaction_boundary ({reason}, {} tokens)",
+                context_tokens_before
+            );
+            switch_route_to_cloud(
+                &app,
+                &session_id,
+                &mut binding,
+                &mut outbound_messages,
+                "compaction_route_applied",
+                &detail,
+                Some(&on_event),
+            );
         }
     }
 
@@ -2548,9 +2447,9 @@ pub async fn chat_stream(
         prompt_tokens = prompt_tokens.max(approximate_messages_tokens(&outbound_messages));
         let result = stream_chat_once(
             &client,
-            &url,
-            bearer.as_deref(),
-            &model_field,
+            &binding.url,
+            binding.bearer.as_deref(),
+            &binding.model_field,
             &outbound_messages,
             &on_event,
         )
@@ -2561,20 +2460,20 @@ pub async fn chat_stream(
                 &app,
                 ChatRunInput {
                     session_id: session_id.clone(),
-                    route: route.clone(),
-                    model: model_field.clone(),
+                    route: binding.route.clone(),
+                    model: binding.model_field.clone(),
                     elapsed_ms: Some(started.elapsed().as_millis() as u64),
                     prompt_tokens: Some(prompt_tokens),
                     completion_tokens: Some(completion_tokens),
                     tool_calls: tool_count,
                     sidekick_spawned: sidekick_plan.spawned,
-                    gateway_used: route == "cloud",
+                    gateway_used: binding.route == "cloud",
                     compacted,
                     compaction_reason: compaction_reason.clone(),
                     context_tokens_before: Some(context_tokens_before),
                     local_mem_gb,
                     gateway_available,
-                    gateway_avoided: gateway_available && route != "cloud",
+                    gateway_avoided: gateway_available && binding.route != "cloud",
                     status: "error".to_string(),
                     error: Some(error),
                 },
@@ -2596,20 +2495,20 @@ pub async fn chat_stream(
                 &app,
                 ChatRunInput {
                     session_id: session_id.clone(),
-                    route: route.clone(),
-                    model: model_field.clone(),
+                    route: binding.route.clone(),
+                    model: binding.model_field.clone(),
                     elapsed_ms: Some(started.elapsed().as_millis() as u64),
                     prompt_tokens: Some(prompt_tokens),
                     completion_tokens: Some(completion_tokens),
                     tool_calls: tool_count,
                     sidekick_spawned: sidekick_plan.spawned,
-                    gateway_used: route == "cloud",
+                    gateway_used: binding.route == "cloud",
                     compacted,
                     compaction_reason: compaction_reason.clone(),
                     context_tokens_before: Some(context_tokens_before),
                     local_mem_gb,
                     gateway_available,
-                    gateway_avoided: gateway_available && route != "cloud",
+                    gateway_avoided: gateway_available && binding.route != "cloud",
                     status: "ok".to_string(),
                     error: None,
                 },
@@ -2659,46 +2558,23 @@ pub async fn chat_stream(
             }));
         }
 
-        if route == "local"
+        if binding.route == "local"
             && !mid_session_escalated
-            && tool_count >= 3
-            && app
-                .state::<crate::db::Db>()
-                .setting_get("fusion.routing")
-                .as_deref()
-                != Some("off")
+            && tool_count >= TOOL_DEPTH_ESCALATION_CALLS
         {
-            if let Some((base, key)) = credentials() {
-                mid_session_escalated = true;
-                route = "cloud".to_string();
-                url = format!("{}/v1/chat/completions", base.trim_end_matches('/'));
-                bearer = Some(key);
-                model_field = "glm-5.2".to_string();
-                if let Some(system) = outbound_messages
-                    .iter_mut()
-                    .find(|message| message.get("role").and_then(|v| v.as_str()) == Some("system"))
-                {
-                    system["content"] = json!(system_prompt_for(&model_field));
-                }
-                let detail = format!(
-                    "local -> cloud · mid_session_tool_depth ({} tool calls)",
-                    tool_count
-                );
-                log_db_write(
-                    "record_sidekick_event(mid_session_route_applied)",
-                    app.state::<crate::db::Db>().record_sidekick_event(
-                        &session_id,
-                        "routing",
-                        "mid_session_route_applied",
-                        &detail,
-                    ),
-                );
-                let _ = on_event.send(ChatEvent::SidekickEvent {
-                    mode: "routing".to_string(),
-                    stage: "mid_session_route_applied".to_string(),
-                    detail,
-                });
-            }
+            let detail = format!(
+                "local -> cloud · mid_session_tool_depth ({} tool calls)",
+                tool_count
+            );
+            mid_session_escalated = switch_route_to_cloud(
+                &app,
+                &session_id,
+                &mut binding,
+                &mut outbound_messages,
+                "mid_session_route_applied",
+                &detail,
+                Some(&on_event),
+            );
         }
     }
 
@@ -2709,20 +2585,20 @@ pub async fn chat_stream(
         &app,
         ChatRunInput {
             session_id: session_id.clone(),
-            route: route.clone(),
-            model: model_field,
+            route: binding.route.clone(),
+            model: binding.model_field.clone(),
             elapsed_ms: Some(started.elapsed().as_millis() as u64),
             prompt_tokens: Some(prompt_tokens),
             completion_tokens: Some(completion_tokens),
             tool_calls: tool_count,
             sidekick_spawned: sidekick_plan.spawned,
-            gateway_used: route == "cloud",
+            gateway_used: binding.route == "cloud",
             compacted,
             compaction_reason,
             context_tokens_before: Some(context_tokens_before),
             local_mem_gb,
             gateway_available,
-            gateway_avoided: gateway_available && route != "cloud",
+            gateway_avoided: gateway_available && binding.route != "cloud",
             status: "tool_limit".to_string(),
             error: Some(format!("tool call limit reached ({MAX_TOOL_ROUNDS})")),
         },
@@ -3246,10 +3122,6 @@ fn finalize_tool_calls(mut tool_calls: Vec<ToolCallAcc>) -> Vec<ToolCallAcc> {
 mod tests {
     use super::*;
 
-    fn feedback(useful: u64, misses: u64) -> SidekickFeedbackSummary {
-        SidekickFeedbackSummary { useful, misses }
-    }
-
     #[test]
     fn sidekick_compaction_never_orphans_tool_replies() {
         let mut messages = vec![json!({"role": "system", "content": "sys"})];
@@ -3297,41 +3169,5 @@ mod tests {
         assert!(cache
             .get(&format!("key-{}", SIDEKICK_SESSION_CACHE_MAX + 7))
             .is_some());
-    }
-
-    #[test]
-    fn sidekick_policy_keeps_judgment_with_main() {
-        let decision = route_parallel_sidekick(
-            "should we redesign the routing architecture?",
-            feedback(0, 0),
-            SidekickRoutingSignals::default(),
-        );
-        assert!(!decision.eligible);
-        assert_eq!(decision.reason, "main_keeps_judgment");
-        assert_eq!(decision.wait_ms, 0);
-    }
-
-    #[test]
-    fn sidekick_policy_waits_longer_for_verification() {
-        let decision = route_parallel_sidekick(
-            "please verify the current model status",
-            feedback(0, 0),
-            SidekickRoutingSignals::default(),
-        );
-        assert!(decision.eligible);
-        assert_eq!(decision.reason, "verification");
-        assert_eq!(decision.wait_ms, CHAT_SIDEKICK_VERIFICATION_WAIT_MS);
-    }
-
-    #[test]
-    fn sidekick_policy_uses_quick_wait_for_summary() {
-        let decision = route_parallel_sidekick(
-            "what's left for fusion reminder",
-            feedback(0, 0),
-            SidekickRoutingSignals::default(),
-        );
-        assert!(decision.eligible);
-        assert_eq!(decision.reason, "summary");
-        assert_eq!(decision.wait_ms, CHAT_SIDEKICK_QUICK_WAIT_MS);
     }
 }

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -12,6 +12,13 @@ use crate::metrics::{Machine, Metrics, MetricsReader};
 use crate::models::{self, LOCAL_BASE_URL};
 use crate::moraine::MoraineState;
 use crate::residency::{Residency, ResidencySnapshot};
+use crate::route_policy::{
+    self, AVG_LOCAL_TOOL_CALLS_CEILING, CHAT_RUNS_SIGNAL_WINDOW, FUSION_BENCHMARK_SIGNAL_WINDOW,
+    GATEWAY_CHAT_MODEL, LOCAL_ERROR_RATE_CEILING, LONG_PROMPT_COMPACTION_CHARS,
+    MIN_ROWS_FOR_RATE_GATES, MIN_ROWS_FOR_TOOL_AVG_GATE, MIN_TOOL_DEPTH_ROWS,
+    PENDING_HANDOFF_RATE_CEILING, SESSION_CHAT_RUNS_SIGNAL_WINDOW, SIDEKICK_RUNS_SIGNAL_WINDOW,
+    TOOL_DEPTH_ESCALATION_CALLS,
+};
 use crate::sidecar::{ServiceState, Services};
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -628,6 +635,8 @@ struct ChatRouteSignals {
     compacted_rows: u64,
     session_compacted_rows: u64,
     session_last_compaction_reason: Option<String>,
+    /// Rows in the tool-depth scope (session when known, else global window).
+    local_tool_rows: u64,
     local_tool_depth_rows: u64,
     avg_local_tool_calls: Option<f64>,
     sidekick_benchmark_rows: u64,
@@ -636,42 +645,17 @@ struct ChatRouteSignals {
     avg_sidekick_elapsed_ms: Option<f64>,
 }
 
-fn fusion_policy_class(
-    route: &str,
-    use_sidekick: bool,
-    escalate_gateway: bool,
-    upgrade_sidekick: bool,
-    reason: &str,
-) -> &'static str {
-    if upgrade_sidekick {
-        "sidekick_upgrade"
-    } else if use_sidekick {
-        "delegate_mechanical"
-    } else if escalate_gateway || route == "gateway" {
-        if reason.contains("compaction") {
-            "compaction_gateway"
-        } else if reason.contains("error") || reason.contains("tool_depth") {
-            "health_gateway"
-        } else {
-            "frontier_gateway"
-        }
-    } else if reason.contains("judgment") || reason.contains("complex") {
-        "main_owns_judgment"
-    } else if reason.starts_with("sidekick_") || reason.contains("sidekick") {
-        "sidekick_suppressed"
-    } else {
-        "local_default"
-    }
-}
-
 fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSignals {
-    let Ok(rows) = app.state::<crate::db::Db>().list_chat_runs(60) else {
+    let Ok(rows) = app
+        .state::<crate::db::Db>()
+        .list_chat_runs(CHAT_RUNS_SIGNAL_WINDOW)
+    else {
         return ChatRouteSignals::default();
     };
     let session_rows = session_id
         .and_then(|id| {
             app.state::<crate::db::Db>()
-                .list_chat_runs_for_session(id, 20)
+                .list_chat_runs_for_session(id, SESSION_CHAT_RUNS_SIGNAL_WINDOW)
                 .ok()
         })
         .unwrap_or_default();
@@ -689,14 +673,28 @@ fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSig
         .iter()
         .filter_map(|row| row.elapsed_ms.map(|v| v as f64))
         .collect();
-    let local_tool_calls: Vec<f64> = local.iter().map(|row| row.tool_calls as f64).collect();
-    let local_tool_depth_rows = local
+    // Tool depth is a property of the current conversation, not machine
+    // health: scope it to the session so a couple of tool-heavy turns in one
+    // session cannot ratchet every other session to the gateway. Fall back to
+    // the global window only when no session is known.
+    let tool_scope: Vec<_> = if session_id.is_some() {
+        session_rows
+            .iter()
+            .filter(|row| row.route == "local")
+            .collect()
+    } else {
+        local.clone()
+    };
+    let local_tool_calls: Vec<f64> = tool_scope.iter().map(|row| row.tool_calls as f64).collect();
+    let local_tool_depth_rows = tool_scope
         .iter()
-        .filter(|row| row.tool_calls >= 3 || row.status == "tool_limit")
+        .filter(|row| {
+            row.tool_calls >= TOOL_DEPTH_ESCALATION_CALLS || row.status == "tool_limit"
+        })
         .count() as u64;
     let benchmark_rows = app
         .state::<crate::db::Db>()
-        .list_fusion_benchmarks(40)
+        .list_fusion_benchmarks(FUSION_BENCHMARK_SIGNAL_WINDOW)
         .unwrap_or_default();
     let sidekick_scores: Vec<f64> = benchmark_rows
         .iter()
@@ -705,8 +703,10 @@ fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSig
         .collect();
     ChatRouteSignals {
         local_rows: local.len() as u64,
-        local_error_rate: (!local.is_empty()).then_some(
-            local.iter().filter(|row| row.status != "ok").count() as f64 / local.len() as f64,
+        // Rows are newest-first; decay old errors so a bad patch fades instead
+        // of pinning the local route unhealthy for the whole window.
+        local_error_rate: route_policy::decayed_rate(
+            local.iter().map(|row| row.status != "ok"),
         ),
         sidekick_rows: sidekick.len() as u64,
         compacted_rows: rows.iter().filter(|row| row.compacted).count() as u64,
@@ -715,6 +715,7 @@ fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSig
             .iter()
             .find(|row| row.compacted)
             .and_then(|row| row.compaction_reason.clone()),
+        local_tool_rows: tool_scope.len() as u64,
         local_tool_depth_rows,
         avg_local_tool_calls: avg(&local_tool_calls),
         sidekick_benchmark_rows: sidekick_scores.len() as u64,
@@ -722,11 +723,6 @@ fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSig
         avg_local_elapsed_ms: avg(&local_elapsed),
         avg_sidekick_elapsed_ms: avg(&sidekick_elapsed),
     }
-}
-
-fn prompt_has_any(prompt: &str, terms: &[&str]) -> bool {
-    let lower = prompt.to_lowercase();
-    terms.iter().any(|term| lower.contains(term))
 }
 
 fn residency<'a>(app: &'a AppHandle) -> &'a Residency {
@@ -1112,7 +1108,7 @@ pub fn fusion_benchmark_matrix() -> FusionBenchmarkMatrix {
                 id: "gateway-glm",
                 label: "GLM 5.2 gateway",
                 route: "gateway",
-                model_hint: "glm-5.2",
+                model_hint: GATEWAY_CHAT_MODEL,
                 description: "Remote gateway candidate for frontier-style comparison.",
             },
             FusionBenchmarkCandidate {
@@ -1298,200 +1294,93 @@ pub fn fusion_route_recommendation_with_persist(
 
     let prompt = request.prompt.trim();
     let current_route = request.current_route.as_deref();
-    let judgment = prompt_has_any(
-        prompt,
-        &[
-            "decide",
-            "should we",
-            "what should",
-            "strategy",
-            "plan",
-            "architect",
-            "tradeoff",
-            "judgment",
-        ],
-    );
-    let mechanical = prompt_has_any(
-        prompt,
-        &[
-            "check",
-            "review",
-            "inspect",
-            "search",
-            "summarize",
-            "open",
-            "ground",
-            "grounding",
-            "read",
-            "locate",
-            "verify",
-            "compare",
-            "find",
-            "trace",
-            "status",
-            "models",
-            "what's left",
-            "whats left",
-            "reminder",
-        ],
-    );
-    let complex = prompt_has_any(
-        prompt,
-        &[
-            "full automationbench",
-            "benchmark",
-            "multi-file",
-            "race condition",
-            "architecture",
-            "frontier",
-            "hard",
-            "complex",
-            "production",
-        ],
-    );
+    let class = route_policy::classify_prompt(prompt);
+    let (mechanical, judgment, complex) = (class.mechanical(), class.judgment, class.complex);
 
-    let metrics = sidekick_metrics(app.clone(), Some(30)).ok();
+    let metrics = sidekick_metrics(app.clone(), Some(SIDEKICK_RUNS_SIGNAL_WINDOW)).ok();
     let route_signals = chat_route_signals(&app, request.session_id.as_deref());
-    let enough_parallel_feedback = metrics
-        .as_ref()
-        .is_some_and(|m| m.parallel_useful_rows + m.parallel_miss_rows >= 5);
-    let low_usefulness = metrics
-        .as_ref()
-        .and_then(|m| {
-            if enough_parallel_feedback {
-                m.parallel_useful_rate
-            } else {
-                m.useful_rate
-            }
-        })
-        .is_some_and(|rate| {
-            metrics.as_ref().is_some_and(|m| {
-                if enough_parallel_feedback {
-                    m.parallel_useful_rows + m.parallel_miss_rows >= 5
-                } else {
-                    m.useful_rows + m.miss_rows >= 5
-                }
-            }) && rate < 0.25
-        });
-    let high_escalation = metrics
-        .as_ref()
-        .and_then(|m| {
-            if m.parallel_rows >= 5 {
-                m.parallel_escalation_rate
-            } else {
-                m.escalation_rate
-            }
-        })
-        .is_some_and(|rate| metrics.as_ref().is_some_and(|m| m.rows >= 5) && rate > 0.6);
-    let pending_sidekick_handoffs = metrics
-        .as_ref()
-        .and_then(|m| m.parallel_pending_handoff_rate)
-        .is_some_and(|rate| metrics.as_ref().is_some_and(|m| m.parallel_rows >= 5) && rate > 0.5);
-    let local_unhealthy = route_signals.local_rows >= 5
+    let low_usefulness = metrics.as_ref().is_some_and(|m| {
+        let parallel_feedback = m.parallel_useful_rows + m.parallel_miss_rows;
+        let (feedback_rows, useful_rate) = if parallel_feedback >= MIN_ROWS_FOR_RATE_GATES {
+            (parallel_feedback, m.parallel_useful_rate)
+        } else {
+            (m.useful_rows + m.miss_rows, m.useful_rate)
+        };
+        route_policy::usefulness_low(feedback_rows, useful_rate)
+    });
+    let high_escalation = metrics.as_ref().is_some_and(|m| {
+        let escalation_rate = if m.parallel_rows >= MIN_ROWS_FOR_RATE_GATES {
+            m.parallel_escalation_rate
+        } else {
+            m.escalation_rate
+        };
+        route_policy::escalation_high(m.rows, escalation_rate)
+    });
+    let pending_sidekick_handoffs = metrics.as_ref().is_some_and(|m| {
+        m.parallel_rows >= MIN_ROWS_FOR_RATE_GATES
+            && m.parallel_pending_handoff_rate
+                .is_some_and(|rate| rate > PENDING_HANDOFF_RATE_CEILING)
+    });
+    let local_unhealthy = route_signals.local_rows >= MIN_ROWS_FOR_RATE_GATES
         && route_signals
             .local_error_rate
-            .is_some_and(|rate| rate >= 0.35);
-    let local_tool_depth_high = route_signals.local_tool_depth_rows >= 2
-        || route_signals
-            .avg_local_tool_calls
-            .is_some_and(|avg| route_signals.local_rows >= 3 && avg >= 2.5);
-    let sidekick_slow = route_signals.sidekick_rows >= 3
-        && matches!(
-            (
-                route_signals.avg_sidekick_elapsed_ms,
-                route_signals.avg_local_elapsed_ms
-            ),
-            (Some(sidekick_ms), Some(local_ms)) if local_ms > 0.0 && sidekick_ms > local_ms * 1.75
-        );
-    let sidekick_benchmark_low = route_signals.sidekick_benchmark_rows >= 4
-        && route_signals
-            .sidekick_benchmark_score
-            .is_some_and(|score| score < 0.5);
+            .is_some_and(|rate| rate >= LOCAL_ERROR_RATE_CEILING);
+    let local_tool_depth_high = route_signals.local_tool_depth_rows >= MIN_TOOL_DEPTH_ROWS
+        || route_signals.avg_local_tool_calls.is_some_and(|avg| {
+            route_signals.local_tool_rows >= MIN_ROWS_FOR_TOOL_AVG_GATE
+                && avg >= AVG_LOCAL_TOOL_CALLS_CEILING
+        });
+    let sidekick_slow = route_policy::sidekick_latency_high(
+        route_signals.sidekick_rows,
+        route_signals.avg_sidekick_elapsed_ms,
+        route_signals.avg_local_elapsed_ms,
+    );
+    let sidekick_benchmark_low = route_policy::sidekick_benchmark_low(
+        route_signals.sidekick_benchmark_rows,
+        route_signals.sidekick_benchmark_score,
+    );
     let upgrade_sidekick = sidekick_ready
         && (high_escalation || sidekick_slow || sidekick_benchmark_low)
         && !low_usefulness;
     let session_compaction_boundary = route_signals.session_compacted_rows > 0;
-    let compaction_boundary =
-        session_compaction_boundary || route_signals.compacted_rows > 0 || prompt.len() > 16_000;
+    let long_prompt = prompt.len() > LONG_PROMPT_COMPACTION_CHARS;
+    // Compaction is per-conversation state: a compaction in some other
+    // session must not push this one to the gateway.
+    let compaction_boundary = session_compaction_boundary || long_prompt;
 
-    let (route, use_sidekick, escalate_gateway, reason) =
-        if matches!(current_route, Some("cloud" | "gateway")) && gateway_ready && !mechanical {
-            ("gateway", false, true, "keep_current_gateway")
-        } else if session_compaction_boundary && gateway_ready && (complex || judgment) {
-            (
-                "gateway",
-                false,
-                true,
-                route_signals
-                    .session_last_compaction_reason
-                    .as_deref()
-                    .unwrap_or("session_compaction_boundary_gateway"),
-            )
-        } else if compaction_boundary && gateway_ready && (complex || judgment) {
-            ("gateway", false, true, "recent_compaction_boundary_gateway")
-        } else if local_unhealthy && gateway_ready && (complex || current_route == Some("local")) {
-            ("gateway", false, true, "local_error_rate_high")
-        } else if local_tool_depth_high
-            && gateway_ready
-            && (complex || judgment || current_route == Some("local"))
-        {
-            ("gateway", false, true, "local_tool_depth_high")
-        } else if judgment || complex {
-            if gateway_ready && complex {
-                ("gateway", false, true, "complex_or_frontier_task")
-            } else if local_ready {
-                ("local", false, false, "main_keeps_judgment")
-            } else if gateway_ready {
-                ("gateway", false, true, "local_unavailable")
-            } else {
-                ("local", false, false, "no_ready_route")
-            }
-        } else if mechanical
-            && local_ready
-            && sidekick_ready
-            && !low_usefulness
-            && !high_escalation
-            && !pending_sidekick_handoffs
-            && !sidekick_slow
-            && !sidekick_benchmark_low
-        {
-            ("local", true, false, "mechanical_with_sidekick")
-        } else if local_ready {
-            (
-                "local",
-                false,
-                false,
-                if low_usefulness {
-                    "sidekick_low_usefulness"
-                } else if high_escalation {
-                    "sidekick_high_escalation"
-                } else if pending_sidekick_handoffs {
-                    "sidekick_pending_handoffs"
-                } else if sidekick_slow {
-                    "sidekick_latency_high"
-                } else if sidekick_benchmark_low {
-                    "sidekick_benchmark_score_low"
-                } else if mechanical {
-                    "no_warm_sidekick"
-                } else {
-                    "local_default"
-                },
-            )
-        } else if gateway_ready {
-            ("gateway", false, true, "local_unavailable")
-        } else {
-            ("local", false, false, "no_ready_route")
-        };
+    let decision = route_policy::recommend_route(&route_policy::RouteInputs {
+        current_route,
+        class,
+        local_ready,
+        sidekick_ready,
+        gateway_ready,
+        low_usefulness,
+        high_escalation,
+        pending_sidekick_handoffs,
+        local_unhealthy,
+        local_tool_depth_high,
+        sidekick_slow,
+        sidekick_benchmark_low,
+        session_compaction_boundary,
+        long_prompt,
+        session_last_compaction_reason: route_signals.session_last_compaction_reason.as_deref(),
+    });
+    let (route, use_sidekick, escalate_gateway, reason) = (
+        decision.route,
+        decision.use_sidekick,
+        decision.escalate_gateway,
+        decision.reason,
+    );
 
     let main_model = main_slot.and_then(|slot| slot.model_id);
     let sidekick_model = sidekick.map(|(_, _, _, model_id)| model_id);
-    let gateway_model = gateway_ready.then(|| "glm-5.2".to_string());
-    let policy_class = fusion_policy_class(
+    let gateway_model = gateway_ready.then(|| GATEWAY_CHAT_MODEL.to_string());
+    let policy_class = route_policy::fusion_policy_class(
         route,
         use_sidekick,
         escalate_gateway,
         upgrade_sidekick,
-        reason,
+        &reason,
     );
     let signals = json!({
         "mechanical": mechanical,
@@ -1517,6 +1406,7 @@ pub fn fusion_route_recommendation_with_persist(
             "compacted_rows": route_signals.compacted_rows,
             "session_compacted_rows": route_signals.session_compacted_rows,
             "session_last_compaction_reason": route_signals.session_last_compaction_reason,
+            "local_tool_rows": route_signals.local_tool_rows,
             "local_tool_depth_rows": route_signals.local_tool_depth_rows,
             "avg_local_tool_calls": route_signals.avg_local_tool_calls,
             "sidekick_benchmark_rows": route_signals.sidekick_benchmark_rows,
@@ -1546,7 +1436,7 @@ pub fn fusion_route_recommendation_with_persist(
         use_sidekick,
         escalate_gateway,
         upgrade_sidekick,
-        reason: reason.to_string(),
+        reason,
         policy_class: policy_class.to_string(),
         signals: signals.clone(),
         main_model,
@@ -1927,7 +1817,7 @@ pub fn export_automationbench_handoff(
             return Err(format!("unknown Fusion benchmark candidate: {candidate}"));
         }
         let (route, model, local_model_required, gateway_required) = match candidate.as_str() {
-            "gateway-glm" => ("gateway", "glm-5.2", false, true),
+            "gateway-glm" => ("gateway", GATEWAY_CHAT_MODEL, false, true),
             "local-fast" => ("local", "warm small/e2b Understudy model", true, false),
             _ => ("local", "warm main Understudy model", true, false),
         };
@@ -2158,12 +2048,12 @@ async fn run_fusion_benchmark_inner(
         .clone()
         .or_else(|| {
             if candidate == "gateway-glm" {
-                Some("glm-5.2".to_string())
+                Some(GATEWAY_CHAT_MODEL.to_string())
             } else {
                 None
             }
         })
-        .unwrap_or_else(|| "glm-5.2".to_string());
+        .unwrap_or_else(|| GATEWAY_CHAT_MODEL.to_string());
     let mut rows = vec![];
     let mut recorded_skips = 0u64;
 

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod metrics;
 mod models;
 mod moraine;
 mod residency;
+mod route_policy;
 mod server;
 mod sidecar;
 

--- a/apps/homescreen/src-tauri/src/route_policy.rs
+++ b/apps/homescreen/src-tauri/src/route_policy.rs
@@ -1,0 +1,597 @@
+//! Single source of truth for the Fusion routing/delegation policy.
+//!
+//! Every keyword class, threshold, and signal window used to decide between
+//! the local model, the parallel sidekick, and the paid gateway lives here.
+//! `chat.rs` (live chat loop) and `commands.rs` (route recommendation command)
+//! both call into this module; neither may hand-copy a policy value.
+
+use crate::db::SidekickFeedbackSummary;
+
+/// Gateway chat model used whenever a turn escalates to the cloud route.
+pub const GATEWAY_CHAT_MODEL: &str = "glm-5.2";
+
+// ----- prompt keyword classes -----
+
+/// Prompts that must keep final judgment with the main agent.
+pub const JUDGMENT_TERMS: &[&str] = &[
+    "decide",
+    "should we",
+    "what should",
+    "strategy",
+    "plan",
+    "architect",
+    "tradeoff",
+    "judgment",
+];
+
+/// Mechanical subtasks that a background sidekick may take in parallel.
+pub const DELEGATE_TERMS: &[&str] = &[
+    "check",
+    "review",
+    "inspect",
+    "search",
+    "summarize",
+    "open",
+    "ground",
+    "grounding",
+    "read",
+    "locate",
+    "verify",
+    "compare",
+    "find",
+    "trace",
+    "status",
+    "models",
+    "what's left",
+    "whats left",
+    "reminder",
+];
+
+/// Frontier-shaped work that justifies the gateway when it is ready.
+pub const COMPLEX_TERMS: &[&str] = &[
+    "full automationbench",
+    "benchmark",
+    "multi-file",
+    "race condition",
+    "architecture",
+    "frontier",
+    "hard",
+    "complex",
+    "production",
+];
+
+// ----- thresholds -----
+
+/// Sidekick lane is "slow" when its average elapsed exceeds local by this ratio.
+pub const SIDEKICK_LATENCY_RATIO: f64 = 1.75;
+/// Escalation rate above which the sidekick lane is considered unhealthy.
+pub const ESCALATION_RATE_CEILING: f64 = 0.6;
+/// Sidekick benchmark score below which delegation is suppressed.
+pub const SIDEKICK_BENCHMARK_SCORE_FLOOR: f64 = 0.5;
+/// Useful-feedback rate below which delegation is suppressed.
+pub const USEFUL_RATE_FLOOR: f64 = 0.25;
+/// Useful-feedback rate treated as a positive prior for delegation.
+pub const USEFUL_RATE_SUCCESS_PRIOR: f64 = 0.75;
+/// Handoff (consumed) rate below which mechanical delegation is suppressed.
+pub const HANDOFF_RATE_FLOOR: f64 = 0.2;
+/// Pending-handoff rate above which new parallel spawns are suppressed.
+pub const PENDING_HANDOFF_RATE_CEILING: f64 = 0.5;
+/// Local error rate at or above which the local route is unhealthy.
+pub const LOCAL_ERROR_RATE_CEILING: f64 = 0.35;
+/// Average tool calls per local turn that marks the session as tool-deep.
+pub const AVG_LOCAL_TOOL_CALLS_CEILING: f64 = 2.5;
+/// Tool calls in one turn that mark it tool-deep (mid-session escalation
+/// trigger in the live loop, and the per-row filter in route signals).
+pub const TOOL_DEPTH_ESCALATION_CALLS: u64 = 3;
+/// Session rows that must be tool-deep before recommending the gateway.
+pub const MIN_TOOL_DEPTH_ROWS: u64 = 2;
+/// Prompt length that by itself counts as a compaction boundary.
+pub const LONG_PROMPT_COMPACTION_CHARS: usize = 16_000;
+
+// ----- minimum-evidence gates (rows required before a rate is trusted) -----
+
+pub const MIN_ROWS_FOR_RATE_GATES: u64 = 5;
+pub const MIN_ROWS_FOR_LATENCY_GATE: u64 = 3;
+pub const MIN_ROWS_FOR_BENCHMARK_GATE: u64 = 4;
+pub const MIN_ROWS_FOR_HANDOFF_GATE: u64 = 3;
+pub const MIN_ROWS_FOR_TOOL_AVG_GATE: u64 = 3;
+/// Useful/miss feedback rows required before feedback priors apply.
+pub const MIN_FEEDBACK_FOR_PRIOR: u64 = 3;
+
+// ----- signal windows (rows read from the durable stores) -----
+
+pub const CHAT_RUNS_SIGNAL_WINDOW: u32 = 60;
+pub const SESSION_CHAT_RUNS_SIGNAL_WINDOW: u32 = 20;
+pub const FUSION_BENCHMARK_SIGNAL_WINDOW: u32 = 40;
+pub const SIDEKICK_RUNS_SIGNAL_WINDOW: u32 = 30;
+pub const SIDEKICK_FEEDBACK_SIGNAL_WINDOW: u32 = 20;
+
+/// Per-row weight decay applied to global (cross-session) rate signals so a
+/// burst of old failures cannot ratchet routing for the whole window.
+pub const SIGNAL_DECAY: f64 = 0.9;
+
+// ----- sidekick wait budgets by delegation class -----
+
+pub const CHAT_SIDEKICK_QUICK_WAIT_MS: u64 = 600;
+pub const CHAT_SIDEKICK_DEFAULT_WAIT_MS: u64 = 1_000;
+pub const CHAT_SIDEKICK_VERIFICATION_WAIT_MS: u64 = 1_800;
+
+// ----- prompt classification -----
+
+#[derive(Clone, Copy, Default)]
+pub struct PromptClass {
+    pub judgment: bool,
+    pub complex: bool,
+    pub mechanical_term: Option<&'static str>,
+}
+
+impl PromptClass {
+    pub fn mechanical(&self) -> bool {
+        self.mechanical_term.is_some()
+    }
+}
+
+pub fn classify_prompt(prompt: &str) -> PromptClass {
+    let lower = prompt.to_lowercase();
+    PromptClass {
+        judgment: JUDGMENT_TERMS.iter().any(|needle| lower.contains(needle)),
+        complex: COMPLEX_TERMS.iter().any(|needle| lower.contains(needle)),
+        mechanical_term: DELEGATE_TERMS
+            .iter()
+            .find(|needle| lower.contains(**needle))
+            .copied(),
+    }
+}
+
+// ----- shared signal math -----
+
+/// Weighted fraction of `true` items, newest first, decaying by `SIGNAL_DECAY`
+/// per row. Recent rows dominate; old rows fade instead of pinning the rate.
+pub fn decayed_rate<I: IntoIterator<Item = bool>>(newest_first: I) -> Option<f64> {
+    let mut weight = 1.0;
+    let mut total = 0.0;
+    let mut hits = 0.0;
+    for item in newest_first {
+        total += weight;
+        if item {
+            hits += weight;
+        }
+        weight *= SIGNAL_DECAY;
+    }
+    (total > 0.0).then(|| hits / total)
+}
+
+// ----- shared gate predicates -----
+
+pub fn sidekick_latency_high(
+    sidekick_rows: u64,
+    avg_sidekick_elapsed_ms: Option<f64>,
+    avg_local_elapsed_ms: Option<f64>,
+) -> bool {
+    sidekick_rows >= MIN_ROWS_FOR_LATENCY_GATE
+        && matches!(
+            (avg_sidekick_elapsed_ms, avg_local_elapsed_ms),
+            (Some(sidekick_ms), Some(local_ms))
+                if local_ms > 0.0 && sidekick_ms > local_ms * SIDEKICK_LATENCY_RATIO
+        )
+}
+
+pub fn sidekick_benchmark_low(benchmark_rows: u64, benchmark_score: Option<f64>) -> bool {
+    benchmark_rows >= MIN_ROWS_FOR_BENCHMARK_GATE
+        && benchmark_score.is_some_and(|score| score < SIDEKICK_BENCHMARK_SCORE_FLOOR)
+}
+
+pub fn escalation_high(rows: u64, escalation_rate: Option<f64>) -> bool {
+    rows >= MIN_ROWS_FOR_RATE_GATES
+        && escalation_rate.is_some_and(|rate| rate > ESCALATION_RATE_CEILING)
+}
+
+pub fn usefulness_low(feedback_rows: u64, useful_rate: Option<f64>) -> bool {
+    feedback_rows >= MIN_ROWS_FOR_RATE_GATES
+        && useful_rate.is_some_and(|rate| rate < USEFUL_RATE_FLOOR)
+}
+
+// ----- parallel sidekick delegation policy -----
+
+pub struct SidekickRoutingDecision {
+    pub eligible: bool,
+    pub reason: &'static str,
+    pub wait_ms: u64,
+}
+
+fn sidekick_ineligible(reason: &'static str) -> SidekickRoutingDecision {
+    SidekickRoutingDecision {
+        eligible: false,
+        reason,
+        wait_ms: 0,
+    }
+}
+
+fn sidekick_eligible(reason: &'static str, wait_ms: u64) -> SidekickRoutingDecision {
+    SidekickRoutingDecision {
+        eligible: true,
+        reason,
+        wait_ms,
+    }
+}
+
+#[derive(Default)]
+pub struct SidekickRoutingSignals {
+    /// Total sidekick runs in the window (denominator of `escalation_rate`).
+    pub rows: u64,
+    /// Rows with explicit useful/miss feedback.
+    pub feedback_rows: u64,
+    pub useful_rate: Option<f64>,
+    pub handoff_rate: Option<f64>,
+    pub escalation_rate: Option<f64>,
+    pub sidekick_rows: u64,
+    pub sidekick_benchmark_rows: u64,
+    pub sidekick_benchmark_score: Option<f64>,
+    pub avg_local_elapsed_ms: Option<f64>,
+    pub avg_sidekick_elapsed_ms: Option<f64>,
+}
+
+/// Decide whether a prompt is eligible for a background parallel sidekick
+/// pass, and how long the main turn should wait for its findings.
+pub fn route_parallel_sidekick(
+    prompt: &str,
+    feedback: SidekickFeedbackSummary,
+    signals: SidekickRoutingSignals,
+) -> SidekickRoutingDecision {
+    let class = classify_prompt(prompt);
+    if class.judgment {
+        return sidekick_ineligible("main_keeps_judgment");
+    }
+    if usefulness_low(signals.feedback_rows, signals.useful_rate) {
+        return sidekick_ineligible("metrics_low_usefulness");
+    }
+    if escalation_high(signals.rows, signals.escalation_rate) {
+        return sidekick_ineligible("metrics_high_escalation");
+    }
+    if sidekick_latency_high(
+        signals.sidekick_rows,
+        signals.avg_sidekick_elapsed_ms,
+        signals.avg_local_elapsed_ms,
+    ) {
+        return sidekick_ineligible("metrics_sidekick_latency_high");
+    }
+    if sidekick_benchmark_low(
+        signals.sidekick_benchmark_rows,
+        signals.sidekick_benchmark_score,
+    ) {
+        return sidekick_ineligible("benchmark_sidekick_score_low");
+    }
+    if let Some(term) = class.mechanical_term {
+        if signals.feedback_rows >= MIN_ROWS_FOR_HANDOFF_GATE
+            && signals
+                .handoff_rate
+                .is_some_and(|rate| rate < HANDOFF_RATE_FLOOR)
+        {
+            return sidekick_ineligible("metrics_low_handoff");
+        }
+        if feedback.misses >= MIN_FEEDBACK_FOR_PRIOR
+            && feedback.misses > feedback.useful.saturating_mul(2)
+        {
+            return sidekick_ineligible("feedback_recent_misses");
+        }
+        let (reason, wait_ms) = match term {
+            "search" | "find" | "trace" => ("mechanical_search", CHAT_SIDEKICK_DEFAULT_WAIT_MS),
+            "check" | "verify" | "inspect" | "review" => {
+                ("verification", CHAT_SIDEKICK_VERIFICATION_WAIT_MS)
+            }
+            "summarize" | "reminder" | "what's left" | "whats left" => {
+                ("summary", CHAT_SIDEKICK_QUICK_WAIT_MS)
+            }
+            "status" | "models" | "compare" => ("runtime_inspection", CHAT_SIDEKICK_QUICK_WAIT_MS),
+            _ => ("eligible", CHAT_SIDEKICK_DEFAULT_WAIT_MS),
+        };
+        return sidekick_eligible(reason, wait_ms);
+    }
+    if feedback.useful >= MIN_FEEDBACK_FOR_PRIOR
+        && feedback.useful >= feedback.misses.saturating_mul(2).max(1)
+    {
+        return sidekick_eligible("feedback_positive_prior", CHAT_SIDEKICK_DEFAULT_WAIT_MS);
+    }
+    if signals.feedback_rows >= MIN_ROWS_FOR_RATE_GATES
+        && signals
+            .useful_rate
+            .is_some_and(|rate| rate >= USEFUL_RATE_SUCCESS_PRIOR)
+    {
+        return sidekick_eligible("metrics_success_prior", CHAT_SIDEKICK_DEFAULT_WAIT_MS);
+    }
+    sidekick_ineligible("no_mechanical_subtask")
+}
+
+// ----- route recommendation policy -----
+
+/// Health and readiness signals feeding the route recommendation ladder.
+/// Callers gather these from the durable stores; the decision itself is pure.
+#[derive(Default)]
+pub struct RouteInputs<'a> {
+    pub current_route: Option<&'a str>,
+    pub class: PromptClass,
+    pub local_ready: bool,
+    pub sidekick_ready: bool,
+    pub gateway_ready: bool,
+    pub low_usefulness: bool,
+    pub high_escalation: bool,
+    pub pending_sidekick_handoffs: bool,
+    pub local_unhealthy: bool,
+    pub local_tool_depth_high: bool,
+    pub sidekick_slow: bool,
+    pub sidekick_benchmark_low: bool,
+    /// This session compacted at least once.
+    pub session_compaction_boundary: bool,
+    /// The prompt alone exceeds `LONG_PROMPT_COMPACTION_CHARS`.
+    pub long_prompt: bool,
+    pub session_last_compaction_reason: Option<&'a str>,
+}
+
+pub struct RouteDecision {
+    pub route: &'static str,
+    pub use_sidekick: bool,
+    pub escalate_gateway: bool,
+    pub reason: String,
+}
+
+impl RouteDecision {
+    fn new(
+        route: &'static str,
+        use_sidekick: bool,
+        escalate_gateway: bool,
+        reason: &str,
+    ) -> Self {
+        RouteDecision {
+            route,
+            use_sidekick,
+            escalate_gateway,
+            reason: reason.to_string(),
+        }
+    }
+}
+
+/// The route recommendation ladder shared by the `fusion_route_recommendation`
+/// command and the live chat loop's pre-turn / compaction-boundary decisions.
+pub fn recommend_route(inputs: &RouteInputs) -> RouteDecision {
+    let class = inputs.class;
+    if matches!(inputs.current_route, Some("cloud" | "gateway"))
+        && inputs.gateway_ready
+        && !class.mechanical()
+    {
+        return RouteDecision::new("gateway", false, true, "keep_current_gateway");
+    }
+    if inputs.session_compaction_boundary
+        && inputs.gateway_ready
+        && (class.complex || class.judgment)
+    {
+        return RouteDecision::new(
+            "gateway",
+            false,
+            true,
+            inputs
+                .session_last_compaction_reason
+                .unwrap_or("session_compaction_boundary_gateway"),
+        );
+    }
+    if inputs.long_prompt && inputs.gateway_ready && (class.complex || class.judgment) {
+        return RouteDecision::new("gateway", false, true, "long_prompt_compaction_gateway");
+    }
+    if inputs.local_unhealthy
+        && inputs.gateway_ready
+        && (class.complex || inputs.current_route == Some("local"))
+    {
+        return RouteDecision::new("gateway", false, true, "local_error_rate_high");
+    }
+    if inputs.local_tool_depth_high
+        && inputs.gateway_ready
+        && (class.complex || class.judgment || inputs.current_route == Some("local"))
+    {
+        return RouteDecision::new("gateway", false, true, "local_tool_depth_high");
+    }
+    if class.judgment || class.complex {
+        return if inputs.gateway_ready && class.complex {
+            RouteDecision::new("gateway", false, true, "complex_or_frontier_task")
+        } else if inputs.local_ready {
+            RouteDecision::new("local", false, false, "main_keeps_judgment")
+        } else if inputs.gateway_ready {
+            RouteDecision::new("gateway", false, true, "local_unavailable")
+        } else {
+            RouteDecision::new("local", false, false, "no_ready_route")
+        };
+    }
+    if class.mechanical()
+        && inputs.local_ready
+        && inputs.sidekick_ready
+        && !inputs.low_usefulness
+        && !inputs.high_escalation
+        && !inputs.pending_sidekick_handoffs
+        && !inputs.sidekick_slow
+        && !inputs.sidekick_benchmark_low
+    {
+        return RouteDecision::new("local", true, false, "mechanical_with_sidekick");
+    }
+    if inputs.local_ready {
+        return RouteDecision::new(
+            "local",
+            false,
+            false,
+            if inputs.low_usefulness {
+                "sidekick_low_usefulness"
+            } else if inputs.high_escalation {
+                "sidekick_high_escalation"
+            } else if inputs.pending_sidekick_handoffs {
+                "sidekick_pending_handoffs"
+            } else if inputs.sidekick_slow {
+                "sidekick_latency_high"
+            } else if inputs.sidekick_benchmark_low {
+                "sidekick_benchmark_score_low"
+            } else if class.mechanical() {
+                "no_warm_sidekick"
+            } else {
+                "local_default"
+            },
+        );
+    }
+    if inputs.gateway_ready {
+        return RouteDecision::new("gateway", false, true, "local_unavailable");
+    }
+    RouteDecision::new("local", false, false, "no_ready_route")
+}
+
+pub fn fusion_policy_class(
+    route: &str,
+    use_sidekick: bool,
+    escalate_gateway: bool,
+    upgrade_sidekick: bool,
+    reason: &str,
+) -> &'static str {
+    if upgrade_sidekick {
+        "sidekick_upgrade"
+    } else if use_sidekick {
+        "delegate_mechanical"
+    } else if escalate_gateway || route == "gateway" {
+        if reason.contains("compaction") {
+            "compaction_gateway"
+        } else if reason.contains("error") || reason.contains("tool_depth") {
+            "health_gateway"
+        } else {
+            "frontier_gateway"
+        }
+    } else if reason.contains("judgment") || reason.contains("complex") {
+        "main_owns_judgment"
+    } else if reason.starts_with("sidekick_") || reason.contains("sidekick") {
+        "sidekick_suppressed"
+    } else {
+        "local_default"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feedback(useful: u64, misses: u64) -> SidekickFeedbackSummary {
+        SidekickFeedbackSummary { useful, misses }
+    }
+
+    #[test]
+    fn sidekick_policy_keeps_judgment_with_main() {
+        let decision = route_parallel_sidekick(
+            "should we redesign the routing architecture?",
+            feedback(0, 0),
+            SidekickRoutingSignals::default(),
+        );
+        assert!(!decision.eligible);
+        assert_eq!(decision.reason, "main_keeps_judgment");
+        assert_eq!(decision.wait_ms, 0);
+    }
+
+    #[test]
+    fn sidekick_policy_waits_longer_for_verification() {
+        let decision = route_parallel_sidekick(
+            "please verify the current model status",
+            feedback(0, 0),
+            SidekickRoutingSignals::default(),
+        );
+        assert!(decision.eligible);
+        assert_eq!(decision.reason, "verification");
+        assert_eq!(decision.wait_ms, CHAT_SIDEKICK_VERIFICATION_WAIT_MS);
+    }
+
+    #[test]
+    fn sidekick_policy_uses_quick_wait_for_summary() {
+        let decision = route_parallel_sidekick(
+            "what's left for fusion reminder",
+            feedback(0, 0),
+            SidekickRoutingSignals::default(),
+        );
+        assert!(decision.eligible);
+        assert_eq!(decision.reason, "summary");
+        assert_eq!(decision.wait_ms, CHAT_SIDEKICK_QUICK_WAIT_MS);
+    }
+
+    #[test]
+    fn escalation_gate_requires_enough_total_rows() {
+        // 4 rows is below the evidence gate: high escalation must not suppress.
+        let signals = SidekickRoutingSignals {
+            rows: MIN_ROWS_FOR_RATE_GATES - 1,
+            escalation_rate: Some(1.0),
+            ..Default::default()
+        };
+        let decision = route_parallel_sidekick("check the runtime status", feedback(0, 0), signals);
+        assert!(decision.eligible);
+
+        let signals = SidekickRoutingSignals {
+            rows: MIN_ROWS_FOR_RATE_GATES,
+            escalation_rate: Some(ESCALATION_RATE_CEILING + 0.01),
+            ..Default::default()
+        };
+        let decision = route_parallel_sidekick("check the runtime status", feedback(0, 0), signals);
+        assert!(!decision.eligible);
+        assert_eq!(decision.reason, "metrics_high_escalation");
+    }
+
+    #[test]
+    fn decayed_rate_weights_recent_rows_higher() {
+        // Newest row is an error, older ones are fine: rate above raw 1/3.
+        let newest_error = decayed_rate([true, false, false]).unwrap();
+        assert!(newest_error > 1.0 / 3.0);
+        // Same rows oldest-first: below raw 1/3.
+        let oldest_error = decayed_rate([false, false, true]).unwrap();
+        assert!(oldest_error < 1.0 / 3.0);
+        assert_eq!(decayed_rate([]), None);
+    }
+
+    #[test]
+    fn recommend_route_scopes_compaction_to_session() {
+        let inputs = RouteInputs {
+            class: classify_prompt("this is a complex architecture question"),
+            local_ready: true,
+            gateway_ready: true,
+            session_compaction_boundary: false,
+            ..Default::default()
+        };
+        // No session compaction and no long prompt: complexity alone decides.
+        let decision = recommend_route(&inputs);
+        assert_eq!(decision.route, "gateway");
+        assert_eq!(decision.reason, "complex_or_frontier_task");
+
+        let inputs = RouteInputs {
+            session_compaction_boundary: true,
+            session_last_compaction_reason: Some("long_context_boundary"),
+            ..inputs
+        };
+        let decision = recommend_route(&inputs);
+        assert_eq!(decision.route, "gateway");
+        assert_eq!(decision.reason, "long_context_boundary");
+    }
+
+    #[test]
+    fn recommend_route_delegates_mechanical_with_warm_sidekick() {
+        let inputs = RouteInputs {
+            class: classify_prompt("check the warm model status"),
+            local_ready: true,
+            sidekick_ready: true,
+            gateway_ready: true,
+            ..Default::default()
+        };
+        let decision = recommend_route(&inputs);
+        assert_eq!(decision.route, "local");
+        assert!(decision.use_sidekick);
+        assert_eq!(decision.reason, "mechanical_with_sidekick");
+    }
+
+    #[test]
+    fn recommend_route_keeps_current_gateway_for_non_mechanical() {
+        let inputs = RouteInputs {
+            current_route: Some("cloud"),
+            class: classify_prompt("tell me a story"),
+            local_ready: true,
+            gateway_ready: true,
+            ..Default::default()
+        };
+        let decision = recommend_route(&inputs);
+        assert_eq!(decision.route, "gateway");
+        assert_eq!(decision.reason, "keep_current_gateway");
+    }
+}

--- a/apps/homescreen/src-tauri/src/route_policy.rs
+++ b/apps/homescreen/src-tauri/src/route_policy.rs
@@ -450,7 +450,9 @@ pub fn fusion_policy_class(
     } else if use_sidekick {
         "delegate_mechanical"
     } else if escalate_gateway || route == "gateway" {
-        if reason.contains("compaction") {
+        // Session boundaries carry the stored compaction reason
+        // ("long_context_boundary"), which doesn't say "compaction".
+        if reason.contains("compaction") || reason.contains("long_context") {
             "compaction_gateway"
         } else if reason.contains("error") || reason.contains("tool_depth") {
             "health_gateway"
@@ -564,6 +566,11 @@ mod tests {
         let decision = recommend_route(&inputs);
         assert_eq!(decision.route, "gateway");
         assert_eq!(decision.reason, "long_context_boundary");
+        // The stored reason must still classify as a compaction escalation.
+        assert_eq!(
+            fusion_policy_class("gateway", false, true, false, &decision.reason),
+            "compaction_gateway"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The Fusion routing/delegation policy was duplicated between `chat.rs` and `commands.rs` with hand-copied keyword lists and magic thresholds that had already drifted. This PR extracts a single `route_policy.rs` module and fixes the routing bugs found along the way.

### Refactor
- **New `route_policy.rs`**: keyword classes (judgment / delegate / complex), every threshold as a named constant (latency ×1.75, escalation >0.6, benchmark <0.5, usefulness <0.25, row windows 60/20/40/30), shared gate predicates, `classify_prompt`, the sidekick delegation policy (`route_parallel_sidekick`), the pure route ladder (`recommend_route`), and `fusion_policy_class`. Both `chat.rs` and `commands.rs` call it; the duplicates are deleted.
- **One switch path in `chat.rs`**: `RouteBinding { route, url, bearer, model_field }` + `switch_route_to_cloud()` replace the three copy-pasted local→cloud blocks (pre-turn, compaction boundary, mid-session). Route and endpoint live in one struct so they cannot desync.
- `"glm-5.2"` is now a single `GATEWAY_CHAT_MODEL` constant (7 Rust sites).

### Bug fixes / reconciliations
- **Compaction-boundary switch obeys the recorded recommendation.** Previously it recorded the recommendation, then switched to cloud unconditionally — the audit trail could contradict actual behavior.
- **High-escalation gate reconciled** to total rows ≥ 5 in both call sites (chat.rs gated on `feedback_rows >= 3`, which was also the wrong denominator for the rate it gates).
- **Cross-session ratchet fixed**: tool-depth signals are computed from the session's own runs (global window only as fallback when no session id), and `compaction_boundary` no longer triggers on other sessions' compactions — only session compaction or a >16k-char prompt (`long_prompt_compaction_gateway`).
- **Local error rate decays by recency** (0.9/row, newest first) instead of pinning the local route unhealthy for the whole 60-row window.

### Composition with the restored tool cap (348ef5a)
Rebased on main. With `MAX_TOOL_ROUNDS = 4` (5 completions) and mid-session escalation at cumulative `tool_count >= 3` (now the shared `TOOL_DEPTH_ESCALATION_CALLS`): worst case escalation lands after round 2, leaving 2 completions on the cloud route; the typical tool-heavy first round leaves 4. The merged tool-limit tail now records `binding.route`/`binding.model_field` so a mid-turn switch is reflected in the `tool_limit` row (the auto-merge had left it on the stale pre-switch values).

## Verification
- `cargo check` / `clippy` clean (warning set identical to main), 19 unit tests pass — including new tests for the reconciled escalation gate, decay ordering, session-scoped compaction routing, and the ladder's mechanical/keep-gateway branches.
- Live smoke test against the dev build (prod app temporarily swapped out, MLX slots re-attached):
  - `/api/fusion/route-recommendation`: mechanical → `local` with sidekick correctly suppressed by the benchmark-score gate; judgment+complex → `gateway` (`complex_or_frontier_task`); signals JSON shows session-scoped `local_tool_rows`/compaction booleans.
  - Fusion benchmark run (`sidekick-parallel`, e2b): completed ok; the live delegation decision (`benchmark_sidekick_score_low`) and the recommendation reason (`sidekick_benchmark_score_low`) now fire from the same shared gate — the drift this PR removes.
  - Left a few clearly-labeled `smoke-rp-*` accounting rows in the local DB.
- Not exercised at runtime: `chat_stream`'s mid-turn switch itself (GUI-only path; screen-control approval timed out). Covered by compile, unit tests, and the identical helper being used at both switch sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->