### PR TITLE
setup: fix ENOENT crash by installing SKILL.md directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ## [Unreleased]
 
+### Fixed
+
+- **`understudy setup` crash.** The legacy Claude-compatible skill-copy path
+  crashed with `ENOENT ... skills/onboard/frontmatter.md` on every run:
+  `frontmatter.md` was folded into `skills/onboard/SKILL.md` in the
+  plugin-first onboarding change (0.2.0) without updating `setup.ts`, so every
+  release 0.2.0–0.6.0 shipped the command broken. `setup` now installs
+  `SKILL.md` directly (rewriting only the frontmatter `name` to match the
+  installed `understudy-onboard` directory) and copies the per-stack recipes
+  and reference docs alongside it, mirroring `skills/onboard/` so relative
+  links keep working. README now presents the Claude Code plugin install as
+  the primary path with `understudy setup` as the legacy loose-copy fallback.
+
 ## [0.6.0] — 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,15 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
   `frontmatter.md` was folded into `skills/onboard/SKILL.md` in the
   plugin-first onboarding change (0.2.0) without updating `setup.ts`, so every
   release 0.2.0–0.6.0 shipped the command broken. `setup` now installs
-  `SKILL.md` directly (rewriting only the frontmatter `name` to match the
-  installed `understudy-onboard` directory) and copies the per-stack recipes
-  and reference docs alongside it, mirroring `skills/onboard/` so relative
-  links keep working. README now presents the Claude Code plugin install as
-  the primary path with `understudy setup` as the legacy loose-copy fallback.
+  `SKILL.md` directly, rewriting the frontmatter `name` to match the installed
+  `understudy-onboard` directory and the `description` to carry both trigger
+  surfaces the loose copy serves (first-run onboarding *and* the historical
+  "convert to Understudy" / "add GEPA" conversion phrases), appending a short
+  routing section that points conversion requests at `setup-code.md`, and
+  copying the per-stack recipes and reference docs alongside it, mirroring
+  `skills/onboard/` so relative links keep working. README now presents the
+  Claude Code plugin install as the primary path with `understudy setup` as
+  the legacy loose-copy fallback.
 
 ## [0.6.0] — 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -418,15 +418,22 @@ email-code prompt by reading the fresh Understudy sign-in email directly. The
 agent should search only for the current login email, use the code once, and not
 print the code or retain it in artifacts.
 
-For agent-led onboarding, run:
+For agent-led onboarding in Claude Code, install the plugin from a clone of
+this repo (see [Install as a Claude Code plugin](#install-as-a-claude-code-plugin)):
 
 ```bash
-understudy setup
+claude plugin marketplace add /path/to/understudy-agent-tools
+claude plugin install understudy@understudy-skills
 ```
 
-Then ask the coding agent to convert the current repo to Understudy or add a
-thin GEPA/DSPy optimizer. The installed onboarding skill starts by checking
-`understudy status --json` and stops with a clear login instruction if
+Then run `/reload-plugins` and `/understudy:onboard`. For agents that read
+loose `.claude/skills/` directories but not plugins, `understudy setup` remains
+as the legacy fallback: it copies the onboarding skill into `./.claude/skills/`
+(`--global` for `~/.claude/skills/`).
+
+Either way, then ask the coding agent to convert the current repo to Understudy
+or add a thin GEPA/DSPy optimizer. The installed onboarding skill starts by
+checking `understudy status --json` and stops with a clear login instruction if
 the user is not authenticated.
 
 ## Public Benchmark Golden Path

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -18,6 +18,38 @@ import { trackSetupCompleted } from "../internal/telemetry.js";
 
 const SKILL_NAME = "understudy-onboard";
 
+/**
+ * Frontmatter description for the installed copy. The plugin ships
+ * onboarding (`SKILL.md`) and code conversion (`setup-code.md` + per-stack
+ * recipes) as separate surfaces, but this loose copy is a single skill — and
+ * Claude-style skill discovery selects on the description. So it must carry
+ * both trigger sets: the first-run onboarding phrases from
+ * `skills/onboard/SKILL.md` and the conversion phrases from the historical
+ * pre-plugin frontmatter ("convert to Understudy", "add GEPA", ...).
+ */
+const INSTALLED_DESCRIPTION =
+  'Use as the engaging first-run experience right after installing Understudy — whenever a developer says "get started", "set me up", "I\'m new to this", "onboard me", or asks what Understudy is and where to begin — and to convert an existing application to route LLM calls through the Understudy gateway or add thin Understudy cookbooks such as a DSPy-style GEPA prompt optimizer. Use when the user asks to "convert to Understudy", "set up Understudy in this repo", "route through Understudy", "siphon traffic to Understudy", "add GEPA", "optimize this prompt", "improve this eval", or any similar phrasing about wiring up Understudy or using an Understudy API key from an agent. Onboarding profiles the machine and the developer, writes a durable ~/.understudy/profile.json, and hands off to the understudy orchestrator; conversion detects the SDK or framework in use (raw Anthropic SDK, raw OpenAI SDK, Mastra, Vercel AI SDK, LangChain, LlamaIndex, DSPy/GEPA, or anything else that speaks Anthropic/OpenAI wire shape) and applies the matching recipe.';
+
+/**
+ * Routing section appended to the installed SKILL.md body. The plugin build
+ * of the onboard skill never mentions the conversion recipes, so the flat
+ * legacy copy needs an explicit pointer from the skill body to the sibling
+ * files it ships with.
+ */
+const CONVERSION_ROUTING = `
+## Converting a repo to Understudy
+
+For "convert this to Understudy", "route through Understudy", "add GEPA", or
+any other request about wiring an application to the Understudy gateway,
+follow [setup-code.md](setup-code.md) in this directory. Its dispatch table
+picks the matching per-stack recipe shipped alongside this file:
+[anthropic-typescript.md](anthropic-typescript.md),
+[openai-typescript.md](openai-typescript.md),
+[mastra-typescript.md](mastra-typescript.md),
+[gepa-typescript.md](gepa-typescript.md),
+[universal-typescript.md](universal-typescript.md).
+`;
+
 interface SetupOpts {
   global?: boolean;
   force?: boolean;
@@ -67,20 +99,21 @@ async function runSetup(cmd: Command, opts: SetupOpts): Promise<void> {
 
   mkdirSync(destRoot, { recursive: true });
 
-  // Write the master SKILL.md straight from the bundled onboarding skill.
-  // `skills/onboard/SKILL.md` carries its own frontmatter (name/description
-  // + body); only the skill name is rewritten so it matches the installed
-  // directory name.
+  // Write the master SKILL.md from the bundled onboarding skill, with three
+  // legacy-copy adjustments: the frontmatter name matches the installed
+  // directory, the description covers both onboarding and conversion
+  // triggers, and the body ends with a routing section for the conversion
+  // recipes shipped alongside.
   const skillSource = readFileSync(
     join(skillsSource, "onboard", "SKILL.md"),
     "utf8",
   );
   const skillPath = join(destRoot, "SKILL.md");
-  writeFileSync(
-    skillPath,
-    skillSource.replace(/^name:.*$/m, `name: ${SKILL_NAME}`),
-    "utf8",
-  );
+  const installedSkill = `${skillSource
+    .replace(/^name:.*$/m, `name: ${SKILL_NAME}`)
+    .replace(/^description:.*$/m, `description: ${INSTALLED_DESCRIPTION}`)
+    .trimEnd()}\n${CONVERSION_ROUTING}`;
+  writeFileSync(skillPath, installedSkill, "utf8");
 
   // Copy the supporting docs (per-target recipes, setup-code task,
   // reference.md) next to SKILL.md, mirroring `skills/onboard/` so relative

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -33,11 +33,11 @@ interface SetupOpts {
  * `install-agent-adapter` skill, which handles Claude Code, Cursor, Codex, and
  * OpenCode without copying skill content per platform.
  *
- * The skill content (master task + per-target recipes) is shipped
- * inside the CLI at `dist/skills/` (copied from repo-root `skills/`
- * by the build script). This means a user who just installed `understudy` via
- * curl or npm has the latest skill content embedded — no separate
- * download, no network dependency at install time.
+ * The skill content (`SKILL.md` + per-target recipes) ships inside the
+ * package at `skills/` (with a `dist/skills/` fallback for older layouts).
+ * This means a user who just installed `understudy` via curl or npm has the
+ * latest skill content embedded — no separate download, no network dependency
+ * at install time.
  */
 export function registerSetupCommand(program: Command): void {
   program
@@ -66,29 +66,34 @@ async function runSetup(cmd: Command, opts: SetupOpts): Promise<void> {
     : join(process.cwd(), ".claude", "skills", SKILL_NAME);
 
   mkdirSync(destRoot, { recursive: true });
-  mkdirSync(join(destRoot, "references"), { recursive: true });
 
-  // Write the master SKILL.md = frontmatter + focused setup-code recipe.
-  const frontmatter = readFileSync(
-    join(skillsSource, "onboard", "frontmatter.md"),
-    "utf8",
-  );
-  const taskBody = readFileSync(
-    join(skillsSource, "onboard", "setup-code.md"),
+  // Write the master SKILL.md straight from the bundled onboarding skill.
+  // `skills/onboard/SKILL.md` carries its own frontmatter (name/description
+  // + body); only the skill name is rewritten so it matches the installed
+  // directory name.
+  const skillSource = readFileSync(
+    join(skillsSource, "onboard", "SKILL.md"),
     "utf8",
   );
   const skillPath = join(destRoot, "SKILL.md");
-  writeFileSync(skillPath, `${frontmatter.trimEnd()}\n\n${taskBody}`, "utf8");
+  writeFileSync(
+    skillPath,
+    skillSource.replace(/^name:.*$/m, `name: ${SKILL_NAME}`),
+    "utf8",
+  );
 
-  // Copy every per-target recipe into references/. We don't pick by
-  // language here — the agent reads the dispatch table in SKILL.md and
-  // picks the right recipe at run time. Shipping all of them lets the
-  // agent handle whichever stack the user actually has.
+  // Copy the supporting docs (per-target recipes, setup-code task,
+  // reference.md) next to SKILL.md, mirroring `skills/onboard/` so relative
+  // links keep working. We don't pick by language here — the agent reads the
+  // dispatch table and picks the right recipe at run time. Shipping all of
+  // them lets the agent handle whichever stack the user actually has.
   const recipesDir = join(skillsSource, "onboard");
-  const recipeFiles = readdirSync(recipesDir).filter((f) => f.endsWith(".md") && f !== "frontmatter.md");
+  const recipeFiles = readdirSync(recipesDir).filter(
+    (f) => f.endsWith(".md") && f !== "SKILL.md",
+  );
   const referencePaths: string[] = [];
   for (const filename of recipeFiles) {
-    const dest = join(destRoot, "references", filename);
+    const dest = join(destRoot, filename);
     copyFileSync(join(recipesDir, filename), dest);
     referencePaths.push(dest);
   }

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -1094,6 +1094,45 @@ describe("understudy CLI", () => {
     assert.equal(payload.skill, "skills/onboard/setup-code.md");
     assert.equal(payload.recipe, "skills/onboard/openai-typescript.md");
     assert.equal(payload.file_hint, "src/client.ts");
+  });
+
+  it("installs a valid onboarding skill copy via setup", () => {
+    // realpathSync: the CLI reports paths from the resolved cwd, and macOS
+    // tmpdir() is a symlink (/var -> /private/var).
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), "understudy-setup-")));
+    const home = realpathSync(mkdtempSync(join(tmpdir(), "understudy-setup-home-")));
+    try {
+      const result = runWithEnv(["setup", "--json"], { HOME: home, USERPROFILE: home }, repo);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.ok, true);
+      const skillPath = join(repo, ".claude", "skills", "understudy-onboard", "SKILL.md");
+      assert.equal(payload.skill_path, skillPath);
+      // The installed SKILL.md must be a valid Claude skill: frontmatter with
+      // a name matching the install directory, plus a description and body.
+      const skill = readFileSync(skillPath, "utf8");
+      assert.match(skill, /^---\nname: understudy-onboard\n/);
+      assert.match(skill, /\ndescription: .+/);
+      // Per-stack recipes ship alongside SKILL.md.
+      assert.ok(payload.references.length > 0);
+      assert.ok(payload.references.some((ref) => ref.endsWith("openai-typescript.md")));
+      for (const ref of payload.references) {
+        assert.ok(existsSync(ref), `missing reference ${ref}`);
+      }
+
+      const globalResult = runWithEnv(
+        ["setup", "--global", "--json"],
+        { HOME: home, USERPROFILE: home },
+        repo,
+      );
+      assert.equal(globalResult.status, 0, globalResult.stderr);
+      assert.ok(
+        existsSync(join(home, ".claude", "skills", "understudy-onboard", "SKILL.md")),
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it("exposes model routing commands in the public CLI", () => {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1113,6 +1113,15 @@ describe("understudy CLI", () => {
       const skill = readFileSync(skillPath, "utf8");
       assert.match(skill, /^---\nname: understudy-onboard\n/);
       assert.match(skill, /\ndescription: .+/);
+      // The description must trigger on both surfaces this copy serves:
+      // first-run onboarding and repo conversion (the README flow says
+      // "run understudy setup, then ask the agent to convert this repo").
+      const description = skill.match(/\ndescription: (.+)/)[1];
+      assert.match(description, /onboard me/);
+      assert.match(description, /convert to Understudy/);
+      // The body must route conversion requests to the sibling recipes.
+      assert.match(skill, /\[setup-code\.md\]\(setup-code\.md\)/);
+      assert.match(skill, /\[openai-typescript\.md\]\(openai-typescript\.md\)/);
       // Per-stack recipes ship alongside SKILL.md.
       assert.ok(payload.references.length > 0);
       assert.ok(payload.references.some((ref) => ref.endsWith("openai-typescript.md")));


### PR DESCRIPTION
## Bug

`understudy setup` (and `setup --global`) crashes for every user:

```text
error: ENOENT: no such file or directory, open '.../skills/onboard/frontmatter.md'
```

## Root cause

`skills/onboard/frontmatter.md` was folded into a full `skills/onboard/SKILL.md` in b79e360 (PR #45, plugin-first onboarding, 2026-06-06), but `src/commands/setup.ts` was never updated: it still read `frontmatter.md` to assemble the installed skill and filtered recipe copies against it. The command has been broken at HEAD ever since, so every release from 0.2.0 through 0.6.0 shipped it broken. Reproduced on unpatched HEAD (c75d521 lineage) before fixing.

## Fix

Keep `setup` as the working legacy loose-copy path (deleting it outright is a product call for maintainers — see below):

- Install `skills/onboard/SKILL.md` directly instead of composing frontmatter + `setup-code.md`. The only transformation is rewriting the frontmatter `name` to `understudy-onboard` so it matches the installed directory, keeping the copy a valid Claude skill.
- Copy the supporting docs (per-stack recipes, `setup-code.md`, `reference.md`) alongside `SKILL.md`, mirroring `skills/onboard/` so relative links inside the skill keep working (previously they went into a `references/` subdir that broke them).
- README: the "First Auth Journey" onboarding pointer now leads with the plugin flow (`claude plugin marketplace add` + `claude plugin install understudy@understudy-skills`) and keeps `understudy setup` as the legacy fallback for agents that read loose `.claude/skills/` dirs.
- CHANGELOG entry under `[Unreleased]` → `Fixed`.

**Alternative considered:** removing the legacy command entirely now that `install-agent-adapter` / `install.sh --agents` is the primary path. Left as a maintainer decision; this PR just makes the shipped command work.

## Verification

- Reproduced the ENOENT crash on an unpatched build, then on the fixed build ran `node dist/bin.js setup` and `setup --global --json` against a temp cwd and temp `HOME` (real `~/.claude/skills` untouched): both exit 0, install `SKILL.md` with valid frontmatter (`name: understudy-onboard`, description, body) plus all 7 supporting .md files.
- Added a CLI test (`installs a valid onboarding skill copy via setup`) that runs the built binary against temp cwd/HOME and asserts exit status, JSON payload, frontmatter validity, and recipe presence.
- `npm run check` (build + typecheck + tests + skills:validate + package:smoke) passes: 154/154 tests. `git diff --check` clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->