### PR TITLE
Harden the local daemon server: token, auth ordering, deadlines

### DIFF
--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4426,6 +4426,7 @@ dependencies = [
  "axum",
  "chrono",
  "futures-util",
+ "getrandom 0.2.17",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -29,3 +29,4 @@ tokio = { version = "1", features = ["full"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio"] }
 sha2 = "0.10"
+getrandom = "0.2"

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -1561,6 +1561,12 @@ async fn call_sidekick_model(
     })
 }
 
+/// MCP tools that legitimately run for many minutes over one request (a
+/// non-dry-run benchmark awaits the whole run inline). These keep the
+/// connect timeout but skip the whole-request cap; the run registry's
+/// single-flight guard and cancel tool bound them instead.
+const LONG_RUNNING_MCP_TOOLS: &[&str] = &["run_fusion_benchmark", "run_fusion_benchmark_matrix"];
+
 async fn call_understudy_mcp(app: &AppHandle, args: &Value) -> Result<Value, String> {
     let tool_name = args
         .get("tool_name")
@@ -1575,14 +1581,18 @@ async fn call_understudy_mcp(app: &AppHandle, args: &Value) -> Result<Value, Str
         "method": "tools/call",
         "params": { "name": tool_name, "arguments": arguments }
     });
-    let response = reqwest::Client::builder()
+    let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
-        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
         .build()
-        .map_err(|e| format!("understudy MCP client failed: {e}"))?
+        .map_err(|e| format!("understudy MCP client failed: {e}"))?;
+    let mut request = client
         .post(format!("{}/mcp", base.trim_end_matches('/')))
         .bearer_auth(token)
-        .json(&body)
+        .json(&body);
+    if !LONG_RUNNING_MCP_TOOLS.contains(&tool_name) {
+        request = request.timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS));
+    }
+    let response = request
         .send()
         .await
         .map_err(|e| format!("understudy MCP request failed: {e}"))?;

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -90,6 +90,15 @@ const MAX_TOOL_ROUNDS: usize = 4;
 const BENCHMARK_MAX_TOOL_ROUNDS: usize = 4;
 const SIDEKICK_MAX_TOOL_ROUNDS: usize = 2;
 const SIDEKICK_REQUEST_TIMEOUT_SECS: u64 = 120;
+/// Connect timeout for every chat/benchmark HTTP client: a local server that
+/// isn't accepting should fail in seconds, not hang the turn.
+const CHAT_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Streaming path: idle (per-read) timeout instead of a whole-request
+/// timeout, so long generations survive as long as tokens keep flowing.
+const CHAT_STREAM_IDLE_TIMEOUT_SECS: u64 = 300;
+/// Non-streaming path (benchmark rows, agent chat, MCP tool calls): nothing
+/// arrives until generation finishes, so cap the whole request generously.
+const CHAT_REQUEST_TIMEOUT_SECS: u64 = 600;
 const SIDEKICK_MAX_CONTEXT_MESSAGES: usize = 16;
 const SIDEKICK_RECENT_CONTEXT_MESSAGES: usize = 10;
 const SIDEKICK_FILE_READ_LIMIT: usize = 48 * 1024;
@@ -657,23 +666,26 @@ async fn tool_result(
         "list_models" => json!(c::list_models()),
         "list_snapshot_models" => json!(c::list_snapshot_models()),
         "list_traces" => {
-            c::list_traces(args.get("limit").and_then(|v| v.as_u64()).map(|x| x as u32))
-                .map_err(|e| e.to_string())?
+            c::list_traces(args.get("limit").and_then(|v| v.as_u64()).map(|x| x as u32)).await?
         }
-        "search_traces" => c::search_traces(
-            args.get("q")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
-        "open_trace" => c::open_trace(
-            args.get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
+        "search_traces" => {
+            c::search_traces(
+                args.get("q")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            )
+            .await?
+        }
+        "open_trace" => {
+            c::open_trace(
+                args.get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            )
+            .await?
+        }
         "delegate_to_sidekick" => {
             delegate_to_sidekick(app, mgr, active_slot_id, session_id, "tool", args).await?
         }
@@ -1016,24 +1028,23 @@ fn sidekick_tool_result(app: &AppHandle, name: &str, args: &Value) -> Result<Val
         "status" => json!(c::get_status(app.clone())),
         "residency" => json!(c::get_residency(app.clone())),
         "list_models" => json!(c::list_models()),
+        // Sync dispatch: the _sync trace lookups block, bounded by the
+        // moraine-mcp call deadline.
         "list_traces" => {
-            c::list_traces(args.get("limit").and_then(|v| v.as_u64()).map(|x| x as u32))
-                .map_err(|e| e.to_string())?
+            c::list_traces_sync(args.get("limit").and_then(|v| v.as_u64()).map(|x| x as u32))?
         }
-        "search_traces" => c::search_traces(
+        "search_traces" => c::search_traces_sync(
             args.get("q")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
-        "open_trace" => c::open_trace(
+        )?,
+        "open_trace" => c::open_trace_sync(
             args.get("id")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
+        )?,
         "repo_files" => sidekick_repo_files(args)?,
         "repo_search" => sidekick_repo_search(args)?,
         "repo_open" => sidekick_repo_open(args)?,
@@ -1395,29 +1406,26 @@ fn sidekick_understudy_mcp_read(app: &AppHandle, args: &Value) -> Result<Value, 
                 .map(|x| x as u32)
         )
         .map_err(|e| e.to_string())?),
-        "list_traces" => c::list_traces(
+        "list_traces" => c::list_traces_sync(
             arguments
                 .get("limit")
                 .and_then(|v| v.as_u64())
                 .map(|x| x as u32),
-        )
-        .map_err(|e| e.to_string())?,
-        "search_traces" => c::search_traces(
+        )?,
+        "search_traces" => c::search_traces_sync(
             arguments
                 .get("q")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
-        "open_trace" => c::open_trace(
+        )?,
+        "open_trace" => c::open_trace_sync(
             arguments
                 .get("id")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
+        )?,
         other => return Err(format!("unsupported sidekick MCP read tool: {other}")),
     })
 }
@@ -1567,7 +1575,11 @@ async fn call_understudy_mcp(app: &AppHandle, args: &Value) -> Result<Value, Str
         "method": "tools/call",
         "params": { "name": tool_name, "arguments": arguments }
     });
-    let response = reqwest::Client::new()
+    let response = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("understudy MCP client failed: {e}"))?
         .post(format!("{}/mcp", base.trim_end_matches('/')))
         .bearer_auth(token)
         .json(&body)
@@ -2450,6 +2462,8 @@ pub async fn chat_stream(
     }
 
     let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
+        .read_timeout(Duration::from_secs(CHAT_STREAM_IDLE_TIMEOUT_SECS))
         .build()
         .map_err(|e| e.to_string())?;
 
@@ -2685,6 +2699,8 @@ pub async fn benchmark_local_chat(
     }
 
     let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
         .build()
         .map_err(|e| e.to_string())?;
     let mut final_content = String::new();
@@ -2789,6 +2805,8 @@ pub async fn benchmark_gateway_chat(
     let compacted = compaction_reason.is_some();
 
     let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
         .build()
         .map_err(|e| e.to_string())?;
     let mut final_content = String::new();
@@ -2896,6 +2914,8 @@ pub async fn agent_chat(
     ];
 
     let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
         .build()
         .map_err(|e| e.to_string())?;
     let mut final_content = String::new();

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -860,6 +860,7 @@ pub fn connect(app: AppHandle) -> Result<(), String> {
     if !status.success() {
         return Err(format!("moraine up exited with {status}"));
     }
+    crate::sidecar::invalidate_moraine_state_cache();
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }
@@ -873,6 +874,7 @@ pub fn disconnect(app: AppHandle) -> Result<(), String> {
     if !status.success() {
         return Err(format!("moraine down exited with {status}"));
     }
+    crate::sidecar::invalidate_moraine_state_cache();
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }
@@ -1036,8 +1038,13 @@ pub fn get_moraine_state() -> MoraineState {
     crate::moraine::detect()
 }
 
-#[tauri::command]
-pub fn list_traces(limit: Option<u32>) -> Result<Value, String> {
+// The trace lookups spawn `moraine-mcp` and block on its stdout (bounded by
+// the deadline in `mcp::call_tool`). The `_sync` cores exist for callers that
+// already run on a blocking thread (the local server); the Tauri commands are
+// async and push the work off the main thread so a slow child never freezes
+// the GUI.
+
+pub fn list_traces_sync(limit: Option<u32>) -> Result<Value, String> {
     let end = chrono::Utc::now();
     let start = end - chrono::Duration::days(60);
     let args = json!({
@@ -1049,15 +1056,37 @@ pub fn list_traces(limit: Option<u32>) -> Result<Value, String> {
     mcp::call_tool("list_sessions", args).map_err(|e| e.to_string())
 }
 
-#[tauri::command]
-pub fn search_traces(query: String) -> Result<Value, String> {
+pub fn search_traces_sync(query: String) -> Result<Value, String> {
     mcp::call_tool("search_sessions", json!({ "query": query, "n_hits": 20 }))
         .map_err(|e| e.to_string())
 }
 
-#[tauri::command]
-pub fn open_trace(id: String) -> Result<Value, String> {
+pub fn open_trace_sync(id: String) -> Result<Value, String> {
     mcp::call_tool("open", json!({ "id": id })).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn list_traces(limit: Option<u32>) -> Result<Value, String> {
+    run_trace_blocking(move || list_traces_sync(limit)).await
+}
+
+#[tauri::command]
+pub async fn search_traces(query: String) -> Result<Value, String> {
+    run_trace_blocking(move || search_traces_sync(query)).await
+}
+
+#[tauri::command]
+pub async fn open_trace(id: String) -> Result<Value, String> {
+    run_trace_blocking(move || open_trace_sync(id)).await
+}
+
+async fn run_trace_blocking<F>(f: F) -> Result<Value, String>
+where
+    F: FnOnce() -> Result<Value, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(f)
+        .await
+        .map_err(|e| format!("trace task failed: {e}"))?
 }
 
 #[tauri::command]
@@ -1083,6 +1112,7 @@ pub fn start_moraine(app: AppHandle) -> Result<(), String> {
     if !status.success() {
         return Err(format!("moraine up exited with {status}"));
     }
+    crate::sidecar::invalidate_moraine_state_cache();
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }
@@ -1096,6 +1126,7 @@ pub fn stop_moraine(app: AppHandle) -> Result<(), String> {
     if !status.success() {
         return Err(format!("moraine down exited with {status}"));
     }
+    crate::sidecar::invalidate_moraine_state_cache();
     let _ = app.emit("status-changed", get_status(app.clone()));
     Ok(())
 }

--- a/apps/homescreen/src-tauri/src/mcp.rs
+++ b/apps/homescreen/src-tauri/src/mcp.rs
@@ -3,14 +3,30 @@ use anyhow::anyhow;
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
 use std::process::Stdio;
+use std::sync::mpsc;
+use std::time::Duration;
 
 const PROTOCOL_VERSION: &str = "2024-11-05";
+/// Hard deadline for one moraine-mcp round trip. A hung or wedged child is
+/// killed at the deadline so the caller gets an error instead of a pinned
+/// worker (HTTP) or a frozen GUI (Tauri command).
+const CALL_DEADLINE: Duration = Duration::from_secs(30);
 
 /// Spawn `moraine-mcp`, initialize, call one tool, return the parsed envelope.
 /// Per-call spawn keeps state simple at the cost of a re-init each invocation
-/// (tens of ms) — fine for UI-driven lookups.
+/// (tens of ms) — fine for UI-driven lookups. Blocking: run it under
+/// `spawn_blocking` from async contexts.
 pub fn call_tool(name: &str, args: Value) -> anyhow::Result<Value> {
-    let mut child = bin::command("moraine-mcp")
+    call_tool_on(bin::command("moraine-mcp"), name, args, CALL_DEADLINE)
+}
+
+fn call_tool_on(
+    mut cmd: std::process::Command,
+    name: &str,
+    args: Value,
+    deadline: Duration,
+) -> anyhow::Result<Value> {
+    let mut child = cmd
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -47,6 +63,25 @@ pub fn call_tool(name: &str, args: Value) -> anyhow::Result<Value> {
     }
 
     let stdout = child.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
+
+    // Watchdog: kill the child at the deadline unless the read loop finishes
+    // first. Killing closes stdout, so the read loop unblocks on EOF.
+    let child = std::sync::Arc::new(std::sync::Mutex::new(child));
+    let (done_tx, done_rx) = mpsc::channel::<()>();
+    let watchdog_child = child.clone();
+    let watchdog = std::thread::spawn(move || {
+        let timed_out = matches!(
+            done_rx.recv_timeout(deadline),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+        if timed_out {
+            if let Ok(mut c) = watchdog_child.lock() {
+                let _ = c.kill();
+            }
+        }
+        timed_out
+    });
+
     let mut result: Option<Value> = None;
     for line in BufReader::new(stdout).lines() {
         let line = match line {
@@ -63,17 +98,26 @@ pub fn call_tool(name: &str, args: Value) -> anyhow::Result<Value> {
         };
         if v.get("id").and_then(|i| i.as_u64()) == Some(2) {
             if let Some(err) = v.get("error") {
-                let _ = child.kill();
+                let _ = done_tx.send(());
+                let _ = watchdog.join();
+                reap(&child);
                 return Err(anyhow!("MCP error: {err}"));
             }
             result = v.get("result").cloned();
             break;
         }
     }
-    let _ = child.kill();
-    let _ = child.wait();
+    let _ = done_tx.send(());
+    let timed_out = watchdog.join().unwrap_or(false);
+    reap(&child);
 
-    let result = result.ok_or_else(|| anyhow!("no result from moraine-mcp"))?;
+    let result = result.ok_or_else(|| {
+        if timed_out {
+            anyhow!("moraine-mcp timed out after {deadline:?} and was killed")
+        } else {
+            anyhow!("no result from moraine-mcp")
+        }
+    })?;
     // Moraine returns the machine-readable envelope in `structuredContent`;
     // `content[0].text` is only a human-readable summary.
     if let Some(sc) = result.get("structuredContent") {
@@ -86,4 +130,52 @@ pub fn call_tool(name: &str, args: Value) -> anyhow::Result<Value> {
         .and_then(|t| t.as_str())
         .ok_or_else(|| anyhow!("malformed MCP result content"))?;
     Ok(serde_json::from_str::<Value>(text).unwrap_or_else(|_| Value::String(text.to_string())))
+}
+
+fn reap(child: &std::sync::Arc<std::sync::Mutex<std::process::Child>>) {
+    if let Ok(mut c) = child.lock() {
+        let _ = c.kill();
+        let _ = c.wait();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use std::time::Instant;
+
+    #[test]
+    fn hung_child_is_killed_at_the_deadline() {
+        // `sleep` never writes a response; the watchdog must kill it and the
+        // call must return an error near the deadline, not hang.
+        let mut cmd = Command::new("sleep");
+        cmd.arg("60");
+        let started = Instant::now();
+        let result = call_tool_on(cmd, "noop", json!({}), Duration::from_millis(300));
+        assert!(result.is_err());
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "deadline did not fire: took {:?}",
+            started.elapsed()
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("timed out"),
+            "error should say it timed out"
+        );
+    }
+
+    #[test]
+    fn responsive_child_returns_before_the_deadline() {
+        // A stub that answers the id-2 call immediately; stdin is drained to
+        // /dev/null so writes never block.
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(
+            r#"cat > /dev/null &
+echo '{"jsonrpc":"2.0","id":2,"result":{"structuredContent":{"ok":true}}}'"#,
+        );
+        let value = call_tool_on(cmd, "noop", json!({}), Duration::from_secs(10))
+            .expect("stub responds in time");
+        assert_eq!(value, json!({ "ok": true }));
+    }
 }

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -125,10 +125,19 @@ pub fn start(app: AppHandle) {
         // 256-bit token and persist it. Old tokens stop working on upgrade.
         _ => {
             let t = gen_token();
-            if let Err(err) = db.setting_set(TOKEN_KEY, &t) {
-                eprintln!("understudy db: persisting server token failed: {err:#}");
+            match db.setting_set(TOKEN_KEY, &t) {
+                Ok(()) => t,
+                Err(err) => {
+                    eprintln!("understudy db: persisting server token failed: {err:#}");
+                    // Serve whatever the DB holds: `info()` reads the token
+                    // from the DB, so serving the unpersisted one would 401
+                    // every caller. Retry the upgrade next launch.
+                    match db.setting_get(TOKEN_KEY) {
+                        Some(existing) => existing,
+                        None => t,
+                    }
+                }
             }
-            t
         }
     };
     let port = db

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -11,9 +11,10 @@
 // run on the Tauri async runtime.
 
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Path, Query, Request, State},
     http::{HeaderMap, StatusCode},
-    response::IntoResponse,
+    middleware::Next,
+    response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
 };
@@ -92,7 +93,22 @@ pub fn router(ctx: Ctx) -> Router {
         .route("/mcp", post(mcp))
         .route("/.well-known/agent.json", get(a2a_card))
         .route("/a2a", post(a2a_task))
+        .layer(axum::middleware::from_fn_with_state(ctx.clone(), auth_mw))
         .with_state(ctx)
+}
+
+/// Reject unauthenticated requests before any extractor runs, so callers
+/// without a token get a bare 401 instead of 422 body-schema detail they
+/// could use to probe the API shape. Handlers keep their own `auth` call as
+/// defense in depth.
+async fn auth_mw(State(ctx): State<Ctx>, req: Request, next: Next) -> Response {
+    if req.uri().path() == "/health" {
+        return next.run(req).await;
+    }
+    match auth(&ctx, req.headers()) {
+        Ok(()) => next.run(req).await,
+        Err(e) => e.into_response(),
+    }
 }
 
 /// Resolve (or create) a bearer token + port, then run the server on a dedicated
@@ -103,8 +119,11 @@ pub fn start(app: AppHandle) {
         None => return,
     };
     let token = match db.setting_get(TOKEN_KEY) {
-        Some(t) => t,
-        None => {
+        Some(t) if !is_legacy_token(&t) => t,
+        // Missing, or minted by the old 64-bit time/pid scheme (guessable by
+        // any local process that can estimate install time): mint a fresh
+        // 256-bit token and persist it. Old tokens stop working on upgrade.
+        _ => {
             let t = gen_token();
             if let Err(err) = db.setting_set(TOKEN_KEY, &t) {
                 eprintln!("understudy db: persisting server token failed: {err:#}");
@@ -150,17 +169,33 @@ fn auth(ctx: &Ctx, headers: &HeaderMap) -> Result<(), (StatusCode, String)> {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     let provided = h.strip_prefix("Bearer ").unwrap_or("");
-    if provided.is_empty() || provided != ctx.token {
+    if provided.is_empty() || !token_matches(provided, &ctx.token) {
         return Err((StatusCode::UNAUTHORIZED, "unauthorized".into()));
     }
     Ok(())
+}
+
+/// Constant-time bearer comparison: compare fixed-size digests so neither
+/// content nor length differences shape the timing.
+fn token_matches(provided: &str, expected: &str) -> bool {
+    use sha2::{Digest, Sha256};
+    let a = Sha256::digest(provided.as_bytes());
+    let b = Sha256::digest(expected.as_bytes());
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
 }
 
 // ---------------- REST handlers ----------------
 
 async fn status(State(ctx): State<Ctx>, h: HeaderMap) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
-    Ok(Json(json!(crate::commands::get_status(ctx.app.clone()))))
+    // get_status can probe `moraine status` on a cold cache — keep it off
+    // the axum workers.
+    let app = ctx.app.clone();
+    let snapshot = blocking(move || Ok::<_, String>(crate::commands::get_status(app))).await?;
+    Ok(Json(json!(snapshot)))
 }
 async fn models(State(ctx): State<Ctx>, h: HeaderMap) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
@@ -193,10 +228,19 @@ where
     T: Send + 'static,
     F: FnOnce() -> Result<T, String> + Send + 'static,
 {
+    blocking_status(f, StatusCode::BAD_REQUEST).await
+}
+
+/// `blocking`, with the caller's error status (trace lookups report 502).
+async fn blocking_status<T, F>(f: F, err_status: StatusCode) -> Result<T, (StatusCode, String)>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
     tokio::task::spawn_blocking(f)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("task failed: {e}")))?
-        .map_err(|e| (StatusCode::BAD_REQUEST, e))
+        .map_err(|e| (err_status, e))
 }
 
 #[derive(serde::Deserialize)]
@@ -582,9 +626,12 @@ async fn traces_list(
     Query(q): Query<LimitQ>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
-    crate::commands::list_traces(q.limit)
-        .map(Json)
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e))
+    blocking_status(
+        move || crate::commands::list_traces_sync(q.limit),
+        StatusCode::BAD_GATEWAY,
+    )
+    .await
+    .map(Json)
 }
 #[derive(serde::Deserialize)]
 struct SearchQ {
@@ -596,9 +643,12 @@ async fn traces_search(
     Query(q): Query<SearchQ>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
-    crate::commands::search_traces(q.q)
-        .map(Json)
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e))
+    blocking_status(
+        move || crate::commands::search_traces_sync(q.q),
+        StatusCode::BAD_GATEWAY,
+    )
+    .await
+    .map(Json)
 }
 async fn traces_open(
     State(ctx): State<Ctx>,
@@ -606,9 +656,12 @@ async fn traces_open(
     Path(id): Path<String>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
-    crate::commands::open_trace(id)
-        .map(Json)
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e))
+    blocking_status(
+        move || crate::commands::open_trace_sync(id),
+        StatusCode::BAD_GATEWAY,
+    )
+    .await
+    .map(Json)
 }
 
 /// Inbound: an agent asks the GUI to focus a pane / show something.
@@ -941,7 +994,7 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
     use crate::commands as c;
     let app = ctx.app.clone();
     Ok(match name {
-        "status" => json!(c::get_status(app)),
+        "status" => json!(call_blocking(move || Ok::<_, String>(c::get_status(app))).await?),
         "list_models" => json!(c::list_models()),
         "list_snapshot_models" => json!(c::list_snapshot_models()),
         "residency" => json!(c::get_residency(app)),
@@ -1104,23 +1157,25 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
         }
         "aa_models" => json!(c::aa_models(app).await.map_err(|e| e.to_string())?),
         "list_traces" => {
-            c::list_traces(args.get("limit").and_then(|v| v.as_u64()).map(|x| x as u32))
-                .map_err(|e| e.to_string())?
+            let limit = args.get("limit").and_then(|v| v.as_u64()).map(|x| x as u32);
+            call_blocking(move || c::list_traces_sync(limit)).await?
         }
-        "search_traces" => c::search_traces(
-            args.get("q")
+        "search_traces" => {
+            let q = args
+                .get("q")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
-                .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
-        "open_trace" => c::open_trace(
-            args.get("id")
+                .to_string();
+            call_blocking(move || c::search_traces_sync(q)).await?
+        }
+        "open_trace" => {
+            let id = args
+                .get("id")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
-                .to_string(),
-        )
-        .map_err(|e| e.to_string())?,
+                .to_string();
+            call_blocking(move || c::open_trace_sync(id)).await?
+        }
         "ui_focus" => {
             let _ = app.emit(
                 "server-focus",
@@ -1169,15 +1224,22 @@ async fn a2a_task(
     })))
 }
 
+/// 256-bit random bearer token, hex-encoded (64 chars).
 fn gen_token() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let mut x: u64 = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(0);
-    x ^= std::process::id() as u64;
-    x = x.wrapping_mul(0x9E3779B97F4A7C15).rotate_left(13) ^ x;
-    format!("{x:016x}")
+    let mut bytes = [0u8; 32];
+    if getrandom::getrandom(&mut bytes).is_err() {
+        // Last-resort entropy; getrandom does not fail on supported platforms.
+        use sha2::{Digest, Sha256};
+        let seed = format!("{:?}:{}", std::time::SystemTime::now(), std::process::id());
+        bytes = Sha256::digest(seed.as_bytes()).into();
+    }
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Tokens minted before the random scheme were 16 hex chars derived from
+/// time XOR pid — treat anything but 64 hex chars as legacy.
+fn is_legacy_token(token: &str) -> bool {
+    token.len() != 64 || !token.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 /// Info for the GUI (Account/Status): how to reach the local server + its token.
@@ -1200,6 +1262,34 @@ fn _unused() -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gen_token_is_64_hex_and_unique() {
+        let a = gen_token();
+        let b = gen_token();
+        assert_eq!(a.len(), 64);
+        assert!(a.bytes().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "two generated tokens collided");
+        assert!(!is_legacy_token(&a));
+    }
+
+    #[test]
+    fn legacy_tokens_are_detected() {
+        // The old scheme emitted 16 hex chars from time XOR pid.
+        assert!(is_legacy_token("9e3779b97f4a7c15"));
+        assert!(is_legacy_token(""));
+        // Right length, non-hex content is still not one of ours.
+        assert!(is_legacy_token(&"g".repeat(64)));
+    }
+
+    #[test]
+    fn token_matches_is_exact_and_length_safe() {
+        let token = gen_token();
+        assert!(token_matches(&token, &token));
+        assert!(!token_matches(&token[..32], &token));
+        assert!(!token_matches(&gen_token(), &token));
+        assert!(!token_matches("", &token));
+    }
 
     #[test]
     fn every_mcp_tool_advertises_a_real_object_schema() {

--- a/apps/homescreen/src-tauri/src/sidecar.rs
+++ b/apps/homescreen/src-tauri/src/sidecar.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -39,39 +40,46 @@ struct CachedState {
 }
 
 static MORAINE_STATE: Mutex<Option<CachedState>> = Mutex::new(None);
+/// Bumped on invalidation so an in-flight background refresh (started before
+/// `moraine up`/`down`) can't write its stale result over the fresh probe.
+static MORAINE_STATE_GEN: AtomicU64 = AtomicU64::new(0);
 
 /// Drop the cached state; the next read probes synchronously. Call after
 /// `moraine up`/`moraine down` so connect/disconnect reflect immediately.
 pub fn invalidate_moraine_state_cache() {
     let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
+    MORAINE_STATE_GEN.fetch_add(1, Ordering::SeqCst);
     *guard = None;
+}
+
+fn store_state(state: &'static str, generation: u64) {
+    let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
+    if MORAINE_STATE_GEN.load(Ordering::SeqCst) != generation {
+        return; // invalidated while probing; the result is stale
+    }
+    *guard = Some(CachedState {
+        state,
+        at: Instant::now(),
+        refreshing: false,
+    });
 }
 
 fn moraine_state() -> &'static str {
     let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
+    let generation = MORAINE_STATE_GEN.load(Ordering::SeqCst);
     if let Some(cached) = guard.as_mut() {
         if cached.at.elapsed() > MORAINE_STATE_TTL && !cached.refreshing {
             cached.refreshing = true;
-            std::thread::spawn(|| {
+            std::thread::spawn(move || {
                 let state = probe_moraine_state();
-                let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
-                *guard = Some(CachedState {
-                    state,
-                    at: Instant::now(),
-                    refreshing: false,
-                });
+                store_state(state, generation);
             });
         }
         return cached.state;
     }
     drop(guard);
     let state = probe_moraine_state();
-    let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
-    *guard = Some(CachedState {
-        state,
-        at: Instant::now(),
-        refreshing: false,
-    });
+    store_state(state, generation);
     state
 }
 

--- a/apps/homescreen/src-tauri/src/sidecar.rs
+++ b/apps/homescreen/src-tauri/src/sidecar.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 use std::process::Stdio;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 #[derive(Serialize, Clone)]
 pub struct ServiceState {
@@ -24,7 +26,56 @@ impl Services {
     }
 }
 
+/// Status polls arrive every few seconds from the GUI and agents; shelling
+/// out to `moraine status` on every poll is the hot-path cost this cache
+/// removes. The first read probes synchronously (so the GUI never sees a
+/// made-up state); stale reads return the last value and refresh off-thread.
+const MORAINE_STATE_TTL: Duration = Duration::from_secs(5);
+
+struct CachedState {
+    state: &'static str,
+    at: Instant,
+    refreshing: bool,
+}
+
+static MORAINE_STATE: Mutex<Option<CachedState>> = Mutex::new(None);
+
+/// Drop the cached state; the next read probes synchronously. Call after
+/// `moraine up`/`moraine down` so connect/disconnect reflect immediately.
+pub fn invalidate_moraine_state_cache() {
+    let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
+    *guard = None;
+}
+
 fn moraine_state() -> &'static str {
+    let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(cached) = guard.as_mut() {
+        if cached.at.elapsed() > MORAINE_STATE_TTL && !cached.refreshing {
+            cached.refreshing = true;
+            std::thread::spawn(|| {
+                let state = probe_moraine_state();
+                let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
+                *guard = Some(CachedState {
+                    state,
+                    at: Instant::now(),
+                    refreshing: false,
+                });
+            });
+        }
+        return cached.state;
+    }
+    drop(guard);
+    let state = probe_moraine_state();
+    let mut guard = MORAINE_STATE.lock().unwrap_or_else(|p| p.into_inner());
+    *guard = Some(CachedState {
+        state,
+        at: Instant::now(),
+        refreshing: false,
+    });
+    state
+}
+
+fn probe_moraine_state() -> &'static str {
     match crate::bin::command("moraine")
         .arg("status")
         .stdout(Stdio::null())


### PR DESCRIPTION
Executes `docs/dev-run/backlog-server-hardening.md` (all five items, severity order). Now that #126 made the desktop app the canonical local daemon, its 127.0.0.1 HTTP/MCP surface is what agents depend on — this PR makes that surface hold up.

## What changed

1. **Bearer token strength + comparison** (`server.rs`): token is now 32 random bytes (`getrandom`) hex-encoded, replacing the brute-forceable 64-bit time-XOR-pid scheme. Legacy-format tokens are detected and regenerated on startup. Comparison is constant-time over SHA-256 digests, so neither content nor length shapes the timing.
2. **Auth before body extraction** (`server.rs`): an axum middleware rejects unauthenticated requests before any `Json<T>` extractor runs — no more 422 schema-probing without a token. `/health` stays public; handler-level `auth` calls remain as defense in depth.
3. **Subprocess deadlines** (`mcp.rs`, `commands.rs`): every `moraine-mcp` round trip gets a 30s watchdog that kills a hung child (read loop unblocks on EOF). The `list_traces`/`search_traces`/`open_trace` Tauri commands are now async + `spawn_blocking`, so a wedged child can't freeze the GUI; the server's trace/status handlers and MCP tool dispatch run off the axum workers (trace errors keep their 502 status).
4. **HTTP client timeouts** (`chat.rs`): all chat/benchmark `reqwest` clients get a 10s connect timeout. Non-streaming paths (benchmark rows, agent chat, local MCP tool calls) get a 600s whole-request cap; the streaming chat path uses a 300s idle **read** timeout instead, so long generations survive while a stalled server still fails the turn.
5. **`get_status` off the hot path** (`sidecar.rs`): `moraine status` result is cached for 5s and refreshed off-thread; first read probes synchronously, and the cache is invalidated on `moraine up`/`down` so connect/disconnect reflect immediately.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean; `cargo check --all-targets` clean
- 54 Rust tests pass — 5 new: token format/uniqueness, legacy-token detection, constant-time compare (incl. length mismatch), hung-child killed at deadline, responsive stub child returns
- `npm run check` + `npm test` (139 tests) pass
- Behavior note: upgrading regenerates the server token by design (old 64-bit tokens are invalid); agents re-read it from the same place as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->