### PR TITLE
Expose residency, downloads, benchmarks, and chat to agents; CLI daemon discovery

### DIFF
--- a/apps/homescreen/src-tauri/src/agent_ops.rs
+++ b/apps/homescreen/src-tauri/src/agent_ops.rs
@@ -1,0 +1,541 @@
+// Agent-facing operational state behind the local API server: an in-memory
+// model-download progress registry (tees `bootstrap`'s Channel events so
+// agents can poll per-file progress over HTTP/MCP) and a single-flight
+// fusion-benchmark run registry with cooperative cancellation (a second
+// concurrent run is rejected instead of interleaving rows; a cancel flips a
+// token the run loop checks between rows).
+
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+/// Lock with poison recovery, matching `residency.rs`: a panic in one holder
+/// must not brick every later status call.
+fn locked<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+fn now_iso() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+// ---------------- model download registry ----------------
+
+const DOWNLOAD_LOG_CAP: usize = 20;
+/// Terminal entries kept for late status polls before pruning.
+const DOWNLOAD_HISTORY_CAP: usize = 16;
+
+#[derive(Serialize, Clone, Debug)]
+pub struct FileProgress {
+    pub downloaded: u64,
+    pub total: Option<u64>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct DownloadProgress {
+    pub id: String,
+    pub model_id: String,
+    /// running | done | error | cancelled
+    pub status: String,
+    pub started_at: String,
+    pub files: BTreeMap<String, FileProgress>,
+    pub downloaded_bytes: u64,
+    /// Sum of known totals; None until every seen file reports a total.
+    pub total_bytes: Option<u64>,
+    pub dest: Option<String>,
+    pub error: Option<String>,
+    pub logs: Vec<String>,
+}
+
+impl DownloadProgress {
+    fn new(id: &str, model_id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            model_id: model_id.to_string(),
+            status: "running".to_string(),
+            started_at: now_iso(),
+            files: BTreeMap::new(),
+            downloaded_bytes: 0,
+            total_bytes: None,
+            dest: None,
+            error: None,
+            logs: vec![],
+        }
+    }
+
+    fn terminal(&self) -> bool {
+        self.status != "running"
+    }
+}
+
+/// Fold one serialized `bootstrap::DownloadEvent` into the progress record.
+/// Pure so it is unit-testable without a Tauri app; a cancelled download
+/// ignores late events from the aborted task.
+pub fn apply_download_event(progress: &mut DownloadProgress, event: &Value) {
+    if progress.status == "cancelled" {
+        return;
+    }
+    match event.get("type").and_then(|t| t.as_str()) {
+        Some("Log") => {
+            if let Some(message) = event.get("message").and_then(|m| m.as_str()) {
+                progress.logs.push(message.to_string());
+                if progress.logs.len() > DOWNLOAD_LOG_CAP {
+                    let drop = progress.logs.len() - DOWNLOAD_LOG_CAP;
+                    progress.logs.drain(..drop);
+                }
+            }
+        }
+        Some("File") => {
+            let Some(name) = event.get("name").and_then(|n| n.as_str()) else {
+                return;
+            };
+            let downloaded = event.get("downloaded").and_then(|v| v.as_u64()).unwrap_or(0);
+            let total = event.get("total").and_then(|v| v.as_u64());
+            progress
+                .files
+                .insert(name.to_string(), FileProgress { downloaded, total });
+            progress.downloaded_bytes = progress.files.values().map(|f| f.downloaded).sum();
+            progress.total_bytes = progress
+                .files
+                .values()
+                .map(|f| f.total)
+                .sum::<Option<u64>>();
+        }
+        Some("Done") => {
+            progress.status = "done".to_string();
+            progress.dest = event
+                .get("dest")
+                .and_then(|d| d.as_str())
+                .map(str::to_string);
+        }
+        Some("Error") => {
+            progress.status = "error".to_string();
+            progress.error = event
+                .get("message")
+                .and_then(|m| m.as_str())
+                .map(str::to_string);
+        }
+        _ => {}
+    }
+}
+
+struct DownloadEntry {
+    progress: DownloadProgress,
+    handle: Option<tauri::async_runtime::JoinHandle<()>>,
+}
+
+/// App-managed registry of model downloads started by agents.
+#[derive(Default)]
+pub struct Downloads {
+    inner: Mutex<HashMap<String, DownloadEntry>>,
+    seq: AtomicU64,
+}
+
+impl Downloads {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new download; one running download per model id, so two
+    /// agents cannot race writers into the same destination directory.
+    pub fn begin(&self, model_id: &str) -> Result<String, String> {
+        let mut inner = locked(&self.inner);
+        if let Some(active) = inner
+            .values()
+            .find(|e| e.progress.model_id == model_id && !e.progress.terminal())
+        {
+            return Err(format!(
+                "download already in progress for {model_id}: {}",
+                active.progress.id
+            ));
+        }
+        // Prune old terminal entries so the map stays bounded.
+        if inner.len() >= DOWNLOAD_HISTORY_CAP {
+            let mut stale: Vec<(String, String)> = inner
+                .iter()
+                .filter(|(_, e)| e.progress.terminal())
+                .map(|(id, e)| (e.progress.started_at.clone(), id.clone()))
+                .collect();
+            stale.sort();
+            for (_, id) in stale
+                .into_iter()
+                .take(inner.len().saturating_sub(DOWNLOAD_HISTORY_CAP) + 1)
+            {
+                inner.remove(&id);
+            }
+        }
+        let id = format!(
+            "dl-{}-{}",
+            chrono::Utc::now().timestamp_millis(),
+            self.seq.fetch_add(1, Ordering::Relaxed)
+        );
+        inner.insert(
+            id.clone(),
+            DownloadEntry {
+                progress: DownloadProgress::new(&id, model_id),
+                handle: None,
+            },
+        );
+        Ok(id)
+    }
+
+    pub fn attach_handle(&self, id: &str, handle: tauri::async_runtime::JoinHandle<()>) {
+        if let Some(entry) = locked(&self.inner).get_mut(id) {
+            entry.handle = Some(handle);
+        }
+    }
+
+    /// Tee point for the download task's Channel events.
+    pub fn apply(&self, id: &str, event: &Value) {
+        if let Some(entry) = locked(&self.inner).get_mut(id) {
+            apply_download_event(&mut entry.progress, event);
+            if entry.progress.terminal() {
+                entry.handle = None;
+            }
+        }
+    }
+
+    /// The spawned task finished; make sure the status is terminal even if a
+    /// Done/Error event was lost.
+    pub fn finalize(&self, id: &str, result: Result<(), String>) {
+        if let Some(entry) = locked(&self.inner).get_mut(id) {
+            entry.handle = None;
+            if !entry.progress.terminal() {
+                match result {
+                    Ok(()) => entry.progress.status = "done".to_string(),
+                    Err(err) => {
+                        entry.progress.status = "error".to_string();
+                        entry.progress.error = Some(err);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn cancel(&self, id: &str) -> Result<DownloadProgress, String> {
+        let mut inner = locked(&self.inner);
+        let entry = inner
+            .get_mut(id)
+            .ok_or_else(|| format!("unknown download id: {id}"))?;
+        if entry.progress.terminal() {
+            return Err(format!(
+                "download {id} is not running (status: {})",
+                entry.progress.status
+            ));
+        }
+        if let Some(handle) = entry.handle.take() {
+            handle.abort();
+        }
+        entry.progress.status = "cancelled".to_string();
+        Ok(entry.progress.clone())
+    }
+
+    pub fn get(&self, id: &str) -> Option<DownloadProgress> {
+        locked(&self.inner).get(id).map(|e| e.progress.clone())
+    }
+
+    pub fn list(&self) -> Vec<DownloadProgress> {
+        let mut rows: Vec<DownloadProgress> = locked(&self.inner)
+            .values()
+            .map(|e| e.progress.clone())
+            .collect();
+        rows.sort_by(|a, b| b.started_at.cmp(&a.started_at).then(b.id.cmp(&a.id)));
+        rows
+    }
+}
+
+/// Start a snapshot download in the background (never on the caller's
+/// thread); progress is polled via the `Downloads` registry.
+pub fn start_model_download(app: &tauri::AppHandle, model_id: String) -> Result<String, String> {
+    use tauri::Manager;
+    let id = app.state::<Downloads>().begin(&model_id)?;
+
+    let tee_app = app.clone();
+    let tee_id = id.clone();
+    let channel = tauri::ipc::Channel::<crate::bootstrap::DownloadEvent>::new(move |message| {
+        if let tauri::ipc::InvokeResponseBody::Json(raw) = message {
+            if let Ok(event) = serde_json::from_str::<Value>(&raw) {
+                if let Some(downloads) = tee_app.try_state::<Downloads>() {
+                    downloads.apply(&tee_id, &event);
+                }
+            }
+        }
+        Ok(())
+    });
+
+    let task_app = app.clone();
+    let task_id = id.clone();
+    let handle = tauri::async_runtime::spawn(async move {
+        let result = crate::bootstrap::download_model(task_app.clone(), model_id, channel).await;
+        if let Some(downloads) = task_app.try_state::<Downloads>() {
+            downloads.finalize(&task_id, result);
+        }
+    });
+    app.state::<Downloads>().attach_handle(&id, handle);
+    Ok(id)
+}
+
+// ---------------- fusion benchmark run registry ----------------
+
+/// Error prefix for the single-flight gate; the HTTP layer maps it to 409.
+pub const RUN_CONFLICT: &str = "benchmark run already in progress";
+
+#[derive(Debug)]
+struct ActiveRun {
+    run_id: String,
+    started_at: String,
+    cancel: Arc<AtomicBool>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct ActiveRunView {
+    pub run_id: String,
+    pub started_at: String,
+    pub cancel_requested: bool,
+}
+
+/// Single-flight registry for fusion benchmark runs. Concurrent runs would
+/// interleave rows under overlapping run ids (a known review finding), so a
+/// second `begin` fails while a run is active; the guard clears the slot on
+/// drop even when the run errors.
+#[derive(Default)]
+pub struct BenchRuns {
+    inner: Arc<Mutex<Option<ActiveRun>>>,
+}
+
+impl BenchRuns {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn begin(&self, run_id: &str) -> Result<BenchRunGuard, String> {
+        let mut inner = locked(&self.inner);
+        if let Some(active) = inner.as_ref() {
+            return Err(format!("{RUN_CONFLICT}: {}", active.run_id));
+        }
+        *inner = Some(ActiveRun {
+            run_id: run_id.to_string(),
+            started_at: now_iso(),
+            cancel: Arc::new(AtomicBool::new(false)),
+        });
+        Ok(BenchRunGuard {
+            inner: self.inner.clone(),
+        })
+    }
+
+    /// Flip the active run's cancellation token; returns the cancelled run id.
+    pub fn cancel(&self) -> Option<String> {
+        locked(&self.inner).as_ref().map(|active| {
+            active.cancel.store(true, Ordering::SeqCst);
+            active.run_id.clone()
+        })
+    }
+
+    pub fn active(&self) -> Option<ActiveRunView> {
+        locked(&self.inner).as_ref().map(|active| ActiveRunView {
+            run_id: active.run_id.clone(),
+            started_at: active.started_at.clone(),
+            cancel_requested: active.cancel.load(Ordering::SeqCst),
+        })
+    }
+
+    /// True when cancellation was requested for `run_id`. Matrix runs persist
+    /// rows under candidate-suffixed ids (`<run_id>-<candidate>`), so those
+    /// match their parent registration too.
+    pub fn is_cancelled(&self, run_id: &str) -> bool {
+        locked(&self.inner)
+            .as_ref()
+            .map(|active| {
+                active.cancel.load(Ordering::SeqCst)
+                    && (run_id == active.run_id
+                        || run_id.starts_with(&format!("{}-", active.run_id)))
+            })
+            .unwrap_or(false)
+    }
+}
+
+/// Clears the single-flight slot when the run finishes (ok, error, or panic).
+#[derive(Debug)]
+pub struct BenchRunGuard {
+    inner: Arc<Mutex<Option<ActiveRun>>>,
+}
+
+impl Drop for BenchRunGuard {
+    fn drop(&mut self) {
+        *locked(&self.inner) = None;
+    }
+}
+
+/// App-state wrappers used by `commands.rs` (kept tiny so the benchmark run
+/// loop diff stays minimal).
+pub fn begin_benchmark_run(
+    app: &tauri::AppHandle,
+    run_id: &str,
+) -> Result<Option<BenchRunGuard>, String> {
+    use tauri::Manager;
+    match app.try_state::<BenchRuns>() {
+        Some(runs) => runs.begin(run_id).map(Some),
+        // State is managed in setup(); missing only in stripped-down tests.
+        None => Ok(None),
+    }
+}
+
+pub fn benchmark_run_cancelled(app: &tauri::AppHandle, run_id: &str) -> bool {
+    use tauri::Manager;
+    app.try_state::<BenchRuns>()
+        .map(|runs| runs.is_cancelled(run_id))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ----- benchmark run registry (the 409 gate) -----
+
+    #[test]
+    fn second_concurrent_run_is_rejected_until_guard_drops() {
+        let runs = BenchRuns::new();
+        let guard = runs.begin("run-a").expect("first run starts");
+        let err = runs.begin("run-b").expect_err("second run must be rejected");
+        assert!(err.starts_with(RUN_CONFLICT), "conflict prefix: {err}");
+        assert!(err.contains("run-a"), "conflict names the active run: {err}");
+        drop(guard);
+        // Slot is free again after the guard drops (ok, error, or panic path).
+        let _guard = runs.begin("run-b").expect("slot freed after drop");
+    }
+
+    #[test]
+    fn cancel_flags_active_run_and_candidate_suffixed_ids() {
+        let runs = BenchRuns::new();
+        let _guard = runs.begin("run-a").unwrap();
+        assert!(!runs.is_cancelled("run-a"));
+        assert_eq!(runs.cancel().as_deref(), Some("run-a"));
+        assert!(runs.is_cancelled("run-a"));
+        // Matrix candidates persist under `<run_id>-<candidate>`.
+        assert!(runs.is_cancelled("run-a-local-main"));
+        // Other runs (and prefix-unrelated ids) are untouched.
+        assert!(!runs.is_cancelled("run-ab"));
+        assert!(!runs.is_cancelled("run-b"));
+    }
+
+    #[test]
+    fn cancel_without_active_run_is_a_noop() {
+        let runs = BenchRuns::new();
+        assert_eq!(runs.cancel(), None);
+        assert!(!runs.is_cancelled("anything"));
+        assert!(runs.active().is_none());
+    }
+
+    #[test]
+    fn active_view_reports_cancel_request() {
+        let runs = BenchRuns::new();
+        let _guard = runs.begin("run-a").unwrap();
+        let view = runs.active().expect("active run visible");
+        assert_eq!(view.run_id, "run-a");
+        assert!(!view.cancel_requested);
+        runs.cancel();
+        assert!(runs.active().unwrap().cancel_requested);
+    }
+
+    // ----- download progress map -----
+
+    #[test]
+    fn file_events_accumulate_per_file_progress() {
+        let mut p = DownloadProgress::new("dl-1", "model-x");
+        apply_download_event(
+            &mut p,
+            &json!({ "type": "File", "name": "a.safetensors", "downloaded": 10, "total": 100 }),
+        );
+        apply_download_event(
+            &mut p,
+            &json!({ "type": "File", "name": "b.json", "downloaded": 5, "total": 5 }),
+        );
+        apply_download_event(
+            &mut p,
+            &json!({ "type": "File", "name": "a.safetensors", "downloaded": 60, "total": 100 }),
+        );
+        assert_eq!(p.status, "running");
+        assert_eq!(p.files.len(), 2);
+        assert_eq!(p.files["a.safetensors"].downloaded, 60);
+        assert_eq!(p.downloaded_bytes, 65);
+        assert_eq!(p.total_bytes, Some(105));
+    }
+
+    #[test]
+    fn total_is_unknown_until_every_file_reports_one() {
+        let mut p = DownloadProgress::new("dl-1", "model-x");
+        apply_download_event(
+            &mut p,
+            &json!({ "type": "File", "name": "a", "downloaded": 10, "total": null }),
+        );
+        apply_download_event(
+            &mut p,
+            &json!({ "type": "File", "name": "b", "downloaded": 5, "total": 50 }),
+        );
+        assert_eq!(p.downloaded_bytes, 15);
+        assert_eq!(p.total_bytes, None);
+    }
+
+    #[test]
+    fn done_and_error_events_are_terminal() {
+        let mut done = DownloadProgress::new("dl-1", "model-x");
+        apply_download_event(&mut done, &json!({ "type": "Done", "dest": "/models/x", "files": 3 }));
+        assert_eq!(done.status, "done");
+        assert_eq!(done.dest.as_deref(), Some("/models/x"));
+
+        let mut failed = DownloadProgress::new("dl-2", "model-x");
+        apply_download_event(&mut failed, &json!({ "type": "Error", "message": "sha256 mismatch" }));
+        assert_eq!(failed.status, "error");
+        assert_eq!(failed.error.as_deref(), Some("sha256 mismatch"));
+    }
+
+    #[test]
+    fn cancelled_download_ignores_late_events_from_aborted_task() {
+        let mut p = DownloadProgress::new("dl-1", "model-x");
+        p.status = "cancelled".to_string();
+        apply_download_event(&mut p, &json!({ "type": "Done", "dest": "/models/x", "files": 3 }));
+        apply_download_event(&mut p, &json!({ "type": "File", "name": "a", "downloaded": 1 }));
+        assert_eq!(p.status, "cancelled");
+        assert!(p.files.is_empty());
+    }
+
+    #[test]
+    fn logs_are_bounded() {
+        let mut p = DownloadProgress::new("dl-1", "model-x");
+        for i in 0..(DOWNLOAD_LOG_CAP + 10) {
+            apply_download_event(&mut p, &json!({ "type": "Log", "message": format!("m{i}") }));
+        }
+        assert_eq!(p.logs.len(), DOWNLOAD_LOG_CAP);
+        assert_eq!(p.logs.last().map(String::as_str), Some("m29"));
+    }
+
+    #[test]
+    fn registry_rejects_second_running_download_for_same_model() {
+        let downloads = Downloads::new();
+        let id = downloads.begin("model-x").expect("first download starts");
+        let err = downloads
+            .begin("model-x")
+            .expect_err("same model must not race two writers");
+        assert!(err.contains("already in progress"), "{err}");
+        // A different model can download concurrently.
+        downloads.begin("model-y").expect("other model unaffected");
+        // Once terminal, the same model can be pulled again.
+        downloads.apply(&id, &json!({ "type": "Done", "dest": "/m/x", "files": 1 }));
+        downloads.begin("model-x").expect("terminal frees the slot");
+    }
+
+    #[test]
+    fn cancel_requires_a_running_download() {
+        let downloads = Downloads::new();
+        let id = downloads.begin("model-x").unwrap();
+        let cancelled = downloads.cancel(&id).expect("running download cancels");
+        assert_eq!(cancelled.status, "cancelled");
+        let err = downloads.cancel(&id).expect_err("already terminal");
+        assert!(err.contains("not running"), "{err}");
+        assert!(downloads.cancel("dl-missing").is_err());
+    }
+}

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -52,6 +52,7 @@ pub struct ChatMsg {
     pub content: String,
 }
 
+#[derive(Serialize)]
 pub struct BenchmarkChatResult {
     pub content: String,
     pub status: String,
@@ -78,6 +79,10 @@ struct NonstreamChatOnceResult {
 
 const CHAT_MAX_TOKENS: u32 = 8192;
 const BENCHMARK_MAX_TOKENS: u32 = 384;
+/// Default cap for agent-driven chat over the local server. Deliberately much
+/// larger than the benchmark cap: reasoning-enabled models spend their budget
+/// thinking, and a benchmark-sized cap reads as an empty final answer.
+const AGENT_CHAT_DEFAULT_MAX_TOKENS: u32 = 2048;
 const CHAT_THINKING_BUDGET: u32 = 2048;
 const BENCHMARK_THINKING_BUDGET: u32 = 0;
 const BENCHMARK_SIDEKICK_WAIT_MS: u64 = 2_500;
@@ -2857,6 +2862,114 @@ pub async fn benchmark_gateway_chat(
         tool_calls: tool_count,
         compacted,
         context_tokens_before,
+    })
+}
+
+/// Agent-facing, non-streaming chat completion against one warm slot, served
+/// over the local API server. Reuses the benchmark chat plumbing
+/// (`nonstream_chat_once` + the local tool loop) — NOT the GUI `chat_stream`
+/// — but without the benchmark prompt wrapper, sidekick spawning, or
+/// persistence, and with an agent-sized token cap.
+pub async fn agent_chat(
+    app: &AppHandle,
+    mgr: &Residency,
+    slot_id: u32,
+    session_id: &str,
+    prompt: &str,
+    max_tokens: Option<u32>,
+) -> Result<BenchmarkChatResult, String> {
+    let started = Instant::now();
+    let max_tokens = max_tokens
+        .unwrap_or(AGENT_CHAT_DEFAULT_MAX_TOKENS)
+        .clamp(1, CHAT_MAX_TOKENS);
+    let (port, model_field) = mgr
+        .endpoint(slot_id)
+        .ok_or_else(|| format!("slot {slot_id} is not warm; warm it first"))?;
+    let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
+    let mut outbound_messages = vec![
+        json!({ "role": "system", "content": system_prompt_for(&model_field) }),
+        json!({ "role": "user", "content": prompt }),
+    ];
+
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|e| e.to_string())?;
+    let mut final_content = String::new();
+    let mut reasoning_tokens = 0u64;
+    let mut tool_count = 0u64;
+    let mut status = "tool_limit".to_string();
+    let mut repaired_empty_final = false;
+
+    for _round in 0..=BENCHMARK_MAX_TOOL_ROUNDS {
+        let result = nonstream_chat_once(
+            &client,
+            &url,
+            None,
+            &model_field,
+            &outbound_messages,
+            max_tokens,
+            BENCHMARK_THINKING_BUDGET,
+            false,
+        )
+        .await?;
+        final_content = result.content.clone();
+        reasoning_tokens += approximate_token_count(&result.reasoning);
+        let tool_calls = result.tool_calls;
+        if tool_calls.is_empty() {
+            if final_content.trim().is_empty() && !repaired_empty_final {
+                repaired_empty_final = true;
+                outbound_messages.push(benchmark_finalize_prompt(&result.reasoning));
+                continue;
+            }
+            if final_content.trim().is_empty() {
+                status = "empty_final".to_string();
+                break;
+            }
+            status = "ok".to_string();
+            break;
+        }
+        let assistant_tool_calls: Vec<Value> = tool_calls
+            .iter()
+            .map(|call| {
+                json!({
+                    "id": call.id,
+                    "type": "function",
+                    "function": { "name": call.name, "arguments": call.arguments },
+                })
+            })
+            .collect();
+        outbound_messages.push(json!({
+            "role": "assistant",
+            "content": final_content,
+            "tool_calls": assistant_tool_calls,
+        }));
+
+        for call in tool_calls {
+            let args = serde_json::from_str::<Value>(&call.arguments).unwrap_or_else(|_| json!({}));
+            let result =
+                match tool_result(app, mgr, Some(slot_id), session_id, &call.name, &args).await {
+                    Ok(value) => value,
+                    Err(err) => json!({ "error": err }),
+                };
+            tool_count += 1;
+            outbound_messages.push(json!({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": result.to_string(),
+            }));
+        }
+    }
+
+    Ok(BenchmarkChatResult {
+        prompt_tokens: approximate_messages_tokens(&outbound_messages),
+        completion_tokens: final_content.split_whitespace().count() as u64,
+        reasoning_tokens,
+        content: final_content,
+        status,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        tool_calls: tool_count,
+        compacted: false,
+        context_tokens_before: 0,
     })
 }
 

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -1974,8 +1974,14 @@ pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRout
 #[tauri::command]
 pub async fn run_fusion_benchmark(
     app: AppHandle,
-    request: RunFusionBenchmarkRequest,
+    mut request: RunFusionBenchmarkRequest,
 ) -> Result<FusionBenchmarkRun, String> {
+    // Resolve the run id up front so the single-flight registration and the
+    // rows persist under the same id.
+    let run_id = request.run_id.take().unwrap_or_else(default_fusion_run_id);
+    request.run_id = Some(run_id.clone());
+    // Single-flight: a second concurrent run would interleave rows.
+    let _run_guard = crate::agent_ops::begin_benchmark_run(&app, &run_id)?;
     run_fusion_benchmark_inner(app, request, None, None, None).await
 }
 
@@ -2070,6 +2076,11 @@ async fn run_fusion_benchmark_inner(
             .find(|task| task.id == task_id)
             .ok_or_else(|| format!("unknown Fusion benchmark task: {task_id}"))?;
         for mode in &requested_modes {
+            // Cooperative cancellation between rows: an agent cancelled the
+            // run via the local server; stop before spending on the next row.
+            if crate::agent_ops::benchmark_run_cancelled(&app, &run_id) {
+                return Err(format!("benchmark run cancelled: {run_id}"));
+            }
             let recommendation =
                 (mode == "sidekick-routing" && candidate != "gateway-glm").then(|| {
                     fusion_route_recommendation_with_persist(
@@ -2419,6 +2430,9 @@ async fn run_fusion_benchmark_matrix_impl(
     if run_id.trim().is_empty() {
         return Err("run_id is required".to_string());
     }
+    // Single-flight across all benchmark entry points; candidates below run
+    // sequentially under this one registration.
+    let _run_guard = crate::agent_ops::begin_benchmark_run(&app, &run_id)?;
     let suite = request.suite.unwrap_or_else(|| "full-matrix".to_string());
     let candidates = request.candidates.unwrap_or_else(|| {
         vec![

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod aa;
 mod account;
 mod agent_card;
+mod agent_ops;
 mod bin;
 mod bootstrap;
 mod chat;
@@ -43,6 +44,10 @@ pub fn run() {
             app.manage(metrics::MetricsReader::new());
             app.manage(machine);
             app.manage(residency);
+            // Agent-facing registries behind the local API server: model
+            // download progress + the single-flight benchmark run gate.
+            app.manage(agent_ops::Downloads::new());
+            app.manage(agent_ops::BenchRuns::new());
 
             // Re-warm the previously-warm model set (background-safe).
             let handle = app.handle().clone();

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -1,8 +1,14 @@
 // Local server pillar: one service core (the `commands::*` functions) exposed
 // through HTTP REST, a minimal MCP JSON-RPC endpoint, and an A2A agent card —
-// all on 127.0.0.1 behind a bearer token. Coding agents can drive the app
-// (warm a model, run a benchmark, search traces, push a view to the GUI) by
-// calling this server; the GUI itself keeps using Tauri commands.
+// all on 127.0.0.1 behind a bearer token. Coding agents get full model and
+// serving control: mutate residency (add/assign/warm/cool/remove a slot),
+// start/poll/cancel model downloads, run fusion benchmarks (single-flight —
+// a concurrent second run gets 409 — with cooperative cancel between rows),
+// run a non-streaming chat completion against a warm slot, plus the read
+// surfaces (status, models, traces, metrics) and `ui_focus` to drive the GUI.
+// The GUI itself keeps using Tauri commands. Blocking work never runs on the
+// axum workers: residency mutations go through `spawn_blocking`, downloads
+// run on the Tauri async runtime.
 
 use axum::{
     extract::{Path, Query, State},
@@ -32,6 +38,14 @@ pub fn router(ctx: Ctx) -> Router {
         .route("/api/models", get(models))
         .route("/api/snapshots", get(snapshots))
         .route("/api/residency", get(residency))
+        .route("/api/residency/slots", post(residency_add_slot))
+        .route("/api/residency/assign", post(residency_assign))
+        .route("/api/residency/warm", post(residency_warm))
+        .route("/api/residency/cool", post(residency_cool))
+        .route("/api/residency/remove", post(residency_remove))
+        .route("/api/downloads", get(downloads_list).post(download_start))
+        .route("/api/downloads/:id", get(download_status))
+        .route("/api/downloads/:id/cancel", post(download_cancel))
         .route("/api/dossiers", get(dossiers))
         .route("/api/benchmarks", get(benchmarks))
         .route("/api/fusion/benchmark-matrix", get(fusion_benchmark_matrix))
@@ -64,6 +78,9 @@ pub fn router(ctx: Ctx) -> Router {
         .route("/api/chat/route-metrics", get(chat_route_metrics))
         .route("/api/fusion/run", post(run_fusion_benchmark))
         .route("/api/fusion/run-matrix", post(run_fusion_benchmark_matrix))
+        .route("/api/fusion/run-active", get(fusion_run_active))
+        .route("/api/fusion/run-cancel", post(fusion_run_cancel))
+        .route("/api/chat/completion", post(chat_completion))
         .route("/api/sidekick/metrics", get(sidekick_metrics))
         .route("/api/sidekick/sessions", get(sidekick_session_summaries))
         .route("/api/profile/:id", get(profile))
@@ -162,6 +179,216 @@ async fn residency(
 ) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
     Ok(Json(json!(crate::commands::get_residency(ctx.app.clone()))))
+}
+
+// ----- residency mutation (agent parity with the GUI slot controls) -----
+//
+// The wrapped `commands::*` functions kill/spawn model server processes, so
+// they run under `spawn_blocking`, never on the axum workers. Reliability
+// semantics (budget/LRU eviction, ready polling) live in `residency.rs`.
+
+/// Run a blocking residency/commands call off the axum workers.
+async fn blocking<T, F>(f: F) -> Result<T, (StatusCode, String)>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("task failed: {e}")))?
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))
+}
+
+#[derive(serde::Deserialize)]
+struct SlotBody {
+    slot_id: u32,
+}
+
+#[derive(serde::Deserialize)]
+struct AssignBody {
+    slot_id: u32,
+    model_id: String,
+}
+
+async fn residency_add_slot(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let app = ctx.app.clone();
+    let slot_id = blocking(move || crate::commands::add_slot(app)).await?;
+    Ok(Json(json!({ "ok": true, "slot_id": slot_id })))
+}
+
+async fn residency_assign(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<AssignBody>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let app = ctx.app.clone();
+    blocking(move || crate::commands::assign_slot(app, b.slot_id, b.model_id)).await?;
+    Ok(Json(json!({ "ok": true, "slot_id": b.slot_id })))
+}
+
+async fn residency_warm(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<SlotBody>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let app = ctx.app.clone();
+    // Warming is asynchronous by design: this flips the slot to `loading`
+    // and returns; agents poll /api/residency until the slot is `running`.
+    blocking(move || crate::commands::warm_slot(app, b.slot_id)).await?;
+    Ok(Json(
+        json!({ "ok": true, "slot_id": b.slot_id, "state": "loading" }),
+    ))
+}
+
+async fn residency_cool(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<SlotBody>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let app = ctx.app.clone();
+    blocking(move || crate::commands::cool_slot(app, b.slot_id)).await?;
+    Ok(Json(json!({ "ok": true, "slot_id": b.slot_id })))
+}
+
+async fn residency_remove(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<SlotBody>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let app = ctx.app.clone();
+    blocking(move || crate::commands::remove_slot(app, b.slot_id)).await?;
+    Ok(Json(json!({ "ok": true, "slot_id": b.slot_id })))
+}
+
+// ----- model downloads (start / poll / cancel) -----
+
+#[derive(serde::Deserialize)]
+struct DownloadBody {
+    model_id: String,
+}
+
+async fn download_start(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<DownloadBody>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let id = crate::agent_ops::start_model_download(&ctx.app, b.model_id.clone())
+        .map_err(|e| (StatusCode::CONFLICT, e))?;
+    Ok(Json(
+        json!({ "ok": true, "download_id": id, "model_id": b.model_id }),
+    ))
+}
+
+async fn downloads_list(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let downloads = ctx.app.state::<crate::agent_ops::Downloads>();
+    Ok(Json(json!({ "downloads": downloads.list() })))
+}
+
+async fn download_status(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let downloads = ctx.app.state::<crate::agent_ops::Downloads>();
+    downloads
+        .get(&id)
+        .map(|p| Json(json!(p)))
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("unknown download id: {id}")))
+}
+
+async fn download_cancel(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let downloads = ctx.app.state::<crate::agent_ops::Downloads>();
+    downloads
+        .cancel(&id)
+        .map(|p| Json(json!(p)))
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))
+}
+
+// ----- fusion benchmark run registry (single-flight + cancel) -----
+
+/// A run rejected by the single-flight gate is a 409, not a 400.
+fn run_error_status(e: &str) -> StatusCode {
+    if e.starts_with(crate::agent_ops::RUN_CONFLICT) {
+        StatusCode::CONFLICT
+    } else {
+        StatusCode::BAD_REQUEST
+    }
+}
+
+async fn fusion_run_active(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let runs = ctx.app.state::<crate::agent_ops::BenchRuns>();
+    Ok(Json(json!({ "active": runs.active() })))
+}
+
+async fn fusion_run_cancel(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let runs = ctx.app.state::<crate::agent_ops::BenchRuns>();
+    match runs.cancel() {
+        Some(run_id) => Ok(Json(json!({ "ok": true, "cancelled_run_id": run_id }))),
+        None => Err((
+            StatusCode::NOT_FOUND,
+            "no benchmark run in progress".to_string(),
+        )),
+    }
+}
+
+// ----- chat completion against a warm slot -----
+
+#[derive(serde::Deserialize)]
+struct ChatBody {
+    slot_id: u32,
+    prompt: String,
+    session_id: Option<String>,
+    max_tokens: Option<u32>,
+}
+
+async fn chat_completion(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<ChatBody>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let session_id = b
+        .session_id
+        .unwrap_or_else(|| format!("agent-{}", chrono::Utc::now().timestamp_millis()));
+    let residency = ctx.app.state::<crate::residency::Residency>();
+    crate::chat::agent_chat(
+        &ctx.app,
+        &residency,
+        b.slot_id,
+        &session_id,
+        &b.prompt,
+        b.max_tokens,
+    )
+    .await
+    .map(|r| Json(json!(r)))
+    .map_err(|e| (StatusCode::BAD_REQUEST, e))
 }
 async fn dossiers(
     State(ctx): State<Ctx>,
@@ -276,7 +503,7 @@ async fn run_fusion_benchmark(
     crate::commands::run_fusion_benchmark(ctx.app.clone(), body)
         .await
         .map(|run| Json(json!(run)))
-        .map_err(|e| (StatusCode::BAD_REQUEST, e))
+        .map_err(|e| (run_error_status(&e), e))
 }
 async fn run_fusion_benchmark_matrix(
     State(ctx): State<Ctx>,
@@ -287,7 +514,7 @@ async fn run_fusion_benchmark_matrix(
     crate::commands::run_fusion_benchmark_matrix(ctx.app.clone(), body)
         .await
         .map(|run| Json(json!(run)))
-        .map_err(|e| (StatusCode::BAD_REQUEST, e))
+        .map_err(|e| (run_error_status(&e), e))
 }
 async fn sidekick_metrics(
     State(ctx): State<Ctx>,
@@ -445,38 +672,269 @@ async fn mcp(
     }
 }
 
+/// Build one object input schema; `required` is emitted only when non-empty.
+fn obj_schema(properties: Value, required: &[&str]) -> Value {
+    let mut schema = json!({ "type": "object", "properties": properties });
+    if !required.is_empty() {
+        schema["required"] = json!(required);
+    }
+    schema
+}
+
+fn empty_schema() -> Value {
+    obj_schema(json!({}), &[])
+}
+
+fn limit_schema() -> Value {
+    obj_schema(
+        json!({ "limit": { "type": "integer", "minimum": 1, "description": "Max rows to return." } }),
+        &[],
+    )
+}
+
+fn slot_schema() -> Value {
+    obj_schema(
+        json!({ "slot_id": { "type": "integer", "minimum": 1, "description": "Residency slot id (see the residency tool)." } }),
+        &["slot_id"],
+    )
+}
+
+fn download_id_schema() -> Value {
+    obj_schema(
+        json!({ "download_id": { "type": "string", "description": "Download id returned by start_model_download." } }),
+        &["download_id"],
+    )
+}
+
+fn run_benchmark_properties(with_candidates: bool) -> Value {
+    let mut props = json!({
+        "run_id": { "type": "string", "description": "Run id; generated when omitted." },
+        "suite": { "type": "string", "enum": ["routing-smoke", "local-comparison", "full-matrix", "automationbench-proxy"] },
+        "modes": { "type": "array", "items": { "type": "string", "enum": ["main-only", "sidekick-advisory", "sidekick-parallel", "sidekick-routing"] } },
+        "task_ids": { "type": "array", "items": { "type": "string" } },
+        "dry_run": { "type": "boolean", "description": "Default true: plan without spending tokens." },
+        "record_skips": { "type": "boolean" }
+    });
+    if with_candidates {
+        props["candidates"] = json!({
+            "type": "array",
+            "items": { "type": "string", "enum": ["gateway-glm", "local-main", "local-fast"] },
+            "description": "Defaults to gateway-glm, local-main, local-fast."
+        });
+    } else {
+        props["candidate"] = json!({ "type": "string", "enum": ["gateway-glm", "local-main", "local-fast"] });
+        props["route"] = json!({ "type": "string", "enum": ["local", "gateway"] });
+        props["model"] = json!({ "type": "string", "description": "Override the model id/path." });
+    }
+    props
+}
+
 fn tools() -> Vec<Value> {
-    [
-        ("status", "Local runtime status: services, warm slots, metrics."),
-        ("list_models", "List locally cached models."),
-        ("list_snapshot_models", "Bundled local MLX snapshot catalog."),
-        ("residency", "Warm-slot residency (which models are loaded)."),
-        ("knowledge_dossiers", "Bundled public per-model dossiers."),
-        ("local_benchmarks", "Local live benchmark rows."),
-        ("fusion_benchmark_matrix", "Fusion benchmark modes and fixed local task set."),
-        ("fusion_route_recommendation", "Recommend local, local+sidekick, or gateway for a prompt. Args: {prompt, current_route?, active_slot_id?, session_id?}."),
-        ("fusion_route_decisions", "Recent persisted Fusion route policy decisions with sidekick, gateway, token, and memory accounting. Args: {limit?}."),
-        ("fusion_benchmark_results", "Recent Fusion benchmark result rows. Args: {limit?}."),
-        ("fusion_benchmark_summary", "Aggregate Fusion benchmark results by route, mode, and model. Args: {limit?}."),
-        ("fusion_benchmark_run_summary", "Compare Fusion benchmark modes within each run. Args: {limit?}."),
-        ("export_fusion_benchmark_comparison", "Write a local Fusion comparison packet for external eval tooling. Args: {limit?, output_path?}."),
-        ("export_automationbench_handoff", "Write a local AutomationBench handoff packet with candidates, runner hints, and desktop callback mapping. Args: {run_id?, candidates?, domains?, num_examples?, output_path?}."),
-        ("chat_runs", "Recent desktop chat route accounting rows. Args: {limit?}."),
-        ("chat_route_metrics", "Aggregate desktop chat route latency, token, tool, sidekick, and gateway usage. Args: {limit?}."),
-        ("sidekick_metrics", "Aggregate recent sidekick usage, handoff, escalation, and feedback metrics. Args: {limit?}."),
-        ("sidekick_session_summaries", "Inspect persisted sidekick session memory and compacted summaries. Args: {limit?}."),
-        ("record_fusion_benchmark", "Record one Fusion benchmark result row."),
-        ("run_fusion_benchmark", "Plan or run a Fusion benchmark for one candidate. Args: {run_id?, suite?, candidate?, route?, modes?, task_ids?, model?, dry_run?, record_skips?}. Suites: routing-smoke, local-comparison, full-matrix, automationbench-proxy. Candidates: gateway-glm, local-main, local-fast."),
-        ("run_fusion_benchmark_matrix", "Plan or run a Fusion benchmark across candidates. Args: {run_id?, suite?, candidates?, modes?, task_ids?, dry_run?, record_skips?}. Defaults candidates to gateway-glm, local-main, local-fast."),
-        ("aa_models", "Artificial Analysis external pricing/speed/quality."),
-        ("list_traces", "List recent Moraine sessions. Args: {limit?}."),
-        ("search_traces", "Search Moraine traces. Args: {q}."),
-        ("open_trace", "Open a session/turn/event. Args: {id}."),
-        ("ui_focus", "Drive the GUI to a pane. Args: {pane?, model?}."),
-    ]
-    .into_iter()
-    .map(|(n, d)| json!({ "name": n, "description": d, "inputSchema": { "type":"object","properties":{} } }))
-    .collect()
+    let tools: Vec<(&str, &str, Value)> = vec![
+        // ----- read surfaces -----
+        ("status", "Local runtime status: services, warm slots, metrics.", empty_schema()),
+        ("list_models", "List locally cached models.", empty_schema()),
+        ("list_snapshot_models", "Bundled local MLX snapshot catalog.", empty_schema()),
+        ("residency", "Warm-slot residency (which models are loaded).", empty_schema()),
+        ("knowledge_dossiers", "Bundled public per-model dossiers.", empty_schema()),
+        ("local_benchmarks", "Local live benchmark rows.", empty_schema()),
+        ("fusion_benchmark_matrix", "Fusion benchmark modes and fixed local task set.", empty_schema()),
+        ("aa_models", "Artificial Analysis external pricing/speed/quality.", empty_schema()),
+        // ----- residency mutation -----
+        ("add_slot", "Add an empty residency slot; returns its slot_id.", empty_schema()),
+        (
+            "assign_slot",
+            "Assign a locally cached model to a residency slot (cools the slot first if warm).",
+            obj_schema(
+                json!({
+                    "slot_id": { "type": "integer", "minimum": 1 },
+                    "model_id": { "type": "string", "description": "Model id from list_models." }
+                }),
+                &["slot_id", "model_id"],
+            ),
+        ),
+        (
+            "warm_slot",
+            "Warm a residency slot: evicts LRU slots to fit the memory budget, spawns the model server, then loads in the background. Poll residency until the slot state is 'running'.",
+            slot_schema(),
+        ),
+        ("cool_slot", "Cool a residency slot (stops its model server).", slot_schema()),
+        ("remove_slot", "Remove a residency slot entirely.", slot_schema()),
+        // ----- model downloads -----
+        (
+            "start_model_download",
+            "Start a snapshot model download in the background; returns a download_id to poll with model_download_status. One running download per model id.",
+            obj_schema(
+                json!({ "model_id": { "type": "string", "description": "Snapshot id from list_snapshot_models." } }),
+                &["model_id"],
+            ),
+        ),
+        (
+            "model_download_status",
+            "Per-file progress, status (running|done|error|cancelled), and recent logs for one download.",
+            download_id_schema(),
+        ),
+        ("list_model_downloads", "All tracked model downloads with progress.", empty_schema()),
+        ("cancel_model_download", "Cancel a running model download.", download_id_schema()),
+        // ----- fusion routing + benchmarks -----
+        (
+            "fusion_route_recommendation",
+            "Recommend local, local+sidekick, or gateway for a prompt.",
+            obj_schema(
+                json!({
+                    "prompt": { "type": "string" },
+                    "current_route": { "type": "string", "enum": ["local", "gateway"] },
+                    "active_slot_id": { "type": "integer", "minimum": 1 },
+                    "session_id": { "type": "string" }
+                }),
+                &["prompt"],
+            ),
+        ),
+        (
+            "fusion_route_decisions",
+            "Recent persisted Fusion route policy decisions with sidekick, gateway, token, and memory accounting.",
+            limit_schema(),
+        ),
+        ("fusion_benchmark_results", "Recent Fusion benchmark result rows.", limit_schema()),
+        ("fusion_benchmark_summary", "Aggregate Fusion benchmark results by route, mode, and model.", limit_schema()),
+        ("fusion_benchmark_run_summary", "Compare Fusion benchmark modes within each run.", limit_schema()),
+        (
+            "export_fusion_benchmark_comparison",
+            "Write a local Fusion comparison packet for external eval tooling.",
+            obj_schema(
+                json!({
+                    "limit": { "type": "integer", "minimum": 1 },
+                    "output_path": { "type": "string" }
+                }),
+                &[],
+            ),
+        ),
+        (
+            "export_automationbench_handoff",
+            "Write a local AutomationBench handoff packet with candidates, runner hints, and desktop callback mapping.",
+            obj_schema(
+                json!({
+                    "run_id": { "type": "string" },
+                    "candidates": { "type": "array", "items": { "type": "string" } },
+                    "domains": { "type": "array", "items": { "type": "string" } },
+                    "num_examples": { "type": "integer", "minimum": 1 },
+                    "output_path": { "type": "string" }
+                }),
+                &[],
+            ),
+        ),
+        (
+            "record_fusion_benchmark",
+            "Record one Fusion benchmark result row.",
+            obj_schema(
+                json!({
+                    "run_id": { "type": "string" },
+                    "task_id": { "type": "string" },
+                    "mode": { "type": "string" },
+                    "model": { "type": "string" },
+                    "elapsed_ms": { "type": "integer", "minimum": 0 },
+                    "prompt_tokens": { "type": "integer", "minimum": 0 },
+                    "completion_tokens": { "type": "integer", "minimum": 0 },
+                    "sidekick_runs": { "type": "integer", "minimum": 0 },
+                    "sidekick_tool_calls": { "type": "integer", "minimum": 0 },
+                    "gateway_used": { "type": "boolean" },
+                    "compacted": { "type": "boolean" },
+                    "context_tokens_before": { "type": "integer", "minimum": 0 },
+                    "local_mem_gb": { "type": "number", "minimum": 0 },
+                    "score": { "type": "number" },
+                    "status": { "type": "string" },
+                    "notes": { "type": "string" }
+                }),
+                &["run_id", "task_id", "mode", "model"],
+            ),
+        ),
+        (
+            "run_fusion_benchmark",
+            "Plan or run a Fusion benchmark for one candidate. Single-flight: fails with a conflict while another run is active; cancel via cancel_fusion_benchmark_run.",
+            obj_schema(run_benchmark_properties(false), &[]),
+        ),
+        (
+            "run_fusion_benchmark_matrix",
+            "Plan or run a Fusion benchmark across candidates. Single-flight: fails with a conflict while another run is active.",
+            obj_schema(run_benchmark_properties(true), &[]),
+        ),
+        ("fusion_benchmark_run_status", "The active benchmark run (run_id, started_at, cancel_requested), or null.", empty_schema()),
+        (
+            "cancel_fusion_benchmark_run",
+            "Request cancellation of the active benchmark run; the run loop stops between rows.",
+            empty_schema(),
+        ),
+        // ----- chat -----
+        (
+            "chat_completion",
+            "Non-streaming chat completion against a warm residency slot (local tool loop included). Warm a slot first.",
+            obj_schema(
+                json!({
+                    "slot_id": { "type": "integer", "minimum": 1, "description": "A warm slot from residency." },
+                    "prompt": { "type": "string" },
+                    "session_id": { "type": "string" },
+                    "max_tokens": { "type": "integer", "minimum": 1, "maximum": 8192, "description": "Completion cap; default 2048." }
+                }),
+                &["slot_id", "prompt"],
+            ),
+        ),
+        // ----- accounting + traces + GUI -----
+        ("chat_runs", "Recent desktop chat route accounting rows.", limit_schema()),
+        ("chat_route_metrics", "Aggregate desktop chat route latency, token, tool, sidekick, and gateway usage.", limit_schema()),
+        ("sidekick_metrics", "Aggregate recent sidekick usage, handoff, escalation, and feedback metrics.", limit_schema()),
+        ("sidekick_session_summaries", "Inspect persisted sidekick session memory and compacted summaries.", limit_schema()),
+        ("list_traces", "List recent Moraine sessions.", limit_schema()),
+        (
+            "search_traces",
+            "Search Moraine traces.",
+            obj_schema(json!({ "q": { "type": "string", "description": "Search query." } }), &["q"]),
+        ),
+        (
+            "open_trace",
+            "Open a session/turn/event.",
+            obj_schema(json!({ "id": { "type": "string", "description": "Session/turn/event id." } }), &["id"]),
+        ),
+        (
+            "ui_focus",
+            "Drive the GUI to a pane.",
+            obj_schema(
+                json!({
+                    "pane": { "type": "string" },
+                    "model": { "type": "string" }
+                }),
+                &[],
+            ),
+        ),
+    ];
+    tools
+        .into_iter()
+        .map(|(n, d, schema)| json!({ "name": n, "description": d, "inputSchema": schema }))
+        .collect()
+}
+
+fn required_u32(args: &Value, key: &str) -> Result<u32, String> {
+    args.get(key)
+        .and_then(|v| v.as_u64())
+        .map(|x| x as u32)
+        .ok_or_else(|| format!("{key} is required"))
+}
+
+fn required_str(args: &Value, key: &str) -> Result<String, String> {
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| format!("{key} is required"))
+}
+
+/// Run a blocking commands call off the MCP request task.
+async fn call_blocking<T, F>(f: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| format!("task failed: {e}"))?
 }
 
 async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String> {
@@ -487,6 +945,81 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
         "list_models" => json!(c::list_models()),
         "list_snapshot_models" => json!(c::list_snapshot_models()),
         "residency" => json!(c::get_residency(app)),
+        "add_slot" => {
+            let slot_id = call_blocking(move || c::add_slot(app)).await?;
+            json!({ "ok": true, "slot_id": slot_id })
+        }
+        "assign_slot" => {
+            let slot_id = required_u32(args, "slot_id")?;
+            let model_id = required_str(args, "model_id")?;
+            call_blocking(move || c::assign_slot(app, slot_id, model_id)).await?;
+            json!({ "ok": true, "slot_id": slot_id })
+        }
+        "warm_slot" => {
+            let slot_id = required_u32(args, "slot_id")?;
+            call_blocking(move || c::warm_slot(app, slot_id)).await?;
+            json!({ "ok": true, "slot_id": slot_id, "state": "loading" })
+        }
+        "cool_slot" => {
+            let slot_id = required_u32(args, "slot_id")?;
+            call_blocking(move || c::cool_slot(app, slot_id)).await?;
+            json!({ "ok": true, "slot_id": slot_id })
+        }
+        "remove_slot" => {
+            let slot_id = required_u32(args, "slot_id")?;
+            call_blocking(move || c::remove_slot(app, slot_id)).await?;
+            json!({ "ok": true, "slot_id": slot_id })
+        }
+        "start_model_download" => {
+            let model_id = required_str(args, "model_id")?;
+            let id = crate::agent_ops::start_model_download(&app, model_id.clone())?;
+            json!({ "ok": true, "download_id": id, "model_id": model_id })
+        }
+        "model_download_status" => {
+            let id = required_str(args, "download_id")?;
+            let downloads = app.state::<crate::agent_ops::Downloads>();
+            json!(downloads
+                .get(&id)
+                .ok_or_else(|| format!("unknown download id: {id}"))?)
+        }
+        "list_model_downloads" => {
+            let downloads = app.state::<crate::agent_ops::Downloads>();
+            json!({ "downloads": downloads.list() })
+        }
+        "cancel_model_download" => {
+            let id = required_str(args, "download_id")?;
+            let downloads = app.state::<crate::agent_ops::Downloads>();
+            json!(downloads.cancel(&id)?)
+        }
+        "fusion_benchmark_run_status" => {
+            let runs = app.state::<crate::agent_ops::BenchRuns>();
+            json!({ "active": runs.active() })
+        }
+        "cancel_fusion_benchmark_run" => {
+            let runs = app.state::<crate::agent_ops::BenchRuns>();
+            match runs.cancel() {
+                Some(run_id) => json!({ "ok": true, "cancelled_run_id": run_id }),
+                None => return Err("no benchmark run in progress".to_string()),
+            }
+        }
+        "chat_completion" => {
+            let slot_id = required_u32(args, "slot_id")?;
+            let prompt = required_str(args, "prompt")?;
+            let session_id = args
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("agent-{}", chrono::Utc::now().timestamp_millis()));
+            let max_tokens = args
+                .get("max_tokens")
+                .and_then(|v| v.as_u64())
+                .map(|x| x as u32);
+            let residency = app.state::<crate::residency::Residency>();
+            json!(
+                crate::chat::agent_chat(&app, &residency, slot_id, &session_id, &prompt, max_tokens)
+                    .await?
+            )
+        }
         "knowledge_dossiers" => json!(c::knowledge_dossiers()),
         "local_benchmarks" => json!(c::local_benchmarks(app).map_err(|e| e.to_string())?),
         "fusion_benchmark_matrix" => json!(c::fusion_benchmark_matrix()),
@@ -662,4 +1195,57 @@ pub fn info(app: &AppHandle) -> Option<(String, String)> {
 #[allow(unused)]
 fn _unused() -> impl IntoResponse {
     "ok"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_mcp_tool_advertises_a_real_object_schema() {
+        let tools = tools();
+        assert!(tools.len() >= 30, "tool list unexpectedly small");
+        let mut names = std::collections::HashSet::new();
+        for tool in &tools {
+            let name = tool["name"].as_str().expect("tool has a name");
+            assert!(names.insert(name.to_string()), "duplicate tool: {name}");
+            assert!(tool["description"].as_str().is_some_and(|d| !d.is_empty()));
+            let schema = &tool["inputSchema"];
+            assert_eq!(schema["type"], "object", "{name} schema is an object");
+            assert!(schema["properties"].is_object(), "{name} has properties");
+        }
+    }
+
+    #[test]
+    fn tools_with_required_args_declare_them() {
+        let tools = tools();
+        let required_of = |name: &str| -> Vec<String> {
+            tools
+                .iter()
+                .find(|t| t["name"] == name)
+                .unwrap_or_else(|| panic!("tool {name} exists"))["inputSchema"]["required"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        assert_eq!(required_of("warm_slot"), ["slot_id"]);
+        assert_eq!(required_of("assign_slot"), ["slot_id", "model_id"]);
+        assert_eq!(required_of("start_model_download"), ["model_id"]);
+        assert_eq!(required_of("cancel_model_download"), ["download_id"]);
+        assert_eq!(required_of("chat_completion"), ["slot_id", "prompt"]);
+        assert_eq!(required_of("fusion_route_recommendation"), ["prompt"]);
+        assert_eq!(required_of("search_traces"), ["q"]);
+        assert_eq!(required_of("open_trace"), ["id"]);
+        assert_eq!(
+            required_of("record_fusion_benchmark"),
+            ["run_id", "task_id", "mode", "model"]
+        );
+        // Args-optional tools stay unconstrained.
+        assert!(required_of("run_fusion_benchmark").is_empty());
+        assert!(required_of("list_traces").is_empty());
+    }
 }

--- a/skills/manage-local-models/SKILL.md
+++ b/skills/manage-local-models/SKILL.md
@@ -43,6 +43,16 @@ user's experience tier (set tone accordingly). Inventory what is already cached
 before proposing a download — the best pull is often one they already have. Disk
 locations and registry links are in [`reference.md`](reference.md).
 
+**If the Understudy desktop app is running, prefer its daemon.** Check
+`~/.understudy/agent-card.json` and trust the `app` block only after a pid
+check on `app.pid` plus a health probe of `<app.base_url>/health`
+(`understudy daemon status` does exactly this; schema in
+[`../onboard/reference.md`](../onboard/reference.md)). A running app can
+start/poll/cancel verified snapshot downloads into the same
+`~/.understudy/models` cache and already serves warm slots
+(`app.warm_models`) — reuse it instead of spawning your own mlx servers or a
+second download of the same weights.
+
 ## Flow
 
 1. **Inventory.** List installed runtimes and already-cached models, and report

--- a/skills/run-local-model-lab/SKILL.md
+++ b/skills/run-local-model-lab/SKILL.md
@@ -54,6 +54,18 @@ route for compliance. For pure remote inference/routing use
   only speed up a paired target while preserving its quality. See
   [`reference.md`](reference.md).
 
+## If the Understudy desktop app is running, prefer its daemon
+
+Before spawning your own MLX server, check for the desktop app's local daemon:
+read `~/.understudy/agent-card.json` and trust its `app` block only after a
+pid check on `app.pid` and a health probe of `<app.base_url>/health`
+(`understudy daemon status` does exactly this; schema in
+[`../onboard/reference.md`](../onboard/reference.md)). A running app already
+manages warm model slots (`app.warm_models`, each an OpenAI-compatible
+endpoint on its own port) and exposes warm/cool/assign, downloads, benchmarks,
+and chat over its authenticated HTTP + MCP server — reuse those slots instead
+of standing up a second server against the same weights and memory budget.
+
 ## Flow
 
 1. **Inventory hardware + runtime.** Confirm Apple Silicon (M-series) and the

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -1,0 +1,41 @@
+import { Command } from "commander";
+import kleur from "kleur";
+
+import { daemonStatus } from "../internal/daemon.js";
+
+export function registerDaemonCommand(program: Command): void {
+  const daemon = program
+    .command("daemon")
+    .description("Inspect the Understudy desktop app's local daemon.");
+
+  daemon
+    .command("status")
+    .description(
+      "Report whether the desktop app daemon is running: reads ~/.understudy/agent-card.json, pid-checks the recorded pid, then health-probes the recorded base_url.",
+    )
+    .option("--json", "Output JSON")
+    .action(async function (this: Command, opts: { json?: boolean }) {
+      const status = await daemonStatus();
+      const json =
+        opts.json === true || this.optsWithGlobals<{ json?: boolean }>().json === true;
+      if (json) {
+        process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+      } else if (status.running) {
+        const warm =
+          status.warmModels.length > 0
+            ? `, warm: ${status.warmModels.map((m) => m.id).join(", ")}`
+            : ", no warm models";
+        process.stdout.write(
+          `${kleur.green("●")} desktop app daemon: running at ${status.baseUrl} (pid ${status.pid}${warm})\n`,
+        );
+      } else {
+        process.stdout.write(
+          `${kleur.dim("○")} desktop app daemon: not detected — ${status.detail}\n`,
+        );
+      }
+      // Scriptable: `understudy daemon status && ...` gates on a live daemon.
+      if (!status.running) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -22,7 +22,10 @@ interface DoctorOpts {
 
 type Check = { name: string; ok: boolean; detail?: string };
 
-export function registerDoctorCommand(program: Command, runLocalDoctor: () => void): void {
+export function registerDoctorCommand(
+  program: Command,
+  runLocalDoctor: () => void | Promise<void>,
+): void {
   program
     .command("doctor")
     .description("Run local repository diagnostics or hosted readiness checks.")
@@ -34,7 +37,7 @@ export function registerDoctorCommand(program: Command, runLocalDoctor: () => vo
     .option("--org <id>", "Org id to use.")
     .action(async function (this: Command, opts: DoctorOpts) {
       if (!opts.hosted) {
-        runLocalDoctor();
+        await runLocalDoctor();
         return;
       }
       await runAction(this, () => runHostedDoctor(this, opts));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
 import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
 import { registerCapturesCommand } from "./commands/captures.js";
+import { registerDaemonCommand } from "./commands/daemon.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
 import { registerGatewayCommand } from "./commands/gateway.js";
 import { registerKeysCommand } from "./commands/keys.js";
@@ -23,6 +24,7 @@ import { registerStatusCommand } from "./commands/status.js";
 import { registerOptimizeWorkloadCommand } from "./commands/optimize-workload.js";
 import { registerWorkloadsCommand } from "./commands/workloads.js";
 import { registerExperimentsCommands, registerNextCommand } from "./commands/experiments.js";
+import { daemonStatus } from "./internal/daemon.js";
 import { readCliVersion, readManifestVersions } from "./internal/version.js";
 
 export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -215,7 +217,7 @@ function printPlatforms(json: boolean, inspect?: string): void {
   }
 }
 
-function printDoctorJson(): void {
+async function printDoctorJson(): Promise<void> {
   const required = [
     "README.md",
     "LICENSE",
@@ -237,6 +239,9 @@ function printDoctorJson(): void {
     versions.cli === versions.codexMarketplace &&
     versions.cli === versions.opencodeAdapter &&
     versions.cli === versions.hermesAdapter;
+  // Desktop-app daemon discovery (agent-card + pid check + health probe).
+  // Informational: a missing daemon never fails the doctor.
+  const daemon = await daemonStatus();
   console.log(
     JSON.stringify(
       {
@@ -246,6 +251,8 @@ function printDoctorJson(): void {
         versions,
         versions_consistent: versionsConsistent,
         missing,
+        desktop_app_daemon: daemon.running ? `running at ${daemon.baseUrl}` : "not detected",
+        daemon,
         ok: missing.length === 0 && versionsConsistent,
       },
       null,
@@ -433,6 +440,7 @@ export function buildProgram(): Command {
   });
 
   registerDoctorCommand(program, printDoctorJson);
+  registerDaemonCommand(program);
 
   registerLoginCommand(program);
   registerLogoutCommand(program);

--- a/src/internal/daemon.ts
+++ b/src/internal/daemon.ts
@@ -1,0 +1,178 @@
+// Desktop-app daemon discovery. The Understudy desktop app is the canonical
+// local daemon: while it runs, it maintains the `app` block of
+// `~/.understudy/agent-card.json` (written by
+// apps/homescreen/src-tauri/src/agent_card.rs — pid, base_url, warm models;
+// never the bearer token). Discovery never trusts `running: true` alone: the
+// recorded pid must be alive AND the recorded base_url must answer a health
+// probe, because a crashed app (no graceful shutdown) leaves a stale card
+// behind.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_PROBE_TIMEOUT_MS = 800;
+
+export interface DaemonWarmModel {
+  id: string;
+  port: number | null;
+  model_path: string;
+}
+
+export interface DaemonStatus {
+  /** An agent card with an `app` block exists (the app ran at least once). */
+  detected: boolean;
+  /** Card says running, the pid is alive, and the health probe answered. */
+  running: boolean;
+  baseUrl: string | null;
+  pid: number | null;
+  version: string | null;
+  warmModels: DaemonWarmModel[];
+  /** Human-readable reason for the verdict. */
+  detail: string;
+  cardPath: string;
+}
+
+export function agentCardPath(): string {
+  return join(homedir(), ".understudy", "agent-card.json");
+}
+
+/** Parse the agent card; null when missing or unreadable JSON. */
+export function readAgentCard(cardPath: string): Record<string, unknown> | null {
+  let raw: string;
+  try {
+    raw = readFileSync(cardPath, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Signal-0 liveness check. EPERM means the pid exists but belongs to another
+ * user — still alive for our purposes.
+ */
+export function pidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/** GET <baseUrl>/health with a short timeout; the route is unauthenticated. */
+export async function probeDaemonHealth(
+  baseUrl: string,
+  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+  try {
+    const url = new URL("/health", baseUrl);
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface DaemonStatusOptions {
+  /** Override the card location (tests use a temp fixture). */
+  cardPath?: string;
+  /** Health probe timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+export async function daemonStatus(options: DaemonStatusOptions = {}): Promise<DaemonStatus> {
+  const cardPath = options.cardPath ?? agentCardPath();
+  const notRunning = (detail: string, extra: Partial<DaemonStatus> = {}): DaemonStatus => ({
+    detected: false,
+    running: false,
+    baseUrl: null,
+    pid: null,
+    version: null,
+    warmModels: [],
+    detail,
+    cardPath,
+    ...extra,
+  });
+
+  const card = readAgentCard(cardPath);
+  if (!card) {
+    return notRunning(`no agent card at ${cardPath} (desktop app not installed or never started)`);
+  }
+  const app = card.app;
+  if (typeof app !== "object" || app === null || Array.isArray(app)) {
+    return notRunning("agent card has no app block (desktop app has not run)");
+  }
+  const appBlock = app as Record<string, unknown>;
+  const pid = typeof appBlock.pid === "number" ? appBlock.pid : null;
+  const baseUrl = typeof appBlock.base_url === "string" ? appBlock.base_url : null;
+  const version = typeof appBlock.version === "string" ? appBlock.version : null;
+  const detected: Partial<DaemonStatus> = { detected: true, pid, baseUrl, version };
+
+  if (appBlock.running !== true) {
+    const stoppedAt = typeof appBlock.stopped_at === "string" ? ` at ${appBlock.stopped_at}` : "";
+    return notRunning(`desktop app marked stopped${stoppedAt}`, detected);
+  }
+  // Never trust `running: true` alone: a crash skips the graceful-shutdown
+  // card update, so verify the pid before believing the card.
+  if (pid === null || !pidAlive(pid)) {
+    return notRunning(
+      `agent card claims running but pid ${pid ?? "?"} is not alive (stale card)`,
+      detected,
+    );
+  }
+  if (!baseUrl) {
+    return notRunning("agent card has no base_url for the local server", detected);
+  }
+  const healthy = await probeDaemonHealth(baseUrl, options.timeoutMs);
+  if (!healthy) {
+    return notRunning(
+      `pid ${pid} is alive but ${baseUrl}/health did not respond`,
+      detected,
+    );
+  }
+
+  const warmModels: DaemonWarmModel[] = Array.isArray(appBlock.warm_models)
+    ? appBlock.warm_models.flatMap((entry: unknown): DaemonWarmModel[] => {
+        if (typeof entry !== "object" || entry === null) return [];
+        const row = entry as Record<string, unknown>;
+        if (typeof row.id !== "string") return [];
+        return [
+          {
+            id: row.id,
+            port: typeof row.port === "number" ? row.port : null,
+            model_path: typeof row.model_path === "string" ? row.model_path : "",
+          },
+        ];
+      })
+    : [];
+
+  return {
+    detected: true,
+    running: true,
+    baseUrl,
+    pid,
+    version,
+    warmModels,
+    detail: `desktop app daemon running at ${baseUrl}`,
+    cardPath,
+  };
+}
+
+/** One-line summary for doctor-style output. */
+export function describeDaemon(status: DaemonStatus): string {
+  return status.running
+    ? `running at ${status.baseUrl}`
+    : `not detected (${status.detail})`;
+}

--- a/tests/daemon.test.mjs
+++ b/tests/daemon.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, afterEach, before, beforeEach, describe, it } from "node:test";
+
+import {
+  daemonStatus,
+  describeDaemon,
+  pidAlive,
+  probeDaemonHealth,
+  readAgentCard,
+} from "../dist/internal/daemon.js";
+
+/** A pid that existed and has exited: spawn a no-op node child and reap it. */
+function deadPid() {
+  const child = spawnSync(process.execPath, ["-e", ""]);
+  assert.equal(child.status, 0);
+  return child.pid;
+}
+
+function writeCard(cardPath, app) {
+  writeFileSync(
+    cardPath,
+    JSON.stringify(
+      {
+        schema_version: "understudy.agent_card.v1",
+        created_at: "2026-06-06T18:00:00Z",
+        updated_at: "2026-06-06T18:05:00Z",
+        understudy: { name: "Gemma 4 E2B", healthy: true },
+        ...(app === undefined ? {} : { app }),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+describe("desktop-app daemon discovery from the agent card", () => {
+  let dir;
+  let cardPath;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "understudy-daemon-test-"));
+    cardPath = join(dir, "agent-card.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports not detected when there is no card", async () => {
+    const status = await daemonStatus({ cardPath });
+    assert.equal(status.detected, false);
+    assert.equal(status.running, false);
+    assert.match(status.detail, /no agent card/);
+    assert.match(describeDaemon(status), /^not detected/);
+  });
+
+  it("reports not detected when the card has no app block", async () => {
+    writeCard(cardPath, undefined);
+    const status = await daemonStatus({ cardPath });
+    assert.equal(status.detected, false);
+    assert.equal(status.running, false);
+    assert.match(status.detail, /no app block/);
+  });
+
+  it("tolerates a corrupt card", async () => {
+    writeFileSync(cardPath, "{not json");
+    assert.equal(readAgentCard(cardPath), null);
+    const status = await daemonStatus({ cardPath });
+    assert.equal(status.running, false);
+  });
+
+  it("reports stopped when the app shut down gracefully", async () => {
+    writeCard(cardPath, {
+      running: false,
+      pid: process.pid,
+      stopped_at: "2026-06-06T19:00:00Z",
+      base_url: "http://127.0.0.1:17790",
+    });
+    const status = await daemonStatus({ cardPath });
+    assert.equal(status.detected, true);
+    assert.equal(status.running, false);
+    assert.match(status.detail, /marked stopped/);
+  });
+
+  it("running with a dead pid reports not running (stale card after a crash)", async () => {
+    writeCard(cardPath, {
+      running: true,
+      pid: deadPid(),
+      base_url: "http://127.0.0.1:17790",
+      version: "0.2.2",
+    });
+    const status = await daemonStatus({ cardPath });
+    assert.equal(status.detected, true);
+    assert.equal(status.running, false);
+    assert.match(status.detail, /pid \d+ is not alive/);
+  });
+
+  it("running with a live pid but unreachable base_url reports not running", async () => {
+    writeCard(cardPath, {
+      running: true,
+      pid: process.pid,
+      // Nothing listens here; connection is refused immediately.
+      base_url: "http://127.0.0.1:1",
+    });
+    const status = await daemonStatus({ cardPath, timeoutMs: 500 });
+    assert.equal(status.detected, true);
+    assert.equal(status.running, false);
+    assert.match(status.detail, /did not respond/);
+  });
+});
+
+describe("daemon discovery against a live health endpoint", () => {
+  let server;
+  let baseUrl;
+
+  before(async () => {
+    server = createServer((req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("ok");
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise((resolveListen) => {
+      server.listen(0, "127.0.0.1", resolveListen);
+    });
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  after(async () => {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  });
+
+  it("probeDaemonHealth answers true for a live /health", async () => {
+    assert.equal(await probeDaemonHealth(baseUrl), true);
+  });
+
+  it("reports running when the card, pid, and health probe all agree", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-daemon-live-"));
+    const cardPath = join(dir, "agent-card.json");
+    try {
+      writeCard(cardPath, {
+        running: true,
+        pid: process.pid,
+        base_url: baseUrl,
+        version: "0.2.2",
+        warm_models: [
+          { id: "gemma-4-e2b-it-qat-mlx-vlm-understudy", port: 8089, model_path: "/m/e2b" },
+          { id: "broken-row-without-strings", port: "not-a-port" },
+        ],
+      });
+      const status = await daemonStatus({ cardPath });
+      assert.equal(status.detected, true);
+      assert.equal(status.running, true);
+      assert.equal(status.baseUrl, baseUrl);
+      assert.equal(status.pid, process.pid);
+      assert.equal(status.version, "0.2.2");
+      // Malformed warm rows are dropped, well-formed ones normalized.
+      assert.equal(status.warmModels.length, 2);
+      assert.equal(status.warmModels[0].id, "gemma-4-e2b-it-qat-mlx-vlm-understudy");
+      assert.equal(status.warmModels[0].port, 8089);
+      assert.equal(status.warmModels[1].port, null);
+      assert.equal(describeDaemon(status), `running at ${baseUrl}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("pidAlive", () => {
+  it("is true for this process and false for a reaped child or nonsense", () => {
+    assert.equal(pidAlive(process.pid), true);
+    assert.equal(pidAlive(deadPid()), false);
+    assert.equal(pidAlive(0), false);
+    assert.equal(pidAlive(-4), false);
+    assert.equal(pidAlive(1.5), false);
+  });
+});


### PR DESCRIPTION
Wave 5a of the dev run (daemon agent parity). Resumes salvaged WIP from `wip/wave5a-daemon-parity` (an earlier agent was stopped mid-flight; this branch verifies, merges main — including the #125 clippy CI — and lands it).

## What this adds

**HTTP + MCP agent surface on the local server** (`server.rs`, `agent_ops.rs`, `lib.rs`):
- Residency mutation parity with the GUI: `POST /api/residency/{slots,assign,warm,cool,remove}` wrapping the existing `commands::*` functions, run under `spawn_blocking` (never on the axum workers).
- Model downloads: `POST /api/downloads` returns a `download_id`; `GET /api/downloads/:id` reports per-file progress teed from `bootstrap`'s Channel events into a shared progress map; `POST /api/downloads/:id/cancel` aborts. One running download per model id.
- Fusion benchmarks: single-flight run registry — a second concurrent run gets **409** naming the active run id — plus `GET /api/fusion/run-active` and `POST /api/fusion/run-cancel` with cooperative cancellation checked between rows (minimal diff in `run_fusion_benchmark_inner`; matrix candidates share one registration, candidate-suffixed ids prefix-match).
- `POST /api/chat/completion`: non-streaming chat against a warm slot via a new `chat::agent_chat` that reuses the benchmark chat plumbing (`nonstream_chat_once` + local tool loop), NOT the GUI `chat_stream`.
- All behind the existing bearer auth; same tools exposed over the MCP endpoint.

**Typed MCP inputSchemas** for all ~35 tools in `tools/list` (previously empty objects even where args were required), with tests asserting every tool has a real object schema and required args are declared.

**CLI daemon discovery** (`src/internal/daemon.ts`, `src/commands/daemon.ts`): reads `~/.understudy/agent-card.json` (shape from #122's `agent_card.rs`), never trusts `running: true` alone — pid-check first, then a short-timeout health probe of `base_url`. Wired into `understudy doctor` (informational; never fails doctor) and a new `understudy daemon status` (exit 1 when not running, so scripts can gate on it). Discovery + status only; pull/serve flows untouched.

**Skills**: "prefer the app daemon when running" notes in `run-local-model-lab` and `manage-local-models`.

**server.rs header comment** updated to tell the truth about agent capabilities.

## Test evidence

In `apps/homescreen/src-tauri`:
- `cargo check --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (post-#125 gate)
- `cargo test` — 47 passed, 1 ignored, 0 failed; includes the 409 run-registry tests (`second_concurrent_run_is_rejected_until_guard_drops`, cancel + candidate-suffix matching), the download progress map tests (accumulation, unknown totals, terminal events, late-event suppression after cancel, bounded logs, per-model single-flight), and the MCP schema tests.

At repo root:
- `npm ci && npm test` — 138 pass, 0 fail; includes `tests/daemon.test.mjs` (dead-pid stale card ⇒ not running, live pid + unreachable base_url ⇒ not running, live `/health` fixture ⇒ running with warm-model normalization).
- `npm run check` (build + typecheck + test + skills:validate + package:smoke) — all green.

Manual CLI smoke: `understudy daemon status` and `understudy doctor` verified against this machine's real agent card (app not running ⇒ "not detected", exit 1).

## Caveats

- **No manual HTTP smoke of the new endpoints**: exercising them requires launching the desktop Tauri app (GUI + model server processes), which was not feasible from this agent worktree. Coverage relies on the unit tests above plus the fact that the handlers are thin wrappers over existing `commands::*` functions.
- `warm_slot` stays asynchronous by design: it flips the slot to `loading` and returns; agents poll `/api/residency`.
- Benchmark cancellation is cooperative (between rows), so an in-flight row completes before the run stops.
- Wave 3 (eval schema) is concurrently active in `db.rs`/export-packet code; this PR's `commands.rs` changes are scoped to the benchmark-run entry points only and do not touch `TrainingPane.tsx` or eval panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->