### PR TITLE
CLI: securely control the desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ provider calls, and nothing spent by default**.
 curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash
 ```
 
+When Understudy Desktop is running, the CLI discovers it through the local
+agent card and uses a separate owner-only capability file for authenticated
+HTTP/MCP control. The token is never printed or stored in the agent card:
+
+```bash
+understudy daemon status
+understudy daemon tools
+understudy daemon call list_snapshot_models
+understudy daemon call start_model_download --arguments '{"model_id":"gemma-4-e2b-it-qat-mlx-vlm-understudy"}'
+```
+
 The installer sets up the CLI, asks which coding agents to attach to (Claude
 Code, Cursor, Codex, OpenCode, Hermes Agent, all, or CLI-only), and — if you
 pick Claude Code — opens it in the current directory. Then, in Claude Code:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import kleur from "kleur";
 
-import { daemonStatus } from "../internal/daemon.js";
+import { daemonMcpRequest, daemonStatus } from "../internal/daemon.js";
 
 export function registerDaemonCommand(program: Command): void {
   const daemon = program
@@ -37,5 +37,59 @@ export function registerDaemonCommand(program: Command): void {
       if (!status.running) {
         process.exitCode = 1;
       }
+    });
+
+  daemon
+    .command("tools")
+    .description("List the protected tools exposed by the running desktop app.")
+    .option("--json", "Output JSON")
+    .action(async function (this: Command, opts: { json?: boolean }) {
+      const result = await daemonMcpRequest("tools/list");
+      const json = opts.json === true || this.optsWithGlobals<{ json?: boolean }>().json === true;
+      if (json) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+        return;
+      }
+      const tools =
+        typeof result === "object" && result !== null && Array.isArray((result as { tools?: unknown }).tools)
+          ? (result as { tools: Array<{ name?: unknown; description?: unknown }> }).tools
+          : [];
+      for (const tool of tools) {
+        if (typeof tool.name === "string") {
+          process.stdout.write(`${kleur.cyan(tool.name)}${typeof tool.description === "string" ? ` — ${tool.description}` : ""}\n`);
+        }
+      }
+    });
+
+  daemon
+    .command("call")
+    .description("Call one protected desktop MCP tool through the private local capability.")
+    .argument("<tool>", "Tool name from `understudy daemon tools`")
+    .option("--arguments <json>", "JSON object of tool arguments", "{}")
+    .option("--json", "Output JSON")
+    .action(async function (this: Command, tool: string, opts: { arguments: string; json?: boolean }) {
+      let args: unknown;
+      try {
+        args = JSON.parse(opts.arguments);
+      } catch (error) {
+        throw new Error(`--arguments must be valid JSON: ${String(error)}`);
+      }
+      if (typeof args !== "object" || args === null || Array.isArray(args)) {
+        throw new Error("--arguments must be a JSON object");
+      }
+      const result = await daemonMcpRequest("tools/call", {
+        name: tool,
+        arguments: args as Record<string, unknown>,
+      });
+      const json = opts.json === true || this.optsWithGlobals<{ json?: boolean }>().json === true;
+      if (json) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+        return;
+      }
+      const structured =
+        typeof result === "object" && result !== null
+          ? (result as { structuredContent?: unknown }).structuredContent
+          : undefined;
+      process.stdout.write(`${JSON.stringify(structured ?? result, null, 2)}\n`);
     });
 }

--- a/src/internal/daemon.ts
+++ b/src/internal/daemon.ts
@@ -7,7 +7,7 @@
 // probe, because a crashed app (no graceful shutdown) leaves a stale card
 // behind.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -28,13 +28,47 @@ export interface DaemonStatus {
   pid: number | null;
   version: string | null;
   warmModels: DaemonWarmModel[];
+  /** Protected local HTTP/MCP calls can be authenticated without exposing the token. */
+  controlReady: boolean;
   /** Human-readable reason for the verdict. */
   detail: string;
   cardPath: string;
+  capabilityPath: string;
 }
 
 export function agentCardPath(): string {
   return join(homedir(), ".understudy", "agent-card.json");
+}
+
+export function desktopCapabilityPath(): string {
+  return join(homedir(), ".understudy", "desktop-api.json");
+}
+
+type DesktopCapability = {
+  baseUrl: string;
+  mcpUrl: string;
+  pid: number;
+  token: string;
+};
+
+function readDesktopCapability(path: string): DesktopCapability | null {
+  try {
+    if (process.platform !== "win32" && (statSync(path).mode & 0o077) !== 0) return null;
+    const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+    const row = value as Record<string, unknown>;
+    if (row.schema_version !== "understudy.desktop_api.v1") return null;
+    if (typeof row.base_url !== "string" || typeof row.mcp_url !== "string") return null;
+    if (typeof row.pid !== "number" || !Number.isInteger(row.pid) || row.pid <= 0) return null;
+    if (typeof row.token !== "string" || row.token.length < 32) return null;
+    const base = new URL(row.base_url);
+    const mcp = new URL(row.mcp_url);
+    if (base.protocol !== "http:" || base.hostname !== "127.0.0.1") return null;
+    if (mcp.origin !== base.origin || mcp.pathname !== "/mcp") return null;
+    return { baseUrl: base.origin, mcpUrl: mcp.toString(), pid: row.pid, token: row.token };
+  } catch {
+    return null;
+  }
 }
 
 /** Parse the agent card; null when missing or unreadable JSON. */
@@ -90,10 +124,13 @@ export interface DaemonStatusOptions {
   cardPath?: string;
   /** Health probe timeout in milliseconds. */
   timeoutMs?: number;
+  /** Override the private desktop capability location (tests use a temp fixture). */
+  capabilityPath?: string;
 }
 
 export async function daemonStatus(options: DaemonStatusOptions = {}): Promise<DaemonStatus> {
   const cardPath = options.cardPath ?? agentCardPath();
+  const capabilityPath = options.capabilityPath ?? desktopCapabilityPath();
   const notRunning = (detail: string, extra: Partial<DaemonStatus> = {}): DaemonStatus => ({
     detected: false,
     running: false,
@@ -101,8 +138,10 @@ export async function daemonStatus(options: DaemonStatusOptions = {}): Promise<D
     pid: null,
     version: null,
     warmModels: [],
+    controlReady: false,
     detail,
     cardPath,
+    capabilityPath,
     ...extra,
   });
 
@@ -157,6 +196,9 @@ export async function daemonStatus(options: DaemonStatusOptions = {}): Promise<D
         ];
       })
     : [];
+  const capability = readDesktopCapability(capabilityPath);
+  const controlReady =
+    capability !== null && capability.pid === pid && capability.baseUrl === new URL(baseUrl).origin;
 
   return {
     detected: true,
@@ -165,9 +207,44 @@ export async function daemonStatus(options: DaemonStatusOptions = {}): Promise<D
     pid,
     version,
     warmModels,
-    detail: `desktop app daemon running at ${baseUrl}`,
+    controlReady,
+    detail: `desktop app daemon running at ${baseUrl}${controlReady ? ", control ready" : ", health only"}`,
     cardPath,
+    capabilityPath,
   };
+}
+
+export async function daemonMcpRequest(
+  method: "tools/list" | "tools/call",
+  params: Record<string, unknown> = {},
+  options: DaemonStatusOptions = {},
+): Promise<unknown> {
+  const status = await daemonStatus(options);
+  if (!status.running) throw new Error(`desktop app is not running: ${status.detail}`);
+  if (!status.controlReady) {
+    throw new Error(
+      `desktop app control is unavailable: no matching owner-only capability at ${status.capabilityPath}`,
+    );
+  }
+  const capability = readDesktopCapability(status.capabilityPath);
+  if (!capability) throw new Error("desktop app capability became unavailable");
+  const response = await fetch(capability.mcpUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${capability.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: "understudy-cli", method, params }),
+    signal: AbortSignal.timeout(options.timeoutMs ?? 10_000),
+  });
+  const body: unknown = await response.json().catch(() => null);
+  if (!response.ok) throw new Error(`desktop app returned HTTP ${response.status}`);
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new Error("desktop app returned an invalid MCP response");
+  }
+  const envelope = body as Record<string, unknown>;
+  if (envelope.error) throw new Error(`desktop MCP error: ${JSON.stringify(envelope.error)}`);
+  return envelope.result;
 }
 
 /** One-line summary for doctor-style output. */

--- a/tests/daemon.test.mjs
+++ b/tests/daemon.test.mjs
@@ -1,13 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createServer } from "node:http";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 
 import {
   daemonStatus,
+  daemonMcpRequest,
   describeDaemon,
   pidAlive,
   probeDaemonHealth,
@@ -117,12 +118,28 @@ describe("desktop-app daemon discovery from the agent card", () => {
 describe("daemon discovery against a live health endpoint", () => {
   let server;
   let baseUrl;
+  const token = "test-token-that-is-long-enough-for-capability";
 
   before(async () => {
     server = createServer((req, res) => {
       if (req.url === "/health") {
         res.writeHead(200, { "content-type": "text/plain" });
         res.end("ok");
+        return;
+      }
+      if (req.url === "/mcp" && req.method === "POST") {
+        if (req.headers.authorization !== `Bearer ${token}`) {
+          res.writeHead(401);
+          res.end();
+          return;
+        }
+        const chunks = [];
+        req.on("data", (chunk) => chunks.push(chunk));
+        req.on("end", () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { tools: [{ name: "status" }] } }));
+        });
         return;
       }
       res.writeHead(404);
@@ -168,6 +185,45 @@ describe("daemon discovery against a live health endpoint", () => {
       assert.equal(status.warmModels[0].port, 8089);
       assert.equal(status.warmModels[1].port, null);
       assert.equal(describeDaemon(status), `running at ${baseUrl}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("authenticates protected MCP calls through a matching owner-only capability", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-daemon-control-"));
+    const cardPath = join(dir, "agent-card.json");
+    const capabilityPath = join(dir, "desktop-api.json");
+    try {
+      writeCard(cardPath, {
+        running: true,
+        pid: process.pid,
+        base_url: baseUrl,
+        version: "0.3.1",
+      });
+      writeFileSync(
+        capabilityPath,
+        JSON.stringify({
+          schema_version: "understudy.desktop_api.v1",
+          base_url: baseUrl,
+          mcp_url: `${baseUrl}/mcp`,
+          pid: process.pid,
+          token,
+        }),
+        { mode: 0o600 },
+      );
+      chmodSync(capabilityPath, 0o600);
+      const status = await daemonStatus({ cardPath, capabilityPath });
+      assert.equal(status.running, true);
+      assert.equal(status.controlReady, true);
+      const result = await daemonMcpRequest("tools/list", {}, { cardPath, capabilityPath });
+      assert.deepEqual(result, { tools: [{ name: "status" }] });
+
+      if (process.platform !== "win32") {
+        chmodSync(capabilityPath, 0o644);
+        const insecure = await daemonStatus({ cardPath, capabilityPath });
+        assert.equal(insecure.controlReady, false);
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes the CLI-to-desktop half of the local contract.

- daemon status now reports control readiness
- daemon tools lists the protected desktop MCP surface
- daemon call invokes any desktop MCP tool through an owner-only local capability
- rejects stale, mismatched, non-loopback, and overly permissive capability files
- never prints or stores the bearer token in the public agent card
- bumps the public CLI to 0.6.1

Validated: full npm check with 162 tests, typecheck, skill validation, package smoke, plus live calls against Desktop 0.3.2 for tool listing, pane focus, download inspection, and cancellation.

Paired with understudy-agent PR from yolo/first-use-model-download.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->