### PR TITLE
docs: create scoped gateway workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,18 +508,24 @@ the first auth journey is intentionally narrow:
 understudy login --email you@company.com   # emails a one-time code
 understudy login --code 123456             # completes sign-in (non-TTY shells)
 understudy doctor --hosted
-understudy workloads list
-understudy workloads create classify --capture
-understudy gateway probe --provider anthropic --project rehearsal --workload classify
-understudy captures list --project rehearsal --workload classify
-understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
-understudy routes show classify --project rehearsal
-understudy routes clear classify --project rehearsal
+understudy projects create customer-support --name "Customer support"
+understudy workloads create answer-ticket --project customer-support --capture
+understudy gateway probe --provider anthropic --project customer-support --workload answer-ticket
+understudy captures list --project customer-support --workload answer-ticket
+understudy routes set answer-ticket --project customer-support --model-id glm-5.1 --traffic-pct 10
+understudy routes show answer-ticket --project customer-support
+understudy routes clear answer-ticket --project customer-support
 ```
 
 `routes set` writes control-plane route config: your application keeps calling
 the normal gateway while a percentage of traffic goes to the selected
 Understudy model and the rest remains passthrough/frontier.
+
+Every application request should also send the same
+`x-understudy-project: customer-support` and
+`x-understudy-workload: answer-ticket` headers. They bind a trace, capture,
+and future replacement route to a stable call site instead of whichever default
+the organization happens to have.
 
 <details>
 <summary><b>How login, doctor, probes, captures, and routes behave</b></summary>

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -101,26 +101,45 @@ node dist/bin.js status --json
    Understudy sign-in email and pass the code to `understudy login --code`. Read
    only that email, and do not persist the code anywhere else.
 
-3. Confirm project/key readiness:
+3. With the developer's approval, create one explicit project and one
+   workload for the call site being connected. Capture attaches to the
+   workload, and future route changes replace only that workload's behavior.
+   Do not rely on the default `rehearsal` / `main` pair for a production app.
+
+   ```sh
+   understudy projects create customer-support --name "Customer support"
+   understudy workloads create answer-ticket --project customer-support --capture
+   ```
+
+   Project slugs use lowercase letters, numbers, and hyphens; workload names
+   additionally allow underscores. Reuse an existing project or workload when
+   it already represents the same stable call site rather than creating a
+   duplicate.
+
+4. Confirm project/workload/key readiness:
 
    ```sh
    understudy projects list --json
+   understudy workloads list --project customer-support --json
    understudy keys list --json
    ```
 
-4. For frontier-vs-Understudy comparison, list public model IDs first. If the
+5. For frontier-vs-Understudy comparison, list public model IDs first. If the
    account is keyless for frontier providers, prefer the **keyless catalog
    sweep** recipe below: clear the workload route and vary the request-body
    `model`. Use traffic-split A/B only after confirming the non-routed
    passthrough share has a managed provider credential or BYO key.
 
-5. Run the local command through the gateway wrapper only after approval:
+6. Run the local command through the gateway wrapper only after approval. Make
+   the application send both `x-understudy-project: customer-support` and
+   `x-understudy-workload: answer-ticket` on every gateway request; this keeps
+   captures and replacement routes attributable to the intended workload.
 
    ```sh
    understudy run -- <local command>
    ```
 
-6. Monitor the command output and local artifacts. For optimization work, route
+7. Monitor the command output and local artifacts. For optimization work, route
    back to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) once
    the run has produced candidate/proof evidence.
 


### PR DESCRIPTION
## Summary

- update the hosted quickstart to create a named project and capture-enabled workload
- make the gateway skill provision and verify the project/workload pair before probe or routing
- require explicit project and workload request headers for trace attribution and future replacement routes

## Why

The CLI already supports project and workload creation, but the previous primary gateway flow only listed resources. This aligns the skill with the supported platform contract.

## Validation

- `npm run skills:validate`
- `npm run package:smoke`
- `npm run check` (one unrelated AutomationBench tmux-status test fails under the current Node runtime)
