### PR TITLE
Add Anthropic (Claude) as a desktop chat provider

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -101,7 +101,18 @@ type ModelChoice =
       route: "cloud";
       slotId: null;
       active: boolean;
+    }
+  | {
+      id: string;
+      label: string;
+      detail: string;
+      route: "anthropic";
+      slotId: null;
+      active: boolean;
     };
+
+type AnthropicModel = { id: string; label: string; detail: string };
+type AnthropicStatus = { present: boolean; source: string | null };
 
 const CLOUD_MODEL: ModelChoice = {
   id: "cloud:glm-5.2",
@@ -244,10 +255,21 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
 
   const refreshModels = async () => {
     try {
-      const [residency, snapshots] = await Promise.all([
+      const [residency, snapshots, anthropicStatus] = await Promise.all([
         invoke<ResidencySnapshot>("get_residency"),
         invoke<SnapshotModel[]>("list_snapshot_models"),
+        invoke<AnthropicStatus>("anthropic_status").catch(() => ({ present: false, source: null })),
       ]);
+      const anthropic: ModelChoice[] = anthropicStatus.present
+        ? (await invoke<AnthropicModel[]>("anthropic_models").catch(() => [])).map((model) => ({
+            id: `anthropic:${model.id}`,
+            label: model.label,
+            detail: model.detail,
+            route: "anthropic" as const,
+            slotId: null,
+            active: true,
+          }))
+        : [];
       const local = residency.slots
         .filter((slot) => (slot.state === "running" || slot.state === "loading") && slot.model_id)
         .map<LocalModelChoice>((slot) => ({
@@ -266,7 +288,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
         if (slot?.active && slot.thinking === pending.thinking) return null;
         return pending;
       });
-      const next = [...local, CLOUD_MODEL];
+      const next = [...local, CLOUD_MODEL, ...anthropic];
       setChoices(next);
       setSelectedModel((current) => {
         if (current && next.some((choice) => choice.id === current)) return current;
@@ -417,7 +439,8 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     try {
       await invoke("chat_stream", {
         messages: toSend.map(({ role, content }) => ({ role, content })),
-        route: choice.route,
+        // Anthropic choices encode the model in the id (anthropic:<model>).
+        route: choice.route === "anthropic" ? choice.id : choice.route,
         slotId: choice.slotId,
         sessionId,
         onEvent: ch,
@@ -426,6 +449,19 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
       setErr(String(e));
       setStreaming(false);
       setAssistantSpeaking(false);
+    }
+  };
+
+  const connectAnthropic = async () => {
+    const key = window.prompt(
+      "Anthropic API key (stored locally in the app database, never uploaded):",
+    );
+    if (!key?.trim()) return;
+    try {
+      await invoke("anthropic_key_set", { key: key.trim() });
+      await refreshModels();
+    } catch (e: unknown) {
+      setErr(String(e));
     }
   };
 
@@ -634,6 +670,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
                 choices={choices}
                 selected={selectedChoice}
                 onSelect={(id) => setSelectedModel(id)}
+                onConnectAnthropic={connectAnthropic}
               />
               <ThinkingToggle
                 selected={selectedChoice}
@@ -684,17 +721,26 @@ function ModelPicker({
   choices,
   selected,
   onSelect,
+  onConnectAnthropic,
 }: {
   choices: ModelChoice[];
   selected: ModelChoice;
   onSelect: (id: string) => void;
+  onConnectAnthropic: () => void;
 }) {
+  const anthropicChoices = choices.filter((choice) => choice.route === "anthropic");
   return (
     <ModelSelector>
       <ModelSelectorTrigger asChild>
         <button type="button" className="ai-model-trigger">
           <span>{selected.label}</span>
-          <span>{selected.route === "local" ? "local" : "gateway"}</span>
+          <span>
+            {selected.route === "local"
+              ? "local"
+              : selected.route === "anthropic"
+                ? "anthropic"
+                : "gateway"}
+          </span>
         </button>
       </ModelSelectorTrigger>
       <ModelSelectorContent>
@@ -720,6 +766,26 @@ function ModelPicker({
                   <span className="font-mono text-[11px] text-muted-foreground">{choice.detail}</span>
                 </ModelSelectorItem>
               ))}
+          </ModelSelectorGroup>
+          <ModelSelectorGroup heading="Anthropic">
+            {anthropicChoices.map((choice) => (
+              <ModelSelectorItem key={choice.id} value={choice.id} onSelect={() => onSelect(choice.id)}>
+                <ModelSelectorName>{choice.label}</ModelSelectorName>
+                <span className="font-mono text-[11px] text-muted-foreground">{choice.detail}</span>
+              </ModelSelectorItem>
+            ))}
+            {anthropicChoices.length === 0 && (
+              <ModelSelectorItem
+                key="anthropic:connect"
+                value="anthropic:connect"
+                onSelect={onConnectAnthropic}
+              >
+                <ModelSelectorName>Connect Anthropic…</ModelSelectorName>
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  add an API key to chat with Claude
+                </span>
+              </ModelSelectorItem>
+            )}
           </ModelSelectorGroup>
         </ModelSelectorList>
       </ModelSelectorContent>

--- a/apps/homescreen/src-tauri/src/anthropic.rs
+++ b/apps/homescreen/src-tauri/src/anthropic.rs
@@ -1,0 +1,528 @@
+// Anthropic (Claude) as a first-class chat route. The desktop chat loop
+// keeps its OpenAI-shape transcript; this module translates that transcript
+// to the Anthropic Messages API at the request boundary and translates the
+// SSE stream back into the app's ChatEvent/tool-call shapes. Raw HTTP by
+// design: Anthropic ships no official Rust SDK, and the Messages API is not
+// OpenAI-compatible (no shim).
+//
+// Replay fidelity: Anthropic requires the assistant turn of a tool round to
+// be echoed back with its original content blocks (thinking blocks included,
+// unmodified). Each streamed turn therefore returns `assistant_content` —
+// the reconstructed raw blocks — which the chat loop stores on the
+// transcript message under "anthropic_content"; the translator prefers that
+// verbatim over re-deriving blocks from the OpenAI shape.
+
+use serde_json::{json, Value};
+use tauri::ipc::Channel;
+use tauri::AppHandle;
+
+use crate::chat::{ChatEvent, StreamChatOnceResult, ToolCallAcc};
+
+pub const API_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const SETTING_KEY: &str = "anthropic.api_key";
+
+pub struct AnthropicModel {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub detail: &'static str,
+}
+
+/// Current lineup (platform.claude.com models overview, 2026-06). Opus 4.8
+/// first: it is the default recommendation for agentic work; Fable 5 is the
+/// highest-capability option at premium pricing.
+pub fn models() -> Vec<AnthropicModel> {
+    vec![
+        AnthropicModel {
+            id: "claude-opus-4-8",
+            label: "Claude Opus 4.8",
+            detail: "Anthropic · $5/$25 per MTok",
+        },
+        AnthropicModel {
+            id: "claude-sonnet-5",
+            label: "Claude Sonnet 5",
+            detail: "Anthropic · $3/$15 per MTok",
+        },
+        AnthropicModel {
+            id: "claude-haiku-4-5",
+            label: "Claude Haiku 4.5",
+            detail: "Anthropic · $1/$5 per MTok",
+        },
+        AnthropicModel {
+            id: "claude-fable-5",
+            label: "Claude Fable 5",
+            detail: "Anthropic · $10/$50 per MTok",
+        },
+    ]
+}
+
+pub fn models_json() -> Value {
+    json!(models()
+        .iter()
+        .map(|m| json!({ "id": m.id, "label": m.label, "detail": m.detail }))
+        .collect::<Vec<_>>())
+}
+
+/// API key resolution: the app setting wins (set from the GUI), then the
+/// environment. Returns the key and where it came from.
+pub fn api_key(app: &AppHandle) -> Option<(String, &'static str)> {
+    use tauri::Manager;
+    if let Some(db) = app.try_state::<crate::db::Db>() {
+        if let Some(key) = db.setting_get(SETTING_KEY) {
+            let key = key.trim().to_string();
+            if !key.is_empty() {
+                return Some((key, "settings"));
+            }
+        }
+    }
+    std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+        .map(|k| (k, "env"))
+}
+
+pub fn set_api_key(app: &AppHandle, key: &str) -> Result<(), String> {
+    use tauri::Manager;
+    let db = app
+        .try_state::<crate::db::Db>()
+        .ok_or_else(|| "database unavailable".to_string())?;
+    db.setting_set(SETTING_KEY, key.trim())
+        .map_err(|e| e.to_string())
+}
+
+/// Thinking configuration per model family:
+/// - Fable 5: thinking is always on; the parameter must be omitted entirely
+///   (an explicit config is rejected with a 400).
+/// - Haiku 4.5: no adaptive thinking; omit (runs without thinking).
+/// - Opus 4.8 / Sonnet 5: adaptive, with summarized display so the app's
+///   reasoning substream has text to show (the default display is omitted).
+fn thinking_config(model: &str) -> Option<Value> {
+    if model.starts_with("claude-fable") || model.starts_with("claude-haiku") {
+        return None;
+    }
+    Some(json!({ "type": "adaptive", "display": "summarized" }))
+}
+
+/// OpenAI function-tool schemas -> Anthropic tool definitions.
+fn convert_tools(openai_tools: &[Value]) -> Vec<Value> {
+    openai_tools
+        .iter()
+        .filter_map(|tool| {
+            let function = tool.get("function")?;
+            let name = function.get("name")?.as_str()?;
+            Some(json!({
+                "name": name,
+                "description": function.get("description").and_then(|d| d.as_str()).unwrap_or(""),
+                "input_schema": function
+                    .get("parameters")
+                    .cloned()
+                    .unwrap_or_else(|| json!({ "type": "object", "properties": {} })),
+            }))
+        })
+        .collect()
+}
+
+/// OpenAI-shape transcript -> (system, Anthropic messages). Consecutive
+/// role:"tool" results merge into ONE user turn (parallel tool results must
+/// not be split across messages). Assistant messages carrying
+/// "anthropic_content" are replayed verbatim.
+fn convert_messages(messages: &[Value]) -> (Option<String>, Vec<Value>) {
+    let mut system: Option<String> = None;
+    let mut out: Vec<Value> = vec![];
+    let mut pending_tool_results: Vec<Value> = vec![];
+
+    let flush_tools = |pending: &mut Vec<Value>, out: &mut Vec<Value>| {
+        if !pending.is_empty() {
+            out.push(json!({ "role": "user", "content": std::mem::take(pending) }));
+        }
+    };
+
+    for message in messages {
+        let role = message.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        match role {
+            "system" => {
+                if system.is_none() {
+                    system = message
+                        .get("content")
+                        .and_then(|c| c.as_str())
+                        .map(str::to_string);
+                }
+            }
+            "tool" => {
+                let id = message
+                    .get("tool_call_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let content = message.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                pending_tool_results.push(json!({
+                    "type": "tool_result",
+                    "tool_use_id": id,
+                    "content": content,
+                }));
+            }
+            "assistant" => {
+                flush_tools(&mut pending_tool_results, &mut out);
+                if let Some(raw) = message.get("anthropic_content") {
+                    out.push(json!({ "role": "assistant", "content": raw.clone() }));
+                    continue;
+                }
+                let text = message.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                let calls = message.get("tool_calls").and_then(|v| v.as_array());
+                match calls {
+                    Some(calls) if !calls.is_empty() => {
+                        let mut blocks: Vec<Value> = vec![];
+                        if !text.trim().is_empty() {
+                            blocks.push(json!({ "type": "text", "text": text }));
+                        }
+                        for call in calls {
+                            let function = call.get("function").cloned().unwrap_or(json!({}));
+                            let arguments = function
+                                .get("arguments")
+                                .and_then(|a| a.as_str())
+                                .unwrap_or("{}");
+                            blocks.push(json!({
+                                "type": "tool_use",
+                                "id": call.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+                                "name": function.get("name").and_then(|v| v.as_str()).unwrap_or(""),
+                                "input": serde_json::from_str::<Value>(arguments)
+                                    .unwrap_or_else(|_| json!({})),
+                            }));
+                        }
+                        out.push(json!({ "role": "assistant", "content": blocks }));
+                    }
+                    _ => {
+                        if !text.is_empty() {
+                            out.push(json!({ "role": "assistant", "content": text }));
+                        }
+                    }
+                }
+            }
+            _ => {
+                flush_tools(&mut pending_tool_results, &mut out);
+                let text = message.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                out.push(json!({ "role": "user", "content": text }));
+            }
+        }
+    }
+    flush_tools(&mut pending_tool_results, &mut out);
+    (system, out)
+}
+
+pub struct AnthropicTurn {
+    pub result: StreamChatOnceResult,
+    /// Raw content blocks of the assistant turn, for verbatim replay on the
+    /// next tool round (thinking blocks must go back unmodified).
+    pub assistant_content: Value,
+}
+
+fn error_turn(message: String, on_event: &Channel<ChatEvent>) -> AnthropicTurn {
+    let _ = on_event.send(ChatEvent::Error {
+        message: message.clone(),
+    });
+    AnthropicTurn {
+        result: StreamChatOnceResult {
+            content: String::new(),
+            tool_calls: vec![],
+            error: Some(message),
+        },
+        assistant_content: json!([]),
+    }
+}
+
+/// One streamed Messages API turn. Mirrors chat.rs::stream_chat_once
+/// semantics: transport/API errors are reported as events plus a soft error
+/// in the result, never as Err (the loop records them as failed runs).
+#[allow(clippy::too_many_arguments)]
+pub async fn stream_chat_once(
+    client: &reqwest::Client,
+    api_key: &str,
+    model: &str,
+    messages: &[Value],
+    openai_tools: &[Value],
+    max_tokens: u32,
+    on_event: &Channel<ChatEvent>,
+) -> AnthropicTurn {
+    let (system, converted) = convert_messages(messages);
+    let mut payload = json!({
+        "model": model,
+        "max_tokens": max_tokens,
+        "stream": true,
+        "messages": converted,
+        "tools": convert_tools(openai_tools),
+    });
+    if let Some(system) = system {
+        payload["system"] = json!(system);
+    }
+    if let Some(thinking) = thinking_config(model) {
+        payload["thinking"] = thinking;
+    }
+
+    let resp = match client
+        .post(API_URL)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .json(&payload)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => return error_turn(format!("anthropic request failed: {e}"), on_event),
+    };
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return error_turn(format!("anthropic {status}: {body}"), on_event);
+    }
+
+    use futures_util::StreamExt;
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+    let mut content = String::new();
+    let mut raw_blocks: Vec<Value> = vec![];
+    let mut tool_calls: Vec<ToolCallAcc> = vec![];
+    let mut stop_reason: Option<String> = None;
+
+    while let Some(item) = stream.next().await {
+        let chunk = match item {
+            Ok(c) => c,
+            Err(e) => return error_turn(format!("anthropic stream failed: {e}"), on_event),
+        };
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(pos) = buf.find('\n') {
+            let line = buf[..pos].trim().to_string();
+            buf.drain(..=pos);
+            let Some(data) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            let Ok(event) = serde_json::from_str::<Value>(data) else {
+                continue;
+            };
+            match event.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+                "content_block_start" => {
+                    let block = event.get("content_block").cloned().unwrap_or(json!({}));
+                    if block.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
+                        tool_calls.push(ToolCallAcc {
+                            index: raw_blocks.len(),
+                            id: block
+                                .get("id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            name: block
+                                .get("name")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            arguments: String::new(),
+                        });
+                    }
+                    raw_blocks.push(block);
+                }
+                "content_block_delta" => {
+                    let Some(block) = raw_blocks.last_mut() else {
+                        continue;
+                    };
+                    let delta = event.get("delta").cloned().unwrap_or(json!({}));
+                    match delta.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+                        "text_delta" => {
+                            if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
+                                content.push_str(text);
+                                append_str(block, "text", text);
+                                let _ = on_event.send(ChatEvent::Chunk {
+                                    text: text.to_string(),
+                                });
+                            }
+                        }
+                        "thinking_delta" => {
+                            if let Some(text) = delta.get("thinking").and_then(|t| t.as_str()) {
+                                append_str(block, "thinking", text);
+                                if !text.is_empty() {
+                                    let _ = on_event.send(ChatEvent::ReasoningChunk {
+                                        text: text.to_string(),
+                                    });
+                                }
+                            }
+                        }
+                        "signature_delta" => {
+                            if let Some(sig) = delta.get("signature").and_then(|s| s.as_str()) {
+                                append_str(block, "signature", sig);
+                            }
+                        }
+                        "input_json_delta" => {
+                            if let Some(partial) =
+                                delta.get("partial_json").and_then(|p| p.as_str())
+                            {
+                                if let Some(acc) = tool_calls.last_mut() {
+                                    acc.arguments.push_str(partial);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                "content_block_stop" => {
+                    // Materialize accumulated tool input onto the raw block
+                    // so replay carries the exact parsed arguments.
+                    if let Some(block) = raw_blocks.last_mut() {
+                        if block.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
+                            if let Some(acc) = tool_calls.last_mut() {
+                                if acc.arguments.trim().is_empty() {
+                                    acc.arguments = "{}".to_string();
+                                }
+                                block["input"] = serde_json::from_str::<Value>(&acc.arguments)
+                                    .unwrap_or_else(|_| json!({}));
+                            }
+                        }
+                    }
+                }
+                "message_delta" => {
+                    if let Some(reason) = event
+                        .pointer("/delta/stop_reason")
+                        .and_then(|r| r.as_str())
+                    {
+                        stop_reason = Some(reason.to_string());
+                    }
+                }
+                "error" => {
+                    let message = event
+                        .pointer("/error/message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown anthropic stream error")
+                        .to_string();
+                    return error_turn(format!("anthropic: {message}"), on_event);
+                }
+                "message_stop" => break,
+                _ => {}
+            }
+        }
+    }
+
+    // A pre-output safety decline arrives as a clean 200 with an empty
+    // content array — surface it instead of showing a silent empty turn.
+    let error = if stop_reason.as_deref() == Some("refusal")
+        && content.is_empty()
+        && tool_calls.is_empty()
+    {
+        let message = "Anthropic declined this request (stop_reason: refusal)".to_string();
+        let _ = on_event.send(ChatEvent::Error {
+            message: message.clone(),
+        });
+        Some(message)
+    } else {
+        None
+    };
+
+    tool_calls.retain(|call| !call.name.is_empty());
+    AnthropicTurn {
+        result: StreamChatOnceResult {
+            content,
+            tool_calls,
+            error,
+        },
+        assistant_content: Value::Array(raw_blocks),
+    }
+}
+
+fn append_str(block: &mut Value, key: &str, text: &str) {
+    let existing = block.get(key).and_then(|v| v.as_str()).unwrap_or("");
+    block[key] = json!(format!("{existing}{text}"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_uses_current_model_ids_with_opus_default() {
+        let models = models();
+        assert_eq!(models[0].id, "claude-opus-4-8", "Opus 4.8 is the default");
+        let ids: Vec<&str> = models.iter().map(|m| m.id).collect();
+        assert!(ids.contains(&"claude-fable-5"));
+        assert!(ids.contains(&"claude-sonnet-5"));
+        assert!(ids.contains(&"claude-haiku-4-5"));
+        // Never date-suffixed aliases.
+        assert!(ids.iter().all(|id| !id.ends_with("-20251001")));
+    }
+
+    #[test]
+    fn thinking_config_respects_model_constraints() {
+        // Fable 5: explicit thinking config is a 400 — must be omitted.
+        assert!(thinking_config("claude-fable-5").is_none());
+        // Haiku 4.5: no adaptive thinking.
+        assert!(thinking_config("claude-haiku-4-5").is_none());
+        // Opus/Sonnet: adaptive with summarized display.
+        let opus = thinking_config("claude-opus-4-8").unwrap();
+        assert_eq!(opus["type"], "adaptive");
+        assert_eq!(opus["display"], "summarized");
+    }
+
+    #[test]
+    fn converts_transcript_to_messages_api_shape() {
+        let transcript = vec![
+            json!({ "role": "system", "content": "be helpful" }),
+            json!({ "role": "user", "content": "hi" }),
+            json!({ "role": "assistant", "content": "", "tool_calls": [
+                { "id": "toolu_1", "type": "function",
+                  "function": { "name": "status", "arguments": "{\"x\":1}" } },
+                { "id": "toolu_2", "type": "function",
+                  "function": { "name": "residency", "arguments": "not-json" } },
+            ]}),
+            json!({ "role": "tool", "tool_call_id": "toolu_1", "content": "ok" }),
+            json!({ "role": "tool", "tool_call_id": "toolu_2", "content": "also ok" }),
+        ];
+        let (system, messages) = convert_messages(&transcript);
+        assert_eq!(system.as_deref(), Some("be helpful"));
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "user");
+        // Assistant tool calls become tool_use blocks with parsed input;
+        // unparseable arguments degrade to an empty object.
+        let blocks = messages[1]["content"].as_array().unwrap();
+        assert_eq!(blocks[0]["type"], "tool_use");
+        assert_eq!(blocks[0]["input"]["x"], 1);
+        assert_eq!(blocks[1]["input"], json!({}));
+        // Parallel tool results merge into ONE user message.
+        let results = messages[2]["content"].as_array().unwrap();
+        assert_eq!(messages[2]["role"], "user");
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0]["type"], "tool_result");
+        assert_eq!(results[0]["tool_use_id"], "toolu_1");
+    }
+
+    #[test]
+    fn raw_anthropic_content_replays_verbatim() {
+        let raw = json!([
+            { "type": "thinking", "thinking": "hmm", "signature": "sig" },
+            { "type": "tool_use", "id": "toolu_1", "name": "status", "input": {} },
+        ]);
+        let transcript = vec![
+            json!({ "role": "user", "content": "hi" }),
+            json!({ "role": "assistant", "content": "", "anthropic_content": raw,
+                    "tool_calls": [{ "id": "toolu_1", "type": "function",
+                                     "function": { "name": "status", "arguments": "{}" } }] }),
+            json!({ "role": "tool", "tool_call_id": "toolu_1", "content": "ok" }),
+        ];
+        let (_, messages) = convert_messages(&transcript);
+        // The raw blocks (thinking included) are echoed unmodified — never
+        // re-derived from the OpenAI shape.
+        assert_eq!(messages[1]["content"], raw);
+    }
+
+    #[test]
+    fn converts_openai_tools_to_input_schema_shape() {
+        let tools = vec![json!({
+            "type": "function",
+            "function": {
+                "name": "status",
+                "description": "Read runtime status.",
+                "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+            }
+        })];
+        let converted = convert_tools(&tools);
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0]["name"], "status");
+        assert!(converted[0]["input_schema"].is_object());
+        assert!(converted[0].get("function").is_none());
+    }
+}

--- a/apps/homescreen/src-tauri/src/anthropic.rs
+++ b/apps/homescreen/src-tauri/src/anthropic.rs
@@ -142,11 +142,19 @@ fn convert_messages(messages: &[Value]) -> (Option<String>, Vec<Value>) {
         let role = message.get("role").and_then(|r| r.as_str()).unwrap_or("");
         match role {
             "system" => {
+                let content = message.get("content").and_then(|c| c.as_str()).unwrap_or("");
                 if system.is_none() {
-                    system = message
-                        .get("content")
-                        .and_then(|c| c.as_str())
-                        .map(str::to_string);
+                    system = Some(content.to_string());
+                } else if !content.trim().is_empty() {
+                    // Mid-transcript system content (compaction summaries,
+                    // sidekick handoffs) has no top-level slot on the
+                    // Messages API: keep it in position as an operator-marked
+                    // user turn instead of dropping it.
+                    flush_tools(&mut pending_tool_results, &mut out);
+                    out.push(json!({
+                        "role": "user",
+                        "content": format!("<system-reminder>\n{content}\n</system-reminder>"),
+                    }));
                 }
             }
             "tool" => {
@@ -277,7 +285,7 @@ pub async fn stream_chat_once(
 
     use futures_util::StreamExt;
     let mut stream = resp.bytes_stream();
-    let mut buf = String::new();
+    let mut buf: Vec<u8> = Vec::new();
     let mut content = String::new();
     let mut raw_blocks: Vec<Value> = vec![];
     let mut tool_calls: Vec<ToolCallAcc> = vec![];
@@ -288,11 +296,10 @@ pub async fn stream_chat_once(
             Ok(c) => c,
             Err(e) => return error_turn(format!("anthropic stream failed: {e}"), on_event),
         };
-        buf.push_str(&String::from_utf8_lossy(&chunk));
+        buf.extend_from_slice(&chunk);
 
-        while let Some(pos) = buf.find('\n') {
-            let line = buf[..pos].trim().to_string();
-            buf.drain(..=pos);
+        for line in drain_lines(&mut buf) {
+            let line = line.trim();
             let Some(data) = line.strip_prefix("data: ") else {
                 continue;
             };
@@ -425,6 +432,21 @@ pub async fn stream_chat_once(
     }
 }
 
+/// Split complete `\n`-terminated lines out of a raw byte buffer, decoding
+/// per line. Decoding AFTER the split means a multi-byte UTF-8 character
+/// split across network chunks is never corrupted: a UTF-8 continuation
+/// byte can never be 0x0A, so byte-level newline splits are char-safe.
+/// (Corrupted thinking text would otherwise be replayed against its
+/// signature on the next tool round and rejected by the API.)
+fn drain_lines(buf: &mut Vec<u8>) -> Vec<String> {
+    let mut lines = vec![];
+    while let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+        let line: Vec<u8> = buf.drain(..=pos).collect();
+        lines.push(String::from_utf8_lossy(&line).to_string());
+    }
+    lines
+}
+
 fn append_str(block: &mut Value, key: &str, text: &str) {
     let existing = block.get(key).and_then(|v| v.as_str()).unwrap_or("");
     block[key] = json!(format!("{existing}{text}"));
@@ -507,6 +529,45 @@ mod tests {
         // The raw blocks (thinking included) are echoed unmodified — never
         // re-derived from the OpenAI shape.
         assert_eq!(messages[1]["content"], raw);
+    }
+
+    #[test]
+    fn later_system_messages_stay_in_position_as_system_reminders() {
+        // Compaction summaries and sidekick handoffs arrive as a SECOND
+        // role:"system" message mid-transcript; dropping them would silently
+        // erase the model's compressed history.
+        let transcript = vec![
+            json!({ "role": "system", "content": "base prompt" }),
+            json!({ "role": "user", "content": "hi" }),
+            json!({ "role": "system", "content": "[compacted] earlier turns summary" }),
+            json!({ "role": "user", "content": "continue" }),
+        ];
+        let (system, messages) = convert_messages(&transcript);
+        assert_eq!(system.as_deref(), Some("base prompt"));
+        assert_eq!(messages.len(), 3);
+        let reminder = messages[1]["content"].as_str().unwrap();
+        assert_eq!(messages[1]["role"], "user");
+        assert!(reminder.contains("<system-reminder>"));
+        assert!(reminder.contains("earlier turns summary"));
+        assert_eq!(messages[2]["content"], "continue");
+    }
+
+    #[test]
+    fn drain_lines_survives_multibyte_chars_split_across_chunks() {
+        // Worst-case chunking: one byte at a time. Curly quotes/em-dashes are
+        // 3-byte UTF-8; decoding per chunk would corrupt them (and corrupted
+        // thinking text is later rejected against its signature on replay).
+        let payload = "data: {\"text\":\"café — “ok”\"}\n".as_bytes();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut lines: Vec<String> = vec![];
+        for byte in payload {
+            buf.push(*byte);
+            lines.extend(drain_lines(&mut buf));
+        }
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("café — “ok”"));
+        assert!(!lines[0].contains('\u{FFFD}'));
+        assert!(buf.is_empty());
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -65,10 +65,10 @@ pub struct BenchmarkChatResult {
     pub context_tokens_before: u64,
 }
 
-struct StreamChatOnceResult {
-    content: String,
-    tool_calls: Vec<ToolCallAcc>,
-    error: Option<String>,
+pub(crate) struct StreamChatOnceResult {
+    pub(crate) content: String,
+    pub(crate) tool_calls: Vec<ToolCallAcc>,
+    pub(crate) error: Option<String>,
 }
 
 struct NonstreamChatOnceResult {
@@ -479,11 +479,11 @@ fn system_prompt_for(model: &str) -> String {
 }
 
 #[derive(Clone, Debug, Default)]
-struct ToolCallAcc {
-    index: usize,
-    id: String,
-    name: String,
-    arguments: String,
+pub(crate) struct ToolCallAcc {
+    pub(crate) index: usize,
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) arguments: String,
 }
 
 fn tool_schemas() -> Vec<Value> {
@@ -1919,6 +1919,19 @@ fn cloud_route_binding() -> Option<RouteBinding> {
     })
 }
 
+fn anthropic_route_binding(app: &AppHandle, model: &str) -> Result<RouteBinding, String> {
+    let (key, _source) = crate::anthropic::api_key(app).ok_or_else(|| {
+        "no Anthropic API key configured — add one in the model picker or set ANTHROPIC_API_KEY"
+            .to_string()
+    })?;
+    Ok(RouteBinding {
+        route: "anthropic".to_string(),
+        url: crate::anthropic::API_URL.to_string(),
+        bearer: Some(key),
+        model_field: model.to_string(),
+    })
+}
+
 fn local_route_binding(
     route: &str,
     mgr: &Residency,
@@ -2395,7 +2408,13 @@ pub async fn chat_stream(
 ) -> Result<(), String> {
     let started = Instant::now();
     let session_id = session_id.unwrap_or_else(|| "default".to_string());
-    let route = apply_dynamic_chat_route(&app, &session_id, &route, slot_id, &messages, &on_event);
+    // Anthropic routes are an explicit user choice — never rewritten by the
+    // Fusion routing policy (which only reasons about local vs gateway).
+    let route = if route.starts_with("anthropic") {
+        route
+    } else {
+        apply_dynamic_chat_route(&app, &session_id, &route, slot_id, &messages, &on_event)
+    };
     let sidekick_plan = maybe_spawn_parallel_sidekick(
         &app,
         &route,
@@ -2404,9 +2423,13 @@ pub async fn chat_stream(
         &messages,
         Some(&on_event),
     );
-    let mut binding = match route.as_str() {
-        "cloud" => cloud_route_binding().ok_or_else(|| "not signed in".to_string())?,
-        _ => local_route_binding(&route, &mgr, slot_id)?,
+    let mut binding = if let Some(model) = route.strip_prefix("anthropic:") {
+        anthropic_route_binding(&app, model)?
+    } else {
+        match route.as_str() {
+            "cloud" => cloud_route_binding().ok_or_else(|| "not signed in".to_string())?,
+            _ => local_route_binding(&route, &mgr, slot_id)?,
+        }
     };
 
     let mut outbound_messages = vec![json!({
@@ -2477,17 +2500,33 @@ pub async fn chat_stream(
         .build()
         .map_err(|e| e.to_string())?;
 
+    let mut pending_anthropic_content: Option<Value> = None;
     for _round in 0..=MAX_TOOL_ROUNDS {
         prompt_tokens = prompt_tokens.max(approximate_messages_tokens(&outbound_messages));
-        let result = stream_chat_once(
-            &client,
-            &binding.url,
-            binding.bearer.as_deref(),
-            &binding.model_field,
-            &outbound_messages,
-            &on_event,
-        )
-        .await?;
+        let result = if binding.route == "anthropic" {
+            let turn = crate::anthropic::stream_chat_once(
+                &client,
+                binding.bearer.as_deref().unwrap_or(""),
+                &binding.model_field,
+                &outbound_messages,
+                &tool_schemas(),
+                CHAT_MAX_TOKENS,
+                &on_event,
+            )
+            .await;
+            pending_anthropic_content = Some(turn.assistant_content);
+            turn.result
+        } else {
+            stream_chat_once(
+                &client,
+                &binding.url,
+                binding.bearer.as_deref(),
+                &binding.model_field,
+                &outbound_messages,
+                &on_event,
+            )
+            .await?
+        };
         completion_tokens += approximate_token_count(&result.content);
         if let Some(error) = result.error {
             record_chat_run(
@@ -2562,11 +2601,18 @@ pub async fn chat_stream(
                 })
             })
             .collect();
-        outbound_messages.push(json!({
+        let mut assistant_message = json!({
             "role": "assistant",
             "content": "",
             "tool_calls": assistant_tool_calls,
-        }));
+        });
+        // Anthropic tool rounds must replay the assistant turn's original
+        // content blocks (thinking included, unmodified) — carry them on the
+        // transcript for the translator; other providers ignore the field.
+        if let Some(raw) = pending_anthropic_content.take() {
+            assistant_message["anthropic_content"] = raw;
+        }
+        outbound_messages.push(assistant_message);
 
         for call in tool_calls {
             let args = serde_json::from_str::<Value>(&call.arguments).unwrap_or_else(|_| json!({}));

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -3567,3 +3567,24 @@ mod tests {
         );
     }
 }
+
+// ----- Anthropic (Claude) provider -----
+
+#[tauri::command]
+pub fn anthropic_models() -> Value {
+    crate::anthropic::models_json()
+}
+
+#[tauri::command]
+pub fn anthropic_status(app: AppHandle) -> Value {
+    match crate::anthropic::api_key(&app) {
+        Some((_, source)) => json!({ "present": true, "source": source }),
+        None => json!({ "present": false, "source": Value::Null }),
+    }
+}
+
+#[tauri::command]
+pub fn anthropic_key_set(app: AppHandle, key: String) -> Result<Value, String> {
+    crate::anthropic::set_api_key(&app, &key)?;
+    Ok(anthropic_status(app))
+}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod aa;
 mod account;
+mod anthropic;
 mod agent_card;
 mod agent_ops;
 mod bin;
@@ -123,6 +124,9 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::get_status,
+            commands::anthropic_models,
+            commands::anthropic_status,
+            commands::anthropic_key_set,
             commands::connect,
             commands::disconnect,
             commands::list_models,


### PR DESCRIPTION
Adds Anthropic as a third chat route in the desktop app, alongside local slots and the Understudy gateway.

## What changed
- **`anthropic.rs`**: native Messages API client over raw HTTP (Anthropic ships no Rust SDK, and the API is not OpenAI-compatible — no shim). Model catalog: **Claude Opus 4.8** (default), **Sonnet 5**, **Haiku 4.5**, **Fable 5**, current IDs/pricing.
- **Boundary translation**: the chat loop keeps its OpenAI-shape transcript; the module translates outbound (system extraction, `tool_calls` → `tool_use` blocks, consecutive tool results merged into ONE user turn of `tool_result` blocks) and translates the SSE stream back into `ChatEvent`s and the shared tool loop's `ToolCallAcc` shape.
- **Replay fidelity**: each turn returns its raw content blocks; the loop stores them on the transcript under `anthropic_content` and the translator echoes them verbatim on the next tool round — thinking blocks go back unmodified, as the API requires.
- **Model constraints respected**: no `temperature`/`top_p`/`budget_tokens`; thinking omitted on Fable 5 (explicit config 400s) and Haiku 4.5 (no adaptive), `{type: adaptive, display: summarized}` on Opus 4.8/Sonnet 5 so the reasoning substream renders; pre-output `stop_reason: refusal` surfaces as a chat error instead of a silent empty turn.
- **Routing**: `anthropic:<model>` route string from the GUI; explicitly excluded from Fusion dynamic routing (user's explicit provider choice) and from local→cloud escalation. Chat runs record `route: "anthropic"`, `gateway_used: false`.
- **Key management**: `anthropic_status` / `anthropic_key_set` / `anthropic_models` Tauri commands; key stored in the app DB (or `ANTHROPIC_API_KEY` env); "Connect Anthropic…" item in the model picker when no key is present. Auth via `x-api-key` + `anthropic-version: 2023-06-01`.

## Verification
- `cargo clippy --all-targets -- -D warnings` clean; 62 Rust tests pass (5 new: catalog IDs, thinking constraints, transcript/tool conversion incl. parallel-result merging and unparseable-arguments degradation, verbatim raw-block replay, tool-schema conversion)
- `bun run build` (static export) passes; `npm run check` + 139 node tests pass
- Live end-to-end (real key, streamed turn + tool round) still to be exercised in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->