### PR TITLE
docs: restructure README for scanability and faster time-to-value

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ evidence you can trust.**
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-docs.understudylabs.com-6e56cf)](https://docs.understudylabs.com)
 [![Skills](https://img.shields.io/badge/skill%20library-skills%2F-2ea44f)](skills/README.md)
+[![Backed by Y Combinator](https://img.shields.io/badge/backed%20by-Y%20Combinator-F0652F)](https://www.ycombinator.com)
 
 Works with **Claude Code** · **Cursor** · **Codex** · **OpenCode** · **Hermes Agent**
 

--- a/README.md
+++ b/README.md
@@ -1,103 +1,68 @@
-# understudy-agent-tools
+<div align="center">
 
-Public, MIT-licensed Understudy skill library and thin CLI.
+# Understudy Agent Tools
 
-This repo is the public skills surface for local-first AI workload evaluation,
-optimization planning, gateway handoff, and agent-led implementation. The CLI is
-thin TypeScript/Node: durable shortcuts, auth, artifact checks, and runtime
-wrappers that a coding agent can monitor.
+**Type `/understudy:onboard` in your coding agent and it walks your LLM app
+from captured traces to a measured, cheaper — often local — model, with
+evidence you can trust.**
 
-Understudy is agent-platform-neutral at the skill layer. Claude Code, Cursor,
-Codex, OpenCode, and Hermes Agent share the same [`skills/`](skills/) tree and only
-differ in a thin platform adapter: manifest, install path, reload step, and
-onboarding invocation. The current adapter registry is documented in
-[`docs/agent-platform-adapters.md`](docs/agent-platform-adapters.md) and exposed
-through `understudy platforms`.
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-docs.understudylabs.com-6e56cf)](https://docs.understudylabs.com)
+[![Skills](https://img.shields.io/badge/skill%20library-skills%2F-2ea44f)](skills/README.md)
 
-The OSS MVP loop is local-first and skill-led:
+Works with **Claude Code** · **Cursor** · **Codex** · **OpenCode** · **Hermes Agent**
 
-```text
-capture evidence -> attach harness/environment
-  -> confirm metric/validator/holdout -> rerun baseline
-  -> optimize workload -> conservative claim packet
-```
+</div>
 
-Registration is not required for that loop. Hosted gateway access is available
-after `understudy login`; browser, channel, daemon, and desktop-runtime
-commands remain outside this public CLI until intentionally extracted.
+---
 
-The hosted surface this CLI consumes is documented at
-[docs.understudylabs.com](https://docs.understudylabs.com) — see
-[open-source/agent-tools](https://docs.understudylabs.com/open-source/agent-tools)
-for how this repo fits the platform and
-[open-source/cli](https://docs.understudylabs.com/open-source/cli) for the
-command-level CLI reference. The skills here stay local-first; the docs site
-covers the hosted contracts behind them.
+Understudy is a public, MIT-licensed skill library plus a thin CLI. It gives
+your coding agent the playbooks to evaluate an AI workload locally, optimize
+it, and route it to a better-value model — **local-first, with no uploads, no
+provider calls, and nothing spent by default**.
 
-## Shape
-
-| Spine | Path | Purpose |
-| --- | --- | --- |
-| CLI | `src/` | Thin TypeScript shortcuts for auth, artifact checks, and durable runs. |
-| Skills | `skills/` | MVP progressive-disclosure agent playbooks. |
-| Docs | `docs/` | Public methodology and release-boundary notes. |
-| Platform adapters | `.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `.opencode/`, `.hermes/`, `.agents/`, `AGENTS.md` | Thin manifests or durable instructions that expose the same skill tree to each coding-agent surface. |
-| Scripts | `scripts/` | Repo hygiene checks, not product CLI code. |
-| Vendor | `vendor/` | Vendored or mirrored compatibility shims, with license metadata. |
-
-The CLI should stay boring. Workflow judgment belongs in skills;
-durable shortcuts belong in TypeScript only when the agent needs reliable
-execution, auth injection, artifact writes, or a safety gate.
-
-## Install Locally
-
-Fast first-run installer:
+## Get started (30 seconds)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash
 ```
 
-This installs the CLI, then asks where to install the local coding-agent plugin:
-Claude Code, Cursor, Codex, OpenCode, Hermes Agent, all detected agents, or CLI-only.
-Non-interactive installs keep the old script-friendly autodetect behavior. Override
-the prompt with `--agents auto|all|claude-code|cursor|codex|opencode|hermes|none`.
-
-| Agent harness | Default installer behavior | Activation |
-| --- | --- | --- |
-| Claude Code | Autodetected when `claude` is on `PATH`; installs the local Claude plugin. | Run `/reload-plugins`, then `/understudy:onboard`. |
-| Cursor | Autodetected when Cursor is present; links this repo into `~/.cursor/plugins/local/understudy`. | Restart Cursor or run **Developer: Reload Window**, then ask Cursor Agent to use the Understudy onboarding skill. |
-| Codex | Autodetected when `codex` is on `PATH`; registers the local Codex marketplace from `.agents/plugins/marketplace.json`. | Run `/plugins`, choose `understudy-skills`, install or enable `understudy`, then start a new thread if needed. |
-| OpenCode | Autodetected when `opencode` is on `PATH` or OpenCode config/data exists; links the shared skills into `~/.config/opencode/skills`. | Restart OpenCode or open a new TUI session, then run `/understudy-onboard`. |
-| Hermes Agent | Autodetected when `hermes` is on `PATH` or `~/.hermes` exists; registers a stable `~/.understudy/skills` symlink in `skills.external_dirs`. | Run `/reload-skills` (or start a new `hermes` session), then `/onboard` or ask Hermes to use the Understudy onboarding skill. |
-
-If Claude Code is selected, the installer opens Claude Code in the current
-directory. In Claude Code, run:
+The installer sets up the CLI, asks which coding agents to attach to (Claude
+Code, Cursor, Codex, OpenCode, Hermes Agent, all, or CLI-only), and — if you
+pick Claude Code — opens it in the current directory. Then:
 
 ```text
 /reload-plugins
 /understudy:onboard
 ```
 
-The installer intentionally does **not** download model weights, start MLX,
-launch the ladder server, or make frontier calls. Those belong inside the
-Claude Code skill flow, where the agent can explain the tradeoffs, ask consent,
-coach the user on opening their preferred terminal, and run the same commands
-itself when appropriate.
+That's it. Onboarding profiles your machine, interviews you about your
+workload, and starts the improvement loop. No registration required.
 
-For non-interactive installs, add `--yes`:
+> The installer intentionally does **not** download model weights, start MLX,
+> launch the ladder server, or make frontier calls. Those happen inside the
+> skill flow, where the agent explains tradeoffs and asks consent first.
+
+<details>
+<summary><b>Installer options: non-interactive, resume, agent selection, developer install</b></summary>
+
+Non-interactive installs keep script-friendly autodetect behavior:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --yes
 ```
 
+Override the agent prompt with
+`--agents auto|all|claude-code|cursor|codex|opencode|hermes|none`.
+
 The installer is resumable. It writes step markers under
-`~/.understudy/agent-tools/install-state`; after a failed run, use:
+`~/.understudy/agent-tools/install-state`; after a failed run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --resume
 ```
 
-You can also jump directly to a step:
+Or jump directly to a step:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --from-step 2
@@ -118,18 +83,91 @@ npm install -g @understudylabs/understudy-agent-tools
 understudy spine
 ```
 
-No provider calls, uploads, model downloads, secret-value inspection, or hosted
-jobs run by default. After authentication, the CLI emits bounded product
-telemetry documented in [`docs/telemetry.md`](docs/telemetry.md); disable it
-with `UNDERSTUDY_TELEMETRY=0`.
+</details>
 
-## Install as a Claude Code plugin
+## What it does
+
+- **Captures evidence** from your real LLM traffic — traces, transcripts, or a
+  public benchmark — into a local, redacted evidence base.
+- **Builds a real eval** — harness, environment, metric, validator, and
+  holdout — so improvements are measured, not vibed.
+- **Optimizes the workload** — prompt optimization (GEPA/DSPy), local model
+  labs, distillation, and RLM training, all runnable on your machine.
+- **Picks a route** — compare model sweeps, estimate hosted costs, then ramp a
+  percentage of traffic to a cheaper model while the rest stays on your
+  current provider.
+- **Ships a conservative claim packet** — what changed, how it was measured,
+  and what it saves, stated only as strongly as the evidence supports.
+
+The whole OSS loop runs locally and is skill-led:
+
+```mermaid
+flowchart LR
+    A["Capture<br/>evidence"] --> B["Attach harness +<br/>environment"]
+    B --> C["Confirm metric,<br/>validator, holdout"]
+    C --> D["Rerun<br/>baseline"]
+    D --> E["Optimize<br/>workload"]
+    E --> F["Conservative<br/>claim packet"]
+```
+
+Registration is not required for that loop. Hosted gateway access is available
+after `understudy login`; browser, channel, daemon, and desktop-runtime
+commands remain outside this public CLI until intentionally extracted.
+
+## How it's built
+
+Understudy is **agent-platform-neutral at the skill layer**. All five
+supported coding agents share the same [`skills/`](skills/) tree and differ
+only in a thin adapter: manifest, install path, reload step, and onboarding
+invocation. The adapter registry lives in
+[`docs/agent-platform-adapters.md`](docs/agent-platform-adapters.md) and is
+exposed through `understudy platforms`.
+
+| Spine | Path | Purpose |
+| --- | --- | --- |
+| CLI | `src/` | Thin TypeScript shortcuts for auth, artifact checks, and durable runs. |
+| Skills | `skills/` | MVP progressive-disclosure agent playbooks — **the product**. |
+| Docs | `docs/` | Public methodology and release-boundary notes. |
+| Platform adapters | `.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `.opencode/`, `.hermes/`, `.agents/`, `AGENTS.md` | Thin manifests exposing the same skill tree to each coding-agent surface. |
+| Scripts | `scripts/` | Repo hygiene checks, not product CLI code. |
+| Vendor | `vendor/` | Vendored or mirrored compatibility shims, with license metadata. |
+
+The CLI stays boring on purpose. Workflow judgment belongs in skills; durable
+shortcuts belong in TypeScript only when the agent needs reliable execution,
+auth injection, artifact writes, or a safety gate.
+
+The hosted surface this CLI consumes is documented at
+[docs.understudylabs.com](https://docs.understudylabs.com) — see
+[open-source/agent-tools](https://docs.understudylabs.com/open-source/agent-tools)
+for how this repo fits the platform and
+[open-source/cli](https://docs.understudylabs.com/open-source/cli) for the
+command-level CLI reference.
+
+## Pick your platform
+
+The installer autodetects these; each can also be set up by hand. The
+[`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill contains
+the agent-run install/update/verify flow for every platform.
+
+| Agent harness | Default installer behavior | Activation |
+| --- | --- | --- |
+| Claude Code | Autodetected when `claude` is on `PATH`; installs the local Claude plugin. | Run `/reload-plugins`, then `/understudy:onboard`. |
+| Cursor | Autodetected when Cursor is present; links this repo into `~/.cursor/plugins/local/understudy`. | Restart Cursor or run **Developer: Reload Window**, then ask Cursor Agent to use the Understudy onboarding skill. |
+| Codex | Autodetected when `codex` is on `PATH`; registers the local Codex marketplace from `.agents/plugins/marketplace.json`. | Run `/plugins`, choose `understudy-skills`, install or enable `understudy`, then start a new thread if needed. |
+| OpenCode | Autodetected when `opencode` is on `PATH` or OpenCode config/data exists; links the shared skills into `~/.config/opencode/skills`. | Restart OpenCode or open a new TUI session, then run `/understudy-onboard`. |
+| Hermes Agent | Autodetected when `hermes` is on `PATH` or `~/.hermes` exists; registers a stable `~/.understudy/skills` symlink in `skills.external_dirs`. | Run `/reload-skills` (or start a new `hermes` session), then `/onboard` or ask Hermes to use the Understudy onboarding skill. |
+
+Every path is local-only: installing an adapter does not authenticate, upload
+data, download model weights, or make provider calls.
+
+<details>
+<summary><b>Claude Code — install as a plugin (recommended)</b></summary>
 
 The skills in [`skills/`](skills/) ship as a Claude Code plugin, declared in
 [`.claude-plugin/`](.claude-plugin/) (`plugin.json` + `marketplace.json`).
-Installing it registers the public invocable skills in [`skills/`](skills/),
-including the `understudy` orchestrator, onboarding, capture/eval, optimization,
-local model, distillation, RLM, and verifier-handoff workers.
+Installing it registers the public invocable skills, including the
+`understudy` orchestrator, onboarding, capture/eval, optimization, local
+model, distillation, RLM, and verifier-handoff workers.
 
 From a clone of this repo:
 
@@ -151,8 +189,8 @@ agent guides the first local model, launches the ladder climb, and handles any
 frontier comparison with explicit consent.
 
 Installing as a plugin is the recommended way to use Understudy: the skills are
-what let a coding agent explain what Understudy is and walk you from a trace to a
-shipped improvement. It is also fully reversible —
+what let a coding agent explain what Understudy is and walk you from a trace to
+a shipped improvement. It is also fully reversible —
 
 ```bash
 claude plugin uninstall understudy@understudy-skills
@@ -161,9 +199,12 @@ claude plugin marketplace remove understudy-skills
 
 — and nothing outside Claude Code's plugin registry is touched.
 
-## Install as a Cursor plugin
+</details>
 
-The same skills also ship as a Cursor plugin, declared in
+<details>
+<summary><b>Cursor — install as a plugin</b></summary>
+
+The same skills ship as a Cursor plugin, declared in
 [`.cursor-plugin/plugin.json`](.cursor-plugin/plugin.json). Cursor discovers
 the repo's existing [`skills/`](skills/) tree from the plugin root, so there is
 no Cursor-specific fork of the playbooks.
@@ -185,15 +226,18 @@ rm -f ~/.cursor/plugins/local/understudy
 The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
 contains the agent-run install/update/verify flow; ask for platform `cursor`.
 The older [`install-cursor-plugin`](skills/install-cursor-plugin/SKILL.md) skill
-remains as a compatibility shim. This path is local-only: adding the plugin does
-not authenticate, upload data, download model weights, or make provider calls.
+remains as a compatibility shim.
 
-## Install as a Codex plugin
+</details>
+
+<details>
+<summary><b>Codex — install as a plugin</b></summary>
 
 The same skills ship as a Codex plugin, declared in
 [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json) and exposed through the
-repo marketplace at [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
-The plugin points at the repo's existing [`skills/`](skills/) tree.
+repo marketplace at
+[`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json). The
+plugin points at the repo's existing [`skills/`](skills/) tree.
 
 From a clone of this repo:
 
@@ -205,9 +249,8 @@ Then open Codex, run `/plugins`, choose the `understudy-skills` marketplace, and
 install or enable the `understudy` plugin. The
 [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill contains
 the agent-run registration/verify flow; ask for platform `codex`. The older
-[`install-codex-plugin`](skills/install-codex-plugin/SKILL.md) skill remains as a
-compatibility shim. This path is local-only: registering the marketplace does not
-authenticate, upload data, download model weights, or make provider calls.
+[`install-codex-plugin`](skills/install-codex-plugin/SKILL.md) skill remains as
+a compatibility shim.
 
 To remove the marketplace registration:
 
@@ -215,15 +258,18 @@ To remove the marketplace registration:
 codex plugin marketplace remove understudy-skills
 ```
 
-`AGENTS.md` remains repo guidance for Codex, but the Codex plugin is the reusable
-distribution unit for the skills.
+`AGENTS.md` remains repo guidance for Codex, but the Codex plugin is the
+reusable distribution unit for the skills.
 
-## Install as OpenCode skills
+</details>
 
-OpenCode loads `SKILL.md` files natively. This repo exposes the shared skill tree
-through [`.opencode/skills`](.opencode/skills), a symlink to [`skills/`](skills/),
-and ships a small [`/understudy-onboard`](.opencode/commands/understudy-onboard.md)
-command.
+<details>
+<summary><b>OpenCode — install as skills</b></summary>
+
+OpenCode loads `SKILL.md` files natively. This repo exposes the shared skill
+tree through [`.opencode/skills`](.opencode/skills), a symlink to
+[`skills/`](skills/), and ships a small
+[`/understudy-onboard`](.opencode/commands/understudy-onboard.md) command.
 
 This is an OpenCode skills/commands adapter, not an OpenCode JS/TS plugin.
 OpenCode plugins are for lifecycle hooks and custom behavior; Understudy only
@@ -255,10 +301,9 @@ Then restart OpenCode or open a new TUI session and run:
 The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
 contains the agent-run install/update/verify flow; ask for platform `opencode`.
 The older [`install-opencode-plugin`](skills/install-opencode-plugin/SKILL.md)
-skill remains as a compatibility shim for the old name. This path is local-only:
-linking the skills does not authenticate, upload data, download model weights,
-or make provider calls. Because symlink targets can live outside the current
-project, OpenCode may ask before reading linked external resources.
+skill remains as a compatibility shim for the old name. Because symlink targets
+can live outside the current project, OpenCode may ask before reading linked
+external resources.
 
 To remove Understudy-owned symlinks:
 
@@ -267,16 +312,20 @@ find ~/.config/opencode/skills -type l -lname '*/understudy-agent-tools/skills/*
 rm -f ~/.config/opencode/commands/understudy-onboard.md
 ```
 
-## Install as Hermes skills
+</details>
+
+<details>
+<summary><b>Hermes Agent — install as skills</b></summary>
 
 Hermes Agent (Nous Research) loads `SKILL.md` files natively and scans any
-directory listed in `skills.external_dirs` in `~/.hermes/config.yaml`. The shared
-skill tree already ships valid Hermes skills, so the adapter registers the
-directory rather than copying it. To keep the config entry stable across checkout
-or package moves, it registers a durable `~/.understudy/skills` symlink to
-[`skills/`](skills/) — a path indirection, not a fork.
-[`.hermes/adapter.json`](.hermes/adapter.json) is an Understudy version/staleness
-sentinel for release checks, not a manifest consumed by Hermes.
+directory listed in `skills.external_dirs` in `~/.hermes/config.yaml`. The
+shared skill tree already ships valid Hermes skills, so the adapter registers
+the directory rather than copying it. To keep the config entry stable across
+checkout or package moves, it registers a durable `~/.understudy/skills`
+symlink to [`skills/`](skills/) — a path indirection, not a fork.
+[`.hermes/adapter.json`](.hermes/adapter.json) is an Understudy
+version/staleness sentinel for release checks, not a manifest consumed by
+Hermes.
 
 For global local testing from a clone:
 
@@ -310,10 +359,8 @@ Then, in Hermes, rescan without restarting and start onboarding:
 
 The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
 contains the agent-run install/update/verify flow; ask for platform `hermes`.
-This path is local-only: registering the skills does not authenticate, upload
-data, download model weights, or make provider calls. Local `~/.hermes/skills/`
-entries win on name conflicts, so a few generically named skills may be shadowed
-by Hermes bundled skills.
+Local `~/.hermes/skills/` entries win on name conflicts, so a few generically
+named skills may be shadowed by Hermes bundled skills.
 
 To remove the registration, drop the entry from `skills.external_dirs` and the
 symlink:
@@ -334,7 +381,7 @@ PY
 [ -L "$LINK" ] && rm -f "$LINK"
 ```
 
-## Agent Platform Adapters
+</details>
 
 Use the platform registry to see the current install/reload surface across
 agent clients:
@@ -342,138 +389,47 @@ agent clients:
 ```bash
 understudy platforms
 understudy platforms --inspect claude-code
-understudy platforms --inspect cursor
-understudy platforms --inspect opencode
 understudy --json platforms
 ```
 
-Claude Code, Cursor, Codex, OpenCode, and Hermes Agent are supported adapters. All
-five reuse the same `skills/` tree instead of copying platform-specific skill
-content.
-
-## First Commands
+## First commands
 
 ```bash
-understudy spine
-understudy skills --list
+understudy spine              # prints the public workflow
+understudy skills --list      # list every installed skill
 understudy skills --search gateway
-understudy platforms
-understudy doctor
+understudy platforms          # supported agent adapters
+understudy doctor             # local environment check
 ```
 
 `spine` prints the public workflow and points agents at
 `skills/understudy/SKILL.md`.
 
-## First Auth Journey
+## The skill tree
 
-The first hosted journey is intentionally narrow:
+`skills/understudy/SKILL.md` is the public entrypoint. It routes to exactly
+one capability worker per intent, grouped by journey stage; deeper playbooks
+live in each skill's `references/` directory:
 
-```bash
-understudy login --email you@company.com   # emails a one-time code
-understudy login --code 123456             # completes sign-in (non-TTY shells)
-understudy doctor --hosted
-understudy workloads list
-understudy workloads create classify --capture
-understudy gateway probe --provider anthropic --project rehearsal --workload classify
-understudy captures list --project rehearsal --workload classify
-understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
-understudy routes show classify --project rehearsal
-understudy routes clear classify --project rehearsal
-```
-
-`login --email` uses the Understudy email-code registration flow. In an
-interactive terminal it prompts for the code inline; in a non-TTY shell (a
-coding agent, a script) it sends the code and exits, and `login --code`
-completes the pending sign-in — so an agent can drive sign-up as two plain
-shell commands. It stores the
-returned `sk_*` in `~/.understudy/credentials.json` with mode `600` and writes a
-repo-local `.understudy/config.json` when the platform returns a default
-project. `run` injects `UNDERSTUDY_API_KEY`, `UNDERSTUDY_GATEWAY_URL`, and the
-non-secret `UNDERSTUDY_ORG_ID` when known into the child process; do not copy
-secrets into repo files or chat output.
-`doctor --hosted` checks credentials, gateway health, projects, keys, models,
-and workloads without provider calls. `gateway probe` is an explicit tiny live
-call and prints request metadata, not the completion text. If you need BYOK for
-the probe, pass `--byok-env ENV_NAME`; the CLI reads the key from the
-environment and never persists or prints it. `captures list/get` are
-metadata-first and redacted by default. Full capture export is opt-in,
-file-only, and requires `--include-payload --yes`. `models list` shows public
-Understudy model IDs and display names only. `routes set/clear` writes
-control-plane route config, so the application keeps calling the normal gateway
-while a percentage of traffic goes to the selected Understudy model and the
-rest remains passthrough/frontier.
-
-The hosted contracts behind these commands are documented on the docs site: the
-[control-plane API](https://docs.understudylabs.com/reference/control-plane)
-(what `workloads`, `routes`, and `captures` call), the
-[routing](https://docs.understudylabs.com/concepts/routing) and
-[capture](https://docs.understudylabs.com/concepts/capture) semantics, the
-gateway [request headers](https://docs.understudylabs.com/reference/request-headers)
-and [response headers](https://docs.understudylabs.com/reference/response-headers),
-and the [CLI command reference](https://docs.understudylabs.com/open-source/cli)
-for every command in the journey above.
-
-If the coding agent has an approved native email connector, it may complete the
-email-code prompt by reading the fresh Understudy sign-in email directly. The
-agent should search only for the current login email, use the code once, and not
-print the code or retain it in artifacts.
-
-For agent-led onboarding in Claude Code, install the plugin from a clone of
-this repo (see [Install as a Claude Code plugin](#install-as-a-claude-code-plugin)):
-
-```bash
-claude plugin marketplace add /path/to/understudy-agent-tools
-claude plugin install understudy@understudy-skills
-```
-
-Then run `/reload-plugins` and `/understudy:onboard`. For agents that read
-loose `.claude/skills/` directories but not plugins, `understudy setup` remains
-as the legacy fallback: it copies the onboarding skill into `./.claude/skills/`
-(`--global` for `~/.claude/skills/`).
-
-Either way, then ask the coding agent to convert the current repo to Understudy
-or add a thin GEPA/DSPy optimizer. The installed onboarding skill starts by
-checking `understudy status --json` and stops with a clear login instruction if
-the user is not authenticated.
-
-## Public Benchmark Golden Path
-
-For a public demo or agent smoke test, use the public-benchmark on-ramp in
-[`skills/capture-evidence/references/public-benchmark-path.md`](skills/capture-evidence/references/public-benchmark-path.md).
-It points agents at public upstream benchmarks such as
-[Zapier AutomationBench](https://github.com/zapier/AutomationBench) and
-[Harvey LAB](https://github.com/harveyai/harvey-labs). Keep benchmark harnesses
-upstream; use Understudy for capture, splits, baselines, optimization, and
-conservative claims.
-
-## Skill Tree
-
-`skills/understudy/SKILL.md` is the public entrypoint. It routes to exactly one
-capability worker per intent. The workers are grouped by journey stage; deeper
-playbooks live in each skill's `references/` directory:
-
-- **Setup & first run** — install-agent-adapter, compatibility install shims,
-  onboard, ladder (the onboarding "climb")
-- **Understand & capture** — understand-workload, ingest-traces (incl. the
-  capture-directory profiler), capture-evidence (incl. the public-benchmark
-  on-ramp), design-simulated-environment
-- **Local models** — manage-local-models, run-local-model-lab,
-  recursive-language-model (incl. RLM pedagogical training)
-- **Compare & diagnose** — compare-model-sweep, compare-trajectories
-- **Plan hosted runs** — plan-hosted-run (provider routing + cost estimation)
-- **Optimize** — optimize-workload, optimize-agentic-workload (read-only
-  search loops and state-mutating API workflows)
-- **Train locally** — curate-trajectories, distill-classifier,
-  local-distillation-lab (incl. the pedagogical arm)
-- **RL handoff** — prepare-verifier-handoff (decide → author env → package →
-  hand off)
-- **Gateway & routing** — use-understudy-gateway (incl. the frontier-keys
-  decision), ramp-and-verify
+| Stage | Skills |
+| --- | --- |
+| **Setup & first run** | install-agent-adapter, compatibility install shims, onboard, ladder (the onboarding "climb") |
+| **Understand & capture** | understand-workload, ingest-traces (incl. the capture-directory profiler), capture-evidence (incl. the public-benchmark on-ramp), design-simulated-environment |
+| **Local models** | manage-local-models, run-local-model-lab, recursive-language-model (incl. RLM pedagogical training) |
+| **Compare & diagnose** | compare-model-sweep, compare-trajectories |
+| **Plan hosted runs** | plan-hosted-run (provider routing + cost estimation) |
+| **Optimize** | optimize-workload, optimize-agentic-workload (read-only search loops and state-mutating API workflows) |
+| **Train locally** | curate-trajectories, distill-classifier, local-distillation-lab (incl. the pedagogical arm) |
+| **RL handoff** | prepare-verifier-handoff (decide → author env → package → hand off) |
+| **Gateway & routing** | use-understudy-gateway (incl. the frontier-keys decision), ramp-and-verify |
 
 [`skills/README.md`](skills/README.md) is the authoritative index with
 per-skill descriptions — keep it in sync when adding skills. See
 [`docs/current-functionality.md`](docs/current-functionality.md) for the
 migration ledger.
+
+<details>
+<summary><b>Skill design notes: handoff-only skills, optimizer boundary, benchmarks</b></summary>
 
 `prepare-verifier-handoff` is intentionally handoff-only. It is for workloads
 that need a future Understudy verifier/RL-environment release or an external
@@ -488,9 +444,95 @@ the evidence-ladder methodology behind it in
 TypeScript-to-`uv` Python bridge pattern is documented in
 [`docs/uv-python-bridge.md`](docs/uv-python-bridge.md).
 
-## CLI Surface
+**Public benchmark golden path.** For a public demo or agent smoke test, use
+the public-benchmark on-ramp in
+[`skills/capture-evidence/references/public-benchmark-path.md`](skills/capture-evidence/references/public-benchmark-path.md).
+It points agents at public upstream benchmarks such as
+[Zapier AutomationBench](https://github.com/zapier/AutomationBench) and
+[Harvey LAB](https://github.com/harveyai/harvey-labs). Keep benchmark harnesses
+upstream; use Understudy for capture, splits, baselines, optimization, and
+conservative claims.
 
-The TypeScript CLI currently owns the public tools surface:
+</details>
+
+## Going hosted (optional)
+
+Everything above runs without an account. When you want the hosted gateway,
+the first auth journey is intentionally narrow:
+
+```bash
+understudy login --email you@company.com   # emails a one-time code
+understudy login --code 123456             # completes sign-in (non-TTY shells)
+understudy doctor --hosted
+understudy workloads list
+understudy workloads create classify --capture
+understudy gateway probe --provider anthropic --project rehearsal --workload classify
+understudy captures list --project rehearsal --workload classify
+understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
+understudy routes show classify --project rehearsal
+understudy routes clear classify --project rehearsal
+```
+
+`routes set` writes control-plane route config: your application keeps calling
+the normal gateway while a percentage of traffic goes to the selected
+Understudy model and the rest remains passthrough/frontier.
+
+<details>
+<summary><b>How login, doctor, probes, captures, and routes behave</b></summary>
+
+`login --email` uses the Understudy email-code registration flow. In an
+interactive terminal it prompts for the code inline; in a non-TTY shell (a
+coding agent, a script) it sends the code and exits, and `login --code`
+completes the pending sign-in — so an agent can drive sign-up as two plain
+shell commands. It stores the returned `sk_*` in
+`~/.understudy/credentials.json` with mode `600` and writes a repo-local
+`.understudy/config.json` when the platform returns a default project. `run`
+injects `UNDERSTUDY_API_KEY`, `UNDERSTUDY_GATEWAY_URL`, and the non-secret
+`UNDERSTUDY_ORG_ID` when known into the child process; do not copy secrets
+into repo files or chat output.
+
+`doctor --hosted` checks credentials, gateway health, projects, keys, models,
+and workloads without provider calls. `gateway probe` is an explicit tiny live
+call and prints request metadata, not the completion text. If you need BYOK for
+the probe, pass `--byok-env ENV_NAME`; the CLI reads the key from the
+environment and never persists or prints it. `captures list/get` are
+metadata-first and redacted by default. Full capture export is opt-in,
+file-only, and requires `--include-payload --yes`. `models list` shows public
+Understudy model IDs and display names only.
+
+If the coding agent has an approved native email connector, it may complete the
+email-code prompt by reading the fresh Understudy sign-in email directly. The
+agent should search only for the current login email, use the code once, and
+not print the code or retain it in artifacts.
+
+The hosted contracts behind these commands are documented on the docs site: the
+[control-plane API](https://docs.understudylabs.com/reference/control-plane)
+(what `workloads`, `routes`, and `captures` call), the
+[routing](https://docs.understudylabs.com/concepts/routing) and
+[capture](https://docs.understudylabs.com/concepts/capture) semantics, the
+gateway [request headers](https://docs.understudylabs.com/reference/request-headers)
+and [response headers](https://docs.understudylabs.com/reference/response-headers),
+and the [CLI command reference](https://docs.understudylabs.com/open-source/cli)
+for every command in the journey above.
+
+For agents that read loose `.claude/skills/` directories but not plugins,
+`understudy setup` remains as the legacy fallback: it copies the onboarding
+skill into `./.claude/skills/` (`--global` for `~/.claude/skills/`). Either
+way, then ask the coding agent to convert the current repo to Understudy or
+add a thin GEPA/DSPy optimizer. The installed onboarding skill starts by
+checking `understudy status --json` and stops with a clear login instruction
+if the user is not authenticated.
+
+</details>
+
+## CLI reference
+
+The TypeScript CLI currently owns the public tools surface. Every command
+accepts the global `--json` flag (before or after the subcommand) and emits
+machine-readable JSON where supported.
+
+<details>
+<summary><b>Full command list and CLI boundaries</b></summary>
 
 ```text
 spine
@@ -519,9 +561,6 @@ experiments
 next
 ```
 
-Every command accepts the global `--json` flag (before or after the
-subcommand) and emits machine-readable JSON where supported.
-
 `setup-code` is skill-routed. It does not patch files directly; it tells the
 coding agent to use `skills/onboard/setup-code.md` and the matching framework
 recipe.
@@ -548,7 +587,14 @@ must not be committed.
 For the exact before/after functionality ledger, see
 [`docs/current-functionality.md`](docs/current-functionality.md).
 
-## Public Boundary
+</details>
+
+## Privacy
+
+No provider calls, uploads, model downloads, secret-value inspection, or
+hosted jobs run by default. After authentication, the CLI emits bounded
+product telemetry documented in [`docs/telemetry.md`](docs/telemetry.md);
+disable it with `UNDERSTUDY_TELEMETRY=0`.
 
 Read the full policies:
 
@@ -556,28 +602,25 @@ Read the full policies:
 - [`docs/security.md`](docs/security.md)
 - [`docs/telemetry.md`](docs/telemetry.md)
 - [`docs/oss-release-boundary.md`](docs/oss-release-boundary.md)
-- [`docs/release-checklist.md`](docs/release-checklist.md)
 
+## Contributing
+
+Agent and contributor conventions live in [`AGENTS.md`](AGENTS.md); the
+release process in [`docs/release-checklist.md`](docs/release-checklist.md).
 Release archives should pass:
 
 ```bash
 npm run check
 ```
 
-Do not commit:
+**Do not commit:** customer names, domains, prompts, completions, traces, or
+datasets; private repo paths or internal-only runbooks; API keys, tokens,
+provider secrets, or local env files; hosted production URLs except documented
+public defaults.
 
-- customer names, domains, prompts, completions, traces, or datasets
-- private repo paths or internal-only runbooks
-- API keys, tokens, provider secrets, or local env files
-- hosted production URLs except documented public defaults
-
-Do commit:
-
-- local-only TypeScript CLI code
-- public agent skills
-- synthetic templates and docs
-- vendored shims with license metadata
-- reproducible command outputs that do not contain private payloads
+**Do commit:** local-only TypeScript CLI code, public agent skills, synthetic
+templates and docs, vendored shims with license metadata, and reproducible
+command outputs that do not contain private payloads.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Understudy Agent Tools
 
-**Type `/understudy:onboard` in your coding agent and it walks your LLM app
-from captured traces to a measured, cheaper — often local — model, with
-evidence you can trust.**
+**Type `/understudy:onboard` in Claude Code — or the matching onboarding
+command in your agent — and it walks your LLM app from captured traces to a
+measured, cheaper — often local — model, with evidence you can trust.**
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-docs.understudylabs.com-6e56cf)](https://docs.understudylabs.com)
@@ -30,7 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-too
 
 The installer sets up the CLI, asks which coding agents to attach to (Claude
 Code, Cursor, Codex, OpenCode, Hermes Agent, all, or CLI-only), and — if you
-pick Claude Code — opens it in the current directory. Then:
+pick Claude Code — opens it in the current directory. Then, in Claude Code:
 
 ```text
 /reload-plugins
@@ -38,7 +38,9 @@ pick Claude Code — opens it in the current directory. Then:
 ```
 
 That's it. Onboarding profiles your machine, interviews you about your
-workload, and starts the improvement loop. No registration required.
+workload, and starts the improvement loop. No registration required. On other
+agents the activation command differs slightly — see
+[Pick your platform](#pick-your-platform).
 
 > The installer intentionally does **not** download model weights, start MLX,
 > launch the ladder server, or make frontier calls. Those happen inside the
@@ -161,6 +163,7 @@ the agent-run install/update/verify flow for every platform.
 Every path is local-only: installing an adapter does not authenticate, upload
 data, download model weights, or make provider calls.
 
+<a id="install-as-a-claude-code-plugin"></a>
 <details>
 <summary><b>Claude Code — install as a plugin (recommended)</b></summary>
 
@@ -202,6 +205,7 @@ claude plugin marketplace remove understudy-skills
 
 </details>
 
+<a id="install-as-a-cursor-plugin"></a>
 <details>
 <summary><b>Cursor — install as a plugin</b></summary>
 
@@ -231,6 +235,7 @@ remains as a compatibility shim.
 
 </details>
 
+<a id="install-as-a-codex-plugin"></a>
 <details>
 <summary><b>Codex — install as a plugin</b></summary>
 
@@ -264,6 +269,7 @@ reusable distribution unit for the skills.
 
 </details>
 
+<a id="install-as-opencode-skills"></a>
 <details>
 <summary><b>OpenCode — install as skills</b></summary>
 
@@ -315,6 +321,7 @@ rm -f ~/.config/opencode/commands/understudy-onboard.md
 
 </details>
 
+<a id="install-as-hermes-skills"></a>
 <details>
 <summary><b>Hermes Agent — install as skills</b></summary>
 


### PR DESCRIPTION
## Why

We got feedback that the README is hard to understand compared to [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify). Theirs works because it leads with a one-sentence "what this does for you" hook, a 30-second quickstart, and progressive depth — short action sections up top, heavy reference collapsed below. Ours opened with abstract library framing ("public skills surface", "gateway handoff"), buried the install at line 52, and spent ~250 lines on five near-duplicate platform install walkthroughs.

## What changed

Structure only — every command snippet, link, and factual claim from the old README is preserved.

- **Header**: one-sentence tagline (what typing `/understudy:onboard` gets you), MIT/docs/skills badges, supported-agents line.
- **Get started (30 seconds)** moves to the top; installer flags, `--resume`, and developer install collapse into a `<details>` block.
- **What it does**: five outcome bullets plus a Mermaid diagram of the local loop (replaces the ASCII block).
- **Pick your platform**: the existing comparison table stays visible; the five long per-platform install sections become collapsible `<details>` blocks with their content intact.
- **Skill tree** becomes a stage → skills table; design notes (handoff-only rationale, optimizer boundary, public-benchmark path) fold into a details block.
- **Going hosted (optional)**: auth journey commands stay visible; the long behavioral prose collapses.
- **CLI reference** collapses; **Privacy** gets its own top-level section; boundary do/don't lists fold into **Contributing**.

## Verification

- `git diff --check` clean; all relative links in the new README verified to resolve.
- `npm run check` could not run locally (no Node runtime in this environment) — relying on CI here.
- Worth eyeballing the rendered Rich diff for the Mermaid diagram and `<details>` blocks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->