### PR TITLE
Bridge app benchmark evidence into the CLI promotion flow

### DIFF
--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.2.2"
+version = "0.2.4"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/account.rs
+++ b/apps/homescreen/src-tauri/src/account.rs
@@ -42,10 +42,7 @@ pub fn status() -> Result<Value> {
                     ("api_key_suffix", json!(resolved.api_key_suffix())),
                     ("org_id", json!(resolved.org_id)),
                 ] {
-                    let missing = obj
-                        .get(key)
-                        .map(|v| v.is_null())
-                        .unwrap_or(true);
+                    let missing = obj.get(key).map(|v| v.is_null()).unwrap_or(true);
                     if missing && !fill.is_null() {
                         obj.insert(key.into(), fill);
                     }

--- a/apps/homescreen/src-tauri/src/agent_card.rs
+++ b/apps/homescreen/src-tauri/src/agent_card.rs
@@ -35,8 +35,7 @@ fn card_path() -> Option<PathBuf> {
 }
 
 fn now_iso() -> String {
-    chrono::Utc::now()
-        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 /// The local API server came up (bind succeeded). Records how a fresh coding
@@ -94,7 +93,9 @@ static CARD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn update<F: FnOnce(&mut Map<String, Value>)>(f: F) {
     let Some(path) = card_path() else { return };
-    let _guard = CARD_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = CARD_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     if let Err(err) = update_at(&path, f) {
         eprintln!("understudy agent-card: write failed: {err}");
     }
@@ -195,8 +196,7 @@ mod tests {
         })
         .unwrap();
 
-        let card: Value =
-            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let card: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         // Skill-written blocks survive untouched.
         assert_eq!(card["understudy"]["name"], "Gemma 4 E2B");
         assert_eq!(card["companion"]["alive"], false);
@@ -216,8 +216,7 @@ mod tests {
             app.insert("running".into(), json!(true));
         })
         .unwrap();
-        let card: Value =
-            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let card: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(card["schema_version"], SCHEMA_VERSION);
         assert!(card["created_at"].is_string());
         assert_eq!(card["app"]["running"], true);
@@ -238,8 +237,7 @@ mod tests {
             app.insert("running".into(), json!(false));
         })
         .unwrap();
-        let card: Value =
-            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let card: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(card["app"]["running"], false);
     }
 }

--- a/apps/homescreen/src-tauri/src/agent_ops.rs
+++ b/apps/homescreen/src-tauri/src/agent_ops.rs
@@ -91,7 +91,10 @@ pub fn apply_download_event(progress: &mut DownloadProgress, event: &Value) {
             let Some(name) = event.get("name").and_then(|n| n.as_str()) else {
                 return;
             };
-            let downloaded = event.get("downloaded").and_then(|v| v.as_u64()).unwrap_or(0);
+            let downloaded = event
+                .get("downloaded")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             let total = event.get("total").and_then(|v| v.as_u64());
             progress
                 .files
@@ -400,9 +403,14 @@ mod tests {
     fn second_concurrent_run_is_rejected_until_guard_drops() {
         let runs = BenchRuns::new();
         let guard = runs.begin("run-a").expect("first run starts");
-        let err = runs.begin("run-b").expect_err("second run must be rejected");
+        let err = runs
+            .begin("run-b")
+            .expect_err("second run must be rejected");
         assert!(err.starts_with(RUN_CONFLICT), "conflict prefix: {err}");
-        assert!(err.contains("run-a"), "conflict names the active run: {err}");
+        assert!(
+            err.contains("run-a"),
+            "conflict names the active run: {err}"
+        );
         drop(guard);
         // Slot is free again after the guard drops (ok, error, or panic path).
         let _guard = runs.begin("run-b").expect("slot freed after drop");
@@ -483,12 +491,18 @@ mod tests {
     #[test]
     fn done_and_error_events_are_terminal() {
         let mut done = DownloadProgress::new("dl-1", "model-x");
-        apply_download_event(&mut done, &json!({ "type": "Done", "dest": "/models/x", "files": 3 }));
+        apply_download_event(
+            &mut done,
+            &json!({ "type": "Done", "dest": "/models/x", "files": 3 }),
+        );
         assert_eq!(done.status, "done");
         assert_eq!(done.dest.as_deref(), Some("/models/x"));
 
         let mut failed = DownloadProgress::new("dl-2", "model-x");
-        apply_download_event(&mut failed, &json!({ "type": "Error", "message": "sha256 mismatch" }));
+        apply_download_event(
+            &mut failed,
+            &json!({ "type": "Error", "message": "sha256 mismatch" }),
+        );
         assert_eq!(failed.status, "error");
         assert_eq!(failed.error.as_deref(), Some("sha256 mismatch"));
     }
@@ -497,8 +511,14 @@ mod tests {
     fn cancelled_download_ignores_late_events_from_aborted_task() {
         let mut p = DownloadProgress::new("dl-1", "model-x");
         p.status = "cancelled".to_string();
-        apply_download_event(&mut p, &json!({ "type": "Done", "dest": "/models/x", "files": 3 }));
-        apply_download_event(&mut p, &json!({ "type": "File", "name": "a", "downloaded": 1 }));
+        apply_download_event(
+            &mut p,
+            &json!({ "type": "Done", "dest": "/models/x", "files": 3 }),
+        );
+        apply_download_event(
+            &mut p,
+            &json!({ "type": "File", "name": "a", "downloaded": 1 }),
+        );
         assert_eq!(p.status, "cancelled");
         assert!(p.files.is_empty());
     }
@@ -507,7 +527,10 @@ mod tests {
     fn logs_are_bounded() {
         let mut p = DownloadProgress::new("dl-1", "model-x");
         for i in 0..(DOWNLOAD_LOG_CAP + 10) {
-            apply_download_event(&mut p, &json!({ "type": "Log", "message": format!("m{i}") }));
+            apply_download_event(
+                &mut p,
+                &json!({ "type": "Log", "message": format!("m{i}") }),
+            );
         }
         assert_eq!(p.logs.len(), DOWNLOAD_LOG_CAP);
         assert_eq!(p.logs.last().map(String::as_str), Some("m29"));

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -471,8 +471,7 @@ fn safe_target(root: &Path, name: &str) -> Result<PathBuf, String> {
 /// Shared model cache root (UNDERSTUDY_MODEL_HOME override, else
 /// ~/.understudy/models) — see `models::models_dir`.
 fn models_dir() -> PathBuf {
-    models::models_dir()
-        .unwrap_or_else(|| PathBuf::from(".").join(".understudy").join("models"))
+    models::models_dir().unwrap_or_else(|| PathBuf::from(".").join(".understudy").join("models"))
 }
 
 fn command_status(id: &str, label: &str, command: String, args: &[&str]) -> ToolStatus {

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -428,6 +428,69 @@ pub struct FusionBenchmarkComparisonPacket {
     /// `understudy.eval_result.v1` shape. Existing consumers of `summary` and
     /// `route_policy` are unaffected.
     pub eval_results: Vec<EvalResultV1>,
+    /// Additive: packet-level provenance so skills can admit this packet as
+    /// claim evidence — hash of the eval rows, the frozen-split identities,
+    /// and the cost bases present (see the claim-packet contract in
+    /// skills/optimize-workload/SKILL.md).
+    pub provenance: ExportPacketProvenance,
+}
+
+/// Packet-level provenance for exported eval evidence. `eval_results_sha256`
+/// is the SHA-256 of the compact JSON serialization of the `eval_results`
+/// array, so a consumer can verify the rows were not edited after export.
+/// The remaining fields are the distinct row-level identities, surfaced at
+/// packet level so a skill can check split identity and cost basis without
+/// re-scanning every row.
+#[derive(Serialize, Clone)]
+pub struct ExportPacketProvenance {
+    pub eval_results_sha256: String,
+    pub eval_result_rows: u64,
+    pub run_ids: Vec<String>,
+    pub splits: Vec<String>,
+    pub harness_sha256s: Vec<String>,
+    pub split_sha256s: Vec<String>,
+    pub cost_bases: Vec<String>,
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+fn export_packet_provenance(
+    eval_results: &[EvalResultV1],
+) -> Result<ExportPacketProvenance, String> {
+    let canonical = serde_json::to_vec(eval_results).map_err(|e| e.to_string())?;
+    let mut run_ids = std::collections::BTreeSet::new();
+    let mut splits = std::collections::BTreeSet::new();
+    let mut harness_sha256s = std::collections::BTreeSet::new();
+    let mut split_sha256s = std::collections::BTreeSet::new();
+    let mut cost_bases = std::collections::BTreeSet::new();
+    for row in eval_results {
+        run_ids.insert(row.run_id.clone());
+        splits.insert(row.split.clone());
+        if let Some(h) = &row.provenance.harness_sha256 {
+            harness_sha256s.insert(h.clone());
+        }
+        if let Some(s) = &row.provenance.split_sha256 {
+            split_sha256s.insert(s.clone());
+        }
+        if let Some(basis) = &row.cost.basis {
+            cost_bases.insert(basis.clone());
+        }
+    }
+    Ok(ExportPacketProvenance {
+        eval_results_sha256: sha256_hex(&canonical),
+        eval_result_rows: eval_results.len() as u64,
+        run_ids: run_ids.into_iter().collect(),
+        splits: splits.into_iter().collect(),
+        harness_sha256s: harness_sha256s.into_iter().collect(),
+        split_sha256s: split_sha256s.into_iter().collect(),
+        cost_bases: cost_bases.into_iter().collect(),
+    })
 }
 
 #[derive(Serialize, Clone)]
@@ -713,15 +776,65 @@ fn default_fusion_run_id() -> String {
     format!("fusion-{}", chrono::Utc::now().timestamp_millis())
 }
 
-fn resolve_repo_output_path(path: PathBuf) -> PathBuf {
+/// Root for app-generated evidence exports. Skills (ramp-and-verify,
+/// capture-evidence) discover packets here; keep the location stable.
+pub fn exports_root() -> PathBuf {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    exports_root_under(&home)
+}
+
+fn exports_root_under(home: &std::path::Path) -> PathBuf {
+    home.join(".understudy").join("exports")
+}
+
+/// Resolve where an export packet is written. No path → the default name
+/// under the exports root. A relative path lands under the exports root. An
+/// absolute path is an explicit override — honored for the GUI (webview),
+/// but HTTP/MCP callers (`constrain_to_exports`) hold nothing more than the
+/// bearer token, so their writes must stay inside the exports root and `..`
+/// components are rejected outright.
+fn resolve_export_output_path(
+    requested: Option<String>,
+    default_rel: PathBuf,
+    constrain_to_exports: bool,
+) -> Result<PathBuf, String> {
+    resolve_export_output_path_under(
+        &exports_root(),
+        requested,
+        default_rel,
+        constrain_to_exports,
+    )
+}
+
+fn resolve_export_output_path_under(
+    root: &std::path::Path,
+    requested: Option<String>,
+    default_rel: PathBuf,
+    constrain_to_exports: bool,
+) -> Result<PathBuf, String> {
+    let Some(requested) = requested else {
+        return Ok(root.join(default_rel));
+    };
+    let path = PathBuf::from(requested);
+    if constrain_to_exports
+        && path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err("output_path may not contain '..'".to_string());
+    }
     if path.is_absolute() {
-        path
+        if constrain_to_exports && !path.starts_with(root) {
+            return Err(format!(
+                "output_path must stay under {} for API/MCP callers",
+                root.display()
+            ));
+        }
+        Ok(path)
     } else {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("..")
-            .join("..")
-            .join("..")
-            .join(path)
+        Ok(root.join(path))
     }
 }
 
@@ -786,9 +899,7 @@ fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSig
     let local_tool_calls: Vec<f64> = tool_scope.iter().map(|row| row.tool_calls as f64).collect();
     let local_tool_depth_rows = tool_scope
         .iter()
-        .filter(|row| {
-            row.tool_calls >= TOOL_DEPTH_ESCALATION_CALLS || row.status == "tool_limit"
-        })
+        .filter(|row| row.tool_calls >= TOOL_DEPTH_ESCALATION_CALLS || row.status == "tool_limit")
         .count() as u64;
     let benchmark_rows = app
         .state::<crate::db::Db>()
@@ -803,9 +914,7 @@ fn chat_route_signals(app: &AppHandle, session_id: Option<&str>) -> ChatRouteSig
         local_rows: local.len() as u64,
         // Rows are newest-first; decay old errors so a bad patch fades instead
         // of pinning the local route unhealthy for the whole window.
-        local_error_rate: route_policy::decayed_rate(
-            local.iter().map(|row| row.status != "ok"),
-        ),
+        local_error_rate: route_policy::decayed_rate(local.iter().map(|row| row.status != "ok")),
         sidekick_rows: sidekick.len() as u64,
         compacted_rows: rows.iter().filter(|row| row.compacted).count() as u64,
         session_compacted_rows: session_rows.iter().filter(|row| row.compacted).count() as u64,
@@ -1868,6 +1977,23 @@ pub fn export_fusion_benchmark_comparison(
     app: AppHandle,
     request: ExportFusionBenchmarkComparisonRequest,
 ) -> Result<FusionBenchmarkComparisonExport, String> {
+    export_fusion_benchmark_comparison_impl(app, request, false)
+}
+
+/// HTTP/MCP entry point: same export, but `output_path` is constrained to
+/// the exports root (any local token holder can call this).
+pub fn export_fusion_benchmark_comparison_constrained(
+    app: AppHandle,
+    request: ExportFusionBenchmarkComparisonRequest,
+) -> Result<FusionBenchmarkComparisonExport, String> {
+    export_fusion_benchmark_comparison_impl(app, request, true)
+}
+
+fn export_fusion_benchmark_comparison_impl(
+    app: AppHandle,
+    request: ExportFusionBenchmarkComparisonRequest,
+    constrain_to_exports: bool,
+) -> Result<FusionBenchmarkComparisonExport, String> {
     let limit = request.limit.unwrap_or(500);
     let summary = fusion_benchmark_run_summary(app.clone(), Some(limit))?;
     let eval_results = app
@@ -1907,6 +2033,7 @@ pub fn export_fusion_benchmark_comparison(
         })
         .collect::<Vec<_>>();
     groups.sort_by_key(|g| std::cmp::Reverse(g.rows));
+    let provenance = export_packet_provenance(&eval_results)?;
     let packet = FusionBenchmarkComparisonPacket {
         schema_version: "understudy.fusion_benchmark_comparison.v1",
         created_at: chrono::Utc::now().to_rfc3339(),
@@ -1919,16 +2046,16 @@ pub fn export_fusion_benchmark_comparison(
             decisions,
         },
         eval_results,
+        provenance,
     };
-    let path = request.output_path.map(PathBuf::from).unwrap_or_else(|| {
-        PathBuf::from(".understudy")
-            .join("fusion-benchmark")
-            .join(format!(
-                "comparison-{}.json",
-                chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
-            ))
-    });
-    let path = resolve_repo_output_path(path);
+    let path = resolve_export_output_path(
+        request.output_path,
+        PathBuf::from("fusion-benchmark").join(format!(
+            "comparison-{}.json",
+            chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
+        )),
+        constrain_to_exports,
+    )?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
@@ -1947,6 +2074,20 @@ pub fn export_fusion_benchmark_comparison(
 #[tauri::command]
 pub fn export_automationbench_handoff(
     request: ExportAutomationBenchHandoffRequest,
+) -> Result<AutomationBenchHandoffExport, String> {
+    export_automationbench_handoff_impl(request, false)
+}
+
+/// HTTP/MCP entry point: `output_path` constrained to the exports root.
+pub fn export_automationbench_handoff_constrained(
+    request: ExportAutomationBenchHandoffRequest,
+) -> Result<AutomationBenchHandoffExport, String> {
+    export_automationbench_handoff_impl(request, true)
+}
+
+fn export_automationbench_handoff_impl(
+    request: ExportAutomationBenchHandoffRequest,
+    constrain_to_exports: bool,
 ) -> Result<AutomationBenchHandoffExport, String> {
     let run_id = request
         .run_id
@@ -2033,15 +2174,14 @@ pub fn export_automationbench_handoff(
             "Use the candidate run_id when posting each result row so desktop summaries can compare gateway-glm, local-main, and local-fast.".to_string(),
         ],
     };
-    let path = request.output_path.map(PathBuf::from).unwrap_or_else(|| {
-        PathBuf::from(".understudy")
-            .join("fusion-benchmark")
-            .join(format!(
-                "automationbench-handoff-{}.json",
-                chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
-            ))
-    });
-    let path = resolve_repo_output_path(path);
+    let path = resolve_export_output_path(
+        request.output_path,
+        PathBuf::from("fusion-benchmark").join(format!(
+            "automationbench-handoff-{}.json",
+            chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
+        )),
+        constrain_to_exports,
+    )?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
@@ -2883,8 +3023,188 @@ pub fn server_info(app: AppHandle) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{eval_result_v1, fusion_benchmark_score};
+    use super::{
+        eval_result_v1, export_packet_provenance, fusion_benchmark_score,
+        resolve_export_output_path_under, sha256_hex,
+    };
     use crate::db::{Db, FusionBenchmarkInput};
+    use std::path::PathBuf;
+
+    #[test]
+    fn export_packet_provenance_hashes_and_summarizes_rows() {
+        let dir = std::env::temp_dir().join(format!(
+            "understudy-export-provenance-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let db = Db::open(dir.clone()).expect("open temp db");
+        let mut scored = benchmark_input("repo-search-summary", Some(0.6), "ok");
+        scored.harness_sha256 = Some("h-abc".to_string());
+        scored.split_sha256 = Some("s-def".to_string());
+        scored.cost_basis = Some("local-zero-marginal-cost".to_string());
+        db.record_fusion_benchmark(&scored).unwrap();
+        db.record_fusion_benchmark(&benchmark_input("repo-open-grounding", None, "skipped"))
+            .unwrap();
+
+        let rows: Vec<_> = db
+            .list_fusion_benchmarks(10)
+            .unwrap()
+            .iter()
+            .map(eval_result_v1)
+            .collect();
+        let provenance = export_packet_provenance(&rows).unwrap();
+
+        assert_eq!(provenance.eval_result_rows, 2);
+        // The hash is over the compact serialization of exactly these rows,
+        // so a consumer can recompute and compare.
+        let recomputed = sha256_hex(&serde_json::to_vec(&rows).unwrap());
+        assert_eq!(provenance.eval_results_sha256, recomputed);
+        assert_eq!(provenance.eval_results_sha256.len(), 64);
+        assert_eq!(provenance.run_ids, vec!["fusion-run-1".to_string()]);
+        assert_eq!(provenance.splits, vec!["none".to_string()]);
+        assert_eq!(provenance.harness_sha256s, vec!["h-abc".to_string()]);
+        assert_eq!(provenance.split_sha256s, vec!["s-def".to_string()]);
+        assert_eq!(
+            provenance.cost_bases,
+            vec!["local-zero-marginal-cost".to_string()]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn export_output_paths_default_and_constrain_to_exports_root() {
+        let root = std::env::temp_dir().join("understudy-exports-root-test");
+        let default_rel = PathBuf::from("fusion-benchmark").join("d.json");
+
+        // No path: default name under the exports root.
+        let p = resolve_export_output_path_under(&root, None, default_rel.clone(), true).unwrap();
+        assert_eq!(p, root.join(&default_rel));
+
+        // Relative paths land under the exports root for every caller.
+        let p = resolve_export_output_path_under(
+            &root,
+            Some("sub/file.json".to_string()),
+            default_rel.clone(),
+            true,
+        )
+        .unwrap();
+        assert_eq!(p, root.join("sub/file.json"));
+
+        // Constrained callers: `..` rejected, absolute-outside rejected,
+        // absolute-inside allowed.
+        assert!(resolve_export_output_path_under(
+            &root,
+            Some("../escape.json".to_string()),
+            default_rel.clone(),
+            true
+        )
+        .is_err());
+        assert!(resolve_export_output_path_under(
+            &root,
+            Some(
+                root.join("inside")
+                    .join("..")
+                    .join("..")
+                    .join("escape.json")
+                    .to_string_lossy()
+                    .to_string()
+            ),
+            default_rel.clone(),
+            true
+        )
+        .is_err());
+        assert!(resolve_export_output_path_under(
+            &root,
+            Some("/tmp/elsewhere.json".to_string()),
+            default_rel.clone(),
+            true
+        )
+        .is_err());
+        let inside = root.join("ok.json");
+        assert_eq!(
+            resolve_export_output_path_under(
+                &root,
+                Some(inside.to_string_lossy().to_string()),
+                default_rel.clone(),
+                true
+            )
+            .unwrap(),
+            inside
+        );
+
+        // The GUI (webview) may write anywhere it names explicitly.
+        assert_eq!(
+            resolve_export_output_path_under(
+                &root,
+                Some("/tmp/elsewhere.json".to_string()),
+                default_rel,
+                false
+            )
+            .unwrap(),
+            PathBuf::from("/tmp/elsewhere.json")
+        );
+    }
+
+    /// The rows an export packet carries must satisfy the shared schema file
+    /// itself (schemas/understudy.eval_result.v1.schema.json), not just our
+    /// hardcoded expectations — required fields, status/split enums, score
+    /// range, all read from the schema.
+    #[test]
+    fn export_eval_rows_validate_against_the_schema_file() {
+        let schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("schemas")
+            .join("understudy.eval_result.v1.schema.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&schema_path).expect("schema file"))
+                .expect("schema parses");
+        let required: Vec<&str> = schema["required"]
+            .as_array()
+            .expect("required list")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        let status_enum: Vec<&str> = schema["properties"]["status"]["enum"]
+            .as_array()
+            .expect("status enum")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        let split_enum: Vec<serde_json::Value> = schema["properties"]["split"]["enum"]
+            .as_array()
+            .expect("split enum")
+            .to_vec();
+
+        let dir = std::env::temp_dir().join(format!(
+            "understudy-export-schema-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let db = Db::open(dir.clone()).expect("open temp db");
+        db.record_fusion_benchmark(&benchmark_input("repo-search-summary", Some(1.0), "ok"))
+            .unwrap();
+        db.record_fusion_benchmark(&benchmark_input("judgment-boundary", None, "error"))
+            .unwrap();
+
+        for row in db.list_fusion_benchmarks(10).unwrap().iter() {
+            let value = serde_json::to_value(eval_result_v1(row)).unwrap();
+            for field in &required {
+                assert!(
+                    !value[*field].is_null(),
+                    "required field {field} missing/null in exported row"
+                );
+            }
+            assert_eq!(value["schema_version"], "understudy.eval_result.v1");
+            assert!(status_enum.contains(&value["status"].as_str().unwrap()));
+            assert!(split_enum.contains(&value["split"]));
+            if let Some(score) = value["score"].as_f64() {
+                assert!((0.0..=1.0).contains(&score));
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     fn benchmark_input(task_id: &str, score: Option<f64>, status: &str) -> FusionBenchmarkInput {
         FusionBenchmarkInput {

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -830,6 +830,11 @@ fn resolve_export_output_path_under(
     default_rel: PathBuf,
     constrain_to_exports: bool,
 ) -> Result<PathBuf, String> {
+    // An empty/whitespace path is treated as "no path": joining it would
+    // resolve to the root itself and put sibling files one level above it.
+    let requested = requested
+        .map(|r| r.trim().to_string())
+        .filter(|r| !r.is_empty());
     let Some(requested) = requested else {
         return Ok(root.join(default_rel));
     };
@@ -841,17 +846,27 @@ fn resolve_export_output_path_under(
     {
         return Err("output_path may not contain '..'".to_string());
     }
-    if path.is_absolute() {
+    let path = if path.is_absolute() {
         if constrain_to_exports && !path.starts_with(root) {
             return Err(format!(
                 "output_path must stay under {} for API/MCP callers",
                 root.display()
             ));
         }
-        Ok(path)
+        path
     } else {
-        Ok(root.join(path))
+        root.join(path)
+    };
+    if constrain_to_exports {
+        // The sibling JSONL lands in the packet's parent directory, so the
+        // requested path must name a file whose parent is still inside the
+        // root ("." or the root itself would escape one level up).
+        let parent_ok = path.parent().is_some_and(|p| p.starts_with(root));
+        if path.file_name().is_none() || !parent_ok {
+            return Err("output_path must name a file inside the exports root".to_string());
+        }
     }
+    Ok(path)
 }
 
 #[derive(Default)]
@@ -2088,7 +2103,13 @@ fn export_fusion_benchmark_comparison_impl(
     let bytes = serde_json::to_vec_pretty(&packet).map_err(|e| e.to_string())?;
     let mut text = String::from_utf8(bytes).map_err(|e| e.to_string())?;
     text.push('\n');
-    fs::write(&path, text).map_err(|e| e.to_string())?;
+    if let Err(err) = fs::write(&path, text) {
+        // Don't leave a hash-committed JSONL with no packet citing it.
+        if let Some(parent) = path.parent() {
+            let _ = fs::remove_file(parent.join(&jsonl_name));
+        }
+        return Err(err.to_string());
+    }
     let path = fs::canonicalize(&path).unwrap_or(path);
     Ok(FusionBenchmarkComparisonExport {
         schema_version: "understudy.fusion_benchmark_comparison_export.v1",
@@ -3079,11 +3100,8 @@ mod tests {
             .map(eval_result_v1)
             .collect();
         let jsonl = eval_results_jsonl(&rows).unwrap();
-        let provenance = export_packet_provenance(
-            &rows,
-            &jsonl,
-            "comparison-x.eval-results.jsonl".to_string(),
-        );
+        let provenance =
+            export_packet_provenance(&rows, &jsonl, "comparison-x.eval-results.jsonl".to_string());
 
         assert_eq!(provenance.eval_result_rows, 2);
         // The hash commits to the JSONL sibling file's bytes, so a consumer
@@ -3171,6 +3189,44 @@ mod tests {
             .unwrap(),
             inside
         );
+
+        // Empty/whitespace paths are "no path" (joining them would resolve
+        // to the root itself and place sibling files one level above it).
+        assert_eq!(
+            resolve_export_output_path_under(
+                &root,
+                Some("".to_string()),
+                default_rel.clone(),
+                true
+            )
+            .unwrap(),
+            root.join(&default_rel)
+        );
+        assert_eq!(
+            resolve_export_output_path_under(
+                &root,
+                Some("  ".to_string()),
+                default_rel.clone(),
+                true
+            )
+            .unwrap(),
+            root.join(&default_rel)
+        );
+        // "." and the root itself don't name a file inside the root.
+        assert!(resolve_export_output_path_under(
+            &root,
+            Some(".".to_string()),
+            default_rel.clone(),
+            true
+        )
+        .is_err());
+        assert!(resolve_export_output_path_under(
+            &root,
+            Some(root.to_string_lossy().to_string()),
+            default_rel.clone(),
+            true
+        )
+        .is_err());
 
         // The GUI (webview) may write anywhere it names explicitly.
         assert_eq!(

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -435,15 +435,18 @@ pub struct FusionBenchmarkComparisonPacket {
     pub provenance: ExportPacketProvenance,
 }
 
-/// Packet-level provenance for exported eval evidence. `eval_results_sha256`
-/// is the SHA-256 of the compact JSON serialization of the `eval_results`
-/// array, so a consumer can verify the rows were not edited after export.
-/// The remaining fields are the distinct row-level identities, surfaced at
-/// packet level so a skill can check split identity and cost basis without
-/// re-scanning every row.
+/// Packet-level provenance for exported eval evidence. The eval rows are
+/// also written to a sibling JSONL file (`eval_results_path`, one compact
+/// row per line) and `eval_results_sha256` is the SHA-256 of that file's
+/// bytes — so a consumer verifies the rows with a plain
+/// `shasum -a 256 <file>`, the same file-hash idiom the skills already use
+/// for `harness_sha256`/`splits_sha256`. The remaining fields are the
+/// distinct row-level identities, surfaced at packet level so a skill can
+/// check split identity and cost basis without re-scanning every row.
 #[derive(Serialize, Clone)]
 pub struct ExportPacketProvenance {
     pub eval_results_sha256: String,
+    pub eval_results_path: String,
     pub eval_result_rows: u64,
     pub run_ids: Vec<String>,
     pub splits: Vec<String>,
@@ -460,10 +463,22 @@ fn sha256_hex(bytes: &[u8]) -> String {
         .collect()
 }
 
+/// One compact `understudy.eval_result.v1` row per line — the byte-stable
+/// artifact the packet-level hash commits to.
+fn eval_results_jsonl(eval_results: &[EvalResultV1]) -> Result<String, String> {
+    let mut out = String::new();
+    for row in eval_results {
+        out.push_str(&serde_json::to_string(row).map_err(|e| e.to_string())?);
+        out.push('\n');
+    }
+    Ok(out)
+}
+
 fn export_packet_provenance(
     eval_results: &[EvalResultV1],
-) -> Result<ExportPacketProvenance, String> {
-    let canonical = serde_json::to_vec(eval_results).map_err(|e| e.to_string())?;
+    jsonl: &str,
+    eval_results_path: String,
+) -> ExportPacketProvenance {
     let mut run_ids = std::collections::BTreeSet::new();
     let mut splits = std::collections::BTreeSet::new();
     let mut harness_sha256s = std::collections::BTreeSet::new();
@@ -482,15 +497,16 @@ fn export_packet_provenance(
             cost_bases.insert(basis.clone());
         }
     }
-    Ok(ExportPacketProvenance {
-        eval_results_sha256: sha256_hex(&canonical),
+    ExportPacketProvenance {
+        eval_results_sha256: sha256_hex(jsonl.as_bytes()),
+        eval_results_path,
         eval_result_rows: eval_results.len() as u64,
         run_ids: run_ids.into_iter().collect(),
         splits: splits.into_iter().collect(),
         harness_sha256s: harness_sha256s.into_iter().collect(),
         split_sha256s: split_sha256s.into_iter().collect(),
         cost_bases: cost_bases.into_iter().collect(),
-    })
+    }
 }
 
 #[derive(Serialize, Clone)]
@@ -2033,7 +2049,24 @@ fn export_fusion_benchmark_comparison_impl(
         })
         .collect::<Vec<_>>();
     groups.sort_by_key(|g| std::cmp::Reverse(g.rows));
-    let provenance = export_packet_provenance(&eval_results)?;
+    let path = resolve_export_output_path(
+        request.output_path,
+        PathBuf::from("fusion-benchmark").join(format!(
+            "comparison-{}.json",
+            chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
+        )),
+        constrain_to_exports,
+    )?;
+    // The rows also go to a sibling JSONL file whose bytes the packet-level
+    // hash commits to, so consumers verify with `shasum -a 256`.
+    let jsonl_name = format!(
+        "{}.eval-results.jsonl",
+        path.file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "comparison".to_string())
+    );
+    let jsonl = eval_results_jsonl(&eval_results)?;
+    let provenance = export_packet_provenance(&eval_results, &jsonl, jsonl_name.clone());
     let packet = FusionBenchmarkComparisonPacket {
         schema_version: "understudy.fusion_benchmark_comparison.v1",
         created_at: chrono::Utc::now().to_rfc3339(),
@@ -2048,16 +2081,9 @@ fn export_fusion_benchmark_comparison_impl(
         eval_results,
         provenance,
     };
-    let path = resolve_export_output_path(
-        request.output_path,
-        PathBuf::from("fusion-benchmark").join(format!(
-            "comparison-{}.json",
-            chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
-        )),
-        constrain_to_exports,
-    )?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        fs::write(parent.join(&jsonl_name), &jsonl).map_err(|e| e.to_string())?;
     }
     let bytes = serde_json::to_vec_pretty(&packet).map_err(|e| e.to_string())?;
     let mut text = String::from_utf8(bytes).map_err(|e| e.to_string())?;
@@ -3024,7 +3050,7 @@ pub fn server_info(app: AppHandle) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use super::{
-        eval_result_v1, export_packet_provenance, fusion_benchmark_score,
+        eval_result_v1, eval_results_jsonl, export_packet_provenance, fusion_benchmark_score,
         resolve_export_output_path_under, sha256_hex,
     };
     use crate::db::{Db, FusionBenchmarkInput};
@@ -3052,14 +3078,28 @@ mod tests {
             .iter()
             .map(eval_result_v1)
             .collect();
-        let provenance = export_packet_provenance(&rows).unwrap();
+        let jsonl = eval_results_jsonl(&rows).unwrap();
+        let provenance = export_packet_provenance(
+            &rows,
+            &jsonl,
+            "comparison-x.eval-results.jsonl".to_string(),
+        );
 
         assert_eq!(provenance.eval_result_rows, 2);
-        // The hash is over the compact serialization of exactly these rows,
-        // so a consumer can recompute and compare.
-        let recomputed = sha256_hex(&serde_json::to_vec(&rows).unwrap());
-        assert_eq!(provenance.eval_results_sha256, recomputed);
+        // The hash commits to the JSONL sibling file's bytes, so a consumer
+        // verifies with a plain file hash (shasum -a 256).
+        assert_eq!(provenance.eval_results_sha256, sha256_hex(jsonl.as_bytes()));
         assert_eq!(provenance.eval_results_sha256.len(), 64);
+        assert_eq!(
+            provenance.eval_results_path,
+            "comparison-x.eval-results.jsonl"
+        );
+        // One compact row per line, each still a valid eval_result.v1 object.
+        assert_eq!(jsonl.lines().count(), 2);
+        for line in jsonl.lines() {
+            let row: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(row["schema_version"], "understudy.eval_result.v1");
+        }
         assert_eq!(provenance.run_ids, vec!["fusion-run-1".to_string()]);
         assert_eq!(provenance.splits, vec!["none".to_string()]);
         assert_eq!(provenance.harness_sha256s, vec!["h-abc".to_string()]);

--- a/apps/homescreen/src-tauri/src/creds.rs
+++ b/apps/homescreen/src-tauri/src/creds.rs
@@ -253,7 +253,10 @@ mod tests {
         // Nothing anywhere: not signed in.
         assert_eq!(resolve_from(None, None, None), None);
         let empty = temp_credentials_file(&json!({ "orgs": {} }));
-        assert_eq!(resolve_from(None, None, read_credentials_value(&empty)), None);
+        assert_eq!(
+            resolve_from(None, None, read_credentials_value(&empty)),
+            None
+        );
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -405,11 +405,16 @@ mod tests {
         assert_eq!(rows[0].certified, Some(true));
         assert!(rows[0].default_rung);
 
-        let wrong_schema = good.replace("understudy.model_catalog.v1", "understudy.model_catalog.v2");
-        assert!(parse_catalog(&wrong_schema).is_err(), "unknown schema_version must be rejected");
+        let wrong_schema =
+            good.replace("understudy.model_catalog.v1", "understudy.model_catalog.v2");
+        assert!(
+            parse_catalog(&wrong_schema).is_err(),
+            "unknown schema_version must be rejected"
+        );
         assert!(parse_catalog("not json").is_err());
         assert!(
-            parse_catalog(r#"{"schema_version":"understudy.model_catalog.v1","models":[]}"#).is_err(),
+            parse_catalog(r#"{"schema_version":"understudy.model_catalog.v1","models":[]}"#)
+                .is_err(),
             "an empty catalog must not clobber the fallback"
         );
     }

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -412,9 +412,9 @@ impl Residency {
             // Persist + benchmark record.
             if ready {
                 residency.persist(&app);
-                if let Err(err) = app
-                    .state::<Db>()
-                    .record_benchmark(&model_id, None, mem_gb, Some(load_ms))
+                if let Err(err) =
+                    app.state::<Db>()
+                        .record_benchmark(&model_id, None, mem_gb, Some(load_ms))
                 {
                     eprintln!("understudy db: record_benchmark failed: {err:#}");
                 }

--- a/apps/homescreen/src-tauri/src/route_policy.rs
+++ b/apps/homescreen/src-tauri/src/route_policy.rs
@@ -335,12 +335,7 @@ pub struct RouteDecision {
 }
 
 impl RouteDecision {
-    fn new(
-        route: &'static str,
-        use_sidekick: bool,
-        escalate_gateway: bool,
-        reason: &str,
-    ) -> Self {
+    fn new(route: &'static str, use_sidekick: bool, escalate_gateway: bool, reason: &str) -> Self {
         RouteDecision {
             route,
             use_sidekick,

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -248,7 +248,12 @@ where
 {
     tokio::task::spawn_blocking(f)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("task failed: {e}")))?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("task failed: {e}"),
+            )
+        })?
         .map_err(|e| (err_status, e))
 }
 
@@ -523,7 +528,7 @@ async fn export_fusion_benchmark_comparison(
     Json(body): Json<crate::commands::ExportFusionBenchmarkComparisonRequest>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
-    crate::commands::export_fusion_benchmark_comparison(ctx.app.clone(), body)
+    crate::commands::export_fusion_benchmark_comparison_constrained(ctx.app.clone(), body)
         .map(|v| Json(json!(v)))
         .map_err(|e| (StatusCode::BAD_GATEWAY, e))
 }
@@ -533,7 +538,7 @@ async fn export_automationbench_handoff(
     Json(body): Json<crate::commands::ExportAutomationBenchHandoffRequest>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
-    crate::commands::export_automationbench_handoff(body)
+    crate::commands::export_automationbench_handoff_constrained(body)
         .map(|v| Json(json!(v)))
         .map_err(|e| (StatusCode::BAD_GATEWAY, e))
 }
@@ -784,7 +789,8 @@ fn run_benchmark_properties(with_candidates: bool) -> Value {
             "description": "Defaults to gateway-glm, local-main, local-fast."
         });
     } else {
-        props["candidate"] = json!({ "type": "string", "enum": ["gateway-glm", "local-main", "local-fast"] });
+        props["candidate"] =
+            json!({ "type": "string", "enum": ["gateway-glm", "local-main", "local-fast"] });
         props["route"] = json!({ "type": "string", "enum": ["local", "gateway"] });
         props["model"] = json!({ "type": "string", "description": "Override the model id/path." });
     }
@@ -1078,8 +1084,15 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
                 .map(|x| x as u32);
             let residency = app.state::<crate::residency::Residency>();
             json!(
-                crate::chat::agent_chat(&app, &residency, slot_id, &session_id, &prompt, max_tokens)
-                    .await?
+                crate::chat::agent_chat(
+                    &app,
+                    &residency,
+                    slot_id,
+                    &session_id,
+                    &prompt,
+                    max_tokens
+                )
+                .await?
             )
         }
         "knowledge_dossiers" => json!(c::knowledge_dossiers()),
@@ -1115,13 +1128,16 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
             let request =
                 serde_json::from_value::<c::ExportFusionBenchmarkComparisonRequest>(args.clone())
                     .map_err(|e| format!("invalid Fusion comparison export request: {e}"))?;
-            json!(c::export_fusion_benchmark_comparison(app, request).map_err(|e| e.to_string())?)
+            json!(
+                c::export_fusion_benchmark_comparison_constrained(app, request)
+                    .map_err(|e| e.to_string())?
+            )
         }
         "export_automationbench_handoff" => {
             let request =
                 serde_json::from_value::<c::ExportAutomationBenchHandoffRequest>(args.clone())
                     .map_err(|e| format!("invalid AutomationBench handoff request: {e}"))?;
-            json!(c::export_automationbench_handoff(request).map_err(|e| e.to_string())?)
+            json!(c::export_automationbench_handoff_constrained(request).map_err(|e| e.to_string())?)
         }
         "chat_runs" => json!(c::chat_runs(
             app,

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -76,8 +76,11 @@ token/memory accounting.
 ### Export packet provenance
 
 Every `understudy.fusion_benchmark_comparison.v1` packet also carries a
-packet-level `provenance` block: `eval_results_sha256` (SHA-256 of the compact
-JSON serialization of the `eval_results` array — recompute it to verify the
-rows were not edited), row count, and the distinct run ids, split identities,
-row-level harness/split hashes, and cost bases. Skills admit an app export as
-claim evidence by checking this block; see `skills/ramp-and-verify/SKILL.md`.
+packet-level `provenance` block. The eval rows are written to a sibling JSONL
+file (`provenance.eval_results_path`, one compact `eval_result.v1` row per
+line) and `provenance.eval_results_sha256` is the SHA-256 of that file's bytes
+— verify with `shasum -a 256 <file>`, the same file-hash idiom as
+`harness_sha256`/`splits_sha256`. The block also surfaces row count and the
+distinct run ids, split identities, row-level harness/split hashes, and cost
+bases. Skills admit an app export as claim evidence by checking this block;
+see `skills/ramp-and-verify/SKILL.md`.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -53,3 +53,31 @@ The schema is standard JSON Schema (draft 2020-12). Repo tests use a
 lightweight structural check (required fields, enums, score range) so no
 validator dependency is needed; external consumers can use any draft-2020-12
 validator.
+
+## `understudy.route_decision_packet.v1`
+
+[`understudy.route_decision_packet.v1.schema.json`](understudy.route_decision_packet.v1.schema.json)
+is the route decision for one workload — written by the CLI planner
+(`src/route-decision.ts`) and validated by `understudy routes promote` before
+any field is consumed. `decision: "evaluate-first"` / `"local-only"` packets
+must never mutate hosted traffic; promotion-grade packets should cite their
+eval evidence (an app export packet path + `eval_results_sha256`, or a
+`claim.json`) in the optional `evidence` block.
+
+## `understudy.fusion_route_policy_export.v1`
+
+[`understudy.fusion_route_policy_export.v1.schema.json`](understudy.fusion_route_policy_export.v1.schema.json)
+is the desktop app's persisted Fusion route-decision evidence, carried in the
+`route_policy` field of every `understudy.fusion_benchmark_comparison.v1`
+export packet. It is the app-side counterpart a CLI route decision reconciles
+against: per-prompt decisions with policy class, readiness signals, and
+token/memory accounting.
+
+### Export packet provenance
+
+Every `understudy.fusion_benchmark_comparison.v1` packet also carries a
+packet-level `provenance` block: `eval_results_sha256` (SHA-256 of the compact
+JSON serialization of the `eval_results` array — recompute it to verify the
+rows were not edited), row count, and the distinct run ids, split identities,
+row-level harness/split hashes, and cost bases. Skills admit an app export as
+claim evidence by checking this block; see `skills/ramp-and-verify/SKILL.md`.

--- a/schemas/understudy.fusion_route_policy_export.v1.schema.json
+++ b/schemas/understudy.fusion_route_policy_export.v1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.fusion_route_policy_export.v1.schema.json",
+  "title": "understudy.fusion_route_policy_export.v1",
+  "description": "The desktop app's persisted Fusion route-policy decisions, exported inside an understudy.fusion_benchmark_comparison.v1 packet (route_policy field). This is the app-side evidence a CLI route decision can cite: per-prompt routing decisions with the policy class, readiness signals, and token/memory accounting, plus per-policy-class rollups. Additive-extensible; consumers must ignore unknown fields.",
+  "type": "object",
+  "required": ["schema_version", "rows", "groups", "decisions"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "understudy.fusion_route_policy_export.v1"
+    },
+    "rows": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of decision rows in `decisions`."
+    },
+    "groups": {
+      "type": "array",
+      "description": "Per-policy-class rollups, sorted by row count descending.",
+      "items": {
+        "type": "object",
+        "required": ["policy_class", "rows"],
+        "additionalProperties": true,
+        "properties": {
+          "policy_class": { "type": "string" },
+          "rows": { "type": "integer", "minimum": 0 },
+          "sidekick_rows": { "type": "integer", "minimum": 0 },
+          "gateway_rows": { "type": "integer", "minimum": 0 },
+          "sidekick_upgrade_rows": { "type": "integer", "minimum": 0 },
+          "local_rows": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "decisions": {
+      "type": "array",
+      "description": "One row per routing decision, newest first (the app's fusion_route_decisions table).",
+      "items": {
+        "type": "object",
+        "required": ["id", "recommended_route", "policy_class", "created_at"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "integer", "minimum": 0 },
+          "prompt_excerpt": { "type": "string", "description": "Truncated prompt only — never the full prompt." },
+          "current_route": { "type": ["string", "null"] },
+          "recommended_route": { "type": "string", "description": "local | gateway" },
+          "use_sidekick": { "type": "boolean" },
+          "escalate_gateway": { "type": "boolean" },
+          "upgrade_sidekick": { "type": "boolean" },
+          "reason": { "type": "string" },
+          "policy_class": { "type": "string" },
+          "signals": { "type": ["string", "null"], "description": "JSON-encoded routing signals snapshot." },
+          "main_model": { "type": ["string", "null"] },
+          "sidekick_model": { "type": ["string", "null"] },
+          "gateway_model": { "type": ["string", "null"] },
+          "local_ready": { "type": "boolean" },
+          "sidekick_ready": { "type": "boolean" },
+          "gateway_ready": { "type": "boolean" },
+          "prompt_tokens": { "type": "integer", "minimum": 0 },
+          "local_mem_gb": { "type": ["number", "null"], "minimum": 0 },
+          "created_at": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/understudy.route_decision_packet.v1.schema.json
+++ b/schemas/understudy.route_decision_packet.v1.schema.json
@@ -62,7 +62,7 @@
     "model_id": { "type": ["string", "null"], "description": "Model id to route to on promotion." },
     "route_model_id": { "type": ["string", "null"] },
     "route_traffic_pct": {
-      "type": ["number", "string", "null"],
+      "type": ["number", "null"],
       "description": "Traffic percentage for the promoted route; defaults to 10 when absent."
     },
     "recommended_next_command": { "type": ["string", "null"] },

--- a/schemas/understudy.route_decision_packet.v1.schema.json
+++ b/schemas/understudy.route_decision_packet.v1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.route_decision_packet.v1.schema.json",
+  "title": "understudy.route_decision_packet.v1",
+  "description": "A route decision for one workload: written by the CLI's route-decision planner (src/route-decision.ts) and consumed by `understudy routes promote`. `decision` gates what a consumer may do: 'evaluate-first' and 'local-only' packets must never mutate hosted traffic. Packets are additive-extensible; consumers must ignore fields they do not understand.",
+  "type": "object",
+  "required": ["schema_version", "decision"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "understudy.route_decision_packet.v1",
+      "description": "Version stamp for this packet shape. Consumers reject packets without it."
+    },
+    "decision": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The routing decision. 'evaluate-first' and 'local-only' block hosted promotion; other values (e.g. 'hosted-promotion-ready') may be promoted after review."
+    },
+    "workload_card": {
+      "type": ["string", "null"],
+      "description": "Path to the workload card the decision was planned from."
+    },
+    "incumbent": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "provider": { "type": ["string", "null"] },
+        "model": { "type": ["string", "null"] },
+        "known_latency_ms": { "type": ["number", "null"] },
+        "known_cost_usd": { "type": ["number", "null"] }
+      }
+    },
+    "constraints": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "description": "Workload shape, privacy boundary, data class, context/latency budgets, and the quality gate the route must satisfy."
+    },
+    "readiness": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "description": "What has actually been checked: local runner fit, redacted provider keys, supplier profiles, pricing sources."
+    },
+    "candidate_routes": {
+      "type": ["array", "null"],
+      "items": { "type": "object", "additionalProperties": true },
+      "description": "Ranked candidate routes with kind, provider/model, approval requirements, and pricing provenance."
+    },
+    "evidence": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "description": "Optional pointers to the eval evidence behind the decision — e.g. an app export packet path plus its provenance.eval_results_sha256, or a claim.json path. Promotion-grade packets should cite evidence here.",
+      "properties": {
+        "packet_path": { "type": ["string", "null"] },
+        "eval_results_sha256": { "type": ["string", "null"] },
+        "claim_path": { "type": ["string", "null"] }
+      }
+    },
+    "project_id": { "type": ["string", "null"] },
+    "project_slug": { "type": ["string", "null"] },
+    "workload_id": { "type": ["string", "null"], "description": "Hosted workload id for promotion." },
+    "workload_name": { "type": ["string", "null"], "description": "Hosted workload name for promotion." },
+    "model_id": { "type": ["string", "null"], "description": "Model id to route to on promotion." },
+    "route_model_id": { "type": ["string", "null"] },
+    "route_traffic_pct": {
+      "type": ["number", "string", "null"],
+      "description": "Traffic percentage for the promoted route; defaults to 10 when absent."
+    },
+    "recommended_next_command": { "type": ["string", "null"] },
+    "approval_required_before": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -130,7 +130,16 @@ enough provenance for another agent to repeat the step without guessing.
 
 Inspect the repo first to find where LLM calls happen and the current
 model/provider/harness/eval state, then surface that inventory before building
-anything. If the request/response path, dataset/trace shape, prompt purpose, or
+anything. The inventory includes evidence that already exists outside the
+repo: the Understudy desktop app exports benchmark comparison packets
+(`understudy.fusion_benchmark_comparison.v1`) under `~/.understudy/exports/`,
+each carrying `understudy.eval_result.v1` rows plus a packet-level
+`provenance` block (rows in a sibling JSONL file; verify
+`shasum -a 256 <provenance.eval_results_path>` equals
+`provenance.eval_results_sha256` before admitting it). Surface any verified
+packets in the inventory so the developer isn't asked to re-measure what the
+app already measured — the admission checklist lives in
+[`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md). If the request/response path, dataset/trace shape, prompt purpose, or
 success criteria are not already clear, route to
 [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) first and
 use its workload profile as the narrative source of truth. The deep inspection

--- a/skills/ramp-and-verify/SKILL.md
+++ b/skills/ramp-and-verify/SKILL.md
@@ -64,6 +64,11 @@ node dist/bin.js status --json
    incumbent by construction; confirm the workload's passthrough path works
    (`gateway probe`) before sending anything to the candidate.
 
+Desktop app export packets under `~/.understudy/exports/` are admissible for
+gate 1 once verified — shape, sibling-JSONL hash, split identity, and cost
+basis all check out. The admission checklist and verification transcript live
+in [`reference.md`](reference.md).
+
 ## The ladder
 
 Default tiers: **5% → 25% → 100%** (note: `routes set` defaults `--traffic-pct`

--- a/skills/ramp-and-verify/reference.md
+++ b/skills/ramp-and-verify/reference.md
@@ -1,0 +1,43 @@
+# ramp-and-verify — reference
+
+## Admitting desktop app exports as pre-ramp evidence
+
+The Understudy desktop app writes benchmark comparison packets
+(`understudy.fusion_benchmark_comparison.v1`) under `~/.understudy/exports/`
+(default `fusion-benchmark/comparison-<timestamp>.json`). List that directory
+and pick by the packet's `created_at`. A packet is admissible for pre-ramp
+gate 1 only after every check below passes:
+
+1. **Shape.** `schema_version` is `understudy.fusion_benchmark_comparison.v1`
+   and `eval_results` rows are `understudy.eval_result.v1`
+   ([`schemas/`](../../schemas/README.md)).
+2. **Hash.** The rows live in a sibling JSONL file named by
+   `provenance.eval_results_path` (one compact row per line);
+   `shasum -a 256 <that file>` must equal `provenance.eval_results_sha256`.
+   A mismatch means the rows were edited after export — reject the packet.
+3. **Split identity.** `provenance.splits` names the frozen-split identities
+   present in the rows. `none` rows are smoke evidence — fine for a
+   directional read, not sufficient alone for the frozen-eval verdict on a
+   workload that has a split contract; when one exists,
+   `provenance.split_sha256s` must match the workload's `splits.json` hashes.
+4. **Cost basis.** Only rows whose `cost.basis` is set (surfaced in
+   `provenance.cost_bases`) may back a cost statement; a null basis carries
+   no price — never invent one.
+5. **Scoring rules.** `unscored` rows are excluded from averages; a `score`
+   of 0 is a scored failure, never a missing value.
+
+The packet's `route_policy` block
+(`understudy.fusion_route_policy_export.v1`) is the app-side routing evidence
+a route-decision packet may cite in its `evidence` field before
+`understudy routes promote` consumes it (promote validates
+`understudy.route_decision_packet.v1` and refuses unversioned or
+evaluate-first packets).
+
+### Quick verification transcript
+
+```bash
+ls ~/.understudy/exports/fusion-benchmark/
+jq '.schema_version, .provenance' ~/.understudy/exports/fusion-benchmark/comparison-<ts>.json
+shasum -a 256 ~/.understudy/exports/fusion-benchmark/<provenance.eval_results_path>
+# compare against .provenance.eval_results_sha256 — must be equal
+```

--- a/src/commands/routes.ts
+++ b/src/commands/routes.ts
@@ -14,6 +14,7 @@ import {
   writeRouteSnapshot,
   type Workload,
 } from "../internal/workloads.js";
+import { validateRouteDecisionPacket } from "../route-decision.js";
 
 interface RouteOpts extends ProjectResolutionOptions {}
 
@@ -154,6 +155,7 @@ async function runRollback(cmd: Command, workloadValue: string, opts: RouteOpts)
 
 async function runPromote(cmd: Command, opts: PromoteOpts): Promise<void> {
   const packet = readPacket(opts.from);
+  validateRouteDecisionPacket(packet);
   const decision = stringValue(packet.decision);
   if (decision === "evaluate-first" || decision === "local-only") {
     throw new Error("Route packet is evaluate-first, not hosted-promotion-ready. Run local evaluation or pass explicit route inputs after review.");

--- a/src/route-decision.ts
+++ b/src/route-decision.ts
@@ -29,6 +29,49 @@ function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+export const ROUTE_DECISION_PACKET_SCHEMA_VERSION = "understudy.route_decision_packet.v1";
+
+/**
+ * Structural validation for `understudy.route_decision_packet.v1` (the shape
+ * `planRouteDecision` writes; mirrored by
+ * schemas/understudy.route_decision_packet.v1.schema.json). `routes promote`
+ * runs this before consuming any field, so an unversioned or malformed
+ * packet is rejected with every issue named instead of silently promoting
+ * from garbage. Extra fields are allowed — packets are additive-extensible.
+ */
+export function validateRouteDecisionPacket(packet: JsonObject): void {
+  const issues: string[] = [];
+  if (packet.schema_version === undefined) {
+    issues.push("missing schema_version");
+  } else if (packet.schema_version !== ROUTE_DECISION_PACKET_SCHEMA_VERSION) {
+    issues.push(
+      `unsupported schema_version ${JSON.stringify(packet.schema_version)} (expected ${ROUTE_DECISION_PACKET_SCHEMA_VERSION})`,
+    );
+  }
+  if (typeof packet.decision !== "string" || packet.decision.length === 0) {
+    issues.push("missing decision");
+  }
+  if (packet.candidate_routes !== undefined && !Array.isArray(packet.candidate_routes)) {
+    issues.push("candidate_routes must be an array when present");
+  }
+  for (const key of ["incumbent", "constraints", "readiness"] as const) {
+    if (packet[key] !== undefined && !isObject(packet[key])) {
+      issues.push(`${key} must be an object when present`);
+    }
+  }
+  if (
+    packet.route_traffic_pct !== undefined &&
+    packet.route_traffic_pct !== null &&
+    typeof packet.route_traffic_pct !== "number" &&
+    typeof packet.route_traffic_pct !== "string"
+  ) {
+    issues.push("route_traffic_pct must be a number when present");
+  }
+  if (issues.length > 0) {
+    throw new Error(`Invalid route decision packet: ${issues.join("; ")}`);
+  }
+}
+
 function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }

--- a/src/route-decision.ts
+++ b/src/route-decision.ts
@@ -51,19 +51,24 @@ export function validateRouteDecisionPacket(packet: JsonObject): void {
   if (typeof packet.decision !== "string" || packet.decision.length === 0) {
     issues.push("missing decision");
   }
-  if (packet.candidate_routes !== undefined && !Array.isArray(packet.candidate_routes)) {
+  if (
+    packet.candidate_routes !== undefined &&
+    packet.candidate_routes !== null &&
+    !Array.isArray(packet.candidate_routes)
+  ) {
     issues.push("candidate_routes must be an array when present");
   }
   for (const key of ["incumbent", "constraints", "readiness"] as const) {
-    if (packet[key] !== undefined && !isObject(packet[key])) {
+    if (packet[key] !== undefined && packet[key] !== null && !isObject(packet[key])) {
       issues.push(`${key} must be an object when present`);
     }
   }
+  // Strictly a number: promote's numberValue ignores strings, so admitting
+  // "15" here would silently promote at the default percentage instead.
   if (
     packet.route_traffic_pct !== undefined &&
     packet.route_traffic_pct !== null &&
-    typeof packet.route_traffic_pct !== "number" &&
-    typeof packet.route_traffic_pct !== "string"
+    typeof packet.route_traffic_pct !== "number"
   ) {
     issues.push("route_traffic_pct must be a number when present");
   }

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1310,6 +1310,34 @@ describe("understudy CLI", () => {
       const promote = await runWithEnvAsync(["routes", "promote", "--from", packetPath, "--yes"], env, repo);
       assert.notEqual(promote.status, 0);
       assert.match(promote.stderr, /evaluate-first/);
+
+      // Packets without a schema_version stamp are rejected before any field
+      // is consumed — promote never acts on unversioned evidence.
+      const unversionedPath = join(repo, "route-decision-unversioned.json");
+      writeFileSync(unversionedPath, JSON.stringify({ decision: "hosted-promotion-ready", workload_name: "classify", model_id: "glm-5.2" }));
+      const unversioned = await runWithEnvAsync(["routes", "promote", "--from", unversionedPath, "--yes"], env, repo);
+      assert.notEqual(unversioned.status, 0);
+      assert.match(unversioned.stderr, /missing schema_version/);
+
+      const wrongVersionPath = join(repo, "route-decision-wrong-version.json");
+      writeFileSync(wrongVersionPath, JSON.stringify({ schema_version: "understudy.route_decision_packet.v2", decision: "hosted-promotion-ready" }));
+      const wrongVersion = await runWithEnvAsync(["routes", "promote", "--from", wrongVersionPath, "--yes"], env, repo);
+      assert.notEqual(wrongVersion.status, 0);
+      assert.match(wrongVersion.stderr, /unsupported schema_version/);
+
+      // A valid hosted-promotion-ready packet passes validation and promotes.
+      const readyPath = join(repo, "route-decision-ready.json");
+      writeFileSync(readyPath, JSON.stringify({
+        schema_version: "understudy.route_decision_packet.v1",
+        decision: "hosted-promotion-ready",
+        workload_name: "classify",
+        model_id: "glm-5.2",
+        route_traffic_pct: 15,
+      }));
+      const promoted = await runWithEnvAsync(["--json", "routes", "promote", "--from", readyPath, "--yes"], env, repo);
+      assert.equal(promoted.status, 0, promoted.stderr);
+      assert.equal(JSON.parse(promoted.stdout).route_traffic_pct, 15);
+      assert.deepEqual(requests.at(-1).body, { model_id: "glm-5.2", route_traffic_pct: 15 });
     });
   });
 


### PR DESCRIPTION
Executes `docs/dev-run/wave-4-evidence-bridge.md` — the last dev-run wave. Evidence generated in the desktop app is now admissible, promotable evidence in the CLI/skills loop: one evidence chain across surfaces.

## What changed (one commit per plan item group)

1. **App exports satisfy the claim-packet contract.** `understudy.fusion_benchmark_comparison.v1` packets gain a packet-level `provenance` block: the eval rows are also written to a sibling JSONL file (one compact `eval_result.v1` row per line) and `provenance.eval_results_sha256` commits to that file's bytes — verifiable with plain `shasum -a 256`, the same file-hash idiom as `harness_sha256`/`splits_sha256`. The block also surfaces row count and distinct run ids, split identities, row-level harness/split hashes, and cost bases. Additive: `summary`, `route_policy`, and inline `eval_results` are unchanged.
2. **`resolve_repo_output_path` fixed.** The `CARGO_MANIFEST_DIR` build-machine path baked into the binary is gone. Exports default under `~/.understudy/exports/`; relative paths join that root; absolute paths are explicit overrides for the GUI only — HTTP/MCP callers (any token holder) are constrained to the exports root with `..` rejected.
3. **Skills read app evidence.** `ramp-and-verify` admits verified app export packets as pre-ramp gate-1 evidence; the admission checklist (shape, sibling-JSONL hash, split identity, cost basis, scoring rules) and a verification transcript live in its new `reference.md`. `capture-evidence` surfaces verified packets in its repo inventory.
4. **`routes promote` validates.** `validateRouteDecisionPacket` (src/route-decision.ts) rejects unversioned or wrong-version packets before any field is consumed. Shared contracts land next to the eval schema: `schemas/understudy.route_decision_packet.v1.schema.json` (with an optional `evidence` block citing an app export) and `schemas/understudy.fusion_route_policy_export.v1.schema.json` (the app-side `route_policy` shape).

## End-to-end proof (plan item 5, run live on this machine)

Built this branch's binary and ran it against the real app database (117 recorded Fusion benchmark rows from the June 30 sprint, 39 runs):

```text
1. unauth POST /api/fusion/benchmark-export (bad body)  -> 401 "unauthorized"  (auth before body extraction, #129)
   [startup also live-upgraded the legacy 16-char token to 64-hex, #129]
2. GET /api/status                                       -> connected: true, moraine running
3. POST /api/fusion/run-matrix {dry_run: true}           -> plan rows for gateway-glm / local-main / local-fast
4. POST /api/fusion/benchmark-export {}                  -> /Users/luis/.understudy/exports/fusion-benchmark/comparison-20260702T015904Z.json
5. POST benchmark-export {"output_path": "/tmp/evil.json"} -> rejected: "output_path must stay under /Users/luis/.understudy/exports"; file not created
6. ramp-and-verify admission: schema_version ok; 117 rows; splits=[none] (correctly smoke-grade);
   cost_bases=[] (no invented prices); shasum -a 256 of the sibling JSONL == provenance.eval_results_sha256
   (d540f60b...ca6a37, byte-exact)
7. routes promote --from <unversioned packet> --yes      -> "Invalid route decision packet: missing schema_version"
   routes promote --from <evaluate-first packet citing the export + its sha256> --yes
                                                          -> "Route packet is evaluate-first, not hosted-promotion-ready."
```

The full valid-path promotion (hosted-promotion-ready packet → route set with traffic pct) is exercised against the hosted fixture in `tests/cli.test.mjs` rather than live, so no real hosted route was mutated.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean; 57 Rust tests pass (3 new: provenance hash + JSONL rows, path defaulting/constraint matrix, export rows validated against the schema file's own required/enum definitions)
- `npm run check` (incl. skill-length lint) + 139 node tests pass (promote coverage extended: missing schema_version, unsupported version, evaluate-first, valid packet promotes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->