### PR TITLE
Add dev-run handoff plans for coding agents

### DIFF
--- a/docs/dev-run/README.md
+++ b/docs/dev-run/README.md
@@ -1,0 +1,80 @@
+# Dev run: "one spine, two surfaces" — handoff plans
+
+Self-contained work plans for coding agents (Claude Code, Devin, Codex, Cursor,
+or a fresh session). Each plan carries all the context needed to execute
+without access to the session that authored it. Read this index first, then
+the plan you are assigned.
+
+## Thesis (why this run exists)
+
+Understudy is a flywheel: real usage → captures → evals with provenance →
+Fusion routing (certified local `-understudy` models ↔ paid gateway) →
+verified savings → training data → better local models. The **CLI** is the
+control plane and evidence state machine; the **desktop app**
+(`apps/homescreen`) is the local runtime/daemon and cockpit; the **skills**
+are the methodology. The recurring disease this run cures: contracts that
+exist in prose get copied instead of shared, then drift (the 2026-07-01
+onboarding failure was exactly this).
+
+## State as of 2026-07-01 (main @ 44343ca)
+
+Done and merged:
+- `#115` hygiene (chat tool cap restored, real timestamps), `#116` download
+  hardening, `#117` benchmark scoring/run-id fixes (introduced "unscored"),
+  `#118` SQLite hardening (shared conn, WAL, migrations-once) + sidekick
+  transcript fixes, `#120` route policy extracted to
+  `apps/homescreen/src-tauri/src/route_policy.rs`, `#121` compaction guard.
+- Wave 1 — catalog spine: `GET https://models.understudylabs.com/catalog`
+  is live (`understudy.model_catalog.v1`, 10 pullable models, ETag/304);
+  CLI + app fetch it with bundled fallbacks synced (`#123`); downloads
+  self-heal against fresh SHA256SUMS on both surfaces.
+- Wave 2 — identity: one credential resolution (env > top-level key >
+  sole-org entry, matching `resolveAuth`), `$HOME` never a project root, and
+  the app owns `~/.understudy/agent-card.json`
+  (`apps/homescreen/src-tauri/src/agent_card.rs`) (`#122`).
+
+In flight (check `gh pr list` — land via [landing-checklist.md](landing-checklist.md)):
+- Wave 3 — `understudy.eval_result.v1` schema adopted by app/ladder/skills/CLI
+  (branch `anthro/wave3-eval-result-v1`).
+- Wave 5a — daemon agent parity: HTTP+MCP warm/download/benchmark/chat,
+  typed MCP schemas, CLI daemon discovery (branch `anthro/wave5a-daemon-parity`).
+
+Queued (this directory):
+1. [wave-4-evidence-bridge.md](wave-4-evidence-bridge.md) — start after wave 3 lands.
+2. [wave-5b-eval-gallery.md](wave-5b-eval-gallery.md) — start after wave 3 lands
+   (coordinates with 5a if unlanded).
+3. [backlog-server-hardening.md](backlog-server-hardening.md) — independent.
+4. [backlog-desktop-hygiene-ci.md](backlog-desktop-hygiene-ci.md) — independent;
+   the CI item is the highest-leverage single change in this directory.
+
+## Settled decisions (do not relitigate)
+
+- **The app is the daemon.** CLI and agents defer to the app for
+  models/serving when present (discovery via agent-card + health probe),
+  standalone fallback otherwise.
+- **`understudy.eval_result.v1`** is the one eval-row schema; app tables and
+  skills claim packets both adopt it. No converters between parallel formats.
+- **Eval gallery gets real data; the Capture pane backend stays deferred.**
+- **Official model ladder = certified `-understudy` QAT snapshots** (e2b
+  default, 26b-a4b), vanilla rungs are diagnostics/interims; the snapshot
+  service's `/catalog` is the single source of truth — never embed a model
+  list without marking it a fallback.
+
+## Conventions (all plans)
+
+- Branch from fresh `origin/main`; never commit to main directly (branch
+  policy: `gates` CI + review required; repo admins land with
+  `gh pr merge N --merge --admin` after gates pass and review).
+- Work in a git worktree; never touch the user's main working tree
+  (it usually carries uncommitted work).
+- Verify before opening the PR: `npm ci && npm test` at root AND
+  `cargo check --all-targets && cargo test` in `apps/homescreen/src-tauri`
+  when Rust changed. CI does NOT run cargo (see the hygiene plan) — you are
+  the Rust gate.
+- Commit messages end with the agent's Co-Authored-By line. PR bodies state
+  test evidence and caveats honestly.
+- The platform pieces (Cloudflare Worker `understudy-model-downloads`, R2
+  bucket `understudy-model-snapshots`) deploy via the CF API with wrangler
+  OAuth; procedure and registry layout are documented in the session memory
+  `model-downloads-worker.md` (Claude) — other agents: ask the user before
+  any worker/R2 change.

--- a/docs/dev-run/backlog-desktop-hygiene-ci.md
+++ b/docs/dev-run/backlog-desktop-hygiene-ci.md
@@ -1,0 +1,82 @@
+# Backlog — Desktop hygiene + Rust CI gate
+
+**Dependencies:** none. Item 1 is the highest-leverage single change in this
+directory — do it first and land it alone if time is short.
+
+## 1. Put Rust in CI (do this first)
+
+`.github/workflows/ci.yml` runs ONLY `npm run check` — zero cargo coverage.
+Every desktop bug this dev run fixed shipped through green gates. Add a job:
+
+```yaml
+  rust:
+    runs-on: macos-latest
+    defaults: { run: { working-directory: apps/homescreen/src-tauri } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with: { components: clippy }
+      - uses: Swatinem/rust-cache@v2
+        with: { workspaces: apps/homescreen/src-tauri }
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test
+```
+
+Notes: Tauri on ubuntu needs system webkit deps; macos-latest avoids that
+(and matches the shipping target). `-D warnings` requires first clearing the
+~23 existing clippy warnings (see item 2) — either fix them in the same PR or
+start with `cargo clippy --all-targets` non-fatal + `cargo test`, then
+tighten. The branch-protection required-checks list must be updated to
+include the new job (repo admin action — ask the user).
+
+## 2. Clippy zero (quick)
+
+`cargo clippy --all-targets` currently reports ~23 warnings (clamp patterns,
+`&Vec` params, identity map, elidable lifetimes, too-many-args). Most are
+`cargo clippy --fix`-able. Zero them so item 1 can be `-D warnings`.
+
+## 3. Deduplicate hand-rolled helpers (verified duplicates)
+
+- Byte-boundary truncation implemented 3x: commands.rs (`prompt_excerpt`,
+  `truncate_for_event`) and db.rs (memory preview). One `truncate_chars`.
+- Duplicated positional row mappers in db.rs (ChatRunRow 2x, SidekickRunRow
+  2x) — one mapper each; positional column drift is a silent-corruption bug
+  waiting.
+- Suite catalog defined twice and already diverged once (commands.rs
+  `fusion_benchmark_matrix()` vs `fusion_benchmark_suite()`; #117 may have
+  unified — verify before changing).
+- Inconsistent list-limit clamps (min(500)/min(100)/min(50)/min(5) scattered
+  through db.rs) — named constants, and commands' defaults should not exceed
+  the db clamps.
+
+## 4. Dead code sweep
+
+`db.rs` `init()` shim, `server.rs` `_unused()`, `residency.rs`
+`_unused(SystemTime)` and identity `.map()`, any leftovers flagged by
+`cargo clippy` after item 2.
+
+## 5. Frontend/runtime consistency checks (small, verified issues)
+
+- `models.rs` `LOCAL_BASE_URL` advertises port 8089 but the first residency
+  slot binds 8090 on fresh launch (`alloc_port` pre-increments; restore path
+  without persisted ports yields 8089). Make first allocation and the
+  advertised URL agree (verify current behavior post-#116 first).
+- `residency.rs` `HEADROOM_GB = 24.0` makes `usable_gb` 0 on 8/16 GB
+  machines, silently disabling the memory budget exactly where it matters.
+  Scale headroom to machine size and refuse warms that cannot fit instead of
+  proceeding.
+- `"understudy-small"` substring match in residency/commands never fires
+  (slot ids are directory names; short names live in the catalog) — replace
+  with catalog-driven lookup or delete.
+
+## Verification
+
+Standard: `cargo clippy --all-targets` (clean), `cargo test`,
+`npm ci && npm test`. For item 1, prove the new job fails on a seeded clippy
+warning in a scratch commit, then remove it.
+
+## Landing
+
+One PR for item 1 (+2 if included), separate PR(s) for 3-5. Branches
+`anthro/rust-ci-gate`, `anthro/desktop-hygiene`. Follow
+docs/dev-run/landing-checklist.md.

--- a/docs/dev-run/backlog-server-hardening.md
+++ b/docs/dev-run/backlog-server-hardening.md
@@ -1,0 +1,57 @@
+# Backlog — Local server hardening (desktop app)
+
+**Dependencies:** none hard; if wave 5a (`anthro/wave5a-daemon-parity`) is
+unmerged, coordinate — it adds endpoints to the same files (server.rs,
+mcp.rs). Prefer landing after 5a to avoid churn.
+
+**Goal:** the app's local HTTP/MCP server (127.0.0.1) holds up as the daemon
+surface agents depend on. All findings below came from a verified code review
+of `apps/homescreen/src-tauri` (2026-07-01); re-locate line numbers — the
+files move fast.
+
+## Work (ordered by severity)
+
+1. **Bearer token strength + comparison** (server.rs, token generation near
+   the bottom of the file; comparison in the auth middleware): the token is
+   64 bits derived from first-launch timestamp XOR pid, mixed once —
+   brute-forceable by any local process that can estimate install time — and
+   compared with `!=` (not constant-time). Generate 32 random bytes
+   (`getrandom`/`rand`), hex-encode, persist as today; compare
+   constant-time (subtle crate or a hand-rolled fold like the snapshot
+   worker's `timingSafeEqual`). Invalidate/regenerate the old-format token on
+   upgrade.
+2. **Auth before body extraction** (server.rs handlers): handlers take
+   `Json<T>` extractors before the auth check runs, so unauthenticated
+   callers get detailed 422 schema errors — schema probing without a token.
+   Restructure so auth middleware runs first (axum middleware or manual
+   ordering).
+3. **Blocking subprocess I/O with no deadline** (mcp.rs `call_tool`;
+   commands.rs `list_traces`/`search_traces`/`open_trace`; sidecar.rs
+   `moraine_state`): `moraine-mcp` is spawned and its stdout read with
+   blocking `BufReader::lines()` and no timeout — a hung child pins an axum
+   worker forever, and the sync Tauri command variants freeze the GUI main
+   thread. Add a hard deadline (kill the child on expiry), move the calls off
+   async workers (`spawn_blocking`), and make the Tauri commands async.
+4. **Benchmark/chat HTTP clients without timeouts** (chat.rs: the
+   `reqwest::Client::builder().build()` sites used by `stream_chat_once` /
+   `nonstream_chat_once`): a local server that accepts and stalls hangs the
+   turn or benchmark row forever. The sidekick client already has a
+   `SIDEKICK_REQUEST_TIMEOUT_SECS` timeout (post-#118) — mirror that
+   pattern. For the streaming chat path use a read/idle timeout rather than a
+   whole-request timeout so long generations survive.
+5. **`get_status` subprocess on the hot path** (commands.rs → sidecar.rs):
+   every status poll shells out to `moraine status` synchronously. Cache the
+   result for a few seconds and refresh it off-thread.
+
+## Verification
+
+- `cargo check --all-targets` + `cargo test`; add tests where logic allows
+  (token format/compare, deadline behavior with a stub child process).
+- Manual: with the app running, `curl` unauthenticated requests must get
+  401 without schema detail; kill/hang `moraine-mcp` mid-call and confirm the
+  API returns an error instead of hanging.
+
+## Landing
+
+Branch `anthro/server-hardening`, PR titled "Harden the local daemon server:
+token, auth ordering, deadlines". Follow docs/dev-run/landing-checklist.md.

--- a/docs/dev-run/landing-checklist.md
+++ b/docs/dev-run/landing-checklist.md
@@ -1,0 +1,51 @@
+# Landing checklist — how PRs merge in this repo
+
+The dev-run discipline that caught real bugs in every PR so far (precedence
+inversion, write races, wedged downloads, stale docs). Any agent landing a PR
+follows this; it is cheap insurance, not ceremony.
+
+## Per PR
+
+1. **Merge-test first.** In a scratch worktree:
+   `git worktree add /tmp/prN-tree origin/<pr-branch> && cd /tmp/prN-tree &&
+   git merge origin/main` — must be conflict-free or resolved deliberately.
+   Then `cargo check --all-targets && cargo test` (if Rust changed) and
+   `npm ci && npm test`. The merge RESULT is what ships, not the branch.
+2. **Adversarial review, scaled to risk.** For concurrency, persistence,
+   auth, or money-adjacent changes: review with distinct lenses (correctness
+   of the new logic; semantic composition with what merged since the branch
+   point) and try to REFUTE each finding by reading the code before believing
+   it. For docs/config-only PRs a single careful read suffices.
+3. **Fix findings on the PR branch** (small follow-up commits, honest
+   messages), re-run both test suites, push.
+4. **Gates + merge.** Wait for the `gates` check; repo admins land with
+   `gh pr merge N --merge --admin` (auto-merge is disabled; review
+   requirement is satisfied by the review above — record findings in a PR
+   comment if the reviewer isn't the merger).
+5. **After merge:** delete scratch worktrees, verify `origin/main` builds if
+   anything non-trivial was resolved during merge.
+
+## Known cross-PR hotspots (check when merging concurrent work)
+
+- `apps/homescreen/src-tauri/src/lib.rs` — every workstream registers
+  commands/modules here; textual merges usually succeed, so check the
+  registration list compiles and nothing was dropped.
+- `commands.rs` and `chat.rs` — multiple workstreams touch different regions;
+  semantic composition matters more than textual (e.g. a new loop bound
+  composing with an error path added by another PR).
+- `skills/onboard/reference.md` and `skills/manage-local-models/reference.md`
+  — doc PRs keep colliding here; after any model-registry change, grep the
+  whole tree for ids that are no longer published:
+  every id in docs must exist in `https://models.understudylabs.com/catalog`.
+
+## In-flight PRs this checklist was written for
+
+- `anthro/wave3-eval-result-v1` — schema + adoption. Review lenses:
+  schema completeness vs the three producers; db migration correctness on
+  the #118 migrations-once path; export packet backward compatibility;
+  ladder JSONL persistence doesn't break `tests/ladder.test.mjs`.
+- `anthro/wave5a-daemon-parity` — new agent surface. Review lenses: auth on
+  every new endpoint; blocking work off the axum workers; run-registry 409 +
+  cancellation correctness (token checked between rows, DB rows marked);
+  MCP inputSchemas actually match handler expectations; CLI discovery
+  pid-check (dead pid ⇒ not running).

--- a/docs/dev-run/wave-4-evidence-bridge.md
+++ b/docs/dev-run/wave-4-evidence-bridge.md
@@ -1,0 +1,56 @@
+# Wave 4 — Evidence bridge: app evidence promotable from the CLI
+
+**Dependency:** start only after the wave-3 PR (`understudy.eval_result.v1`,
+branch `anthro/wave3-eval-result-v1`) has merged to main. Check
+`ls schemas/` — the schema file must exist on your base commit. Route policy
+(`apps/homescreen/src-tauri/src/route_policy.rs`) is already merged (#120).
+
+**Goal:** evidence generated in the desktop app becomes admissible,
+promotable evidence in the CLI/skills loop — one evidence chain across
+surfaces.
+
+## Work
+
+1. **App exports satisfy the claim-packet contract.** Read
+   `skills/optimize-workload/SKILL.md` (claim-packet requirements: sha256
+   provenance, frozen split identity, cost basis) and make
+   `export_fusion_benchmark_comparison` (apps/homescreen/src-tauri/src/commands.rs)
+   emit packets containing `eval_result.v1` rows plus the packet-level fields
+   the skills require. Additive: keep existing export shapes working.
+2. **Fix `resolve_repo_output_path`** (commands.rs, search for
+   `CARGO_MANIFEST_DIR`): it bakes the build machine's absolute path into the
+   binary — broken in any packaged .app. Default exports to
+   `~/.understudy/exports/` (create it); treat caller-supplied paths as
+   explicit overrides. Security note from review: the HTTP/MCP `output_path`
+   argument is an unrestricted absolute write path for any token holder —
+   constrain non-webview callers to the exports root.
+3. **Skills read app evidence.** Teach `skills/ramp-and-verify/SKILL.md` (and
+   `skills/capture-evidence/SKILL.md` where it inventories existing evidence)
+   to discover and read app export packets from `~/.understudy/exports/` as
+   admissible pre-ramp evidence — including how to verify their hashes.
+4. **`routes promote` validates.** `src/commands/routes.ts` (promote,
+   ~line 155-186) consumes route-decision packets without validation. Add
+   schema validation for `understudy.route_decision_packet.v1`
+   (`src/route-decision.ts` ~116-156 defines it) and reconcile with the app's
+   `fusion_route_decisions` rows + `understudy.fusion_route_policy_export.v1`
+   (db.rs / commands.rs) — the serialized shape both sides share should live
+   next to the eval schema in `schemas/`.
+5. **End-to-end proof (required):** run a benchmark matrix in the app (or via
+   the wave-5a HTTP endpoints if merged), export, run ramp-and-verify's
+   evidence-reading step against that export, and `understudy routes promote`
+   a decision derived from it in dry-run form against a test workload.
+   Document the transcript in the PR body.
+
+## Verification
+
+- `cargo check --all-targets` + `cargo test` (apps/homescreen/src-tauri);
+  `npm ci && npm test` at root. CI does not run cargo — you are the gate.
+- New tests: packet validation in `routes promote` (valid packet passes,
+  missing schema_version / evaluate-first packets rejected), and a Rust test
+  that an export packet's eval rows validate against the schema file.
+
+## Landing
+
+Branch `anthro/wave4-evidence-bridge`, PR titled "Bridge app benchmark
+evidence into the CLI promotion flow". Prefer small commits per numbered item.
+Do not merge yourself; follow docs/dev-run/landing-checklist.md.

--- a/docs/dev-run/wave-5b-eval-gallery.md
+++ b/docs/dev-run/wave-5b-eval-gallery.md
@@ -1,0 +1,54 @@
+# Wave 5b — Real eval gallery: wire the drilldown UI to live benchmark data
+
+**Dependencies:** wave 3 (`understudy.eval_result.v1`) merged. If wave 5a
+(`anthro/wave5a-daemon-parity`) is unmerged, coordinate: it adds a run
+registry + cancellation to the benchmark loop but does NOT touch the frontend
+eval panes (those are yours).
+
+**Warning:** `apps/homescreen/app/components/TrainingPane.tsx` may carry
+uncommitted user changes in the primary working tree — always work in a fresh
+worktree from origin/main, and expect the user to reconcile their local edits
+after your PR lands. Flag this in the PR body.
+
+**Goal:** the app's eval surface shows real benchmark data, live. Today the
+mounted `EvalExplorerPane` renders fully mocked data while the actually-wired
+`FusionEvaluationPane` is unmounted dead code (both in
+`apps/homescreen/app/components/TrainingPane.tsx`; find current line numbers
+with grep — the file moves fast).
+
+## Work
+
+1. **Wire the explorer/drilldown UI to real data.** Replace
+   `EvalExplorerPane`'s mocked rows with the real `fusion_benchmark_*` tauri
+   commands (list/summary/results — see `apps/homescreen/src-tauri/src/commands.rs`
+   registrations in `lib.rs`) and `eval_result.v1` rows from the export path.
+   Live runs stream via the `FusionEvalEvent` channel (RunStarted /
+   CandidateStarted / RowStarted / RowFinished / RunFinished) — #117 made the
+   event `run_id` consistent (parent id + candidate field); correlate on that.
+2. **Remove or fold in the dead pane.** `FusionEvaluationPane` is unmounted;
+   keep whichever pieces the explorer needs and delete the rest — no dead
+   code left behind.
+3. **Score rendering:** wave 3 fixed score-0-renders-as-queued via null
+   checks; verify it holds in whatever rendering you build (a 0.0 score is a
+   real result, "unscored"/null is not — treat `status: "unscored"` rows
+   distinctly).
+4. **Do NOT build the Capture pane backend** — explicitly deferred by the
+   user. Do not add gateway capture calls to the app in this PR.
+5. **Prove it end-to-end:** run a small benchmark suite (via the UI, or the
+   wave-5a HTTP endpoint if merged), watch rows stream into the gallery,
+   drill into a row, export. Screenshot or transcript in the PR body.
+   The repo runs with `pnpm tauri dev` in `apps/homescreen` (or check
+   `.claude/launch.json` / package.json scripts).
+
+## Verification
+
+- `npm ci && npm test` at root; `cargo check --all-targets` + `cargo test`
+  if any Rust changed; frontend typecheck (`npm run check` covers it).
+- Manual: the end-to-end run above. If a headless environment prevents
+  running the GUI, say so explicitly in the PR and get a human smoke test
+  before merge.
+
+## Landing
+
+Branch `anthro/wave5b-eval-gallery`, PR titled "Wire the eval gallery to real
+benchmark data". Follow docs/dev-run/landing-checklist.md.


### PR DESCRIPTION
Docs-only. Adds docs/dev-run/ — self-contained execution plans for the remaining dev-run work (wave 4 evidence bridge, wave 5b eval gallery, server hardening, desktop hygiene + Rust CI gate) plus the landing checklist, so any coding agent can pick these up without the originating session's context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->