### PR TITLE
Add quiet Pi cache health evidence

### DIFF
--- a/apps/homescreen/app/components/UsagePane.tsx
+++ b/apps/homescreen/app/components/UsagePane.tsx
@@ -4,15 +4,46 @@ import { invoke } from "@tauri-apps/api/core";
 import type { StatusController } from "../lib/useStatus";
 
 type Any = Record<string, unknown>;
+type CacheHealth = {
+  status: "unavailable" | "warming" | "healthy" | "regressed";
+  alert: boolean;
+  score_pct: number | null;
+  baseline_score_pct: number | null;
+  regression_points: number | null;
+  comparable_turns: number;
+  recent_comparable_turns: number;
+  recent_missed_tokens: number;
+  detail: string;
+};
 
 export function UsagePane({ status }: { status: StatusController }) {
   const [captures, setCaptures] = useState<Any | null>(null);
+  const [cacheHealth, setCacheHealth] = useState<CacheHealth | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
     invoke<Any>("account_captures")
       .then(setCaptures)
       .catch((e) => setErr(String(e)));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = () => {
+      invoke<CacheHealth>("runtime_cache_health")
+        .then((health) => {
+          if (!cancelled) setCacheHealth(health);
+        })
+        .catch(() => {
+          if (!cancelled) setCacheHealth(null);
+        });
+    };
+    refresh();
+    const timer = window.setInterval(refresh, 10_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
   }, []);
 
   const snap = status.snap;
@@ -39,6 +70,7 @@ export function UsagePane({ status }: { status: StatusController }) {
           <Metric label="CPU" value={m ? `${m.cpu_pct.toFixed(0)}%` : "…"} pct={m?.cpu_pct ?? 0} />
           <Metric label="Memory" value={m ? `${m.mem_used_gb.toFixed(1)} / ${m.mem_total_gb.toFixed(0)} GB` : "…"} pct={m && m.mem_total_gb ? (m.mem_used_gb / m.mem_total_gb) * 100 : 0} />
           <Metric label="Model memory (warm)" value={res ? `${res.used_gb.toFixed(1)} / ${res.usable_gb.toFixed(0)} GB` : "…"} pct={res && res.usable_gb > 0 ? (res.used_gb / res.usable_gb) * 100 : 0} />
+          <CacheHealthMetric health={cacheHealth} />
         </div>
 
         <div className="card">
@@ -76,6 +108,23 @@ export function UsagePane({ status }: { status: StatusController }) {
         </div>
       </div>
     </>
+  );
+}
+
+function CacheHealthMetric({ health }: { health: CacheHealth | null }) {
+  const value = health?.score_pct == null ? "—" : `${health.score_pct.toFixed(0)}%`;
+  const detail = health?.detail ?? "Cache evidence becomes available after supported Pi turns.";
+  return (
+    <div className={`cache-health${health?.alert ? " regressed" : ""}`}>
+      <div className="card-row">
+        <span className="cache-health-label">
+          <i aria-hidden="true" />
+          Cache health
+        </span>
+        <span className="metric">{value}</span>
+      </div>
+      <div className="cache-health-detail">{detail}</div>
+    </div>
   );
 }
 

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -620,6 +620,40 @@ select,
 }
 .meter.warn > i { background: var(--loading); }
 
+/* One aggregate for prompt-prefix reuse. It stays visually quiet unless the
+   evidence window crosses the significant-regression threshold. */
+.cache-health {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.cache-health-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-2);
+  font-size: 12px;
+}
+.cache-health-label i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-3);
+}
+.cache-health-detail {
+  margin-top: 4px;
+  color: var(--text-3);
+  font-size: 11px;
+}
+.cache-health.regressed .cache-health-label,
+.cache-health.regressed .metric,
+.cache-health.regressed .cache-health-detail {
+  color: var(--loading);
+}
+.cache-health.regressed .cache-health-label i {
+  background: var(--loading);
+}
+
 /* ---------- Service list ---------- */
 .svc {
   display: grid;

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -1198,6 +1198,31 @@ pub fn get_moraine_state() -> MoraineState {
     crate::moraine::detect()
 }
 
+/// Read the canonical Pi session ledger through the bundled CLI and return one
+/// quiet aggregate for the desktop. Unsupported providers are represented as
+/// `status: unavailable`; they are not treated as a 0% cache hit rate.
+#[tauri::command]
+pub async fn runtime_cache_health() -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let output = bin::command("understudy")
+            .args(["runtime", "cache-health", "--json"])
+            .output()
+            .map_err(|error| format!("understudy cache-health failed to start: {error}"))?;
+        if !output.status.success() {
+            let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(if detail.is_empty() {
+                format!("understudy cache-health exited with {}", output.status)
+            } else {
+                detail
+            });
+        }
+        serde_json::from_slice::<Value>(&output.stdout)
+            .map_err(|error| format!("understudy cache-health returned invalid JSON: {error}"))
+    })
+    .await
+    .map_err(|error| format!("cache-health task failed: {error}"))?
+}
+
 // The trace lookups spawn `moraine-mcp` and block on its stdout (bounded by
 // the deadline in `mcp::call_tool`). The `_sync` cores exist for callers that
 // already run on a blocking thread (the local server); the Tauri commands are

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.3";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.4";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -129,6 +129,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::get_status,
+            commands::runtime_cache_health,
             commands::anthropic_models,
             commands::anthropic_status,
             commands::anthropic_key_set,

--- a/experiments/pi-runtime-spike/DECISION.md
+++ b/experiments/pi-runtime-spike/DECISION.md
@@ -74,6 +74,12 @@ the remaining packaging and production soak gates pass.
   timeout with stderr discarded.
 - The expanded dependency graph passed the package smoke and `npm audit` with
   zero known vulnerabilities at this checkpoint.
+- Canonical usage events now retain provider-reported cache reads, cache writes,
+  total prompt input, and per-turn reuse. `understudy runtime cache-health`
+  derives a quiet rolling metric from the private append-only Pi session ledger.
+  It shows unavailable rather than a false 0% for providers that do not report
+  caching, and alerts only after a same-model, within-TTL window drops at least
+  20 points with at least 2,048 newly missed tokens.
 - The CLI-managed, fully offline MLX-VLM runtime passed all eight frozen
   scenarios in one immutable run. The long-chat case compacted 18 messages to
   6 and reduced its estimate from 1,043 tokens to 463. The image, tool,
@@ -102,6 +108,15 @@ One shared prefix can retain the small-model attempt, uninterrupted
 counterfactual, teacher correction, alternate candidate, and human-selected
 path. That can simplify correction-pair export and judge evaluation while
 keeping normal chat UI linear.
+
+Cache-preserving dynamic tool loading remains release-gated. Pi `main` now
+documents additive deferred definitions for supported Anthropic and OpenAI
+models, with a safe normal-tool fallback elsewhere, but the latest published
+package (`0.80.6`, released before the 2026-07-10 change) does not contain that
+contract. Do not use the older cache-busting `setActiveTools` behavior as a
+substitute. Once Pi publishes the supporting release: pin the exact version,
+keep one loader tool active, add tools monotonically, omit active-only prompt
+metadata, and use this cache-health metric as the regression gate.
 
 ## Promotion gate
 

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -307,7 +307,7 @@ export function registerRuntimeCommand(program: Command): void {
     .option("--json", "Output JSON")
     .action(function (this: Command) {
       const health = cacheHealthFromSessionRoot(
-        join(conversationRuntimeHome(), "sessions"),
+        join(conversationRuntimeHome(), "pi-sessions"),
       );
       const score = health.score_pct === null ? "unavailable" : `${health.score_pct.toFixed(1)}%`;
       emit(

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -3,10 +3,11 @@ import kleur from "kleur";
 import { closeSync, mkdirSync, openSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { isJsonMode, runAction } from "../internal/output.js";
 import {
+  conversationRuntimeHome,
   conversationRuntimeStatus,
   doctorConversationRuntime,
   installConversationRuntime,
@@ -14,6 +15,7 @@ import {
   startConversationRuntime,
   stopConversationRuntime,
 } from "../runtime/conversation/lifecycle.js";
+import { cacheHealthFromSessionRoot } from "../runtime/conversation/cache-health.js";
 import {
   CONFORMANCE_SCHEMA,
   EVENT_SCHEMA,
@@ -297,6 +299,22 @@ export function registerRuntimeCommand(program: Command): void {
       const status = await conversationRuntimeStatus();
       emit(this, status, statusLine(status));
       if (!status.healthy) process.exitCode = 1;
+    });
+
+  runtime
+    .command("cache-health")
+    .description("Summarize prompt-cache reuse without printing per-turn notices.")
+    .option("--json", "Output JSON")
+    .action(function (this: Command) {
+      const health = cacheHealthFromSessionRoot(
+        join(conversationRuntimeHome(), "sessions"),
+      );
+      const score = health.score_pct === null ? "unavailable" : `${health.score_pct.toFixed(1)}%`;
+      emit(
+        this,
+        health,
+        `cache health: ${score} · ${health.detail}`,
+      );
     });
 
   runtime

--- a/src/runtime/conversation/cache-health.ts
+++ b/src/runtime/conversation/cache-health.ts
@@ -1,0 +1,218 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const CACHE_HEALTH_SCHEMA = "understudy-cache-health-v1";
+export const CACHE_TTL_MS = 5 * 60 * 1_000;
+export const CACHE_REGRESSION_POINTS = 20;
+export const CACHE_REGRESSION_MIN_ELIGIBLE_TOKENS = 4_096;
+export const CACHE_REGRESSION_MIN_MISSED_TOKENS = 2_048;
+
+type Usage = {
+  input?: unknown;
+  cacheRead?: unknown;
+  cacheWrite?: unknown;
+};
+
+export type CacheUsageSample = {
+  session_id: string;
+  timestamp: number;
+  model_key: string;
+  input_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reset_before?: boolean;
+};
+
+export type CacheHealth = {
+  schema_version: typeof CACHE_HEALTH_SCHEMA;
+  status: "unavailable" | "warming" | "healthy" | "regressed";
+  alert: boolean;
+  score_pct: number | null;
+  baseline_score_pct: number | null;
+  regression_points: number | null;
+  turns: number;
+  comparable_turns: number;
+  recent_comparable_turns: number;
+  recent_cache_read_tokens: number;
+  recent_cache_eligible_tokens: number;
+  recent_missed_tokens: number;
+  significant_miss_count: number;
+  detail: string;
+};
+
+type ComparableTurn = {
+  timestamp: number;
+  eligible: number;
+  read: number;
+  missed: number;
+};
+
+function finiteNonnegative(value: unknown): number {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function score(turns: ComparableTurn[]): number | null {
+  const eligible = turns.reduce((total, turn) => total + turn.eligible, 0);
+  if (eligible <= 0) return null;
+  const read = turns.reduce((total, turn) => total + turn.read, 0);
+  return Math.max(0, Math.min(100, (read / eligible) * 100));
+}
+
+function rounded(value: number | null): number | null {
+  return value === null ? null : Math.round(value * 10) / 10;
+}
+
+export function computeCacheHealth(samples: CacheUsageSample[]): CacheHealth {
+  const ordered = [...samples].sort(
+    (left, right) => left.timestamp - right.timestamp,
+  );
+  const reportedCache = ordered.some(
+    (sample) => sample.cache_read_tokens + sample.cache_write_tokens > 0,
+  );
+  const comparable: ComparableTurn[] = [];
+  const previousBySession = new Map<string, CacheUsageSample>();
+  const reportedBySession = new Map<string, boolean>();
+
+  for (const sample of ordered) {
+    const sessionReported =
+      (reportedBySession.get(sample.session_id) ?? false) ||
+      sample.cache_read_tokens + sample.cache_write_tokens > 0;
+    reportedBySession.set(sample.session_id, sessionReported);
+    const previous = sample.reset_before
+      ? undefined
+      : previousBySession.get(sample.session_id);
+    previousBySession.set(sample.session_id, sample);
+    if (!previous) continue;
+    if (!sessionReported) continue;
+    if (previous.model_key !== sample.model_key) continue;
+    if (sample.timestamp - previous.timestamp > CACHE_TTL_MS) continue;
+
+    const previousPrompt =
+      previous.input_tokens +
+      previous.cache_read_tokens +
+      previous.cache_write_tokens;
+    const prompt =
+      sample.input_tokens + sample.cache_read_tokens + sample.cache_write_tokens;
+    const eligible = Math.min(previousPrompt, prompt);
+    if (eligible <= 0) continue;
+    const read = Math.min(sample.cache_read_tokens, eligible);
+    comparable.push({
+      timestamp: sample.timestamp,
+      eligible,
+      read,
+      missed: Math.max(0, eligible - read),
+    });
+  }
+
+  const recent = comparable.slice(-5);
+  const baseline = comparable.slice(-10, -5);
+  const recentScore = score(recent);
+  const baselineScore = score(baseline);
+  const eligible = recent.reduce((total, turn) => total + turn.eligible, 0);
+  const read = recent.reduce((total, turn) => total + turn.read, 0);
+  const missed = recent.reduce((total, turn) => total + turn.missed, 0);
+  const regression =
+    recentScore !== null && baselineScore !== null
+      ? baselineScore - recentScore
+      : null;
+  const alert = Boolean(
+    recent.length >= 3 &&
+      baseline.length >= 3 &&
+      regression !== null &&
+      regression >= CACHE_REGRESSION_POINTS &&
+      eligible >= CACHE_REGRESSION_MIN_ELIGIBLE_TOKENS &&
+      missed >= CACHE_REGRESSION_MIN_MISSED_TOKENS,
+  );
+
+  let status: CacheHealth["status"] = "healthy";
+  let detail = `Stable across ${recent.length} comparable turn${recent.length === 1 ? "" : "s"}.`;
+  if (!reportedCache) {
+    status = "unavailable";
+    detail = "The active provider has not reported prompt-cache usage yet.";
+  } else if (comparable.length < 3) {
+    status = "warming";
+    detail = `Collecting cache evidence (${comparable.length}/3 comparable turns).`;
+  } else if (alert) {
+    status = "regressed";
+    detail = `Cache reuse fell ${rounded(regression)} points across the recent window.`;
+  }
+
+  return {
+    schema_version: CACHE_HEALTH_SCHEMA,
+    status,
+    alert,
+    score_pct: reportedCache ? rounded(recentScore) : null,
+    baseline_score_pct: reportedCache ? rounded(baselineScore) : null,
+    regression_points: reportedCache ? rounded(regression) : null,
+    turns: ordered.length,
+    comparable_turns: comparable.length,
+    recent_comparable_turns: recent.length,
+    recent_cache_read_tokens: read,
+    recent_cache_eligible_tokens: eligible,
+    recent_missed_tokens: missed,
+    significant_miss_count: recent.filter(
+      (turn) => turn.missed > 1_024,
+    ).length,
+    detail,
+  };
+}
+
+function sessionFiles(root: string): string[] {
+  try {
+    return readdirSync(root, { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+      .map((entry) => join(entry.parentPath, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+export function readCacheUsageSamples(sessionRoot: string): CacheUsageSample[] {
+  const samples: CacheUsageSample[] = [];
+  for (const path of sessionFiles(sessionRoot)) {
+    const sessionId = path;
+    let resetBefore = false;
+    let lines: string[];
+    try {
+      lines = readFileSync(path, "utf8").split("\n");
+    } catch {
+      continue;
+    }
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (entry.type === "compaction" || entry.type === "branch_summary") {
+        resetBefore = true;
+        continue;
+      }
+      if (entry.type !== "message") continue;
+      const message = entry.message as Record<string, unknown> | undefined;
+      if (!message || message.role !== "assistant") continue;
+      const usage = (message.usage ?? {}) as Usage;
+      const timestamp = finiteNonnegative(message.timestamp) || Date.now();
+      const provider = String(message.provider ?? "unknown");
+      const model = String(message.model ?? "unknown");
+      samples.push({
+        session_id: sessionId,
+        timestamp,
+        model_key: `${provider}/${model}`,
+        input_tokens: finiteNonnegative(usage.input),
+        cache_read_tokens: finiteNonnegative(usage.cacheRead),
+        cache_write_tokens: finiteNonnegative(usage.cacheWrite),
+        ...(resetBefore ? { reset_before: true } : {}),
+      });
+      resetBefore = false;
+    }
+  }
+  return samples;
+}
+
+export function cacheHealthFromSessionRoot(sessionRoot: string): CacheHealth {
+  return computeCacheHealth(readCacheUsageSamples(sessionRoot));
+}

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -431,7 +431,33 @@ export function validateRuntimeTrace(values: readonly unknown[]): RuntimeEventEn
       const input = nonNegativeInteger(data, "input_tokens", "usage.input_tokens");
       const output = nonNegativeInteger(data, "output_tokens", "usage.output_tokens");
       nonNegativeInteger(data, "reasoning_tokens", "usage.reasoning_tokens");
-      nonNegativeInteger(data, "cached_input_tokens", "usage.cached_input_tokens");
+      const cached = nonNegativeInteger(data, "cached_input_tokens", "usage.cached_input_tokens");
+      if ("cache_write_input_tokens" in data) {
+        nonNegativeInteger(data, "cache_write_input_tokens", "usage.cache_write_input_tokens");
+      }
+      if ("prompt_input_tokens" in data) {
+        const promptInput = nonNegativeInteger(
+          data,
+          "prompt_input_tokens",
+          "usage.prompt_input_tokens",
+        );
+        if (promptInput < cached) {
+          throw new Error("usage.prompt_input_tokens cannot be less than cached input");
+        }
+      }
+      if ("cache_reported" in data && typeof data.cache_reported !== "boolean") {
+        throw new Error("usage.cache_reported must be a boolean");
+      }
+      if (
+        "cache_read_pct" in data &&
+        data.cache_read_pct !== null &&
+        (typeof data.cache_read_pct !== "number" ||
+          !Number.isFinite(data.cache_read_pct) ||
+          data.cache_read_pct < 0 ||
+          data.cache_read_pct > 100)
+      ) {
+        throw new Error("usage.cache_read_pct must be null or a percentage from 0 to 100");
+      }
       const total = nonNegativeInteger(data, "total_tokens", "usage.total_tokens");
       if (total < input + output) {
         throw new Error("usage.total_tokens cannot be less than input + output");

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.3";
+export const RUNTIME_VERSION = "0.3.4";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -102,6 +102,7 @@ function usageData(
       output?: number;
       reasoning?: number;
       cacheRead?: number;
+      cacheWrite?: number;
       totalTokens?: number;
     };
   },
@@ -111,6 +112,9 @@ function usageData(
   const usage = message.usage ?? {};
   const input = Number.isFinite(usage.input) ? usage.input! : 0;
   const output = Number.isFinite(usage.output) ? usage.output! : 0;
+  const cacheRead = Number.isFinite(usage.cacheRead) ? usage.cacheRead! : 0;
+  const cacheWrite = Number.isFinite(usage.cacheWrite) ? usage.cacheWrite! : 0;
+  const promptInput = input + cacheRead + cacheWrite;
   const total = Number.isFinite(usage.totalTokens) ? usage.totalTokens! : input + output;
   const complete =
     Number.isFinite(usage.input) &&
@@ -123,8 +127,15 @@ function usageData(
     input_tokens: input,
     output_tokens: output,
     reasoning_tokens: Number.isFinite(usage.reasoning) ? usage.reasoning : 0,
-    cached_input_tokens: Number.isFinite(usage.cacheRead) ? usage.cacheRead : 0,
-    total_tokens: Math.max(total, input + output),
+    cached_input_tokens: cacheRead,
+    cache_write_input_tokens: cacheWrite,
+    prompt_input_tokens: promptInput,
+    cache_reported: cacheRead + cacheWrite > 0,
+    cache_read_pct:
+      cacheRead + cacheWrite > 0 && promptInput > 0
+        ? Math.round((cacheRead / promptInput) * 1_000) / 10
+        : null,
+    total_tokens: Math.max(total, promptInput + output),
     source: complete ? "provider" : "unavailable",
     complete,
   };
@@ -299,6 +310,12 @@ function buildTools(request: RuntimeRunRequest) {
     }),
   );
 }
+
+// Pi 0.80.6 supports changing active tools, but its published behavior rebuilds
+// the normal tool list and can invalidate prompt caches. Keep the full static
+// set until the post-2026-07-10 release containing native additive deferred
+// definitions is published and pinned. Do not emulate that release with the
+// older cache-busting setActiveTools path.
 
 function deterministicCompactionFixture(pi: ExtensionAPI): void {
   pi.on("session_before_compact", (event) => ({

--- a/src/runtime/conversation/vercel-runtime.ts
+++ b/src/runtime/conversation/vercel-runtime.ts
@@ -114,6 +114,8 @@ function usageData(
     outputTokenDetails?: { reasoningTokens?: number };
   },
 ): Record<string, unknown> {
+  const promptInput = usage.inputTokens ?? 0;
+  const cacheRead = usage.inputTokenDetails?.cacheReadTokens ?? 0;
   const complete =
     usage.inputTokens != null &&
     usage.outputTokens != null &&
@@ -124,7 +126,14 @@ function usageData(
     input_tokens: usage.inputTokens ?? 0,
     output_tokens: usage.outputTokens ?? 0,
     reasoning_tokens: usage.outputTokenDetails?.reasoningTokens ?? 0,
-    cached_input_tokens: usage.inputTokenDetails?.cacheReadTokens ?? 0,
+    cached_input_tokens: cacheRead,
+    cache_write_input_tokens: 0,
+    prompt_input_tokens: promptInput,
+    cache_reported: cacheRead > 0,
+    cache_read_pct:
+      cacheRead > 0 && promptInput > 0
+        ? Math.round((cacheRead / promptInput) * 1_000) / 10
+        : null,
     total_tokens:
       usage.totalTokens ??
       (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -37,6 +37,9 @@ import {
   classifyShellToolCall,
   commandGuardBlockMessage,
 } from "../dist/runtime/conversation/command-guard.js";
+import {
+  computeCacheHealth,
+} from "../dist/runtime/conversation/cache-health.js";
 
 const runtimeHome = mkdtempSync(join(tmpdir(), "understudy-conversation-runtime-"));
 const basicChatFixture = JSON.parse(
@@ -133,6 +136,88 @@ test("runtime errors redact provider-shaped secrets", () => {
     new Error(`provider rejected ${anthropicShaped} and ${understudyShaped}`),
   );
   assert.equal(message, "provider rejected [redacted] and [redacted]");
+});
+
+test("cache health stays quiet until supported evidence exists and alerts only on regression", () => {
+  const sample = (index, input, read, write = 0) => ({
+    session_id: "cache-session",
+    timestamp: 1_000 + index * 1_000,
+    model_key: "provider/model",
+    input_tokens: input,
+    cache_read_tokens: read,
+    cache_write_tokens: write,
+  });
+  const unavailable = computeCacheHealth([
+    sample(0, 1_000, 0),
+    sample(1, 1_000, 0),
+  ]);
+  assert.equal(unavailable.status, "unavailable");
+  assert.equal(unavailable.score_pct, null);
+  assert.equal(unavailable.alert, false);
+
+  const mixed = computeCacheHealth([
+    sample(0, 100, 0, 900),
+    sample(1, 100, 900),
+    {
+      ...sample(2, 5_000, 0),
+      session_id: "provider-without-cache-reporting",
+    },
+    {
+      ...sample(3, 5_000, 0),
+      session_id: "provider-without-cache-reporting",
+    },
+  ]);
+  assert.equal(mixed.score_pct, 90);
+  assert.equal(mixed.comparable_turns, 1);
+  assert.equal(mixed.alert, false);
+
+  const regression = computeCacheHealth([
+    sample(0, 100, 0, 4_900),
+    ...Array.from({ length: 5 }, (_, offset) => sample(offset + 1, 500, 4_500)),
+    ...Array.from({ length: 5 }, (_, offset) => sample(offset + 6, 4_000, 1_000)),
+  ]);
+  assert.equal(regression.status, "regressed");
+  assert.equal(regression.alert, true);
+  assert.equal(regression.baseline_score_pct, 90);
+  assert.equal(regression.score_pct, 20);
+  assert.equal(regression.regression_points, 70);
+  assert.equal(regression.recent_missed_tokens, 20_000);
+});
+
+test("runtime cache-health command reads the private Pi session ledger", async () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-cache-health-cli-"));
+  const sessions = join(root, "sessions");
+  mkdirSync(sessions, { recursive: true });
+  const rows = [
+    { input: 100, cacheRead: 0, cacheWrite: 900 },
+    { input: 100, cacheRead: 900, cacheWrite: 0 },
+    { input: 100, cacheRead: 900, cacheWrite: 0 },
+    { input: 100, cacheRead: 900, cacheWrite: 0 },
+  ].map((usage, index) => JSON.stringify({
+    type: "message",
+    message: {
+      role: "assistant",
+      provider: "fixture-provider",
+      model: "fixture-model",
+      usage,
+      timestamp: 1_000 + index * 1_000,
+    },
+  }));
+  writeFileSync(join(sessions, "fixture.jsonl"), `${rows.join("\n")}\n`);
+  try {
+    const result = await runCli(
+      ["runtime", "cache-health", "--json"],
+      { UNDERSTUDY_CONVERSATION_RUNTIME_HOME: root },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    const health = JSON.parse(result.stdout);
+    assert.equal(health.status, "healthy");
+    assert.equal(health.score_pct, 90);
+    assert.equal(health.comparable_turns, 3);
+    assert.equal(health.alert, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("CLI lifecycle installs, starts, diagnoses, and stops the packaged sidecar", async () => {
@@ -1400,7 +1485,12 @@ test("managed sidecar dispatches an authenticated Pi run", async () => {
         created: 1,
         model: "managed-sidecar-pi",
         choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-        usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+        usage: {
+          prompt_tokens: 3,
+          completion_tokens: 4,
+          total_tokens: 7,
+          prompt_tokens_details: { cached_tokens: 2 },
+        },
       },
     ]);
   });
@@ -1436,6 +1526,12 @@ test("managed sidecar dispatches an authenticated Pi run", async () => {
       .map((line) => JSON.parse(line));
     assert.deepEqual(events.map((event) => event.event), ["message", "delta", "usage"]);
     assert.ok(events.every((event) => event.runtime_id === "pi-agent-session"));
+    const usage = events.find((event) => event.event === "usage").data;
+    assert.equal(usage.cached_input_tokens, 2);
+    assert.equal(usage.cache_write_input_tokens, 0);
+    assert.equal(usage.prompt_input_tokens, 3);
+    assert.equal(usage.cache_reported, true);
+    assert.equal(usage.cache_read_pct, 66.7);
     validateRuntimeTrace(events);
   } finally {
     await stopConversationRuntime().catch(() => {});

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -186,7 +186,9 @@ test("cache health stays quiet until supported evidence exists and alerts only o
 
 test("runtime cache-health command reads the private Pi session ledger", async () => {
   const root = mkdtempSync(join(tmpdir(), "understudy-cache-health-cli-"));
-  const sessions = join(root, "sessions");
+  // Pi partitions public session ids by hash, then lets its session manager
+  // create a nested sessions ledger below that partition.
+  const sessions = join(root, "pi-sessions", "fixture-session-hash", "sessions");
   mkdirSync(sessions, { recursive: true });
   const rows = [
     { input: 100, cacheRead: 0, cacheWrite: 900 },


### PR DESCRIPTION
## What changed

- retain Pi/OpenAI-compatible cache read, cache write, prompt-input, and reuse evidence in canonical usage events
- add `understudy runtime cache-health` over the private append-only Pi session ledger
- show one quiet aggregate Cache health metric in Desktop Usage
- alert only when a same-model, within-TTL window drops at least 20 percentage points and misses at least 2,048 reusable tokens
- report providers without cache evidence as unavailable, never as 0%
- gate dynamic tool loading until the Pi release with the cache-preserving deferred-tool contract is published

## Why

This creates a trustworthy baseline before dynamic loading changes the active tool schema. Users get one low-noise health signal rather than per-turn cache warnings. Dynamic loading does not fall back to the older cache-busting `setActiveTools` path.

## Live correction

The first pass scanned `sessions/`, while Pi stores Desktop sessions under `pi-sessions/*/sessions/`. The corrected reader now finds 1,099 local turns and correctly reports cache health as unavailable because the local MLX provider does not report prompt-cache use. It emits no alert.

## Stack and compatibility

- rebased onto #149 after the supervision-replacement P0 fix
- runtime contract 0.3.4 prevents reuse of older 0.3.3 sidecars
- registry check on 2026-07-12: `@earendil-works/pi-coding-agent` and `pi-ai` remain 0.80.6, so dynamic loading remains intentionally gated

## Verification

- `npm run check`: 207/207 tests, typecheck, skills validation, and package smoke
- Rust: 128 passed, 1 intentionally ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- production Next build
- `git diff --check`

`cargo fmt --check` still reports pre-existing formatting differences in unrelated Rust files; this PR does not rewrite them.
