### PR TITLE
Add Rust CI gate: clippy -D warnings + tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,25 @@ jobs:
 
       - name: Node checks
         run: npm run check
+
+  rust:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: apps/homescreen/src-tauri
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/homescreen/src-tauri
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -229,7 +229,7 @@ async fn download_model_inner(
         .await
         .map_err(|e| format!("session manifest parse failed: {e}"))?;
     let mut files = manifest.files;
-    files.sort_by(|a, b| file_name(a).cmp(&file_name(b)));
+    files.sort_by_key(file_name);
     let mut out = Vec::with_capacity(files.len());
 
     // Pull SHA256SUMS first (never cache-skipped) so every other file,

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -1417,6 +1417,8 @@ fn sidekick_understudy_mcp_read(app: &AppHandle, args: &Value) -> Result<Value, 
     })
 }
 
+// Parameter list mirrors the sidekick call contract; not restructured to avoid churn.
+#[allow(clippy::too_many_arguments)]
 async fn call_sidekick_model(
     app: &AppHandle,
     port: u16,
@@ -1967,6 +1969,8 @@ fn switch_route_to_cloud(
     true
 }
 
+// Parameter list mirrors the route-decision record; not restructured to avoid churn.
+#[allow(clippy::too_many_arguments)]
 fn record_compaction_route_decision(
     app: &AppHandle,
     session_id: &str,
@@ -2860,6 +2864,8 @@ pub async fn benchmark_gateway_chat(
     })
 }
 
+// Parameter list mirrors the chat request contract; not restructured to avoid churn.
+#[allow(clippy::too_many_arguments)]
 async fn nonstream_chat_once(
     client: &reqwest::Client,
     url: &str,

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -725,7 +725,7 @@ fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSig
     }
 }
 
-fn residency<'a>(app: &'a AppHandle) -> &'a Residency {
+fn residency(app: &AppHandle) -> &Residency {
     app.state::<Residency>().inner()
 }
 
@@ -1759,7 +1759,7 @@ pub fn export_fusion_benchmark_comparison(
                 .count() as u64,
         })
         .collect::<Vec<_>>();
-    groups.sort_by(|a, b| b.rows.cmp(&a.rows));
+    groups.sort_by_key(|g| std::cmp::Reverse(g.rows));
     let packet = FusionBenchmarkComparisonPacket {
         schema_version: "understudy.fusion_benchmark_comparison.v1",
         created_at: chrono::Utc::now().to_rfc3339(),
@@ -1964,7 +1964,7 @@ pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRout
             avg_local_mem_gb: avg(&local_mem_values),
         });
     }
-    out.sort_by(|a, b| b.rows.cmp(&a.rows));
+    out.sort_by_key(|g| std::cmp::Reverse(g.rows));
     Ok(ChatRouteMetrics {
         schema_version: "understudy.chat_route_metrics.v1",
         groups: out,

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -575,7 +575,7 @@ impl Db {
                     created_at
              FROM fusion_route_decisions ORDER BY id DESC LIMIT ?1",
         )?;
-        let rows = stmt.query_map([limit.max(1).min(500) as i64], |r| {
+        let rows = stmt.query_map([limit.clamp(1, 500) as i64], |r| {
             Ok(FusionRouteDecisionRow {
                 id: r.get::<_, i64>(0)? as u64,
                 prompt_excerpt: r.get(1)?,
@@ -643,7 +643,7 @@ impl Db {
                     status, error, run_at
              FROM chat_runs ORDER BY id DESC LIMIT ?1",
         )?;
-        let rows = stmt.query_map([limit.max(1).min(500) as i64], |r| {
+        let rows = stmt.query_map([limit.clamp(1, 500) as i64], |r| {
             Ok(ChatRunRow {
                 id: r.get::<_, i64>(0)? as u64,
                 session_id: r.get(1)?,
@@ -686,7 +686,7 @@ impl Db {
              ORDER BY id DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(
-            rusqlite::params![session_id, limit.max(1).min(100) as i64],
+            rusqlite::params![session_id, limit.clamp(1, 100) as i64],
             |r| {
                 Ok(ChatRunRow {
                     id: r.get::<_, i64>(0)? as u64,
@@ -729,7 +729,7 @@ impl Db {
                     notes, run_at
              FROM fusion_benchmarks ORDER BY id DESC LIMIT ?1",
         )?;
-        let rows = stmt.query_map([limit.max(1).min(500) as i64], |r| {
+        let rows = stmt.query_map([limit.clamp(1, 500) as i64], |r| {
             Ok(FusionBenchmarkRow {
                 id: r.get::<_, i64>(0)? as u64,
                 run_id: r.get(1)?,
@@ -773,6 +773,8 @@ impl Db {
         Ok(())
     }
 
+    // Mirrors the sidekick_runs column list; not restructured to avoid churn.
+    #[allow(clippy::too_many_arguments)]
     pub fn record_sidekick_run(
         &self,
         session_id: &str,
@@ -812,7 +814,7 @@ impl Db {
             "SELECT id, session_id, mode, task, model, content, elapsed_ms, tool_calls, session_messages, escalated, accepted, consumed, run_at
              FROM sidekick_runs ORDER BY id DESC LIMIT ?1",
         )?;
-        let rows = stmt.query_map([limit.max(1).min(100) as i64], |r| {
+        let rows = stmt.query_map([limit.clamp(1, 100) as i64], |r| {
             Ok(SidekickRunRow {
                 id: r.get::<_, i64>(0)? as u64,
                 session_id: r.get(1)?,
@@ -856,7 +858,7 @@ impl Db {
                 WHERE mode='parallel' AND accepted IS NOT NULL
                 ORDER BY id DESC LIMIT ?1
              )",
-            [limit.max(1).min(100) as i64],
+            [limit.clamp(1, 100) as i64],
             |r| Ok((r.get(0)?, r.get(1)?)),
         )?;
         Ok(SidekickFeedbackSummary {
@@ -883,7 +885,7 @@ impl Db {
              ORDER BY id ASC LIMIT ?2",
         )?;
         let rows = stmt.query_map(
-            rusqlite::params![session_id, limit.max(1).min(5) as i64],
+            rusqlite::params![session_id, limit.clamp(1, 5) as i64],
             |r| {
                 Ok(SidekickRunRow {
                     id: r.get::<_, i64>(0)? as u64,
@@ -963,7 +965,7 @@ impl Db {
             "SELECT id, session_id, route, prompt_excerpt, eligible, reason, created_at
              FROM sidekick_decisions ORDER BY id DESC LIMIT ?1",
         )?;
-        let rows = stmt.query_map([limit.max(1).min(100) as i64], |r| {
+        let rows = stmt.query_map([limit.clamp(1, 100) as i64], |r| {
             Ok(SidekickDecisionRow {
                 id: r.get::<_, i64>(0)? as u64,
                 session_id: r.get(1)?,
@@ -1000,7 +1002,7 @@ impl Db {
             "SELECT id, session_id, mode, stage, detail, created_at
              FROM sidekick_events ORDER BY id DESC LIMIT ?1",
         )?;
-        let rows = stmt.query_map([limit.max(1).min(100) as i64], |r| {
+        let rows = stmt.query_map([limit.clamp(1, 100) as i64], |r| {
             Ok(SidekickEventRow {
                 id: r.get::<_, i64>(0)? as u64,
                 session_id: r.get(1)?,
@@ -1027,7 +1029,7 @@ impl Db {
              ORDER BY id DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(
-            rusqlite::params![session_id, limit.max(1).min(50) as i64],
+            rusqlite::params![session_id, limit.clamp(1, 50) as i64],
             |r| {
                 Ok(SidekickEventRow {
                     id: r.get::<_, i64>(0)? as u64,
@@ -1123,7 +1125,7 @@ impl Db {
                     memory, updated_at
              FROM sidekick_sessions ORDER BY updated_at DESC LIMIT ?1",
         )?;
-        let rows = stmt.query_map([limit.max(1).min(100) as i64], |r| {
+        let rows = stmt.query_map([limit.clamp(1, 100) as i64], |r| {
             let messages_raw: String = r.get(3)?;
             let stored_message_count = r.get::<_, i64>(4)?;
             let memory: Option<String> = r.get(6)?;

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -141,10 +141,10 @@ fn parse_catalog(body: &str) -> Result<Vec<SnapshotInfo>, String> {
     for row in &rows {
         if row.id.trim().is_empty()
             || row.loader.trim().is_empty()
-            || !row
+            || row
                 .session_url
                 .as_deref()
-                .is_some_and(|u| !u.trim().is_empty())
+                .is_none_or(|u| u.trim().is_empty())
         {
             return Err(format!("catalog row invalid: {:?}", row.id));
         }

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -288,7 +288,7 @@ impl Residency {
         let inner = locked(&self.inner);
         inner.iter().find(|r| r.id == slot_id).and_then(|r| {
             if matches!(r.state, SlotState::Warm) {
-                r.port.zip(r.model_path.clone()).map(|(p, path)| (p, path))
+                r.port.zip(r.model_path.clone())
             } else {
                 None
             }
@@ -428,7 +428,7 @@ impl Residency {
         self.cool_locked(&mut inner, slot_id)
     }
 
-    fn cool_locked(&self, inner: &mut Vec<Resident>, slot_id: u32) -> anyhow::Result<()> {
+    fn cool_locked(&self, inner: &mut [Resident], slot_id: u32) -> anyhow::Result<()> {
         if let Some(r) = inner.iter_mut().find(|r| r.id == slot_id) {
             if let Some(child) = r.child.as_mut() {
                 let _ = child.kill();


### PR DESCRIPTION
Executes items 1 and 2 of `docs/dev-run/backlog-desktop-hygiene-ci.md`.

## What changed

1. **New `rust` CI job** in `.github/workflows/ci.yml`: macos-latest (matches the shipping target, avoids ubuntu webkit deps), `dtolnay/rust-toolchain@stable` with clippy, `Swatinem/rust-cache` keyed to `apps/homescreen/src-tauri`, then `cargo clippy --all-targets -- -D warnings` and `cargo test`. The existing `gates` (node) job is untouched.
2. **Clippy zeroed** so `-D warnings` is enforceable from day one.

## Clippy warning count

| | `cargo clippy --all-targets` (lib) |
|---|---|
| before | **22 warnings** (11 manual_clamp in db.rs, 4 too_many_arguments, 3 unnecessary_sort_by, 1 needless_lifetimes, 1 nonminimal_bool, 1 map_identity, 1 ptr_arg) |
| after | **0 warnings** |

All fixes are mechanical, sized to coexist with the in-flight Rust branches (`anthro/wave3-eval-result-v1`, `anthro/wave5a-daemon-parity`): the four `too_many_arguments` hits (3x chat.rs, 1x db.rs `record_sidekick_run`) got a scoped `#[allow(clippy::too_many_arguments)]` with a one-line comment instead of signature restructuring, precisely to avoid colliding with that work. Everything else is a one-line rewrite of the flagged expression (`clamp`, `sort_by_key`, `is_none_or`, elided lifetime, dropped identity `.map`, `&mut Vec` -> `&mut [_]`).

## Gate proof (seeded failure)

The branch was first pushed with a scratch commit (`222b974`) seeding a `manual_clamp` warning in `lib.rs`. The new `rust` job failed on it while `gates` stayed green — [run 28555038413](https://github.com/understudylabs/understudy-agent-tools/actions/runs/28555038413) (rust: failure, gates: success) — proving the gate rejects clippy warnings. The scratch commit was then rebased away.

## Verification

- `cargo clippy --all-targets -- -D warnings` exits clean (apps/homescreen/src-tauri)
- `cargo test`: 34 passed, 0 failed, 1 ignored
- `npm ci && npm test` at repo root: 129 pass, 0 fail (no JS touched)
- Workflow YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`

## Admin action required (cannot be done from this PR)

**Branch protection's required-checks list must be updated by a repo admin to include the new `rust` job** — until then the job runs but is not required for merge. This is a console/settings action on the `main` branch protection rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)