### PR TITLE
Build-your-own evals in the eval gallery

### DIFF
--- a/apps/homescreen/app/components/TrainingPane.tsx
+++ b/apps/homescreen/app/components/TrainingPane.tsx
@@ -173,6 +173,22 @@ type FusionLiveRow = {
   reason: string;
 };
 
+type CustomEvalSummary = {
+  eval_id: string;
+  name: string;
+  scoring_rule: string;
+  example_count: number;
+  created_at: string;
+};
+
+type CustomEvalImportResult = {
+  eval_id: string;
+  name: string;
+  imported: number;
+  skipped_total: number;
+  skipped: { line: number; reason: string }[];
+};
+
 type FusionEvalEvent =
   | { type: "RunStarted"; run_id: string; suite: string; candidates: string[]; rows: number }
   | { type: "CandidateStarted"; run_id: string; candidate: string }
@@ -330,8 +346,14 @@ function FusionEvaluationPane() {
   const [plan, setPlan] = useState<FusionMatrixRun | null>(null);
   const [suite, setSuite] = useState("local-fusion-smoke");
   const [candidate, setCandidate] = useState("local-fast");
-  const [busy, setBusy] = useState<"plan" | "run" | null>(null);
+  const [busy, setBusy] = useState<"plan" | "run" | "import" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [customEvals, setCustomEvals] = useState<CustomEvalSummary[]>([]);
+  const [importName, setImportName] = useState("");
+  const [importRule, setImportRule] = useState("contains");
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importNotice, setImportNotice] = useState<string | null>(null);
+  const [fileInputKey, setFileInputKey] = useState(0);
   const [liveRunId, setLiveRunId] = useState<string | null>(null);
   const [liveSuite, setLiveSuite] = useState<string | null>(null);
   const [liveRows, setLiveRows] = useState<FusionLiveRow[]>([]);
@@ -339,16 +361,18 @@ function FusionEvaluationPane() {
   const [finishedScore, setFinishedScore] = useState<number | null>(null);
 
   const refresh = async () => {
-    const [nextMatrix, nextSummary, nextRows, nextDecisions] = await Promise.all([
+    const [nextMatrix, nextSummary, nextRows, nextDecisions, nextCustomEvals] = await Promise.all([
       invoke<FusionMatrix>("fusion_benchmark_matrix"),
       invoke<FusionRunSummary>("fusion_benchmark_run_summary", { limit: 80 }),
       invoke<FusionBenchmarkResultRow[]>("fusion_benchmark_results", { limit: 500 }),
       invoke<FusionRouteDecision[]>("fusion_route_decisions", { limit: 8 }),
+      invoke<CustomEvalSummary[]>("list_custom_evals"),
     ]);
     setMatrix(nextMatrix);
     setRunSummary(nextSummary);
     setPersistedRows(nextRows);
     setDecisions(nextDecisions);
+    setCustomEvals(nextCustomEvals);
   };
 
   useEffect(() => {
@@ -380,79 +404,81 @@ function FusionEvaluationPane() {
     [],
   );
 
+  const handleLiveEvent = (event: FusionEvalEvent) => {
+    if (event.type === "RunStarted") {
+      setLiveRunId(event.run_id);
+      setLiveSuite(event.suite);
+      setFinishedScore(null);
+      setLiveRows([]);
+      setActiveRowKey(null);
+      return;
+    }
+    if (event.type === "RowStarted") {
+      const key = `${event.candidate}:${event.task_id}:${event.mode}`;
+      setActiveRowKey(key);
+      setLiveRows((rows) => {
+        const nextRow: FusionLiveRow = {
+          key,
+          run_id: event.run_id,
+          candidate: event.candidate,
+          task_id: event.task_id,
+          mode: event.mode,
+          route: event.route,
+          model: event.model,
+          prompt: event.prompt,
+          expected_signal: event.expected_signal,
+          status: "running",
+          score: null,
+          elapsed_ms: null,
+          sidekick_runs: 0,
+          sidekick_tool_calls: 0,
+          output: "",
+          reason: "",
+        };
+        const existing = rows.findIndex((row) => row.key === key);
+        if (existing === -1) return [...rows, nextRow];
+        return rows.map((row, index) => index === existing ? { ...row, ...nextRow } : row);
+      });
+      return;
+    }
+    if (event.type === "RowFinished") {
+      const key = `${event.candidate}:${event.task_id}:${event.mode}`;
+      setActiveRowKey(key);
+      setLiveRows((rows) =>
+        rows.map((row) =>
+          row.key === key
+            ? {
+                ...row,
+                status: normalizeRowStatus(event.status),
+                score: event.score,
+                elapsed_ms: event.elapsed_ms,
+                sidekick_runs: event.sidekick_runs,
+                sidekick_tool_calls: event.sidekick_tool_calls,
+                output: event.output,
+                reason: event.reason,
+              }
+            : row,
+        ),
+      );
+      return;
+    }
+    if (event.type === "RunFinished") {
+      setFinishedScore(event.avg_score);
+      setActiveRowKey(null);
+      return;
+    }
+    if (event.type === "Error") {
+      setError(event.message);
+    }
+  };
+
   const invokeRun = async (dryRun: boolean) => {
     setBusy(dryRun ? "plan" : "run");
     setError(null);
     try {
       if (!dryRun) {
         const ch = new Channel<FusionEvalEvent>();
-        ch.onmessage = (event) => {
-          if (event.type === "RunStarted") {
-            setLiveRunId(event.run_id);
-            setLiveSuite(event.suite);
-            setFinishedScore(null);
-            setLiveRows([]);
-            setActiveRowKey(null);
-            return;
-          }
-          if (event.type === "RowStarted") {
-            const key = `${event.candidate}:${event.task_id}:${event.mode}`;
-            setActiveRowKey(key);
-            setLiveRows((rows) => {
-              const nextRow: FusionLiveRow = {
-                key,
-                run_id: event.run_id,
-                candidate: event.candidate,
-                task_id: event.task_id,
-                mode: event.mode,
-                route: event.route,
-                model: event.model,
-                prompt: event.prompt,
-                expected_signal: event.expected_signal,
-                status: "running",
-                score: null,
-                elapsed_ms: null,
-                sidekick_runs: 0,
-                sidekick_tool_calls: 0,
-                output: "",
-                reason: "",
-              };
-              const existing = rows.findIndex((row) => row.key === key);
-              if (existing === -1) return [...rows, nextRow];
-              return rows.map((row, index) => index === existing ? { ...row, ...nextRow } : row);
-            });
-            return;
-          }
-          if (event.type === "RowFinished") {
-            const key = `${event.candidate}:${event.task_id}:${event.mode}`;
-            setActiveRowKey(key);
-            setLiveRows((rows) =>
-              rows.map((row) =>
-                row.key === key
-                  ? {
-                      ...row,
-                      status: normalizeRowStatus(event.status),
-                      score: event.score,
-                      elapsed_ms: event.elapsed_ms,
-                      sidekick_runs: event.sidekick_runs,
-                      sidekick_tool_calls: event.sidekick_tool_calls,
-                      output: event.output,
-                      reason: event.reason,
-                    }
-                  : row,
-              ),
-            );
-            return;
-          }
-          if (event.type === "RunFinished") {
-            setFinishedScore(event.avg_score);
-            setActiveRowKey(null);
-            return;
-          }
-          if (event.type === "Error") {
-            setError(event.message);
-          }
-        };
+        ch.onmessage = handleLiveEvent;
         const result = await invoke<FusionMatrixRun>("run_fusion_benchmark_matrix_live", {
           request: {
             suite,
@@ -483,6 +509,74 @@ function FusionEvaluationPane() {
       setBusy(null);
     }
   };
+  const importCustomEval = async () => {
+    if (!importName.trim()) {
+      setImportNotice("Name the eval before importing.");
+      return;
+    }
+    if (!importFile) {
+      setImportNotice("Choose a .jsonl or .csv file of examples.");
+      return;
+    }
+    setBusy("import");
+    setImportNotice(null);
+    try {
+      const content = await importFile.text();
+      const format = importFile.name.toLowerCase().endsWith(".csv") ? "csv" : "jsonl";
+      const result = await invoke<CustomEvalImportResult>("import_custom_eval", {
+        request: {
+          name: importName.trim(),
+          scoring_rule: importRule,
+          format,
+          content,
+          source_file: importFile.name,
+        },
+      });
+      const skipped = result.skipped_total
+        ? ` · ${result.skipped_total} malformed rows skipped (${result.skipped
+            .slice(0, 3)
+            .map((row) => `line ${row.line}: ${row.reason}`)
+            .join("; ")}${result.skipped_total > 3 ? "; ..." : ""})`
+        : "";
+      setImportNotice(`Imported ${result.imported} examples into "${result.name}"${skipped}.`);
+      setImportName("");
+      setImportFile(null);
+      setFileInputKey((key) => key + 1);
+      await refresh();
+    } catch (err) {
+      setImportNotice(String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const runCustomEval = async (evalId: string) => {
+    setBusy("run");
+    setError(null);
+    try {
+      const ch = new Channel<FusionEvalEvent>();
+      ch.onmessage = handleLiveEvent;
+      await invoke("run_custom_eval_live", {
+        request: { eval_id: evalId },
+        onEvent: ch,
+      });
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const removeCustomEval = async (evalId: string) => {
+    try {
+      await invoke("delete_custom_eval", { evalId });
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
   const activeRow = liveRows.find((row) => row.key === activeRowKey) ?? liveRows.at(-1) ?? null;
   const completedRows = liveRows.filter((row) => ["ok", "error", "skipped"].includes(row.status));
   const visibleScore =
@@ -561,6 +655,88 @@ function FusionEvaluationPane() {
             </label>
           </div>
           {error && <div className="eval-error">{error}</div>}
+        </div>
+
+        <div className="card evals-wide">
+          <div className="card-row">
+            <div>
+              <div className="card-title">Custom evals</div>
+              <div className="card-sub">
+                Import a JSONL or CSV of prompts and expected outputs, then score a warm local model
+                with a deterministic rule — exact match, contains, or regex.
+              </div>
+            </div>
+            <span className="svc-state">{customEvals.length} registered</span>
+          </div>
+          <div className="eval-controls">
+            <label>
+              Name
+              <input
+                value={importName}
+                placeholder="support-triage"
+                onChange={(event) => setImportName(event.target.value)}
+              />
+            </label>
+            <label>
+              Scoring rule
+              <select value={importRule} onChange={(event) => setImportRule(event.target.value)}>
+                <option value="exact">Exact match</option>
+                <option value="contains">Contains</option>
+                <option value="regex">Regex</option>
+              </select>
+            </label>
+            <label>
+              Examples file
+              <input
+                key={fileInputKey}
+                type="file"
+                accept=".jsonl,.csv"
+                onChange={(event) => setImportFile(event.target.files?.[0] ?? null)}
+              />
+            </label>
+            <label>
+              Import
+              <button className="btn" type="button" onClick={importCustomEval} disabled={busy !== null}>
+                {busy === "import" ? "Importing..." : "Import eval"}
+              </button>
+            </label>
+          </div>
+          {importNotice && <div className="svc-desc" style={{ marginTop: 10 }}>{importNotice}</div>}
+          {customEvals.length ? (
+            <div className="eval-table">
+              {customEvals.map((row) => (
+                <div className="eval-row" key={row.eval_id}>
+                  <span>{row.name}</span>
+                  <span>{row.example_count} examples</span>
+                  <span>{row.scoring_rule}</span>
+                  <span>{row.created_at}</span>
+                  <span style={{ display: "flex", gap: 8 }}>
+                    <button
+                      className="btn"
+                      type="button"
+                      onClick={() => runCustomEval(row.eval_id)}
+                      disabled={busy !== null}
+                    >
+                      Run
+                    </button>
+                    <button
+                      className="btn"
+                      type="button"
+                      onClick={() => removeCustomEval(row.eval_id)}
+                      disabled={busy !== null}
+                    >
+                      Delete
+                    </button>
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="svc-desc" style={{ marginTop: 10 }}>
+              No custom evals yet. JSONL rows need input/prompt and expected fields; CSV needs those
+              column headers. Runs use the first warm local slot and land in the results below.
+            </div>
+          )}
         </div>
 
         <ModelCandidateResults results={candidateResults} liveRows={liveRows} />

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -1243,7 +1243,8 @@ select,
   text-transform: uppercase;
   font-family: var(--mono);
 }
-.eval-controls select {
+.eval-controls select,
+.eval-controls input {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--r-control);

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -3004,6 +3004,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4427,6 +4433,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "getrandom 0.2.17",
+ "regex-lite",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -30,3 +30,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio"] }
 sha2 = "0.10"
 getrandom = "0.2"
+# Deterministic regex scoring for build-your-own evals; the -lite build keeps
+# the dependency footprint at a single crate.
+regex-lite = "0.1"

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -381,7 +381,7 @@ pub struct EvalResultV1 {
 /// `unscored` (excluded from averages, never counted as 0); `skipped` rows
 /// never executed; every other terminal status (`error`, `tool_limit`, ...)
 /// maps to `error`.
-fn eval_result_v1(row: &FusionBenchmarkRow) -> EvalResultV1 {
+pub(crate) fn eval_result_v1(row: &FusionBenchmarkRow) -> EvalResultV1 {
     let status = match row.status.as_str() {
         "skipped" => "skipped",
         "ok" if row.score.is_some() => "ok",
@@ -455,7 +455,7 @@ pub struct ExportPacketProvenance {
     pub cost_bases: Vec<String>,
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     Sha256::digest(bytes)
         .iter()
@@ -631,7 +631,10 @@ fn valid_fusion_mode(mode: &str) -> bool {
 }
 
 fn valid_fusion_result_mode(mode: &str) -> bool {
-    if valid_fusion_mode(mode) || mode == "automationbench" {
+    if valid_fusion_mode(mode)
+        || mode == "automationbench"
+        || mode == crate::custom_evals::CUSTOM_EVAL_MODE
+    {
         return true;
     }
     mode.strip_prefix("candidate-")
@@ -2745,7 +2748,7 @@ async fn run_fusion_benchmark_inner(
     })
 }
 
-fn truncate_for_event(text: &str, max: usize) -> String {
+pub(crate) fn truncate_for_event(text: &str, max: usize) -> String {
     if text.len() <= max {
         return text.to_string();
     }
@@ -3390,6 +3393,14 @@ mod tests {
         assert_eq!(eval_result_v1(&rows[1]).status, "skipped");
         assert_eq!(eval_result_v1(&rows[0]).status, "error"); // tool_limit maps to error
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn custom_eval_mode_is_a_valid_result_mode() {
+        assert!(super::valid_fusion_result_mode(
+            crate::custom_evals::CUSTOM_EVAL_MODE
+        ));
+        assert!(!super::valid_fusion_result_mode("custom-eval-other"));
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/custom_evals.rs
+++ b/apps/homescreen/src-tauri/src/custom_evals.rs
@@ -102,6 +102,10 @@ pub fn parse_examples(
     format: &str,
     rule: ScoringRule,
 ) -> Result<(Vec<ParsedExample>, Vec<ImportRowError>), String> {
+    // Spreadsheet exports commonly lead with a UTF-8 BOM; without stripping
+    // it the first JSONL row fails to parse and the first CSV header cell
+    // never matches its column name.
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
     let (candidates, mut errors) = match format {
         "jsonl" => parse_jsonl_rows(content),
         "csv" => parse_csv_rows(content)?,
@@ -216,18 +220,22 @@ fn id_field(object: &serde_json::Map<String, Value>) -> Option<String> {
     }
 }
 
-/// CSV import. The first record is a header naming at least an
+/// CSV import. The first non-blank record is a header naming at least an
 /// `input`/`prompt` column and an `expected`/`expected_output`/`scoring_hint`
-/// column (case-insensitive); an `id`/`task_id` column is optional. Record
-/// numbers in errors count the header as record 1.
+/// column (case-insensitive); an `id`/`task_id` column is optional. Error
+/// line numbers are absolute 1-based record numbers (blank records keep
+/// their slot, so a blank line mid-file never shifts later numbers).
 type CsvRows = (Vec<(usize, ParsedExample)>, Vec<ImportRowError>);
 
 fn parse_csv_rows(content: &str) -> Result<CsvRows, String> {
     let records = parse_csv_records(content);
-    let Some((header, data)) = records.split_first() else {
-        return Err("CSV file is empty".to_string());
-    };
-    let header: Vec<String> = header
+    let is_blank =
+        |record: &[String]| record.iter().all(|cell| cell.trim().is_empty());
+    let header_idx = records
+        .iter()
+        .position(|record| !is_blank(record))
+        .ok_or_else(|| "CSV file is empty".to_string())?;
+    let header: Vec<String> = records[header_idx]
         .iter()
         .map(|cell| cell.trim().to_ascii_lowercase())
         .collect();
@@ -246,9 +254,9 @@ fn parse_csv_rows(content: &str) -> Result<CsvRows, String> {
 
     let mut rows = vec![];
     let mut errors = vec![];
-    for (index, record) in data.iter().enumerate() {
-        let line = index + 2; // header is record 1
-        if record.iter().all(|cell| cell.trim().is_empty()) {
+    for (index, record) in records.iter().enumerate().skip(header_idx + 1) {
+        let line = index + 1; // absolute 1-based record number
+        if is_blank(record) {
             continue;
         }
         let needed = 1 + prompt_idx.max(expected_idx).max(id_idx.unwrap_or(0));
@@ -344,11 +352,9 @@ fn parse_csv_records(content: &str) -> Vec<Vec<String>> {
         record.push(field);
         records.push(record);
     }
-    // Drop records that are entirely one empty cell (blank lines).
+    // Blank lines stay as single-empty-cell records so callers can keep
+    // absolute record numbers; parse_csv_rows skips them explicitly.
     records
-        .into_iter()
-        .filter(|record| !(record.len() == 1 && record[0].is_empty()))
-        .collect()
 }
 
 /// Content hash of the eval definition — the custom-eval analogue of the
@@ -659,38 +665,43 @@ async fn run_custom_eval_inner(
                 String::new(),
                 format!("error={}", err.replace('\n', " ")),
             ),
-            Ok(result) if result.status == "ok" => match score_output(
-                rule,
-                &example.expected,
-                &result.content,
-            ) {
-                Ok(score) => (
-                    "ok".to_string(),
-                    Some(score),
-                    Some(result.elapsed_ms),
-                    Some((result.prompt_tokens, result.completion_tokens)),
-                    result.content,
-                    format!("output_chars_scored={score}"),
-                ),
-                // The pattern was validated at import; a compile failure here
-                // means the stored definition changed underneath us.
-                Err(err) => (
-                    "error".to_string(),
+            Ok(result) if result.status == "ok" => {
+                match score_output(rule, &example.expected, &result.content) {
+                    Ok(score) => {
+                        let note =
+                            format!("score={score}; output_chars={}", result.content.len());
+                        (
+                            "ok".to_string(),
+                            Some(score),
+                            Some(result.elapsed_ms),
+                            Some((result.prompt_tokens, result.completion_tokens)),
+                            result.content,
+                            note,
+                        )
+                    }
+                    // The pattern was validated at import; a compile failure
+                    // here means the stored definition changed underneath us.
+                    Err(err) => (
+                        "error".to_string(),
+                        Some(0.0),
+                        Some(result.elapsed_ms),
+                        Some((result.prompt_tokens, result.completion_tokens)),
+                        result.content,
+                        format!("error={err}"),
+                    ),
+                }
+            }
+            Ok(result) => {
+                let note = format!("status={}", result.status);
+                (
+                    result.status.clone(),
                     Some(0.0),
                     Some(result.elapsed_ms),
                     Some((result.prompt_tokens, result.completion_tokens)),
                     result.content,
-                    format!("error={err}"),
-                ),
-            },
-            Ok(result) => (
-                result.status.clone(),
-                Some(0.0),
-                Some(result.elapsed_ms),
-                Some((result.prompt_tokens, result.completion_tokens)),
-                result.content.clone(),
-                format!("status={}", result.status),
-            ),
+                    note,
+                )
+            }
         };
         db.record_fusion_benchmark(&FusionBenchmarkInput {
             run_id: run_id.clone(),
@@ -942,6 +953,32 @@ mod tests {
         assert!(examples.is_empty());
         assert_eq!(errors.len(), 1);
         assert!(errors[0].reason.contains("columns"));
+    }
+
+    #[test]
+    fn csv_blank_lines_keep_absolute_record_numbers() {
+        // Blank record between header and data, and between data rows: the
+        // reported record number for the bad row must stay absolute.
+        let content = "\ninput,expected\n\nq1,a1\n\nq2,\n";
+        let (examples, errors) = parse_examples(content, "csv", ScoringRule::Exact).unwrap();
+        assert_eq!(examples.len(), 1);
+        assert_eq!(examples[0].task_id, "row-4");
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].line, 6);
+        assert!(errors[0].reason.contains("empty expected cell"));
+    }
+
+    #[test]
+    fn leading_utf8_bom_is_stripped_for_both_formats() {
+        let jsonl = "\u{feff}{\"input\": \"q\", \"expected\": \"a\"}\n";
+        let (examples, errors) = parse_examples(jsonl, "jsonl", ScoringRule::Exact).unwrap();
+        assert_eq!(examples.len(), 1);
+        assert!(errors.is_empty());
+
+        let csv = "\u{feff}input,expected\nq,a\n";
+        let (examples, errors) = parse_examples(csv, "csv", ScoringRule::Exact).unwrap();
+        assert_eq!(examples.len(), 1);
+        assert!(errors.is_empty());
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/custom_evals.rs
+++ b/apps/homescreen/src-tauri/src/custom_evals.rs
@@ -1,0 +1,1096 @@
+//! Build-your-own evals.
+//!
+//! A user imports a JSONL or CSV file of examples (input prompt + expected
+//! output or scoring hint), names the eval, and picks a deterministic scoring
+//! rule (exact match, contains, or regex — no LLM judge). The eval definition
+//! registers in the app database; runs execute each example against a warm
+//! local slot through the agent chat path (`chat::agent_chat`) and record
+//! rows into `fusion_benchmarks` under mode `custom-eval`, so results surface
+//! in the existing eval gallery and flow through the
+//! `understudy.eval_result.v1` export path with the same score/status
+//! semantics as every other producer: score 0 is a scored failure, unscored
+//! rows are excluded from averages.
+
+use crate::commands::{sha256_hex, truncate_for_event, FusionEvalEvent};
+use crate::db::{CustomEvalExampleInput, CustomEvalInput, CustomEvalRow, FusionBenchmarkInput};
+use crate::residency::Residency;
+use serde::Serialize;
+use serde_json::{json, Value};
+use tauri::ipc::Channel;
+use tauri::{AppHandle, Manager};
+
+/// Mode stamped on fusion_benchmarks rows produced by custom eval runs. Also
+/// accepted by `record_fusion_benchmark` (see `valid_fusion_result_mode`).
+pub const CUSTOM_EVAL_MODE: &str = "custom-eval";
+
+/// Import ceiling: keeps a single local run bounded (a 500-example run at a
+/// few seconds per example is already a long sit at one warm slot).
+const MAX_EXAMPLES: usize = 500;
+
+/// How many malformed-row reasons we return in the import response; the
+/// total count is always reported.
+const MAX_REPORTED_SKIPS: usize = 20;
+
+const MAX_NAME_CHARS: usize = 120;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ScoringRule {
+    /// Trimmed, case-sensitive string equality.
+    Exact,
+    /// Case-sensitive substring match of the expected text in the output.
+    Contains,
+    /// The expected text is a regex pattern matched against the raw output
+    /// (validated at import time; use `(?i)` for case-insensitive rules).
+    Regex,
+}
+
+impl ScoringRule {
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "exact" => Ok(Self::Exact),
+            "contains" => Ok(Self::Contains),
+            "regex" => Ok(Self::Regex),
+            other => Err(format!(
+                "unknown scoring rule: {other} (expected exact, contains, or regex)"
+            )),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Contains => "contains",
+            Self::Regex => "regex",
+        }
+    }
+}
+
+/// Deterministic pass/fail against the example's expected text. A hit is 1.0,
+/// a miss is 0.0 — a real scored failure, never a missing value.
+pub fn score_output(rule: ScoringRule, expected: &str, output: &str) -> Result<f64, String> {
+    let hit = match rule {
+        ScoringRule::Exact => output.trim() == expected.trim(),
+        ScoringRule::Contains => output.contains(expected),
+        ScoringRule::Regex => regex_lite::Regex::new(expected)
+            .map_err(|err| format!("invalid regex pattern: {err}"))?
+            .is_match(output),
+    };
+    Ok(if hit { 1.0 } else { 0.0 })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParsedExample {
+    pub task_id: String,
+    pub prompt: String,
+    pub expected: String,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct ImportRowError {
+    /// 1-based line number (JSONL) or record number counting the header
+    /// (CSV) the row came from.
+    pub line: usize,
+    pub reason: String,
+}
+
+/// Parse an import payload into examples plus per-row errors. Malformed rows
+/// are skipped and reported, never silently dropped; structural problems
+/// (unknown format, missing CSV columns, too many rows) fail the whole
+/// import.
+pub fn parse_examples(
+    content: &str,
+    format: &str,
+    rule: ScoringRule,
+) -> Result<(Vec<ParsedExample>, Vec<ImportRowError>), String> {
+    let (candidates, mut errors) = match format {
+        "jsonl" => parse_jsonl_rows(content),
+        "csv" => parse_csv_rows(content)?,
+        other => {
+            return Err(format!(
+                "unknown eval file format: {other} (expected jsonl or csv)"
+            ))
+        }
+    };
+
+    let mut examples: Vec<ParsedExample> = vec![];
+    let mut seen_ids = std::collections::HashSet::new();
+    for (line, candidate) in candidates {
+        if !seen_ids.insert(candidate.task_id.clone()) {
+            errors.push(ImportRowError {
+                line,
+                reason: format!("duplicate task id '{}'", candidate.task_id),
+            });
+            continue;
+        }
+        if rule == ScoringRule::Regex {
+            if let Err(err) = regex_lite::Regex::new(&candidate.expected) {
+                errors.push(ImportRowError {
+                    line,
+                    reason: format!("invalid regex pattern: {err}"),
+                });
+                continue;
+            }
+        }
+        examples.push(candidate);
+    }
+    errors.sort_by_key(|e| e.line);
+    if examples.len() > MAX_EXAMPLES {
+        return Err(format!(
+            "too many examples: {} (max {MAX_EXAMPLES} per eval)",
+            examples.len()
+        ));
+    }
+    Ok((examples, errors))
+}
+
+/// One candidate example per non-empty JSONL line. Accepted keys:
+/// `input`/`prompt`, `expected`/`expected_output`/`scoring_hint`, and an
+/// optional `id`/`task_id` (string or number). Missing ids fall back to the
+/// 1-based line number.
+fn parse_jsonl_rows(content: &str) -> (Vec<(usize, ParsedExample)>, Vec<ImportRowError>) {
+    let mut rows = vec![];
+    let mut errors = vec![];
+    for (index, raw_line) in content.lines().enumerate() {
+        let line = index + 1;
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let value: Value = match serde_json::from_str(trimmed) {
+            Ok(value) => value,
+            Err(err) => {
+                errors.push(ImportRowError {
+                    line,
+                    reason: format!("invalid JSON: {err}"),
+                });
+                continue;
+            }
+        };
+        let Some(object) = value.as_object() else {
+            errors.push(ImportRowError {
+                line,
+                reason: "row is not a JSON object".to_string(),
+            });
+            continue;
+        };
+        let prompt = string_field(object, &["input", "prompt"]);
+        let expected = string_field(object, &["expected", "expected_output", "scoring_hint"]);
+        let task_id = id_field(object).unwrap_or_else(|| format!("row-{line}"));
+        match (prompt, expected) {
+            (Some(prompt), Some(expected)) => rows.push((
+                line,
+                ParsedExample {
+                    task_id,
+                    prompt,
+                    expected,
+                },
+            )),
+            (None, _) => errors.push(ImportRowError {
+                line,
+                reason: "missing or empty 'input'/'prompt' field".to_string(),
+            }),
+            (_, None) => errors.push(ImportRowError {
+                line,
+                reason: "missing or empty 'expected'/'expected_output'/'scoring_hint' field"
+                    .to_string(),
+            }),
+        }
+    }
+    (rows, errors)
+}
+
+fn string_field(object: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| object.get(*key))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn id_field(object: &serde_json::Map<String, Value>) -> Option<String> {
+    let value = ["id", "task_id"].iter().find_map(|key| object.get(*key))?;
+    match value {
+        Value::String(s) if !s.trim().is_empty() => Some(s.trim().to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// CSV import. The first record is a header naming at least an
+/// `input`/`prompt` column and an `expected`/`expected_output`/`scoring_hint`
+/// column (case-insensitive); an `id`/`task_id` column is optional. Record
+/// numbers in errors count the header as record 1.
+type CsvRows = (Vec<(usize, ParsedExample)>, Vec<ImportRowError>);
+
+fn parse_csv_rows(content: &str) -> Result<CsvRows, String> {
+    let records = parse_csv_records(content);
+    let Some((header, data)) = records.split_first() else {
+        return Err("CSV file is empty".to_string());
+    };
+    let header: Vec<String> = header
+        .iter()
+        .map(|cell| cell.trim().to_ascii_lowercase())
+        .collect();
+    let column = |names: &[&str]| -> Option<usize> {
+        header
+            .iter()
+            .position(|cell| names.contains(&cell.as_str()))
+    };
+    let prompt_idx = column(&["input", "prompt"])
+        .ok_or_else(|| "CSV header must include an 'input' or 'prompt' column".to_string())?;
+    let expected_idx = column(&["expected", "expected_output", "scoring_hint"]).ok_or_else(
+        || "CSV header must include an 'expected', 'expected_output', or 'scoring_hint' column"
+            .to_string(),
+    )?;
+    let id_idx = column(&["id", "task_id"]);
+
+    let mut rows = vec![];
+    let mut errors = vec![];
+    for (index, record) in data.iter().enumerate() {
+        let line = index + 2; // header is record 1
+        if record.iter().all(|cell| cell.trim().is_empty()) {
+            continue;
+        }
+        let needed = 1 + prompt_idx.max(expected_idx).max(id_idx.unwrap_or(0));
+        if record.len() < needed {
+            errors.push(ImportRowError {
+                line,
+                reason: format!(
+                    "expected at least {needed} columns, found {}",
+                    record.len()
+                ),
+            });
+            continue;
+        }
+        let prompt = record[prompt_idx].clone();
+        let expected = record[expected_idx].clone();
+        if prompt.trim().is_empty() {
+            errors.push(ImportRowError {
+                line,
+                reason: "empty prompt cell".to_string(),
+            });
+            continue;
+        }
+        if expected.trim().is_empty() {
+            errors.push(ImportRowError {
+                line,
+                reason: "empty expected cell".to_string(),
+            });
+            continue;
+        }
+        let task_id = id_idx
+            .map(|idx| record[idx].trim().to_string())
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| format!("row-{line}"));
+        rows.push((
+            line,
+            ParsedExample {
+                task_id,
+                prompt,
+                expected,
+            },
+        ));
+    }
+    Ok((rows, errors))
+}
+
+/// Minimal RFC 4180-style CSV reader: quoted fields, doubled-quote escapes,
+/// commas and newlines inside quotes, and CRLF line endings. Small enough to
+/// own outright rather than pulling a dependency for one import path.
+fn parse_csv_records(content: &str) -> Vec<Vec<String>> {
+    let mut records = vec![];
+    let mut record = vec![];
+    let mut field = String::new();
+    let mut in_quotes = false;
+    let mut chars = content.chars().peekable();
+    let mut saw_any = false;
+    while let Some(c) = chars.next() {
+        saw_any = true;
+        if in_quotes {
+            match c {
+                '"' => {
+                    if chars.peek() == Some(&'"') {
+                        chars.next();
+                        field.push('"');
+                    } else {
+                        in_quotes = false;
+                    }
+                }
+                _ => field.push(c),
+            }
+            continue;
+        }
+        match c {
+            '"' => in_quotes = true,
+            ',' => {
+                record.push(std::mem::take(&mut field));
+                // Keep trailing empty fields: `a,` is two cells.
+            }
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                record.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut record));
+            }
+            '\n' => {
+                record.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut record));
+            }
+            _ => field.push(c),
+        }
+    }
+    if saw_any && (!field.is_empty() || !record.is_empty()) {
+        record.push(field);
+        records.push(record);
+    }
+    // Drop records that are entirely one empty cell (blank lines).
+    records
+        .into_iter()
+        .filter(|record| !(record.len() == 1 && record[0].is_empty()))
+        .collect()
+}
+
+/// Content hash of the eval definition — the custom-eval analogue of the
+/// capture-evidence `harness_sha256` chain. Stamped on every result row so a
+/// consumer can tell which frozen definition produced a score.
+pub fn harness_sha256(name: &str, rule: ScoringRule, examples: &[ParsedExample]) -> String {
+    let canonical = json!({
+        "kind": "understudy.custom_eval.v1",
+        "name": name,
+        "scoring_rule": rule.as_str(),
+        "examples": examples
+            .iter()
+            .map(|example| json!({
+                "task_id": example.task_id,
+                "prompt": example.prompt,
+                "expected": example.expected,
+            }))
+            .collect::<Vec<_>>(),
+    });
+    sha256_hex(canonical.to_string().as_bytes())
+}
+
+fn slugify(name: &str) -> String {
+    let mut out = String::new();
+    for c in name.chars() {
+        if out.len() >= 24 {
+            break;
+        }
+        if c.is_ascii_alphanumeric() {
+            out.extend(c.to_lowercase());
+        } else if !out.is_empty() && !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let out = out.trim_matches('-').to_string();
+    if out.is_empty() {
+        "eval".to_string()
+    } else {
+        out
+    }
+}
+
+fn new_eval_id(name: &str) -> String {
+    format!(
+        "{}-{}",
+        slugify(name),
+        chrono::Utc::now().timestamp_millis()
+    )
+}
+
+// ----- Tauri commands -----
+
+#[derive(serde::Deserialize)]
+pub struct ImportCustomEvalRequest {
+    pub name: String,
+    /// exact | contains | regex
+    pub scoring_rule: String,
+    /// jsonl | csv
+    pub format: String,
+    /// Raw file content, read by the frontend (webview file input).
+    pub content: String,
+    pub source_file: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct CustomEvalImportResult {
+    pub schema_version: &'static str,
+    pub eval_id: String,
+    pub name: String,
+    pub scoring_rule: String,
+    pub imported: u64,
+    pub skipped_total: u64,
+    /// First `MAX_REPORTED_SKIPS` malformed rows with reasons.
+    pub skipped: Vec<ImportRowError>,
+    pub harness_sha256: String,
+}
+
+#[tauri::command]
+pub fn import_custom_eval(
+    app: AppHandle,
+    request: ImportCustomEvalRequest,
+) -> Result<CustomEvalImportResult, String> {
+    let name = request.name.trim();
+    if name.is_empty() {
+        return Err("name is required".to_string());
+    }
+    if name.chars().count() > MAX_NAME_CHARS {
+        return Err(format!("name is too long (max {MAX_NAME_CHARS} chars)"));
+    }
+    let rule = ScoringRule::parse(&request.scoring_rule)?;
+    let (examples, skipped) = parse_examples(&request.content, &request.format, rule)?;
+    if examples.is_empty() {
+        return Err(match skipped.first() {
+            Some(first) => format!(
+                "no valid examples ({} malformed rows; first: line {}: {})",
+                skipped.len(),
+                first.line,
+                first.reason
+            ),
+            None => "no examples found in file".to_string(),
+        });
+    }
+    let harness = harness_sha256(name, rule, &examples);
+    let eval_id = new_eval_id(name);
+    app.state::<crate::db::Db>()
+        .insert_custom_eval(&CustomEvalInput {
+            eval_id: eval_id.clone(),
+            name: name.to_string(),
+            scoring_rule: rule.as_str().to_string(),
+            harness_sha256: Some(harness.clone()),
+            source_file: request.source_file,
+            examples: examples
+                .iter()
+                .map(|example| CustomEvalExampleInput {
+                    task_id: example.task_id.clone(),
+                    prompt: example.prompt.clone(),
+                    expected: example.expected.clone(),
+                })
+                .collect(),
+        })
+        .map_err(|e| e.to_string())?;
+    let skipped_total = skipped.len() as u64;
+    Ok(CustomEvalImportResult {
+        schema_version: "understudy.custom_eval_import.v1",
+        eval_id,
+        name: name.to_string(),
+        scoring_rule: rule.as_str().to_string(),
+        imported: examples.len() as u64,
+        skipped_total,
+        skipped: skipped.into_iter().take(MAX_REPORTED_SKIPS).collect(),
+        harness_sha256: harness,
+    })
+}
+
+#[tauri::command]
+pub fn list_custom_evals(app: AppHandle) -> Result<Vec<CustomEvalRow>, String> {
+    app.state::<crate::db::Db>()
+        .list_custom_evals()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_custom_eval(app: AppHandle, eval_id: String) -> Result<bool, String> {
+    app.state::<crate::db::Db>()
+        .delete_custom_eval(&eval_id)
+        .map_err(|e| e.to_string())
+}
+
+#[derive(serde::Deserialize)]
+pub struct RunCustomEvalRequest {
+    pub eval_id: String,
+    pub run_id: Option<String>,
+    /// Warm slot to run on; defaults to the first running slot.
+    pub slot_id: Option<u32>,
+    pub max_examples: Option<u32>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct CustomEvalRunRow {
+    pub task_id: String,
+    pub status: String,
+    pub score: Option<f64>,
+    pub elapsed_ms: Option<u64>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct CustomEvalRun {
+    pub schema_version: &'static str,
+    pub run_id: String,
+    pub eval_id: String,
+    pub name: String,
+    pub model: String,
+    pub rows: u64,
+    pub ok_rows: u64,
+    pub error_rows: u64,
+    pub avg_score: Option<f64>,
+    pub results: Vec<CustomEvalRunRow>,
+}
+
+#[tauri::command]
+pub async fn run_custom_eval(
+    app: AppHandle,
+    request: RunCustomEvalRequest,
+) -> Result<CustomEvalRun, String> {
+    run_custom_eval_inner(app, request, None).await
+}
+
+#[tauri::command]
+pub async fn run_custom_eval_live(
+    app: AppHandle,
+    request: RunCustomEvalRequest,
+    on_event: Channel<FusionEvalEvent>,
+) -> Result<CustomEvalRun, String> {
+    run_custom_eval_inner(app, request, Some(&on_event)).await
+}
+
+async fn run_custom_eval_inner(
+    app: AppHandle,
+    request: RunCustomEvalRequest,
+    on_event: Option<&Channel<FusionEvalEvent>>,
+) -> Result<CustomEvalRun, String> {
+    let db = app.state::<crate::db::Db>();
+    let eval = db
+        .get_custom_eval(&request.eval_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("unknown custom eval: {}", request.eval_id))?;
+    let rule = ScoringRule::parse(&eval.scoring_rule)?;
+    let mut examples = db
+        .list_custom_eval_examples(&eval.eval_id)
+        .map_err(|e| e.to_string())?;
+    if let Some(max) = request.max_examples {
+        examples.truncate(max.max(1) as usize);
+    }
+    if examples.is_empty() {
+        return Err(format!("custom eval {} has no examples", eval.eval_id));
+    }
+
+    let run_id = request.run_id.unwrap_or_else(|| {
+        format!(
+            "custom-{}-{}",
+            eval.eval_id,
+            chrono::Utc::now().timestamp_millis()
+        )
+    });
+    if run_id.trim().is_empty() {
+        return Err("run_id is required".to_string());
+    }
+    // Same single-flight gate as the Fusion benchmark entry points: one live
+    // run at a time, cancellable between rows from the agent surface.
+    let _run_guard = crate::agent_ops::begin_benchmark_run(&app, &run_id)?;
+
+    let mgr = app.state::<Residency>();
+    let snapshot = mgr.snapshot();
+    let slot = match request.slot_id {
+        Some(id) => snapshot
+            .slots
+            .iter()
+            .find(|slot| slot.id == id && slot.state == "running")
+            .ok_or_else(|| format!("slot {id} is not warm; warm it first"))?,
+        None => snapshot
+            .slots
+            .iter()
+            .find(|slot| slot.state == "running")
+            .ok_or_else(|| "no warm local slot; warm a model first".to_string())?,
+    };
+    let slot_id = slot.id;
+    let model = slot
+        .model_id
+        .clone()
+        .unwrap_or_else(|| "unassigned".to_string());
+    let local_mem_gb = {
+        let mem = snapshot
+            .slots
+            .iter()
+            .filter(|slot| slot.state == "running")
+            .map(|slot| slot.mem_gb as f64)
+            .sum::<f64>();
+        (mem > 0.0).then_some(mem)
+    };
+
+    if let Some(on_event) = on_event {
+        let _ = on_event.send(FusionEvalEvent::RunStarted {
+            run_id: run_id.clone(),
+            suite: eval.eval_id.clone(),
+            candidates: vec![eval.eval_id.clone()],
+            rows: examples.len() as u64,
+        });
+    }
+
+    let mut results = vec![];
+    let mut scores = vec![];
+    for example in &examples {
+        if crate::agent_ops::benchmark_run_cancelled(&app, &run_id) {
+            return Err(format!("custom eval run cancelled: {run_id}"));
+        }
+        if let Some(on_event) = on_event {
+            let _ = on_event.send(FusionEvalEvent::RowStarted {
+                run_id: run_id.clone(),
+                candidate: eval.eval_id.clone(),
+                task_id: example.task_id.clone(),
+                mode: CUSTOM_EVAL_MODE.to_string(),
+                route: "local".to_string(),
+                model: model.clone(),
+                prompt: example.prompt.clone(),
+                expected_signal: format!("{}: {}", rule.as_str(), example.expected),
+            });
+        }
+        let attempt = crate::chat::agent_chat(
+            &app,
+            mgr.inner(),
+            slot_id,
+            &run_id,
+            &example.prompt,
+            None,
+        )
+        .await;
+        // Mirror the Fusion harness semantics: an executed non-ok attempt and
+        // a failed request both count as scored failures (score 0) because a
+        // gold answer exists for every example; the recorded status keeps the
+        // distinction (error / tool_limit / empty_final map to `error` in the
+        // eval_result.v1 view, a wrong-but-clean answer stays `ok`).
+        let (status, score, elapsed_ms, tokens, output, note) = match attempt {
+            Err(err) => (
+                "error".to_string(),
+                Some(0.0),
+                None,
+                None,
+                String::new(),
+                format!("error={}", err.replace('\n', " ")),
+            ),
+            Ok(result) if result.status == "ok" => match score_output(
+                rule,
+                &example.expected,
+                &result.content,
+            ) {
+                Ok(score) => (
+                    "ok".to_string(),
+                    Some(score),
+                    Some(result.elapsed_ms),
+                    Some((result.prompt_tokens, result.completion_tokens)),
+                    result.content,
+                    format!("output_chars_scored={score}"),
+                ),
+                // The pattern was validated at import; a compile failure here
+                // means the stored definition changed underneath us.
+                Err(err) => (
+                    "error".to_string(),
+                    Some(0.0),
+                    Some(result.elapsed_ms),
+                    Some((result.prompt_tokens, result.completion_tokens)),
+                    result.content,
+                    format!("error={err}"),
+                ),
+            },
+            Ok(result) => (
+                result.status.clone(),
+                Some(0.0),
+                Some(result.elapsed_ms),
+                Some((result.prompt_tokens, result.completion_tokens)),
+                result.content.clone(),
+                format!("status={}", result.status),
+            ),
+        };
+        db.record_fusion_benchmark(&FusionBenchmarkInput {
+            run_id: run_id.clone(),
+            task_id: example.task_id.clone(),
+            mode: CUSTOM_EVAL_MODE.to_string(),
+            model: model.clone(),
+            elapsed_ms,
+            prompt_tokens: tokens.map(|(prompt, _)| prompt),
+            completion_tokens: tokens.map(|(_, completion)| completion),
+            sidekick_runs: 0,
+            sidekick_tool_calls: 0,
+            gateway_used: false,
+            compacted: false,
+            context_tokens_before: None,
+            local_mem_gb,
+            score,
+            status: status.clone(),
+            notes: Some(format!(
+                "custom-eval:{}; rule={}; {}",
+                eval.eval_id,
+                rule.as_str(),
+                note
+            )),
+            // Local slot, no price table: never invent costs.
+            cost_usd: None,
+            cost_basis: None,
+            split: Some("none".to_string()),
+            harness_sha256: eval.harness_sha256.clone(),
+            split_sha256: None,
+        })
+        .map_err(|e| e.to_string())?;
+        if let Some(on_event) = on_event {
+            let _ = on_event.send(FusionEvalEvent::RowFinished {
+                run_id: run_id.clone(),
+                candidate: eval.eval_id.clone(),
+                task_id: example.task_id.clone(),
+                mode: CUSTOM_EVAL_MODE.to_string(),
+                route: "local".to_string(),
+                model: model.clone(),
+                status: if status == "ok" { "ok" } else { "error" }.to_string(),
+                score,
+                elapsed_ms,
+                sidekick_runs: 0,
+                sidekick_tool_calls: 0,
+                output: truncate_for_event(&output, 4000),
+                reason: format!("rule={}; expected={}", rule.as_str(), example.expected),
+            });
+        }
+        if let Some(score) = score {
+            scores.push(score);
+        }
+        results.push(CustomEvalRunRow {
+            task_id: example.task_id.clone(),
+            status,
+            score,
+            elapsed_ms,
+        });
+    }
+
+    let avg_score = if scores.is_empty() {
+        None
+    } else {
+        Some(scores.iter().sum::<f64>() / scores.len() as f64)
+    };
+    if let Some(on_event) = on_event {
+        let _ = on_event.send(FusionEvalEvent::RunFinished {
+            run_id: run_id.clone(),
+            suite: eval.eval_id.clone(),
+            rows: results.len() as u64,
+            recorded_skips: 0,
+            avg_score,
+        });
+    }
+    let ok_rows = results.iter().filter(|row| row.status == "ok").count() as u64;
+    Ok(CustomEvalRun {
+        schema_version: "understudy.custom_eval_run.v1",
+        run_id,
+        eval_id: eval.eval_id,
+        name: eval.name,
+        model,
+        rows: results.len() as u64,
+        ok_rows,
+        error_rows: results.len() as u64 - ok_rows,
+        avg_score,
+        results,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::eval_result_v1;
+    use crate::db::Db;
+    use std::path::PathBuf;
+
+    // ----- scoring rules -----
+
+    #[test]
+    fn exact_rule_trims_but_stays_case_sensitive() {
+        assert_eq!(
+            score_output(ScoringRule::Exact, " billing \n", "billing").unwrap(),
+            1.0
+        );
+        assert_eq!(
+            score_output(ScoringRule::Exact, "billing", "Billing").unwrap(),
+            0.0
+        );
+        assert_eq!(
+            score_output(ScoringRule::Exact, "billing", "the answer is billing").unwrap(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn contains_rule_is_substring_match() {
+        assert_eq!(
+            score_output(ScoringRule::Contains, "billing", "Route this to billing please").unwrap(),
+            1.0
+        );
+        assert_eq!(
+            score_output(ScoringRule::Contains, "billing", "Route to BILLING").unwrap(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn regex_rule_matches_and_reports_invalid_patterns() {
+        assert_eq!(
+            score_output(ScoringRule::Regex, r"^answer:\s*42$", "answer: 42").unwrap(),
+            1.0
+        );
+        assert_eq!(
+            score_output(ScoringRule::Regex, r"(?i)billing", "goes to BILLING").unwrap(),
+            1.0
+        );
+        assert_eq!(
+            score_output(ScoringRule::Regex, r"^\d+$", "forty-two").unwrap(),
+            0.0
+        );
+        assert!(score_output(ScoringRule::Regex, r"(unclosed", "x").is_err());
+    }
+
+    // ----- JSONL parsing -----
+
+    #[test]
+    fn jsonl_parses_valid_rows_and_reports_malformed_ones() {
+        let content = concat!(
+            "{\"input\": \"What is 2+2?\", \"expected\": \"4\"}\n",
+            "\n",
+            "{\"prompt\": \"Capital of France?\", \"expected_output\": \"Paris\", \"id\": \"caps-1\"}\n",
+            "not json at all\n",
+            "[1, 2, 3]\n",
+            "{\"input\": \"\", \"expected\": \"x\"}\n",
+            "{\"input\": \"no expected here\"}\n",
+            "{\"input\": \"numeric id\", \"scoring_hint\": \"hint\", \"task_id\": 7}\n",
+        );
+        let (examples, errors) =
+            parse_examples(content, "jsonl", ScoringRule::Contains).unwrap();
+        assert_eq!(examples.len(), 3);
+        assert_eq!(examples[0].task_id, "row-1");
+        assert_eq!(examples[0].prompt, "What is 2+2?");
+        assert_eq!(examples[0].expected, "4");
+        assert_eq!(examples[1].task_id, "caps-1");
+        assert_eq!(examples[1].expected, "Paris");
+        assert_eq!(examples[2].task_id, "7");
+        assert_eq!(examples[2].expected, "hint");
+
+        assert_eq!(errors.len(), 4);
+        assert_eq!(errors[0].line, 4);
+        assert!(errors[0].reason.contains("invalid JSON"));
+        assert_eq!(errors[1].line, 5);
+        assert!(errors[1].reason.contains("not a JSON object"));
+        assert_eq!(errors[2].line, 6);
+        assert!(errors[2].reason.contains("input"));
+        assert_eq!(errors[3].line, 7);
+        assert!(errors[3].reason.contains("expected"));
+    }
+
+    #[test]
+    fn jsonl_rejects_duplicate_task_ids() {
+        let content = concat!(
+            "{\"input\": \"a\", \"expected\": \"1\", \"id\": \"t\"}\n",
+            "{\"input\": \"b\", \"expected\": \"2\", \"id\": \"t\"}\n",
+        );
+        let (examples, errors) = parse_examples(content, "jsonl", ScoringRule::Exact).unwrap();
+        assert_eq!(examples.len(), 1);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].line, 2);
+        assert!(errors[0].reason.contains("duplicate task id 't'"));
+    }
+
+    #[test]
+    fn jsonl_regex_rule_validates_patterns_at_import() {
+        let content = concat!(
+            "{\"input\": \"a\", \"expected\": \"^ok$\"}\n",
+            "{\"input\": \"b\", \"expected\": \"(broken\"}\n",
+        );
+        let (examples, errors) = parse_examples(content, "jsonl", ScoringRule::Regex).unwrap();
+        assert_eq!(examples.len(), 1);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].line, 2);
+        assert!(errors[0].reason.contains("invalid regex"));
+    }
+
+    // ----- CSV parsing -----
+
+    #[test]
+    fn csv_parses_headers_quotes_and_reports_bad_rows() {
+        let content = concat!(
+            "id,Input,Expected\r\n",
+            "t1,\"What is 2+2, really?\",4\r\n",
+            "t2,\"He said \"\"hi\"\"\",\"multi\nline expected\"\r\n",
+            ",no id falls back,to-row-id\r\n",
+            "t4,,missing prompt\r\n",
+            "t5,missing expected,\r\n",
+            "\r\n",
+        );
+        let (examples, errors) = parse_examples(content, "csv", ScoringRule::Contains).unwrap();
+        assert_eq!(examples.len(), 3);
+        assert_eq!(examples[0].task_id, "t1");
+        assert_eq!(examples[0].prompt, "What is 2+2, really?");
+        assert_eq!(examples[0].expected, "4");
+        assert_eq!(examples[1].prompt, "He said \"hi\"");
+        assert_eq!(examples[1].expected, "multi\nline expected");
+        assert_eq!(examples[2].task_id, "row-4");
+
+        assert_eq!(errors.len(), 2);
+        assert!(errors[0].reason.contains("empty prompt cell"));
+        assert!(errors[1].reason.contains("empty expected cell"));
+    }
+
+    #[test]
+    fn csv_requires_prompt_and_expected_columns() {
+        assert!(parse_examples("a,b\n1,2\n", "csv", ScoringRule::Exact)
+            .unwrap_err()
+            .contains("'input' or 'prompt'"));
+        assert!(parse_examples("input,b\n1,2\n", "csv", ScoringRule::Exact)
+            .unwrap_err()
+            .contains("expected"));
+        assert!(parse_examples("", "csv", ScoringRule::Exact)
+            .unwrap_err()
+            .contains("empty"));
+    }
+
+    #[test]
+    fn csv_short_rows_are_reported_not_dropped_silently() {
+        let content = "input,expected\nonly-one-cell\n";
+        let (examples, errors) = parse_examples(content, "csv", ScoringRule::Exact).unwrap();
+        assert!(examples.is_empty());
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].reason.contains("columns"));
+    }
+
+    #[test]
+    fn unknown_format_is_rejected() {
+        assert!(parse_examples("{}", "yaml", ScoringRule::Exact).is_err());
+    }
+
+    #[test]
+    fn import_caps_example_count() {
+        let content = (0..(MAX_EXAMPLES + 1))
+            .map(|i| format!("{{\"input\": \"q{i}\", \"expected\": \"a{i}\"}}\n"))
+            .collect::<String>();
+        let err = parse_examples(&content, "jsonl", ScoringRule::Exact).unwrap_err();
+        assert!(err.contains("too many examples"));
+    }
+
+    // ----- ids and hashing -----
+
+    #[test]
+    fn slugify_and_eval_ids_stay_readable() {
+        assert_eq!(slugify("Support Triage v2!"), "support-triage-v2");
+        assert_eq!(slugify("///"), "eval");
+        assert!(new_eval_id("Support Triage").starts_with("support-triage-"));
+    }
+
+    #[test]
+    fn harness_hash_is_deterministic_and_definition_sensitive() {
+        let examples = vec![ParsedExample {
+            task_id: "t".into(),
+            prompt: "p".into(),
+            expected: "e".into(),
+        }];
+        let a = harness_sha256("n", ScoringRule::Exact, &examples);
+        assert_eq!(a, harness_sha256("n", ScoringRule::Exact, &examples));
+        assert_eq!(a.len(), 64);
+        assert_ne!(a, harness_sha256("n", ScoringRule::Contains, &examples));
+        assert_ne!(a, harness_sha256("m", ScoringRule::Exact, &examples));
+    }
+
+    // ----- eval_result.v1 row validity -----
+
+    /// Custom-eval rows recorded into fusion_benchmarks must map to rows that
+    /// satisfy schemas/understudy.eval_result.v1.schema.json, mirroring the
+    /// schema-file check the Fusion export rows already pass in commands.rs.
+    #[test]
+    fn custom_eval_rows_validate_against_the_schema_file() {
+        let schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("schemas")
+            .join("understudy.eval_result.v1.schema.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&schema_path).expect("schema file"))
+                .expect("schema parses");
+        let required: Vec<&str> = schema["required"]
+            .as_array()
+            .expect("required list")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        let status_enum: Vec<&str> = schema["properties"]["status"]["enum"]
+            .as_array()
+            .expect("status enum")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        let split_enum: Vec<serde_json::Value> = schema["properties"]["split"]["enum"]
+            .as_array()
+            .expect("split enum")
+            .to_vec();
+
+        let dir = std::env::temp_dir().join(format!(
+            "understudy-custom-eval-v1-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let db = Db::open(dir.clone()).expect("open temp db");
+        let harness = harness_sha256(
+            "Support triage",
+            ScoringRule::Contains,
+            &[ParsedExample {
+                task_id: "row-1".into(),
+                prompt: "p".into(),
+                expected: "billing".into(),
+            }],
+        );
+        let row = |task_id: &str, score: Option<f64>, status: &str, elapsed: Option<u64>| {
+            crate::db::FusionBenchmarkInput {
+                run_id: "custom-support-triage-1-99".into(),
+                task_id: task_id.into(),
+                mode: CUSTOM_EVAL_MODE.into(),
+                model: "gemma-4-e2b-it-qat-understudy".into(),
+                elapsed_ms: elapsed,
+                prompt_tokens: elapsed.map(|_| 80),
+                completion_tokens: elapsed.map(|_| 20),
+                sidekick_runs: 0,
+                sidekick_tool_calls: 0,
+                gateway_used: false,
+                compacted: false,
+                context_tokens_before: None,
+                local_mem_gb: Some(3.1),
+                score,
+                status: status.into(),
+                notes: Some("custom-eval:support-triage-1; rule=contains".into()),
+                cost_usd: None,
+                cost_basis: None,
+                split: Some("none".into()),
+                harness_sha256: Some(harness.clone()),
+                split_sha256: None,
+            }
+        };
+        // Scored pass, scored failure (score 0 stays a real value), an
+        // execution error, and a tool_limit attempt.
+        db.record_fusion_benchmark(&row("row-1", Some(1.0), "ok", Some(1200)))
+            .unwrap();
+        db.record_fusion_benchmark(&row("row-2", Some(0.0), "ok", Some(900)))
+            .unwrap();
+        db.record_fusion_benchmark(&row("row-3", Some(0.0), "error", None))
+            .unwrap();
+        db.record_fusion_benchmark(&row("row-4", Some(0.0), "tool_limit", Some(4000)))
+            .unwrap();
+
+        let rows = db.list_fusion_benchmarks(10).unwrap();
+        assert_eq!(rows.len(), 4);
+        for row in &rows {
+            let value = serde_json::to_value(eval_result_v1(row)).unwrap();
+            for field in &required {
+                assert!(
+                    !value[*field].is_null(),
+                    "required field {field} missing/null in custom eval row"
+                );
+            }
+            assert_eq!(value["schema_version"], "understudy.eval_result.v1");
+            assert!(status_enum.contains(&value["status"].as_str().unwrap()));
+            assert!(split_enum.contains(&value["split"]));
+            let score = value["score"].as_f64().expect("custom rows always score");
+            assert!((0.0..=1.0).contains(&score));
+            assert_eq!(value["route"], "local");
+            assert_eq!(value["mode"], CUSTOM_EVAL_MODE);
+            assert_eq!(value["provenance"]["harness_sha256"], harness.as_str());
+            assert!(value["cost"]["usd"].is_null(), "no invented costs");
+        }
+        // Newest-first: row-4, row-3, row-2, row-1.
+        assert_eq!(eval_result_v1(&rows[0]).status, "error"); // tool_limit -> error
+        assert_eq!(eval_result_v1(&rows[1]).status, "error");
+        assert_eq!(eval_result_v1(&rows[2]).status, "ok"); // scored 0 stays ok
+        assert_eq!(eval_result_v1(&rows[2]).score, Some(0.0));
+        assert_eq!(eval_result_v1(&rows[3]).status, "ok");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -217,6 +217,43 @@ pub struct SidekickFeedbackSummary {
     pub misses: u64,
 }
 
+#[derive(Serialize, Clone)]
+pub struct CustomEvalRow {
+    pub eval_id: String,
+    pub name: String,
+    pub scoring_rule: String,
+    pub example_count: u64,
+    pub harness_sha256: Option<String>,
+    pub source_file: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct CustomEvalExampleRow {
+    pub eval_id: String,
+    pub task_id: String,
+    pub prompt: String,
+    pub expected: String,
+    pub ordinal: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct CustomEvalExampleInput {
+    pub task_id: String,
+    pub prompt: String,
+    pub expected: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct CustomEvalInput {
+    pub eval_id: String,
+    pub name: String,
+    pub scoring_rule: String,
+    pub harness_sha256: Option<String>,
+    pub source_file: Option<String>,
+    pub examples: Vec<CustomEvalExampleInput>,
+}
+
 /// App-owned SQLite store, under the macOS app-data dir. Profile, credentials,
 /// and the model cache continue to live under `~/.understudy/`.
 ///
@@ -394,7 +431,27 @@ fn migrate(conn: &Connection) -> Result<()> {
                 compacted_count INTEGER NOT NULL DEFAULT 0,
                 memory      TEXT,
                 updated_at  TEXT NOT NULL
-            );",
+            );
+            CREATE TABLE IF NOT EXISTS custom_evals (
+                id             INTEGER PRIMARY KEY,
+                eval_id        TEXT NOT NULL UNIQUE,
+                name           TEXT NOT NULL,
+                scoring_rule   TEXT NOT NULL,
+                example_count  INTEGER NOT NULL DEFAULT 0,
+                harness_sha256 TEXT,
+                source_file    TEXT,
+                created_at     TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS custom_eval_examples (
+                id       INTEGER PRIMARY KEY,
+                eval_id  TEXT NOT NULL,
+                task_id  TEXT NOT NULL,
+                prompt   TEXT NOT NULL,
+                expected TEXT NOT NULL,
+                ordinal  INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_custom_eval_examples_eval
+                ON custom_eval_examples(eval_id);",
     )?;
     const ALTERS: &[&str] = &[
         "ALTER TABLE residency ADD COLUMN thinking INTEGER NOT NULL DEFAULT 0",
@@ -790,6 +847,121 @@ impl Db {
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
             .map_err(Into::into)
+    }
+
+    /// Register a custom eval and its examples atomically: readers never see
+    /// an eval row without its examples (or the other way around).
+    pub fn insert_custom_eval(&self, input: &CustomEvalInput) -> Result<()> {
+        let mut conn = self.conn()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute(
+            "INSERT INTO custom_evals (
+                eval_id, name, scoring_rule, example_count, harness_sha256, source_file, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                input.eval_id,
+                input.name,
+                input.scoring_rule,
+                input.examples.len() as i64,
+                input.harness_sha256,
+                input.source_file,
+                now_iso(),
+            ],
+        )?;
+        for (ordinal, example) in input.examples.iter().enumerate() {
+            tx.execute(
+                "INSERT INTO custom_eval_examples (eval_id, task_id, prompt, expected, ordinal)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![
+                    input.eval_id,
+                    example.task_id,
+                    example.prompt,
+                    example.expected,
+                    ordinal as i64,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn list_custom_evals(&self) -> Result<Vec<CustomEvalRow>> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT eval_id, name, scoring_rule, example_count, harness_sha256, source_file, created_at
+             FROM custom_evals ORDER BY id DESC",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(CustomEvalRow {
+                eval_id: r.get(0)?,
+                name: r.get(1)?,
+                scoring_rule: r.get(2)?,
+                example_count: r.get::<_, i64>(3)?.max(0) as u64,
+                harness_sha256: r.get(4)?,
+                source_file: r.get(5)?,
+                created_at: r.get(6)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    pub fn get_custom_eval(&self, eval_id: &str) -> Result<Option<CustomEvalRow>> {
+        let conn = self.conn()?;
+        match conn.query_row(
+            "SELECT eval_id, name, scoring_rule, example_count, harness_sha256, source_file, created_at
+             FROM custom_evals WHERE eval_id=?1",
+            [eval_id],
+            |r| {
+                Ok(CustomEvalRow {
+                    eval_id: r.get(0)?,
+                    name: r.get(1)?,
+                    scoring_rule: r.get(2)?,
+                    example_count: r.get::<_, i64>(3)?.max(0) as u64,
+                    harness_sha256: r.get(4)?,
+                    source_file: r.get(5)?,
+                    created_at: r.get(6)?,
+                })
+            },
+        ) {
+            Ok(row) => Ok(Some(row)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub fn list_custom_eval_examples(&self, eval_id: &str) -> Result<Vec<CustomEvalExampleRow>> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT eval_id, task_id, prompt, expected, ordinal
+             FROM custom_eval_examples WHERE eval_id=?1 ORDER BY ordinal ASC, id ASC",
+        )?;
+        let rows = stmt.query_map([eval_id], |r| {
+            Ok(CustomEvalExampleRow {
+                eval_id: r.get(0)?,
+                task_id: r.get(1)?,
+                prompt: r.get(2)?,
+                expected: r.get(3)?,
+                ordinal: r.get::<_, i64>(4)?.max(0) as u64,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Remove a custom eval definition and its examples together. Recorded
+    /// benchmark result rows stay: they are run history, not eval definition.
+    /// Returns false when no such eval existed.
+    pub fn delete_custom_eval(&self, eval_id: &str) -> Result<bool> {
+        let mut conn = self.conn()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let deleted = tx.execute("DELETE FROM custom_evals WHERE eval_id=?1", [eval_id])?;
+        tx.execute(
+            "DELETE FROM custom_eval_examples WHERE eval_id=?1",
+            [eval_id],
+        )?;
+        tx.commit()?;
+        Ok(deleted > 0)
     }
 
     pub fn setting_get(&self, key: &str) -> Option<String> {
@@ -1323,6 +1495,92 @@ mod tests {
         // Handing claims back makes them consumable again (failed-turn path).
         db.unconsume_sidekick_handoffs(&all).unwrap();
         assert_eq!(db.consume_sidekick_handoffs("s", 5).unwrap().len(), 5);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn custom_eval_round_trips_with_ordered_examples() {
+        let (dir, db) = temp_db("custom-eval");
+        db.insert_custom_eval(&CustomEvalInput {
+            eval_id: "support-triage-1".into(),
+            name: "Support triage".into(),
+            scoring_rule: "contains".into(),
+            harness_sha256: Some("b".repeat(64)),
+            source_file: Some("triage.jsonl".into()),
+            examples: vec![
+                CustomEvalExampleInput {
+                    task_id: "row-1".into(),
+                    prompt: "Classify: refund request".into(),
+                    expected: "billing".into(),
+                },
+                CustomEvalExampleInput {
+                    task_id: "row-2".into(),
+                    prompt: "Classify: login broken".into(),
+                    expected: "auth".into(),
+                },
+            ],
+        })
+        .unwrap();
+
+        let evals = db.list_custom_evals().unwrap();
+        assert_eq!(evals.len(), 1);
+        assert_eq!(evals[0].eval_id, "support-triage-1");
+        assert_eq!(evals[0].scoring_rule, "contains");
+        assert_eq!(evals[0].example_count, 2);
+        assert_eq!(evals[0].harness_sha256.as_deref(), Some("b".repeat(64).as_str()));
+
+        let fetched = db.get_custom_eval("support-triage-1").unwrap().unwrap();
+        assert_eq!(fetched.name, "Support triage");
+        assert!(db.get_custom_eval("missing").unwrap().is_none());
+
+        let examples = db.list_custom_eval_examples("support-triage-1").unwrap();
+        assert_eq!(examples.len(), 2);
+        assert_eq!(examples[0].task_id, "row-1");
+        assert_eq!(examples[0].ordinal, 0);
+        assert_eq!(examples[1].task_id, "row-2");
+        assert_eq!(examples[1].expected, "auth");
+
+        // Duplicate eval_id is rejected (UNIQUE), and the failed transaction
+        // leaves the original examples intact.
+        assert!(db
+            .insert_custom_eval(&CustomEvalInput {
+                eval_id: "support-triage-1".into(),
+                name: "dup".into(),
+                scoring_rule: "exact".into(),
+                harness_sha256: None,
+                source_file: None,
+                examples: vec![CustomEvalExampleInput {
+                    task_id: "x".into(),
+                    prompt: "p".into(),
+                    expected: "e".into(),
+                }],
+            })
+            .is_err());
+        assert_eq!(db.list_custom_eval_examples("support-triage-1").unwrap().len(), 2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn delete_custom_eval_removes_definition_and_examples() {
+        let (dir, db) = temp_db("custom-eval-delete");
+        db.insert_custom_eval(&CustomEvalInput {
+            eval_id: "e1".into(),
+            name: "E1".into(),
+            scoring_rule: "exact".into(),
+            harness_sha256: None,
+            source_file: None,
+            examples: vec![CustomEvalExampleInput {
+                task_id: "t".into(),
+                prompt: "p".into(),
+                expected: "e".into(),
+            }],
+        })
+        .unwrap();
+        assert!(db.delete_custom_eval("e1").unwrap());
+        assert!(db.list_custom_evals().unwrap().is_empty());
+        assert!(db.list_custom_eval_examples("e1").unwrap().is_empty());
+        // Deleting again reports that nothing existed.
+        assert!(!db.delete_custom_eval("e1").unwrap());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod bootstrap;
 mod chat;
 mod commands;
 mod creds;
+mod custom_evals;
 mod db;
 mod knowledge;
 mod mcp;
@@ -175,6 +176,11 @@ pub fn run() {
             commands::run_fusion_benchmark,
             commands::run_fusion_benchmark_matrix,
             commands::run_fusion_benchmark_matrix_live,
+            custom_evals::import_custom_eval,
+            custom_evals::list_custom_evals,
+            custom_evals::delete_custom_eval,
+            custom_evals::run_custom_eval,
+            custom_evals::run_custom_eval_live,
             commands::sidekick_runs,
             commands::sidekick_metrics,
             commands::set_sidekick_run_feedback,


### PR DESCRIPTION
## What

Adds a custom-eval creation flow to the desktop app's eval gallery (Training → Evals):

- **Import**: the user provides a JSONL or CSV file of examples (input prompt + expected output / scoring hint), a name, and a deterministic scoring rule — `exact` (trimmed, case-sensitive equality), `contains` (substring), or `regex` (regex-lite, validated at import; `(?i)` for case-insensitive). No LLM judge. Malformed rows are skipped and reported with line numbers, never silently dropped; duplicate task ids rejected; 500-example cap.
- **Register**: eval definitions land in new `custom_evals` / `custom_eval_examples` tables (additive `CREATE IF NOT EXISTS` in the existing migrations-once path, atomic insert/delete). A `harness_sha256` over the canonical definition is stamped at import.
- **Run**: each example executes against a warm local slot through `chat::agent_chat` (the agent-facing non-streaming path), under the same single-flight + between-rows cancellation gate as the Fusion benchmarks. Live progress streams over the existing `FusionEvalEvent` channel into the existing rollout card.
- **Record**: results are `fusion_benchmarks` rows under mode `custom-eval` with `understudy.eval_result.v1` semantics — score 0 is a scored failure; error/tool_limit/empty_final attempts record score 0 with a non-ok status (mapping to `error` in the v1 view); split `none`; costs never invented; `harness_sha256` carried on every row. Because they are ordinary benchmark rows, they appear in the gallery's persisted results / run summaries and flow through the existing eval_result.v1 export packets with no changes to the export code.

## Why

Users can currently only run the bundled Fusion suites. This lets them measure a warm local model on *their own* workload with honest, deterministic scoring, using the row shape and gallery surfaces that already exist.

## Not in scope (cut deliberately)

- LLM-judge scoring; gateway/remote candidates for custom runs (local slot only, v1); per-eval split contracts (rows record split `none`); editing an imported eval (delete + re-import instead).

## Verification

- `apps/homescreen/src-tauri`: `cargo clippy --all-targets -- -D warnings` clean; `cargo test` 81 passed (new: import parsing incl. malformed rows/dup ids/regex validation, RFC4180 CSV edge cases, scoring rules, db round-trip/delete, and a schema-file test validating recorded custom rows against `schemas/understudy.eval_result.v1.schema.json`, mirroring the existing export test).
- `apps/homescreen`: `bun install && bun run build` pass.
- Repo root: `npm ci && npm run check && npm test` pass (139 tests).
- Not run: live GUI smoke (constraint: no GUI launch tonight); the run path reuses the already-shipped `agent_chat` + benchmark recording plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->