### PR TITLE
docs: mlx-optiq safety caveats in optimize-local-model-compression

### DIFF
--- a/skills/optimize-local-model-compression/reference.md
+++ b/skills/optimize-local-model-compression/reference.md
@@ -15,6 +15,16 @@ uv venv .understudy/venvs/mlx && uv pip install --python .understudy/venvs/mlx/b
 uv pip install --python .understudy/venvs/mlx/bin/python 'mlx-optiq'
 ```
 
+> **Before installing mlx-optiq, tell the user and get consent.** The package
+> is published on PyPI without a public source repository, so the code cannot
+> be audited before install. Its model-loading path enables
+> `trust_remote_code` by default, which executes arbitrary Python shipped
+> inside model repos — pass `trust_remote_code=False` (or the CLI equivalent)
+> unless the model source is trusted, and prefer weights from
+> `mlx-community` or `models.understudylabs.com`. Known issue: its
+> Anthropic-compatible streaming endpoint can hang; use the OpenAI-compatible
+> path for serving.
+
 ## QAT group-size conversion (the g32 fix)
 
 The single most impactful parameter. Google's QAT checkpoints are trained
@@ -215,7 +225,6 @@ leveled. Always serve all variants through the same runtime when comparing.
 ## Reproduction
 
 All experiments are reproducible from:
-- **Runner scripts:** `understudy-rollout-lab/experiments/optiq_*.sh`
 - **Eval harness:** `understudy workload evaluate automationbench-next-tool-call`
 - **Models:** `mlx-community` on HuggingFace or `models.understudylabs.com`
 - **Hardware:** Apple M5 Max, 128 GB unified memory

--- a/skills/optimize-local-model-compression/references/browser-webgpu-inference.md
+++ b/skills/optimize-local-model-compression/references/browser-webgpu-inference.md
@@ -14,7 +14,7 @@ opportunity to deploy Understudy's stacked QAT compression in a new runtime.
 - Custom WGSL compute kernels for every operation: quantized matmul, fused
   attention, RMSNorm, GELU, argmax. The 550 KB JS bundle (`gemma-4-e2b.js`)
   is a complete inference engine — it does not use transformers.js or ONNX
-  Runtime Web. Every kernel was written and optimized by Fable 5.
+  Runtime Web.
 - Per-tensor quantization baked into the kernel design: each weight tensor
   carries its own `bits`, `scaleT` (scale factor), and `codesT` (codebook
   indices), enabling mixed-precision decode at the WGSL level.
@@ -133,5 +133,5 @@ preserve the full mixed-precision allocation.
 
 - **HF Space:** https://huggingface.co/spaces/webml-community/gemma-4-webgpu-kernels
 - **Model:** `google/gemma-4-E2B-it-qat-mobile-transformers`
-- **Kernels:** Custom WGSL, authored by Fable 5
+- **Kernels:** Custom WGSL (see the space source)
 - **License:** Check the space README for current terms


### PR DESCRIPTION
Follow-up to the compression skill landing on main (originally staged in #105, split out per review).

- `reference.md` now requires user consent before installing `mlx-optiq` and documents why: the PyPI package has **no public source repository** (unauditable) and its model-loading path defaults to `trust_remote_code=True`, an arbitrary-code-execution surface for untrusted model repos. Also notes the known Anthropic-streaming hang and points serving at the OpenAI-compatible path.
- Removes a private-repo runner-script path (`understudy-rollout-lab/...`) from the Reproduction section, per the AGENTS.md public-boundary rule.
- Drops model-authorship notes ("authored by Fable 5") from the WebGPU reference — not verifiable product claims for a public doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->