### PR TITLE
Fetch model catalog from snapshot service; sync fallbacks to pullable set

### DIFF
--- a/apps/homescreen/app/lib/model-aliases.ts
+++ b/apps/homescreen/app/lib/model-aliases.ts
@@ -4,6 +4,12 @@ export type SnapshotAlias = {
   name?: string;
 };
 
+// Offline fallback only. Short names are owned by the model catalog
+// (live /catalog via the Rust snapshot cache, else knowledge/snapshots.json):
+// `modelShortName` always prefers the `short_name` on the snapshot rows the
+// caller passes in. This map covers callers with no snapshot rows in hand
+// (e.g. the sidekick header) plus legacy alias ids, and must stay in sync
+// with the catalog's short_names.
 const FALLBACK_ALIASES: Record<string, string> = {
   "gemma-4-e2b-it-qat-mlx-vlm-understudy": "understudy-small",
   "gemma-4-e2b-it-qat-mlx-vlm-4bit-understudy": "understudy-small",

--- a/apps/homescreen/src-tauri/knowledge/snapshots.json
+++ b/apps/homescreen/src-tauri/knowledge/snapshots.json
@@ -6,6 +6,10 @@
     "approx_gb": 3.6,
     "loader": "mlx_vlm",
     "default_rung": true,
+    "certified": true,
+    "family": "gemma-4",
+    "tier": "e2b",
+    "quant": "qat-4bit-g32",
     "notes": "Default onboarding rung. QAT-derived 4-bit at group_size=32. Certified generation, OpenAI-compatible serving, logprobs+top_logprobs, and tool_calls at the prescribed decode.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-e2b-it-qat-mlx-vlm-understudy&ttl=21600"
   },
@@ -15,17 +19,12 @@
     "approx_gb": 3.3,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "gemma-4",
+    "tier": "e2b",
+    "quant": "4bit",
     "notes": "Vanilla non-QAT bf16 to MLX 4-bit. Diagnostic rung for isolating quantization artifacts against the QAT default.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit&ttl=21600"
-  },
-  {
-    "id": "gemma-4-e2b-it-mlx-vlm-bf16",
-    "name": "Gemma 4 E2B IT MLX-VLM BF16",
-    "approx_gb": 9.5,
-    "loader": "mlx_vlm",
-    "default_rung": false,
-    "notes": "Full-precision diagnostic rung for small-model quality checks.",
-    "session_url": "https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-bf16&ttl=21600"
   },
   {
     "id": "gemma-4-e4b-it-mlx-vlm-4bit",
@@ -33,6 +32,10 @@
     "approx_gb": 4.8,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "gemma-4",
+    "tier": "e4b",
+    "quant": "4bit",
     "notes": "First climb when E2B understands the task but lacks quality.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit&ttl=21600"
   },
@@ -42,6 +45,10 @@
     "approx_gb": 6.3,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "gemma-4",
+    "tier": "12b",
+    "quant": "4bit",
     "notes": "M4/M5 MacBook Pro or high-RAM Air rung when E4B behavior is right but not deep enough.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit&ttl=21600"
   },
@@ -51,17 +58,12 @@
     "approx_gb": 22,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "gemma-4",
+    "tier": "12b",
+    "quant": "bf16",
     "notes": "Quality/perf profiling rung on larger-memory Macs.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16&ttl=21600"
-  },
-  {
-    "id": "gemma-4-26b-a4b-it-mlx-vlm-4bit",
-    "name": "Gemma 4 26B A4B IT MLX-VLM 4-bit",
-    "approx_gb": 14,
-    "loader": "mlx_vlm",
-    "default_rung": false,
-    "notes": "MoE-style local climb for strong quality with lower active-parameter cost.",
-    "session_url": "https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit&ttl=21600"
   },
   {
     "id": "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy",
@@ -70,6 +72,10 @@
     "approx_gb": 16,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": true,
+    "family": "gemma-4",
+    "tier": "26b-a4b",
+    "quant": "qat-4bit-g32",
     "notes": "Certified MLX 4-bit QAT MoE from Google's QAT checkpoint. Certified generation, logprobs/top_logprobs, and tool calls.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-qat-mlx-vlm-understudy&ttl=21600"
   },
@@ -79,17 +85,12 @@
     "approx_gb": 52,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "gemma-4",
+    "tier": "26b-a4b",
+    "quant": "bf16",
     "notes": "Full-precision MoE high end for 64 GB+ Macs when 4-bit quality is in question.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-bf16&ttl=21600"
-  },
-  {
-    "id": "gemma-4-31b-it-mlx-vlm-4bit",
-    "name": "Gemma 4 31B IT MLX-VLM 4-bit",
-    "approx_gb": 17,
-    "loader": "mlx_vlm",
-    "default_rung": false,
-    "notes": "Workstation/high-memory local rung when dense capacity matters.",
-    "session_url": "https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-4bit&ttl=21600"
   },
   {
     "id": "gemma-4-31b-it-mlx-vlm-bf16",
@@ -97,6 +98,10 @@
     "approx_gb": 62,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "gemma-4",
+    "tier": "31b",
+    "quant": "bf16",
     "notes": "Full-precision dense high end for 96 GB+ Macs.",
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-bf16&ttl=21600"
   },
@@ -106,6 +111,10 @@
     "approx_gb": 16,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "diffusiongemma",
+    "tier": "26b-a4b",
+    "quant": "4bit",
     "notes": "Block-diffusion variant of the 26B A4B MoE. Requires mlx-vlm 0.6.3 or newer.",
     "session_url": "https://models.understudylabs.com/session?model=diffusiongemma-26b-a4b-it-mlx-vlm-4bit&ttl=21600"
   },
@@ -115,6 +124,10 @@
     "approx_gb": 52,
     "loader": "mlx_vlm",
     "default_rung": false,
+    "certified": false,
+    "family": "diffusiongemma",
+    "tier": "26b-a4b",
+    "quant": "bf16",
     "notes": "Full-precision diffusion rung for 64 GB+ Macs.",
     "session_url": "https://models.understudylabs.com/session?model=diffusiongemma-26b-a4b-it-mlx-vlm-bf16&ttl=21600"
   }

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -4,6 +4,7 @@ use crate::models::{self, SnapshotInfo};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
@@ -230,10 +231,30 @@ async fn download_model_inner(
     let mut files = manifest.files;
     files.sort_by(|a, b| file_name(a).cmp(&file_name(b)));
     let mut out = Vec::with_capacity(files.len());
-    for file in files {
-        out.push(download_file(&client, dest, file, on_event).await?);
+
+    // Pull SHA256SUMS first (never cache-skipped) so every other file,
+    // cached or fresh, verifies against this snapshot's current hashes.
+    // Without this, a stale same-name file from another snapshot passes the
+    // size heuristic and wedges the download at final verify with no
+    // in-app way to recover.
+    let mut expected_hashes: HashMap<String, String> = HashMap::new();
+    if let Some(pos) = files.iter().position(|f| is_sums_file(&file_name(f))) {
+        let sums_entry = files.remove(pos);
+        out.push(download_file(&client, dest, sums_entry, None, on_event).await?);
+        expected_hashes = parse_sha256sums(dest).await?;
     }
-    verify_sha256sums(dest).await?;
+
+    let mut verified: HashSet<String> = HashSet::new();
+    for file in files {
+        let key = normalize_sums_name(&file_name(&file));
+        let expected = expected_hashes.get(&key).cloned();
+        let had_expected = expected.is_some();
+        out.push(download_file(&client, dest, file, expected, on_event).await?);
+        if had_expected {
+            verified.insert(key);
+        }
+    }
+    verify_sha256sums(dest, &verified).await?;
     Ok(out)
 }
 
@@ -241,6 +262,7 @@ async fn download_file(
     client: &reqwest::Client,
     dest: &Path,
     file: SessionFile,
+    expected_sha: Option<String>,
     on_event: &Channel<DownloadEvent>,
 ) -> Result<FileMetadata, String> {
     let name = file_name(&file);
@@ -254,21 +276,25 @@ async fn download_file(
             .map_err(|e| format!("create parent dir failed: {e}"))?;
     }
     let total = file.size_bytes.or(file.size);
+    // The freshly pulled SHA256SUMS entry wins over any manifest hash.
+    let expected = expected_sha
+        .or(file.sha256.clone())
+        .map(|h| h.to_lowercase());
     // Never cache-skip SHA256SUMS itself: a stale sums file left by a
     // previous snapshot in the same dest would make verify_sha256sums
     // validate the wrong weights. It is tiny — always refetch it.
-    if name != "SHA256SUMS" {
+    if !is_sums_file(&name) {
         if let Ok(meta) = fs::metadata(&target).await {
             let size_matches = total.map(|t| t == meta.len()).unwrap_or(meta.len() > 0);
             // A size match alone can hide a stale or corrupt file; when the
             // manifest carries a hash, only a hash match counts as cached.
             let verified = if !size_matches {
                 false
-            } else if let Some(expected) = file.sha256.as_ref() {
+            } else if let Some(expected) = expected.as_deref() {
                 let _ = on_event.send(DownloadEvent::Log {
                     message: format!("verifying cached {name}"),
                 });
-                sha256_of_file(&target).await.ok().as_deref() == Some(&expected.to_lowercase())
+                sha256_of_file(&target).await.ok().as_deref() == Some(expected)
             } else {
                 true
             };
@@ -282,6 +308,11 @@ async fn download_file(
                     cached: true,
                 });
             }
+            // Self-heal: a cached file that fails verification is replaced by
+            // a fresh download instead of wedging the pull at final verify.
+            let _ = on_event.send(DownloadEvent::Log {
+                message: format!("cached {name} failed verification; re-downloading"),
+            });
         }
     }
 
@@ -305,7 +336,7 @@ async fn download_file(
         .map_err(|e| format!("create partial file failed for {name}: {e}"))?;
     let mut stream = response.bytes_stream();
     let mut downloaded = 0u64;
-    let mut hasher = file.sha256.as_ref().map(|_| Sha256::new());
+    let mut hasher = expected.as_ref().map(|_| Sha256::new());
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|e| format!("download stream failed for {name}: {e}"))?;
         downloaded += chunk.len() as u64;
@@ -334,9 +365,9 @@ async fn download_file(
             ));
         }
     }
-    if let (Some(hash), Some(expected)) = (hasher, file.sha256.as_ref()) {
+    if let (Some(hash), Some(expected)) = (hasher, expected.as_deref()) {
         let actual = format!("{:x}", hash.finalize());
-        if actual != expected.to_lowercase() {
+        if actual != expected {
             let _ = fs::remove_file(&part).await;
             return Err(format!("sha256 mismatch for {name}"));
         }
@@ -351,10 +382,12 @@ async fn download_file(
     })
 }
 
-async fn verify_sha256sums(dest: &Path) -> Result<(), String> {
+/// Parse the snapshot's SHA256SUMS into normalized-name -> lowercase hex.
+async fn parse_sha256sums(dest: &Path) -> Result<HashMap<String, String>, String> {
     let sums = dest.join("SHA256SUMS");
+    let mut out = HashMap::new();
     if !sums.exists() {
-        return Ok(());
+        return Ok(out);
     }
     let text = fs::read_to_string(&sums)
         .await
@@ -366,16 +399,39 @@ async fn verify_sha256sums(dest: &Path) -> Result<(), String> {
         if expected.len() != 64 {
             continue;
         }
-        let name = raw.trim().trim_start_matches('*').trim_start_matches("./");
-        let target = safe_target(dest, name)?;
+        out.insert(normalize_sums_name(raw), expected.to_lowercase());
+    }
+    Ok(out)
+}
+
+/// Final backstop over the whole dest. `already_verified` holds normalized
+/// names hashed during download this run; re-hashing 50+ GB of weights a
+/// second time is pointless.
+async fn verify_sha256sums(dest: &Path, already_verified: &HashSet<String>) -> Result<(), String> {
+    for (name, expected) in parse_sha256sums(dest).await? {
+        if already_verified.contains(&name) {
+            continue;
+        }
+        let target = safe_target(dest, &name)?;
         let actual = sha256_of_file(&target)
             .await
             .map_err(|e| format!("read {name} for SHA256 failed: {e}"))?;
-        if actual != expected.to_lowercase() {
+        if actual != expected {
             return Err(format!("sha256 mismatch for {name}"));
         }
     }
     Ok(())
+}
+
+fn normalize_sums_name(name: &str) -> String {
+    name.trim()
+        .trim_start_matches('*')
+        .trim_start_matches("./")
+        .to_string()
+}
+
+fn is_sums_file(name: &str) -> bool {
+    normalize_sums_name(name) == "SHA256SUMS"
 }
 
 /// Hash a file in fixed-size chunks; weights run 50+ GB and must never be

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -254,29 +254,34 @@ async fn download_file(
             .map_err(|e| format!("create parent dir failed: {e}"))?;
     }
     let total = file.size_bytes.or(file.size);
-    if let Ok(meta) = fs::metadata(&target).await {
-        let size_matches = total.map(|t| t == meta.len()).unwrap_or(meta.len() > 0);
-        // A size match alone can hide a stale or corrupt file; when the
-        // manifest carries a hash, only a hash match counts as cached.
-        let verified = if !size_matches {
-            false
-        } else if let Some(expected) = file.sha256.as_ref() {
-            let _ = on_event.send(DownloadEvent::Log {
-                message: format!("verifying cached {name}"),
-            });
-            sha256_of_file(&target).await.ok().as_deref() == Some(&expected.to_lowercase())
-        } else {
-            true
-        };
-        if verified {
-            let _ = on_event.send(DownloadEvent::Log {
-                message: format!("cached {name}"),
-            });
-            return Ok(FileMetadata {
-                name,
-                bytes: meta.len(),
-                cached: true,
-            });
+    // Never cache-skip SHA256SUMS itself: a stale sums file left by a
+    // previous snapshot in the same dest would make verify_sha256sums
+    // validate the wrong weights. It is tiny — always refetch it.
+    if name != "SHA256SUMS" {
+        if let Ok(meta) = fs::metadata(&target).await {
+            let size_matches = total.map(|t| t == meta.len()).unwrap_or(meta.len() > 0);
+            // A size match alone can hide a stale or corrupt file; when the
+            // manifest carries a hash, only a hash match counts as cached.
+            let verified = if !size_matches {
+                false
+            } else if let Some(expected) = file.sha256.as_ref() {
+                let _ = on_event.send(DownloadEvent::Log {
+                    message: format!("verifying cached {name}"),
+                });
+                sha256_of_file(&target).await.ok().as_deref() == Some(&expected.to_lowercase())
+            } else {
+                true
+            };
+            if verified {
+                let _ = on_event.send(DownloadEvent::Log {
+                    message: format!("cached {name}"),
+                });
+                return Ok(FileMetadata {
+                    name,
+                    bytes: meta.len(),
+                    cached: true,
+                });
+            }
         }
     }
 
@@ -407,12 +412,11 @@ fn safe_target(root: &Path, name: &str) -> Result<PathBuf, String> {
     Ok(root.join(path))
 }
 
+/// Shared model cache root (UNDERSTUDY_MODEL_HOME override, else
+/// ~/.understudy/models) — see `models::models_dir`.
 fn models_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".understudy")
-        .join("models")
+    models::models_dir()
+        .unwrap_or_else(|| PathBuf::from(".").join(".understudy").join("models"))
 }
 
 fn command_status(id: &str, label: &str, command: String, args: &[&str]) -> ToolStatus {

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -864,6 +864,12 @@ pub fn list_models() -> Vec<models::ModelInfo> {
 
 #[tauri::command]
 pub fn list_snapshot_models() -> Vec<models::SnapshotInfo> {
+    // Kick a background catalog refresh (no-op while fresh or backed off);
+    // this call never blocks on the network — it serves the last good live
+    // catalog or the bundled fallback.
+    tauri::async_runtime::spawn(async {
+        let _ = models::refresh_catalog().await;
+    });
     models::snapshots()
 }
 

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -49,6 +49,13 @@ pub fn run() {
                 }
             });
 
+            // Refresh the model catalog from the snapshot service in the
+            // background; snapshots() serves the bundled fallback until (and
+            // unless) a live catalog lands.
+            tauri::async_runtime::spawn(async {
+                let _ = models::refresh_catalog().await;
+            });
+
             // Local API server (HTTP + MCP + A2A) for coding agents.
             server::start(app.handle().clone());
 

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -135,6 +135,20 @@ fn parse_catalog(body: &str) -> Result<Vec<SnapshotInfo>, String> {
     if rows.is_empty() {
         return Err("catalog listed no models".to_string());
     }
+    // A live catalog REPLACES the bundled table, so a field-dropping or
+    // half-empty payload must be rejected wholesale rather than silently
+    // shadowing complete bundled data with unpullable rows.
+    for row in &rows {
+        if row.id.trim().is_empty()
+            || row.loader.trim().is_empty()
+            || !row
+                .session_url
+                .as_deref()
+                .is_some_and(|u| !u.trim().is_empty())
+        {
+            return Err(format!("catalog row invalid: {:?}", row.id));
+        }
+    }
     Ok(rows)
 }
 
@@ -143,7 +157,9 @@ fn parse_catalog(body: &str) -> Result<Vec<SnapshotInfo>, String> {
 /// the result and `snapshots()` keeps serving the bundled fallback.
 pub async fn refresh_catalog() -> Result<usize, String> {
     {
-        let state = catalog_state().lock().unwrap();
+        // One lock span for freshness check + attempt stamp: two separate
+        // acquisitions let concurrent callers both pass the backoff gate.
+        let mut state = catalog_state().lock().unwrap();
         if let Some((fetched_at, rows)) = state.rows.as_ref() {
             if fetched_at.elapsed() < CATALOG_MAX_AGE {
                 return Ok(rows.len());
@@ -154,8 +170,8 @@ pub async fn refresh_catalog() -> Result<usize, String> {
                 return Err("catalog fetch backed off".to_string());
             }
         }
+        state.last_attempt = Some(Instant::now());
     }
-    catalog_state().lock().unwrap().last_attempt = Some(Instant::now());
     let client = reqwest::Client::builder()
         .connect_timeout(CATALOG_TIMEOUT)
         .timeout(CATALOG_TIMEOUT)

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
-/// A locally cached, MLX-format model under `~/.understudy/models`.
+/// A locally cached, MLX-format model under the model cache root.
 #[derive(Serialize, Clone)]
 pub struct ModelInfo {
     pub id: String,   // directory name, e.g. "gemma-4-26b-a4b-it-optiq-4bit"
@@ -9,18 +11,42 @@ pub struct ModelInfo {
     pub size_gb: f32,
 }
 
+/// One downloadable snapshot row. Deserializes from both the bundled
+/// `knowledge/snapshots.json` fallback and the live `/catalog` rows, so
+/// everything past `id`/`name` is defaulted. `cached`/`path`/`manifest` are
+/// local-state decorations filled in by `snapshots()`.
 #[derive(Deserialize, Serialize, Clone)]
 pub struct SnapshotInfo {
     pub id: String,
+    #[serde(default)]
     pub short_name: Option<String>,
+    #[serde(default)]
     pub session_url: Option<String>,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub approx_gb: f32,
+    #[serde(default)]
     pub loader: String,
+    #[serde(default)]
     pub default_rung: bool,
+    #[serde(default)]
     pub notes: String,
+    #[serde(default)]
+    pub certified: Option<bool>,
+    #[serde(default)]
+    pub family: Option<String>,
+    #[serde(default)]
+    pub tier: Option<String>,
+    #[serde(default)]
+    pub quant: Option<String>,
+    #[serde(default)]
+    pub file_count: Option<u64>,
+    #[serde(default)]
     pub cached: bool,
+    #[serde(default)]
     pub path: Option<String>,
+    #[serde(default)]
     pub manifest: bool,
 }
 
@@ -40,9 +66,129 @@ pub const LOCAL_BASE_URL: &str = "http://127.0.0.1:8089/v1";
 /// be treated as serveable.
 pub const INCOMPLETE_MARKER: &str = ".understudy-snapshot.incomplete";
 
-fn models_dir() -> Option<PathBuf> {
+/// Model cache root — same convention as the CLI and skills/ladder/serve.py:
+/// `UNDERSTUDY_MODEL_HOME` overrides, else `~/.understudy/models`.
+pub fn models_dir() -> Option<PathBuf> {
+    if let Some(custom) = std::env::var_os("UNDERSTUDY_MODEL_HOME") {
+        if !custom.is_empty() {
+            return Some(PathBuf::from(custom));
+        }
+    }
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".understudy").join("models"))
+}
+
+/// Live model catalog served by the snapshot service.
+pub const DEFAULT_CATALOG_URL: &str = "https://models.understudylabs.com/catalog";
+pub const CATALOG_SCHEMA_VERSION: &str = "understudy.model_catalog.v1";
+/// Mirrors the endpoint's `Cache-Control: max-age=300`.
+const CATALOG_MAX_AGE: Duration = Duration::from_secs(300);
+/// Back off failed fetch attempts so callers don't hammer a dead endpoint.
+const CATALOG_RETRY_AFTER: Duration = Duration::from_secs(60);
+const CATALOG_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Deserialize)]
+struct CatalogEnvelope {
+    schema_version: String,
+    models: Vec<SnapshotInfo>,
+}
+
+#[derive(Default)]
+struct CatalogState {
+    /// Last good response, cached in memory.
+    rows: Option<(Instant, Vec<SnapshotInfo>)>,
+    last_attempt: Option<Instant>,
+}
+
+fn catalog_state() -> &'static Mutex<CatalogState> {
+    static STATE: OnceLock<Mutex<CatalogState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(CatalogState::default()))
+}
+
+pub fn catalog_url() -> String {
+    std::env::var("UNDERSTUDY_CATALOG_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_CATALOG_URL.to_string())
+}
+
+fn parse_catalog(body: &str) -> Result<Vec<SnapshotInfo>, String> {
+    let envelope: CatalogEnvelope =
+        serde_json::from_str(body).map_err(|e| format!("catalog parse failed: {e}"))?;
+    if envelope.schema_version != CATALOG_SCHEMA_VERSION {
+        return Err(format!(
+            "catalog schema mismatch: {}",
+            envelope.schema_version
+        ));
+    }
+    let rows: Vec<SnapshotInfo> = envelope
+        .models
+        .into_iter()
+        .filter(|row| !row.id.trim().is_empty())
+        .map(|mut row| {
+            if row.name.is_empty() {
+                row.name = row.id.clone();
+            }
+            row
+        })
+        .collect();
+    if rows.is_empty() {
+        return Err("catalog listed no models".to_string());
+    }
+    Ok(rows)
+}
+
+/// Fetch the live catalog and cache the last good response in memory.
+/// Failures are expected (the endpoint may not exist yet) — callers ignore
+/// the result and `snapshots()` keeps serving the bundled fallback.
+pub async fn refresh_catalog() -> Result<usize, String> {
+    {
+        let state = catalog_state().lock().unwrap();
+        if let Some((fetched_at, rows)) = state.rows.as_ref() {
+            if fetched_at.elapsed() < CATALOG_MAX_AGE {
+                return Ok(rows.len());
+            }
+        }
+        if let Some(last_attempt) = state.last_attempt {
+            if last_attempt.elapsed() < CATALOG_RETRY_AFTER {
+                return Err("catalog fetch backed off".to_string());
+            }
+        }
+    }
+    catalog_state().lock().unwrap().last_attempt = Some(Instant::now());
+    let client = reqwest::Client::builder()
+        .connect_timeout(CATALOG_TIMEOUT)
+        .timeout(CATALOG_TIMEOUT)
+        .build()
+        .map_err(|e| format!("catalog client init failed: {e}"))?;
+    let body = client
+        .get(catalog_url())
+        .send()
+        .await
+        .map_err(|e| format!("catalog request failed: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("catalog request failed: {e}"))?
+        .text()
+        .await
+        .map_err(|e| format!("catalog read failed: {e}"))?;
+    let rows = parse_catalog(&body)?;
+    let count = rows.len();
+    catalog_state().lock().unwrap().rows = Some((Instant::now(), rows));
+    Ok(count)
+}
+
+/// Catalog rows: last good live response if we have one, else the bundled
+/// offline fallback (kept in sync with the pullable snapshot set).
+fn catalog_rows() -> Vec<SnapshotInfo> {
+    if let Some((_, rows)) = catalog_state().lock().unwrap().rows.as_ref() {
+        return rows.clone();
+    }
+    bundled_snapshot_rows()
+}
+
+fn bundled_snapshot_rows() -> Vec<SnapshotInfo> {
+    let raw = include_str!("../knowledge/snapshots.json");
+    serde_json::from_str(raw).unwrap_or_default()
 }
 
 /// A snapshot dir is serveable once config.json exists and the download's
@@ -80,8 +226,7 @@ pub fn list() -> Vec<ModelInfo> {
 }
 
 pub fn snapshots() -> Vec<SnapshotInfo> {
-    let raw = include_str!("../knowledge/snapshots.json");
-    let mut rows: Vec<SnapshotInfo> = serde_json::from_str(raw).unwrap_or_default();
+    let mut rows = catalog_rows();
     let root = models_dir();
     for row in rows.iter_mut() {
         let Some(dir) = root.as_ref().map(|root| root.join(&row.id)) else {
@@ -161,5 +306,95 @@ mod tests {
         std::fs::remove_file(dir.join(INCOMPLETE_MARKER)).unwrap();
         assert!(snapshot_ready(&dir));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn models_dir_honors_understudy_model_home() {
+        // Set and unset in a single test: env vars are process-global and
+        // cargo runs tests in parallel threads.
+        std::env::set_var("UNDERSTUDY_MODEL_HOME", "/tmp/custom-model-home");
+        assert_eq!(
+            models_dir(),
+            Some(PathBuf::from("/tmp/custom-model-home")),
+            "UNDERSTUDY_MODEL_HOME must override the default cache root"
+        );
+        std::env::remove_var("UNDERSTUDY_MODEL_HOME");
+        let default = models_dir().expect("HOME is set in the test environment");
+        assert!(
+            default.ends_with(".understudy/models"),
+            "default cache root must be ~/.understudy/models, got {default:?}"
+        );
+    }
+
+    #[test]
+    fn bundled_snapshots_match_pullable_set() {
+        let rows = bundled_snapshot_rows();
+        let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "gemma-4-e2b-it-qat-mlx-vlm-understudy",
+                "gemma-4-e2b-it-mlx-vlm-4bit",
+                "gemma-4-e4b-it-mlx-vlm-4bit",
+                "gemma-4-12b-it-mlx-vlm-4bit",
+                "gemma-4-12b-it-mlx-vlm-bf16",
+                "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy",
+                "gemma-4-26b-a4b-it-mlx-vlm-bf16",
+                "gemma-4-31b-it-mlx-vlm-bf16",
+                "diffusiongemma-26b-a4b-it-mlx-vlm-4bit",
+                "diffusiongemma-26b-a4b-it-mlx-vlm-bf16",
+            ],
+            "bundled fallback must list exactly the pullable snapshot set"
+        );
+        assert_eq!(
+            rows.iter().filter(|r| r.default_rung).count(),
+            1,
+            "exactly one default rung"
+        );
+        assert_eq!(
+            rows.iter().filter(|r| r.certified == Some(true)).count(),
+            2,
+            "exactly the two understudy conversions are certified"
+        );
+        assert!(
+            rows.iter().all(|r| r.session_url.is_some()),
+            "every bundled row keeps a session URL for offline pulls"
+        );
+    }
+
+    #[test]
+    fn parse_catalog_accepts_v1_and_rejects_other_schemas() {
+        let good = r#"{
+            "schema_version": "understudy.model_catalog.v1",
+            "models": [
+                {
+                    "id": "gemma-4-e2b-it-qat-mlx-vlm-understudy",
+                    "name": "Gemma 4 E2B QAT",
+                    "approx_gb": 3.6,
+                    "loader": "mlx_vlm",
+                    "default_rung": true,
+                    "short_name": "understudy-small",
+                    "certified": true,
+                    "family": "gemma-4",
+                    "tier": "e2b",
+                    "quant": "qat-4bit-g32",
+                    "session_url": "https://models.understudylabs.com/session?model=gemma-4-e2b-it-qat-mlx-vlm-understudy&ttl=21600",
+                    "file_count": 11
+                }
+            ]
+        }"#;
+        let rows = parse_catalog(good).expect("v1 catalog parses");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].short_name.as_deref(), Some("understudy-small"));
+        assert_eq!(rows[0].certified, Some(true));
+        assert!(rows[0].default_rung);
+
+        let wrong_schema = good.replace("understudy.model_catalog.v1", "understudy.model_catalog.v2");
+        assert!(parse_catalog(&wrong_schema).is_err(), "unknown schema_version must be rejected");
+        assert!(parse_catalog("not json").is_err());
+        assert!(
+            parse_catalog(r#"{"schema_version":"understudy.model_catalog.v1","models":[]}"#).is_err(),
+            "an empty catalog must not clobber the fallback"
+        );
     }
 }

--- a/skills/manage-local-models/reference.md
+++ b/skills/manage-local-models/reference.md
@@ -67,8 +67,9 @@ as MLX 4-bit (lost both wins); DiffusionGemma's only solved task came at
 BF16; AR Gemma 4 26B-A4B's BF16 rung recovered misses its 4-bit made. The
 weaker a model's baseline tool-calling, the larger the tax. For agentic
 evals: treat 4-bit scores as lower bounds, and re-measure on the BF16 rung
-(now published for every ladder model) before concluding a model can't do a
-workload.
+(published for the 12B, 26B A4B, 31B, and DiffusionGemma ladder models; the
+E2B BF16 snapshot is not currently published, so that comparison needs a
+local conversion) before concluding a model can't do a workload.
 
 ## Understudy verified MLX ladder
 
@@ -80,14 +81,14 @@ or graduate remote when local quality is the bottleneck.
 |---|---|---|---|
 | **Gemma 4 E2B QAT (Understudy, g32)** | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-qat-mlx-vlm-understudy` | **Default onboarding rung.** QAT bf16 -> MLX 4-bit `group_size=32`. About 3.6 GB; 4/4 certified (generation, OpenAI-compatible serving, logprobs+top_logprobs, tool_calls) at the prescribed decode (1.0/0.95/k64). Matches-or-beats vanilla BF16 on tool-call fidelity at 2.6x less memory and 2.6x faster decode. Serve with `--top-logprobs-k 20` — see `understudy.serving.json` and `references/serving-manifest.md`. |
 | Gemma 4 E2B 4-bit (vanilla) | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit` | Diagnostic rung (vanilla non-QAT bf16 -> MLX 4-bit). Keep it to isolate "is this a quant artifact?" questions against the QAT default. About 3.3 GB; verified generation, OpenAI-compatible serving, logprobs/top-logprobs. |
-| Gemma 4 E2B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-bf16` | Full-precision diagnostic rung for small-model quality checks. About 9.5 GB. |
+| Gemma 4 E2B BF16 | `mlx_vlm.server` | Not currently published (weights incomplete on the snapshot service); local conversion only | Full-precision diagnostic rung for small-model quality checks. About 9.5 GB. Convert locally from `google/gemma-4-e2b-it` with `mlx-vlm`, or use the published 12B BF16 rung for the quant-vs-capacity comparison. |
 | Gemma 4 E4B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit` | First climb when E2B understands the task but lacks quality. About 4.8 GB; verified signed snapshot delivery. Official target for this tier: `gemma-4-e4b-it-qat-mlx-vlm-understudy` (QAT conversion staged; certification + publication pending) — switch to it once its session URL resolves. |
 | Gemma 4 12B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit` | M4/M5 MacBook Pro or high-RAM Air rung when E4B has the right behavior but not enough depth. About 6.3 GB; verified generation plus OpenAI-compatible logprobs/top-logprobs. Official target for this tier: `gemma-4-12b-it-qat-mlx-vlm-understudy` (QAT conversion staged; certification + publication pending). |
 | Gemma 4 12B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16` | Quality/perf profiling rung on larger-memory Macs. About 22 GB; use when quantization may be the bottleneck. |
 | **Gemma 4 26B A4B QAT (Understudy)** | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-qat-mlx-vlm-understudy` | **Primary MoE-style climb.** Certified MLX 4-bit QAT MoE (`group_size=32` + 8-bit routers) from Google's QAT checkpoint. About 16 GB; certified generation, logprobs/top-logprobs, and tool calls. |
-| Gemma 4 26B A4B 4-bit (vanilla) | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit` | Diagnostic sibling of the QAT rung (and interim pull while the QAT snapshot publication lands). About 14 GB; verified generation plus logprobs/top-logprobs. |
+| Gemma 4 26B A4B 4-bit (vanilla) | `mlx_vlm.server` | Not currently published (weights incomplete on the snapshot service); local conversion only | Diagnostic sibling of the QAT rung, which is the primary pull for this tier. About 14 GB if converted locally; only worth the conversion when isolating a quant artifact the QAT rung can't explain. |
 | Gemma 4 26B A4B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-bf16` | Full-precision MoE high end for 64 GB+ Macs when 4-bit quality is in question. About 52 GB. |
-| Gemma 4 31B 4-bit | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-4bit` | Workstation/high-memory local rung when dense capacity matters. About 17 GB; verified generation plus logprobs/top-logprobs. |
+| Gemma 4 31B 4-bit | `mlx_vlm.server` | Not currently published (weights incomplete on the snapshot service); local conversion only | Workstation/high-memory local rung when dense capacity matters. About 17 GB if converted locally from `google/gemma-4-31b-it`; the published 31B BF16 snapshot covers this tier for 96 GB+ machines. |
 | Gemma 4 31B BF16 | `mlx_vlm.server` | `https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-bf16` | Full-precision dense high end for 96 GB+ Macs. About 62 GB. |
 | DiffusionGemma 26B A4B 4-bit | `mlx_vlm.server` (mlx-vlm ≥ 0.6.3) | `https://models.understudylabs.com/session?model=diffusiongemma-26b-a4b-it-mlx-vlm-4bit` | Block-diffusion variant of the 26B A4B MoE. About 16 GB; verified generation, chat completions, and tool calls. See the diffusion note below before picking it for speed. |
 | DiffusionGemma 26B A4B BF16 | `mlx_vlm.server` (mlx-vlm ≥ 0.6.3) | `https://models.understudylabs.com/session?model=diffusiongemma-26b-a4b-it-mlx-vlm-bf16` | Full-precision diffusion rung for 64 GB+ Macs. About 52 GB; on bandwidth-bound Apple Silicon it decodes slightly *faster* than the 4-bit snapshot (diffusion decode is compute-bound), so prefer it when memory allows. |
@@ -196,27 +197,29 @@ fixed `seed` for reproducibility, never `temperature: 0`.
 When adding a new model to the cache or ladder, append its row here as part of
 the pull — the bench harness should never have to guess.
 
-Small full-precision diagnostic note: `gemma-4-e2b-it-mlx-vlm-bf16` is the
-smallest BF16 rung. Use it to distinguish model-size limits from quantization
-damage before jumping to 12B or remote.
+Small full-precision diagnostic note: `gemma-4-e2b-it-mlx-vlm-bf16` (the
+smallest BF16 rung) is not currently published on the snapshot service —
+convert it locally if you need it, or use the published
+`gemma-4-12b-it-mlx-vlm-bf16` to distinguish model-size limits from
+quantization damage before jumping to remote.
 
 Known-good high-end smoke:
 
 ```bash
 python -m mlx_vlm.server \
-  --model ~/.understudy/models/gemma-4-26b-a4b-it-mlx-vlm-4bit \
+  --model ~/.understudy/models/gemma-4-26b-a4b-it-qat-mlx-vlm-understudy \
   --host 127.0.0.1 --port 8094
 
 curl -s http://127.0.0.1:8094/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"~/.understudy/models/gemma-4-26b-a4b-it-mlx-vlm-4bit","messages":[{"role":"user","content":"Answer in exactly three words: what is local inference?"}],"max_tokens":24,"temperature":0}'
+  -d '{"model":"~/.understudy/models/gemma-4-26b-a4b-it-qat-mlx-vlm-understudy","messages":[{"role":"user","content":"Answer in exactly three words: what is local inference?"}],"max_tokens":24,"temperature":0}'
 ```
 
 Expected shape: HTTP 200, a `choices[0].message.content` answer such as
 `Running models locally.` or `AI runs locally.`, `finish_reason: "stop"`, and
-usage counts. Repeat the same smoke for `gemma-4-31b-it-mlx-vlm-4bit`. This is
-the supported functional check; raw `mlx_vlm.generate()` can emit odd text if the
-chat template is bypassed.
+usage counts. Repeat the same smoke for `gemma-4-31b-it-mlx-vlm-bf16` on
+machines with the memory for it. This is the supported functional check; raw
+`mlx_vlm.generate()` can emit odd text if the chat template is bypassed.
 
 Full-precision high end: the BF16 rungs for `gemma-4-26b-a4b-it` and
 `gemma-4-31b-it` are published as Understudy signed snapshots

--- a/skills/onboard/reference.md
+++ b/skills/onboard/reference.md
@@ -230,11 +230,13 @@ through MLX on Apple Silicon (see
   (about 4.8 GB, `mlx-vlm 0.6.2`, served with `mlx_vlm.server`) — provenance
   and smoke-test details:
   [`../manage-local-models/reference.md`](../manage-local-models/reference.md).
-- **Small BF16 diagnostic rung** — an Understudy-verified BF16 conversion of
-  `google/gemma-4-e2b-it`, served with `mlx_vlm.server`. Use
-  `https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-bf16`
-  when quantization may be hurting a small-model workload. It is about
-  9.5 GB on disk.
+- **Small BF16 diagnostic rung** — `gemma-4-e2b-it-mlx-vlm-bf16` is **not
+  currently published** on the snapshot service (its session URL answers
+  `unknown model`). When quantization may be hurting a small-model workload,
+  either convert it locally from `google/gemma-4-e2b-it` with `mlx-vlm`, or
+  use the published
+  `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16`
+  (about 22 GB) as the full-precision comparison rung.
 - **Delivery shape** — publish the stable
   `models.understudylabs.com/session?model=...` endpoint. It returns a manifest
   with short-lived signed URLs for the actual model files; do not publish the
@@ -248,13 +250,13 @@ through MLX on Apple Silicon (see
   `https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16`
   only for larger-memory quality/perf profiling; it is about 22 GB on disk.
 - **Larger local Gemma rungs** — the official MoE-style climb is the
-  **certified** `gemma-4-26b-a4b-it-qat-mlx-vlm-understudy` (QAT MLX 4-bit
-  `group_size=32` + 8-bit routers, about 16 GB; certified generation,
-  logprobs/top-logprobs, and tool calls). If its session URL is not yet
-  published, the interim rung is `gemma-4-26b-a4b-it-mlx-vlm-4bit` (about
-  14 GB). `gemma-4-31b-it-mlx-vlm-4bit` is the dense high-memory local rung at
-  about 17 GB. All use stable
-  `https://models.understudylabs.com/session?model=<id>` endpoints; see
+  **certified, published** `gemma-4-26b-a4b-it-qat-mlx-vlm-understudy` (QAT
+  MLX 4-bit `group_size=32` + 8-bit routers, about 16 GB; certified
+  generation, logprobs/top-logprobs, and tool calls). The vanilla
+  `gemma-4-26b-a4b-it-mlx-vlm-4bit` and `gemma-4-31b-it-mlx-vlm-4bit` are
+  **not currently published** (weights incomplete on the snapshot service) —
+  do not send users to their session URLs; the published dense high-memory
+  rung is `gemma-4-31b-it-mlx-vlm-bf16` (about 62 GB, 96 GB+ Macs). See
   [`../manage-local-models/reference.md`](../manage-local-models/reference.md)
   for the canonical provenance statement and the known-good chat smoke.
 - **DiffusionGemma rungs (specialty, not an onboarding default)** —

--- a/skills/run-local-model-lab/reference.md
+++ b/skills/run-local-model-lab/reference.md
@@ -136,7 +136,7 @@ availability, license, checkpoint format, and runtime support before use.
 
 | Candidate class | Use when | Notes |
 | --- | --- | --- |
-| E2B / E4B | Router, triage, extraction, easy classification, edge/mobile, audio-first smoke tests | Smallest Gemma 4 rungs. Good for cheap local iteration and compliance-constrained routing. Use the 4-bit snapshots for speed/size; use `gemma-4-e2b-it-mlx-vlm-bf16` when quantization may be the bottleneck. |
+| E2B / E4B | Router, triage, extraction, easy classification, edge/mobile, audio-first smoke tests | Smallest Gemma 4 rungs. Good for cheap local iteration and compliance-constrained routing. Use the 4-bit snapshots for speed/size; when quantization may be the bottleneck, convert a BF16 rung locally or compare against the published `gemma-4-12b-it-mlx-vlm-bf16`. |
 | 12B | Main laptop eval, multimodal/audio tasks, stronger reasoning without workstation hardware | Google announced Gemma 4 12B on 2026-06-03 as a unified encoder-free multimodal model designed for laptops with 16GB VRAM or unified memory. |
 | 26B A4B MoE | Strong local text/image candidate on serious desktop/workstation hardware | Treat as the local quality/latency sweet spot when the runtime and memory fit. MoE active parameters do not remove the need to fit the checkpoint/KV cache. |
 | 31B dense | Maximum local quality when hardware is available, or remote graduation target | Prefer remote/gateway if local ops friction or memory pressure slows the experiment. |

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -8,10 +8,10 @@ import { isJsonMode, runAction } from "../internal/output.js";
 import { trackControlPlaneAction } from "../internal/telemetry.js";
 import {
   DEFAULT_MODELS_DIR,
-  VERIFIED_SNAPSHOT_MODELS,
+  fetchSnapshotCatalog,
   pullSnapshotModel,
   resolveSnapshotPlan,
-  snapshotModelIds,
+  type SnapshotCatalog,
 } from "../model-snapshots.js";
 
 const PublicModelSchema = z.object({
@@ -57,8 +57,8 @@ export function registerModelsCommand(program: Command): void {
     .command("snapshots")
     .description("List downloadable local Understudy model snapshots.")
     .option("--json", "Output JSON.")
-    .action(function (this: Command, opts: { json?: boolean }) {
-      runSnapshotList(this, opts);
+    .action(async function (this: Command, opts: { json?: boolean }) {
+      await runSnapshotList(this, opts);
     });
 
   models
@@ -118,24 +118,32 @@ async function runList(cmd: Command, opts: OrgOpt): Promise<void> {
   }
 }
 
-function runSnapshotList(cmd: Command, opts: { json?: boolean }): void {
-  const models = snapshotModelIds().map((id) => ({
+function catalogSourceLabel(catalog: SnapshotCatalog): string {
+  return catalog.source === "live" ? `live catalog (${catalog.url})` : "bundled fallback";
+}
+
+async function runSnapshotList(cmd: Command, opts: { json?: boolean }): Promise<void> {
+  const catalog = await fetchSnapshotCatalog();
+  const models = Object.entries(catalog.models).map(([id, info]) => ({
     id,
-    name: VERIFIED_SNAPSHOT_MODELS[id]?.name ?? id,
-    approx_gb: VERIFIED_SNAPSHOT_MODELS[id]?.approxGb ?? null,
-    loader: VERIFIED_SNAPSHOT_MODELS[id]?.loader ?? null,
-    default: VERIFIED_SNAPSHOT_MODELS[id]?.defaultRung === true,
+    name: info.name,
+    short_name: info.shortName ?? null,
+    approx_gb: info.approxGb,
+    loader: info.loader,
+    default: info.defaultRung === true,
+    certified: info.certified === true,
   }));
   if (opts.json || isJsonMode(cmd)) {
-    process.stdout.write(`${JSON.stringify({ models }, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify({ source: catalog.source, catalog_url: catalog.url, models }, null, 2)}\n`);
     return;
   }
-  const headers = ["id", "approx_gb", "loader", "default"];
+  const headers = ["id", "approx_gb", "loader", "default", "short_name"];
   const rows = models.map((model) => ({
     id: model.id,
     approx_gb: model.approx_gb == null ? "" : String(model.approx_gb),
     loader: model.loader ?? "",
     default: model.default ? "yes" : "",
+    short_name: model.short_name ?? "",
   }));
   const widths = headers.map((h) =>
     Math.max(
@@ -148,6 +156,7 @@ function runSnapshotList(cmd: Command, opts: { json?: boolean }): void {
   for (const row of rows) {
     process.stdout.write(`${headers.map((h, i) => pad(row[h as keyof typeof row], widths[i]!)).join("  ")}\n`);
   }
+  process.stdout.write(`${kleur.gray(`source: ${catalogSourceLabel(catalog)}`)}\n`);
 }
 
 async function runPull(cmd: Command, model: string | undefined, opts: PullOpts): Promise<void> {
@@ -160,10 +169,14 @@ async function runPull(cmd: Command, model: string | undefined, opts: PullOpts):
   if (!opts.all && !model) {
     throw new Error("Usage: understudy models pull <model-id> or understudy models pull --all");
   }
-  const ids = opts.all ? snapshotModelIds() : [model!];
+  const catalog = await fetchSnapshotCatalog();
+  if (!opts.json && !isJsonMode(cmd)) {
+    process.stdout.write(`${kleur.gray(`catalog: ${catalogSourceLabel(catalog)}`)}\n`);
+  }
+  const ids = opts.all ? Object.keys(catalog.models) : [model!];
   const results = [];
   for (const id of ids) {
-    const modelInfo = VERIFIED_SNAPSHOT_MODELS[id];
+    const modelInfo = catalog.models[id];
     const dest = opts.all
       ? join(opts.dest ?? DEFAULT_MODELS_DIR, modelInfo?.destName ?? id)
       : opts.dest === DEFAULT_MODELS_DIR
@@ -176,6 +189,7 @@ async function runPull(cmd: Command, model: string | undefined, opts: PullOpts):
         sessionUrl: opts.sessionUrl,
         logDir: opts.logDir,
         dryRun: true,
+        catalog: catalog.models,
       });
       results.push(planned);
       continue;
@@ -185,6 +199,7 @@ async function runPull(cmd: Command, model: string | undefined, opts: PullOpts):
       dest,
       sessionUrl: opts.sessionUrl,
       logDir: opts.logDir,
+      catalog: catalog.models,
       onLog: (line) => {
         if (!opts.json && !isJsonMode(cmd)) process.stdout.write(`${line}\n`);
       },
@@ -193,7 +208,7 @@ async function runPull(cmd: Command, model: string | undefined, opts: PullOpts):
   }
 
   if (opts.json || isJsonMode(cmd)) {
-    process.stdout.write(`${JSON.stringify({ models: results }, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify({ catalog_source: catalog.source, models: results }, null, 2)}\n`);
     return;
   }
   if (opts.dryRun) {

--- a/src/model-snapshots.ts
+++ b/src/model-snapshots.ts
@@ -23,6 +23,20 @@ export type SnapshotModelInfo = {
   loader: string | null;
   defaultRung?: boolean;
   notes?: string;
+  shortName?: string;
+  certified?: boolean;
+  family?: string;
+  tier?: string;
+  quant?: string;
+  fileCount?: number;
+};
+
+export type SnapshotCatalogSource = "live" | "fallback";
+
+export type SnapshotCatalog = {
+  models: Record<string, SnapshotModelInfo>;
+  source: SnapshotCatalogSource;
+  url: string;
 };
 
 export type SnapshotPullOptions = {
@@ -32,6 +46,8 @@ export type SnapshotPullOptions = {
   logDir?: string;
   dryRun?: boolean;
   onLog?: (message: string) => void;
+  /** Resolved model catalog (live or fallback). Defaults to the bundled table. */
+  catalog?: Record<string, SnapshotModelInfo>;
 };
 
 export type SnapshotPullResult = {
@@ -67,11 +83,25 @@ type DownloadResult = {
   name: string;
   bytes: number;
   cached: boolean;
+  /** True when the file's sha256 was verified against the manifest or SHA256SUMS this run. */
+  verified?: boolean;
 };
 
-export const DEFAULT_MODELS_DIR = join(homedir(), ".understudy", "models");
+// Shared model-cache convention (same semantics as skills/ladder/serve.py and
+// the desktop app): UNDERSTUDY_MODEL_HOME overrides, else ~/.understudy/models.
+export const DEFAULT_MODELS_DIR =
+  process.env.UNDERSTUDY_MODEL_HOME && process.env.UNDERSTUDY_MODEL_HOME.trim() !== ""
+    ? process.env.UNDERSTUDY_MODEL_HOME
+    : join(homedir(), ".understudy", "models");
 export const DEFAULT_MODEL_LOG_DIR = join(homedir(), ".understudy", "agent-tools", "logs");
 
+export const DEFAULT_CATALOG_URL = "https://models.understudylabs.com/catalog";
+export const CATALOG_SCHEMA_VERSION = "understudy.model_catalog.v1";
+const CATALOG_TIMEOUT_MS = 5000;
+
+// Offline fallback table. Kept in sync with the set of snapshots that are
+// actually pullable from models.understudylabs.com (verified against R2
+// 2026-07-01). The live /catalog endpoint supersedes this when reachable.
 export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
   "gemma-4-e2b-it-qat-mlx-vlm-understudy": {
     sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-e2b-it-qat-mlx-vlm-understudy&ttl=21600",
@@ -80,6 +110,11 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     approxGb: 3.6,
     loader: "mlx_vlm",
     defaultRung: true,
+    shortName: "understudy-small",
+    certified: true,
+    family: "gemma-4",
+    tier: "e2b",
+    quant: "qat-4bit-g32",
     notes:
       "Default onboarding rung. QAT-derived 4-bit at group_size=32. Certified generation, OpenAI-compatible serving, logprobs+top_logprobs, and tool_calls at the prescribed decode.",
   },
@@ -89,15 +124,12 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "Gemma 4 E2B IT MLX-VLM 4-bit",
     approxGb: 3.3,
     loader: "mlx_vlm",
+    certified: false,
+    family: "gemma-4",
+    tier: "e2b",
+    quant: "4bit",
     notes:
       "Vanilla non-QAT bf16 -> MLX 4-bit. Diagnostic rung for isolating quantization artifacts against the QAT default.",
-  },
-  "gemma-4-e2b-it-mlx-vlm-bf16": {
-    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-bf16&ttl=21600",
-    destName: "gemma-4-e2b-it-mlx-vlm-bf16",
-    name: "Gemma 4 E2B IT MLX-VLM BF16",
-    approxGb: 9.5,
-    loader: "mlx_vlm",
   },
   "gemma-4-e4b-it-mlx-vlm-4bit": {
     sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-e4b-it-mlx-vlm-4bit&ttl=21600",
@@ -105,6 +137,10 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "Gemma 4 E4B IT MLX-VLM 4-bit",
     approxGb: 4.8,
     loader: "mlx_vlm",
+    certified: false,
+    family: "gemma-4",
+    tier: "e4b",
+    quant: "4bit",
   },
   "gemma-4-12b-it-mlx-vlm-4bit": {
     sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-4bit&ttl=21600",
@@ -112,6 +148,10 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "Gemma 4 12B IT MLX-VLM 4-bit",
     approxGb: 6.3,
     loader: "mlx_vlm",
+    certified: false,
+    family: "gemma-4",
+    tier: "12b",
+    quant: "4bit",
   },
   "gemma-4-12b-it-mlx-vlm-bf16": {
     sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-12b-it-mlx-vlm-bf16&ttl=21600",
@@ -119,13 +159,10 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "Gemma 4 12B IT MLX-VLM BF16",
     approxGb: 22,
     loader: "mlx_vlm",
-  },
-  "gemma-4-26b-a4b-it-mlx-vlm-4bit": {
-    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-4bit&ttl=21600",
-    destName: "gemma-4-26b-a4b-it-mlx-vlm-4bit",
-    name: "Gemma 4 26B A4B IT MLX-VLM 4-bit",
-    approxGb: 14,
-    loader: "mlx_vlm",
+    certified: false,
+    family: "gemma-4",
+    tier: "12b",
+    quant: "bf16",
   },
   "gemma-4-26b-a4b-it-mlx-vlm-bf16": {
     sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-mlx-vlm-bf16&ttl=21600",
@@ -133,6 +170,10 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "Gemma 4 26B A4B IT MLX-VLM BF16",
     approxGb: 52,
     loader: "mlx_vlm",
+    certified: false,
+    family: "gemma-4",
+    tier: "26b-a4b",
+    quant: "bf16",
   },
   "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy": {
     sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-26b-a4b-it-qat-mlx-vlm-understudy&ttl=21600",
@@ -140,13 +181,11 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "Gemma 4 26B A4B IT QAT -> MLX 4-bit (group_size=32 + 8-bit routers), Understudy",
     approxGb: 16,
     loader: "mlx_vlm",
-  },
-  "gemma-4-31b-it-mlx-vlm-4bit": {
-    sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-4bit&ttl=21600",
-    destName: "gemma-4-31b-it-mlx-vlm-4bit",
-    name: "Gemma 4 31B IT MLX-VLM 4-bit",
-    approxGb: 17,
-    loader: "mlx_vlm",
+    shortName: "understudy-fast",
+    certified: true,
+    family: "gemma-4",
+    tier: "26b-a4b",
+    quant: "qat-4bit-g32",
   },
   "gemma-4-31b-it-mlx-vlm-bf16": {
     sessionUrl: "https://models.understudylabs.com/session?model=gemma-4-31b-it-mlx-vlm-bf16&ttl=21600",
@@ -154,6 +193,10 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "Gemma 4 31B IT MLX-VLM BF16",
     approxGb: 62,
     loader: "mlx_vlm",
+    certified: false,
+    family: "gemma-4",
+    tier: "31b",
+    quant: "bf16",
   },
   "diffusiongemma-26b-a4b-it-mlx-vlm-4bit": {
     sessionUrl: "https://models.understudylabs.com/session?model=diffusiongemma-26b-a4b-it-mlx-vlm-4bit&ttl=21600",
@@ -161,6 +204,10 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "DiffusionGemma 26B A4B IT MLX-VLM 4-bit",
     approxGb: 16,
     loader: "mlx_vlm",
+    certified: false,
+    family: "diffusiongemma",
+    tier: "26b-a4b",
+    quant: "4bit",
   },
   "diffusiongemma-26b-a4b-it-mlx-vlm-bf16": {
     sessionUrl: "https://models.understudylabs.com/session?model=diffusiongemma-26b-a4b-it-mlx-vlm-bf16&ttl=21600",
@@ -168,6 +215,10 @@ export const VERIFIED_SNAPSHOT_MODELS: Record<string, SnapshotModelInfo> = {
     name: "DiffusionGemma 26B A4B IT MLX-VLM BF16",
     approxGb: 52,
     loader: "mlx_vlm",
+    certified: false,
+    family: "diffusiongemma",
+    tier: "26b-a4b",
+    quant: "bf16",
   },
 };
 
@@ -175,8 +226,87 @@ export function snapshotModelIds(): string[] {
   return Object.keys(VERIFIED_SNAPSHOT_MODELS);
 }
 
+export function catalogUrl(): string {
+  const override = process.env.UNDERSTUDY_CATALOG_URL;
+  if (override && override.trim() !== "") return override;
+  return DEFAULT_CATALOG_URL;
+}
+
+type CatalogRow = {
+  id?: unknown;
+  name?: unknown;
+  approx_gb?: unknown;
+  loader?: unknown;
+  default_rung?: unknown;
+  short_name?: unknown;
+  certified?: unknown;
+  family?: unknown;
+  tier?: unknown;
+  quant?: unknown;
+  session_url?: unknown;
+  file_count?: unknown;
+  notes?: unknown;
+};
+
+function catalogRowToModelInfo(row: CatalogRow): SnapshotModelInfo | null {
+  if (typeof row?.id !== "string" || row.id.trim() === "") return null;
+  const id = row.id;
+  const str = (value: unknown): string | undefined =>
+    typeof value === "string" && value.trim() !== "" ? value : undefined;
+  const num = (value: unknown): number | undefined =>
+    typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return {
+    sessionUrl:
+      str(row.session_url) ?? `https://models.understudylabs.com/session?model=${encodeURIComponent(id)}&ttl=21600`,
+    destName: id,
+    name: str(row.name) ?? id,
+    approxGb: num(row.approx_gb) ?? null,
+    loader: str(row.loader) ?? null,
+    ...(row.default_rung === true ? { defaultRung: true } : {}),
+    ...(str(row.short_name) ? { shortName: str(row.short_name) } : {}),
+    ...(typeof row.certified === "boolean" ? { certified: row.certified } : {}),
+    ...(str(row.family) ? { family: str(row.family) } : {}),
+    ...(str(row.tier) ? { tier: str(row.tier) } : {}),
+    ...(str(row.quant) ? { quant: str(row.quant) } : {}),
+    ...(num(row.file_count) !== undefined ? { fileCount: num(row.file_count) } : {}),
+    ...(str(row.notes) ? { notes: str(row.notes) } : {}),
+  };
+}
+
+/**
+ * Fetch the model catalog from the snapshot service and convert it to the
+ * same shape as VERIFIED_SNAPSHOT_MODELS. Degrades silently to the bundled
+ * fallback table on any fetch error, non-200 status, timeout, or
+ * schema_version mismatch — a catalog fetch must never block or fail a
+ * command that can proceed on the fallback.
+ */
+export async function fetchSnapshotCatalog(options?: { timeoutMs?: number }): Promise<SnapshotCatalog> {
+  const url = catalogUrl();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options?.timeoutMs ?? CATALOG_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) throw new Error(`catalog request failed: ${response.status}`);
+    const body = (await response.json()) as { schema_version?: unknown; models?: unknown };
+    if (body?.schema_version !== CATALOG_SCHEMA_VERSION || !Array.isArray(body.models)) {
+      throw new Error("catalog schema mismatch");
+    }
+    const models: Record<string, SnapshotModelInfo> = {};
+    for (const row of body.models as CatalogRow[]) {
+      const info = catalogRowToModelInfo(row);
+      if (info) models[row.id as string] = info;
+    }
+    if (Object.keys(models).length === 0) throw new Error("catalog listed no models");
+    return { models, source: "live", url };
+  } catch {
+    return { models: VERIFIED_SNAPSHOT_MODELS, source: "fallback", url };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export function resolveSnapshotPlan(options: SnapshotPullOptions): SnapshotPullResult {
-  const modelInfo = modelInfoFor(options.modelId, options.sessionUrl);
+  const modelInfo = modelInfoFor(options.modelId, options.sessionUrl, options.catalog);
   const dest = options.dest ?? join(DEFAULT_MODELS_DIR, modelInfo.destName);
   const logDir = options.logDir ?? DEFAULT_MODEL_LOG_DIR;
   const logFile = join(logDir, `model-pull-${modelInfo.destName}-${nowCompact()}.log`);
@@ -191,7 +321,7 @@ export function resolveSnapshotPlan(options: SnapshotPullOptions): SnapshotPullR
 }
 
 export async function pullSnapshotModel(options: SnapshotPullOptions): Promise<SnapshotPullResult> {
-  const modelInfo = modelInfoFor(options.modelId, options.sessionUrl);
+  const modelInfo = modelInfoFor(options.modelId, options.sessionUrl, options.catalog);
   const dest = options.dest ?? join(DEFAULT_MODELS_DIR, modelInfo.destName);
   const logDir = options.logDir ?? DEFAULT_MODEL_LOG_DIR;
   mkdirSync(logDir, { recursive: true });
@@ -226,9 +356,33 @@ export async function pullSnapshotModel(options: SnapshotPullOptions): Promise<S
       if (!row.name || !row.url) {
         throw new Error("manifest file entries must include name/path and url");
       }
-      results.push(await downloadFile({ row, target: safeTarget(dest, row.name), log }));
     }
-    await verifySha256Sums(dest, log);
+    // Download SHA256SUMS first and never treat an existing copy as cached: a
+    // stale sums file left by a previous snapshot in the same dest would
+    // validate the wrong weights. The session manifest carries no file sizes,
+    // so the fresh sums file is the only way to tell a cached file of the
+    // right name from a leftover of a different model.
+    const sumsRow = rows.find((row) => normalizeSumsName(row.name) === "SHA256SUMS");
+    let sums: Map<string, string> | null = null;
+    const verifiedNames = new Set<string>();
+    if (sumsRow) {
+      results.push(await downloadFile({ row: sumsRow, target: safeTarget(dest, sumsRow.name), log, neverCache: true }));
+      sums = parseSha256Sums(readFileSync(safeTarget(dest, sumsRow.name), "utf8"));
+    } else {
+      log("warning: snapshot has no SHA256SUMS; cached files cannot be verified");
+    }
+    for (const row of rows) {
+      if (row === sumsRow) continue;
+      const expectedSha = sums?.get(normalizeSumsName(row.name)) ?? row.sha256 ?? null;
+      const result = await downloadFile({
+        row: { ...row, sha256: expectedSha },
+        target: safeTarget(dest, row.name),
+        log,
+      });
+      if (result.verified) verifiedNames.add(normalizeSumsName(row.name));
+      results.push(result);
+    }
+    await verifySha256Sums(dest, log, verifiedNames);
   } catch (error) {
     log(`incomplete error=${error instanceof Error ? error.message : String(error)}`);
     throw error;
@@ -250,8 +404,12 @@ export async function pullSnapshotModel(options: SnapshotPullOptions): Promise<S
   return { model: options.modelId, dest, sessionUrl, logFile, files: results.length };
 }
 
-function modelInfoFor(modelId: string, sessionUrl?: string): SnapshotModelInfo {
-  const model = VERIFIED_SNAPSHOT_MODELS[modelId];
+function modelInfoFor(
+  modelId: string,
+  sessionUrl?: string,
+  catalog?: Record<string, SnapshotModelInfo>,
+): SnapshotModelInfo {
+  const model = catalog?.[modelId] ?? VERIFIED_SNAPSHOT_MODELS[modelId];
   if (model) return model;
   if (!sessionUrl) {
     throw new Error(`unknown verified snapshot model id: ${modelId}`);
@@ -347,16 +505,40 @@ function safeTarget(dest: string, name: string): string {
   return target;
 }
 
-async function downloadFile({ row, target, log }: { row: FileRow; target: string; log: (message: string) => void }): Promise<DownloadResult> {
+async function downloadFile({
+  row,
+  target,
+  log,
+  neverCache,
+}: {
+  row: FileRow;
+  target: string;
+  log: (message: string) => void;
+  neverCache?: boolean;
+}): Promise<DownloadResult> {
   mkdirSync(dirname(target), { recursive: true });
   let expectedSize = row.size || (await getContentLength(row.url));
-  if (existsSync(target) && expectedSize && statSync(target).size === expectedSize) {
-    log(`cached ${row.name} (${expectedSize} bytes)`);
-    return { name: row.name, bytes: expectedSize, cached: true };
-  }
-  if (existsSync(target) && !expectedSize && statSync(target).size > 0) {
-    log(`cached ${row.name}`);
-    return { name: row.name, bytes: statSync(target).size, cached: true };
+  const sizeLooksCached = !neverCache
+    && existsSync(target)
+    && (expectedSize ? statSync(target).size === expectedSize : statSync(target).size > 0);
+  if (sizeLooksCached) {
+    // A name+size match alone can hide a leftover file from a different
+    // snapshot pulled into the same dest. When we know the expected hash,
+    // stream-verify the cached file and fall through to a re-download on
+    // mismatch; when we don't, keep it but say so.
+    const bytes = statSync(target).size;
+    if (row.sha256) {
+      log(`verifying cached ${row.name}`);
+      const actualSha = await fileSha256(target);
+      if (actualSha === row.sha256.toLowerCase()) {
+        log(`cached ${row.name} (sha256 verified)`);
+        return { name: row.name, bytes, cached: true, verified: true };
+      }
+      log(`cached ${row.name} sha256 mismatch; re-downloading`);
+    } else {
+      log(`warning: cached ${row.name} kept without sha256 verification (no hash available)`);
+      return { name: row.name, bytes, cached: true };
+    }
   }
 
   const partial = `${target}.part`;
@@ -396,13 +578,13 @@ async function downloadFile({ row, target, log }: { row: FileRow; target: string
   }
   if (hash) {
     const actualSha = hash.digest("hex");
-    if (actualSha !== row.sha256) {
+    if (actualSha !== row.sha256?.toLowerCase()) {
       rmSync(partial, { force: true });
       throw new Error(`sha256 mismatch for ${row.name}: got ${actualSha}, expected ${row.sha256}`);
     }
   }
   renameSync(partial, target);
-  return { name: row.name, bytes: actualSize, cached: false };
+  return { name: row.name, bytes: actualSize, cached: false, ...(hash ? { verified: true } : {}) };
 }
 
 async function fileSha256(path: string): Promise<string> {
@@ -416,7 +598,25 @@ async function fileSha256(path: string): Promise<string> {
   return hash.digest("hex");
 }
 
-async function verifySha256Sums(dest: string, log: (message: string) => void): Promise<string[] | null> {
+function normalizeSumsName(name: string): string {
+  return name.replace(/^\*/, "").replace(/^\.\//, "");
+}
+
+function parseSha256Sums(text: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^([a-fA-F0-9]{64})\s+(.+)$/.exec(line.trim());
+    if (!match) continue;
+    map.set(normalizeSumsName(match[2]!), match[1]!.toLowerCase());
+  }
+  return map;
+}
+
+async function verifySha256Sums(
+  dest: string,
+  log: (message: string) => void,
+  alreadyVerified?: Set<string>,
+): Promise<string[] | null> {
   const sumsPath = join(dest, "SHA256SUMS");
   if (!existsSync(sumsPath)) return null;
   const lines = readFileSync(sumsPath, "utf8").split(/\r?\n/).filter(Boolean);
@@ -425,13 +625,19 @@ async function verifySha256Sums(dest: string, log: (message: string) => void): P
     const match = /^([a-fA-F0-9]{64})\s+(.+)$/.exec(line.trim());
     if (!match) continue;
     const [, expected, rawPath] = match;
-    const name = rawPath.replace(/^\*/, "").replace(/^\.\//, "");
+    const name = normalizeSumsName(rawPath!);
     const target = safeTarget(dest, name);
     if (!existsSync(target)) {
       throw new Error(`SHA256SUMS references missing file: ${name}`);
     }
+    if (alreadyVerified?.has(name)) {
+      // Hash already confirmed against this run's fresh sums during
+      // download/cache-check; don't re-stream multi-GB weights.
+      verified.push(name);
+      continue;
+    }
     const actual = await fileSha256(target);
-    if (actual !== expected.toLowerCase()) {
+    if (actual !== expected!.toLowerCase()) {
       throw new Error(`sha256 mismatch for ${name}: got ${actual}, expected ${expected}`);
     }
     verified.push(name);

--- a/src/model-snapshots.ts
+++ b/src/model-snapshots.ts
@@ -89,9 +89,19 @@ type DownloadResult = {
 
 // Shared model-cache convention (same semantics as skills/ladder/serve.py and
 // the desktop app): UNDERSTUDY_MODEL_HOME overrides, else ~/.understudy/models.
+function resolveModelHome(raw: string): string {
+  const trimmed = raw.trim();
+  // Expand a leading ~ and absolutize so the same value means the same
+  // directory regardless of each tool's working directory.
+  const expanded = trimmed === "~" || trimmed.startsWith("~/")
+    ? join(homedir(), trimmed.slice(1))
+    : trimmed;
+  return resolve(expanded);
+}
+
 export const DEFAULT_MODELS_DIR =
   process.env.UNDERSTUDY_MODEL_HOME && process.env.UNDERSTUDY_MODEL_HOME.trim() !== ""
-    ? process.env.UNDERSTUDY_MODEL_HOME
+    ? resolveModelHome(process.env.UNDERSTUDY_MODEL_HOME)
     : join(homedir(), ".understudy", "models");
 export const DEFAULT_MODEL_LOG_DIR = join(homedir(), ".understudy", "agent-tools", "logs");
 
@@ -382,7 +392,11 @@ export async function pullSnapshotModel(options: SnapshotPullOptions): Promise<S
       if (result.verified) verifiedNames.add(normalizeSumsName(row.name));
       results.push(result);
     }
-    await verifySha256Sums(dest, log, verifiedNames);
+    // Only verify against sums delivered by THIS manifest; a leftover
+    // SHA256SUMS from another snapshot in the same dest proves nothing.
+    if (sumsRow) {
+      await verifySha256Sums(dest, log, verifiedNames);
+    }
   } catch (error) {
     log(`incomplete error=${error instanceof Error ? error.message : String(error)}`);
     throw error;
@@ -409,7 +423,9 @@ function modelInfoFor(
   sessionUrl?: string,
   catalog?: Record<string, SnapshotModelInfo>,
 ): SnapshotModelInfo {
-  const model = catalog?.[modelId] ?? VERIFIED_SNAPSHOT_MODELS[modelId];
+  // When a live catalog was fetched it REPLACES the compiled table: an id
+  // the service no longer lists must not resurrect from the fallback.
+  const model = catalog ? catalog[modelId] : VERIFIED_SNAPSHOT_MODELS[modelId];
   if (model) return model;
   if (!sessionUrl) {
     throw new Error(`unknown verified snapshot model id: ${modelId}`);

--- a/tests/model-catalog.test.mjs
+++ b/tests/model-catalog.test.mjs
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, describe, it } from "node:test";
+
+import {
+  CATALOG_SCHEMA_VERSION,
+  VERIFIED_SNAPSHOT_MODELS,
+  fetchSnapshotCatalog,
+  pullSnapshotModel,
+} from "../dist/model-snapshots.js";
+
+const cli = ["node", resolve("dist/bin.js")];
+const DEAD_CATALOG_URL = "http://127.0.0.1:1/catalog";
+
+const EXPECTED_PULLABLE_IDS = [
+  "gemma-4-e2b-it-qat-mlx-vlm-understudy",
+  "gemma-4-e2b-it-mlx-vlm-4bit",
+  "gemma-4-e4b-it-mlx-vlm-4bit",
+  "gemma-4-12b-it-mlx-vlm-4bit",
+  "gemma-4-12b-it-mlx-vlm-bf16",
+  "gemma-4-26b-a4b-it-mlx-vlm-bf16",
+  "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy",
+  "gemma-4-31b-it-mlx-vlm-bf16",
+  "diffusiongemma-26b-a4b-it-mlx-vlm-4bit",
+  "diffusiongemma-26b-a4b-it-mlx-vlm-bf16",
+];
+
+function sha256(text) {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function listen(server) {
+  return new Promise((resolveListen) => {
+    server.listen(0, "127.0.0.1", () => resolveListen(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolveClose) => server.close(resolveClose));
+}
+
+async function withCatalogUrl(url, fn) {
+  const previous = process.env.UNDERSTUDY_CATALOG_URL;
+  process.env.UNDERSTUDY_CATALOG_URL = url;
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) delete process.env.UNDERSTUDY_CATALOG_URL;
+    else process.env.UNDERSTUDY_CATALOG_URL = previous;
+  }
+}
+
+function runCli(args, env) {
+  return spawnSync(cli[0], [cli[1], ...args], {
+    encoding: "utf8",
+    env: { ...process.env, UNDERSTUDY_TELEMETRY: "0", ...env },
+  });
+}
+
+// spawnSync blocks the test process's event loop, which deadlocks any test
+// whose CLI child must talk to an HTTP server hosted by this same process.
+function runCliAsync(args, env) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(cli[0], [cli[1], ...args], {
+      env: { ...process.env, UNDERSTUDY_TELEMETRY: "0", ...env },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", rejectPromise);
+    child.on("close", (status) => resolvePromise({ status, stdout, stderr }));
+  });
+}
+
+describe("fetchSnapshotCatalog", () => {
+  it("uses live catalog rows when the endpoint serves a valid v1 catalog", async () => {
+    const catalog = {
+      schema_version: CATALOG_SCHEMA_VERSION,
+      models: [
+        {
+          id: "gemma-4-e2b-it-qat-mlx-vlm-understudy",
+          name: "Gemma 4 E2B QAT (live)",
+          approx_gb: 9.9,
+          loader: "mlx_vlm",
+          default_rung: true,
+          short_name: "understudy-small",
+          certified: true,
+          family: "gemma-4",
+          tier: "e2b",
+          quant: "qat-4bit-g32",
+          session_url:
+            "https://models.understudylabs.com/session?model=gemma-4-e2b-it-qat-mlx-vlm-understudy&ttl=21600",
+          file_count: 11,
+        },
+        { id: "brand-new-live-model", name: "Brand New", approx_gb: 1.2, loader: "mlx_vlm" },
+      ],
+    };
+    const server = createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json", ETag: '"abc"' });
+      res.end(JSON.stringify(catalog));
+    });
+    const port = await listen(server);
+    try {
+      const result = await withCatalogUrl(`http://127.0.0.1:${port}/catalog`, () => fetchSnapshotCatalog());
+      assert.equal(result.source, "live");
+      // Live rows win over the compiled-in table.
+      assert.equal(result.models["gemma-4-e2b-it-qat-mlx-vlm-understudy"].approxGb, 9.9);
+      assert.equal(result.models["gemma-4-e2b-it-qat-mlx-vlm-understudy"].name, "Gemma 4 E2B QAT (live)");
+      assert.equal(result.models["gemma-4-e2b-it-qat-mlx-vlm-understudy"].shortName, "understudy-small");
+      assert.equal(result.models["gemma-4-e2b-it-qat-mlx-vlm-understudy"].certified, true);
+      assert.equal(result.models["brand-new-live-model"].approxGb, 1.2);
+      // The live catalog is authoritative: bundled-only ids do not leak back in.
+      assert.deepEqual(Object.keys(result.models).sort(), ["brand-new-live-model", "gemma-4-e2b-it-qat-mlx-vlm-understudy"]);
+      // Rows without a session_url get the conventional one derived from the id.
+      assert.match(result.models["brand-new-live-model"].sessionUrl, /session\?model=brand-new-live-model&ttl=21600$/);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("falls back to the bundled table when the endpoint is unreachable", async () => {
+    const result = await withCatalogUrl(DEAD_CATALOG_URL, () => fetchSnapshotCatalog());
+    assert.equal(result.source, "fallback");
+    assert.deepEqual(result.models, VERIFIED_SNAPSHOT_MODELS);
+    assert.deepEqual(Object.keys(result.models).sort(), [...EXPECTED_PULLABLE_IDS].sort());
+    assert.equal(Object.keys(result.models).length, 10);
+  });
+
+  it("falls back on schema_version mismatch and on non-200 responses", async () => {
+    let mode = "wrong-schema";
+    const server = createServer((req, res) => {
+      if (mode === "wrong-schema") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ schema_version: "understudy.model_catalog.v2", models: [{ id: "x" }] }));
+      } else {
+        res.writeHead(500);
+        res.end("boom");
+      }
+    });
+    const port = await listen(server);
+    try {
+      const url = `http://127.0.0.1:${port}/catalog`;
+      const mismatch = await withCatalogUrl(url, () => fetchSnapshotCatalog());
+      assert.equal(mismatch.source, "fallback");
+      mode = "http-500";
+      const failure = await withCatalogUrl(url, () => fetchSnapshotCatalog());
+      assert.equal(failure.source, "fallback");
+    } finally {
+      await close(server);
+    }
+  });
+});
+
+describe("models snapshots CLI", () => {
+  it("lists the 10 bundled models offline and notes the fallback source", () => {
+    const result = runCli(["models", "snapshots", "--json"], { UNDERSTUDY_CATALOG_URL: DEAD_CATALOG_URL });
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.source, "fallback");
+    assert.equal(parsed.models.length, 10);
+    assert.deepEqual(parsed.models.map((m) => m.id).sort(), [...EXPECTED_PULLABLE_IDS].sort());
+    assert.equal(parsed.models.filter((m) => m.default).length, 1);
+    assert.equal(parsed.models.filter((m) => m.certified).length, 2);
+
+    const human = runCli(["models", "snapshots"], { UNDERSTUDY_CATALOG_URL: DEAD_CATALOG_URL });
+    assert.equal(human.status, 0, human.stderr);
+    assert.match(human.stdout, /source: bundled fallback/);
+    assert.match(human.stdout, /understudy-small/);
+  });
+
+  it("prefers the live catalog and says so", async () => {
+    const catalog = {
+      schema_version: CATALOG_SCHEMA_VERSION,
+      models: [{ id: "live-only-model", name: "Live Only", approx_gb: 2, loader: "mlx_vlm", default_rung: true }],
+    };
+    const server = createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(catalog));
+    });
+    const port = await listen(server);
+    try {
+      const env = { UNDERSTUDY_CATALOG_URL: `http://127.0.0.1:${port}/catalog` };
+      const result = await runCliAsync(["models", "snapshots", "--json"], env);
+      assert.equal(result.status, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.equal(parsed.source, "live");
+      assert.deepEqual(parsed.models.map((m) => m.id), ["live-only-model"]);
+
+      const human = await runCliAsync(["models", "snapshots"], env);
+      assert.match(human.stdout, /source: live catalog \(http:\/\/127\.0\.0\.1/);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("keeps the --session-url escape hatch working without any catalog", () => {
+    const result = runCli(
+      ["models", "pull", "some-custom-model", "--session-url", "http://127.0.0.1:9/session", "--dry-run"],
+      { UNDERSTUDY_CATALOG_URL: DEAD_CATALOG_URL },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /catalog: bundled fallback/);
+    assert.match(result.stdout, /dry-run some-custom-model/);
+    assert.match(result.stdout, /session: http:\/\/127\.0\.0\.1:9\/session/);
+  });
+});
+
+describe("pullSnapshotModel cached-file verification", () => {
+  // The /session manifest carries no file sizes or hashes, so a leftover file
+  // of the right name from a *different* snapshot used to be accepted as
+  // "cached". SHA256SUMS is now always refetched and cached files are
+  // verified against it, re-downloading on mismatch.
+  const GOOD_WEIGHTS = "GOOD-WEIGHTS-0123456789";
+  const EVIL_WEIGHTS = "EVIL-WEIGHTS-0123456789"; // same byte length: defeats size checks
+  const CONFIG = '{"model_type":"test"}';
+
+  function makeSnapshotServer({ withSums }) {
+    const requests = [];
+    const server = createServer((req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      const respond = (body) => {
+        res.writeHead(200, { "Content-Length": Buffer.byteLength(body) });
+        res.end(req.method === "HEAD" ? undefined : body);
+      };
+      if (req.url === "/session") {
+        const files = [
+          ...(withSums ? [{ name: "SHA256SUMS", url: `http://127.0.0.1:${server.address().port}/files/SHA256SUMS` }] : []),
+          { name: "config.json", url: `http://127.0.0.1:${server.address().port}/files/config.json` },
+          { name: "model.safetensors", url: `http://127.0.0.1:${server.address().port}/files/model.safetensors` },
+        ];
+        respond(JSON.stringify({ files }));
+      } else if (req.url === "/files/SHA256SUMS" && withSums) {
+        respond(`${sha256(CONFIG)}  config.json\n${sha256(GOOD_WEIGHTS)}  model.safetensors\n`);
+      } else if (req.url === "/files/config.json") {
+        respond(CONFIG);
+      } else if (req.url === "/files/model.safetensors") {
+        respond(GOOD_WEIGHTS);
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    return { server, requests };
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "understudy-pull-test-"));
+  after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it("re-downloads a stale same-size cached file when SHA256SUMS disagrees", async () => {
+    const { server, requests } = makeSnapshotServer({ withSums: true });
+    const port = await listen(server);
+    const dest = join(tmp, "verified");
+    mkdirSync(dest, { recursive: true });
+    // Leftovers from a different snapshot pulled into the same dest: wrong
+    // weights of the right name and size, plus a stale sums file that matches
+    // the wrong weights (so only a *fresh* SHA256SUMS can catch it).
+    writeFileSync(join(dest, "model.safetensors"), EVIL_WEIGHTS);
+    writeFileSync(join(dest, "SHA256SUMS"), `${sha256(EVIL_WEIGHTS)}  model.safetensors\n`);
+    const logs = [];
+    try {
+      const result = await pullSnapshotModel({
+        modelId: "test-snapshot-model",
+        sessionUrl: `http://127.0.0.1:${port}/session`,
+        dest,
+        logDir: join(tmp, "logs"),
+        onLog: (line) => logs.push(line),
+      });
+      assert.equal(result.files, 3);
+      assert.equal(readFileSync(join(dest, "model.safetensors"), "utf8"), GOOD_WEIGHTS);
+      assert.equal(readFileSync(join(dest, "config.json"), "utf8"), CONFIG);
+      assert.ok(
+        requests.some((r) => r === "GET /files/model.safetensors"),
+        `stale weights must be re-downloaded, saw: ${requests.join(", ")}`,
+      );
+      assert.ok(logs.some((line) => line.includes("model.safetensors sha256 mismatch; re-downloading")), logs.join("\n"));
+      const metadata = JSON.parse(readFileSync(join(dest, ".understudy-snapshot.json"), "utf8"));
+      const weights = metadata.files.find((f) => f.name === "model.safetensors");
+      assert.equal(weights.cached, false);
+      assert.equal(weights.verified, true);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("accepts a hash-matching cached file without re-downloading it", async () => {
+    const { server, requests } = makeSnapshotServer({ withSums: true });
+    const port = await listen(server);
+    const dest = join(tmp, "cached-ok");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, "model.safetensors"), GOOD_WEIGHTS);
+    try {
+      const result = await pullSnapshotModel({
+        modelId: "test-snapshot-model",
+        sessionUrl: `http://127.0.0.1:${port}/session`,
+        dest,
+        logDir: join(tmp, "logs"),
+      });
+      assert.equal(result.files, 3);
+      assert.ok(!requests.some((r) => r === "GET /files/model.safetensors"), requests.join(", "));
+      const metadata = JSON.parse(readFileSync(join(dest, ".understudy-snapshot.json"), "utf8"));
+      const weights = metadata.files.find((f) => f.name === "model.safetensors");
+      assert.equal(weights.cached, true);
+      assert.equal(weights.verified, true);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("warns when a snapshot has no SHA256SUMS to verify cached files against", async () => {
+    const { server } = makeSnapshotServer({ withSums: false });
+    const port = await listen(server);
+    const dest = join(tmp, "no-sums");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, "model.safetensors"), EVIL_WEIGHTS);
+    const logs = [];
+    try {
+      await pullSnapshotModel({
+        modelId: "test-snapshot-model",
+        sessionUrl: `http://127.0.0.1:${port}/session`,
+        dest,
+        logDir: join(tmp, "logs"),
+        onLog: (line) => logs.push(line),
+      });
+      // Unverifiable cache keeps its previous behavior, loudly.
+      assert.ok(logs.some((line) => line.includes("no SHA256SUMS")), logs.join("\n"));
+      assert.ok(
+        logs.some((line) => line.includes("kept without sha256 verification")),
+        logs.join("\n"),
+      );
+    } finally {
+      await close(server);
+    }
+  });
+});


### PR DESCRIPTION
Wave 1 client side of "one spine, two surfaces": the CLI and desktop app fetch the model catalog from `https://models.understudylabs.com/catalog` (`understudy.model_catalog.v1`) instead of trusting compiled-in copies. Bundled tables become offline fallbacks, synced to exactly the 10 snapshots verified pullable from R2 on 2026-07-01.

## What changed

### CLI (`src/`)
- `fetchSnapshotCatalog()` in `src/model-snapshots.ts`: GETs `/catalog` with `UNDERSTUDY_CATALOG_URL` env override, 5s timeout, and `schema_version` check; degrades **silently** to the bundled table on any fetch error, non-200, timeout, or schema mismatch — a catalog fetch never blocks or fails a command.
- `VERIFIED_SNAPSHOT_MODELS` synced to the 10 pullable ids (removed `gemma-4-e2b-it-mlx-vlm-bf16`, `gemma-4-26b-a4b-it-mlx-vlm-4bit`, `gemma-4-31b-it-mlx-vlm-4bit`) and gained additive `short_name`/`certified`/`family`/`tier`/`quant` metadata.
- `understudy models snapshots` / `models pull` use the fetched catalog and print the source (`live catalog (<url>)` vs `bundled fallback`); `--session-url` escape hatch unchanged; `--all` pulls the catalog's set.
- `DEFAULT_MODELS_DIR` honors `UNDERSTUDY_MODEL_HOME` (same semantics as `skills/ladder/serve.py`).

### Pull integrity fix (coordinator-reported, reproduced live)
The `/session` manifest carries no file sizes/hashes, so the old name+size cache heuristic silently kept another model's weights when pulling into a reused dest. Now:
- `SHA256SUMS` is **always refetched** — a stale sums file from a previous snapshot must never validate the wrong weights (same fix applied to the Rust downloader in `bootstrap.rs`).
- Cached files are stream-hash verified against the fresh sums (no whole-file reads); mismatches re-download instead of failing the pull.
- When a snapshot ships no `SHA256SUMS` (e.g. `gemma-4-e2b-it-mlx-vlm-4bit`), cached files are kept but logged with an explicit "kept without sha256 verification" warning.
- The final sums pass skips files already hash-verified this run, so multi-GB weights are not hashed twice.

### Desktop app (`apps/homescreen`)
- `models.rs` fetches `/catalog` (reqwest, 5s connect+total timeout, tokio) in the background and caches the last good response in memory (300s freshness mirroring the endpoint's `max-age`, 60s failure backoff). `snapshots()` never blocks: it serves the cached live rows, else the bundled `knowledge/snapshots.json`. Refresh kicks at app startup and opportunistically on `list_snapshot_models`.
- `knowledge/snapshots.json` synced to the 10 pullable ids with additive fields; `SnapshotInfo` now `serde(default)`s local-state fields so both the bundled file and live catalog rows deserialize (the previous strict struct failed to parse the bundled file at all — `snapshots()` was returning `[]` via `unwrap_or_default`).
- `models_dir()` (and `bootstrap.rs`, now delegating) honor `UNDERSTUDY_MODEL_HOME`.
- `app/lib/model-aliases.ts`: kept — its consumers already prefer catalog `short_name` over the static map; documented as fallback-only (covers the no-snapshots-in-hand sidekick header + legacy alias ids).

### Skills
`skills/manage-local-models/reference.md` ladder rows for the unpublished rungs (E2B BF16, 26B A4B 4-bit vanilla, 31B 4-bit) marked "not currently published (weights incomplete on the snapshot service); local conversion only"; the 26B vanilla "interim pull" note dropped (QAT row is primary); high-end smoke repointed at published snapshots. `skills/onboard/*` untouched.

## Test evidence
- `npm ci && npm test`: **123/123 pass** (full `npm run check` — build, typecheck, tests, skills:validate, package:smoke — also green).
- New `tests/model-catalog.test.mjs` (9 tests): local `node:http` server + `UNDERSTUDY_CATALOG_URL` — live rows win (override + replacement semantics); dead port → fallback with exactly the 10 bundled ids; schema-mismatch and HTTP 500 → fallback; CLI prints/JSON-reports the right source; `--session-url` dry-run works with no catalog; cached-file verification (same-size wrong weights + stale sums → re-downloaded; hash-matching cache kept without refetch; no-sums warning path).
- `cargo check --all-targets` and `cargo test` in `apps/homescreen/src-tauri`: **all pass**, incl. new tests for the `UNDERSTUDY_MODEL_HOME` override, bundled-set parity (exact 10 ids, 1 default rung, 2 certified), and catalog parsing/schema rejection.
- `UNDERSTUDY_CATALOG_URL=http://127.0.0.1:1/catalog node dist/bin.js models snapshots` → prints the 10 bundled models + `source: bundled fallback`, no network, returns instantly.
- Against the now-live endpoint: `node dist/bin.js models snapshots` → same 10 ids, `source: live catalog (https://models.understudylabs.com/catalog)`; live payload verified `understudy.model_catalog.v1` with exactly the 10 spec ids, `cache-control: public, max-age=300` + ETag.
- `UNDERSTUDY_MODEL_HOME=/tmp/custom-cache … models pull --dry-run` → dest resolves under `/tmp/custom-cache/`.

## Caveats
- The desktop app serves the bundled fallback for the first moments after launch until the background fetch lands (by design — `snapshots()` never blocks); a long-lived app picks up catalog changes on the next `list_snapshot_models` after the 300s freshness window.
- The CLI reads `UNDERSTUDY_MODEL_HOME`/`UNDERSTUDY_CATALOG_URL` at module load / call time respectively; no config-file equivalent yet.
- ETag/If-None-Match conditional revalidation is not implemented (fetches are tiny and rate-limited by the freshness window); worth adding if the catalog grows.
- The Rust downloader got the fail-closed stale-SHA256SUMS fix, but unlike the CLI it still errors (rather than re-downloads) if a cached file mismatches the fresh sums at the final verify — acceptable (no silent corruption) but a follow-up could mirror the CLI's self-heal.
- `knowledge/model_cards.json` still carries a card for `gemma-4-26b-a4b-it-mlx-vlm-4bit` — left intentionally so users with a previously-pulled copy keep the right system prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->