### PR TITLE
Unify CLI/app identity: orgs-map credentials, project root, app-owned agent card

### DIFF
--- a/apps/homescreen/src-tauri/src/account.rs
+++ b/apps/homescreen/src-tauri/src/account.rs
@@ -1,6 +1,6 @@
 use crate::bin;
 use anyhow::Result;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 fn out_string(args: &[&str]) -> Result<String> {
     let out = bin::command("understudy").args(args).output()?;
@@ -16,8 +16,59 @@ fn run_json(args: &[&str]) -> Result<Value> {
     Ok(serde_json::from_str(&s).unwrap_or(Value::Null))
 }
 
+/// Signed-in status. The native credentials reader (`crate::creds`, same
+/// resolution order as the CLI) is the source of truth for *whether* we are
+/// signed in; the `understudy status --json` shim contributes project-scoped
+/// fields (project_slug, telemetry) when the CLI is installed. When the CLI
+/// is missing, the status is synthesized natively so the app never shows
+/// "not connected" for a signed-in user just because the CLI isn't on PATH.
 pub fn status() -> Result<Value> {
-    run_json(&["status", "--json"])
+    let native = crate::creds::resolve();
+    match run_json(&["status", "--json"]) {
+        Ok(mut value) if value.is_object() => {
+            if let (Some(resolved), Some(obj)) = (&native, value.as_object_mut()) {
+                let signed_in = obj
+                    .get("signed_in")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if !signed_in {
+                    // The CLI (or its cwd) missed credentials the app can
+                    // resolve — e.g. an orgs-map-only file with an older CLI.
+                    obj.insert("signed_in".into(), json!(true));
+                    obj.insert("auth_mode".into(), json!(resolved.auth_mode));
+                }
+                for (key, fill) in [
+                    ("gateway_url", json!(resolved.gateway_url)),
+                    ("api_key_suffix", json!(resolved.api_key_suffix())),
+                    ("org_id", json!(resolved.org_id)),
+                ] {
+                    let missing = obj
+                        .get(key)
+                        .map(|v| v.is_null())
+                        .unwrap_or(true);
+                    if missing && !fill.is_null() {
+                        obj.insert(key.into(), fill);
+                    }
+                }
+            }
+            Ok(value)
+        }
+        Ok(_) | Err(_) if native.is_some() => {
+            let resolved = native.expect("checked is_some");
+            Ok(json!({
+                "ok": true,
+                "configured": false,
+                "signed_in": true,
+                "auth_mode": resolved.auth_mode,
+                "org_id": resolved.org_id,
+                "project_slug": null,
+                "api_key_suffix": resolved.api_key_suffix(),
+                "gateway_url": resolved.gateway_url,
+                "source": "app-native",
+            }))
+        }
+        other => other,
+    }
 }
 pub fn platforms() -> Result<Value> {
     run_json(&["platforms", "--json"])

--- a/apps/homescreen/src-tauri/src/agent_card.rs
+++ b/apps/homescreen/src-tauri/src/agent_card.rs
@@ -1,0 +1,228 @@
+// The desktop app is the canonical owner of `~/.understudy/agent-card.json`
+// while it is running (schema: skills/onboard/reference.md, "The agent
+// runtime card"). Skills only write the card as a fallback when the app is
+// not installed.
+//
+// Contract:
+//   - Stay schema-compatible: preserve every existing top-level field
+//     (`understudy`, `companion`, `project`, `org`, ...) and only add or
+//     update the `app` block plus `updated_at` / `schema_version` /
+//     `created_at`.
+//   - Never write secrets. The server bearer token is reported only as
+//     `token_present: true`.
+//   - Writes are atomic: temp file in the same directory, then rename.
+
+use serde_json::{json, Map, Value};
+use std::path::{Path, PathBuf};
+
+const SCHEMA_VERSION: &str = "understudy.agent_card.v1";
+
+/// A warm residency slot, as recorded in the card. No secrets — a model id,
+/// its local port, and the weights path.
+pub struct WarmModel {
+    pub id: String,
+    pub port: Option<u16>,
+    pub model_path: String,
+}
+
+fn card_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        PathBuf::from(home)
+            .join(".understudy")
+            .join("agent-card.json"),
+    )
+}
+
+fn now_iso() -> String {
+    chrono::Utc::now()
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// The local API server came up (bind succeeded). Records how a fresh coding
+/// agent can reach the app — base URL, port, pid — without the token itself.
+pub fn record_server_started(port: u16, token_present: bool) {
+    update(|app| {
+        app.insert("name".into(), json!("understudy-desktop"));
+        app.insert("version".into(), json!(env!("CARGO_PKG_VERSION")));
+        app.insert("pid".into(), json!(std::process::id()));
+        app.insert("running".into(), json!(true));
+        app.insert("started_at".into(), json!(now_iso()));
+        app.insert("stopped_at".into(), Value::Null);
+        app.insert("base_url".into(), json!(format!("http://127.0.0.1:{port}")));
+        app.insert("port".into(), json!(port));
+        app.insert("token_present".into(), json!(token_present));
+        if !app.contains_key("warm_models") {
+            app.insert("warm_models".into(), json!([]));
+        }
+    });
+}
+
+/// Residency changed (warm/cool/assign committed): refresh the warm set.
+pub fn record_warm_models(warm: &[WarmModel]) {
+    let rows: Vec<Value> = warm
+        .iter()
+        .map(|m| {
+            json!({
+                "id": m.id,
+                "port": m.port,
+                "model_path": m.model_path,
+            })
+        })
+        .collect();
+    update(|app| {
+        app.insert("running".into(), json!(true));
+        app.insert("pid".into(), json!(std::process::id()));
+        app.insert("warm_models".into(), Value::Array(rows));
+    });
+}
+
+/// Graceful shutdown: the card must not advertise a dead pid as healthy.
+pub fn mark_stopped() {
+    update(|app| {
+        app.insert("running".into(), json!(false));
+        app.insert("stopped_at".into(), json!(now_iso()));
+        app.insert("warm_models".into(), json!([]));
+    });
+}
+
+fn update<F: FnOnce(&mut Map<String, Value>)>(f: F) {
+    let Some(path) = card_path() else { return };
+    if let Err(err) = update_at(&path, f) {
+        eprintln!("understudy agent-card: write failed: {err}");
+    }
+}
+
+/// Read-modify-write of the card at `path`, atomically. Split from `update`
+/// so tests can drive it against a temp directory.
+fn update_at<F: FnOnce(&mut Map<String, Value>)>(path: &Path, f: F) -> std::io::Result<()> {
+    let mut card = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .unwrap_or_else(|| json!({}));
+    if !card.is_object() {
+        card = json!({});
+    }
+    let obj = card.as_object_mut().expect("card is an object");
+
+    let now = now_iso();
+    obj.entry("schema_version".to_string())
+        .or_insert_with(|| json!(SCHEMA_VERSION));
+    obj.entry("created_at".to_string())
+        .or_insert_with(|| json!(now.clone()));
+    obj.insert("updated_at".into(), json!(now));
+
+    if !obj.get("app").map(Value::is_object).unwrap_or(false) {
+        obj.insert("app".into(), json!({}));
+    }
+    let app = obj
+        .get_mut("app")
+        .and_then(Value::as_object_mut)
+        .expect("app block is an object");
+    f(app);
+
+    write_atomic(path, &card)
+}
+
+fn write_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("agent-card path has no parent"))?;
+    std::fs::create_dir_all(dir)?;
+    let tmp = dir.join(format!(
+        ".agent-card.json.tmp-{}",
+        std::process::id()
+    ));
+    std::fs::write(&tmp, format!("{}\n", serde_json::to_string_pretty(value)?))?;
+    std::fs::rename(&tmp, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_card_path() -> PathBuf {
+        // pid + a process-wide counter: parallel tests in one process must
+        // never share a directory (the wall clock is not unique enough).
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "understudy-agent-card-test-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("agent-card.json")
+    }
+
+    #[test]
+    fn preserves_skill_written_fields_and_adds_app_block() {
+        let path = temp_card_path();
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "schema_version": "understudy.agent_card.v1",
+                "created_at": "2026-06-06T18:00:00Z",
+                "updated_at": "2026-06-06T18:05:00Z",
+                "understudy": { "name": "Gemma 4 E2B", "healthy": true },
+                "companion": { "alive": false },
+                "org": { "id": "org_x" }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        update_at(&path, |app| {
+            app.insert("running".into(), json!(true));
+            app.insert("port".into(), json!(17790));
+            app.insert("token_present".into(), json!(true));
+        })
+        .unwrap();
+
+        let card: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        // Skill-written blocks survive untouched.
+        assert_eq!(card["understudy"]["name"], "Gemma 4 E2B");
+        assert_eq!(card["companion"]["alive"], false);
+        assert_eq!(card["org"]["id"], "org_x");
+        assert_eq!(card["created_at"], "2026-06-06T18:00:00Z");
+        // The app block is added, not renamed in.
+        assert_eq!(card["app"]["running"], true);
+        assert_eq!(card["app"]["port"], 17790);
+        assert_eq!(card["app"]["token_present"], true);
+        assert_ne!(card["updated_at"], "2026-06-06T18:05:00Z");
+    }
+
+    #[test]
+    fn creates_card_when_absent_and_never_leaves_temp_files() {
+        let path = temp_card_path();
+        update_at(&path, |app| {
+            app.insert("running".into(), json!(true));
+        })
+        .unwrap();
+        let card: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(card["schema_version"], SCHEMA_VERSION);
+        assert!(card["created_at"].is_string());
+        assert_eq!(card["app"]["running"], true);
+        // Atomic write leaves no temp litter behind.
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty());
+    }
+
+    #[test]
+    fn corrupt_card_is_replaced_not_fatal() {
+        let path = temp_card_path();
+        std::fs::write(&path, "{not json").unwrap();
+        update_at(&path, |app| {
+            app.insert("running".into(), json!(false));
+        })
+        .unwrap();
+        let card: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(card["app"]["running"], false);
+    }
+}

--- a/apps/homescreen/src-tauri/src/agent_card.rs
+++ b/apps/homescreen/src-tauri/src/agent_card.rs
@@ -86,15 +86,23 @@ pub fn mark_stopped() {
     });
 }
 
+/// Serializes every card writer in this process. The three writers run on
+/// three different threads (server bind on the server thread, warm-model
+/// refreshes on the async runtime, mark_stopped on the main thread) and an
+/// unlocked read-modify-write loses whichever update renames first.
+static CARD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn update<F: FnOnce(&mut Map<String, Value>)>(f: F) {
     let Some(path) = card_path() else { return };
+    let _guard = CARD_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     if let Err(err) = update_at(&path, f) {
         eprintln!("understudy agent-card: write failed: {err}");
     }
 }
 
 /// Read-modify-write of the card at `path`, atomically. Split from `update`
-/// so tests can drive it against a temp directory.
+/// so tests can drive it against a temp directory; callers other than
+/// `update` must not touch the real card path (no lock is taken here).
 fn update_at<F: FnOnce(&mut Map<String, Value>)>(path: &Path, f: F) -> std::io::Result<()> {
     let mut card = std::fs::read_to_string(path)
         .ok()
@@ -125,16 +133,25 @@ fn update_at<F: FnOnce(&mut Map<String, Value>)>(path: &Path, f: F) -> std::io::
 }
 
 fn write_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let dir = path
         .parent()
         .ok_or_else(|| std::io::Error::other("agent-card path has no parent"))?;
     std::fs::create_dir_all(dir)?;
+    // pid + per-process counter: a pid-only temp name is shared by every
+    // thread in the process, letting one writer rename another's
+    // half-written file into place.
     let tmp = dir.join(format!(
-        ".agent-card.json.tmp-{}",
-        std::process::id()
+        ".agent-card.json.tmp-{}-{}",
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     ));
-    std::fs::write(&tmp, format!("{}\n", serde_json::to_string_pretty(value)?))?;
-    std::fs::rename(&tmp, path)
+    let result = std::fs::write(&tmp, format!("{}\n", serde_json::to_string_pretty(value)?))
+        .and_then(|_| std::fs::rename(&tmp, path));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
 }
 
 #[cfg(test)]

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -1728,17 +1728,11 @@ impl ThinkParser {
     }
 }
 
-/// Read the gateway URL + API key from ~/.understudy/credentials.json (server-side only).
+/// Read the gateway URL + API key with the same resolution order as the CLI
+/// (env vars > active org entry in the `orgs` map > legacy top-level fields).
+/// See `crate::creds` — orgs-map-only sign-ins must work here too.
 fn credentials() -> Option<(String, String)> {
-    let home = std::env::var_os("HOME")?;
-    let path = PathBuf::from(home)
-        .join(".understudy")
-        .join("credentials.json");
-    let value: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
-    let url = value.get("gateway_url")?.as_str()?.to_string();
-    let key = value.get("api_key")?.as_str()?.to_string();
-    Some((url, key))
+    crate::creds::resolve().map(|c| (c.gateway_url, c.api_key))
 }
 
 pub(crate) fn gateway_credentials_available() -> bool {

--- a/apps/homescreen/src-tauri/src/creds.rs
+++ b/apps/homescreen/src-tauri/src/creds.rs
@@ -102,29 +102,33 @@ pub fn resolve_from(
 
     let file = file?;
 
-    // 2. Active org entry: the orgs map's only entry (`resolveOrgId` with
-    //    no explicit org).
-    if let Some(org_id) = sole_org_id(&file) {
-        if let Some(entry) = file.get("orgs").and_then(|o| o.get(&org_id)) {
-            if let Some(key) = non_empty_str(entry, "api_key") {
-                return Some(ResolvedCredentials {
-                    gateway_url: non_empty_str(entry, "gateway_url")
-                        .unwrap_or(fallback_gateway),
-                    api_key: key,
-                    auth_mode: "api_key",
-                    org_id: Some(org_id),
-                });
-            }
-        }
+    // 2. Top-level api_key, exactly like the CLI's `resolveAuth`
+    //    (src/internal/http.ts): the CLI's actual request path prefers the
+    //    top-level credential (with the fallback gateway, never an org
+    //    entry's gateway) whenever it is present. `login A; login B;
+    //    logout --org B` leaves a sole org A entry plus a top-level B
+    //    credential — both surfaces must pick B or they authenticate as
+    //    different identities from the same file.
+    if let Some(key) = non_empty_str(&file, "api_key") {
+        let org_id = sole_org_id(&file);
+        return Some(ResolvedCredentials {
+            gateway_url: fallback_gateway,
+            api_key: key,
+            auth_mode: "api_key",
+            org_id,
+        });
     }
 
-    // 3. Top-level legacy fields (also the multi-org tiebreaker).
-    let key = non_empty_str(&file, "api_key")?;
+    // 3. Active org entry: the orgs map's only entry (`resolveOrgId` with
+    //    no explicit org), reached only when no top-level key exists.
+    let org_id = sole_org_id(&file)?;
+    let entry = file.get("orgs").and_then(|o| o.get(&org_id))?;
+    let key = non_empty_str(entry, "api_key")?;
     Some(ResolvedCredentials {
-        gateway_url: fallback_gateway,
+        gateway_url: non_empty_str(entry, "gateway_url").unwrap_or(fallback_gateway),
         api_key: key,
         auth_mode: "api_key",
-        org_id: None,
+        org_id: Some(org_id),
     })
 }
 
@@ -183,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn env_beats_orgs_map_beats_legacy() {
+    fn env_beats_legacy_beats_orgs_map() {
         let path = temp_credentials_file(&json!({
             "api_key": "sk_legacy_key_9999",
             "gateway_url": "https://legacy.gateway.example",
@@ -215,10 +219,12 @@ mod tests {
         .unwrap();
         assert_eq!(resolved.gateway_url, "https://legacy.gateway.example");
 
-        // No env: the active (sole) org entry wins over legacy fields.
+        // No env: the top-level key wins over the org entry, matching the
+        // CLI's resolveAuth. `logout --org` can leave a stale top-level
+        // credential next to a sole org entry — both surfaces must agree.
         let resolved = resolve_from(None, None, read_credentials_value(&path)).unwrap();
-        assert_eq!(resolved.api_key, "sk_org_key_1234");
-        assert_eq!(resolved.gateway_url, "https://org.gateway.example");
+        assert_eq!(resolved.api_key, "sk_legacy_key_9999");
+        assert_eq!(resolved.gateway_url, "https://legacy.gateway.example");
         assert_eq!(resolved.org_id.as_deref(), Some("org_ab12"));
     }
 

--- a/apps/homescreen/src-tauri/src/creds.rs
+++ b/apps/homescreen/src-tauri/src/creds.rs
@@ -1,0 +1,309 @@
+// Native reader for `~/.understudy/credentials.json` — the same file the
+// `understudy` CLI writes (`src/config/credentials.ts`) and resolves
+// (`src/internal/http.ts` `resolveAuth` / `resolveOrgId`). The app and the
+// CLI must agree on who is signed in, so this mirrors the CLI's resolution
+// order:
+//
+//   1. `UNDERSTUDY_API_KEY` env var. Gateway comes from
+//      `UNDERSTUDY_GATEWAY_URL`, then the file's top-level `gateway_url`,
+//      then the default.
+//   2. The active org entry in the `orgs` map. With no explicit org
+//      selection (the app has none — there is no `--org` flag and no
+//      project cwd), the active org is the map's only entry, exactly like
+//      the CLI's `resolveOrgId` with no argument.
+//   3. Top-level legacy `api_key` / `gateway_url` fields. Also the
+//      fallback when several orgs make the active org ambiguous: `login`
+//      keeps the top-level credential pointed at the most recent org, so
+//      it is the best "active" guess the app can make without a project.
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+/// Must match `DEFAULT_GATEWAY_URL` in `src/config/defaults.ts`.
+pub const DEFAULT_GATEWAY_URL: &str = "https://api.understudylabs.com";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedCredentials {
+    pub gateway_url: String,
+    pub api_key: String,
+    /// "env_api_key" | "api_key" — same vocabulary as `understudy status --json`.
+    pub auth_mode: &'static str,
+    /// Known only when the orgs map names exactly one org.
+    pub org_id: Option<String>,
+}
+
+impl ResolvedCredentials {
+    /// Last 4 characters of the key, for display. Never more.
+    pub fn api_key_suffix(&self) -> String {
+        let chars: Vec<char> = self.api_key.chars().collect();
+        let start = chars.len().saturating_sub(4);
+        chars[start..].iter().collect()
+    }
+}
+
+/// Resolve the active gateway credentials, or `None` when not signed in.
+pub fn resolve() -> Option<ResolvedCredentials> {
+    resolve_from(
+        non_empty_env("UNDERSTUDY_API_KEY"),
+        non_empty_env("UNDERSTUDY_GATEWAY_URL"),
+        credentials_file_path().and_then(|p| read_credentials_value(&p)),
+    )
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.trim().is_empty())
+}
+
+fn credentials_file_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        PathBuf::from(home)
+            .join(".understudy")
+            .join("credentials.json"),
+    )
+}
+
+/// Parse a credentials file into JSON. Returns `None` when absent or invalid.
+pub fn read_credentials_value(path: &Path) -> Option<Value> {
+    serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
+}
+
+fn non_empty_str(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+}
+
+/// Pure resolution over the env vars + parsed file, so tests can drive it
+/// without mutating process state.
+pub fn resolve_from(
+    env_key: Option<String>,
+    env_url: Option<String>,
+    file: Option<Value>,
+) -> Option<ResolvedCredentials> {
+    let top_gateway = file.as_ref().and_then(|v| non_empty_str(v, "gateway_url"));
+    // Mirrors the CLI's `fallbackGatewayUrl`: env > top-level file > default.
+    let fallback_gateway = env_url
+        .or(top_gateway)
+        .unwrap_or_else(|| DEFAULT_GATEWAY_URL.to_string());
+
+    // 1. Env var wins, exactly like `resolveAuth`.
+    if let Some(key) = env_key {
+        let org_id = file.as_ref().and_then(sole_org_id);
+        return Some(ResolvedCredentials {
+            gateway_url: fallback_gateway,
+            api_key: key,
+            auth_mode: "env_api_key",
+            org_id,
+        });
+    }
+
+    let file = file?;
+
+    // 2. Active org entry: the orgs map's only entry (`resolveOrgId` with
+    //    no explicit org).
+    if let Some(org_id) = sole_org_id(&file) {
+        if let Some(entry) = file.get("orgs").and_then(|o| o.get(&org_id)) {
+            if let Some(key) = non_empty_str(entry, "api_key") {
+                return Some(ResolvedCredentials {
+                    gateway_url: non_empty_str(entry, "gateway_url")
+                        .unwrap_or(fallback_gateway),
+                    api_key: key,
+                    auth_mode: "api_key",
+                    org_id: Some(org_id),
+                });
+            }
+        }
+    }
+
+    // 3. Top-level legacy fields (also the multi-org tiebreaker).
+    let key = non_empty_str(&file, "api_key")?;
+    Some(ResolvedCredentials {
+        gateway_url: fallback_gateway,
+        api_key: key,
+        auth_mode: "api_key",
+        org_id: None,
+    })
+}
+
+fn sole_org_id(file: &Value) -> Option<String> {
+    let orgs = file.get("orgs")?.as_object()?;
+    if orgs.len() == 1 {
+        orgs.keys().next().cloned()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    fn temp_test_dir(prefix: &str) -> PathBuf {
+        // pid + a process-wide counter: parallel tests in one process must
+        // never share a directory (the wall clock is not unique enough).
+        let dir = std::env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn temp_credentials_file(contents: &Value) -> PathBuf {
+        let path = temp_test_dir("understudy-creds-test").join("credentials.json");
+        std::fs::write(&path, serde_json::to_string_pretty(contents).unwrap()).unwrap();
+        path
+    }
+
+    #[test]
+    fn orgs_map_only_credentials_resolve() {
+        // The exact shape that used to show as "not connected" in the app.
+        let path = temp_credentials_file(&json!({
+            "orgs": {
+                "org_ab12": {
+                    "api_key": "sk_org_key_1234",
+                    "gateway_url": "https://org.gateway.example"
+                }
+            }
+        }));
+        let file = read_credentials_value(&path);
+        let resolved = resolve_from(None, None, file).expect("orgs-map-only must resolve");
+        assert_eq!(resolved.api_key, "sk_org_key_1234");
+        assert_eq!(resolved.gateway_url, "https://org.gateway.example");
+        assert_eq!(resolved.auth_mode, "api_key");
+        assert_eq!(resolved.org_id.as_deref(), Some("org_ab12"));
+        assert_eq!(resolved.api_key_suffix(), "1234");
+    }
+
+    #[test]
+    fn env_beats_orgs_map_beats_legacy() {
+        let path = temp_credentials_file(&json!({
+            "api_key": "sk_legacy_key_9999",
+            "gateway_url": "https://legacy.gateway.example",
+            "orgs": {
+                "org_ab12": {
+                    "api_key": "sk_org_key_1234",
+                    "gateway_url": "https://org.gateway.example"
+                }
+            }
+        }));
+
+        // Env var wins over everything; env gateway wins too.
+        let resolved = resolve_from(
+            Some("sk_env_key_5678".into()),
+            Some("https://env.gateway.example".into()),
+            read_credentials_value(&path),
+        )
+        .unwrap();
+        assert_eq!(resolved.api_key, "sk_env_key_5678");
+        assert_eq!(resolved.gateway_url, "https://env.gateway.example");
+        assert_eq!(resolved.auth_mode, "env_api_key");
+
+        // Env key without env gateway: file's top-level gateway backs it.
+        let resolved = resolve_from(
+            Some("sk_env_key_5678".into()),
+            None,
+            read_credentials_value(&path),
+        )
+        .unwrap();
+        assert_eq!(resolved.gateway_url, "https://legacy.gateway.example");
+
+        // No env: the active (sole) org entry wins over legacy fields.
+        let resolved = resolve_from(None, None, read_credentials_value(&path)).unwrap();
+        assert_eq!(resolved.api_key, "sk_org_key_1234");
+        assert_eq!(resolved.gateway_url, "https://org.gateway.example");
+        assert_eq!(resolved.org_id.as_deref(), Some("org_ab12"));
+    }
+
+    #[test]
+    fn legacy_fields_and_multi_org_fallback() {
+        // Legacy-only file still works, with the default gateway filled in.
+        let path = temp_credentials_file(&json!({ "api_key": "sk_legacy_only_4321" }));
+        let resolved = resolve_from(None, None, read_credentials_value(&path)).unwrap();
+        assert_eq!(resolved.api_key, "sk_legacy_only_4321");
+        assert_eq!(resolved.gateway_url, DEFAULT_GATEWAY_URL);
+        assert_eq!(resolved.org_id, None);
+
+        // Multiple orgs are ambiguous (the CLI demands --org); the app
+        // falls back to the top-level credential login keeps current.
+        let path = temp_credentials_file(&json!({
+            "api_key": "sk_top_level_7777",
+            "orgs": {
+                "org_a": { "api_key": "sk_a", "gateway_url": "https://a.example" },
+                "org_b": { "api_key": "sk_b", "gateway_url": "https://b.example" }
+            }
+        }));
+        let resolved = resolve_from(None, None, read_credentials_value(&path)).unwrap();
+        assert_eq!(resolved.api_key, "sk_top_level_7777");
+        assert_eq!(resolved.org_id, None);
+
+        // Nothing anywhere: not signed in.
+        assert_eq!(resolve_from(None, None, None), None);
+        let empty = temp_credentials_file(&json!({ "orgs": {} }));
+        assert_eq!(resolve_from(None, None, read_credentials_value(&empty)), None);
+    }
+
+    #[test]
+    fn full_resolve_reads_orgs_map_only_file_from_temp_home() {
+        // End-to-end through `resolve()` with HOME pointed at a temp dir —
+        // the manual-verification scenario from the wave brief.
+        let home = std::env::temp_dir().join(format!(
+            "understudy-creds-home-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(home.join(".understudy")).unwrap();
+        std::fs::write(
+            home.join(".understudy").join("credentials.json"),
+            serde_json::to_string_pretty(&json!({
+                "orgs": {
+                    "org_home": {
+                        "api_key": "sk_home_org_0042",
+                        "gateway_url": "https://home.gateway.example"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Serialize env mutation against other tests in this binary.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved_home = std::env::var_os("HOME");
+        let saved_key = std::env::var_os("UNDERSTUDY_API_KEY");
+        let saved_url = std::env::var_os("UNDERSTUDY_GATEWAY_URL");
+        std::env::set_var("HOME", &home);
+        std::env::remove_var("UNDERSTUDY_API_KEY");
+        std::env::remove_var("UNDERSTUDY_GATEWAY_URL");
+
+        let resolved = resolve();
+
+        match saved_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        if let Some(v) = saved_key {
+            std::env::set_var("UNDERSTUDY_API_KEY", v);
+        }
+        if let Some(v) = saved_url {
+            std::env::set_var("UNDERSTUDY_GATEWAY_URL", v);
+        }
+
+        let resolved = resolved.expect("orgs-map-only credentials must resolve via HOME");
+        assert_eq!(resolved.api_key, "sk_home_org_0042");
+        assert_eq!(resolved.gateway_url, "https://home.gateway.example");
+        assert_eq!(resolved.org_id.as_deref(), Some("org_home"));
+    }
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -1,9 +1,11 @@
 mod aa;
 mod account;
+mod agent_card;
 mod bin;
 mod bootstrap;
 mod chat;
 mod commands;
+mod creds;
 mod db;
 mod knowledge;
 mod mcp;
@@ -169,6 +171,13 @@ pub fn run() {
             commands::server_info,
             chat::chat_stream,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(|_app, event| {
+            if let tauri::RunEvent::Exit = event {
+                // Graceful shutdown: the agent card must not keep
+                // advertising a dead pid as a healthy local daemon.
+                agent_card::mark_stopped();
+            }
+        });
 }

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -515,6 +515,20 @@ impl Residency {
         if let Err(err) = app.state::<Db>().save_residency(&rows) {
             eprintln!("understudy db: save_residency failed: {err:#}");
         }
+        // Keep the agent card's warm-model facts current on every commit
+        // (warm/cool/assign) so external agents see live runtime truth.
+        let warm: Vec<crate::agent_card::WarmModel> = rows
+            .iter()
+            .filter(|r| r.warm)
+            .filter_map(|r| {
+                Some(crate::agent_card::WarmModel {
+                    id: r.model_id.clone()?,
+                    port: r.port,
+                    model_path: r.model_path.clone().unwrap_or_default(),
+                })
+            })
+            .collect();
+        crate::agent_card::record_warm_models(&warm);
     }
 
     /// On launch, rebuild slots from the persisted plan and re-warm the warm set.

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -121,6 +121,9 @@ async fn serve(ctx: Ctx, port: u16) {
             return;
         }
     };
+    // The app is the canonical local daemon: advertise it in the agent card
+    // once the server is actually reachable (never the token itself).
+    crate::agent_card::record_server_started(port, !ctx.token.is_empty());
     let _ = axum::serve(listener, router(ctx)).await;
 }
 

--- a/skills/manage-local-models/SKILL.md
+++ b/skills/manage-local-models/SKILL.md
@@ -96,8 +96,11 @@ locations and registry links are in [`reference.md`](reference.md).
    `top_logprobs`), the wrong sampling (greedy is off-spec for `do_sample: true`
    models), or a mis-wired MTP draft.
 6. **Verify + record.** Once cached, run a one-line generation to confirm it
-   loads and does tool calls if the workload needs them. Append the model to
-   `local_models` in the profile (id, runtime, quant, size, date).
+   loads and does tool calls if the workload needs them. The models directory
+   plus each snapshot's catalog/serving manifest is the source of truth for
+   what is installed; you may append an interview-time note to `local_models`
+   in the profile (id, runtime, quant, size, date), but never treat that field
+   as the library index — list the models dir to answer "what do I have?".
 
    **Also pre-research and record the recommended serving settings, at pull
    time, not at bench time.** Read the snapshot's `understudy.serving.json`

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -103,11 +103,15 @@ and build an opportunity ledger before any code edits or provider calls.
    [`reference.md`](reference.md)): experience tier, detected tooling, hardware,
    goal, constraints, and the three meet-them-where-they-are dials — vocabulary,
    coaching depth, opinion strength. Append, don't overwrite, the `history` of
-   workloads and decisions. Also refresh `~/.understudy/agent-card.json` with
-   live runtime facts: the local model, endpoint, serving process, companion
-   status, and the exact command or URL for talking to the local Understudy.
-   If `~/.understudy/companion.json` points at a dead pid, clear it and record
-   the stale pid in the card.
+   workloads and decisions. For `~/.understudy/agent-card.json`, check whether
+   the Understudy desktop app is running first (read the card's `app.running` /
+   `app.pid`, or hit `app.base_url`): the app is the canonical local daemon and
+   maintains the card itself — server endpoint, warm models, shutdown state.
+   Only refresh the card yourself as a **fallback when the app isn't installed
+   or running**, recording live runtime facts: the local model, endpoint,
+   serving process, companion status, and the exact command or URL for talking
+   to the local Understudy. If `~/.understudy/companion.json` points at a dead
+   pid, clear it and record the stale pid in the card.
 
 6. **Land the quick win: show the local Understudy exists.** Once the snapshot is
    cached, route through [`../ladder/SKILL.md`](../ladder/SKILL.md) and start the

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -12,6 +12,15 @@ it at the start of every session; create it during onboarding; append to its
 `history` as workloads and decisions accumulate. Never put secrets, keys, tokens,
 prompts, or customer data in it.
 
+The profile is the **skills' interview artifact** — written only by skills,
+during onboarding and later interviews. The desktop app must never write it
+(live runtime facts belong in the agent card below). It is also *not* the
+index of the local model library: the models directory
+(`~/.understudy/models/`) plus each snapshot's catalog/serving manifest is
+the source of truth for what is installed. `local_models` entries are
+interview-time notes (what was pulled, when, with which serving settings),
+not an inventory to keep in sync.
+
 ```jsonc
 {
   "schema_version": "understudy.profile.v1",
@@ -43,14 +52,15 @@ prompts, or customer data in it.
     "coaching": "high",                     // high | medium | low
     "opinion_strength": "prescriptive"      // prescriptive | balanced | options-only
   },
-  "local_models": [],                       // [{id, runtime, quant, size_gb, pulled_at}]
+  "local_models": [],                       // interview notes [{id, runtime, quant, size_gb, pulled_at}] — NOT the library index; ~/.understudy/models/ is
   "history": []                             // [{workload, decision, route, at}]
 }
 ```
 
 Write it with the smallest correct change: merge new fields, append to `history`
 and `local_models`, bump `updated_at`. If a value is unknown, leave it null
-rather than guessing.
+rather than guessing. To answer "what models do I have?", list the models
+directory and read the catalogs — never trust `local_models` as current.
 
 ## The agent runtime card (`~/.understudy/agent-card.json`)
 
@@ -58,6 +68,22 @@ Agent-level, not user-interview memory. This is the single file a fresh coding
 agent reads when the user asks, "is my Understudy active?" or "talk to my
 Understudy." It captures live local runtime facts that do not belong in the
 profile. Never put secrets, prompts, outputs, or customer data in it.
+
+**Ownership: the Understudy desktop app is the canonical local daemon and the
+canonical writer of this card.** While the app runs, it maintains the card
+programmatically (`apps/homescreen/src-tauri/src/agent_card.rs`): it writes
+the `app` block when its local API server starts, refreshes the warm-model
+list on every residency change (warm/cool/assign), and marks itself stopped
+on graceful shutdown. All app writes are atomic (temp file + rename), purely
+additive to the schema below, and secret-free — the local server's bearer
+token appears only as a `token_present` boolean, never the token itself.
+
+Skills write this card only as a **fallback when the desktop app is not
+installed or not running** (the step-5 refresh during onboarding, the ladder
+server, `serve-understudy-snapshot.mjs`). When the app is running, read the
+card and trust its `app` block instead of re-deriving runtime facts — and if
+you do write, add fields rather than rename, and leave the `app` block to the
+app.
 
 ```jsonc
 {
@@ -91,13 +117,33 @@ profile. Never put secrets, prompts, outputs, or customer data in it.
   },
   "org": {
     "id": "org_..."
+  },
+  "app": {                                  // written by the desktop app ONLY
+    "name": "understudy-desktop",
+    "version": "0.2.2",
+    "pid": 12345,
+    "running": true,                        // false after graceful shutdown
+    "started_at": "2026-06-06T18:00:00Z",
+    "stopped_at": null,
+    "base_url": "http://127.0.0.1:17790",   // local API server (HTTP + MCP + A2A)
+    "port": 17790,
+    "token_present": true,                  // a bearer token exists in the app DB; NEVER the token itself
+    "warm_models": [                        // live residency: which models are loaded
+      {
+        "id": "gemma-4-e2b-it-qat-mlx-vlm-understudy",
+        "port": 8089,
+        "model_path": "/Users/me/.understudy/models/gemma-4-e2b-it-qat-mlx-vlm-understudy"
+      }
+    ]
   }
 }
 ```
 
-Refresh this card during onboarding, whenever the ladder server or
-`serve-understudy-snapshot.mjs` serves a model, and whenever a companion process
-starts. If `~/.understudy/companion.json`
+When the desktop app is running it keeps this card fresh on its own — check
+`app.running` and `app.pid` first. Skill-side refreshes (during onboarding,
+whenever the ladder server or `serve-understudy-snapshot.mjs` serves a model,
+and whenever a companion process starts) are the fallback path for machines
+without the app. If `~/.understudy/companion.json`
 contains a dead pid, clear that pid in the companion state file and record it as
 `stale_pid` in the card. A later agent should be able to answer the user's
 runtime question from this card first, using health checks only to refresh stale

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -18,6 +18,7 @@ import { readCredentials, writeCredentials } from "../config/credentials.js";
 import {
   globalCredentialsPath,
   globalLoginPendingPath,
+  isGlobalProjectConfigPath,
   PROJECT_CONFIG_DIR,
 } from "../config/paths.js";
 import { DEFAULT_GATEWAY_URL } from "../config/defaults.js";
@@ -456,10 +457,20 @@ function saveApiKeyResult(
   writeCredentials(next);
 
   if (orgId && result.default_project) {
-    writeProjectConfig(`${PROJECT_CONFIG_DIR}/config.json`, {
-      org_id: orgId,
-      project_slug: result.default_project.slug,
-    });
+    const target = `${PROJECT_CONFIG_DIR}/config.json`;
+    if (isGlobalProjectConfigPath(target)) {
+      // Running from `$HOME`: `.understudy/` there is the global config
+      // dir, not a project. Credentials are saved; the project pin waits
+      // for a real repo.
+      process.stderr.write(
+        "note: current directory is your home directory, so no project config was written. cd into your project and run `understudy projects use <slug>`.\n",
+      );
+    } else {
+      writeProjectConfig(target, {
+        org_id: orgId,
+        project_slug: result.default_project.slug,
+      });
+    }
   }
 }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -90,11 +90,13 @@ export async function runStatus(json = false): Promise<0 | 1> {
   const activeOrgId =
     config?.org_id ?? (orgIds.length === 1 ? orgIds[0] : undefined);
   const orgCredentials = activeOrgId ? credentials?.orgs[activeOrgId] : undefined;
-  const storedApiKey = orgCredentials?.api_key ?? credentials?.api_key;
-  const gatewayUrl =
-    orgCredentials?.gateway_url ??
-    credentials?.gateway_url ??
-    null;
+  // Display what resolveAuth actually sends: the top-level credential wins
+  // over an org entry when both exist (a `logout --org` can leave a stale
+  // top-level key next to a sole org entry, and requests use the top-level).
+  const storedApiKey = credentials?.api_key ?? orgCredentials?.api_key;
+  const gatewayUrl = credentials?.api_key
+    ? (credentials?.gateway_url ?? null)
+    : (orgCredentials?.gateway_url ?? credentials?.gateway_url ?? null);
 
   if (json) {
     await trackStatusChecked({

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -60,10 +60,14 @@ export async function runStatus(json = false): Promise<0 | 1> {
     return 1;
   }
 
+  // A credential in the `orgs` map signs the user in just like the legacy
+  // top-level `api_key` — `resolveAuth` sends requests with it, so status
+  // must agree (and so must the desktop app, which mirrors this order).
+  const orgIds = credentials ? Object.keys(credentials.orgs) : [];
   const envApiKey = process.env.UNDERSTUDY_API_KEY;
   const authMode = envApiKey
     ? "env_api_key"
-    : credentials?.api_key
+    : credentials?.api_key || orgIds.length > 0
       ? "api_key"
       : null;
 
@@ -81,7 +85,11 @@ export async function runStatus(json = false): Promise<0 | 1> {
     return 0;
   }
 
-  const orgCredentials = config ? credentials?.orgs[config.org_id] : undefined;
+  // Active org: the project config names one; otherwise a sole entry in
+  // the orgs map is unambiguous (same rule as `resolveOrgId`).
+  const activeOrgId =
+    config?.org_id ?? (orgIds.length === 1 ? orgIds[0] : undefined);
+  const orgCredentials = activeOrgId ? credentials?.orgs[activeOrgId] : undefined;
   const storedApiKey = orgCredentials?.api_key ?? credentials?.api_key;
   const gatewayUrl =
     orgCredentials?.gateway_url ??
@@ -99,7 +107,7 @@ export async function runStatus(json = false): Promise<0 | 1> {
         configured: Boolean(config),
         signed_in: Boolean(authMode),
         auth_mode: authMode,
-        org_id: config?.org_id ?? null,
+        org_id: activeOrgId ?? null,
         project_slug: config?.project_slug ?? null,
         api_key_suffix: storedApiKey ? storedApiKey.slice(-4) : null,
         gateway_url: gatewayUrl,
@@ -112,7 +120,7 @@ export async function runStatus(json = false): Promise<0 | 1> {
   const lines = [
     `${kleur.bold("signed_in")}     ${authMode ? "yes" : "no"}`,
     `${kleur.bold("auth_mode")}     ${authMode ?? kleur.yellow("none")}`,
-    `${kleur.bold("org_id")}        ${config?.org_id ?? kleur.dim("(none)")}`,
+    `${kleur.bold("org_id")}        ${activeOrgId ?? kleur.dim("(none)")}`,
     `${kleur.bold("project_slug")}  ${config?.project_slug ?? kleur.dim("(none)")}`,
     `${kleur.bold("api_key")}       ${storedApiKey ? maskKey(storedApiKey) : kleur.dim("(none)")}`,
     `${kleur.bold("gateway_url")}   ${gatewayUrl ?? kleur.dim("(unknown)")}`,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { z } from "zod";
 
-import { projectConfigPath } from "./paths.js";
+import { isGlobalProjectConfigPath, projectConfigPath } from "./paths.js";
 
 /**
  * Per-repo `.understudy/config.json` shape. Contains no secrets — it is
@@ -28,6 +28,12 @@ export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
  */
 export function readProjectConfig(startDir?: string): ProjectConfig | null {
   const path = projectConfigPath(startDir);
+  // `~/.understudy/config.json` is global config territory, never a
+  // project config — a stale file there must not claim an active
+  // project (only reachable when startDir is `$HOME` itself).
+  if (isGlobalProjectConfigPath(path)) {
+    return null;
+  }
   if (!existsSync(path)) {
     return null;
   }
@@ -48,6 +54,11 @@ export function readProjectConfig(startDir?: string): ProjectConfig | null {
  * the `.understudy/` directory if it doesn't yet exist.
  */
 export function writeProjectConfig(path: string, config: ProjectConfig): void {
+  if (isGlobalProjectConfigPath(path)) {
+    throw new Error(
+      "Refusing to write project config to ~/.understudy/config.json — that is the global Understudy config dir, not a project. cd into your project repo and retry.",
+    );
+  }
   ProjectConfigSchema.parse(config);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, { encoding: "utf8" });

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
-import { existsSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 
 /**
  * The per-repo config directory name. Sits alongside `.git/`.
@@ -38,15 +38,24 @@ export const GLOBAL_LOGIN_PENDING_FILE = "login-pending.json";
  * This is the same pattern as `package.json` / `.git` lookup — the CLI
  * should "just work" from any subdirectory of a repo that's been
  * signed in with `understudy login`.
+ *
+ * `$HOME` is never a project root: `~/.understudy/` is the *global*
+ * config dir (credentials.json, profile.json, agent-card.json), not a
+ * project marker. Matching it made every walk that reached the home
+ * directory "find" a project there, and per-repo state (the active
+ * project) ended up written to `~/.understudy/config.json`.
  */
 export function findProjectRoot(startDir: string = process.cwd()): string {
   let current = resolve(startDir);
   const root = resolve("/");
+  const home = canonicalDir(resolve(homedir()));
 
   while (true) {
-    const candidate = join(current, PROJECT_CONFIG_DIR);
-    if (existsSync(candidate) && statSync(candidate).isDirectory()) {
-      return current;
+    if (canonicalDir(current) !== home) {
+      const candidate = join(current, PROJECT_CONFIG_DIR);
+      if (existsSync(candidate) && statSync(candidate).isDirectory()) {
+        return current;
+      }
     }
     const parent = dirname(current);
     if (parent === current || parent === root) {
@@ -54,6 +63,39 @@ export function findProjectRoot(startDir: string = process.cwd()): string {
     }
     current = parent;
   }
+}
+
+/**
+ * Resolve symlinks so paths compare structurally — on macOS `$HOME` can
+ * arrive as `/var/...` while `process.cwd()` reports `/private/var/...`
+ * for the same directory. Falls back to the input when it doesn't exist.
+ */
+function canonicalDir(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * True when `path` resolves to the global `~/.understudy/config.json`.
+ * That file is never a *project* config — readers must treat it as
+ * "no project" and writers must refuse it, or the global dir starts
+ * claiming an active project for every directory under `$HOME`.
+ */
+export function isGlobalProjectConfigPath(path: string): boolean {
+  const global = join(globalConfigDir(), PROJECT_CONFIG_FILE);
+  const target = resolve(path);
+  if (target === global) {
+    return true;
+  }
+  // The file itself may not exist yet; canonicalize the parent dirs so
+  // symlinked forms of the same location still match.
+  return (
+    basename(target) === basename(global) &&
+    canonicalDir(dirname(target)) === canonicalDir(dirname(global))
+  );
 }
 
 export function projectConfigPath(startDir: string = process.cwd()): string {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -558,6 +558,61 @@ describe("understudy CLI", () => {
     }
   });
 
+  it("status treats orgs-map-only credentials as signed in", () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-status-orgs-home-"));
+    const repo = mkdtempSync(join(tmpdir(), "understudy-status-orgs-repo-"));
+    try {
+      const configDir = join(home, ".understudy");
+      mkdirSync(configDir, { recursive: true });
+      // No legacy top-level api_key/gateway_url: the per-org map is primary.
+      writeFileSync(
+        join(configDir, "credentials.json"),
+        `${JSON.stringify({
+          orgs: {
+            org_only: {
+              api_key: "sk_test_orgs_map_7391",
+              gateway_url: "https://api.understudylabs.com",
+            },
+          },
+        })}\n`,
+      );
+      const result = runWithHome(["status", "--json"], home, repo);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.signed_in, true);
+      assert.equal(payload.auth_mode, "api_key");
+      assert.equal(payload.org_id, "org_only");
+      assert.equal(payload.api_key_suffix, "7391");
+      assert.equal(payload.gateway_url, "https://api.understudylabs.com");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("status ignores a stale ~/.understudy/config.json project claim", () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-status-stale-home-"));
+    const repo = mkdtempSync(join(tmpdir(), "understudy-status-stale-repo-"));
+    try {
+      const configDir = join(home, ".understudy");
+      mkdirSync(configDir, { recursive: true });
+      // The pre-fix findProjectRoot fallback wrote per-repo config here.
+      writeFileSync(
+        join(configDir, "config.json"),
+        `${JSON.stringify({ org_id: "org_stale", project_slug: "rehearsal" })}\n`,
+      );
+      // Run from $HOME itself — the worst case for the old walk.
+      const result = runWithHome(["status", "--json"], home, home);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.configured, false);
+      assert.notEqual(payload.project_slug, "rehearsal");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it("includes telemetry state in login JSON output", () => {
     const home = mkdtempSync(join(tmpdir(), "understudy-login-home-"));
     try {

--- a/tests/paths.test.mjs
+++ b/tests/paths.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import {
+  findProjectRoot,
+  isGlobalProjectConfigPath,
+  projectConfigPath,
+} from "../dist/config/paths.js";
+import { readProjectConfig, writeProjectConfig } from "../dist/config/index.js";
+
+// These tests re-point $HOME at a temp dir. `os.homedir()` reads the env
+// var on POSIX, so an in-process swap is enough; node:test runs the cases
+// in this file sequentially, so the swap cannot race another test.
+describe("findProjectRoot and the global config dir", () => {
+  let home;
+  const savedHome = process.env.HOME;
+  const savedUserProfile = process.env.USERPROFILE;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "understudy-paths-home-"));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    // The global config dir exists, exactly like a signed-in machine.
+    mkdirSync(join(home, ".understudy"), { recursive: true });
+    assert.equal(homedir(), home);
+  });
+
+  afterEach(() => {
+    process.env.HOME = savedHome;
+    process.env.USERPROFILE = savedUserProfile;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("finds the nearest ancestor with a .understudy marker", () => {
+    const project = join(home, "code", "my-app");
+    mkdirSync(join(project, ".understudy"), { recursive: true });
+    const nested = join(project, "src", "deep");
+    mkdirSync(nested, { recursive: true });
+    assert.equal(findProjectRoot(nested), project);
+    assert.equal(
+      projectConfigPath(nested),
+      join(project, ".understudy", "config.json"),
+    );
+  });
+
+  it("never treats $HOME as a project root even though ~/.understudy exists", () => {
+    const stray = join(home, "Documents", "notes");
+    mkdirSync(stray, { recursive: true });
+    // Pre-guard behavior: the walk hit $HOME, matched ~/.understudy, and
+    // per-repo config landed in the global dir. Now the walk falls back
+    // to the start dir instead.
+    assert.equal(findProjectRoot(stray), stray);
+    assert.equal(findProjectRoot(home), home);
+  });
+
+  it("ignores a stale ~/.understudy/config.json instead of claiming a project", () => {
+    writeFileSync(
+      join(home, ".understudy", "config.json"),
+      `${JSON.stringify({ org_id: "org_stale", project_slug: "rehearsal" })}\n`,
+    );
+    // From $HOME itself the fallback root is $HOME, but the global
+    // config.json must read as "no project".
+    assert.equal(readProjectConfig(home), null);
+    // From a dir under $HOME with no marker, the walk no longer reaches
+    // the stale file at all.
+    const stray = join(home, "Documents");
+    mkdirSync(stray, { recursive: true });
+    assert.equal(readProjectConfig(stray), null);
+  });
+
+  it("refuses to write project config into the global config dir", () => {
+    const globalPath = join(home, ".understudy", "config.json");
+    assert.ok(isGlobalProjectConfigPath(globalPath));
+    assert.throws(
+      () =>
+        writeProjectConfig(globalPath, {
+          org_id: "org_x",
+          project_slug: "some-project",
+        }),
+      /global Understudy config dir/,
+    );
+    assert.ok(!existsSync(globalPath));
+
+    // A real project path is untouched by the guard.
+    const project = join(home, "code", "my-app");
+    mkdirSync(project, { recursive: true });
+    const projectPath = join(project, ".understudy", "config.json");
+    assert.ok(!isGlobalProjectConfigPath(projectPath));
+    writeProjectConfig(projectPath, {
+      org_id: "org_x",
+      project_slug: "some-project",
+    });
+    const written = JSON.parse(readFileSync(projectPath, "utf8"));
+    assert.equal(written.project_slug, "some-project");
+    assert.deepEqual(readProjectConfig(project), {
+      org_id: "org_x",
+      project_slug: "some-project",
+    });
+  });
+});


### PR DESCRIPTION
Wave 2 of the "one spine, two surfaces" run: the CLI and the desktop app now agree on who is signed in, which org/project is active, and which runtime facts are current.

## Fix 1 — orgs-map credentials resolve everywhere

`apps/homescreen/src-tauri/src/chat.rs` read only the top-level `api_key`/`gateway_url` from `~/.understudy/credentials.json` and ignored the per-org `orgs` map that `src/config/credentials.ts` treats as primary — orgs-map-only users showed as "not connected" in the app while CLI requests worked.

- New `apps/homescreen/src-tauri/src/creds.rs` mirrors the CLI's resolution order: `UNDERSTUDY_API_KEY`/`UNDERSTUDY_GATEWAY_URL` env vars > the active org entry in the `orgs` map (active org chosen like `resolveOrgId`: the map's sole entry; multiple orgs fall back to the top-level credential `login` keeps current) > legacy top-level fields, with the CLI's gateway fallback chain (`env > top-level > default`).
- `chat.rs` `credentials()` is now a one-line delegate to the shared reader (diff scoped to exactly that function — the concurrent routing refactor is untouched).
- `account.rs` keeps the `understudy status --json` shim for project-scoped fields, but the native reader is the source of truth for `signed_in` (overlaying `auth_mode`/`org_id`/`api_key_suffix`/`gateway_url` when the shim misses them) and synthesizes the full status when the CLI isn't installed. No divergent readers.
- CLI side of the same contradiction: `understudy status` previously only counted the legacy top-level `api_key` as signed in. It now reports `signed_in: true` for orgs-map-only files and uses the sole org entry as the active org for display when no project config names one.

## Fix 2 — `$HOME` is never a project root

`findProjectRoot` matched `~/.understudy/` (the *global* config dir) as a project marker, so walks that reached `$HOME` "found" a project there — which is how `~/.understudy/config.json` ended up claiming active project `rehearsal`.

- The walk now skips `$HOME` (realpath-aware, so macOS `/var` vs `/private/var` forms of the same dir still match).
- `readProjectConfig` treats `~/.understudy/config.json` as "no project"; `writeProjectConfig` refuses to write there; `login` skips the project pin with a note when run from the home directory.

## Fix 3 — the app owns `~/.understudy/agent-card.json`

The card was documented but had zero programmatic writers and was stale by construction. Per the settled decision, the desktop app is the canonical local daemon and now owns the card (`apps/homescreen/src-tauri/src/agent_card.rs`):

- written when the local API server binds (`base_url`, `port`, `pid`, `started_at`, `token_present` — never the token itself),
- refreshed with warm models `{id, port, model_path}` on every residency commit (warm/cool/assign),
- marked stopped on graceful shutdown (`RunEvent::Exit`),
- writes are atomic (temp file + rename) and purely additive to the `understudy.agent_card.v1` schema — skill-written blocks survive byte-for-byte.

`skills/onboard/reference.md` documents the ownership and the new `app` block; step 5 of the onboard skill now checks for the running app before refreshing the card by hand; the claim that `profile.json` tracks the local model library is corrected (the models dir + catalog is that truth; the profile stays the skills' interview artifact and the app never writes it).

## Test evidence

- `cargo check --all-targets` and `cargo test` in `apps/homescreen/src-tauri`: **25 passed, 0 failed** (1 pre-existing ignore), no warnings. New unit tests cover the credentials resolution order (env > orgs map > legacy) from a temp file, a full `resolve()` through a temp `HOME`, and agent-card merge/atomicity/corrupt-file behavior.
- `npm run build && npm test` at the repo root: **120 pass, 0 fail** (new `tests/paths.test.mjs` + two new status cases in `tests/cli.test.mjs`). `npm run typecheck`, `skills:validate` (31 skills ok), and `package:smoke` also pass.
- Manual verification: an orgs-map-only `credentials.json` in a temp `HOME` resolves through the Rust reader (`creds::tests::full_resolve_reads_orgs_map_only_file_from_temp_home`) and through the CLI:
  ```
  $ HOME=<temp> understudy status --json
  {"ok":true,"configured":false,"signed_in":true,"auth_mode":"api_key","org_id":"org_manual_check","project_slug":null,"api_key_suffix":"5150","gateway_url":"https://api.understudylabs.com",...}
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->