### PR TITLE
Add watch-logs skill: hash-gated log review harness

### DIFF
--- a/skills/watch-logs/SKILL.md
+++ b/skills/watch-logs/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: watch-logs
+description: Use when a developer wants an always-on ops watcher over logs, command output, or endpoints — "every five minutes look at my logs and tell me what's wrong", "watch this log file and flag anomalies", "review my events on a schedule without burning tokens". Deterministic hash-gated triggers fire a cheap model review only on change, and every review is captured as an eval row for a future fine-tune.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Watch Logs
+
+Stand up a scheduled log/event review that is cheap by construction: a
+deterministic trigger script snapshots the watched sources, hashes them, and
+only when the hash **changes** does an inexpensive LLM review fire. The review
+itself is a small, well-bounded workload — summarize what changed, cite lines,
+say "nothing wrong" honestly — sized so a tiny open model (Gemma 2B class)
+could eventually serve it. Every review is recorded from day one as an
+`understudy.eval_result.v1` row, so the workload accumulates training-grade
+evidence without any training now.
+
+## When to use
+
+The developer wants recurring "look at my logs/events and tell me what's
+wrong" monitoring. This skill owns the watcher loop: interview → config →
+deterministic trigger → gated review → eval-row capture. For turning existing
+LLM traces into evals use [`../ingest-traces/SKILL.md`](../ingest-traces/SKILL.md);
+for building a frozen eval from the accumulated reviews use
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md); for eventually
+distilling the review onto a small model use
+[`../distill-classifier/SKILL.md`](../distill-classifier/SKILL.md).
+
+## Safety Gates
+
+- **Deterministic gate before any spend.** Never wire a scheduler directly to a
+  model call. The trigger script must run first; a review fires only on exit
+  code 1 (changed). Unchanged state costs zero tokens.
+- **Logs may contain secrets.** Snapshots stay local under
+  `~/.understudy/watch-logs/`. Before any *remote* review route (gateway or
+  provider), confirm with the developer what the logs can contain and prefer a
+  local model slot for sensitive logs; never upload raw snapshots anywhere.
+- **Approve the review route and spend bound once, up front** (model, route,
+  max tokens, cadence). The cron/launchd job then runs unattended inside that
+  bound. No new routes or models without re-approval.
+- **Command sources run arbitrary shell.** Only put commands in the watch
+  config that the developer typed or explicitly approved; show the final
+  config before installing any schedule.
+- **Honest reviews only.** The prompt contract requires "nothing wrong" when
+  nothing is wrong, and citations for every claimed anomaly. Do not tune the
+  prompt toward always finding something.
+
+## Flow
+
+1. **Interview.** Establish, in the developer's words: which sources to watch
+   (log file paths/globs, command outputs such as a `curl` health probe),
+   the cadence (default: every 5 minutes), and what "wrong" means for this
+   workload (error patterns, silence, restarts, latency lines, unexpected
+   states). Question bank and config mapping in [`reference.md`](reference.md).
+
+2. **Write the watch config** to `~/.understudy/watch-logs/<watch-id>.json`
+   (schema in [`reference.md`](reference.md)) and dry-run the trigger:
+
+   ```sh
+   node skills/watch-logs/scripts/watch-logs.mjs check \
+     --config ~/.understudy/watch-logs/ops.json --json
+   ```
+
+   Exit 0 = unchanged, 1 = changed (a snapshot of exactly what changed is
+   written under `~/.understudy/watch-logs/snapshots/`), 2 = error. The first
+   run always exits 1 (`first_run: true`) — treat it as the baseline review.
+
+3. **Wire the scheduler.** cron or launchd invokes `check`; only exit code 1
+   proceeds to the review step. Copy-paste wiring (including the exit-code-2
+   guard so errors alert instead of silently reviewing) is in
+   [`reference.md`](reference.md).
+
+4. **Run the gated review.** Send the snapshot's changed content through the
+   approved route using the prompt template in [`reference.md`](reference.md):
+   a local slot per [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md)
+   (private, $0), or a cheap catalog model through
+   [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)
+   (always `stream: true`). The review must return strict JSON: a verdict
+   (`nothing-wrong` | `anomaly`), a summary, and per-anomaly cited lines.
+
+5. **Record the eval row.** Pipe the review result back through the helper so
+   it lands as an `understudy.eval_result.v1` row in
+   `~/.understudy/watch-logs/reviews/reviews.jsonl`:
+
+   ```sh
+   node skills/watch-logs/scripts/watch-logs.mjs record --row review.json
+   ```
+
+   Rows start `status: "unscored"` (no gold labels yet); when the developer
+   later marks reviews right/wrong, scored rows make this a frozen eval and a
+   fine-tune corpus. Field mapping in [`reference.md`](reference.md).
+
+6. **Surface anomalies.** Deliver `anomaly` verdicts wherever the developer
+   asked (terminal, notification hook, issue); `nothing-wrong` verdicts stay
+   in the JSONL as evidence, not noise.
+
+## Output Standard
+
+End with: the watch config path and sources; the cadence and scheduler entry
+installed (or the command left for the developer to install); the approved
+review route, model, and spend bound; where snapshots and review rows live;
+and the graduation trigger — once enough scored rows accumulate, route to
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) and
+[`../distill-classifier/SKILL.md`](../distill-classifier/SKILL.md) to move the
+review onto a small local model.

--- a/skills/watch-logs/reference.md
+++ b/skills/watch-logs/reference.md
@@ -59,17 +59,31 @@ payload with the changed sources' full content is written to
 Only exit code 1 may proceed to the review. Exit 2 is an error — alert,
 don't review. cron (every 5 minutes):
 
+Put the pipeline in a wrapper script (say `~/.understudy/watch-logs/tick.sh`)
+so cron and launchd share it:
+
 ```sh
-*/5 * * * * node /path/to/skills/watch-logs/scripts/watch-logs.mjs check \
+#!/bin/sh
+node /path/to/skills/watch-logs/scripts/watch-logs.mjs check \
   --config "$HOME/.understudy/watch-logs/ops.json" --json \
-  >> "$HOME/.understudy/watch-logs/check.log" 2>&1; \
-  case $? in 1) /path/to/run-review.sh ;; 2) /path/to/alert-error.sh ;; esac
+  >> "$HOME/.understudy/watch-logs/check.log" 2>&1
+case $? in
+  1) /path/to/run-review.sh ;;
+  2) /path/to/alert-error.sh ;;
+esac
 ```
 
-launchd (macOS) — save as
-`~/Library/LaunchAgents/com.understudy.watch-logs.ops.plist`, then
-`launchctl load` it; point `ProgramArguments` at a small wrapper shell script
-containing the same `check → case` pipeline, with `StartInterval` set to `300`.
+cron (Linux — `flock` prevents overlapping ticks if a review runs long):
+
+```sh
+*/5 * * * * flock -n "$HOME/.understudy/watch-logs/ops.lock" "$HOME/.understudy/watch-logs/tick.sh"
+```
+
+launchd (macOS, which has no `flock(1)`) — save a plist as
+`~/Library/LaunchAgents/com.understudy.watch-logs.ops.plist` with
+`ProgramArguments` pointing at `tick.sh` and `StartInterval` set to `300`,
+then `launchctl load` it; launchd never starts a job that is still running,
+so no extra lock is needed.
 
 `run-review.sh` reads the newest snapshot, runs the review call, and pipes the
 result JSON to `watch-logs.mjs record`. Keep the whole pipeline idempotent:

--- a/skills/watch-logs/reference.md
+++ b/skills/watch-logs/reference.md
@@ -1,0 +1,171 @@
+# Watch Logs Reference
+
+Depth for [`SKILL.md`](SKILL.md): the interview question bank, the watch
+config schema, scheduler wiring, the review prompt contract, the eval-row
+mapping, and the graduation path to a fine-tuned small model.
+
+## Interview question bank
+
+Ask in the developer's vocabulary; map answers into the config below.
+
+1. **What should be watched?**
+   - Log files: exact paths, or a single-directory glob (`/var/log/app/*.log`).
+     Wildcards are supported in the basename only.
+   - Command outputs: anything printable — `systemctl status app`,
+     `docker ps --format ...`, `curl -fsS --max-time 10 <health-endpoint>`.
+     HTTP endpoints are watched as `curl` command sources so the trigger
+     script itself stays network-free.
+2. **How much history matters?** The trigger hashes the last `tail_bytes`
+   (default 64 KiB) of each file. High-volume logs may want a bigger tail;
+   noisy-but-irrelevant logs a smaller one.
+3. **Cadence?** Default every 5 minutes. Faster than 1 minute rarely helps —
+   the hash gate already makes idle checks free, but review latency is bounded
+   by the model call anyway.
+4. **What does "wrong" mean here?** Collect concrete signals: error/panic
+   patterns, stack traces, restart loops, silence (a log that *stopped*
+   moving also changes state — file size is part of the hash input), status
+   codes, latency lines, queue depth. Write these into the prompt's
+   "workload-specific signals" block.
+5. **What must never leave the machine?** Decides local slot vs gateway route.
+6. **Where should anomalies land?** Terminal, notification, issue tracker.
+
+## Watch config schema
+
+`~/.understudy/watch-logs/<watch-id>.json`:
+
+```json
+{
+  "watch_id": "ops",
+  "sources": [
+    { "id": "app-log", "type": "file", "path": "/var/log/app/server.log", "tail_bytes": 65536 },
+    { "id": "worker-logs", "type": "file", "glob": "/var/log/app/workers/*.log" },
+    { "id": "health", "type": "command", "command": "curl -fsS --max-time 10 http://localhost:8080/health", "timeout_ms": 15000 }
+  ]
+}
+```
+
+- `file` sources hash the tail of every matched file, prefixed with path and
+  current size — so rotation, truncation, growth, and new/removed matches all
+  register as change.
+- `command` sources hash `exit code + stdout + stderr`, so a health probe that
+  flips from 200 to connection-refused changes state even if it prints nothing.
+
+State lives in `~/.understudy/watch-logs/state/<watch-id>.json`; on change a
+payload with the changed sources' full content is written to
+`~/.understudy/watch-logs/snapshots/<run-id>.json` for the review step.
+
+## Scheduler wiring
+
+Only exit code 1 may proceed to the review. Exit 2 is an error — alert,
+don't review. cron (every 5 minutes):
+
+```sh
+*/5 * * * * node /path/to/skills/watch-logs/scripts/watch-logs.mjs check \
+  --config "$HOME/.understudy/watch-logs/ops.json" --json \
+  >> "$HOME/.understudy/watch-logs/check.log" 2>&1; \
+  case $? in 1) /path/to/run-review.sh ;; 2) /path/to/alert-error.sh ;; esac
+```
+
+launchd (macOS) — save as
+`~/Library/LaunchAgents/com.understudy.watch-logs.ops.plist`, then
+`launchctl load` it; point `ProgramArguments` at a small wrapper shell script
+containing the same `check → case` pipeline, with `StartInterval` set to `300`.
+
+`run-review.sh` reads the newest snapshot, runs the review call, and pipes the
+result JSON to `watch-logs.mjs record`. Keep the whole pipeline idempotent:
+one snapshot → at most one review row.
+
+## Review step contract
+
+The review is deliberately a small-model-shaped task: bounded input (only the
+changed tails), strict JSON output, honesty required.
+
+**Route.** Local slot first for sensitive logs —
+[`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md) stands up
+an OpenAI-compatible endpoint (reuse a running desktop-app warm slot when
+present). Otherwise a cheap catalog model through
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) —
+always `stream: true`, aggregate locally. Record model + route in every row.
+
+**Prompt template** (fill the `{{...}}` blocks; hash the filled system prompt
+with sha256 and pass it to `record` as `prompt_sha256` so prompt versions are
+traceable across rows):
+
+```text
+System:
+You are an operations log reviewer. You receive the portions of watched
+sources that CHANGED since the last check. Report only what the text
+supports. If nothing looks wrong, say so plainly — a correct "nothing wrong"
+is a successful review, and inventing problems is a failure.
+
+Workload-specific signals to treat as wrong:
+{{signals_from_interview}}
+
+Respond with STRICT JSON only, no prose outside it:
+{
+  "verdict": "nothing-wrong" | "anomaly",
+  "summary": "<one paragraph: what changed and whether it is healthy>",
+  "anomalies": [
+    { "source_id": "<id>", "line": "<exact quoted line>",
+      "note": "<why this is wrong>", "severity": "low" | "medium" | "high" }
+  ]
+}
+Rules: every anomaly must quote an exact line from the input; "verdict":
+"anomaly" requires at least one anomaly entry; "nothing-wrong" requires an
+empty anomalies array.
+
+User:
+Watch: {{watch_id}}   Snapshot: {{snapshot_run_id}}   Time: {{created_at}}
+Changed sources:
+{{for each changed source: "== <id> ==" + its content}}
+```
+
+Cap the review at a small `max_tokens` (the JSON is short) and validate the
+JSON before recording; a malformed response is recorded with
+`verdict: "review-failed"` (becomes `status: "error"`) so reliability is
+measured too, then retried once.
+
+## Eval-row capture
+
+`watch-logs.mjs record` maps a review result onto
+[`understudy.eval_result.v1`](../../schemas/understudy.eval_result.v1.schema.json):
+
+| Row field | Source |
+| --- | --- |
+| `run_id` | `watch-logs:<watch_id>` — the ongoing watch is the run |
+| `task_id` | the snapshot `run_id` — one changed snapshot is one task |
+| `split` | `"none"` (no split contract yet) |
+| `score` / `status` | `null` / `"unscored"` until a human labels the review; a labeled row carries `score` 0..1 and `"ok"`; `review-failed` → `"error"` |
+| `model`, `route`, `latency_ms` | from the review call |
+| `provenance.harness_sha256` | `prompt_sha256` of the filled system prompt |
+| `provenance.artifact_refs` | the snapshot path (the exact model input) |
+| `review` (extra field) | `verdict`, `summary`, `anomalies` — v1 allows producer extras |
+
+Input shape for `record` (stdin or `--row file.json`):
+
+```json
+{
+  "watch_id": "ops",
+  "snapshot_id": "ops-2026-07-02T09-05-00-000Z",
+  "verdict": "anomaly",
+  "summary": "Worker 3 entered a restart loop after the 09:03 deploy.",
+  "anomalies": [ { "source_id": "worker-logs", "line": "panic: nil deref", "note": "crash on startup", "severity": "high" } ],
+  "model": "gemma-4-e2b", "route": "local", "latency_ms": 840,
+  "prompt_sha256": "<sha256>", "snapshot_path": "<path to snapshot json>"
+}
+```
+
+## Retention and graduation
+
+- Snapshots and `reviews.jsonl` are the training corpus — keep them. If disk
+  matters, prune snapshots older than N days *only after* their rows are
+  scored; never prune the JSONL.
+- Periodically ask the developer to spot-label a batch of rows (was the
+  verdict right?). Once a few hundred scored rows exist:
+  [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) freezes them
+  into splits, [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md)
+  checks how small a model can hold the quality bar, and
+  [`../distill-classifier/SKILL.md`](../distill-classifier/SKILL.md) /
+  [`../local-distillation-lab/SKILL.md`](../local-distillation-lab/SKILL.md)
+  move the review onto a tiny local model — at which point the whole watcher
+  runs at zero marginal cost.

--- a/skills/watch-logs/scripts/watch-logs.mjs
+++ b/skills/watch-logs/scripts/watch-logs.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+// Deterministic trigger + eval-row recorder for the watch-logs skill.
+//
+//   watch-logs.mjs check  --config <watch.json> [--state-dir <dir>] [--json]
+//   watch-logs.mjs record [--state-dir <dir>] [--row <review.json>] [--json]
+//
+// `check` snapshots every configured source (log-file tails, command output),
+// hashes the result, and compares against the last state under the state dir.
+// Exit codes are scheduler-friendly: 0 = unchanged, 1 = changed (state and a
+// snapshot payload were written; fire the cheap model review), 2 = error.
+// `record` appends one review as an understudy.eval_result.v1 row to
+// reviews/reviews.jsonl so the workload accumulates training-grade evidence.
+//
+// Local-only: this script never makes network calls. Command sources run
+// whatever shell command the user configured (which may reach the network,
+// e.g. curl to a health endpoint) — that is the user's explicit choice.
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  writeFileSync,
+  appendFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+
+const SNAPSHOT_SCHEMA = "understudy.watch_logs_snapshot.v1";
+const EVAL_ROW_SCHEMA = "understudy.eval_result.v1";
+const DEFAULT_TAIL_BYTES = 64 * 1024;
+const DEFAULT_COMMAND_TIMEOUT_MS = 15_000;
+
+export function sha256(text) {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+export function defaultStateDir() {
+  return join(homedir(), ".understudy", "watch-logs");
+}
+
+/** Expand a file source into a sorted list of matching paths.
+ *  Supports a literal `path`, or a `glob` whose pattern lives in the
+ *  basename only (e.g. /var/log/workers/*.log). */
+export function expandFileSource(source) {
+  if (source.path) {
+    return [resolve(source.path)];
+  }
+  const glob = source.glob;
+  const dir = dirname(glob);
+  const pattern = basename(glob);
+  if (/[*?]/.test(dir)) {
+    throw new Error(`glob wildcards are only supported in the basename: ${glob}`);
+  }
+  if (!existsSync(dir)) {
+    return [];
+  }
+  const regex = new RegExp(
+    `^${pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*").replace(/\?/g, "[^/]")}$`,
+  );
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && regex.test(entry.name))
+    .map((entry) => join(dir, entry.name))
+    .sort();
+}
+
+/** Read the last `tailBytes` bytes of a file without loading the whole file. */
+export function readTail(path, tailBytes) {
+  const fd = openSync(path, "r");
+  try {
+    const size = fstatSync(fd).size;
+    const length = Math.min(size, tailBytes);
+    const buffer = Buffer.alloc(length);
+    readSync(fd, buffer, 0, length, size - length);
+    return { text: buffer.toString("utf8"), size };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Produce the canonical content string for one source. Deterministic for
+ *  identical underlying state; changes whenever the watched state changes. */
+export function snapshotSource(source) {
+  if (source.type === "file") {
+    const tailBytes = source.tail_bytes ?? DEFAULT_TAIL_BYTES;
+    const paths = expandFileSource(source);
+    if (paths.length === 0) {
+      return { content: "no files matched\n", detail: "0 files" };
+    }
+    const parts = [];
+    for (const path of paths) {
+      if (!existsSync(path)) {
+        parts.push(`==> ${path} (missing) <==\n`);
+        continue;
+      }
+      const { text, size } = readTail(path, tailBytes);
+      parts.push(`==> ${path} (size ${size}) <==\n${text}`);
+    }
+    return { content: parts.join("\n"), detail: `${paths.length} file(s)` };
+  }
+  if (source.type === "command") {
+    const result = spawnSync("/bin/sh", ["-c", source.command], {
+      encoding: "utf8",
+      timeout: source.timeout_ms ?? DEFAULT_COMMAND_TIMEOUT_MS,
+    });
+    const exit = result.status ?? `signal:${result.signal ?? "unknown"}`;
+    return {
+      content: `exit=${exit}\n--- stdout ---\n${result.stdout ?? ""}\n--- stderr ---\n${result.stderr ?? ""}`,
+      detail: `exit ${exit}`,
+    };
+  }
+  throw new Error(`unknown source type: ${JSON.stringify(source.type)}`);
+}
+
+export function loadConfig(path) {
+  const config = JSON.parse(readFileSync(path, "utf8"));
+  if (!config.watch_id || typeof config.watch_id !== "string") {
+    throw new Error("config needs a string watch_id");
+  }
+  if (!Array.isArray(config.sources) || config.sources.length === 0) {
+    throw new Error("config needs a non-empty sources array");
+  }
+  for (const source of config.sources) {
+    if (!source.id) throw new Error("every source needs an id");
+    if (source.type === "file" && !source.path && !source.glob) {
+      throw new Error(`file source ${source.id} needs path or glob`);
+    }
+    if (source.type === "command" && !source.command) {
+      throw new Error(`command source ${source.id} needs a command`);
+    }
+  }
+  return config;
+}
+
+export function runCheck({ config, stateDir, now = new Date() }) {
+  const statePath = join(stateDir, "state", `${config.watch_id}.json`);
+  const previous = existsSync(statePath) ? JSON.parse(readFileSync(statePath, "utf8")) : null;
+
+  const sources = {};
+  const changed = [];
+  const unchanged = [];
+  for (const source of config.sources) {
+    const snapshot = snapshotSource(source);
+    const digest = sha256(snapshot.content);
+    sources[source.id] = { sha256: digest, bytes: Buffer.byteLength(snapshot.content), detail: snapshot.detail };
+    const prevDigest = previous?.sources?.[source.id]?.sha256 ?? null;
+    if (prevDigest === digest) {
+      unchanged.push(source.id);
+    } else {
+      changed.push({ id: source.id, prev_sha256: prevDigest, sha256: digest, content: snapshot.content });
+    }
+  }
+  const combined = sha256(config.sources.map((s) => `${s.id}:${sources[s.id].sha256}`).join("\n"));
+
+  const state = {
+    watch_id: config.watch_id,
+    updated_at: now.toISOString(),
+    combined_sha256: combined,
+    sources,
+  };
+  mkdirSync(dirname(statePath), { recursive: true });
+
+  if (changed.length === 0) {
+    writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+    return { changed: false, watch_id: config.watch_id, combined_sha256: combined };
+  }
+
+  const runId = `${config.watch_id}-${now.toISOString().replace(/[:.]/g, "-")}`;
+  const snapshotPath = join(stateDir, "snapshots", `${runId}.json`);
+  mkdirSync(dirname(snapshotPath), { recursive: true });
+  writeFileSync(
+    snapshotPath,
+    `${JSON.stringify(
+      {
+        schema_version: SNAPSHOT_SCHEMA,
+        run_id: runId,
+        watch_id: config.watch_id,
+        created_at: now.toISOString(),
+        first_run: previous === null,
+        combined_sha256: combined,
+        changed,
+        unchanged,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+  return {
+    changed: true,
+    first_run: previous === null,
+    watch_id: config.watch_id,
+    run_id: runId,
+    snapshot_path: snapshotPath,
+    changed_sources: changed.map((entry) => entry.id),
+    combined_sha256: combined,
+  };
+}
+
+/** Turn a review result into an understudy.eval_result.v1 row and append it. */
+export function recordReview({ review, stateDir, now = new Date() }) {
+  if (!review || typeof review !== "object") {
+    throw new Error("review must be a JSON object");
+  }
+  const watchId = review.watch_id ?? null;
+  const runId = review.run_id ?? (watchId ? `watch-logs:${watchId}` : null);
+  const taskId = review.task_id ?? review.snapshot_id ?? null;
+  if (!runId || !taskId) {
+    throw new Error("review needs run_id (or watch_id) and task_id (or snapshot_id)");
+  }
+  const verdict = review.verdict;
+  if (verdict !== "nothing-wrong" && verdict !== "anomaly" && verdict !== "review-failed") {
+    throw new Error('verdict must be "nothing-wrong", "anomaly", or "review-failed"');
+  }
+  if (typeof review.summary !== "string" || review.summary.length === 0) {
+    throw new Error("review needs a non-empty summary string");
+  }
+  const score = typeof review.score === "number" ? review.score : null;
+  const status = verdict === "review-failed" ? "error" : score === null ? "unscored" : "ok";
+  const row = {
+    schema_version: EVAL_ROW_SCHEMA,
+    run_id: runId,
+    task_id: taskId,
+    split: "none",
+    score,
+    status,
+    model: review.model ?? null,
+    route: review.route ?? null,
+    latency_ms: typeof review.latency_ms === "number" ? review.latency_ms : null,
+    created_at: now.toISOString(),
+    provenance: {
+      harness_sha256: review.prompt_sha256 ?? null,
+      artifact_refs: review.snapshot_path ? [review.snapshot_path] : [],
+    },
+    review: {
+      verdict,
+      summary: review.summary,
+      anomalies: Array.isArray(review.anomalies) ? review.anomalies : [],
+    },
+  };
+  const reviewsPath = join(stateDir, "reviews", "reviews.jsonl");
+  mkdirSync(dirname(reviewsPath), { recursive: true });
+  appendFileSync(reviewsPath, `${JSON.stringify(row)}\n`);
+  return { row, reviews_path: reviewsPath };
+}
+
+function parseArgs(argv) {
+  const args = { command: null, config: null, stateDir: defaultStateDir(), row: null, json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!args.command && !arg.startsWith("--")) args.command = arg;
+    else if (arg === "--config") args.config = argv[++index];
+    else if (arg === "--state-dir") args.stateDir = argv[++index];
+    else if (arg === "--row") args.row = argv[++index];
+    else if (arg === "--json") args.json = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+    if (args.command === "check") {
+      if (!args.config) throw new Error("check requires --config <watch.json>");
+      const result = runCheck({ config: loadConfig(args.config), stateDir: args.stateDir });
+      if (args.json) console.log(JSON.stringify(result, null, 2));
+      else console.log(result.changed ? `changed: ${result.changed_sources.join(", ")}` : "unchanged");
+      process.exit(result.changed ? 1 : 0);
+    }
+    if (args.command === "record") {
+      const text = args.row ? readFileSync(args.row, "utf8") : readFileSync(0, "utf8");
+      const result = recordReview({ review: JSON.parse(text), stateDir: args.stateDir });
+      console.log(args.json ? JSON.stringify(result.row, null, 2) : `recorded → ${result.reviews_path}`);
+      process.exit(0);
+    }
+    throw new Error('usage: watch-logs.mjs <check|record> [--config <path>] [--state-dir <dir>] [--row <path>] [--json]');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === new URL(import.meta.url).pathname) {
+  main();
+}

--- a/skills/watch-logs/scripts/watch-logs.mjs
+++ b/skills/watch-logs/scripts/watch-logs.mjs
@@ -32,6 +32,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SNAPSHOT_SCHEMA = "understudy.watch_logs_snapshot.v1";
 const EVAL_ROW_SCHEMA = "understudy.eval_result.v1";
@@ -222,6 +223,13 @@ export function recordReview({ review, stateDir, now = new Date() }) {
   if (typeof review.summary !== "string" || review.summary.length === 0) {
     throw new Error("review needs a non-empty summary string");
   }
+  const anomalies = Array.isArray(review.anomalies) ? review.anomalies : [];
+  if (verdict === "anomaly" && anomalies.length === 0) {
+    throw new Error('verdict "anomaly" requires at least one anomalies entry');
+  }
+  if (verdict === "nothing-wrong" && anomalies.length > 0) {
+    throw new Error('verdict "nothing-wrong" requires an empty anomalies array');
+  }
   const score = typeof review.score === "number" ? review.score : null;
   const status = verdict === "review-failed" ? "error" : score === null ? "unscored" : "ok";
   const row = {
@@ -242,7 +250,7 @@ export function recordReview({ review, stateDir, now = new Date() }) {
     review: {
       verdict,
       summary: review.summary,
-      anomalies: Array.isArray(review.anomalies) ? review.anomalies : [],
+      anomalies,
     },
   };
   const reviewsPath = join(stateDir, "reviews", "reviews.jsonl");
@@ -289,6 +297,6 @@ function main() {
   }
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === new URL(import.meta.url).pathname) {
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main();
 }

--- a/tests/watch-logs.test.mjs
+++ b/tests/watch-logs.test.mjs
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import {
+  expandFileSource,
+  readTail,
+  recordReview,
+  runCheck,
+  sha256,
+} from "../skills/watch-logs/scripts/watch-logs.mjs";
+
+const script = resolve("skills/watch-logs/scripts/watch-logs.mjs");
+const schema = JSON.parse(readFileSync(resolve("schemas/understudy.eval_result.v1.schema.json"), "utf8"));
+
+let dir;
+let stateDir;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "understudy-watch-logs-"));
+  stateDir = join(dir, "watch-state");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeConfig(sources, watchId = "ops") {
+  const path = join(dir, "watch.json");
+  writeFileSync(path, `${JSON.stringify({ watch_id: watchId, sources }, null, 2)}\n`);
+  return path;
+}
+
+function check(configPath) {
+  return spawnSync("node", [script, "check", "--config", configPath, "--state-dir", stateDir, "--json"], {
+    encoding: "utf8",
+  });
+}
+
+describe("watch-logs check trigger", () => {
+  it("first run exits 1 (changed) and writes state + a baseline snapshot", () => {
+    const log = join(dir, "app.log");
+    writeFileSync(log, "line one\n");
+    const configPath = writeConfig([{ id: "app", type: "file", path: log }]);
+
+    const result = check(configPath);
+    assert.equal(result.status, 1, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.changed, true);
+    assert.equal(payload.first_run, true);
+    assert.deepEqual(payload.changed_sources, ["app"]);
+    assert.ok(existsSync(join(stateDir, "state", "ops.json")));
+    const snapshot = JSON.parse(readFileSync(payload.snapshot_path, "utf8"));
+    assert.equal(snapshot.schema_version, "understudy.watch_logs_snapshot.v1");
+    assert.match(snapshot.changed[0].content, /line one/);
+  });
+
+  it("unchanged second run exits 0 and writes no new snapshot", () => {
+    const log = join(dir, "app.log");
+    writeFileSync(log, "steady\n");
+    const configPath = writeConfig([{ id: "app", type: "file", path: log }]);
+
+    assert.equal(check(configPath).status, 1);
+    const snapshotsBefore = readdirSync(join(stateDir, "snapshots")).length;
+    const second = check(configPath);
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(JSON.parse(second.stdout).changed, false);
+    assert.equal(readdirSync(join(stateDir, "snapshots")).length, snapshotsBefore);
+  });
+
+  it("detects an appended log line and snapshots only the changed source", () => {
+    const app = join(dir, "app.log");
+    const quiet = join(dir, "quiet.log");
+    writeFileSync(app, "boot\n");
+    writeFileSync(quiet, "nothing here\n");
+    const configPath = writeConfig([
+      { id: "app", type: "file", path: app },
+      { id: "quiet", type: "file", path: quiet },
+    ]);
+
+    assert.equal(check(configPath).status, 1);
+    appendFileSync(app, "ERROR: kaboom\n");
+    const result = check(configPath);
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.deepEqual(payload.changed_sources, ["app"]);
+    const snapshot = JSON.parse(readFileSync(payload.snapshot_path, "utf8"));
+    assert.equal(snapshot.changed.length, 1);
+    assert.match(snapshot.changed[0].content, /ERROR: kaboom/);
+    assert.deepEqual(snapshot.unchanged, ["quiet"]);
+  });
+
+  it("glob sources register new matching files as change", () => {
+    const logs = join(dir, "workers");
+    mkdirSync(logs);
+    writeFileSync(join(logs, "w1.log"), "w1 ok\n");
+    const configPath = writeConfig([{ id: "workers", type: "file", glob: join(logs, "*.log") }]);
+
+    assert.equal(check(configPath).status, 1);
+    assert.equal(check(configPath).status, 0);
+    writeFileSync(join(logs, "w2.log"), "w2 up\n");
+    writeFileSync(join(logs, "ignore.txt"), "not a log\n");
+    const result = check(configPath);
+    assert.equal(result.status, 1);
+    const snapshot = JSON.parse(readFileSync(JSON.parse(result.stdout).snapshot_path, "utf8"));
+    assert.match(snapshot.changed[0].content, /w2 up/);
+    assert.doesNotMatch(snapshot.changed[0].content, /not a log/);
+  });
+
+  it("command sources hash exit code and output", () => {
+    const probe = join(dir, "probe.txt");
+    writeFileSync(probe, "healthy\n");
+    const configPath = writeConfig([{ id: "probe", type: "command", command: `cat ${probe}` }]);
+
+    assert.equal(check(configPath).status, 1);
+    assert.equal(check(configPath).status, 0);
+    writeFileSync(probe, "connection refused\n");
+    const result = check(configPath);
+    assert.equal(result.status, 1);
+    const snapshot = JSON.parse(readFileSync(JSON.parse(result.stdout).snapshot_path, "utf8"));
+    assert.match(snapshot.changed[0].content, /exit=0/);
+    assert.match(snapshot.changed[0].content, /connection refused/);
+  });
+
+  it("respects tail_bytes so huge logs stay cheap", () => {
+    const log = join(dir, "big.log");
+    writeFileSync(log, `${"x".repeat(10_000)}\nTAIL-MARKER\n`);
+    const config = { watch_id: "big", sources: [{ id: "big", type: "file", path: log, tail_bytes: 64 }] };
+    const result = runCheck({ config, stateDir });
+    assert.equal(result.changed, true);
+    const snapshot = JSON.parse(readFileSync(result.snapshot_path, "utf8"));
+    assert.match(snapshot.changed[0].content, /TAIL-MARKER/);
+    assert.ok(snapshot.changed[0].content.length < 200);
+  });
+
+  it("missing config exits 2", () => {
+    const result = check(join(dir, "nope.json"));
+    assert.equal(result.status, 2);
+  });
+});
+
+describe("watch-logs unit helpers", () => {
+  it("sha256 is stable and content-sensitive", () => {
+    assert.equal(sha256("abc"), sha256("abc"));
+    assert.notEqual(sha256("abc"), sha256("abd"));
+  });
+
+  it("expandFileSource matches basename globs only, sorted", () => {
+    mkdirSync(join(dir, "logs"));
+    writeFileSync(join(dir, "logs", "b.log"), "");
+    writeFileSync(join(dir, "logs", "a.log"), "");
+    writeFileSync(join(dir, "logs", "c.txt"), "");
+    const matched = expandFileSource({ glob: join(dir, "logs", "*.log") });
+    assert.deepEqual(matched, [join(dir, "logs", "a.log"), join(dir, "logs", "b.log")]);
+    assert.deepEqual(expandFileSource({ glob: join(dir, "absent", "*.log") }), []);
+    assert.throws(() => expandFileSource({ glob: join(dir, "*", "x.log") }), /basename/);
+  });
+
+  it("readTail returns only the last N bytes", () => {
+    const path = join(dir, "tail.log");
+    writeFileSync(path, "0123456789");
+    assert.deepEqual(readTail(path, 4), { text: "6789", size: 10 });
+    assert.deepEqual(readTail(path, 100).text, "0123456789");
+  });
+});
+
+describe("watch-logs record (eval rows)", () => {
+  const review = {
+    watch_id: "ops",
+    snapshot_id: "ops-2026-07-02T09-05-00-000Z",
+    verdict: "anomaly",
+    summary: "Worker restart loop after deploy.",
+    anomalies: [{ source_id: "app", line: "ERROR: kaboom", note: "crash", severity: "high" }],
+    model: "gemma-4-e2b",
+    route: "local",
+    latency_ms: 840,
+    prompt_sha256: sha256("prompt-v1"),
+    snapshot_path: "/tmp/example-snapshot.json",
+  };
+
+  it("appends a schema-valid understudy.eval_result.v1 row", () => {
+    const { row, reviews_path } = recordReview({ review, stateDir });
+    for (const field of schema.required) {
+      assert.ok(row[field] !== undefined && row[field] !== null, `missing required ${field}`);
+    }
+    assert.equal(row.schema_version, schema.properties.schema_version.const);
+    assert.ok(schema.properties.status.enum.includes(row.status));
+    assert.equal(row.run_id, "watch-logs:ops");
+    assert.equal(row.task_id, review.snapshot_id);
+    assert.equal(row.split, "none");
+    assert.equal(row.score, null);
+    assert.equal(row.status, "unscored");
+    assert.equal(row.provenance.harness_sha256, review.prompt_sha256);
+    assert.deepEqual(row.provenance.artifact_refs, [review.snapshot_path]);
+    assert.equal(row.review.verdict, "anomaly");
+
+    const lines = readFileSync(reviews_path, "utf8").trim().split("\n");
+    assert.equal(lines.length, 1);
+    assert.deepEqual(JSON.parse(lines[0]).review.anomalies, review.anomalies);
+  });
+
+  it("a scored row becomes status ok; review-failed becomes error", () => {
+    const scored = recordReview({ review: { ...review, score: 1 }, stateDir }).row;
+    assert.equal(scored.status, "ok");
+    assert.equal(scored.score, 1);
+    const failed = recordReview({ review: { ...review, verdict: "review-failed" }, stateDir }).row;
+    assert.equal(failed.status, "error");
+  });
+
+  it("CLI record appends via --row and accumulates JSONL", () => {
+    const rowPath = join(dir, "review.json");
+    writeFileSync(rowPath, JSON.stringify(review));
+    for (let i = 0; i < 2; i += 1) {
+      const result = spawnSync("node", [script, "record", "--state-dir", stateDir, "--row", rowPath], {
+        encoding: "utf8",
+      });
+      assert.equal(result.status, 0, result.stderr);
+    }
+    const lines = readFileSync(join(stateDir, "reviews", "reviews.jsonl"), "utf8").trim().split("\n");
+    assert.equal(lines.length, 2);
+  });
+
+  it("rejects rows without a verdict, summary, or identifiers", () => {
+    assert.throws(() => recordReview({ review: { ...review, verdict: "maybe" }, stateDir }), /verdict/);
+    assert.throws(() => recordReview({ review: { ...review, summary: "" }, stateDir }), /summary/);
+    assert.throws(
+      () => recordReview({ review: { ...review, watch_id: undefined, snapshot_id: undefined }, stateDir }),
+      /run_id|task_id/,
+    );
+    const result = spawnSync("node", [script, "record", "--state-dir", stateDir, "--row", join(dir, "missing.json")], {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 2);
+  });
+});

--- a/tests/watch-logs.test.mjs
+++ b/tests/watch-logs.test.mjs
@@ -226,6 +226,17 @@ describe("watch-logs record (eval rows)", () => {
   it("rejects rows without a verdict, summary, or identifiers", () => {
     assert.throws(() => recordReview({ review: { ...review, verdict: "maybe" }, stateDir }), /verdict/);
     assert.throws(() => recordReview({ review: { ...review, summary: "" }, stateDir }), /summary/);
+    assert.throws(() => recordReview({ review: { ...review, anomalies: [] }, stateDir }), /at least one/);
+    assert.throws(
+      () => recordReview({ review: { ...review, verdict: "nothing-wrong" }, stateDir }),
+      /empty anomalies/,
+    );
+    // an honest all-clear review records cleanly
+    const clear = recordReview({
+      review: { ...review, verdict: "nothing-wrong", anomalies: [], summary: "Deploy noise only; healthy." },
+      stateDir,
+    }).row;
+    assert.equal(clear.review.verdict, "nothing-wrong");
     assert.throws(
       () => recordReview({ review: { ...review, watch_id: undefined, snapshot_id: undefined }, stateDir }),
       /run_id|task_id/,


### PR DESCRIPTION
## What

New top-level skill `skills/watch-logs/` for the recurring ops workload: *"every five minutes look at all logs/events and tell me what's wrong"* — done cheaply, with deterministic triggers gating every model call.

- **SKILL.md** — interview flow (what to watch, cadence, what "wrong" means), safety gates (hash gate before any spend, logs-may-contain-secrets → local-slot preference, approved spend bound, honest "nothing wrong" contract), and the 6-step flow.
- **reference.md** — interview question bank, watch-config schema, cron/launchd wiring with an exit-code-2 guard, the strict-JSON review prompt template, the eval-row field mapping, retention + graduation path.
- **scripts/watch-logs.mjs** — zero-dep node trigger + recorder. `check` snapshots sources (file tails incl. basename globs + size, command exit/stdout/stderr), sha256s them against last state under `~/.understudy/watch-logs/`, writes a changed-content snapshot payload, exits 0-unchanged / 1-changed / 2-error. `record` appends each review as an `understudy.eval_result.v1` row (`schemas/understudy.eval_result.v1.schema.json`) to `reviews/reviews.jsonl` — rows start `unscored`, become `ok` when human-labeled, so the workload accumulates a fine-tune corpus for a Gemma-2B-class model from day one, without training anything now.
- **tests/watch-logs.test.mjs** — 14 node:test cases: first-run baseline, unchanged idempotence, appended-line detection, glob pickup, command-source change, tail_bytes bounding, schema-required-field validation of recorded rows, scored/failed status mapping, CLI exit codes. Deterministic, no network.

## Catalog growth rule

The utterance "watch my logs on a schedule and tell me what's wrong" is claimed by no existing skill. Checked against: `ingest-traces` (existing LLM traces → evals, not an ops watcher), `capture-evidence` (freezes evals from a workload; watch-logs feeds it), `optimize-agentic-workload` / `ramp-and-verify` (improve/route existing LLM workloads), `use-understudy-gateway` and `run-local-model-lab` (review-route mechanics — referenced, not duplicated), `distill-classifier` / `local-distillation-lab` (the graduation target once rows are scored).

## Verification

`npm ci && npm run check` green at root: build, typecheck, 153 tests, `skills:validate --repo` (ok 32 public skills incl. the new one), package smoke. `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->