### PR TITLE
Bump desktop app to 0.2.5

### DIFF
--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.2.4"
+version = "0.2.5"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/understudy-agent-tools-mcp-app/.mcp-use/project.json
+++ b/understudy-agent-tools-mcp-app/.mcp-use/project.json
@@ -1,0 +1,6 @@
+{
+  "deploymentId": "9ff4ede2-2f56-41fb-861f-795fcf771aa6",
+  "deploymentName": "understudy-agent-tools-mcp-app",
+  "serverId": "4f770075-d4d8-455b-a10b-16ca8d4335b4",
+  "linkedAt": "2026-06-27T18:23:45.665Z"
+}

--- a/understudy-agent-tools-mcp-app/.mcp-use/sessions.json
+++ b/understudy-agent-tools-mcp-app/.mcp-use/sessions.json
@@ -1,0 +1,285 @@
+{
+  "3cd57708-890c-4186-9c4c-1f023cfec0a0": {
+    "lastAccessedAt": 1782584466840,
+    "clientCapabilities": {
+      "sampling": {},
+      "elicitation": {
+        "form": {},
+        "url": {}
+      },
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use Inspector",
+      "title": "mcp-use",
+      "icons": [
+        {
+          "src": "https://mcp-use.com/logo.png"
+        }
+      ],
+      "version": "10.0.1",
+      "websiteUrl": "https://mcp-use.com",
+      "description": "mcp-use is a complete TypeScript framework for building and using MCP"
+    },
+    "protocolVersion": "unknown"
+  },
+  "b117a6ad-f451-47c8-b913-0837e074c9c4": {
+    "lastAccessedAt": 1782584471616,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "d180de7c-724d-4a91-bf3e-364673f88bf3": {
+    "lastAccessedAt": 1782584489086,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "995de735-cf4d-43d9-b967-2104648746a7": {
+    "lastAccessedAt": 1782584489090,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "89fac483-d0b9-4f35-83f9-6908d8c1ca2c": {
+    "lastAccessedAt": 1782584489093,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "197a9a46-02fa-44f6-97e1-87acb85b0f63": {
+    "lastAccessedAt": 1782584516853,
+    "clientCapabilities": {
+      "sampling": {},
+      "elicitation": {
+        "form": {},
+        "url": {}
+      },
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use Inspector",
+      "title": "mcp-use",
+      "icons": [
+        {
+          "src": "https://mcp-use.com/logo.png"
+        }
+      ],
+      "version": "10.0.1",
+      "websiteUrl": "https://mcp-use.com",
+      "description": "mcp-use is a complete TypeScript framework for building and using MCP"
+    },
+    "protocolVersion": "unknown"
+  },
+  "f157e46b-3e3b-45b7-a84c-40c57d003e02": {
+    "lastAccessedAt": 1782584524962,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "efc20155-de9a-4506-86cb-7fe3fd8db1ca": {
+    "lastAccessedAt": 1782584524968,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "fa4cb376-7776-45c4-ab57-aafd9aa0cdc8": {
+    "lastAccessedAt": 1782584524971,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "fd1e1819-f1c2-4b9d-8f63-e9442a843d74": {
+    "lastAccessedAt": 1782584530220,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "fc72c9e2-a63e-484e-80eb-7a5294f2818e": {
+    "lastAccessedAt": 1782584571850,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "1c2192a7-02b9-4981-bf74-f24c5b21aa02": {
+    "lastAccessedAt": 1782584571853,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  },
+  "d6b7aa75-ea92-46a7-adec-19d6907c97c5": {
+    "lastAccessedAt": 1782584571854,
+    "clientCapabilities": {
+      "roots": {
+        "listChanged": true
+      }
+    },
+    "clientInfo": {
+      "name": "mcp-use CLI",
+      "title": "mcp-use CLI",
+      "icons": [
+        {
+          "src": "https://manufact.com/logo.png"
+        }
+      ],
+      "version": "1.33.0",
+      "websiteUrl": "https://manufact.com",
+      "description": "mcp-use CLI - Command-line interface for MCP servers"
+    },
+    "protocolVersion": "unknown"
+  }
+}

--- a/understudy-agent-tools-mcp-app/.mcp-use/skill-catalog/entry.tsx
+++ b/understudy-agent-tools-mcp-app/.mcp-use/skill-catalog/entry.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import './styles.css'
+import Component from '/Users/luis/Developer/understudy/understudy-agent-tools/understudy-agent-tools-mcp-app/resources/skill-catalog/widget.tsx'
+
+const container = document.getElementById('widget-root')
+if (container && Component) {
+  const root = createRoot(container)
+  root.render(<Component />)
+}

--- a/understudy-agent-tools-mcp-app/.mcp-use/skill-catalog/index.html
+++ b/understudy-agent-tools-mcp-app/.mcp-use/skill-catalog/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>skill-catalog Widget</title>
+  </head>
+  <body>
+    <div id="widget-root"></div>
+    <script type="module" src="/entry.tsx"></script>
+  </body>
+</html>

--- a/understudy-agent-tools-mcp-app/.mcp-use/skill-catalog/styles.css
+++ b/understudy-agent-tools-mcp-app/.mcp-use/skill-catalog/styles.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+
+/* Configure Tailwind to scan the resources directory and mcp-use package */
+@source "../../resources";
+@source "../../node_modules/mcp-use/**/*.{ts,tsx,js,jsx}";

--- a/understudy-agent-tools-mcp-app/.mcp-use/tool-registry.d.ts
+++ b/understudy-agent-tools-mcp-app/.mcp-use/tool-registry.d.ts
@@ -1,0 +1,70 @@
+// Auto-generated tool registry types - DO NOT EDIT MANUALLY
+// This file is regenerated whenever tools are added, removed, or updated during development
+// Generated at: 2026-06-27T18:20:59.020Z
+
+declare module "mcp-use/react" {
+  interface ToolRegistry {
+    "get-understudy-ladder-status": {
+      input: { "artifacts": Record<string, unknown> };
+      output: { "stage": string; "readyFor": string; "present": Array<string>; "missing": Array<string>; "blockers": Array<string>; "nextAction": string; "nextCommand": string | null; "requiredSkill": string };
+    };
+    "inspect-understudy-skill": {
+      input: { "skill": string; "includeReference": boolean };
+      output: Record<string, unknown>;
+    };
+    "next-understudy-action": {
+      input: { "objective": string; "constraints": Array<string>; "artifacts": Record<string, unknown> };
+      output: { "objective": string; "constraints": Array<string>; "stage": string; "action": string; "command": string | null; "skill": string; "rationale": Array<string>; "approvalRequiredFor": Array<string> };
+    };
+    "produce-understudy-improvement-report": {
+      input: { "workloadName": string; "objective": string; "baseline": { "model"?: string | undefined; "quality"?: number | undefined; "latencyMs"?: number | undefined; "costUsdPer1k"?: number | undefined }; "candidate": { "model"?: string | undefined; "quality"?: number | undefined; "latencyMs"?: number | undefined; "costUsdPer1k"?: number | undefined }; "artifacts": Record<string, unknown> };
+      output: Record<string, unknown>;
+    };
+    "search-understudy-skills": {
+      input: { "query"?: string | undefined; "category": "all" | "install" | "capture" | "optimize" | "routing" | "cost" | "workflow" };
+      output: { "query": string; "category": string; "results": Array<{ "name": string; "description": string; "path": string; "hasReference": boolean; "category": string }>; "total": number };
+    };
+    "understudy-account-status": {
+      input: { "orgId"?: string | undefined };
+      output: { "ok": boolean; "configured": boolean; "org_id": string | null; "gateway_url": string | null; "auth_mode": string | null; "error"?: string | undefined };
+    };
+    "understudy-cli-guide": {
+      input: { "focus": "overview" | "install" | "capture" | "optimize" | "gateway" | "models" | "privacy" };
+      output: { "focus": string; "commands": Array<string>; "notes": Array<string>; "sources": Array<string> };
+    };
+    "understudy-get-route": {
+      input: { "orgId"?: string | undefined; "project"?: string | undefined; "projectId"?: string | undefined; "workload": string };
+      output: { "ok"?: boolean | undefined; "org_id"?: string | undefined; "project_id"?: string | undefined; "project_slug"?: string | null | undefined; "workload_id"?: string | undefined; "workload_name"?: string | undefined; "route_model_id"?: string | null | undefined; "route_traffic_pct"?: number | undefined; "passthrough_traffic_pct"?: number | undefined; "capture_enabled"?: boolean | undefined; "is_default"?: boolean | undefined; "error"?: string | undefined; "status"?: number | undefined; "requestId"?: string | undefined };
+    };
+    "understudy-list-captures": {
+      input: { "orgId"?: string | undefined; "project"?: string | undefined; "projectId"?: string | undefined; "workload"?: string | undefined; "limit": number; "cursor"?: string | undefined };
+      output: { "ok"?: boolean | undefined; "org_id"?: string | undefined; "project_id"?: string | undefined; "project_slug"?: string | null | undefined; "workload_id"?: string | null | undefined; "captures"?: Array<{ "request_id": string | null; "schema_version": string | null; "ts": string | null; "project_id": string | null; "workload_id": string | null; "mode": string | null; "provider": string | null; "endpoint": string | null; "requested_model": string | null; "upstream_model": string | null; "status_code": number | null; "latency_ms": number | null; "tags": { "count": number; "keys": Array<string> }; "customer_request_body": "present" | "absent"; "upstream_request_body": "present" | "absent"; "response_body": "present" | "absent" }> | undefined; "truncated"?: boolean | undefined; "cursor"?: string | null | undefined; "error"?: string | undefined; "status"?: number | undefined; "requestId"?: string | undefined };
+    };
+    "understudy-list-models": {
+      input: { "orgId"?: string | undefined };
+      output: { "ok"?: boolean | undefined; "org_id"?: string | undefined; "models"?: Array<{ "id": string; "display_name"?: string | undefined; "name"?: string | undefined; "description"?: string | undefined; "capabilities"?: Array<string> | undefined; "context_window"?: number | null | undefined }> | undefined; "error"?: string | undefined; "status"?: number | undefined; "requestId"?: string | undefined };
+    };
+    "understudy-list-projects": {
+      input: { "orgId"?: string | undefined };
+      output: { "ok"?: boolean | undefined; "org_id"?: string | undefined; "projects"?: Array<{ "id": string; "org_id"?: string | undefined; "slug": string; "name"?: string | undefined; "created_at"?: string | undefined; "settings"?: string | undefined; "deleted_at"?: string | null | undefined }> | undefined; "error"?: string | undefined; "status"?: number | undefined; "requestId"?: string | undefined };
+    };
+    "understudy-list-workloads": {
+      input: { "orgId"?: string | undefined; "project"?: string | undefined; "projectId"?: string | undefined };
+      output: { "ok"?: boolean | undefined; "org_id"?: string | undefined; "project_id"?: string | undefined; "project_slug"?: string | null | undefined; "workloads"?: Array<{ "id": string; "project_id"?: string | undefined; "name": string; "capture_enabled"?: boolean | undefined; "route_model_id"?: string | null | undefined; "route_traffic_pct"?: number | null | undefined; "route_deployment_id"?: string | null | undefined; "is_default"?: boolean | undefined; "created_at"?: string | undefined; "updated_at"?: string | undefined }> | undefined; "error"?: string | undefined; "status"?: number | undefined; "requestId"?: string | undefined };
+    };
+    "understudy-set-route-traffic": {
+      input: { "orgId"?: string | undefined; "project"?: string | undefined; "projectId"?: string | undefined; "workload": string; "modelId"?: string | null | undefined; "trafficPct": number; "clear": boolean; "confirm": boolean };
+      output: { "ok"?: boolean | undefined; "dryRun"?: boolean | undefined; "org_id"?: string | undefined; "project_id"?: string | undefined; "workload_id"?: string | undefined; "workload_name"?: string | undefined; "previous_route_model_id"?: string | null | undefined; "previous_route_traffic_pct"?: number | null | undefined; "route_model_id"?: string | null | undefined; "route_traffic_pct"?: number | null | undefined; "message"?: string | undefined; "error"?: string | undefined; "status"?: number | undefined; "requestId"?: string | undefined };
+    };
+    "understudy-submission-readiness": {
+      input: { "includeToolCatalog": boolean };
+      output: { "ok": boolean; "metadata": Record<string, unknown>; "manufact": Record<string, unknown>; "appStores": Record<string, unknown>; "safety": Array<string>; "toolCatalog"?: Array<Record<string, unknown>> | undefined; "submissionArtifacts": Array<string> };
+    };
+    "validate-understudy-proof-artifacts": {
+      input: { "artifacts": Record<string, unknown> };
+      output: { "ok": boolean; "present": Array<string>; "missing": Array<string>; "warnings": Array<string>; "recommendation": string; "localGateCommand": string };
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
Version bump for the v0.2.5 release (Anthropic chat provider, #131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->