### PR TITLE
GEPA visualization: evolution tree and Pareto viewer

### DIFF
--- a/apps/homescreen/app/components/GepaPane.tsx
+++ b/apps/homescreen/app/components/GepaPane.tsx
@@ -1,0 +1,620 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/** Mirrors src-tauri/src/gepa.rs GepaCandidateView / GepaRunView. */
+type GepaCandidate = {
+  idx: number;
+  components: Record<string, string>;
+  parents: number[];
+  val_score: number | null;
+  discovery_evals: number | null;
+  subscores: (number | null)[];
+  front_instance_ids: string[];
+  is_dominator: boolean;
+  is_best: boolean;
+  generation: number;
+};
+
+type GepaRun = {
+  source: string;
+  schema_version: number;
+  best_idx: number;
+  val_ids: string[];
+  candidates: GepaCandidate[];
+  dominators: number[];
+  total_metric_calls: number | null;
+  num_full_val_evals: number | null;
+  seed: number | null;
+  run_dir: string | null;
+  is_demo: boolean;
+};
+
+type Tooltip = { x: number; y: number; lines: string[] };
+
+export function GepaPane() {
+  const [run, setRun] = useState<GepaRun | null>(null);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [path, setPath] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    invoke<GepaRun>("gepa_demo_run")
+      .then((demo) => {
+        setRun(demo);
+        setSelected(demo.best_idx);
+      })
+      .catch((err) => setError(String(err)));
+  }, []);
+
+  const loadFromDisk = async () => {
+    if (!path.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await invoke<GepaRun>("gepa_load_run", { path: path.trim() });
+      setRun(next);
+      setSelected(next.best_idx);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const loadDemo = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const demo = await invoke<GepaRun>("gepa_demo_run");
+      setRun(demo);
+      setSelected(demo.best_idx);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const current = run && selected != null ? run.candidates[selected] : null;
+  const bestScore = run?.candidates[run.best_idx]?.val_score ?? null;
+  const seedScore = run?.candidates[0]?.val_score ?? null;
+
+  return (
+    <>
+      <div className="pane-head">
+        <h1 className="pane-title">Optimization</h1>
+        <p className="pane-sub">
+          GEPA prompt evolution — candidate lineage tree, Pareto frontier, and per-candidate prompt diffs.
+        </p>
+      </div>
+
+      <div className="pane-body gepa-root">
+        <div className="card">
+          <div className="card-row">
+            <div>
+              <div className="card-title">
+                GEPA run viewer
+                {run?.is_demo && <span className="gepa-demo-pill">demo data</span>}
+              </div>
+              <div className="card-sub">
+                File-based viewer: loads a <code>GEPAResult.to_dict()</code> JSON artifact from a finished run.
+                Live in-app GEPA runs are not wired up yet.
+              </div>
+            </div>
+            <span className="svc-state">{run ? runLabel(run) : "loading"}</span>
+          </div>
+          <div className="gepa-loader">
+            <input
+              type="text"
+              value={path}
+              placeholder="/path/to/run-dir or gepa-result.json"
+              onChange={(event) => setPath(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void loadFromDisk();
+              }}
+            />
+            <button className="btn" type="button" onClick={() => void loadFromDisk()} disabled={busy || !path.trim()}>
+              Load run
+            </button>
+            <button className="btn" type="button" onClick={() => void loadDemo()} disabled={busy || (run?.is_demo ?? false)}>
+              Load demo run
+            </button>
+          </div>
+          {error && <div className="eval-error">{error}</div>}
+          {run && (
+            <div className="gepa-stats">
+              <GepaStat label="candidates" value={String(run.candidates.length)} />
+              <GepaStat label="val instances" value={String(run.val_ids.length)} />
+              <GepaStat label="rollouts" value={run.total_metric_calls == null ? "—" : String(run.total_metric_calls)} />
+              <GepaStat label="seed score" value={fmtScore(seedScore)} />
+              <GepaStat label="best score" value={fmtScore(bestScore)} accent />
+            </div>
+          )}
+        </div>
+
+        {run && (
+          <div className="gepa-grid">
+            <div className="card">
+              <div className="card-row">
+                <div>
+                  <div className="card-title">Evolution tree</div>
+                  <div className="card-sub">Each node is a candidate prompt; edges show which parent it was mutated (or merged) from.</div>
+                </div>
+              </div>
+              <GepaLegend />
+              <EvolutionTree run={run} selected={selected} onSelect={setSelected} />
+            </div>
+
+            <div className="card">
+              <div className="card-row">
+                <div>
+                  <div className="card-title">Score vs rollouts</div>
+                  <div className="card-sub">Aggregate validation score against the eval budget consumed when each candidate was discovered.</div>
+                </div>
+              </div>
+              <GepaLegend />
+              <ScoreScatter run={run} selected={selected} onSelect={setSelected} />
+            </div>
+
+            {current && <CandidateDetail run={run} candidate={current} onSelect={setSelected} />}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function runLabel(run: GepaRun): string {
+  if (run.is_demo) return "bundled demo";
+  const parts = run.source.split("/");
+  return parts.slice(-2).join("/") || run.source;
+}
+
+function GepaStat({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className={"gepa-stat" + (accent ? " accent" : "")}>
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function GepaLegend() {
+  return (
+    <div className="gepa-legend">
+      <span><i className="gepa-swatch best" /> best candidate</span>
+      <span><i className="gepa-swatch front" /> Pareto front</span>
+      <span><i className="gepa-swatch other" /> explored</span>
+    </div>
+  );
+}
+
+function roleClass(candidate: GepaCandidate): string {
+  if (candidate.is_best) return "best";
+  if (candidate.is_dominator) return "front";
+  return "other";
+}
+
+function roleLabel(candidate: GepaCandidate): string {
+  if (candidate.is_best) return "best";
+  if (candidate.is_dominator) return "Pareto front";
+  if (candidate.parents.length === 0) return "seed";
+  return "explored";
+}
+
+function fmtScore(score: number | null | undefined): string {
+  return score == null ? "—" : score.toFixed(2);
+}
+
+/* ------------------------------------------------------------------ */
+/* Evolution tree — layered SVG layout of the candidate lineage DAG.  */
+/* ------------------------------------------------------------------ */
+
+const NODE_R = 13;
+const ROW_H = 76;
+const COL_W = 74;
+const PAD = 30;
+
+function treeLayout(run: GepaRun): Map<number, { x: number; y: number }> {
+  const byGen = new Map<number, number[]>();
+  for (const candidate of run.candidates) {
+    byGen.set(candidate.generation, [...(byGen.get(candidate.generation) ?? []), candidate.idx]);
+  }
+  const positions = new Map<number, { x: number; y: number }>();
+  const maxWidth = Math.max(...Array.from(byGen.values(), (row) => row.length));
+  const generations = Array.from(byGen.keys()).sort((a, b) => a - b);
+  for (const gen of generations) {
+    // Order children under the mean x of their parents (one barycenter pass)
+    // so lineages read top-to-bottom without crossing more than needed.
+    const row = [...(byGen.get(gen) ?? [])].sort((a, b) => {
+      const ax = meanParentX(run.candidates[a], positions);
+      const bx = meanParentX(run.candidates[b], positions);
+      return ax - bx || a - b;
+    });
+    const rowWidth = (row.length - 1) * COL_W;
+    const offset = PAD + NODE_R + ((maxWidth - 1) * COL_W - rowWidth) / 2;
+    row.forEach((idx, i) => {
+      positions.set(idx, { x: offset + i * COL_W, y: PAD + NODE_R + gen * ROW_H });
+    });
+  }
+  return positions;
+}
+
+function meanParentX(candidate: GepaCandidate, positions: Map<number, { x: number; y: number }>): number {
+  const xs = candidate.parents
+    .map((p) => positions.get(p)?.x)
+    .filter((x): x is number => x != null);
+  return xs.length ? xs.reduce((sum, x) => sum + x, 0) / xs.length : 0;
+}
+
+function EvolutionTree({
+  run,
+  selected,
+  onSelect,
+}: {
+  run: GepaRun;
+  selected: number | null;
+  onSelect: (idx: number) => void;
+}) {
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const positions = useMemo(() => treeLayout(run), [run]);
+  const maxGen = Math.max(...run.candidates.map((candidate) => candidate.generation));
+  const maxCols = Math.max(...groupSizes(run));
+  const width = PAD * 2 + NODE_R * 2 + (maxCols - 1) * COL_W;
+  const height = PAD * 2 + NODE_R * 2 + maxGen * ROW_H + 16;
+
+  const show = (candidate: GepaCandidate) => (event: React.MouseEvent) => {
+    const bounds = wrapRef.current?.getBoundingClientRect();
+    if (!bounds) return;
+    setTooltip({
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+      lines: [
+        `candidate ${candidate.idx} · ${roleLabel(candidate)}`,
+        `score ${fmtScore(candidate.val_score)}${candidate.discovery_evals == null ? "" : ` · found at ${candidate.discovery_evals} rollouts`}`,
+        candidate.parents.length ? `parent${candidate.parents.length > 1 ? "s" : ""} ${candidate.parents.join(", ")}` : "seed prompt",
+        candidate.front_instance_ids.length ? `leads ${candidate.front_instance_ids.length} val instance${candidate.front_instance_ids.length > 1 ? "s" : ""}` : "",
+      ].filter(Boolean),
+    });
+  };
+
+  return (
+    <div className="gepa-chart-wrap" ref={wrapRef} onMouseLeave={() => setTooltip(null)}>
+      <svg
+        className="gepa-tree"
+        viewBox={`0 0 ${width} ${height}`}
+        width="100%"
+        style={{ maxWidth: width }}
+        role="img"
+        aria-label="GEPA candidate evolution tree"
+      >
+        {run.candidates.flatMap((candidate) =>
+          candidate.parents.map((parent) => {
+            const from = positions.get(parent);
+            const to = positions.get(candidate.idx);
+            if (!from || !to) return null;
+            const midY = (from.y + to.y) / 2;
+            return (
+              <path
+                key={`${parent}-${candidate.idx}`}
+                className="gepa-edge"
+                d={`M ${from.x} ${from.y + NODE_R} C ${from.x} ${midY}, ${to.x} ${midY}, ${to.x} ${to.y - NODE_R}`}
+              />
+            );
+          }),
+        )}
+        {run.candidates.map((candidate) => {
+          const pos = positions.get(candidate.idx);
+          if (!pos) return null;
+          const role = roleClass(candidate);
+          return (
+            <g
+              key={candidate.idx}
+              className={`gepa-node ${role}${selected === candidate.idx ? " selected" : ""}`}
+              transform={`translate(${pos.x}, ${pos.y})`}
+              onClick={() => onSelect(candidate.idx)}
+              onMouseMove={show(candidate)}
+              onMouseLeave={() => setTooltip(null)}
+            >
+              {/* invisible hit target larger than the mark */}
+              <circle r={NODE_R + 9} fill="transparent" stroke="none" />
+              {selected === candidate.idx && <circle className="gepa-select-ring" r={NODE_R + 5} />}
+              <circle className="gepa-node-dot" r={NODE_R} />
+              <text className="gepa-node-idx" dy="0.34em">{candidate.idx}</text>
+              <text className="gepa-node-score" y={NODE_R + 13}>{fmtScore(candidate.val_score)}</text>
+            </g>
+          );
+        })}
+      </svg>
+      {tooltip && <ChartTooltip tooltip={tooltip} />}
+    </div>
+  );
+}
+
+function groupSizes(run: GepaRun): number[] {
+  const counts = new Map<number, number>();
+  for (const candidate of run.candidates) {
+    counts.set(candidate.generation, (counts.get(candidate.generation) ?? 0) + 1);
+  }
+  return Array.from(counts.values());
+}
+
+/* ------------------------------------------------------------------ */
+/* Score vs rollouts scatter with running-best frontier step line.    */
+/* ------------------------------------------------------------------ */
+
+function ScoreScatter({
+  run,
+  selected,
+  onSelect,
+}: {
+  run: GepaRun;
+  selected: number | null;
+  onSelect: (idx: number) => void;
+}) {
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  const W = 440;
+  const H = 240;
+  const M = { top: 14, right: 16, bottom: 34, left: 40 };
+  const plotW = W - M.left - M.right;
+  const plotH = H - M.top - M.bottom;
+
+  const points = run.candidates
+    .filter((candidate) => candidate.val_score != null)
+    .map((candidate) => ({
+      candidate,
+      evals: candidate.discovery_evals ?? candidate.idx,
+      score: candidate.val_score as number,
+    }));
+  const maxEvals = Math.max(1, ...points.map((p) => p.evals), run.total_metric_calls ?? 0);
+  const x = (evals: number) => M.left + (evals / maxEvals) * plotW;
+  const y = (score: number) => M.top + (1 - clamp01(score)) * plotH;
+
+  // Running best: the frontier of "best score found so far" over budget.
+  const frontier = [...points].sort((a, b) => a.evals - b.evals || a.candidate.idx - b.candidate.idx);
+  let best = -Infinity;
+  const steps: string[] = [];
+  for (const p of frontier) {
+    if (p.score <= best) continue;
+    if (best === -Infinity) {
+      steps.push(`M ${x(p.evals)} ${y(p.score)}`);
+    } else {
+      steps.push(`H ${x(p.evals)} V ${y(p.score)}`);
+    }
+    best = p.score;
+  }
+  if (steps.length && frontier.length) {
+    steps.push(`H ${x(maxEvals)}`);
+  }
+
+  const yTicks = [0, 0.25, 0.5, 0.75, 1];
+  const xTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(f * maxEvals));
+
+  const show = (candidate: GepaCandidate, evals: number) => (event: React.MouseEvent) => {
+    const bounds = wrapRef.current?.getBoundingClientRect();
+    if (!bounds) return;
+    setTooltip({
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+      lines: [
+        `candidate ${candidate.idx} · ${roleLabel(candidate)}`,
+        `score ${fmtScore(candidate.val_score)} at ${evals} rollouts`,
+      ],
+    });
+  };
+
+  return (
+    <div className="gepa-chart-wrap" ref={wrapRef} onMouseLeave={() => setTooltip(null)}>
+      <svg
+        className="gepa-scatter"
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        style={{ maxWidth: 560 }}
+        role="img"
+        aria-label="Candidate score against rollouts consumed at discovery"
+      >
+        {yTicks.map((tick) => (
+          <g key={`y${tick}`}>
+            <line className="gepa-grid" x1={M.left} x2={W - M.right} y1={y(tick)} y2={y(tick)} />
+            <text className="gepa-tick" x={M.left - 7} y={y(tick)} dy="0.32em" textAnchor="end">
+              {tick.toFixed(2)}
+            </text>
+          </g>
+        ))}
+        {xTicks.map((tick) => (
+          <text key={`x${tick}`} className="gepa-tick" x={x(tick)} y={H - M.bottom + 16} textAnchor="middle">
+            {tick}
+          </text>
+        ))}
+        <text className="gepa-axis-label" x={M.left + plotW / 2} y={H - 3} textAnchor="middle">
+          rollouts consumed at discovery
+        </text>
+        <line className="gepa-baseline" x1={M.left} x2={W - M.right} y1={y(0)} y2={y(0)} />
+        {steps.length > 0 && <path className="gepa-frontier" d={steps.join(" ")} />}
+        {points.map(({ candidate, evals, score }) => (
+          <g
+            key={candidate.idx}
+            className={`gepa-node ${roleClass(candidate)}${selected === candidate.idx ? " selected" : ""}`}
+            transform={`translate(${x(evals)}, ${y(score)})`}
+            onClick={() => onSelect(candidate.idx)}
+            onMouseMove={show(candidate, evals)}
+            onMouseLeave={() => setTooltip(null)}
+          >
+            <circle r={11} fill="transparent" stroke="none" />
+            {selected === candidate.idx && <circle className="gepa-select-ring" r={8} />}
+            <circle className="gepa-node-dot" r={4.5} />
+          </g>
+        ))}
+      </svg>
+      {tooltip && <ChartTooltip tooltip={tooltip} />}
+    </div>
+  );
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function ChartTooltip({ tooltip }: { tooltip: Tooltip }) {
+  return (
+    <div className="gepa-tooltip" style={{ left: tooltip.x + 12, top: tooltip.y + 12 }}>
+      {tooltip.lines.map((line) => (
+        <div key={line}>{line}</div>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Candidate detail: role, lineage, prompt diff vs parent, subscores. */
+/* ------------------------------------------------------------------ */
+
+function CandidateDetail({
+  run,
+  candidate,
+  onSelect,
+}: {
+  run: GepaRun;
+  candidate: GepaCandidate;
+  onSelect: (idx: number) => void;
+}) {
+  const parent = candidate.parents.length ? run.candidates[candidate.parents[0]] : null;
+  const componentNames = Object.keys(candidate.components);
+
+  return (
+    <div className="card gepa-detail">
+      <div className="card-row">
+        <div>
+          <div className="card-title">
+            Candidate {candidate.idx}
+            <span className={`gepa-role-pill ${roleClass(candidate)}`}>{roleLabel(candidate)}</span>
+          </div>
+          <div className="card-sub">
+            score {fmtScore(candidate.val_score)}
+            {candidate.discovery_evals != null && <> · discovered at {candidate.discovery_evals} rollouts</>}
+            {parent && (
+              <>
+                {" · from "}
+                {candidate.parents.map((p, i) => (
+                  <button key={p} type="button" className="gepa-link" onClick={() => onSelect(p)}>
+                    {i > 0 && " + "}candidate {p}
+                  </button>
+                ))}
+                {candidate.parents.length > 1 && " (merge)"}
+              </>
+            )}
+            {!parent && " · seed prompt"}
+          </div>
+        </div>
+      </div>
+
+      <div className="gepa-detail-grid">
+        <div>
+          {componentNames.map((name) => (
+            <div key={name} className="gepa-component">
+              <div className="gepa-component-head">
+                <span className="gepa-component-name">{name}</span>
+                <span className="gepa-component-note">
+                  {parent ? `diff vs candidate ${candidate.parents[0]}` : "seed text"}
+                </span>
+              </div>
+              <pre className="gepa-diff">
+                {diffLines(parent?.components[name] ?? "", candidate.components[name]).map((line, i) => (
+                  <div key={i} className={`gepa-diff-line ${line.kind}`}>
+                    <span className="gepa-diff-sign">
+                      {line.kind === "added" ? "+" : line.kind === "removed" ? "−" : " "}
+                    </span>
+                    {line.text || " "}
+                  </div>
+                ))}
+              </pre>
+            </div>
+          ))}
+        </div>
+
+        <div>
+          <div className="gepa-component-head">
+            <span className="gepa-component-name">Per-instance scores</span>
+            <span className="gepa-component-note">{parent ? `vs candidate ${candidate.parents[0]}` : "seed"}</span>
+          </div>
+          {run.val_ids.length ? (
+            <table className="gepa-subscores">
+              <thead>
+                <tr>
+                  <th>val instance</th>
+                  {parent && <th>parent</th>}
+                  <th>score</th>
+                  {parent && <th>Δ</th>}
+                  <th>front</th>
+                </tr>
+              </thead>
+              <tbody>
+                {run.val_ids.map((id, i) => {
+                  const score = candidate.subscores[i];
+                  const parentScore = parent?.subscores[i] ?? null;
+                  const delta = score != null && parentScore != null ? score - parentScore : null;
+                  return (
+                    <tr key={id}>
+                      <td>{id}</td>
+                      {parent && <td>{fmtScore(parentScore)}</td>}
+                      <td>{fmtScore(score)}</td>
+                      {parent && (
+                        <td className={delta == null || delta === 0 ? "" : delta > 0 ? "up" : "down"}>
+                          {delta == null ? "—" : `${delta > 0 ? "+" : ""}${delta.toFixed(2)}`}
+                        </td>
+                      )}
+                      <td>{candidate.front_instance_ids.includes(id) ? "●" : ""}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : (
+            <div className="svc-desc">This run recorded no per-instance subscores.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* Minimal line-based LCS diff — prompts are short, O(n·m) is fine. */
+type DiffLine = { kind: "same" | "added" | "removed"; text: string };
+
+export function diffLines(before: string, after: string): DiffLine[] {
+  const a = before ? before.split("\n") : [];
+  const b = after ? after.split("\n") : [];
+  const n = a.length;
+  const m = b.length;
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ kind: "same", text: a[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ kind: "removed", text: a[i] });
+      i++;
+    } else {
+      out.push({ kind: "added", text: b[j] });
+      j++;
+    }
+  }
+  while (i < n) out.push({ kind: "removed", text: a[i++] });
+  while (j < m) out.push({ kind: "added", text: b[j++] });
+  return out;
+}

--- a/apps/homescreen/app/components/GepaPane.tsx
+++ b/apps/homescreen/app/components/GepaPane.tsx
@@ -365,16 +365,22 @@ function ScoreScatter({
   const plotW = W - M.left - M.right;
   const plotH = H - M.top - M.bottom;
 
-  const points = run.candidates
-    .filter((candidate) => candidate.val_score != null)
-    .map((candidate) => ({
-      candidate,
-      evals: candidate.discovery_evals ?? candidate.idx,
-      score: candidate.val_score as number,
-    }));
-  const maxEvals = Math.max(1, ...points.map((p) => p.evals), run.total_metric_calls ?? 0);
+  const scored = run.candidates.filter((candidate) => candidate.val_score != null);
+  // Only use the rollout budget as the x axis when every scored candidate
+  // recorded one — otherwise indices and rollout counts would share a scale.
+  const hasBudget = scored.length > 0 && scored.every((candidate) => candidate.discovery_evals != null);
+  const points = scored.map((candidate) => ({
+    candidate,
+    evals: hasBudget ? (candidate.discovery_evals as number) : candidate.idx,
+    score: candidate.val_score as number,
+  }));
+  const maxEvals = Math.max(1, ...points.map((p) => p.evals), hasBudget ? run.total_metric_calls ?? 0 : 0);
+  // GEPA metrics are arbitrary-scale; keep the canonical 0–1 frame when the
+  // scores fit it, widen the domain when they don't.
+  const scoreLo = Math.min(0, ...points.map((p) => p.score));
+  const scoreHi = Math.max(1, ...points.map((p) => p.score));
   const x = (evals: number) => M.left + (evals / maxEvals) * plotW;
-  const y = (score: number) => M.top + (1 - clamp01(score)) * plotH;
+  const y = (score: number) => M.top + (1 - (score - scoreLo) / (scoreHi - scoreLo)) * plotH;
 
   // Running best: the frontier of "best score found so far" over budget.
   const frontier = [...points].sort((a, b) => a.evals - b.evals || a.candidate.idx - b.candidate.idx);
@@ -393,7 +399,7 @@ function ScoreScatter({
     steps.push(`H ${x(maxEvals)}`);
   }
 
-  const yTicks = [0, 0.25, 0.5, 0.75, 1];
+  const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => scoreLo + f * (scoreHi - scoreLo));
   const xTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(f * maxEvals));
 
   const show = (candidate: GepaCandidate, evals: number) => (event: React.MouseEvent) => {
@@ -404,7 +410,9 @@ function ScoreScatter({
       y: event.clientY - bounds.top,
       lines: [
         `candidate ${candidate.idx} · ${roleLabel(candidate)}`,
-        `score ${fmtScore(candidate.val_score)} at ${evals} rollouts`,
+        hasBudget
+          ? `score ${fmtScore(candidate.val_score)} at ${evals} rollouts`
+          : `score ${fmtScore(candidate.val_score)}`,
       ],
     });
   };
@@ -433,9 +441,9 @@ function ScoreScatter({
           </text>
         ))}
         <text className="gepa-axis-label" x={M.left + plotW / 2} y={H - 3} textAnchor="middle">
-          rollouts consumed at discovery
+          {hasBudget ? "rollouts consumed at discovery" : "candidate index (discovery order)"}
         </text>
-        <line className="gepa-baseline" x1={M.left} x2={W - M.right} y1={y(0)} y2={y(0)} />
+        <line className="gepa-baseline" x1={M.left} x2={W - M.right} y1={y(scoreLo)} y2={y(scoreLo)} />
         {steps.length > 0 && <path className="gepa-frontier" d={steps.join(" ")} />}
         {points.map(({ candidate, evals, score }) => (
           <g
@@ -457,15 +465,11 @@ function ScoreScatter({
   );
 }
 
-function clamp01(value: number): number {
-  return Math.max(0, Math.min(1, value));
-}
-
 function ChartTooltip({ tooltip }: { tooltip: Tooltip }) {
   return (
     <div className="gepa-tooltip" style={{ left: tooltip.x + 12, top: tooltip.y + 12 }}>
-      {tooltip.lines.map((line) => (
-        <div key={line}>{line}</div>
+      {tooltip.lines.map((line, i) => (
+        <div key={i}>{line}</div>
       ))}
     </div>
   );

--- a/apps/homescreen/app/components/TrainingPane.tsx
+++ b/apps/homescreen/app/components/TrainingPane.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
+import { GepaPane } from "./GepaPane";
 import type { PaneId } from "./Sidebar";
 
 export type TrainingPaneId = Extract<
@@ -291,6 +292,7 @@ const SECTIONS: Record<TrainingPaneId, {
 
 export function TrainingPane({ section }: { section: TrainingPaneId }) {
   if (section === "training-evals") return <FusionEvaluationPane />;
+  if (section === "training-optimization") return <GepaPane />;
 
   const current = SECTIONS[section];
   return (

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2244,3 +2244,207 @@ select,
   border-radius: var(--r-control);
   padding: 8px 10px;
 }
+
+/* ---------- GEPA optimization pane ---------- */
+.gepa-root {
+  /* Chart mark colors. Best/front pair validated for CVD separation and
+     3:1 surface contrast in both modes (dataviz six checks). */
+  --gepa-best: var(--c-stamp);
+  --gepa-front: #3987e5;
+  --gepa-other: var(--c-ink-muted);
+}
+:root[data-theme="light"] .gepa-root,
+:root[data-theme="system"][data-sys="light"] .gepa-root {
+  --gepa-front: #2a78d6;
+}
+
+.gepa-demo-pill {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--border-strong);
+  color: var(--text-2);
+  font-size: 11px;
+  font-weight: 500;
+  vertical-align: 1px;
+}
+.gepa-loader { display: flex; gap: 8px; margin-top: 12px; }
+.gepa-loader input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-control);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 7px 10px;
+}
+.gepa-loader input::placeholder { color: var(--text-3); }
+
+.gepa-stats { display: flex; gap: 10px; margin-top: 12px; flex-wrap: wrap; }
+.gepa-stat {
+  flex: 1;
+  min-width: 90px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-control);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.gepa-stat strong { font-size: 16px; font-variant-numeric: tabular-nums; }
+.gepa-stat.accent strong { color: var(--accent); }
+.gepa-stat span { color: var(--text-3); font-size: 11px; }
+
+.gepa-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 14px; }
+.gepa-grid > .gepa-detail { grid-column: 1 / -1; }
+@media (max-width: 980px) {
+  .gepa-grid { grid-template-columns: 1fr; }
+}
+
+.gepa-legend {
+  display: flex;
+  gap: 14px;
+  margin: 8px 0 4px;
+  color: var(--text-2);
+  font-size: 12px;
+}
+.gepa-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.gepa-swatch { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+.gepa-swatch.best { background: var(--gepa-best); }
+.gepa-swatch.front { background: var(--gepa-front); }
+.gepa-swatch.other { background: var(--gepa-other); }
+
+.gepa-chart-wrap { position: relative; overflow-x: auto; }
+.gepa-tree, .gepa-scatter { display: block; margin: 4px auto 0; }
+
+.gepa-edge { fill: none; stroke: var(--border-strong); stroke-width: 1.5; }
+.gepa-node { cursor: pointer; }
+.gepa-node-dot { stroke: none; }
+.gepa-node.best .gepa-node-dot { fill: var(--gepa-best); }
+.gepa-node.front .gepa-node-dot { fill: var(--gepa-front); }
+.gepa-node.other .gepa-node-dot { fill: var(--gepa-other); }
+.gepa-node:hover .gepa-node-dot { stroke: var(--text); stroke-width: 1.5; }
+.gepa-select-ring { fill: none; stroke: var(--text); stroke-width: 1.5; }
+.gepa-node-idx {
+  fill: var(--c-paper);
+  font-size: 12px;
+  font-weight: 600;
+  text-anchor: middle;
+  pointer-events: none;
+}
+.gepa-node-score {
+  fill: var(--text-2);
+  font-size: 10px;
+  text-anchor: middle;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+
+.gepa-grid-line, .gepa-grid { stroke: var(--border); stroke-width: 1; }
+.gepa-baseline { stroke: var(--border-strong); stroke-width: 1; }
+.gepa-tick { fill: var(--text-3); font-size: 9.5px; font-variant-numeric: tabular-nums; }
+.gepa-axis-label { fill: var(--text-3); font-size: 10px; }
+.gepa-frontier {
+  fill: none;
+  stroke: var(--gepa-best);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  opacity: 0.55;
+}
+
+.gepa-tooltip {
+  position: absolute;
+  z-index: 5;
+  pointer-events: none;
+  background: var(--elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-control);
+  padding: 6px 9px;
+  font-size: 11.5px;
+  color: var(--text);
+  line-height: 1.5;
+  white-space: nowrap;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+}
+.gepa-tooltip div:first-child { font-weight: 600; }
+
+.gepa-role-pill {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 500;
+  vertical-align: 1px;
+  border: 1px solid var(--border);
+  color: var(--text-2);
+}
+.gepa-role-pill.best { color: var(--gepa-best); border-color: var(--gepa-best); }
+.gepa-role-pill.front { color: var(--gepa-front); border-color: var(--gepa-front); }
+
+.gepa-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+}
+.gepa-link:hover { text-decoration: underline; }
+
+.gepa-detail-grid { display: grid; grid-template-columns: 3fr 2fr; gap: 16px; margin-top: 10px; }
+@media (max-width: 980px) {
+  .gepa-detail-grid { grid-template-columns: 1fr; }
+}
+.gepa-component { margin-bottom: 12px; }
+.gepa-component-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+.gepa-component-name { font-size: 12px; font-weight: 600; color: var(--text); }
+.gepa-component-note { font-size: 11px; color: var(--text-3); }
+.gepa-diff {
+  margin: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-control);
+  padding: 8px 0;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--text-2);
+  overflow-x: auto;
+  max-height: 340px;
+  overflow-y: auto;
+}
+.gepa-diff-line { padding: 0 10px; white-space: pre-wrap; }
+.gepa-diff-sign { display: inline-block; width: 14px; color: var(--text-3); }
+.gepa-diff-line.added { background: color-mix(in srgb, var(--c-ok) 12%, transparent); color: var(--text); }
+.gepa-diff-line.added .gepa-diff-sign { color: var(--c-ok); }
+.gepa-diff-line.removed { background: color-mix(in srgb, var(--c-bad) 10%, transparent); }
+.gepa-diff-line.removed .gepa-diff-sign { color: var(--c-bad); }
+
+.gepa-subscores { width: 100%; border-collapse: collapse; font-size: 12px; }
+.gepa-subscores th {
+  text-align: left;
+  color: var(--text-3);
+  font-weight: 500;
+  font-size: 11px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
+.gepa-subscores td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-2);
+  font-variant-numeric: tabular-nums;
+}
+.gepa-subscores td.up { color: var(--c-ok); }
+.gepa-subscores td.down { color: var(--c-bad); }

--- a/apps/homescreen/src-tauri/knowledge/gepa_demo_run.json
+++ b/apps/homescreen/src-tauri/knowledge/gepa_demo_run.json
@@ -1,0 +1,270 @@
+{
+ "candidates": [
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\nReturn a JSON list of replacement item ids."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nRespect the customer's stated preference ordering: when they list acceptable\nalternatives, pick the first one that is in stock.\n\nReturn a JSON list of replacement item ids."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nOutput rules:\n- Return ONLY a JSON list of item ids, no prose, no markdown.\n- Item ids are strings, exactly as they appear in the catalog."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nRespect the customer's stated preference ordering: when they list acceptable\nalternatives, pick the first one that is in stock.\n\nFallbacks: if the preferred variant (size/color) is unavailable, fall back to\nthe same item in the closest available variant before considering a different\nitem.\n\nReturn a JSON list of replacement item ids."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nOutput rules:\n- Return ONLY a JSON list of item ids, no prose, no markdown.\n- Item ids are strings, exactly as they appear in the catalog.\n- Keep the list in the same order as the items being replaced.\n- Never repeat an item id."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nRespect the customer's stated preference ordering: when they list acceptable\nalternatives, pick the first one that is in stock.\n\nFallbacks: if the preferred variant (size/color) is unavailable, fall back to\nthe same item in the closest available variant before considering a different\nitem.\n\nTie-breaking: when two candidates are equally acceptable, prefer the lower\npriced one; if prices match, prefer the lexicographically smaller item id.\nNever invent an item id that is not in the catalog.\n\nReturn a JSON list of replacement item ids."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nOutput rules:\n- Return ONLY a JSON list of item ids, no prose, no markdown.\n- Item ids are strings, exactly as they appear in the catalog.\n- Keep the list in the same order as the items being replaced.\n- Never repeat an item id.\n- If no valid replacement exists for an item, return an empty list [] rather\n  than guessing."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nRespect the customer's stated preference ordering: when they list acceptable\nalternatives, pick the first one that is in stock.\n\nFallbacks: if the preferred variant (size/color) is unavailable, fall back to\nthe same item in the closest available variant before considering a different\nitem.\n\nTie-breaking: when two candidates are equally acceptable, prefer the lower\npriced one; if prices match, prefer the lexicographically smaller item id.\nNever invent an item id that is not in the catalog.\n\nOutput rules:\n- Return ONLY a JSON list of item ids, no prose, no markdown.\n- Item ids are strings, exactly as they appear in the catalog.\n- Keep the list in the same order as the items being replaced.\n- Never repeat an item id.\n\nReturn a JSON list of replacement item ids."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nRespect the customer's stated preference ordering: when they list acceptable\nalternatives, pick the first one that is in stock.\n\nFallbacks: if the preferred variant (size/color) is unavailable, fall back to\nthe same item in the closest available variant before considering a different\nitem.\n\nTie-breaking: when two candidates are equally acceptable, prefer the lower\npriced one; if prices match, prefer the lexicographically smaller item id.\nNever invent an item id that is not in the catalog.\n\nMulti-item requests: treat each replaced item independently — resolve its\npreferences, fallbacks, and tie-breaks on its own, then concatenate results in\nthe original order. One item having no replacement does not affect the others.\n\nOutput rules:\n- Return ONLY a JSON list of item ids, no prose, no markdown.\n- Item ids are strings, exactly as they appear in the catalog.\n- Keep the list in the same order as the items being replaced.\n- Never repeat an item id.\n- If an item has no valid replacement, omit it; if none do, return [].\n\nReturn a JSON list of replacement item ids."
+  },
+  {
+   "system_prompt": "Choose the correct replacement item ids for a retail exchange request.\n\nRespect the customer's stated preference ordering: when they list acceptable\nalternatives, pick the first one that is in stock.\n\nFallbacks: if the preferred variant (size/color) is unavailable, fall back to\nthe same item in the closest available variant before considering a different\nitem. Only ever consider items from the same product category, the same brand,\nand the same price band; reject anything else even if the customer asked for it.\n\nTie-breaking: when two candidates are equally acceptable, prefer the lower\npriced one; if prices match, prefer the lexicographically smaller item id.\nNever invent an item id that is not in the catalog.\n\nReturn a JSON list of replacement item ids."
+  }
+ ],
+ "parents": [
+  [
+   null
+  ],
+  [
+   0
+  ],
+  [
+   0
+  ],
+  [
+   1
+  ],
+  [
+   2
+  ],
+  [
+   3
+  ],
+  [
+   4
+  ],
+  [
+   5,
+   4
+  ],
+  [
+   7
+  ],
+  [
+   5
+  ]
+ ],
+ "val_aggregate_scores": [
+  0.4375,
+  0.5625,
+  0.5,
+  0.625,
+  0.5625,
+  0.6875,
+  0.625,
+  0.8125,
+  0.875,
+  0.6875
+ ],
+ "val_subscores": [
+  {
+   "exchange-011": 1,
+   "exchange-023": 0,
+   "exchange-031": 0.5,
+   "exchange-044": 0,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 0.5,
+   "exchange-078": 0.5
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 0.5,
+   "exchange-031": 0.5,
+   "exchange-044": 0,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 1,
+   "exchange-078": 0.5
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 0,
+   "exchange-031": 1,
+   "exchange-044": 0,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 0.5,
+   "exchange-078": 0.5
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 1,
+   "exchange-031": 0.5,
+   "exchange-044": 0.5,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 1,
+   "exchange-078": 0
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 0,
+   "exchange-031": 1,
+   "exchange-044": 0.5,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 0.5,
+   "exchange-078": 0.5
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 1,
+   "exchange-031": 0.5,
+   "exchange-044": 1,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 1,
+   "exchange-078": 0
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 0,
+   "exchange-031": 1,
+   "exchange-044": 0.5,
+   "exchange-052": 1,
+   "exchange-057": 1,
+   "exchange-063": 0.5,
+   "exchange-078": 0
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 1,
+   "exchange-031": 1,
+   "exchange-044": 1,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 1,
+   "exchange-078": 0.5
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 1,
+   "exchange-031": 1,
+   "exchange-044": 1,
+   "exchange-052": 1,
+   "exchange-057": 0.5,
+   "exchange-063": 1,
+   "exchange-078": 0.5
+  },
+  {
+   "exchange-011": 1,
+   "exchange-023": 1,
+   "exchange-031": 0,
+   "exchange-044": 1,
+   "exchange-052": 1,
+   "exchange-057": 0,
+   "exchange-063": 1,
+   "exchange-078": 0.5
+  }
+ ],
+ "best_outputs_valset": null,
+ "per_val_instance_best_candidates": {
+  "exchange-011": [
+   0,
+   1,
+   2,
+   3,
+   4,
+   5,
+   6,
+   7,
+   8,
+   9
+  ],
+  "exchange-023": [
+   3,
+   5,
+   7,
+   8,
+   9
+  ],
+  "exchange-031": [
+   2,
+   4,
+   6,
+   7,
+   8
+  ],
+  "exchange-044": [
+   5,
+   7,
+   8,
+   9
+  ],
+  "exchange-052": [
+   0,
+   1,
+   2,
+   3,
+   4,
+   5,
+   6,
+   7,
+   8,
+   9
+  ],
+  "exchange-057": [
+   6
+  ],
+  "exchange-063": [
+   1,
+   3,
+   5,
+   7,
+   8,
+   9
+  ],
+  "exchange-078": [
+   0,
+   1,
+   2,
+   4,
+   7,
+   8,
+   9
+  ]
+ },
+ "val_aggregate_subscores": null,
+ "per_objective_best_candidates": null,
+ "objective_pareto_front": null,
+ "discovery_eval_counts": [
+  8,
+  26,
+  44,
+  60,
+  78,
+  96,
+  112,
+  132,
+  152,
+  168
+ ],
+ "total_metric_calls": 180,
+ "num_full_val_evals": 10,
+ "run_dir": null,
+ "seed": 7,
+ "_str_candidate_key": null,
+ "best_idx": 8,
+ "validation_schema_version": 2
+}

--- a/apps/homescreen/src-tauri/src/gepa.rs
+++ b/apps/homescreen/src-tauri/src/gepa.rs
@@ -131,12 +131,7 @@ pub fn parse_run(raw: &str, source: &str, is_demo: bool) -> Result<GepaRunView, 
     let parents = parse_parents(obj.get("parents"), n)?;
     let val_scores = parse_scores(obj.get("val_aggregate_scores"), n)?;
     let (val_ids, subscores) = parse_subscores(obj.get("val_subscores"), n, schema_version)?;
-    let fronts = parse_fronts(
-        obj.get("per_val_instance_best_candidates"),
-        n,
-        schema_version,
-        &val_ids,
-    )?;
+    let fronts = parse_fronts(obj.get("per_val_instance_best_candidates"), n, schema_version)?;
     let discovery = parse_discovery(obj.get("discovery_eval_counts"), n)?;
 
     // Merge front-map val ids into the subscore-derived ordering so every
@@ -347,7 +342,6 @@ fn parse_fronts(
     v: Option<&Value>,
     n: usize,
     schema_version: u64,
-    _val_ids: &[String],
 ) -> Result<BTreeMap<String, BTreeSet<usize>>, String> {
     let mut out = BTreeMap::new();
     let entries: Vec<(String, &Value)> = match v {
@@ -406,13 +400,18 @@ fn parse_discovery(v: Option<&Value>, n: usize) -> Result<Vec<Option<u64>>, Stri
     Ok(arr.iter().map(Value::as_u64).collect())
 }
 
+/// First index with the maximum score — ties break toward the earlier
+/// candidate, matching Python's `max(range(n), key=...)` in
+/// `GEPAResult.best_idx`.
 fn best_index(scores: &[Option<f64>]) -> Result<usize, String> {
-    scores
-        .iter()
-        .enumerate()
-        .filter_map(|(i, s)| s.map(|s| (i, s)))
-        .max_by(|a, b| a.1.total_cmp(&b.1))
-        .map(|(i, _)| i)
+    let mut best: Option<(usize, f64)> = None;
+    for (i, score) in scores.iter().enumerate() {
+        let Some(score) = *score else { continue };
+        if best.is_none_or(|(_, top)| score > top) {
+            best = Some((i, score));
+        }
+    }
+    best.map(|(i, _)| i)
         .ok_or_else(|| "run has no scored candidates".into())
 }
 
@@ -627,6 +626,19 @@ mod tests {
         assert!(run.val_ids.is_empty());
         assert!(run.dominators.is_empty());
         assert_eq!(run.candidates[0].discovery_evals, None);
+    }
+
+    #[test]
+    fn best_index_tie_breaks_toward_earlier_candidate() {
+        // Matches Python's max(range(n), key=...) in GEPAResult.best_idx.
+        let raw = r#"{
+            "validation_schema_version": 2,
+            "candidates": [{"p": "a"}, {"p": "b"}, {"p": "c"}],
+            "parents": [[null], [0], [0]],
+            "val_aggregate_scores": [0.25, 0.75, 0.75]
+        }"#;
+        let run = parse_run(raw, "test", false).expect("tie artifact parses");
+        assert_eq!(run.best_idx, 1);
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/gepa.rs
+++ b/apps/homescreen/src-tauri/src/gepa.rs
@@ -1,0 +1,654 @@
+//! GEPA run artifact loading for the Optimization pane.
+//!
+//! Parses the JSON produced by the `gepa` Python package's
+//! `GEPAResult.to_dict()` (validation schema v2, with tolerance for the
+//! legacy v0/v1 list-based shape) and normalizes it into a view the
+//! frontend can render directly: candidate lineage (tree), per-candidate
+//! validation scores, discovery budget, and the Pareto-front/dominator
+//! roles that GEPA's own visualization uses.
+//!
+//! This is a file-based viewer: it never runs GEPA. `gepa_state.bin` is a
+//! Python pickle and is deliberately not supported — runs are loaded from
+//! the JSON result artifact.
+
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+/// Highest `validation_schema_version` this viewer understands
+/// (mirrors `GEPAResult._VALIDATION_SCHEMA_VERSION` in gepa 0.1.x).
+const MAX_SCHEMA_VERSION: u64 = 2;
+
+/// The demo artifact bundled so the pane always renders. Synthetic
+/// retail-exchange workload; validated to round-trip through the real
+/// `gepa` package's `GEPAResult.from_dict`.
+const DEMO_RUN_JSON: &str = include_str!("../knowledge/gepa_demo_run.json");
+pub const DEMO_SOURCE: &str = "demo";
+
+#[derive(Serialize, Clone, Debug)]
+pub struct GepaCandidateView {
+    pub idx: usize,
+    /// Component name → component text (usually the evolved prompt(s)).
+    pub components: BTreeMap<String, String>,
+    /// Parent candidate indices (empty for the seed; two for a merge).
+    pub parents: Vec<usize>,
+    /// Aggregate validation score.
+    pub val_score: Option<f64>,
+    /// Total metric calls consumed when this candidate was discovered.
+    pub discovery_evals: Option<u64>,
+    /// Per-instance scores aligned with `GepaRunView::val_ids` (None where
+    /// the run recorded no score for that instance).
+    pub subscores: Vec<Option<f64>>,
+    /// Validation instance ids where this candidate is on the per-instance
+    /// Pareto front (ties included, as GEPA records them).
+    pub front_instance_ids: Vec<String>,
+    /// True when the candidate survives GEPA's dominator reduction — the
+    /// minimal set that still covers every per-instance front.
+    pub is_dominator: bool,
+    pub is_best: bool,
+    /// Depth in the lineage tree (seed = 0; merge = 1 + deepest parent).
+    pub generation: usize,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct GepaRunView {
+    /// Where the run came from: `"demo"` or the loaded file path.
+    pub source: String,
+    pub schema_version: u64,
+    pub best_idx: usize,
+    /// Ordered validation instance ids (subscore columns align with this).
+    pub val_ids: Vec<String>,
+    pub candidates: Vec<GepaCandidateView>,
+    /// Dominator candidate indices (GEPA's `find_dominator_programs`).
+    pub dominators: Vec<usize>,
+    pub total_metric_calls: Option<u64>,
+    pub num_full_val_evals: Option<u64>,
+    pub seed: Option<i64>,
+    pub run_dir: Option<String>,
+    pub is_demo: bool,
+}
+
+/// Load the bundled demo run. Infallible in practice (the artifact is
+/// compiled in and covered by tests) but surfaces a parse error honestly.
+#[tauri::command]
+pub fn gepa_demo_run() -> Result<GepaRunView, String> {
+    parse_run(DEMO_RUN_JSON, DEMO_SOURCE, true)
+}
+
+/// Load a GEPA run artifact from disk. Accepts a `GEPAResult.to_dict()`
+/// JSON file, or a run directory containing `gepa-result.json` /
+/// `gepa_result.json`.
+#[tauri::command]
+pub fn gepa_load_run(path: String) -> Result<GepaRunView, String> {
+    let requested = Path::new(&path);
+    let file = if requested.is_dir() {
+        ["gepa-result.json", "gepa_result.json"]
+            .iter()
+            .map(|name| requested.join(name))
+            .find(|p| p.is_file())
+            .ok_or_else(|| {
+                format!(
+                    "{path} is a directory without a gepa-result.json. Export one with \
+                     `json.dump(result.to_dict(), f)` in Python — gepa_state.bin is a \
+                     pickle and cannot be read here."
+                )
+            })?
+    } else {
+        requested.to_path_buf()
+    };
+    let raw = std::fs::read_to_string(&file)
+        .map_err(|e| format!("could not read {}: {e}", file.display()))?;
+    parse_run(&raw, &file.display().to_string(), false)
+}
+
+pub fn parse_run(raw: &str, source: &str, is_demo: bool) -> Result<GepaRunView, String> {
+    let root: Value =
+        serde_json::from_str(raw).map_err(|e| format!("not valid JSON: {e}"))?;
+    let obj = root
+        .as_object()
+        .ok_or("expected a JSON object (GEPAResult.to_dict())")?;
+
+    let schema_version = match obj.get("validation_schema_version") {
+        None | Some(Value::Null) => 0,
+        Some(v) => v
+            .as_u64()
+            .ok_or("validation_schema_version must be a non-negative integer")?,
+    };
+    if schema_version > MAX_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported GEPAResult validation schema version {schema_version}; \
+             max supported is {MAX_SCHEMA_VERSION}"
+        ));
+    }
+
+    let components = parse_candidates(obj.get("candidates"))?;
+    let n = components.len();
+    if n == 0 {
+        return Err("run has no candidates".into());
+    }
+
+    let parents = parse_parents(obj.get("parents"), n)?;
+    let val_scores = parse_scores(obj.get("val_aggregate_scores"), n)?;
+    let (val_ids, subscores) = parse_subscores(obj.get("val_subscores"), n, schema_version)?;
+    let fronts = parse_fronts(
+        obj.get("per_val_instance_best_candidates"),
+        n,
+        schema_version,
+        &val_ids,
+    )?;
+    let discovery = parse_discovery(obj.get("discovery_eval_counts"), n)?;
+
+    // Merge front-map val ids into the subscore-derived ordering so every
+    // instance appears even if one side is missing it.
+    let mut all_val_ids: Vec<String> = val_ids.clone();
+    for id in fronts.keys() {
+        if !all_val_ids.iter().any(|v| v == id) {
+            all_val_ids.push(id.clone());
+        }
+    }
+
+    let best_idx = best_index(&val_scores)?;
+    let generations = compute_generations(&parents);
+    let dominators = find_dominators(&fronts, &val_scores);
+    let dominator_set: BTreeSet<usize> = dominators.iter().copied().collect();
+
+    let candidates = (0..n)
+        .map(|idx| {
+            let front_instance_ids: Vec<String> = all_val_ids
+                .iter()
+                .filter(|id| fronts.get(*id).is_some_and(|f| f.contains(&idx)))
+                .cloned()
+                .collect();
+            GepaCandidateView {
+                idx,
+                components: components[idx].clone(),
+                parents: parents[idx].clone(),
+                val_score: val_scores[idx],
+                discovery_evals: discovery[idx],
+                subscores: all_val_ids
+                    .iter()
+                    .map(|id| subscores[idx].get(id).copied())
+                    .collect(),
+                front_instance_ids,
+                is_dominator: dominator_set.contains(&idx),
+                is_best: idx == best_idx,
+                generation: generations[idx],
+            }
+        })
+        .collect();
+
+    Ok(GepaRunView {
+        source: source.to_string(),
+        schema_version,
+        best_idx,
+        val_ids: all_val_ids,
+        candidates,
+        dominators,
+        total_metric_calls: obj.get("total_metric_calls").and_then(Value::as_u64),
+        num_full_val_evals: obj.get("num_full_val_evals").and_then(Value::as_u64),
+        seed: obj.get("seed").and_then(Value::as_i64),
+        run_dir: obj
+            .get("run_dir")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        is_demo,
+    })
+}
+
+fn parse_candidates(v: Option<&Value>) -> Result<Vec<BTreeMap<String, String>>, String> {
+    let arr = v
+        .and_then(Value::as_array)
+        .ok_or("candidates must be an array of component maps")?;
+    arr.iter()
+        .enumerate()
+        .map(|(i, cand)| {
+            let map = cand
+                .as_object()
+                .ok_or(format!("candidates[{i}] must be an object"))?;
+            map.iter()
+                .map(|(k, val)| match val {
+                    Value::String(s) => Ok((k.clone(), s.clone())),
+                    other => Err(format!(
+                        "candidates[{i}].{k} must be a string, got {other}"
+                    )),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn parse_parents(v: Option<&Value>, n: usize) -> Result<Vec<Vec<usize>>, String> {
+    let arr = v
+        .and_then(Value::as_array)
+        .ok_or("parents must be an array of parent-index lists")?;
+    if arr.len() != n {
+        return Err(format!(
+            "parents has {} entries but there are {n} candidates",
+            arr.len()
+        ));
+    }
+    arr.iter()
+        .enumerate()
+        .map(|(child, row)| {
+            let row = row
+                .as_array()
+                .ok_or(format!("parents[{child}] must be a list"))?;
+            let mut out = Vec::new();
+            for p in row {
+                match p {
+                    Value::Null => {}
+                    Value::Number(num) => {
+                        let idx = num
+                            .as_u64()
+                            .ok_or(format!("parents[{child}] contains a non-index {num}"))?
+                            as usize;
+                        // GEPA discovers children after parents; enforcing
+                        // parent < child keeps the lineage a DAG we can walk.
+                        if idx >= child {
+                            return Err(format!(
+                                "parents[{child}] references candidate {idx}, which is not \
+                                 an earlier candidate — lineage must be topological"
+                            ));
+                        }
+                        out.push(idx);
+                    }
+                    other => {
+                        return Err(format!("parents[{child}] contains {other}, expected an index or null"))
+                    }
+                }
+            }
+            Ok(out)
+        })
+        .collect()
+}
+
+fn parse_scores(v: Option<&Value>, n: usize) -> Result<Vec<Option<f64>>, String> {
+    let arr = v
+        .and_then(Value::as_array)
+        .ok_or("val_aggregate_scores must be an array of numbers")?;
+    if arr.len() != n {
+        return Err(format!(
+            "val_aggregate_scores has {} entries but there are {n} candidates",
+            arr.len()
+        ));
+    }
+    arr.iter()
+        .enumerate()
+        .map(|(i, s)| match s {
+            Value::Null => Ok(None),
+            Value::Number(num) => Ok(num.as_f64()),
+            other => Err(format!("val_aggregate_scores[{i}] is {other}, expected a number")),
+        })
+        .collect()
+}
+
+/// Returns the ordered val ids plus, per candidate, a map val id → score.
+#[allow(clippy::type_complexity)]
+fn parse_subscores(
+    v: Option<&Value>,
+    n: usize,
+    schema_version: u64,
+) -> Result<(Vec<String>, Vec<BTreeMap<String, f64>>), String> {
+    let arr = match v {
+        None | Some(Value::Null) => return Ok((Vec::new(), vec![BTreeMap::new(); n])),
+        Some(v) => v.as_array().ok_or("val_subscores must be an array")?,
+    };
+    if arr.len() != n {
+        return Err(format!(
+            "val_subscores has {} entries but there are {n} candidates",
+            arr.len()
+        ));
+    }
+    let mut ordered_ids: Vec<String> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut per_candidate = Vec::with_capacity(n);
+    for (i, row) in arr.iter().enumerate() {
+        let mut map = BTreeMap::new();
+        let entries: Vec<(String, &Value)> = if schema_version >= 2 {
+            row.as_object()
+                .ok_or(format!("val_subscores[{i}] must be an object (schema v2)"))?
+                .iter()
+                .map(|(k, val)| (k.clone(), val))
+                .collect()
+        } else {
+            // Legacy v0/v1: a plain list, positional instance ids.
+            row.as_array()
+                .ok_or(format!("val_subscores[{i}] must be a list (legacy schema)"))?
+                .iter()
+                .enumerate()
+                .map(|(j, val)| (j.to_string(), val))
+                .collect()
+        };
+        for (id, val) in entries {
+            let score = match val {
+                Value::Null => continue,
+                Value::Number(num) => num
+                    .as_f64()
+                    .ok_or(format!("val_subscores[{i}][{id}] is not a finite number"))?,
+                other => {
+                    return Err(format!(
+                        "val_subscores[{i}][{id}] is {other}, expected a number"
+                    ))
+                }
+            };
+            if seen.insert(id.clone()) {
+                ordered_ids.push(id.clone());
+            }
+            map.insert(id, score);
+        }
+        per_candidate.push(map);
+    }
+    Ok((ordered_ids, per_candidate))
+}
+
+/// Per-instance Pareto fronts: val id → set of candidate indices.
+fn parse_fronts(
+    v: Option<&Value>,
+    n: usize,
+    schema_version: u64,
+    _val_ids: &[String],
+) -> Result<BTreeMap<String, BTreeSet<usize>>, String> {
+    let mut out = BTreeMap::new();
+    let entries: Vec<(String, &Value)> = match v {
+        None | Some(Value::Null) => return Ok(out),
+        Some(v) if schema_version >= 2 => v
+            .as_object()
+            .ok_or("per_val_instance_best_candidates must be an object (schema v2)")?
+            .iter()
+            .map(|(k, val)| (k.clone(), val))
+            .collect(),
+        Some(v) => v
+            .as_array()
+            .ok_or("per_val_instance_best_candidates must be a list (legacy schema)")?
+            .iter()
+            .enumerate()
+            .map(|(j, val)| (j.to_string(), val))
+            .collect(),
+    };
+    for (id, front) in entries {
+        let front = front
+            .as_array()
+            .ok_or(format!("per_val_instance_best_candidates[{id}] must be a list"))?;
+        let mut set = BTreeSet::new();
+        for member in front {
+            let idx = member
+                .as_u64()
+                .ok_or(format!(
+                    "per_val_instance_best_candidates[{id}] contains {member}, expected a candidate index"
+                ))? as usize;
+            if idx >= n {
+                return Err(format!(
+                    "per_val_instance_best_candidates[{id}] references candidate {idx}, \
+                     but there are only {n} candidates"
+                ));
+            }
+            set.insert(idx);
+        }
+        out.insert(id, set);
+    }
+    Ok(out)
+}
+
+fn parse_discovery(v: Option<&Value>, n: usize) -> Result<Vec<Option<u64>>, String> {
+    let arr = match v {
+        None | Some(Value::Null) => return Ok(vec![None; n]),
+        Some(v) => v
+            .as_array()
+            .ok_or("discovery_eval_counts must be an array")?,
+    };
+    if arr.len() != n {
+        return Err(format!(
+            "discovery_eval_counts has {} entries but there are {n} candidates",
+            arr.len()
+        ));
+    }
+    Ok(arr.iter().map(Value::as_u64).collect())
+}
+
+fn best_index(scores: &[Option<f64>]) -> Result<usize, String> {
+    scores
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| s.map(|s| (i, s)))
+        .max_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(i, _)| i)
+        .ok_or_else(|| "run has no scored candidates".into())
+}
+
+/// Seed = generation 0; every child sits one level below its deepest parent.
+/// Safe because `parse_parents` enforces parent < child.
+fn compute_generations(parents: &[Vec<usize>]) -> Vec<usize> {
+    let mut gen = vec![0usize; parents.len()];
+    for (child, pars) in parents.iter().enumerate() {
+        gen[child] = pars.iter().map(|&p| gen[p] + 1).max().unwrap_or(0);
+    }
+    gen
+}
+
+/// Port of gepa's `find_dominator_programs` / `remove_dominated_programs`:
+/// greedily discard (lowest aggregate score first) any candidate whose every
+/// per-instance front is still covered by the remaining candidates. What
+/// survives is the minimal set that "illuminates" the whole valset.
+fn find_dominators(
+    fronts: &BTreeMap<String, BTreeSet<usize>>,
+    scores: &[Option<f64>],
+) -> Vec<usize> {
+    let mut programs: Vec<usize> = fronts
+        .values()
+        .flat_map(|f| f.iter().copied())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    programs.sort_by(|&a, &b| {
+        let sa = scores.get(a).copied().flatten().unwrap_or(f64::NEG_INFINITY);
+        let sb = scores.get(b).copied().flatten().unwrap_or(f64::NEG_INFINITY);
+        sa.total_cmp(&sb).then(a.cmp(&b))
+    });
+
+    let mut dominated: BTreeSet<usize> = BTreeSet::new();
+    loop {
+        let mut removed = false;
+        for &y in &programs {
+            if dominated.contains(&y) {
+                continue;
+            }
+            let is_dominated = fronts
+                .values()
+                .filter(|front| front.contains(&y))
+                .all(|front| {
+                    front
+                        .iter()
+                        .any(|&other| other != y && !dominated.contains(&other))
+                });
+            if is_dominated {
+                dominated.insert(y);
+                removed = true;
+                break;
+            }
+        }
+        if !removed {
+            break;
+        }
+    }
+    programs.retain(|p| !dominated.contains(p));
+    programs.sort_unstable();
+    programs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn demo() -> GepaRunView {
+        parse_run(DEMO_RUN_JSON, DEMO_SOURCE, true).expect("demo artifact parses")
+    }
+
+    #[test]
+    fn demo_artifact_parses_and_normalizes() {
+        let run = demo();
+        assert_eq!(run.candidates.len(), 10);
+        assert_eq!(run.val_ids.len(), 8);
+        assert_eq!(run.best_idx, 8);
+        assert!(run.is_demo);
+        assert_eq!(run.schema_version, 2);
+        assert_eq!(run.total_metric_calls, Some(180));
+
+        // Matches gepa's find_dominator_programs on the same data
+        // (verified against the real package during development).
+        assert_eq!(run.dominators, vec![6, 8]);
+
+        let seed = &run.candidates[0];
+        assert!(seed.parents.is_empty());
+        assert_eq!(seed.generation, 0);
+        assert!(seed.components.contains_key("system_prompt"));
+
+        // Candidate 7 is the merge: two parents, one generation below the deepest.
+        let merge = &run.candidates[7];
+        assert_eq!(merge.parents, vec![5, 4]);
+        assert_eq!(merge.generation, 4);
+
+        let best = &run.candidates[8];
+        assert!(best.is_best && best.is_dominator);
+        assert_eq!(best.subscores.len(), run.val_ids.len());
+        assert!(best.val_score.is_some_and(|s| (s - 0.875).abs() < 1e-9));
+
+        // Candidate 6 leads exchange-057 alone — the illumination story.
+        let specialist = &run.candidates[6];
+        assert!(specialist.is_dominator && !specialist.is_best);
+        assert!(specialist
+            .front_instance_ids
+            .iter()
+            .any(|id| id == "exchange-057"));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let err = parse_run("{not json", "test", false).unwrap_err();
+        assert!(err.contains("not valid JSON"), "{err}");
+        let err = parse_run("[1,2,3]", "test", false).unwrap_err();
+        assert!(err.contains("expected a JSON object"), "{err}");
+    }
+
+    #[test]
+    fn rejects_future_schema_version() {
+        let raw = r#"{"validation_schema_version": 3, "candidates": []}"#;
+        let err = parse_run(raw, "test", false).unwrap_err();
+        assert!(err.contains("unsupported"), "{err}");
+    }
+
+    #[test]
+    fn rejects_mismatched_lengths() {
+        let raw = r#"{
+            "validation_schema_version": 2,
+            "candidates": [{"p": "a"}, {"p": "b"}],
+            "parents": [[null]],
+            "val_aggregate_scores": [0.5, 0.6],
+            "val_subscores": [{}, {}],
+            "per_val_instance_best_candidates": {}
+        }"#;
+        let err = parse_run(raw, "test", false).unwrap_err();
+        assert!(err.contains("parents has 1 entries"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_topological_lineage() {
+        let raw = r#"{
+            "validation_schema_version": 2,
+            "candidates": [{"p": "a"}, {"p": "b"}],
+            "parents": [[1], [null]],
+            "val_aggregate_scores": [0.5, 0.6],
+            "val_subscores": [{}, {}],
+            "per_val_instance_best_candidates": {}
+        }"#;
+        let err = parse_run(raw, "test", false).unwrap_err();
+        assert!(err.contains("topological"), "{err}");
+    }
+
+    #[test]
+    fn rejects_front_index_out_of_range() {
+        let raw = r#"{
+            "validation_schema_version": 2,
+            "candidates": [{"p": "a"}],
+            "parents": [[null]],
+            "val_aggregate_scores": [0.5],
+            "val_subscores": [{"v0": 0.5}],
+            "per_val_instance_best_candidates": {"v0": [4]}
+        }"#;
+        let err = parse_run(raw, "test", false).unwrap_err();
+        assert!(err.contains("only 1 candidates"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_string_component() {
+        let raw = r#"{
+            "validation_schema_version": 2,
+            "candidates": [{"p": 42}],
+            "parents": [[null]],
+            "val_aggregate_scores": [0.5],
+            "val_subscores": [{}],
+            "per_val_instance_best_candidates": {}
+        }"#;
+        let err = parse_run(raw, "test", false).unwrap_err();
+        assert!(err.contains("must be a string"), "{err}");
+    }
+
+    #[test]
+    fn parses_legacy_v0_lists() {
+        // Pre-v2 shape: subscores are positional lists and the front map is
+        // a list of per-instance lists.
+        let raw = r#"{
+            "candidates": [{"p": "seed"}, {"p": "child"}],
+            "parents": [[null], [0]],
+            "val_aggregate_scores": [0.25, 0.75],
+            "val_subscores": [[0.0, 0.5], [0.5, 1.0]],
+            "per_val_instance_best_candidates": [[1], [1]],
+            "discovery_eval_counts": [2, 6]
+        }"#;
+        let run = parse_run(raw, "test", false).expect("legacy artifact parses");
+        assert_eq!(run.schema_version, 0);
+        assert_eq!(run.best_idx, 1);
+        assert_eq!(run.val_ids, vec!["0".to_string(), "1".to_string()]);
+        assert_eq!(run.dominators, vec![1]);
+        assert_eq!(run.candidates[1].generation, 1);
+        assert_eq!(run.candidates[1].discovery_evals, Some(6));
+    }
+
+    #[test]
+    fn missing_optional_fields_are_tolerated() {
+        let raw = r#"{
+            "validation_schema_version": 2,
+            "candidates": [{"p": "seed"}],
+            "parents": [[null]],
+            "val_aggregate_scores": [0.5]
+        }"#;
+        let run = parse_run(raw, "test", false).expect("minimal artifact parses");
+        assert_eq!(run.best_idx, 0);
+        assert!(run.val_ids.is_empty());
+        assert!(run.dominators.is_empty());
+        assert_eq!(run.candidates[0].discovery_evals, None);
+    }
+
+    #[test]
+    fn no_scored_candidates_is_an_error() {
+        let raw = r#"{
+            "validation_schema_version": 2,
+            "candidates": [{"p": "seed"}],
+            "parents": [[null]],
+            "val_aggregate_scores": [null]
+        }"#;
+        let err = parse_run(raw, "test", false).unwrap_err();
+        assert!(err.contains("no scored candidates"), "{err}");
+    }
+
+    #[test]
+    fn load_run_rejects_missing_and_dir_without_artifact() {
+        let err = gepa_load_run("/nonexistent/gepa.json".into()).unwrap_err();
+        assert!(err.contains("could not read"), "{err}");
+
+        let dir = std::env::temp_dir().join("gepa-viz-test-empty-dir");
+        std::fs::create_dir_all(&dir).unwrap();
+        let err = gepa_load_run(dir.display().to_string()).unwrap_err();
+        assert!(err.contains("gepa-result.json"), "{err}");
+    }
+}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod chat;
 mod commands;
 mod creds;
 mod db;
+mod gepa;
 mod knowledge;
 mod mcp;
 mod metrics;
@@ -160,6 +161,8 @@ pub fn run() {
             commands::account_login_code,
             commands::account_logout,
             commands::knowledge_dossiers,
+            gepa::gepa_demo_run,
+            gepa::gepa_load_run,
             commands::local_benchmarks,
             commands::fusion_benchmark_matrix,
             commands::fusion_route_recommendation,


### PR DESCRIPTION
## What this is

A GEPA run viewer in the desktop app's **Training → Optimization** pane: "you see this tree — just show it." Load a finished GEPA run artifact from disk (or the bundled demo) and see:

- **Evolution tree** — the candidate lineage DAG (mutations and merges), layered by generation, hand-rolled SVG. Node color = role: best candidate (accent), Pareto-front dominators (blue), explored (gray); seed at the top.
- **Score vs rollouts** — aggregate validation score against the eval budget consumed when each candidate was discovered, with the running-best frontier as a step line.
- **Candidate detail** — role, lineage links, per-component **prompt diff vs parent** (line-based LCS), and a per-instance subscore table vs parent with Pareto-front markers.

Clearly scoped: **file-based viewer + bundled demo artifact** (labeled "demo data" in the UI). Live in-app GEPA runs are intentionally out of scope for this PR.

## RESEARCH SUMMARY

**Online priors.** GEPA (arXiv [2507.19457](https://arxiv.org/abs/2507.19457), ICLR 2026 oral; [gepa-ai/gepa](https://github.com/gepa-ai/gepa)) = genetic prompt evolution + natural-language reflection + Pareto-based candidate selection. The canonical visualizations people render are (a) the **candidate lineage tree** — the paper's own Figure 6 contrasts the balanced Pareto search tree against greedy's stalled chain, and the gepa package itself ships `gepa/visualization.py`, which renders exactly this tree from `(candidates, parents, val_scores, per_val_instance_best_candidates)` with best = cyan, Pareto dominators = orange, others = gray, labels `idx (score)`, full prompt text in tooltips — and (b) **score-vs-rollouts** efficiency curves (GEPA's headline claim is ~400–1200 rollouts vs 24k+ for RL). This pane mirrors both, restyled to the app's tokens.

**Moraine priors.** The founder's demo quote comes from the dinner transcript ("a native [GEPA] visualization — 'you see this tree — just show it'"); the tree he showed matches the gepa package's own candidate-tree rendering of the lineage/Pareto data. Prior GEPA work in the repo/sessions: the live-GEPA adapter branch `yolo/external-skills-live-gepa` (PR #90 — DSPy + gepa ran end-to-end through the gateway, honest no-lift result), the 2026-04-27 `gepa-ruler-live-findings` notes (first real GEPA run), and `skills/optimize-workload` (GEPA on train/dev only, `eval-input-candidate.json` / `proof-packet.json` claim artifacts).

**Artifact format chosen and why.** Real run dirs on this machine (`~/Developer/understudy/tokenopti/experiments/2026-04-23-benchmark-scout/logs/*`) contain `gepa_state.bin` (Python **pickle**, unreadable outside Python) plus bespoke summary JSONs. The one canonical, JSON-safe, versioned serialization the gepa package defines is **`GEPAResult.to_dict()`** (`validation_schema_version` 2, with documented v0/v1 legacy migration) — it carries everything the three views need: `candidates`, `parents` (lineage incl. merges), `val_aggregate_scores`, `val_subscores`, `per_val_instance_best_candidates` (the Pareto fronts), and `discovery_eval_counts` (the budget axis). So the viewer consumes that, ports gepa's `find_dominator_programs` for the orange-node semantics, and tells you how to export one (`json.dump(result.to_dict(), f)`) if you point it at a directory that only has the pickle.

**Fidelity checks done during development** (not in CI): the bundled demo artifact round-trips through the real gepa 0.1.1 `GEPAResult.from_dict`/`to_dict`, its dominator set matches gepa's `find_dominator_programs` (`{6, 8}`), and a real `gepa_state.bin` from the April tokenopti runs was exported via `GEPAResult.from_state(...).to_dict()` and parsed through this exact Rust code path.

## Demo data

Synthetic retail-exchange workload (echoes the shape of the real April runs, no real data): 10 candidates over 8 val instances, one merge node, and a deliberate illumination story — candidate 6 is mid-pack on aggregate but the only solver of one val instance, so it survives on the Pareto front next to the best candidate 8.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean; `cargo test` 76 passed (11 new: demo parse/normalize, malformed JSON, future schema version, mismatched lengths, non-topological lineage, out-of-range front indices, non-string components, legacy v0 lists, missing optional fields, unscored runs, dir-without-artifact).
- `bun install && bun run build` in `apps/homescreen` — clean.
- `npm ci && npm run check && npm test` at repo root — 139 pass.
- Chart colors validated with the dataviz palette checker (CVD separation + 3:1 contrast, light and dark).
- Not verified live: the rendered pane in the running GUI (launching the app is out of scope tonight); layout was exercised through the Next type-checked build only.

## Constraints honored

Additive only (one `mod` line + two command registrations in the `lib.rs` hotspot); follows the TrainingPane/FusionEvaluationPane idioms; zero new dependencies (hand-rolled SVG); no other overnight workstream files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->