### PR TITLE
RLM visualization: live agentic fan-out pane

### DIFF
--- a/apps/homescreen/app/components/RlmPane.tsx
+++ b/apps/homescreen/app/components/RlmPane.tsx
@@ -1,0 +1,716 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Channel, invoke } from "@tauri-apps/api/core";
+import type { ResidencySnapshot } from "../lib/useStatus";
+
+type RlmTask = {
+  id: string;
+  label: string;
+  description: string;
+  quest_verb: string;
+  min_quests: number;
+  max_quests: number;
+  default_quests: number;
+};
+
+type RlmCatalog = {
+  schema_version: string;
+  tasks: RlmTask[];
+  default_concurrency: number;
+  max_concurrency: number;
+  quest_max_tokens: number;
+  reduce_max_tokens: number;
+  quest_timeout_secs: number;
+};
+
+type RlmQuestSpec = {
+  index: number;
+  title: string;
+  prompt: string;
+};
+
+type RlmPlan = {
+  schema_version: string;
+  task_id: string;
+  task_label: string;
+  quest_verb: string;
+  quest_count: number;
+  concurrency: number;
+  quest_max_tokens: number;
+  reduce_max_tokens: number;
+  quests: RlmQuestSpec[];
+  reduce_instruction: string;
+};
+
+type RlmRunSummary = {
+  run_id: string;
+  status: string;
+  quests_ok: number;
+  quests_failed: number;
+  reduce_output: string | null;
+  total_elapsed_ms: number;
+};
+
+type RlmEvent =
+  | {
+      type: "RunStarted";
+      run_id: string;
+      task_id: string;
+      task_label: string;
+      quest_count: number;
+      concurrency: number;
+      models: string[];
+    }
+  | { type: "QuestStarted"; run_id: string; index: number; title: string; slot_id: number; model: string }
+  | {
+      type: "QuestFinished";
+      run_id: string;
+      index: number;
+      title: string;
+      slot_id: number;
+      model: string;
+      status: string;
+      output: string;
+      elapsed_ms: number;
+      completion_tokens: number;
+    }
+  | { type: "ReduceStarted"; run_id: string; slot_id: number; model: string; prompt: string }
+  | { type: "ReduceFinished"; run_id: string; status: string; output: string; elapsed_ms: number; completion_tokens: number }
+  | { type: "RunFinished"; run_id: string; status: string; quests_ok: number; quests_failed: number; total_elapsed_ms: number }
+  | { type: "Error"; run_id: string; message: string };
+
+type NodeState = "planned" | "pending" | "running" | "done" | "error";
+
+type QuestNode = {
+  state: NodeState;
+  /// Raw backend status ("ok" | "error" | "timeout" | ...) once finished.
+  rawStatus: string | null;
+  slotId: number | null;
+  model: string | null;
+  output: string;
+  elapsedMs: number | null;
+  completionTokens: number | null;
+};
+
+type ReduceNode = QuestNode & { prompt: string };
+
+type Selected = { kind: "orchestrator" } | { kind: "quest"; index: number } | { kind: "reduce" };
+
+const IDLE_QUEST: QuestNode = {
+  state: "pending",
+  rawStatus: null,
+  slotId: null,
+  model: null,
+  output: "",
+  elapsedMs: null,
+  completionTokens: null,
+};
+
+function freshQuestNodes(count: number, state: NodeState): QuestNode[] {
+  return Array.from({ length: count }, () => ({ ...IDLE_QUEST, state }));
+}
+
+function shortModel(model: string | null): string {
+  if (!model) return "model";
+  const tail = model.split("/").at(-1) ?? model;
+  return tail.length > 26 ? `${tail.slice(0, 25)}…` : tail;
+}
+
+export function RlmPane() {
+  const [catalog, setCatalog] = useState<RlmCatalog | null>(null);
+  const [residency, setResidency] = useState<ResidencySnapshot | null>(null);
+  const [taskId, setTaskId] = useState("perspectives");
+  const [questCount, setQuestCount] = useState(5);
+  const [concurrency, setConcurrency] = useState(2);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"plan" | "run" | null>(null);
+
+  // Current visualization: the plan gives the tree shape; mode says whether
+  // the node states are a dry-run plan or a live run.
+  const [plan, setPlan] = useState<RlmPlan | null>(null);
+  const [mode, setMode] = useState<"plan" | "live" | null>(null);
+  const [quests, setQuests] = useState<QuestNode[]>([]);
+  const [reduce, setReduce] = useState<ReduceNode | null>(null);
+  const [runId, setRunId] = useState<string | null>(null);
+  const [summary, setSummary] = useState<RlmRunSummary | null>(null);
+  const [selected, setSelected] = useState<Selected | null>(null);
+
+  useEffect(() => {
+    invoke<RlmCatalog>("rlm_demo_catalog")
+      .then((next) => {
+        setCatalog(next);
+        const task = next.tasks.find((t) => t.id === "perspectives") ?? next.tasks[0];
+        if (task) {
+          setTaskId(task.id);
+          setQuestCount(task.default_quests);
+        }
+        setConcurrency(next.default_concurrency);
+      })
+      .catch((err) => setError(String(err)));
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    const refresh = () => {
+      invoke<ResidencySnapshot>("get_residency")
+        .then((snap) => {
+          if (alive) setResidency(snap);
+        })
+        .catch(() => {});
+    };
+    refresh();
+    const poll = setInterval(refresh, 5000);
+    return () => {
+      alive = false;
+      clearInterval(poll);
+    };
+  }, []);
+
+  const task = useMemo(() => catalog?.tasks.find((t) => t.id === taskId) ?? null, [catalog, taskId]);
+  const warmSlots = useMemo(
+    () => residency?.slots.filter((slot) => slot.state === "running") ?? [],
+    [residency],
+  );
+
+  const pickTask = (id: string) => {
+    setTaskId(id);
+    const next = catalog?.tasks.find((t) => t.id === id);
+    if (next) setQuestCount(next.default_quests);
+  };
+
+  const requestBody = () => ({
+    task_id: taskId,
+    quest_count: questCount,
+    concurrency,
+  });
+
+  const planRun = async () => {
+    setBusy("plan");
+    setError(null);
+    try {
+      const next = await invoke<RlmPlan>("rlm_plan", { request: requestBody() });
+      setPlan(next);
+      setMode("plan");
+      setQuests(freshQuestNodes(next.quest_count, "planned"));
+      setReduce({ ...IDLE_QUEST, state: "planned", prompt: "" });
+      setRunId(null);
+      setSummary(null);
+      setSelected({ kind: "orchestrator" });
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const liveRun = async () => {
+    setBusy("run");
+    setError(null);
+    try {
+      // Planning is deterministic, so this tree matches what the backend
+      // will execute for the same request.
+      const next = await invoke<RlmPlan>("rlm_plan", { request: requestBody() });
+      setPlan(next);
+      setMode("live");
+      setQuests(freshQuestNodes(next.quest_count, "pending"));
+      setReduce({ ...IDLE_QUEST, state: "pending", prompt: "" });
+      setRunId(null);
+      setSummary(null);
+      setSelected({ kind: "orchestrator" });
+
+      const ch = new Channel<RlmEvent>();
+      ch.onmessage = (event) => {
+        if (event.type === "RunStarted") {
+          setRunId(event.run_id);
+          return;
+        }
+        if (event.type === "QuestStarted") {
+          setQuests((rows) =>
+            rows.map((row, index) =>
+              index === event.index
+                ? { ...row, state: "running", slotId: event.slot_id, model: event.model }
+                : row,
+            ),
+          );
+          return;
+        }
+        if (event.type === "QuestFinished") {
+          setQuests((rows) =>
+            rows.map((row, index) =>
+              index === event.index
+                ? {
+                    ...row,
+                    state: event.status === "ok" ? "done" : "error",
+                    rawStatus: event.status,
+                    slotId: event.slot_id,
+                    model: event.model,
+                    output: event.output,
+                    elapsedMs: event.elapsed_ms,
+                    completionTokens: event.completion_tokens,
+                  }
+                : row,
+            ),
+          );
+          return;
+        }
+        if (event.type === "ReduceStarted") {
+          setReduce((node) =>
+            node
+              ? { ...node, state: "running", slotId: event.slot_id, model: event.model, prompt: event.prompt }
+              : node,
+          );
+          setSelected({ kind: "reduce" });
+          return;
+        }
+        if (event.type === "ReduceFinished") {
+          setReduce((node) =>
+            node
+              ? {
+                  ...node,
+                  state: event.status === "ok" ? "done" : "error",
+                  rawStatus: event.status,
+                  output: event.output,
+                  elapsedMs: event.elapsed_ms,
+                  completionTokens: event.completion_tokens,
+                }
+              : node,
+          );
+          return;
+        }
+        if (event.type === "Error") {
+          setError(event.message);
+        }
+      };
+      const result = await invoke<RlmRunSummary>("run_rlm_live", {
+        request: requestBody(),
+        onEvent: ch,
+      });
+      setSummary(result);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const doneQuests = quests.filter((q) => q.state === "done" || q.state === "error").length;
+  const orchestratorState: NodeState =
+    mode === "plan"
+      ? "planned"
+      : summary
+        ? summary.status === "ok" || summary.status === "partial"
+          ? "done"
+          : "error"
+        : mode === "live"
+          ? "running"
+          : "pending";
+
+  return (
+    <>
+      <div className="pane-head">
+        <h1 className="pane-title">RLM</h1>
+        <p className="pane-sub">
+          Recursive language model — test-time compute by fanning one task out across warm local model slots.
+        </p>
+      </div>
+
+      <div className="pane-body evals-grid">
+        <div className="card evals-hero">
+          <div>
+            <div className="card-title">Scale agents, not parameters</div>
+            <div className="card-sub">
+              One task decomposes into bounded quests, each a real call to a warm slot; a reduce step combines the
+              results. Is one 31B smarter than fifteen 2Bs? Run it and watch.
+            </div>
+          </div>
+          <div className="evals-actions">
+            <button className="btn" type="button" onClick={planRun} disabled={busy !== null}>
+              {busy === "plan" ? "Planning..." : "Plan (dry run)"}
+            </button>
+            <button
+              className="btn primary"
+              type="button"
+              onClick={liveRun}
+              disabled={busy !== null || warmSlots.length === 0}
+              title={warmSlots.length === 0 ? "Warm a model slot first" : "Run against the warm fleet"}
+            >
+              {busy === "run" ? "Running..." : "Run live"}
+            </button>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card-row">
+            <div>
+              <div className="card-title">Warm fleet</div>
+              <div className="card-sub">Quests round-robin across every warm slot; the reduce step runs on the first.</div>
+            </div>
+            <span className="svc-state">{warmSlots.length} warm</span>
+          </div>
+          {warmSlots.length ? (
+            <div className="env-list">
+              {warmSlots.map((slot) => (
+                <div className="svc" key={slot.id}>
+                  <span className="dot running" />
+                  <div>
+                    <div className="svc-name">Slot {slot.id}</div>
+                    <div className="svc-desc">{shortModel(slot.model_id)} · {slot.mem_gb.toFixed(1)} GB</div>
+                  </div>
+                  <span className="svc-state">running</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rlm-warm-hint">
+              No warm model slot. In <strong>Status → Residency</strong>, add a slot, assign a model, and warm it —
+              then Run works. The dry-run plan below needs no model.
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <div className="card-row">
+            <div>
+              <div className="card-title">Demo task</div>
+              <div className="card-sub">{task?.description ?? "Pick a decomposable demo task."}</div>
+            </div>
+            <span className="svc-state">{questCount} quests</span>
+          </div>
+          <div className="eval-controls rlm-controls">
+            <label>
+              Task
+              <select value={taskId} onChange={(event) => pickTask(event.target.value)}>
+                {catalog?.tasks.map((item) => (
+                  <option key={item.id} value={item.id}>{item.label}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Quests
+              <select value={questCount} onChange={(event) => setQuestCount(Number(event.target.value))}>
+                {task
+                  ? Array.from(
+                      { length: task.max_quests - task.min_quests + 1 },
+                      (_, i) => task.min_quests + i,
+                    ).map((n) => (
+                      <option key={n} value={n}>{n}</option>
+                    ))
+                  : null}
+              </select>
+            </label>
+            <label>
+              Fan-out width
+              <select value={concurrency} onChange={(event) => setConcurrency(Number(event.target.value))}>
+                {Array.from({ length: catalog?.max_concurrency ?? 4 }, (_, i) => i + 1).map((n) => (
+                  <option key={n} value={n}>{n} at a time</option>
+                ))}
+              </select>
+            </label>
+          </div>
+          {error && <div className="eval-error">{error}</div>}
+        </div>
+
+        {plan && (
+          <div className={"card evals-wide rlm-run-card" + (mode === "live" && busy === "run" ? " rollout-live" : "")}>
+            <div className="card-row">
+              <div>
+                <div className="card-title">
+                  {mode === "plan" ? "Plan — no model calls were made" : plan.task_label}
+                </div>
+                <div className="card-sub">
+                  {mode === "plan"
+                    ? `Dry-run of the fan-out: ${plan.quest_count} quests (each would ${plan.quest_verb}), then one reduce call. Warm a slot and press Run live to execute it.`
+                    : `${runId ?? "starting"} · ${doneQuests}/${plan.quest_count} quests · ${plan.concurrency} at a time`}
+                </div>
+              </div>
+              <span className="svc-state">
+                {mode === "plan"
+                  ? "plan"
+                  : summary
+                    ? summary.status
+                    : busy === "run"
+                      ? "running"
+                      : "idle"}
+              </span>
+            </div>
+
+            {mode === "live" && (
+              <div className="rollout-progress">
+                <span style={{ width: `${Math.max(4, Math.min(100, Math.round((doneQuests / Math.max(1, plan.quest_count)) * 100)))}%` }} />
+              </div>
+            )}
+
+            <FanOutTree
+              plan={plan}
+              orchestratorState={orchestratorState}
+              quests={quests}
+              reduce={reduce}
+              selected={selected}
+              onSelect={setSelected}
+              isPlan={mode === "plan"}
+            />
+
+            <NodeDetail plan={plan} quests={quests} reduce={reduce} selected={selected} isPlan={mode === "plan"} />
+
+            {summary && (
+              <div className="rlm-summary">
+                <span>{summary.quests_ok} ok</span>
+                <span>{summary.quests_failed} failed</span>
+                <span>{(summary.total_elapsed_ms / 1000).toFixed(1)}s total</span>
+                <span>run {summary.run_id}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {!plan && (
+          <div className="card evals-wide">
+            <div className="card-title">How this works</div>
+            <div className="rlm-explainer">
+              <div>
+                <strong>1 · Decompose</strong>
+                <p>The orchestrator splits the task into bounded quests — each gets a flat context and a token cap, never the whole problem.</p>
+              </div>
+              <div>
+                <strong>2 · Fan out</strong>
+                <p>Quests dispatch to warm local slots in small waves. More warm slots means more horizontal compute — that is the scaling axis.</p>
+              </div>
+              <div>
+                <strong>3 · Reduce</strong>
+                <p>A final call combines only the quest outputs that succeeded. Failed workers are named as missing, never invented.</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function FanOutTree({
+  plan,
+  orchestratorState,
+  quests,
+  reduce,
+  selected,
+  onSelect,
+  isPlan,
+}: {
+  plan: RlmPlan;
+  orchestratorState: NodeState;
+  quests: QuestNode[];
+  reduce: ReduceNode | null;
+  selected: Selected | null;
+  onSelect: (next: Selected) => void;
+  isPlan: boolean;
+}) {
+  const n = plan.quest_count;
+  const centers = Array.from({ length: n }, (_, i) => ((i + 0.5) / n) * 100);
+
+  return (
+    <div className="rlm-tree">
+      <div className="rlm-tier rlm-tier-single">
+        <TreeNode
+          state={orchestratorState}
+          active={selected?.kind === "orchestrator"}
+          onClick={() => onSelect({ kind: "orchestrator" })}
+          title="Orchestrator"
+          sub={`decomposes into ${n} quests`}
+          badge={isPlan ? "plan" : stateLabel(orchestratorState)}
+        />
+      </div>
+      <TreeLinks centers={centers} direction="down" states={quests.map((q) => q.state)} />
+      <div className="rlm-tier" style={{ gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))` }}>
+        {plan.quests.map((spec) => {
+          const node = quests[spec.index] ?? { ...IDLE_QUEST, state: "pending" as NodeState };
+          return (
+            <TreeNode
+              key={spec.index}
+              state={node.state}
+              active={selected?.kind === "quest" && selected.index === spec.index}
+              onClick={() => onSelect({ kind: "quest", index: spec.index })}
+              title={`Q${spec.index + 1} · ${spec.title}`}
+              sub={node.model ? shortModel(node.model) : plan.quest_verb}
+              badge={questBadge(node, isPlan)}
+              compact
+            />
+          );
+        })}
+      </div>
+      <TreeLinks centers={centers} direction="up" states={quests.map((q) => q.state)} />
+      <div className="rlm-tier rlm-tier-single">
+        <TreeNode
+          state={reduce?.state ?? "pending"}
+          active={selected?.kind === "reduce"}
+          onClick={() => onSelect({ kind: "reduce" })}
+          title="Reduce"
+          sub={reduce?.model ? shortModel(reduce.model) : "combines quest results"}
+          badge={reduce ? questBadge(reduce, isPlan) : "pending"}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Curved connectors between the single node tier and the quest tier. */
+function TreeLinks({
+  centers,
+  direction,
+  states,
+}: {
+  centers: number[];
+  direction: "down" | "up";
+  states: NodeState[];
+}) {
+  return (
+    <svg className="rlm-links" viewBox="0 0 100 24" preserveAspectRatio="none" aria-hidden="true">
+      {centers.map((x, i) => {
+        const d =
+          direction === "down"
+            ? `M 50 0 C 50 14, ${x} 8, ${x} 24`
+            : `M ${x} 0 C ${x} 14, 50 8, 50 24`;
+        return <path key={i} d={d} className={`rlm-link ${states[i] ?? "pending"}`} vectorEffect="non-scaling-stroke" />;
+      })}
+    </svg>
+  );
+}
+
+function stateLabel(state: NodeState): string {
+  return state === "done" ? "done" : state;
+}
+
+function questBadge(node: QuestNode, isPlan: boolean): string {
+  if (isPlan) return "plan";
+  if (node.state === "done" && node.elapsedMs != null) return `${(node.elapsedMs / 1000).toFixed(1)}s`;
+  if (node.state === "error") return node.rawStatus ?? "error";
+  return stateLabel(node.state);
+}
+
+function NodeDetail({
+  plan,
+  quests,
+  reduce,
+  selected,
+  isPlan,
+}: {
+  plan: RlmPlan;
+  quests: QuestNode[];
+  reduce: ReduceNode | null;
+  selected: Selected | null;
+  isPlan: boolean;
+}) {
+  if (!selected) return null;
+
+  if (selected.kind === "orchestrator") {
+    return (
+      <div className="rollout-detail rlm-detail">
+        <div className="rollout-meta">
+          <span>orchestrator</span>
+          <span>{plan.quest_count} quests</span>
+          <span>{plan.concurrency} at a time</span>
+          <span>{plan.quest_max_tokens} tok/quest</span>
+        </div>
+        <div className="rollout-question">{plan.task_label}</div>
+        <div className="rollout-expected">
+          Decomposition is deterministic Rust code, not a model call: each quest gets one bounded unit of the task
+          ({plan.quest_verb}). {isPlan ? "This is the plan only — nothing has been executed." : "Quests below execute for real against warm slots."}
+        </div>
+      </div>
+    );
+  }
+
+  if (selected.kind === "quest") {
+    const spec = plan.quests[selected.index];
+    const node = quests[selected.index];
+    if (!spec) return null;
+    return (
+      <div className="rollout-detail rlm-detail">
+        <div className="rollout-meta">
+          <span>quest {selected.index + 1}</span>
+          {node?.slotId != null && <span>slot {node.slotId}</span>}
+          {node?.model && <span>{shortModel(node.model)}</span>}
+          {node?.elapsedMs != null && <span>{node.elapsedMs}ms</span>}
+          {node?.completionTokens != null && <span>{node.completionTokens} tokens</span>}
+          {node?.rawStatus && <span>{node.rawStatus}</span>}
+        </div>
+        <div className="rollout-question">{spec.title}</div>
+        <div className="rollout-expected">Prompt sent to the model:</div>
+        <pre className="rollout-output rlm-prompt">{spec.prompt}</pre>
+        {!isPlan && (
+          <>
+            <div className="rollout-expected">Output:</div>
+            <pre className="rollout-output">
+              {node?.output || (node?.state === "running" ? "Generating..." : node?.state === "pending" ? "Queued..." : "")}
+            </pre>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rollout-detail rlm-detail">
+      <div className="rollout-meta">
+        <span>reduce</span>
+        {reduce?.slotId != null && <span>slot {reduce.slotId}</span>}
+        {reduce?.model && <span>{shortModel(reduce.model)}</span>}
+        {reduce?.elapsedMs != null && <span>{reduce.elapsedMs}ms</span>}
+        {reduce?.rawStatus && <span>{reduce.rawStatus}</span>}
+      </div>
+      <div className="rollout-question">Combine the quest results</div>
+      {isPlan ? (
+        <>
+          <div className="rollout-expected">Reduce instruction (quest outputs are appended at run time):</div>
+          <pre className="rollout-output rlm-prompt">{plan.reduce_instruction}</pre>
+        </>
+      ) : (
+        <>
+          {reduce?.prompt && (
+            <>
+              <div className="rollout-expected">Reduce prompt (built from successful quests only):</div>
+              <pre className="rollout-output rlm-prompt">{reduce.prompt}</pre>
+            </>
+          )}
+          <div className="rollout-expected">Final answer:</div>
+          <pre className="rollout-output">
+            {reduce?.output || (reduce?.state === "running" ? "Combining..." : "Waiting for quests...")}
+          </pre>
+        </>
+      )}
+    </div>
+  );
+}
+
+function TreeNode({
+  state,
+  active,
+  onClick,
+  title,
+  sub,
+  badge,
+  compact,
+}: {
+  state: NodeState;
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  sub: string;
+  badge: string;
+  compact?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`rlm-node ${state}${active ? " active" : ""}${compact ? " compact" : ""}`}
+      onClick={onClick}
+    >
+      <span className={`rlm-node-dot ${state}`} />
+      <span className="rlm-node-copy">
+        <span className="rlm-node-title">{title}</span>
+        <span className="rlm-node-sub">{sub}</span>
+      </span>
+      <span className="rlm-node-badge">{badge}</span>
+    </button>
+  );
+}

--- a/apps/homescreen/app/components/RlmPane.tsx
+++ b/apps/homescreen/app/components/RlmPane.tsx
@@ -133,6 +133,9 @@ export function RlmPane() {
   const [quests, setQuests] = useState<QuestNode[]>([]);
   const [reduce, setReduce] = useState<ReduceNode | null>(null);
   const [runId, setRunId] = useState<string | null>(null);
+  // Effective width from RunStarted: the backend clamps fan-out to one
+  // in-flight request per warm slot, which can be below the requested width.
+  const [liveConcurrency, setLiveConcurrency] = useState<number | null>(null);
   const [summary, setSummary] = useState<RlmRunSummary | null>(null);
   const [selected, setSelected] = useState<Selected | null>(null);
 
@@ -195,6 +198,7 @@ export function RlmPane() {
       setQuests(freshQuestNodes(next.quest_count, "planned"));
       setReduce({ ...IDLE_QUEST, state: "planned", prompt: "" });
       setRunId(null);
+      setLiveConcurrency(null);
       setSummary(null);
       setSelected({ kind: "orchestrator" });
     } catch (err) {
@@ -216,6 +220,7 @@ export function RlmPane() {
       setQuests(freshQuestNodes(next.quest_count, "pending"));
       setReduce({ ...IDLE_QUEST, state: "pending", prompt: "" });
       setRunId(null);
+      setLiveConcurrency(null);
       setSummary(null);
       setSelected({ kind: "orchestrator" });
 
@@ -223,6 +228,7 @@ export function RlmPane() {
       ch.onmessage = (event) => {
         if (event.type === "RunStarted") {
           setRunId(event.run_id);
+          setLiveConcurrency(event.concurrency);
           return;
         }
         if (event.type === "QuestStarted") {
@@ -421,7 +427,7 @@ export function RlmPane() {
                 <div className="card-sub">
                   {mode === "plan"
                     ? `Dry-run of the fan-out: ${plan.quest_count} quests (each would ${plan.quest_verb}), then one reduce call. Warm a slot and press Run live to execute it.`
-                    : `${runId ?? "starting"} · ${doneQuests}/${plan.quest_count} quests · ${plan.concurrency} at a time`}
+                    : `${runId ?? "starting"} · ${doneQuests}/${plan.quest_count} quests · ${liveConcurrency ?? plan.concurrency} at a time`}
                 </div>
               </div>
               <span className="svc-state">
@@ -431,7 +437,9 @@ export function RlmPane() {
                     ? summary.status
                     : busy === "run"
                       ? "running"
-                      : "idle"}
+                      : error
+                        ? "failed"
+                        : "idle"}
               </span>
             </div>
 

--- a/apps/homescreen/app/components/RlmPane.tsx
+++ b/apps/homescreen/app/components/RlmPane.tsx
@@ -295,6 +295,7 @@ export function RlmPane() {
       setSummary(result);
     } catch (err) {
       setError(String(err));
+      setMode(null);
     } finally {
       setBusy(null);
     }

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -8,6 +8,7 @@ export type PaneId =
   | "account"
   | "usage"
   | "traces"
+  | "rlm"
   | "training-evals"
   | "training-optimization"
   | "training-datasets"
@@ -38,6 +39,17 @@ const ICONS: Record<PaneId, ReactNode> = {
     <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
       <path d="M2.5 4.5h4l1.2-1.5h5.8v9.5h-11z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
       <path d="M5 8h6M8 5.5v5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" opacity=".72" />
+    </svg>
+  ),
+  rlm: (
+    // Fan-out tree: one root, three workers, one reduce.
+    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
+      <circle cx="8" cy="2.8" r="1.6" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="3" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="8" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="13" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="8" cy="13.2" r="1.6" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M7 4 4 6.7M8 4.4V6.5M9 4l3 2.7M4 9.2l3 2.8M8 9.5v2.1M12 9.2l-3 2.8" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
     </svg>
   ),
   "training-evals": (
@@ -98,6 +110,7 @@ const SERVING_NAV: { id: PaneId; label: string }[] = [
   { id: "status", label: "Status" },
   { id: "capture", label: "Capture" },
   { id: "models", label: "Models" },
+  { id: "rlm", label: "RLM" },
   { id: "traces", label: "Traces" },
   { id: "usage", label: "Usage" },
 ];

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -1514,6 +1514,177 @@ select,
   line-height: 1.55;
 }
 
+/* ---------- RLM (fan-out tree) ---------- */
+.rlm-controls {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.rlm-warm-hint {
+  margin-top: 10px;
+  border: 1px dashed var(--border);
+  border-radius: var(--r-control);
+  background: color-mix(in srgb, var(--loading) 7%, transparent);
+  color: var(--text-2);
+  font-size: 12px;
+  line-height: 1.5;
+  padding: 10px 12px;
+}
+.rlm-tree {
+  display: grid;
+  margin-top: 14px;
+}
+.rlm-tier {
+  display: grid;
+  gap: 8px;
+  align-items: stretch;
+}
+.rlm-tier-single {
+  grid-template-columns: minmax(220px, 420px);
+  justify-content: center;
+}
+.rlm-links {
+  width: 100%;
+  height: 34px;
+  display: block;
+}
+.rlm-link {
+  fill: none;
+  stroke: var(--border);
+  stroke-width: 1.4;
+}
+.rlm-link.running { stroke: var(--accent); }
+.rlm-link.done { stroke: var(--success); }
+.rlm-link.error { stroke: var(--danger); }
+.rlm-node {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  min-height: 52px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-control);
+  background: var(--surface-2);
+  color: var(--text-2);
+  font: inherit;
+  text-align: left;
+  padding: 9px 11px;
+  cursor: pointer;
+}
+.rlm-node:hover,
+.rlm-node.active {
+  background: var(--hover);
+}
+.rlm-node.active {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+}
+.rlm-node.running { border-color: color-mix(in srgb, var(--accent) 55%, var(--border)); }
+.rlm-node.done { border-color: color-mix(in srgb, var(--success) 45%, var(--border)); }
+.rlm-node.error { border-color: color-mix(in srgb, var(--danger) 50%, var(--border)); }
+.rlm-node.planned { border-style: dashed; }
+.rlm-node-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--text-3);
+}
+.rlm-node-dot.running {
+  background: var(--accent);
+  animation: rlm-pulse 1.1s ease-in-out infinite;
+}
+.rlm-node-dot.done { background: var(--success); }
+.rlm-node-dot.error { background: var(--danger); }
+.rlm-node-dot.planned { background: var(--loading); }
+@keyframes rlm-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+.rlm-node-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+.rlm-node-title {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rlm-node-sub {
+  color: var(--text-3);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rlm-node-badge {
+  flex: none;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 7px;
+}
+.rlm-node.compact {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  min-height: 74px;
+}
+.rlm-node.compact .rlm-node-badge {
+  align-self: flex-end;
+}
+.rlm-detail {
+  margin-top: 14px;
+}
+.rlm-prompt {
+  max-height: 150px;
+  margin-bottom: 12px;
+  opacity: 0.85;
+}
+.rlm-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+.rlm-summary span {
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 5px 8px;
+}
+.rlm-explainer {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+.rlm-explainer strong {
+  display: block;
+  color: var(--text);
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+.rlm-explainer p {
+  margin: 0;
+  color: var(--text-3);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+@media (max-width: 760px) {
+  .rlm-controls,
+  .rlm-explainer {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 760px) {
   .capture-hero,
   .evals-hero,

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -12,6 +12,7 @@ import { AccountPane } from "./components/AccountPane";
 import { UsagePane } from "./components/UsagePane";
 import { DownloadQrButton } from "./components/DownloadQrButton";
 import { isTrainingPane, TrainingPane } from "./components/TrainingPane";
+import { RlmPane } from "./components/RlmPane";
 import { useStatus } from "./lib/useStatus";
 
 export default function Page() {
@@ -36,6 +37,7 @@ export default function Page() {
       "account",
       "usage",
       "traces",
+      "rlm",
       "training-evals",
       "training-optimization",
       "training-datasets",
@@ -105,6 +107,7 @@ export default function Page() {
         {pane === "chat" && <ChatPane resetToken={chatResetToken} />}
         {pane === "models" && <ModelsPane />}
         {pane === "capture" && <CapturePane />}
+        {pane === "rlm" && <RlmPane />}
         {isTrainingPane(pane) && <TrainingPane section={pane} />}
         {pane === "account" && <AccountPane />}
         {pane === "usage" && <UsagePane status={status} />}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod metrics;
 mod models;
 mod moraine;
 mod residency;
+mod rlm;
 mod route_policy;
 mod server;
 mod sidecar;
@@ -186,6 +187,9 @@ pub fn run() {
             commands::get_setting,
             commands::set_setting,
             commands::server_info,
+            rlm::rlm_demo_catalog,
+            rlm::rlm_plan,
+            rlm::run_rlm_live,
             chat::chat_stream,
         ])
         .build(tauri::generate_context!())

--- a/apps/homescreen/src-tauri/src/rlm.rs
+++ b/apps/homescreen/src-tauri/src/rlm.rs
@@ -1,0 +1,1228 @@
+//! RLM (recursive language model) demo orchestration: test-time compute by
+//! horizontal fan-out. A demo task decomposes into N bounded sub-tasks
+//! ("quests"), each dispatched as a real non-streaming `agent_chat` call
+//! against a warm residency slot, then a reduce step combines the quest
+//! results into one answer.
+//!
+//! Design mirrors the fusion benchmark live path: the GUI passes a Tauri
+//! `Channel` and receives typed events (`RlmEvent`) as the run progresses.
+//! Planning (`rlm_plan`) is pure and never touches a model, so the pane can
+//! show an honest dry-run of the fan-out tree when nothing is warm.
+//!
+//! The orchestration is deliberately simple: quests run in small waves
+//! (bounded concurrency), each quest has a token cap and a timeout, and the
+//! reduce step only sees the quest outputs that actually succeeded.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::ipc::Channel;
+use tauri::{AppHandle, Manager};
+
+use crate::residency::Residency;
+
+/// Per-quest completion cap. Quests are deliberately bounded: the point of
+/// the fan-out is many small flat-context calls, not N long generations.
+const RLM_QUEST_DEFAULT_MAX_TOKENS: u32 = 512;
+/// The reduce step sees every quest summary, so it gets more room.
+const RLM_REDUCE_DEFAULT_MAX_TOKENS: u32 = 1024;
+const RLM_MAX_TOKENS_CEILING: u32 = 2048;
+const RLM_MAX_TOKENS_FLOOR: u32 = 64;
+/// Whole-call timeout per quest / reduce call. Local models with a 512-token
+/// cap should finish well inside this; a wedged server must not hang the run.
+const RLM_QUEST_TIMEOUT_SECS: u64 = 240;
+const RLM_REDUCE_TIMEOUT_SECS: u64 = 360;
+/// Fan-out width. The residency slots share one machine, so keep the wave
+/// small; a single warm slot serializes server-side anyway.
+const RLM_MAX_CONCURRENCY: u32 = 4;
+const RLM_DEFAULT_CONCURRENCY: u32 = 2;
+/// Event payload bound so a chatty model cannot bloat the IPC channel.
+const RLM_EVENT_OUTPUT_MAX: usize = 6_000;
+
+fn default_rlm_run_id() -> String {
+    format!("rlm-{}", chrono::Utc::now().timestamp_millis())
+}
+
+// ---------------------------------------------------------------------------
+// Demo task catalog (synthetic, self-contained — no external data)
+// ---------------------------------------------------------------------------
+
+struct DemoUnit {
+    title: &'static str,
+    body: &'static str,
+}
+
+struct DemoTask {
+    id: &'static str,
+    label: &'static str,
+    description: &'static str,
+    /// What one quest does, shown on the orchestrator node.
+    quest_verb: &'static str,
+    min_quests: u32,
+    max_quests: u32,
+    default_quests: u32,
+    /// Prompt template for one quest; `{title}` and `{body}` are substituted.
+    quest_prompt: &'static str,
+    /// Instruction for the reduce step; quest outputs are appended below it.
+    reduce_instruction: &'static str,
+    units: &'static [DemoUnit],
+}
+
+/// Synthetic field-report sections for the map-reduce brief demo. Written for
+/// this demo; no customer data.
+const REPORT_SECTIONS: &[DemoUnit] = &[
+    DemoUnit {
+        title: "Rollout timeline",
+        body: "Week 1: two workstations received a 4-bit 12B model and served the internal summarize queue. Week 2: five more machines joined; the queue drained 3.1x faster. Week 3: one machine was rolled back after thermal throttling under sustained batch load.",
+    },
+    DemoUnit {
+        title: "Latency observations",
+        body: "Median time-to-first-token stayed under 400ms on every warm slot. P95 full-response latency was 9.8s for 512-token answers. Cold starts cost 21-64 seconds depending on model size, so slots were kept warm during business hours.",
+    },
+    DemoUnit {
+        title: "Memory pressure",
+        body: "Each warm 12B slot held 7.4GB of unified memory. Machines with 16GB could hold one slot comfortably; 32GB machines held two plus headroom. Swapping was only observed when a browser with 60+ tabs competed with the second slot.",
+    },
+    DemoUnit {
+        title: "Quality spot-checks",
+        body: "Reviewers accepted 87% of local summaries without edits, versus 93% for the frontier baseline. Most rejections were missing citations, not wrong facts. A stricter output template recovered roughly half of the gap.",
+    },
+    DemoUnit {
+        title: "Cost accounting",
+        body: "The summarize queue previously cost about $410/month in API fees. Local serving moved 78% of that volume at zero marginal cost; the remainder still routes to the frontier for long documents over 30 pages.",
+    },
+    DemoUnit {
+        title: "Failure modes",
+        body: "Three incidents: one wedged server process after a laptop slept mid-generation, one out-of-memory kill when two loads raced, and one silent quality drop when a quantization mismatch shipped. All three now have preflight checks.",
+    },
+    DemoUnit {
+        title: "Operator feedback",
+        body: "Operators liked the offline capability and the fixed cost. The top complaint was fan noise during long batches. Two operators asked for a visible per-slot queue so they can tell 'busy' from 'stuck'.",
+    },
+    DemoUnit {
+        title: "Next-quarter plan",
+        body: "Plan: promote the 12B model to the default route for summaries under 30 pages, add a nightly eval against a frozen 40-case split, and trial a 2B sidekick for classification so the 12B slot stays free for generation.",
+    },
+];
+
+/// Angles for the one-big-vs-many-small debate demo.
+const PERSPECTIVE_ANGLES: &[DemoUnit] = &[
+    DemoUnit {
+        title: "Task decomposability",
+        body: "Whether the workload splits into independent bounded sub-tasks, or is one long chain of dependent reasoning.",
+    },
+    DemoUnit {
+        title: "Latency",
+        body: "Wall-clock time: parallel small models versus one big model generating sequentially.",
+    },
+    DemoUnit {
+        title: "Memory footprint",
+        body: "Fitting one 31B model in unified memory versus scheduling fifteen 2B models across the same budget.",
+    },
+    DemoUnit {
+        title: "Quality ceiling",
+        body: "Capabilities that emerge with scale versus what an ensemble of small models can recover through voting and reduction.",
+    },
+    DemoUnit {
+        title: "Failure isolation",
+        body: "One bad generation poisoning the whole answer versus a reduce step that can discard a bad worker's output.",
+    },
+    DemoUnit {
+        title: "Orchestration overhead",
+        body: "The cost of planning, dispatching, and combining sub-results — tokens and code that the single big model does not pay.",
+    },
+    DemoUnit {
+        title: "Cost shape",
+        body: "Marginal cost per token, hardware utilization, and where the spend concentrates in each design.",
+    },
+    DemoUnit {
+        title: "Trainability",
+        body: "Which design improves faster: fine-tuning one generalist or hill-climbing many small specialists on narrow steps.",
+    },
+];
+
+/// Sub-estimates for the Fermi-decomposition demo.
+const FERMI_PARTS: &[DemoUnit] = &[
+    DemoUnit {
+        title: "Coding sessions per day",
+        body: "Estimate how many distinct coding-agent sessions a busy developer runs in one workday.",
+    },
+    DemoUnit {
+        title: "Model calls per session",
+        body: "Estimate how many model calls (turns, tool loops, retries) one coding-agent session makes.",
+    },
+    DemoUnit {
+        title: "Output tokens per call",
+        body: "Estimate the average completion length in tokens for one coding-agent model call, counting code and prose.",
+    },
+    DemoUnit {
+        title: "Background calls",
+        body: "Estimate the extra model calls from background work: summarization, embeddings-adjacent rewriting, commit messages, and lint fixes.",
+    },
+    DemoUnit {
+        title: "Retry and error overhead",
+        body: "Estimate what fraction of calls are retried or regenerated because of truncation, tool errors, or bad formats.",
+    },
+    DemoUnit {
+        title: "Working days and duty cycle",
+        body: "Estimate the effective active hours in a workday during which the agent is actually generating.",
+    },
+];
+
+const DEMO_TASKS: &[DemoTask] = &[
+    DemoTask {
+        id: "chunk-brief",
+        label: "Map-reduce a field report",
+        description:
+            "Split a synthetic 8-section deployment report across N analyst quests; each extracts key facts from one section, then a reduce step writes the brief.",
+        quest_verb: "extract key facts from one section",
+        min_quests: 2,
+        max_quests: 8,
+        default_quests: 4,
+        quest_prompt: "You are one of several parallel analyst agents. You see exactly one section of a larger field report; other agents handle the other sections. Extract the 2-3 most decision-relevant facts from your section as short bullet points. Do not speculate about sections you cannot see.\n\nSection \"{title}\":\n{body}",
+        reduce_instruction: "You are the reduce step of a map-reduce analysis. Below are fact bullets extracted by parallel analyst agents, one per report section. Combine them into a single briefing of at most 6 bullet points for an engineering lead deciding whether to expand a local-model rollout. Merge duplicates; keep numbers.",
+        units: REPORT_SECTIONS,
+    },
+    DemoTask {
+        id: "perspectives",
+        label: "One 31B vs fifteen 2Bs",
+        description:
+            "Fan one question out to N quests, each arguing a different angle of \"what's smarter: one big model or many small ones?\", then reduce to a verdict.",
+        quest_verb: "argue one angle of the question",
+        min_quests: 2,
+        max_quests: 8,
+        default_quests: 5,
+        quest_prompt: "Question under debate: for agentic workloads, what is smarter — one large 31B model, or fifteen 2B models fanned out in parallel with an orchestrator?\n\nYou are one of several parallel debater agents. Argue ONLY from this angle, in at most 4 sentences, and end with a one-line verdict for your angle.\n\nYour angle — {title}: {body}",
+        reduce_instruction: "You are the reduce step of a parallel debate. Below are per-angle verdicts from parallel debater agents on the question: one large 31B model versus fifteen 2B models fanned out in parallel. Synthesize them into a balanced final answer of at most 5 sentences: state when the fan-out wins, when the single big model wins, and the single most decision-relevant factor.",
+        units: PERSPECTIVE_ANGLES,
+    },
+    DemoTask {
+        id: "fermi",
+        label: "Fermi estimate, decomposed",
+        description:
+            "Decompose \"how many tokens does a busy coding agent generate per day?\" into N independent sub-estimates, then reduce them into one estimate.",
+        quest_verb: "produce one sub-estimate",
+        min_quests: 2,
+        max_quests: 6,
+        default_quests: 4,
+        quest_prompt: "You are one of several parallel estimator agents working on the Fermi question: how many output tokens does one busy developer's coding agent generate in a single workday? Produce ONLY your assigned sub-estimate. Give a single number with brief reasoning (at most 3 sentences), then the line 'ESTIMATE: <number> <unit>'.\n\nYour sub-estimate — {title}: {body}",
+        reduce_instruction: "You are the reduce step of a decomposed Fermi estimate for: how many output tokens does one busy developer's coding agent generate in a single workday? Below are independent sub-estimates from parallel estimator agents. Combine them arithmetically into one final estimate; show the multiplication in one line, state the final number, and note the biggest source of uncertainty.",
+        units: FERMI_PARTS,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Plan (pure, deterministic — safe without a warm slot)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Clone)]
+pub struct RlmTaskView {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub description: &'static str,
+    pub quest_verb: &'static str,
+    pub min_quests: u32,
+    pub max_quests: u32,
+    pub default_quests: u32,
+}
+
+#[derive(Serialize, Clone)]
+pub struct RlmCatalog {
+    pub schema_version: &'static str,
+    pub tasks: Vec<RlmTaskView>,
+    pub default_concurrency: u32,
+    pub max_concurrency: u32,
+    pub quest_max_tokens: u32,
+    pub reduce_max_tokens: u32,
+    pub quest_timeout_secs: u64,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct RlmQuestSpec {
+    pub index: u32,
+    pub title: String,
+    pub prompt: String,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct RlmPlan {
+    pub schema_version: &'static str,
+    pub task_id: String,
+    pub task_label: String,
+    pub quest_verb: String,
+    pub quest_count: u32,
+    pub concurrency: u32,
+    pub quest_max_tokens: u32,
+    pub reduce_max_tokens: u32,
+    pub quests: Vec<RlmQuestSpec>,
+    pub reduce_instruction: String,
+}
+
+#[derive(Deserialize)]
+pub struct RlmPlanRequest {
+    pub task_id: String,
+    pub quest_count: Option<u32>,
+    pub concurrency: Option<u32>,
+    pub quest_max_tokens: Option<u32>,
+    pub reduce_max_tokens: Option<u32>,
+}
+
+#[derive(Deserialize)]
+pub struct RlmRunRequest {
+    pub run_id: Option<String>,
+    pub task_id: String,
+    pub quest_count: Option<u32>,
+    pub concurrency: Option<u32>,
+    pub quest_max_tokens: Option<u32>,
+    pub reduce_max_tokens: Option<u32>,
+}
+
+fn demo_task(task_id: &str) -> Result<&'static DemoTask, String> {
+    DEMO_TASKS
+        .iter()
+        .find(|task| task.id == task_id)
+        .ok_or_else(|| format!("unknown RLM demo task: {task_id}"))
+}
+
+fn clamp_tokens(requested: Option<u32>, default: u32) -> u32 {
+    requested
+        .unwrap_or(default)
+        .clamp(RLM_MAX_TOKENS_FLOOR, RLM_MAX_TOKENS_CEILING)
+}
+
+pub(crate) fn plan_rlm_run(request: &RlmPlanRequest) -> Result<RlmPlan, String> {
+    let task = demo_task(&request.task_id)?;
+    let quest_count = request
+        .quest_count
+        .unwrap_or(task.default_quests)
+        .clamp(task.min_quests, task.max_quests.min(task.units.len() as u32));
+    let concurrency = request
+        .concurrency
+        .unwrap_or(RLM_DEFAULT_CONCURRENCY)
+        .clamp(1, RLM_MAX_CONCURRENCY)
+        .min(quest_count);
+    let quests = task
+        .units
+        .iter()
+        .take(quest_count as usize)
+        .enumerate()
+        .map(|(index, unit)| RlmQuestSpec {
+            index: index as u32,
+            title: unit.title.to_string(),
+            prompt: task
+                .quest_prompt
+                .replace("{title}", unit.title)
+                .replace("{body}", unit.body),
+        })
+        .collect();
+    Ok(RlmPlan {
+        schema_version: "understudy.rlm_plan.v1",
+        task_id: task.id.to_string(),
+        task_label: task.label.to_string(),
+        quest_verb: task.quest_verb.to_string(),
+        quest_count,
+        concurrency,
+        quest_max_tokens: clamp_tokens(request.quest_max_tokens, RLM_QUEST_DEFAULT_MAX_TOKENS),
+        reduce_max_tokens: clamp_tokens(request.reduce_max_tokens, RLM_REDUCE_DEFAULT_MAX_TOKENS),
+        quests,
+        reduce_instruction: task.reduce_instruction.to_string(),
+    })
+}
+
+/// Reduce prompt over the quest outputs that actually succeeded, in quest
+/// order. Failed quests are named as missing so the reducer never invents
+/// content for them.
+pub(crate) fn build_reduce_prompt(
+    instruction: &str,
+    results: &[(String, Option<String>)],
+) -> String {
+    let mut prompt = String::from(instruction);
+    prompt.push_str("\n\n");
+    for (title, output) in results {
+        match output {
+            Some(output) => {
+                prompt.push_str(&format!("## {title}\n{}\n\n", output.trim()));
+            }
+            None => {
+                prompt.push_str(&format!(
+                    "## {title}\n(no result — this quest failed; do not guess its content)\n\n"
+                ));
+            }
+        }
+    }
+    prompt.trim_end().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Live run events + driver
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Clone)]
+#[serde(tag = "type")]
+pub enum RlmEvent {
+    RunStarted {
+        run_id: String,
+        task_id: String,
+        task_label: String,
+        quest_count: u32,
+        concurrency: u32,
+        models: Vec<String>,
+    },
+    QuestStarted {
+        run_id: String,
+        index: u32,
+        title: String,
+        slot_id: u32,
+        model: String,
+    },
+    QuestFinished {
+        run_id: String,
+        index: u32,
+        title: String,
+        slot_id: u32,
+        model: String,
+        status: String,
+        output: String,
+        elapsed_ms: u64,
+        completion_tokens: u64,
+    },
+    ReduceStarted {
+        run_id: String,
+        slot_id: u32,
+        model: String,
+        prompt: String,
+    },
+    ReduceFinished {
+        run_id: String,
+        status: String,
+        output: String,
+        elapsed_ms: u64,
+        completion_tokens: u64,
+    },
+    RunFinished {
+        run_id: String,
+        status: String,
+        quests_ok: u32,
+        quests_failed: u32,
+        total_elapsed_ms: u64,
+    },
+    Error {
+        run_id: String,
+        message: String,
+    },
+}
+
+/// Which warm slot serves a quest (round-robin across the warm fleet).
+#[derive(Clone)]
+pub(crate) struct QuestAssignment {
+    pub slot_id: u32,
+    pub model: String,
+}
+
+/// Outcome of one bounded model call (quest or reduce). Errors are folded
+/// into `status`/`output` so a failed quest never aborts its siblings.
+pub(crate) struct QuestOutcome {
+    pub status: String,
+    pub output: String,
+    pub elapsed_ms: u64,
+    pub completion_tokens: u64,
+}
+
+impl QuestOutcome {
+    fn is_ok(&self) -> bool {
+        self.status == "ok"
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct RlmRunSummary {
+    pub schema_version: &'static str,
+    pub run_id: String,
+    pub task_id: String,
+    pub status: String,
+    pub quests_ok: u32,
+    pub quests_failed: u32,
+    pub reduce_status: Option<String>,
+    pub reduce_output: Option<String>,
+    pub total_elapsed_ms: u64,
+}
+
+pub(crate) type CallFuture = Pin<Box<dyn Future<Output = QuestOutcome> + Send>>;
+
+fn truncate_event_text(text: &str, max: usize) -> String {
+    if text.len() <= max {
+        return text.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &text[..end])
+}
+
+/// Drives one RLM run: fan quests out in waves of `plan.concurrency`, then
+/// reduce over the successful outputs. Model IO is injected (`run_quest`,
+/// `run_reduce`) so the event sequencing is testable without a warm slot.
+///
+/// Event contract (what the UI relies on):
+/// - `RunStarted` first, exactly one `RunFinished` last.
+/// - Every quest gets `QuestStarted` then `QuestFinished` (in that order per
+///   index); at most `concurrency` quests are in flight at once.
+/// - `ReduceStarted`/`ReduceFinished` only after all quests finished, and
+///   only when at least one quest succeeded.
+/// - Cancellation is checked between waves and before reduce; a cancelled
+///   run still emits `RunFinished { status: "cancelled" }`.
+pub(crate) async fn drive_rlm_run(
+    run_id: &str,
+    plan: &RlmPlan,
+    assignments: &[QuestAssignment],
+    emit: &impl Fn(RlmEvent),
+    run_quest: impl Fn(u32) -> CallFuture,
+    run_reduce: impl FnOnce(String) -> CallFuture,
+    cancelled: impl Fn() -> bool,
+) -> Result<RlmRunSummary, String> {
+    if assignments.len() != plan.quests.len() {
+        return Err("quest assignments do not match plan".to_string());
+    }
+    let started = std::time::Instant::now();
+    emit(RlmEvent::RunStarted {
+        run_id: run_id.to_string(),
+        task_id: plan.task_id.clone(),
+        task_label: plan.task_label.clone(),
+        quest_count: plan.quest_count,
+        concurrency: plan.concurrency,
+        models: assignments
+            .iter()
+            .map(|assignment| assignment.model.clone())
+            .collect(),
+    });
+
+    let mut outcomes: Vec<Option<QuestOutcome>> = Vec::new();
+    outcomes.resize_with(plan.quests.len(), || None);
+    let mut was_cancelled = false;
+
+    for wave in plan.quests.chunks(plan.concurrency.max(1) as usize) {
+        if cancelled() {
+            was_cancelled = true;
+            break;
+        }
+        let mut futures = Vec::with_capacity(wave.len());
+        for quest in wave {
+            let assignment = &assignments[quest.index as usize];
+            emit(RlmEvent::QuestStarted {
+                run_id: run_id.to_string(),
+                index: quest.index,
+                title: quest.title.clone(),
+                slot_id: assignment.slot_id,
+                model: assignment.model.clone(),
+            });
+            futures.push(run_quest(quest.index));
+        }
+        let results = futures_util::future::join_all(futures).await;
+        for (quest, outcome) in wave.iter().zip(results) {
+            let assignment = &assignments[quest.index as usize];
+            emit(RlmEvent::QuestFinished {
+                run_id: run_id.to_string(),
+                index: quest.index,
+                title: quest.title.clone(),
+                slot_id: assignment.slot_id,
+                model: assignment.model.clone(),
+                status: outcome.status.clone(),
+                output: truncate_event_text(&outcome.output, RLM_EVENT_OUTPUT_MAX),
+                elapsed_ms: outcome.elapsed_ms,
+                completion_tokens: outcome.completion_tokens,
+            });
+            outcomes[quest.index as usize] = Some(outcome);
+        }
+    }
+
+    let quests_ok = outcomes
+        .iter()
+        .filter(|outcome| outcome.as_ref().is_some_and(QuestOutcome::is_ok))
+        .count() as u32;
+    // Quests that ran and failed, or never ran because of cancellation.
+    let quests_failed = plan.quest_count - quests_ok;
+
+    let finish = |status: &str,
+                  reduce_status: Option<String>,
+                  reduce_output: Option<String>|
+     -> RlmRunSummary {
+        let total_elapsed_ms = started.elapsed().as_millis() as u64;
+        emit(RlmEvent::RunFinished {
+            run_id: run_id.to_string(),
+            status: status.to_string(),
+            quests_ok,
+            quests_failed,
+            total_elapsed_ms,
+        });
+        RlmRunSummary {
+            schema_version: "understudy.rlm_run.v1",
+            run_id: run_id.to_string(),
+            task_id: plan.task_id.clone(),
+            status: status.to_string(),
+            quests_ok,
+            quests_failed,
+            reduce_status,
+            reduce_output,
+            total_elapsed_ms,
+        }
+    };
+
+    if was_cancelled || cancelled() {
+        return Ok(finish("cancelled", None, None));
+    }
+    if quests_ok == 0 {
+        return Ok(finish("error", None, None));
+    }
+
+    let reduce_inputs: Vec<(String, Option<String>)> = plan
+        .quests
+        .iter()
+        .map(|quest| {
+            let output = outcomes[quest.index as usize]
+                .as_ref()
+                .filter(|outcome| outcome.is_ok())
+                .map(|outcome| outcome.output.clone());
+            (quest.title.clone(), output)
+        })
+        .collect();
+    let reduce_prompt = build_reduce_prompt(&plan.reduce_instruction, &reduce_inputs);
+    let reduce_assignment = &assignments[0];
+    emit(RlmEvent::ReduceStarted {
+        run_id: run_id.to_string(),
+        slot_id: reduce_assignment.slot_id,
+        model: reduce_assignment.model.clone(),
+        prompt: truncate_event_text(&reduce_prompt, RLM_EVENT_OUTPUT_MAX),
+    });
+    let reduce = run_reduce(reduce_prompt).await;
+    emit(RlmEvent::ReduceFinished {
+        run_id: run_id.to_string(),
+        status: reduce.status.clone(),
+        output: truncate_event_text(&reduce.output, RLM_EVENT_OUTPUT_MAX),
+        elapsed_ms: reduce.elapsed_ms,
+        completion_tokens: reduce.completion_tokens,
+    });
+
+    let status = if !reduce.is_ok() {
+        "error"
+    } else if quests_failed > 0 {
+        "partial"
+    } else {
+        "ok"
+    };
+    Ok(finish(
+        status,
+        Some(reduce.status.clone()),
+        Some(reduce.output.clone()),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn rlm_demo_catalog() -> RlmCatalog {
+    RlmCatalog {
+        schema_version: "understudy.rlm_catalog.v1",
+        tasks: DEMO_TASKS
+            .iter()
+            .map(|task| RlmTaskView {
+                id: task.id,
+                label: task.label,
+                description: task.description,
+                quest_verb: task.quest_verb,
+                min_quests: task.min_quests,
+                max_quests: task.max_quests.min(task.units.len() as u32),
+                default_quests: task.default_quests,
+            })
+            .collect(),
+        default_concurrency: RLM_DEFAULT_CONCURRENCY,
+        max_concurrency: RLM_MAX_CONCURRENCY,
+        quest_max_tokens: RLM_QUEST_DEFAULT_MAX_TOKENS,
+        reduce_max_tokens: RLM_REDUCE_DEFAULT_MAX_TOKENS,
+        quest_timeout_secs: RLM_QUEST_TIMEOUT_SECS,
+    }
+}
+
+#[tauri::command]
+pub fn rlm_plan(request: RlmPlanRequest) -> Result<RlmPlan, String> {
+    plan_rlm_run(&request)
+}
+
+/// Real recursive run against the warm residency fleet, streamed to the GUI
+/// over a Tauri channel. Quests round-robin across every warm slot (this is
+/// the horizontal fan-out); the reduce step runs on the first warm slot.
+#[tauri::command]
+pub async fn run_rlm_live(
+    app: AppHandle,
+    request: RlmRunRequest,
+    on_event: Channel<RlmEvent>,
+) -> Result<RlmRunSummary, String> {
+    let plan = plan_rlm_run(&RlmPlanRequest {
+        task_id: request.task_id.clone(),
+        quest_count: request.quest_count,
+        concurrency: request.concurrency,
+        quest_max_tokens: request.quest_max_tokens,
+        reduce_max_tokens: request.reduce_max_tokens,
+    })?;
+    let run_id = request.run_id.unwrap_or_else(default_rlm_run_id);
+    if run_id.trim().is_empty() {
+        return Err("run_id is required".to_string());
+    }
+    // Single-flight with the benchmark entry points: two heavy local runs
+    // would contend for the same warm slots and interleave confusingly.
+    let _run_guard = crate::agent_ops::begin_benchmark_run(&app, &run_id)?;
+
+    let warm_slots: Vec<QuestAssignment> = app
+        .state::<Residency>()
+        .snapshot()
+        .slots
+        .iter()
+        .filter(|slot| slot.state == "running")
+        .map(|slot| QuestAssignment {
+            slot_id: slot.id,
+            model: slot
+                .model_id
+                .clone()
+                .unwrap_or_else(|| "unknown-model".to_string()),
+        })
+        .collect();
+    if warm_slots.is_empty() {
+        let message =
+            "no warm model slot; warm a slot (Status → Residency) or use the dry-run plan"
+                .to_string();
+        let _ = on_event.send(RlmEvent::Error {
+            run_id: run_id.clone(),
+            message: message.clone(),
+        });
+        return Err(message);
+    }
+
+    let assignments: Vec<QuestAssignment> = (0..plan.quests.len())
+        .map(|index| warm_slots[index % warm_slots.len()].clone())
+        .collect();
+
+    let emit = |event: RlmEvent| {
+        let _ = on_event.send(event);
+    };
+    let quest_app = app.clone();
+    let quest_prompts: Vec<String> = plan.quests.iter().map(|q| q.prompt.clone()).collect();
+    let quest_session = run_id.clone();
+    let quest_max_tokens = plan.quest_max_tokens;
+    let quest_assignments = assignments.clone();
+    let run_quest = move |index: u32| -> CallFuture {
+        let app = quest_app.clone();
+        let prompt = quest_prompts[index as usize].clone();
+        let session = quest_session.clone();
+        let slot_id = quest_assignments[index as usize].slot_id;
+        Box::pin(async move {
+            bounded_agent_chat(
+                &app,
+                slot_id,
+                &session,
+                &prompt,
+                quest_max_tokens,
+                RLM_QUEST_TIMEOUT_SECS,
+            )
+            .await
+        })
+    };
+    let reduce_app = app.clone();
+    let reduce_session = run_id.clone();
+    let reduce_slot = assignments[0].slot_id;
+    let reduce_max_tokens = plan.reduce_max_tokens;
+    let run_reduce = move |prompt: String| -> CallFuture {
+        Box::pin(async move {
+            bounded_agent_chat(
+                &reduce_app,
+                reduce_slot,
+                &reduce_session,
+                &prompt,
+                reduce_max_tokens,
+                RLM_REDUCE_TIMEOUT_SECS,
+            )
+            .await
+        })
+    };
+    let cancel_app = app.clone();
+    let cancel_run_id = run_id.clone();
+    let cancelled = move || crate::agent_ops::benchmark_run_cancelled(&cancel_app, &cancel_run_id);
+
+    drive_rlm_run(
+        &run_id,
+        &plan,
+        &assignments,
+        &emit,
+        run_quest,
+        run_reduce,
+        cancelled,
+    )
+    .await
+}
+
+/// One bounded model call: `agent_chat` against a warm slot with a token cap
+/// and a whole-call timeout, with errors folded into the outcome.
+async fn bounded_agent_chat(
+    app: &AppHandle,
+    slot_id: u32,
+    session_id: &str,
+    prompt: &str,
+    max_tokens: u32,
+    timeout_secs: u64,
+) -> QuestOutcome {
+    let started = std::time::Instant::now();
+    let residency = app.state::<Residency>();
+    let call = crate::chat::agent_chat(
+        app,
+        residency.inner(),
+        slot_id,
+        session_id,
+        prompt,
+        Some(max_tokens),
+    );
+    match tokio::time::timeout(Duration::from_secs(timeout_secs), call).await {
+        Err(_) => QuestOutcome {
+            status: "timeout".to_string(),
+            output: format!("no result within {timeout_secs}s"),
+            elapsed_ms: started.elapsed().as_millis() as u64,
+            completion_tokens: 0,
+        },
+        Ok(Err(err)) => QuestOutcome {
+            status: "error".to_string(),
+            output: err,
+            elapsed_ms: started.elapsed().as_millis() as u64,
+            completion_tokens: 0,
+        },
+        Ok(Ok(result)) => QuestOutcome {
+            status: result.status,
+            output: result.content,
+            elapsed_ms: result.elapsed_ms,
+            completion_tokens: result.completion_tokens,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    fn plan_for(task_id: &str, quest_count: u32, concurrency: u32) -> RlmPlan {
+        plan_rlm_run(&RlmPlanRequest {
+            task_id: task_id.to_string(),
+            quest_count: Some(quest_count),
+            concurrency: Some(concurrency),
+            quest_max_tokens: None,
+            reduce_max_tokens: None,
+        })
+        .expect("plan")
+    }
+
+    fn assignments_for(plan: &RlmPlan) -> Vec<QuestAssignment> {
+        (0..plan.quests.len())
+            .map(|index| QuestAssignment {
+                slot_id: (index % 2) as u32,
+                model: format!("model-{}", index % 2),
+            })
+            .collect()
+    }
+
+    fn ok_outcome(text: &str) -> QuestOutcome {
+        QuestOutcome {
+            status: "ok".to_string(),
+            output: text.to_string(),
+            elapsed_ms: 5,
+            completion_tokens: 12,
+        }
+    }
+
+    fn err_outcome(text: &str) -> QuestOutcome {
+        QuestOutcome {
+            status: "error".to_string(),
+            output: text.to_string(),
+            elapsed_ms: 5,
+            completion_tokens: 0,
+        }
+    }
+
+    fn event_names(events: &[RlmEvent]) -> Vec<&'static str> {
+        events
+            .iter()
+            .map(|event| match event {
+                RlmEvent::RunStarted { .. } => "RunStarted",
+                RlmEvent::QuestStarted { .. } => "QuestStarted",
+                RlmEvent::QuestFinished { .. } => "QuestFinished",
+                RlmEvent::ReduceStarted { .. } => "ReduceStarted",
+                RlmEvent::ReduceFinished { .. } => "ReduceFinished",
+                RlmEvent::RunFinished { .. } => "RunFinished",
+                RlmEvent::Error { .. } => "Error",
+            })
+            .collect()
+    }
+
+    // ---- planning -------------------------------------------------------
+
+    #[test]
+    fn plan_is_deterministic_and_bounded() {
+        let a = plan_for("chunk-brief", 4, 2);
+        let b = plan_for("chunk-brief", 4, 2);
+        assert_eq!(a.quest_count, 4);
+        assert_eq!(a.quests.len(), 4);
+        assert_eq!(a.concurrency, 2);
+        for (qa, qb) in a.quests.iter().zip(b.quests.iter()) {
+            assert_eq!(qa.title, qb.title);
+            assert_eq!(qa.prompt, qb.prompt);
+        }
+        // Every quest prompt embeds its own unit and stays bounded.
+        for quest in &a.quests {
+            assert!(quest.prompt.contains(&quest.title));
+            assert!(quest.prompt.len() < 2_000, "quest prompt stays bounded");
+        }
+    }
+
+    #[test]
+    fn plan_clamps_quest_count_and_concurrency() {
+        let plan = plan_for("perspectives", 99, 99);
+        assert_eq!(plan.quest_count, 8); // max angles available
+        assert_eq!(plan.concurrency, RLM_MAX_CONCURRENCY);
+
+        let plan = plan_for("fermi", 0, 0);
+        assert_eq!(plan.quest_count, 2); // task minimum
+        assert_eq!(plan.concurrency, 1);
+
+        // Concurrency never exceeds the quest count.
+        let plan = plan_for("fermi", 2, 4);
+        assert_eq!(plan.concurrency, 2);
+    }
+
+    #[test]
+    fn plan_rejects_unknown_task() {
+        let err = plan_rlm_run(&RlmPlanRequest {
+            task_id: "not-a-task".to_string(),
+            quest_count: None,
+            concurrency: None,
+            quest_max_tokens: None,
+            reduce_max_tokens: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("unknown RLM demo task"));
+    }
+
+    #[test]
+    fn plan_clamps_token_caps() {
+        let plan = plan_rlm_run(&RlmPlanRequest {
+            task_id: "chunk-brief".to_string(),
+            quest_count: None,
+            concurrency: None,
+            quest_max_tokens: Some(1_000_000),
+            reduce_max_tokens: Some(1),
+        })
+        .expect("plan");
+        assert_eq!(plan.quest_max_tokens, RLM_MAX_TOKENS_CEILING);
+        assert_eq!(plan.reduce_max_tokens, RLM_MAX_TOKENS_FLOOR);
+    }
+
+    #[test]
+    fn every_demo_task_plans_at_defaults() {
+        for task in DEMO_TASKS {
+            let plan = plan_rlm_run(&RlmPlanRequest {
+                task_id: task.id.to_string(),
+                quest_count: None,
+                concurrency: None,
+                quest_max_tokens: None,
+                reduce_max_tokens: None,
+            })
+            .expect("default plan");
+            assert_eq!(plan.quest_count, task.default_quests);
+            assert!(task.default_quests as usize <= task.units.len());
+            assert!(!plan.reduce_instruction.is_empty());
+        }
+    }
+
+    // ---- reduce prompt ---------------------------------------------------
+
+    #[test]
+    fn reduce_prompt_keeps_order_and_marks_failures() {
+        let prompt = build_reduce_prompt(
+            "Combine the notes.",
+            &[
+                ("First".to_string(), Some("alpha facts".to_string())),
+                ("Second".to_string(), None),
+                ("Third".to_string(), Some("gamma facts".to_string())),
+            ],
+        );
+        assert!(prompt.starts_with("Combine the notes."));
+        let first = prompt.find("## First").unwrap();
+        let second = prompt.find("## Second").unwrap();
+        let third = prompt.find("## Third").unwrap();
+        assert!(first < second && second < third);
+        assert!(prompt.contains("alpha facts"));
+        assert!(prompt.contains("gamma facts"));
+        assert!(prompt.contains("this quest failed; do not guess"));
+    }
+
+    // ---- event sequencing ------------------------------------------------
+
+    #[tokio::test]
+    async fn happy_path_emits_ordered_events_and_reduces_all_quests() {
+        let plan = plan_for("chunk-brief", 4, 2);
+        let assignments = assignments_for(&plan);
+        let events: Arc<Mutex<Vec<RlmEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let emit_events = events.clone();
+        let emit = move |event: RlmEvent| emit_events.lock().unwrap().push(event);
+        let reduce_prompt_seen: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let reduce_prompt_slot = reduce_prompt_seen.clone();
+
+        let summary = drive_rlm_run(
+            "rlm-test",
+            &plan,
+            &assignments,
+            &emit,
+            |index| Box::pin(async move { ok_outcome(&format!("facts-{index}")) }),
+            move |prompt| {
+                *reduce_prompt_slot.lock().unwrap() = Some(prompt);
+                Box::pin(async move { ok_outcome("the brief") })
+            },
+            || false,
+        )
+        .await
+        .expect("run");
+
+        assert_eq!(summary.status, "ok");
+        assert_eq!(summary.quests_ok, 4);
+        assert_eq!(summary.quests_failed, 0);
+        assert_eq!(summary.reduce_output.as_deref(), Some("the brief"));
+
+        let events = events.lock().unwrap();
+        let names = event_names(&events);
+        assert_eq!(names.first(), Some(&"RunStarted"));
+        assert_eq!(names.last(), Some(&"RunFinished"));
+        assert_eq!(names.iter().filter(|n| **n == "RunFinished").count(), 1);
+        assert_eq!(names.iter().filter(|n| **n == "QuestStarted").count(), 4);
+        assert_eq!(names.iter().filter(|n| **n == "QuestFinished").count(), 4);
+        // Reduce happens strictly after the last quest event.
+        let last_quest = names.iter().rposition(|n| *n == "QuestFinished").unwrap();
+        let reduce_started = names.iter().position(|n| *n == "ReduceStarted").unwrap();
+        assert!(reduce_started > last_quest);
+        // Each quest's Started precedes its Finished.
+        for index in 0..4u32 {
+            let started = events
+                .iter()
+                .position(|e| matches!(e, RlmEvent::QuestStarted { index: i, .. } if *i == index))
+                .unwrap();
+            let finished = events
+                .iter()
+                .position(|e| matches!(e, RlmEvent::QuestFinished { index: i, .. } if *i == index))
+                .unwrap();
+            assert!(started < finished);
+        }
+        // Reduce saw every quest output.
+        let prompt = reduce_prompt_seen.lock().unwrap().clone().unwrap();
+        for index in 0..4 {
+            assert!(prompt.contains(&format!("facts-{index}")));
+        }
+    }
+
+    #[tokio::test]
+    async fn fan_out_respects_concurrency_bound() {
+        let plan = plan_for("chunk-brief", 6, 2);
+        let assignments = assignments_for(&plan);
+        let emit = |_event: RlmEvent| {};
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let in_flight_ref = in_flight.clone();
+        let max_ref = max_in_flight.clone();
+
+        let summary = drive_rlm_run(
+            "rlm-test",
+            &plan,
+            &assignments,
+            &emit,
+            move |index| {
+                let in_flight = in_flight_ref.clone();
+                let max = max_ref.clone();
+                Box::pin(async move {
+                    let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    max.fetch_max(now, Ordering::SeqCst);
+                    tokio::task::yield_now().await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    ok_outcome(&format!("q{index}"))
+                })
+            },
+            |_prompt| Box::pin(async move { ok_outcome("done") }),
+            || false,
+        )
+        .await
+        .expect("run");
+
+        assert_eq!(summary.status, "ok");
+        let observed_max = max_in_flight.load(Ordering::SeqCst);
+        assert!(observed_max <= 2, "max in flight {observed_max} > 2");
+        assert_eq!(observed_max, 2, "waves actually overlap quest execution");
+    }
+
+    #[tokio::test]
+    async fn partial_failure_reduces_over_survivors_only() {
+        let plan = plan_for("perspectives", 3, 3);
+        let assignments = assignments_for(&plan);
+        let events: Arc<Mutex<Vec<RlmEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let emit_events = events.clone();
+        let emit = move |event: RlmEvent| emit_events.lock().unwrap().push(event);
+        let reduce_prompt_seen: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let reduce_prompt_slot = reduce_prompt_seen.clone();
+
+        let summary = drive_rlm_run(
+            "rlm-test",
+            &plan,
+            &assignments,
+            &emit,
+            |index| {
+                Box::pin(async move {
+                    if index == 1 {
+                        err_outcome("slot 1 is not warm; warm it first")
+                    } else {
+                        ok_outcome(&format!("angle-{index}"))
+                    }
+                })
+            },
+            move |prompt| {
+                *reduce_prompt_slot.lock().unwrap() = Some(prompt);
+                Box::pin(async move { ok_outcome("verdict") })
+            },
+            || false,
+        )
+        .await
+        .expect("run");
+
+        assert_eq!(summary.status, "partial");
+        assert_eq!(summary.quests_ok, 2);
+        assert_eq!(summary.quests_failed, 1);
+        let prompt = reduce_prompt_seen.lock().unwrap().clone().unwrap();
+        assert!(prompt.contains("angle-0"));
+        assert!(prompt.contains("angle-2"));
+        // The failed quest's error text never leaks into the reduce prompt.
+        assert!(!prompt.contains("not warm"));
+        assert!(prompt.contains("do not guess"));
+    }
+
+    #[tokio::test]
+    async fn all_failures_skip_reduce_and_finish_with_error() {
+        let plan = plan_for("fermi", 2, 2);
+        let assignments = assignments_for(&plan);
+        let events: Arc<Mutex<Vec<RlmEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let emit_events = events.clone();
+        let emit = move |event: RlmEvent| emit_events.lock().unwrap().push(event);
+
+        let summary = drive_rlm_run(
+            "rlm-test",
+            &plan,
+            &assignments,
+            &emit,
+            |_index| Box::pin(async move { err_outcome("boom") }),
+            |_prompt| {
+                Box::pin(async move { panic!("reduce must not run when every quest failed") })
+            },
+            || false,
+        )
+        .await
+        .expect("run");
+
+        assert_eq!(summary.status, "error");
+        assert_eq!(summary.quests_ok, 0);
+        assert!(summary.reduce_output.is_none());
+        let names = event_names(&events.lock().unwrap());
+        assert!(!names.contains(&"ReduceStarted"));
+        assert_eq!(names.last(), Some(&"RunFinished"));
+    }
+
+    #[tokio::test]
+    async fn failed_reduce_yields_error_status() {
+        let plan = plan_for("fermi", 2, 2);
+        let assignments = assignments_for(&plan);
+        let emit = |_event: RlmEvent| {};
+
+        let summary = drive_rlm_run(
+            "rlm-test",
+            &plan,
+            &assignments,
+            &emit,
+            |index| Box::pin(async move { ok_outcome(&format!("est-{index}")) }),
+            |_prompt| Box::pin(async move { err_outcome("reduce timed out") }),
+            || false,
+        )
+        .await
+        .expect("run");
+
+        assert_eq!(summary.status, "error");
+        assert_eq!(summary.reduce_status.as_deref(), Some("error"));
+    }
+
+    #[tokio::test]
+    async fn cancellation_between_waves_skips_remaining_quests_and_reduce() {
+        let plan = plan_for("chunk-brief", 4, 2);
+        let assignments = assignments_for(&plan);
+        let events: Arc<Mutex<Vec<RlmEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let emit_events = events.clone();
+        let emit = move |event: RlmEvent| emit_events.lock().unwrap().push(event);
+        // First wave completes, then cancellation is observed before wave 2.
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_setter = cancel.clone();
+
+        let summary = drive_rlm_run(
+            "rlm-test",
+            &plan,
+            &assignments,
+            &emit,
+            move |index| {
+                let cancel = cancel_setter.clone();
+                Box::pin(async move {
+                    cancel.store(true, Ordering::SeqCst);
+                    ok_outcome(&format!("q{index}"))
+                })
+            },
+            |_prompt| Box::pin(async move { panic!("reduce must not run after cancellation") }),
+            move || cancel.load(Ordering::SeqCst),
+        )
+        .await
+        .expect("run");
+
+        assert_eq!(summary.status, "cancelled");
+        assert_eq!(summary.quests_ok, 2, "only the first wave ran");
+        assert_eq!(summary.quests_failed, 2, "unrun quests count as not ok");
+        let names = event_names(&events.lock().unwrap());
+        assert_eq!(names.iter().filter(|n| **n == "QuestStarted").count(), 2);
+        assert!(!names.contains(&"ReduceStarted"));
+        assert_eq!(names.last(), Some(&"RunFinished"));
+    }
+
+    #[test]
+    fn event_output_truncation_respects_char_boundaries() {
+        let text = "é".repeat(RLM_EVENT_OUTPUT_MAX); // 2 bytes per char
+        let truncated = truncate_event_text(&text, RLM_EVENT_OUTPUT_MAX);
+        assert!(truncated.len() <= RLM_EVENT_OUTPUT_MAX + "…".len());
+        assert!(truncated.ends_with('…'));
+        assert_eq!(truncate_event_text("short", RLM_EVENT_OUTPUT_MAX), "short");
+    }
+
+    #[test]
+    fn rlm_events_serialize_with_type_tags() {
+        let event = RlmEvent::QuestFinished {
+            run_id: "rlm-1".to_string(),
+            index: 0,
+            title: "t".to_string(),
+            slot_id: 1,
+            model: "m".to_string(),
+            status: "ok".to_string(),
+            output: "o".to_string(),
+            elapsed_ms: 3,
+            completion_tokens: 4,
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["type"], "QuestFinished");
+        assert_eq!(value["index"], 0);
+    }
+}

--- a/apps/homescreen/src-tauri/src/rlm.rs
+++ b/apps/homescreen/src-tauri/src/rlm.rs
@@ -451,6 +451,14 @@ pub struct RlmRunSummary {
 
 pub(crate) type CallFuture = Pin<Box<dyn Future<Output = QuestOutcome> + Send>>;
 
+/// One request in flight per warm slot: each wave covers consecutive quest
+/// indices and assignment is round-robin, so a wave no wider than the warm
+/// fleet always hits distinct slots. Two concurrent generations on one local
+/// server process would contend (or wedge a busy shared machine).
+pub(crate) fn effective_concurrency(planned: u32, warm_slots: usize) -> u32 {
+    planned.min(warm_slots as u32).max(1)
+}
+
 fn truncate_event_text(text: &str, max: usize) -> String {
     if text.len() <= max {
         return text.to_string();
@@ -661,7 +669,7 @@ pub async fn run_rlm_live(
     request: RlmRunRequest,
     on_event: Channel<RlmEvent>,
 ) -> Result<RlmRunSummary, String> {
-    let plan = plan_rlm_run(&RlmPlanRequest {
+    let mut plan = plan_rlm_run(&RlmPlanRequest {
         task_id: request.task_id.clone(),
         quest_count: request.quest_count,
         concurrency: request.concurrency,
@@ -700,6 +708,7 @@ pub async fn run_rlm_live(
         });
         return Err(message);
     }
+    plan.concurrency = effective_concurrency(plan.concurrency, warm_slots.len());
 
     let assignments: Vec<QuestAssignment> = (0..plan.quests.len())
         .map(|index| warm_slots[index % warm_slots.len()].clone())
@@ -940,7 +949,18 @@ mod tests {
             assert_eq!(plan.quest_count, task.default_quests);
             assert!(task.default_quests as usize <= task.units.len());
             assert!(!plan.reduce_instruction.is_empty());
+            // clamp() panics when min > max, so guard the static task data.
+            assert!(task.min_quests <= task.max_quests.min(task.units.len() as u32));
         }
+    }
+
+    #[test]
+    fn live_concurrency_never_exceeds_the_warm_fleet() {
+        assert_eq!(effective_concurrency(4, 1), 1);
+        assert_eq!(effective_concurrency(4, 2), 2);
+        assert_eq!(effective_concurrency(2, 8), 2);
+        // Degenerate input still yields a driveable width.
+        assert_eq!(effective_concurrency(0, 3), 1);
     }
 
     // ---- reduce prompt ---------------------------------------------------


### PR DESCRIPTION
## What

An **RLM** pane in the desktop app that runs and visualizes a real recursive-language-model run — test-time compute by horizontal fan-out across the warm local fleet. Not a canned animation: every quest is a real `agent_chat` call against a warm residency slot.

### Backend (`src-tauri/src/rlm.rs`)
- **Demo task catalog** (3 synthetic, self-contained tasks): map-reduce over a field report, the "one 31B vs fifteen 2Bs" debate fanned across angles, and a decomposed Fermi estimate.
- **Pure planning** (`rlm_plan`): deterministic decomposition into N bounded quests + a reduce instruction; safe with nothing warm, powers the dry-run view.
- **Live run** (`run_rlm_live`): quests round-robin across every warm slot, run in waves of bounded concurrency (1–4), each with a token cap and a whole-call timeout; the reduce step combines only the outputs that succeeded (failed quests are named as missing, never invented). Events stream over a Tauri `Channel` mirroring the `run_fusion_benchmark_matrix_live` pattern.
- **Safety**: single-flight shared with the benchmark run gate (incl. cooperative cancellation between waves and before reduce); a failed quest never aborts its siblings; event payloads truncated.

### Frontend (`app/components/RlmPane.tsx`)
- Fan-out tree (orchestrator → quests → reduce) with per-node status (pending/running/done/error), live progress, and per-node drilldown (exact prompt sent, output, slot, model, latency, tokens).
- **Graceful degradation**: with no warm slot, Run is disabled, the pane says exactly what to warm (Status → Residency), and the dry-run plan is offered — clearly labeled "Plan — no model calls were made".

## Testing
- 14 new Rust tests: decomposition determinism/clamping, reduce-prompt construction (order kept, failures marked, error text never leaks into the reduce prompt), and event sequencing via injected quest runners — ordering invariants, concurrency bound actually respected, partial-failure reduce, all-failure skip, cancellation, truncation char-boundary safety, serde tags.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo test` 92 passed.
- `bun install && bun run build` clean in apps/homescreen; `npm ci && npm run check && npm test` clean at root.

## Deliberately out of scope
- No DB persistence of RLM runs (no migrations; the pane is a live visualization).
- No local-server/MCP surface for RLM (GUI-only for now).
- No model warming from the pane (shared machine tonight; it only reads residency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->