### PR TITLE
Route native desktop chat through canonical Pi runtime

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -45,6 +45,7 @@ import {
   type ToolPart,
 } from "@/components/ai-elements/tool";
 import { modelShortName, type SnapshotAlias } from "../lib/model-aliases";
+import type { FileUIPart } from "ai";
 
 type Role = "user" | "assistant";
 type ToolTrace = {
@@ -54,7 +55,20 @@ type ToolTrace = {
   output?: unknown;
   errorText?: string;
 };
-type Msg = { role: Role; content: string; model?: string; reasoning?: string; tools?: ToolTrace[] };
+type ChatAttachment = {
+  id: string;
+  filename: string;
+  media_type: string;
+  data_url: string;
+};
+type Msg = {
+  role: Role;
+  content: string;
+  model?: string;
+  reasoning?: string;
+  tools?: ToolTrace[];
+  attachments?: ChatAttachment[];
+};
 type ChatEvent =
   | { type: "Notice"; message: string }
   | { type: "Chunk"; text: string }
@@ -75,6 +89,25 @@ type ResidencySnapshot = {
 };
 type SnapshotModel = SnapshotAlias;
 type ChatStatus = "ready" | "streaming" | "error";
+
+const canonicalAttachment = async (file: FileUIPart): Promise<ChatAttachment> => {
+  const mediaType = file.mediaType || "";
+  if (!mediaType.startsWith("image/") || !file.url.startsWith(`data:${mediaType};base64,`)) {
+    throw new Error("Only valid image attachments are supported.");
+  }
+  const bytes = new Uint8Array(await (await fetch(file.url)).arrayBuffer());
+  if (bytes.byteLength === 0 || bytes.byteLength > 8 * 1024 * 1024) {
+    throw new Error("Each image must be between 1 byte and 8 MB.");
+  }
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  const id = Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return {
+    id,
+    filename: file.filename || "image",
+    media_type: mediaType,
+    data_url: file.url,
+  };
+};
 type SidekickEvent = {
   id: number;
   session_id: string;
@@ -353,16 +386,20 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     [choices, selectedModel],
   );
 
-  const send = async (text: string, files = 0) => {
+  const send = async (text: string, files: FileUIPart[] = []) => {
     const clean = text.trim();
-    if ((!clean && files === 0) || streaming) return;
-    if (files > 0) {
-      setErr("Image/file attachment UI is enabled, but multimodal chat payloads are not wired yet.");
-      return;
-    }
+    if ((!clean && files.length === 0) || streaming) return;
     setInput("");
     setErr(null);
     setNotice(null);
+
+    let attachments: ChatAttachment[];
+    try {
+      attachments = await Promise.all(files.map(canonicalAttachment));
+    } catch (error) {
+      setErr(String(error));
+      throw error;
+    }
 
     const choice = selectedChoice;
     if (choice.route === "local" && choice.slotId == null) {
@@ -374,7 +411,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
       return;
     }
 
-    const toSend: Msg[] = [...messages, { role: "user", content: clean, model: choice.label }];
+    const toSend: Msg[] = [
+      ...messages,
+      { role: "user", content: clean, model: choice.label, attachments },
+    ];
     setMessages([...toSend, { role: "assistant", content: "", reasoning: "", model: choice.label }]);
     setStreaming(true);
     setAssistantSpeaking(false);
@@ -457,7 +497,11 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
 
     try {
       await invoke("chat_stream", {
-        messages: toSend.map(({ role, content }) => ({ role, content })),
+        messages: toSend.map(({ role, content, attachments: messageAttachments }) => ({
+          role,
+          content,
+          attachments: messageAttachments ?? [],
+        })),
         // Anthropic choices encode the model in the id (anthropic:<model>).
         route: choice.route === "anthropic" ? choice.id : choice.route,
         slotId: choice.slotId,
@@ -617,6 +661,16 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
                 >
                   <div className="chat-role">{m.role === "assistant" ? m.model ?? "Assistant" : "You"}</div>
                   <MessageContent>
+                    {m.role === "user" && m.attachments && m.attachments.length > 0 && (
+                      <div className="chat-image-list">
+                        {m.attachments.map((attachment) => (
+                          <figure className="chat-image" key={attachment.id}>
+                            <img src={attachment.data_url} alt={attachment.filename} />
+                            <figcaption>{attachment.filename}</figcaption>
+                          </figure>
+                        ))}
+                      </div>
+                    )}
                     {m.role === "assistant" && reasoningText && (
                       <ReasoningSubstream active={isActiveAssistant} text={reasoningText} />
                     )}
@@ -668,7 +722,9 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
           accept="image/*"
           multiple
           maxFiles={4}
-          onSubmit={(message) => send(message.text, message.files.length)}
+          maxFileSize={8 * 1024 * 1024}
+          onError={(error) => setErr(error.message)}
+          onSubmit={(message) => send(message.text, message.files)}
           className="border-rule bg-card"
         >
           <PromptInputBody>

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -587,8 +587,17 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     latestSidekickEvent?.stage === "queued" ||
     latestSidekickEvent?.stage === "started" ||
     latestSidekickEvent?.stage === "waiting";
+  const supervisionVisible =
+    latestSidekickEvent?.mode === "supervision" &&
+    (streaming ||
+      latestSidekickEvent.stage === "interrupt" ||
+      latestSidekickEvent.stage === "nudge" ||
+      latestSidekickEvent.stage === "stop" ||
+      latestSidekickEvent.stage === "student_interrupted" ||
+      latestSidekickEvent.stage === "teacher_continuation");
   const sidekickMonitorVisible =
     backgroundSidekickActive ||
+    supervisionVisible ||
     (streaming &&
       (latestSidekickEvent?.stage === "handoff_ready" ||
         latestSidekickEvent?.stage === "handoff_deferred" ||
@@ -696,13 +705,29 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
               <div className="sidekick-orbit" aria-hidden="true" />
               <div className="sidekick-active-copy">
                 <div className="sidekick-active-kicker">
-                  {latestSidekickEvent.mode === "routing" ? "Routing" : "Sidekick"}
+                  {latestSidekickEvent.mode === "routing"
+                    ? "Routing"
+                    : latestSidekickEvent.mode === "supervision"
+                      ? "Supervisor"
+                      : "Sidekick"}
                 </div>
                 <div className="sidekick-active-title">
                   {latestSidekickEvent.stage === "compaction_boundary"
                     ? "Compaction boundary"
                     : latestSidekickEvent.stage === "route_applied"
                       ? "Route switched"
+                    : latestSidekickEvent.stage === "student_interrupted"
+                      ? "Student interrupted"
+                    : latestSidekickEvent.stage === "teacher_continuation"
+                      ? "Teacher continuing"
+                    : latestSidekickEvent.stage === "interrupt"
+                      ? "Intervention requested"
+                    : latestSidekickEvent.stage === "nudge"
+                      ? "Student nudged"
+                    : latestSidekickEvent.stage === "stop"
+                      ? "Turn stopped"
+                    : latestSidekickEvent.mode === "supervision"
+                      ? "Checking the smaller model"
                     : backgroundSidekickActive
                       ? "Working in background"
                       : "Background update"}

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -56,6 +56,7 @@ type ToolTrace = {
 };
 type Msg = { role: Role; content: string; model?: string; reasoning?: string; tools?: ToolTrace[] };
 type ChatEvent =
+  | { type: "Notice"; message: string }
   | { type: "Chunk"; text: string }
   | { type: "ReasoningChunk"; text: string }
   | { type: "ToolCall"; name: string; args: unknown }
@@ -245,6 +246,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const [streaming, setStreaming] = useState(false);
   const [assistantSpeaking, setAssistantSpeaking] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [choices, setChoices] = useState<ModelChoice[]>([CLOUD_MODEL]);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [thinkingPending, setThinkingPending] = useState<{ slotId: number; thinking: boolean } | null>(null);
@@ -300,6 +302,20 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     }
   };
 
+  const stopStreaming = () => {
+    void invoke<{ status: string }>("conversation_runtime_cancel", { sessionId })
+      .then((result) => {
+        if (result.status === "idle") {
+          setNotice("This turn is using the one-release compatibility engine and cannot be stopped yet.");
+        }
+      })
+      .catch((e) => {
+        setErr(String(e));
+        setStreaming(false);
+        setAssistantSpeaking(false);
+      });
+  };
+
   useEffect(() => {
     refreshModels();
     const timer = window.setInterval(refreshModels, 2500);
@@ -346,6 +362,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     }
     setInput("");
     setErr(null);
+    setNotice(null);
 
     const choice = selectedChoice;
     if (choice.route === "local" && choice.slotId == null) {
@@ -364,7 +381,9 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
 
     const ch = new Channel<ChatEvent>();
     ch.onmessage = (msg) => {
-      if (msg.type === "Chunk") {
+      if (msg.type === "Notice") {
+        setNotice(msg.message);
+      } else if (msg.type === "Chunk") {
         setAssistantSpeaking(true);
         setMessages((prev) => {
           if (prev.length === 0) return prev;
@@ -470,6 +489,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     setMessages([]);
     setInput("");
     setErr(null);
+    setNotice(null);
     setSessionId(crypto.randomUUID());
     setAssistantSpeaking(false);
     setPersonaReady(false);
@@ -638,6 +658,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
             </div>
           )}
           {err && <div className="chat-err">{err}</div>}
+          {notice && !err && <div className="chat-runtime-notice">{notice}</div>}
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
@@ -681,7 +702,8 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
             </PromptInputTools>
             <PromptInputSubmit
               status={streaming ? "streaming" : err ? "error" : "ready"}
-              disabled={streaming || !input.trim() || (selectedChoice.route === "local" && !selectedChoice.active)}
+              onStop={stopStreaming}
+              disabled={!streaming && (!input.trim() || (selectedChoice.route === "local" && !selectedChoice.active))}
             />
           </PromptInputFooter>
         </PromptInput>

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -72,6 +72,7 @@ type Msg = {
 type ChatEvent =
   | { type: "Notice"; message: string }
   | { type: "Chunk"; text: string }
+  | { type: "ReplaceChunk"; text: string }
   | { type: "ReasoningChunk"; text: string }
   | { type: "ToolCall"; name: string; args: unknown }
   | { type: "ToolResult"; name: string; ok: boolean; result: unknown }
@@ -466,6 +467,15 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
           const p = [...prev];
           const last = p.length - 1;
           p[last] = { ...p[last], content: p[last].content + msg.text };
+          return p;
+        });
+      } else if (msg.type === "ReplaceChunk") {
+        setAssistantSpeaking(true);
+        setMessages((prev) => {
+          if (prev.length === 0) return prev;
+          const p = [...prev];
+          const last = p.length - 1;
+          p[last] = { ...p[last], content: msg.text };
           return p;
         });
       } else if (msg.type === "ReasoningChunk") {

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -116,6 +116,11 @@ type SidekickEvent = {
   detail: string;
   created_at: string;
 };
+type PersistedChatSession = {
+  session_id: string;
+  messages: Msg[];
+  updated_at: string;
+};
 type LocalModelChoice = {
   id: string;
   label: string;
@@ -287,6 +292,8 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const [personaCycle, setPersonaCycle] = useState(0);
   const [introThinking, setIntroThinking] = useState(true);
   const [sidekickEvents, setSidekickEvents] = useState<SidekickEvent[]>([]);
+  const [sessionHydrated, setSessionHydrated] = useState(false);
+  const observedResetToken = useRef(false);
 
   const refreshModels = async () => {
     try {
@@ -354,6 +361,35 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     const timer = window.setInterval(refreshModels, 2500);
     return () => window.clearInterval(timer);
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    invoke<PersistedChatSession | null>("chat_session_latest")
+      .then((saved) => {
+        if (cancelled || !saved) return;
+        setSessionId(saved.session_id);
+        setMessages(saved.messages);
+      })
+      .catch(() => {
+        // A corrupt or legacy session must never block a fresh local chat.
+      })
+      .finally(() => {
+        if (!cancelled) setSessionHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!sessionHydrated || streaming) return;
+    const timer = window.setTimeout(() => {
+      invoke("chat_session_save", { sessionId, messages }).catch(() => {
+        setNotice("This chat could not be saved for restart; the current turn is unaffected.");
+      });
+    }, 150);
+    return () => window.clearTimeout(timer);
+  }, [messages, sessionHydrated, sessionId, streaming]);
 
   useEffect(() => {
     setIntroThinking(true);
@@ -542,6 +578,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   };
 
   useEffect(() => {
+    if (!observedResetToken.current) {
+      observedResetToken.current = true;
+      return;
+    }
     restartChat();
   }, [resetToken]);
 
@@ -584,9 +624,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const sidekickTool = latestAssistant?.tools?.find((tool) => tool.name === "delegate_to_sidekick");
   const latestSidekickEvent = sidekickEvents[0];
   const backgroundSidekickActive =
-    latestSidekickEvent?.stage === "queued" ||
-    latestSidekickEvent?.stage === "started" ||
-    latestSidekickEvent?.stage === "waiting";
+    latestSidekickEvent?.mode !== "supervision" &&
+    (latestSidekickEvent?.stage === "queued" ||
+      latestSidekickEvent?.stage === "started" ||
+      latestSidekickEvent?.stage === "waiting");
   const supervisionVisible =
     latestSidekickEvent?.mode === "supervision" &&
     (streaming ||

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2319,6 +2319,12 @@ select,
   font-size: 12px;
   padding: 6px 0;
 }
+.chat-runtime-notice {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+  padding: 5px 0;
+}
 .chat-input {
   display: flex;
   gap: 10px;

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2325,6 +2325,29 @@ select,
   line-height: 1.4;
   padding: 5px 0;
 }
+.chat-image-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.chat-image {
+  margin: 0;
+  max-width: min(280px, 100%);
+}
+.chat-image img {
+  display: block;
+  max-height: 220px;
+  max-width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--r-control);
+  object-fit: contain;
+}
+.chat-image figcaption {
+  color: var(--text-muted);
+  font-size: 10px;
+  margin-top: 3px;
+}
 .chat-input {
   display: flex;
   gap: 10px;

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4430,6 +4430,7 @@ version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "futures-util",
  "getrandom 0.2.17",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio"] }
 sha2 = "0.10"
 getrandom = "0.2"
+base64 = "0.22"
 # Deterministic regex scoring for build-your-own evals; the -lite build keeps
 # the dependency footprint at a single crate.
 regex-lite = "0.1"

--- a/apps/homescreen/src-tauri/src/agent_card.rs
+++ b/apps/homescreen/src-tauri/src/agent_card.rs
@@ -90,6 +90,7 @@ pub fn record_api_capability(port: u16, token: &str) {
         },
         "control_api": {
             "status_url": format!("http://127.0.0.1:{port}/v1/status"),
+            "migration_status_url": format!("http://127.0.0.1:{port}/v1/metrics/chat-routes"),
             "models_url": format!("http://127.0.0.1:{port}/v1/models"),
             "model_catalog_url": format!("http://127.0.0.1:{port}/v1/models/catalog"),
             "residency_url": format!("http://127.0.0.1:{port}/v1/residency"),

--- a/apps/homescreen/src-tauri/src/agent_card.rs
+++ b/apps/homescreen/src-tauri/src/agent_card.rs
@@ -13,6 +13,7 @@
 //   - Writes are atomic: temp file in the same directory, then rename.
 
 use serde_json::{json, Map, Value};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 const SCHEMA_VERSION: &str = "understudy.agent_card.v1";
@@ -31,6 +32,15 @@ fn card_path() -> Option<PathBuf> {
         PathBuf::from(home)
             .join(".understudy")
             .join("agent-card.json"),
+    )
+}
+
+fn api_capability_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        PathBuf::from(home)
+            .join(".understudy")
+            .join("desktop-api.json"),
     )
 }
 
@@ -55,6 +65,52 @@ pub fn record_server_started(port: u16, token_present: bool) {
             app.insert("warm_models".into(), json!([]));
         }
     });
+}
+
+/// Owner-only CLI-to-app capability. Unlike the public agent card, this file
+/// contains the bearer token for the authenticated loopback API. The CLI also
+/// verifies the pid and `/health` before accepting it.
+pub fn record_api_capability(port: u16, token: &str) {
+    let Some(path) = api_capability_path() else {
+        return;
+    };
+    let value = json!({
+        "schema_version": "understudy.desktop_api.v2",
+        "api_version": "2.1.0",
+        "base_url": format!("http://127.0.0.1:{port}"),
+        "mcp_url": format!("http://127.0.0.1:{port}/mcp"),
+        "status_url": format!("http://127.0.0.1:{port}/v1/status"),
+        "capabilities_url": format!("http://127.0.0.1:{port}/v1/capabilities"),
+        "conversation_api": {
+            "event_schema": crate::conversation_runtime::EVENT_SCHEMA,
+            "start_turn_template": format!("http://127.0.0.1:{port}/v1/conversations/{{session_id}}/turns"),
+            "cancel_run_template": format!("http://127.0.0.1:{port}/v1/runs/{{run_id}}/cancel"),
+            "run_events_template": format!("http://127.0.0.1:{port}/v1/runs/{{run_id}}/events"),
+            "supervisor_feedback_url": format!("http://127.0.0.1:{port}/v1/feedback/supervisor"),
+        },
+        "control_api": {
+            "status_url": format!("http://127.0.0.1:{port}/v1/status"),
+            "models_url": format!("http://127.0.0.1:{port}/v1/models"),
+            "model_catalog_url": format!("http://127.0.0.1:{port}/v1/models/catalog"),
+            "residency_url": format!("http://127.0.0.1:{port}/v1/residency"),
+            "downloads_url": format!("http://127.0.0.1:{port}/v1/downloads"),
+        },
+        "chat": {
+            "supports_inline_images": true,
+            "supports_local_supervision": true,
+            "max_images_per_turn": 4,
+            "max_image_bytes": 8 * 1024 * 1024,
+            "accepted_media_types": ["image/png", "image/jpeg", "image/webp", "image/gif"],
+            "attachment_fields": ["filename", "mediaType", "dataUrl"],
+        },
+        "pid": std::process::id(),
+        "app_version": env!("CARGO_PKG_VERSION"),
+        "token": token,
+        "updated_at": now_iso(),
+    });
+    if let Err(err) = write_private_atomic(&path, &value) {
+        eprintln!("understudy desktop capability: write failed: {err}");
+    }
 }
 
 /// Residency changed (warm/cool/assign committed): refresh the warm set.
@@ -83,6 +139,9 @@ pub fn mark_stopped() {
         app.insert("stopped_at".into(), json!(now_iso()));
         app.insert("warm_models".into(), json!([]));
     });
+    if let Some(path) = api_capability_path() {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// Serializes every card writer in this process. The three writers run on
@@ -149,6 +208,42 @@ fn write_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
     ));
     let result = std::fs::write(&tmp, format!("{}\n", serde_json::to_string_pretty(value)?))
         .and_then(|_| std::fs::rename(&tmp, path));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
+
+fn write_private_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
+    static PRIVATE_TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let dir = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("capability path has no parent"))?;
+    std::fs::create_dir_all(dir)?;
+    let tmp = dir.join(format!(
+        ".desktop-api.json.tmp-{}-{}",
+        std::process::id(),
+        PRIVATE_TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let result = (|| {
+        let mut file = options.open(&tmp)?;
+        file.write_all(format!("{}\n", serde_json::to_string_pretty(value)?).as_bytes())?;
+        file.sync_all()?;
+        std::fs::rename(&tmp, path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(())
+    })();
     if result.is_err() {
         let _ = std::fs::remove_file(&tmp);
     }
@@ -239,5 +334,38 @@ mod tests {
         .unwrap();
         let card: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(card["app"]["running"], false);
+    }
+
+    #[test]
+    fn private_api_capability_is_atomic_and_owner_only() {
+        let path = temp_card_path().with_file_name("desktop-api.json");
+        let value = json!({
+            "schema_version": "understudy.desktop_api.v2",
+            "base_url": "http://127.0.0.1:17790",
+            "pid": 123,
+            "token": "secret-test-token"
+        });
+        write_private_atomic(&path, &value).unwrap();
+        let parsed: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(parsed["token"], "secret-test-token");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o077,
+                0
+            );
+        }
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .contains("desktop-api.json.tmp")
+            })
+            .collect();
+        assert!(leftovers.is_empty());
     }
 }

--- a/apps/homescreen/src-tauri/src/bin.rs
+++ b/apps/homescreen/src-tauri/src/bin.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde_json::Value;
+
 /// Resolve a sidecar/CLI binary to an absolute path so the app works when
 /// launched from Finder (no shell PATH). Falls back to the bare name under
 /// `tauri dev`, which inherits the terminal PATH.
@@ -71,6 +73,36 @@ pub fn moraine_mcp() -> String {
     resolve("moraine-mcp")
 }
 pub fn mlx_server() -> String {
+    if let Some(candidate) = std::env::var_os("UNDERSTUDY_MLX_VLM_SERVER") {
+        let candidate = PathBuf::from(candidate);
+        if candidate.is_file() {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+    // The CLI owns the exact mlx-vlm source pin and repair lifecycle. Asking
+    // it for the healthy managed binary prevents Finder-launched Desktop from
+    // accidentally selecting an older global `mlx_vlm.server` on PATH.
+    if let Ok(output) = command("understudy")
+        .args(["models", "runtime", "status", "--json"])
+        .output()
+    {
+        if output.status.success() {
+            if let Ok(status) = serde_json::from_slice::<Value>(&output.stdout) {
+                let healthy = status
+                    .get("healthy")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if healthy {
+                    if let Some(path) = status.get("server_binary").and_then(Value::as_str) {
+                        let candidate = PathBuf::from(path);
+                        if candidate.is_file() {
+                            return candidate.to_string_lossy().into_owned();
+                        }
+                    }
+                }
+            }
+        }
+    }
     resolve("mlx_vlm.server")
 }
 pub fn understudy() -> String {

--- a/apps/homescreen/src-tauri/src/bin.rs
+++ b/apps/homescreen/src-tauri/src/bin.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Resolve a sidecar/CLI binary to an absolute path so the app works when
@@ -23,7 +23,19 @@ pub fn resolve(name: &str) -> String {
 }
 
 pub fn command(name: &str) -> Command {
-    let mut cmd = Command::new(resolve(name));
+    let resolved = resolve(name);
+    let mut cmd = if name == "understudy"
+        && Path::new(&resolved)
+            .extension()
+            .and_then(|value| value.to_str())
+            == Some("js")
+    {
+        let mut command = Command::new("node");
+        command.arg(resolved);
+        command
+    } else {
+        Command::new(resolved)
+    };
     cmd.env("PATH", runtime_path());
     cmd
 }

--- a/apps/homescreen/src-tauri/src/bin.rs
+++ b/apps/homescreen/src-tauri/src/bin.rs
@@ -5,6 +5,14 @@ use std::process::Command;
 /// launched from Finder (no shell PATH). Falls back to the bare name under
 /// `tauri dev`, which inherits the terminal PATH.
 pub fn resolve(name: &str) -> String {
+    if name == "understudy" {
+        if let Some(candidate) = std::env::var_os("UNDERSTUDY_BIN") {
+            let candidate = PathBuf::from(candidate);
+            if candidate.is_file() {
+                return candidate.to_string_lossy().into_owned();
+            }
+        }
+    }
     if let Some(home) = std::env::var_os("HOME") {
         let candidate = PathBuf::from(&home).join(".local/bin").join(name);
         if candidate.is_file() {

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -2008,10 +2008,11 @@ fn automatic_supervision_config(
 }
 
 fn sidecar_provider_base_url(endpoint: &str) -> String {
+    let endpoint = endpoint.trim_end_matches('/');
     endpoint
-        .trim_end_matches('/')
         .strip_suffix("/chat/completions")
-        .unwrap_or(endpoint.trim_end_matches('/'))
+        .or_else(|| endpoint.strip_suffix("/v1/messages"))
+        .unwrap_or(endpoint)
         .to_string()
 }
 
@@ -2179,6 +2180,7 @@ fn sidecar_run_request(
         "session_id": session_id,
         "base_url": sidecar_provider_base_url(&binding.url),
         "model": binding.model_field,
+        "provider_kind": if binding.route == "anthropic" { "anthropic" } else { "openai-compatible" },
         "role": if supervision.is_some() { "student" } else { "primary" },
         "messages": messages,
         "tools": sidecar_tool_definitions(supervision.is_none()),
@@ -2186,9 +2188,14 @@ fn sidecar_run_request(
         "max_tool_rounds": MAX_TOOL_ROUNDS,
         "initial_sequence": 0,
         "emit_input": true,
-        "allow_remote": binding.route == "cloud",
+        "allow_remote": matches!(binding.route.as_str(), "cloud" | "anthropic"),
         "runtime_backend": "pi",
     });
+    if binding.route == "anthropic" {
+        request["provider_api_key"] = json!(binding.bearer.as_deref().ok_or_else(|| {
+            "Anthropic route lost its in-memory provider credential".to_string()
+        })?);
+    }
     if let Some(url) = tool_executor_url {
         request["tool_executor_url"] = json!(url);
     }
@@ -2809,7 +2816,7 @@ pub async fn chat_stream(
         }
     }
 
-    if binding.route != "anthropic" {
+    {
         if let Some(config) = supervision.as_ref() {
             let student = config
                 .pointer("/student/model")
@@ -4040,6 +4047,18 @@ mod tests {
         assert!(result.elapsed_ms >= 777);
         assert!(result.compacted);
         assert_eq!(result.context_tokens_before, 15_000);
+    }
+
+    #[test]
+    fn canonical_runtime_receives_provider_base_urls_not_completion_endpoints() {
+        assert_eq!(
+            sidecar_provider_base_url("https://api.anthropic.com/v1/messages"),
+            "https://api.anthropic.com"
+        );
+        assert_eq!(
+            sidecar_provider_base_url("https://gateway.example/v1/chat/completions"),
+            "https://gateway.example/v1"
+        );
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -119,6 +119,7 @@ const SIDEKICK_MEMORY_PREFIX: &str = "Sidekick compacted memory:";
 const CHAT_COMPACTION_TOKEN_THRESHOLD: u64 = 12_000;
 const CHAT_RECENT_CONTEXT_MESSAGES: usize = 12;
 const CHAT_COMPACTED_CONTEXT_PREFIX: &str = "Chat compacted context:";
+const SMALL_FIRST_SUPERVISOR_PROMPT: &str = "Judge whether the smaller student's partial answer is correct, relevant, safe, and using tools appropriately. INTERRUPT factual errors, invented evidence, wrong tool arguments, irrelevant refusals, or confident claims unsupported by tool results so the teacher can correct them. NUDGE only when a short concrete correction can let the student continue. CONTINUE when the partial is sound, including when a sound answer is complete. Never use STOP for an incorrect, incomplete, irrelevant, or otherwise correctable answer; STOP is reserved for a turn that must end without any teacher response. Give one concise, specific reason for every INTERRUPT or NUDGE.";
 
 const SIDEKICK_SESSION_CACHE_MAX: usize = 32;
 
@@ -1949,6 +1950,61 @@ struct RouteBinding {
     model_field: String,
 }
 
+fn model_size_billions(model: &str) -> Option<f64> {
+    let regex = regex_lite::Regex::new(r"(?i)(?:^|[^0-9])(\d+(?:\.\d+)?)b(?:[^a-z0-9]|$)")
+        .expect("model-size regex is valid");
+    regex
+        .captures(model)
+        .and_then(|captures| captures.get(1))
+        .and_then(|value| value.as_str().parse::<f64>().ok())
+}
+
+fn automatic_supervision_config(
+    app: &AppHandle,
+    mgr: &Residency,
+    binding: &RouteBinding,
+    active_slot_id: Option<u32>,
+) -> Option<Value> {
+    if binding.route == "anthropic"
+        || matches!(
+            app.state::<crate::db::Db>()
+                .setting_get("conversation.supervision")
+                .as_deref(),
+            Some("off" | "disabled" | "false")
+        )
+    {
+        return None;
+    }
+    let (_student_slot, student_port, student_path, _student_id) =
+        mgr.sidekick_endpoint(active_slot_id)?;
+    if binding.route == "local" {
+        let student_size = model_size_billions(&student_path)?;
+        let teacher_size = model_size_billions(&binding.model_field)?;
+        if student_size >= teacher_size {
+            return None;
+        }
+    }
+    let teacher_base_url = sidecar_provider_base_url(&binding.url);
+    Some(json!({
+        "student": {
+            "base_url": format!("http://127.0.0.1:{student_port}/v1"),
+            "model": student_path,
+        },
+        "supervisor": {
+            "base_url": teacher_base_url,
+            "model": binding.model_field,
+            "system_prompt": SMALL_FIRST_SUPERVISOR_PROMPT,
+            "max_output_tokens": 48,
+        },
+        "teacher": {
+            "base_url": sidecar_provider_base_url(&binding.url),
+            "model": binding.model_field,
+        },
+        "boundary_chars": 240,
+        "max_nudges": 2,
+    }))
+}
+
 fn sidecar_provider_base_url(endpoint: &str) -> String {
     endpoint
         .trim_end_matches('/')
@@ -2010,7 +2066,10 @@ fn openai_chat_message(message: &ChatMsg) -> Result<Value, String> {
     Ok(json!({ "role": message.role, "content": content }))
 }
 
-fn sidecar_runtime_messages(original: &[ChatMsg], outbound: &[Value]) -> Result<Vec<Value>, String> {
+fn sidecar_runtime_messages(
+    original: &[ChatMsg],
+    outbound: &[Value],
+) -> Result<Vec<Value>, String> {
     let attachment_meta: HashMap<&str, &ChatAttachment> = original
         .iter()
         .flat_map(|message| message.attachments.iter())
@@ -2039,9 +2098,9 @@ fn sidecar_runtime_messages(original: &[ChatMsg], outbound: &[Value]) -> Result<
             let mut attachments = Vec::new();
             for part in parts {
                 match part.get("type").and_then(Value::as_str) {
-                    Some("text") => text.push_str(
-                        part.get("text").and_then(Value::as_str).unwrap_or_default(),
-                    ),
+                    Some("text") => {
+                        text.push_str(part.get("text").and_then(Value::as_str).unwrap_or_default())
+                    }
                     Some("image_url") => {
                         let data_url = part
                             .pointer("/image_url/url")
@@ -2066,14 +2125,22 @@ fn sidecar_runtime_messages(original: &[ChatMsg], outbound: &[Value]) -> Result<
         .collect()
 }
 
-fn sidecar_tool_definitions() -> Vec<Value> {
+fn sidecar_tool_definitions(allow_sidekick_delegation: bool) -> Vec<Value> {
     tool_schemas()
         .into_iter()
+        .filter(|tool| {
+            allow_sidekick_delegation
+                || tool.pointer("/function/name").and_then(Value::as_str)
+                    != Some("delegate_to_sidekick")
+        })
         .filter_map(|tool| {
             let function = tool.get("function")?;
             let mut definition = serde_json::Map::new();
             definition.insert("name".to_string(), function.get("name")?.clone());
-            if let Some(description) = function.get("description").filter(|value| value.is_string()) {
+            if let Some(description) = function
+                .get("description")
+                .filter(|value| value.is_string())
+            {
                 definition.insert("description".to_string(), description.clone());
             }
             definition.insert(
@@ -2093,10 +2160,11 @@ fn sidecar_run_request(
     original: &[ChatMsg],
     outbound: &[Value],
     binding: &RouteBinding,
+    supervision: Option<&Value>,
     slot_id: Option<u32>,
-    session_id: &str,
-    run_id: &str,
+    identity: (&str, &str),
 ) -> Result<Value, String> {
+    let (session_id, run_id) = identity;
     let messages = sidecar_runtime_messages(original, outbound)?;
     let tool_executor_url = crate::server::info(app).map(|(base_url, _)| {
         let query = slot_id
@@ -2109,9 +2177,9 @@ fn sidecar_run_request(
         "session_id": session_id,
         "base_url": sidecar_provider_base_url(&binding.url),
         "model": binding.model_field,
-        "role": "primary",
+        "role": if supervision.is_some() { "student" } else { "primary" },
         "messages": messages,
-        "tools": sidecar_tool_definitions(),
+        "tools": sidecar_tool_definitions(supervision.is_none()),
         "max_output_tokens": CHAT_MAX_TOKENS,
         "max_tool_rounds": MAX_TOOL_ROUNDS,
         "initial_sequence": 0,
@@ -2121,6 +2189,9 @@ fn sidecar_run_request(
     });
     if let Some(url) = tool_executor_url {
         request["tool_executor_url"] = json!(url);
+    }
+    if let Some(supervision) = supervision {
+        request["supervision"] = supervision.clone();
     }
     Ok(request)
 }
@@ -2637,14 +2708,6 @@ pub async fn chat_stream(
     } else {
         apply_dynamic_chat_route(&app, &session_id, &route, slot_id, &messages, &on_event)
     };
-    let sidekick_plan = maybe_spawn_parallel_sidekick(
-        &app,
-        &route,
-        slot_id,
-        &session_id,
-        &messages,
-        Some(&on_event),
-    );
     let mut binding = if let Some(model) = route.strip_prefix("anthropic:") {
         anthropic_route_binding(&app, model)?
     } else {
@@ -2653,7 +2716,26 @@ pub async fn chat_stream(
             _ => local_route_binding(&route, &mgr, slot_id)?,
         }
     };
-    if binding.route == "anthropic" && messages.iter().any(|message| !message.attachments.is_empty())
+    let mut supervision = automatic_supervision_config(&app, &mgr, &binding, slot_id);
+    let sidekick_plan = if supervision.is_some() {
+        ParallelSidekickPlan {
+            spawned: false,
+            wait_ms: 0,
+        }
+    } else {
+        maybe_spawn_parallel_sidekick(
+            &app,
+            &route,
+            slot_id,
+            &session_id,
+            &messages,
+            Some(&on_event),
+        )
+    };
+    if binding.route == "anthropic"
+        && messages
+            .iter()
+            .any(|message| !message.attachments.is_empty())
     {
         return Err(
             "Image attachments currently require a local model or the Understudy gateway"
@@ -2721,32 +2803,54 @@ pub async fn chat_stream(
                 &detail,
                 Some(&on_event),
             );
+            supervision = automatic_supervision_config(&app, &mgr, &binding, slot_id);
         }
     }
 
     if binding.route != "anthropic" {
+        if let Some(config) = supervision.as_ref() {
+            let student = config
+                .pointer("/student/model")
+                .and_then(Value::as_str)
+                .unwrap_or("smaller local model");
+            let teacher = config
+                .pointer("/teacher/model")
+                .and_then(Value::as_str)
+                .unwrap_or(&binding.model_field);
+            let detail = format!("run={run_id} · {student} is answering; {teacher} is supervising");
+            log_db_write(
+                "record_sidekick_event(supervision_started)",
+                app.state::<crate::db::Db>().record_sidekick_event(
+                    &session_id,
+                    "supervision",
+                    "started",
+                    &detail,
+                ),
+            );
+            let _ = on_event.send(ChatEvent::SidekickEvent {
+                mode: "supervision".to_string(),
+                stage: "started".to_string(),
+                detail,
+            });
+        }
         match sidecar_run_request(
             &app,
             &messages,
             &outbound_messages,
             &binding,
+            supervision.as_ref(),
             slot_id,
-            &session_id,
-            &run_id,
+            (&session_id, &run_id),
         ) {
             Ok(request) => {
                 match crate::conversation_sidecar::try_run_chat(&app, request, &on_event).await {
                     crate::conversation_sidecar::SidecarAttempt::Completed(sidecar) => {
-                        let completion_tokens = sidecar_usage_tokens(
-                            sidecar.usage.as_ref(),
-                            "completion_tokens",
-                        )
-                        .unwrap_or_else(|| approximate_token_count(&sidecar.content));
-                        let prompt_tokens = sidecar_usage_tokens(
-                            sidecar.usage.as_ref(),
-                            "prompt_tokens",
-                        )
-                        .unwrap_or(prompt_tokens);
+                        let completion_tokens =
+                            sidecar_usage_tokens(sidecar.usage.as_ref(), "completion_tokens")
+                                .unwrap_or_else(|| approximate_token_count(&sidecar.content));
+                        let prompt_tokens =
+                            sidecar_usage_tokens(sidecar.usage.as_ref(), "prompt_tokens")
+                                .unwrap_or(prompt_tokens);
                         record_chat_run(
                             &app,
                             ChatRunInput {
@@ -3686,7 +3790,10 @@ mod tests {
 
         let projected = sidecar_runtime_messages(&original, &outbound).unwrap();
         assert_eq!(projected[0]["content"], "inspect this");
-        assert_eq!(projected[0]["attachments"][0]["id"], original[0].attachments[0].id);
+        assert_eq!(
+            projected[0]["attachments"][0]["id"],
+            original[0].attachments[0].id
+        );
         assert_eq!(projected[0]["attachments"][0]["filename"], "fixture.png");
 
         let mut tampered = image_message();
@@ -3694,6 +3801,29 @@ mod tests {
         assert!(openai_chat_message(&tampered)
             .unwrap_err()
             .contains("content hash"));
+    }
+
+    #[test]
+    fn supervision_requires_a_strictly_smaller_model_size() {
+        assert_eq!(model_size_billions("gemma-4-2b-understudy"), Some(2.0));
+        assert_eq!(
+            model_size_billions("gemma-4-26b-a4b-it-qat-mlx-vlm-understudy"),
+            Some(26.0)
+        );
+        assert_eq!(model_size_billions("frontier-model"), None);
+    }
+
+    #[test]
+    fn supervised_runtime_cannot_delegate_recursively_to_the_sidekick() {
+        let supervised = sidecar_tool_definitions(false);
+        assert!(supervised.iter().all(|tool| {
+            tool.get("name").and_then(Value::as_str) != Some("delegate_to_sidekick")
+        }));
+
+        let unsupervised = sidecar_tool_definitions(true);
+        assert!(unsupervised.iter().any(|tool| {
+            tool.get("name").and_then(Value::as_str) == Some("delegate_to_sidekick")
+        }));
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -20,6 +20,9 @@ use crate::route_policy::{
 #[derive(Serialize, Clone)]
 #[serde(tag = "type")]
 pub enum ChatEvent {
+    Notice {
+        message: String,
+    },
     Chunk {
         text: String,
     },
@@ -486,7 +489,7 @@ pub(crate) struct ToolCallAcc {
     pub(crate) arguments: String,
 }
 
-fn tool_schemas() -> Vec<Value> {
+pub(crate) fn tool_schemas() -> Vec<Value> {
     vec![
         json!({
             "type": "function",
@@ -651,7 +654,7 @@ fn benchmark_tool_schemas(allow_sidekick_tool: bool) -> Vec<Value> {
         .collect()
 }
 
-async fn tool_result(
+pub(crate) async fn tool_result(
     app: &AppHandle,
     mgr: &Residency,
     active_slot_id: Option<u32>,
@@ -1909,6 +1912,95 @@ struct RouteBinding {
     model_field: String,
 }
 
+fn sidecar_provider_base_url(endpoint: &str) -> String {
+    endpoint
+        .trim_end_matches('/')
+        .strip_suffix("/chat/completions")
+        .unwrap_or(endpoint.trim_end_matches('/'))
+        .to_string()
+}
+
+fn sidecar_runtime_messages(outbound: &[Value]) -> Result<Vec<Value>, String> {
+    outbound
+        .iter()
+        .map(|message| {
+            let role = message
+                .get("role")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "conversation runtime message is missing role".to_string())?;
+            let content = message
+                .get("content")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "conversation runtime message content must be text".to_string())?;
+            Ok(json!({ "role": role, "content": content }))
+        })
+        .collect()
+}
+
+fn sidecar_tool_definitions() -> Vec<Value> {
+    tool_schemas()
+        .into_iter()
+        .filter_map(|tool| {
+            let function = tool.get("function")?;
+            let mut definition = serde_json::Map::new();
+            definition.insert("name".to_string(), function.get("name")?.clone());
+            if let Some(description) = function.get("description").filter(|value| value.is_string()) {
+                definition.insert("description".to_string(), description.clone());
+            }
+            definition.insert(
+                "input_schema".to_string(),
+                function
+                    .get("parameters")
+                    .cloned()
+                    .unwrap_or_else(|| json!({ "type": "object" })),
+            );
+            Some(Value::Object(definition))
+        })
+        .collect()
+}
+
+fn sidecar_run_request(
+    app: &AppHandle,
+    outbound: &[Value],
+    binding: &RouteBinding,
+    slot_id: Option<u32>,
+    session_id: &str,
+    run_id: &str,
+) -> Result<Value, String> {
+    let messages = sidecar_runtime_messages(outbound)?;
+    let tool_executor_url = crate::server::info(app).map(|(base_url, _)| {
+        let query = slot_id
+            .map(|slot| format!("?slot_id={slot}"))
+            .unwrap_or_default();
+        format!("{base_url}/api/conversation-runtime/tool{query}")
+    });
+    let mut request = json!({
+        "run_id": run_id,
+        "session_id": session_id,
+        "base_url": sidecar_provider_base_url(&binding.url),
+        "model": binding.model_field,
+        "role": "primary",
+        "messages": messages,
+        "tools": sidecar_tool_definitions(),
+        "max_output_tokens": CHAT_MAX_TOKENS,
+        "max_tool_rounds": MAX_TOOL_ROUNDS,
+        "initial_sequence": 0,
+        "emit_input": true,
+        "allow_remote": binding.route == "cloud",
+        "runtime_backend": "pi",
+    });
+    if let Some(url) = tool_executor_url {
+        request["tool_executor_url"] = json!(url);
+    }
+    Ok(request)
+}
+
+fn sidecar_usage_tokens(usage: Option<&Value>, key: &str) -> Option<u64> {
+    usage
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_u64)
+}
+
 fn cloud_route_binding() -> Option<RouteBinding> {
     let (base, key) = credentials()?;
     Some(RouteBinding {
@@ -2460,6 +2552,7 @@ pub async fn chat_stream(
     let compacted = compaction_reason.is_some();
     let gateway_available = credentials().is_some();
     let local_mem_gb = local_resident_mem_gb(&app);
+    let run_id = crate::conversation_runtime::new_run_id()?;
     if let Some(reason) = compaction_reason.as_deref() {
         let recommendation = record_compaction_route_decision(
             &app,
@@ -2491,6 +2584,109 @@ pub async fn chat_stream(
                 &detail,
                 Some(&on_event),
             );
+        }
+    }
+
+    if binding.route != "anthropic" {
+        match sidecar_run_request(
+            &app,
+            &outbound_messages,
+            &binding,
+            slot_id,
+            &session_id,
+            &run_id,
+        ) {
+            Ok(request) => {
+                match crate::conversation_sidecar::try_run_chat(&app, request, &on_event).await {
+                    crate::conversation_sidecar::SidecarAttempt::Completed(sidecar) => {
+                        let completion_tokens = sidecar_usage_tokens(
+                            sidecar.usage.as_ref(),
+                            "completion_tokens",
+                        )
+                        .unwrap_or_else(|| approximate_token_count(&sidecar.content));
+                        let prompt_tokens = sidecar_usage_tokens(
+                            sidecar.usage.as_ref(),
+                            "prompt_tokens",
+                        )
+                        .unwrap_or(prompt_tokens);
+                        record_chat_run(
+                            &app,
+                            ChatRunInput {
+                                run_id: run_id.clone(),
+                                runtime_backend: "pi".to_string(),
+                                session_id: session_id.clone(),
+                                route: binding.route.clone(),
+                                model: binding.model_field.clone(),
+                                elapsed_ms: Some(sidecar.elapsed_ms),
+                                prompt_tokens: Some(prompt_tokens),
+                                completion_tokens: Some(completion_tokens),
+                                tool_calls: sidecar.tool_calls,
+                                sidekick_spawned: sidekick_plan.spawned,
+                                gateway_used: binding.route == "cloud",
+                                compacted,
+                                compaction_reason: compaction_reason.clone(),
+                                context_tokens_before: Some(context_tokens_before),
+                                local_mem_gb,
+                                gateway_available,
+                                gateway_avoided: gateway_available && binding.route != "cloud",
+                                status: "ok".to_string(),
+                                error: None,
+                            },
+                        );
+                        let _ = on_event.send(ChatEvent::Done);
+                        return Ok(());
+                    }
+                    crate::conversation_sidecar::SidecarAttempt::NativeFallback(reason) => {
+                        let _ = on_event.send(ChatEvent::Notice {
+                            message: format!(
+                                "Canonical runtime unavailable ({reason}). Continuing with the local compatibility engine."
+                            ),
+                        });
+                    }
+                    crate::conversation_sidecar::SidecarAttempt::FailedAfterOutput(reason) => {
+                        let message = format!(
+                            "Conversation runtime stopped after the turn began: {reason}. The compatibility engine was not retried, preventing a duplicate answer or tool execution."
+                        );
+                        let _ = on_event.send(ChatEvent::Error {
+                            message: message.clone(),
+                        });
+                        record_chat_run(
+                            &app,
+                            ChatRunInput {
+                                run_id: run_id.clone(),
+                                runtime_backend: "pi".to_string(),
+                                session_id: session_id.clone(),
+                                route: binding.route.clone(),
+                                model: binding.model_field.clone(),
+                                elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                                prompt_tokens: Some(prompt_tokens),
+                                completion_tokens: None,
+                                tool_calls: 0,
+                                sidekick_spawned: sidekick_plan.spawned,
+                                gateway_used: binding.route == "cloud",
+                                compacted,
+                                compaction_reason: compaction_reason.clone(),
+                                context_tokens_before: Some(context_tokens_before),
+                                local_mem_gb,
+                                gateway_available,
+                                gateway_avoided: gateway_available && binding.route != "cloud",
+                                status: "error".to_string(),
+                                error: Some(reason),
+                            },
+                        );
+                        let _ = on_event.send(ChatEvent::Done);
+                        return Ok(());
+                    }
+                    crate::conversation_sidecar::SidecarAttempt::NotSelected => {}
+                }
+            }
+            Err(reason) => {
+                let _ = on_event.send(ChatEvent::Notice {
+                    message: format!(
+                        "Canonical runtime could not accept this turn ({reason}). Continuing with the local compatibility engine."
+                    ),
+                });
+            }
         }
     }
 
@@ -2532,6 +2728,8 @@ pub async fn chat_stream(
             record_chat_run(
                 &app,
                 ChatRunInput {
+                    run_id: run_id.clone(),
+                    runtime_backend: "native-rust".to_string(),
                     session_id: session_id.clone(),
                     route: binding.route.clone(),
                     model: binding.model_field.clone(),
@@ -2567,6 +2765,8 @@ pub async fn chat_stream(
             record_chat_run(
                 &app,
                 ChatRunInput {
+                    run_id: run_id.clone(),
+                    runtime_backend: "native-rust".to_string(),
                     session_id: session_id.clone(),
                     route: binding.route.clone(),
                     model: binding.model_field.clone(),
@@ -2664,6 +2864,8 @@ pub async fn chat_stream(
     record_chat_run(
         &app,
         ChatRunInput {
+            run_id,
+            runtime_backend: "native-rust".to_string(),
             session_id: session_id.clone(),
             route: binding.route.clone(),
             model: binding.model_field.clone(),

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -65,6 +65,14 @@ pub struct ChatAttachment {
     pub data_url: String,
 }
 
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentChatAttachmentUpload {
+    pub(crate) filename: String,
+    pub(crate) media_type: String,
+    pub(crate) data_url: String,
+}
+
 #[derive(Serialize)]
 pub struct BenchmarkChatResult {
     pub capture_run_id: String,
@@ -602,15 +610,8 @@ pub(crate) fn tool_schemas() -> Vec<Value> {
                         "tool_name": {
                             "type": "string",
                             "enum": [
-                                "status",
-                                "list_models",
-                                "list_snapshot_models",
-                                "residency",
                                 "knowledge_dossiers",
                                 "local_benchmarks",
-                                "list_traces",
-                                "search_traces",
-                                "open_trace",
                                 "ui_focus"
                             ]
                         },
@@ -639,8 +640,6 @@ pub(crate) fn tool_schemas() -> Vec<Value> {
                                 "skills_search",
                                 "skills_inspect",
                                 "doctor",
-                                "status",
-                                "models_snapshots",
                                 "models_pull_plan"
                             ]
                         },
@@ -1009,10 +1008,6 @@ fn sidekick_tool_schemas() -> Vec<Value> {
                         "tool_name": {
                             "type": "string",
                             "enum": [
-                                "status",
-                                "list_models",
-                                "list_snapshot_models",
-                                "residency",
                                 "knowledge_dossiers",
                                 "local_benchmarks",
                                 "fusion_benchmark_matrix",
@@ -1022,10 +1017,7 @@ fn sidekick_tool_schemas() -> Vec<Value> {
                                 "chat_runs",
                                 "chat_route_metrics",
                                 "sidekick_metrics",
-                                "sidekick_session_summaries",
-                                "list_traces",
-                                "search_traces",
-                                "open_trace"
+                                "sidekick_session_summaries"
                             ]
                         },
                         "arguments": { "type": "object" }
@@ -2209,6 +2201,144 @@ fn sidecar_usage_tokens(usage: Option<&Value>, key: &str) -> Option<u64> {
     usage
         .and_then(|value| value.get(key))
         .and_then(Value::as_u64)
+}
+
+/// Build the canonical Pi request used by the authenticated Desktop API. This
+/// is deliberately a projection into the existing runtime contract, not a
+/// second agent loop.
+pub(crate) struct AgentSidecarRequest<'a> {
+    pub(crate) slot_id: u32,
+    pub(crate) supervisor_slot_id: Option<u32>,
+    pub(crate) session_id: &'a str,
+    pub(crate) run_id: &'a str,
+    pub(crate) prompt: &'a str,
+    pub(crate) attachments: &'a [AgentChatAttachmentUpload],
+    pub(crate) max_tokens: Option<u32>,
+}
+
+pub(crate) fn agent_sidecar_request(
+    app: &AppHandle,
+    mgr: &Residency,
+    input: AgentSidecarRequest<'_>,
+) -> Result<Value, String> {
+    use sha2::Digest as _;
+
+    if input.attachments.len() > 4 {
+        return Err("at most four image attachments are allowed per message".to_string());
+    }
+    let decoded_attachments = input
+        .attachments
+        .iter()
+        .map(|upload| {
+            let prefix = format!("data:{};base64,", upload.media_type);
+            let encoded = upload
+                .data_url
+                .strip_prefix(&prefix)
+                .ok_or_else(|| "image data URL does not match its media type".to_string())?;
+            let bytes = {
+                use base64::Engine as _;
+                base64::engine::general_purpose::STANDARD
+                    .decode(encoded)
+                    .map_err(|_| "image data URL contains invalid base64".to_string())?
+            };
+            let attachment = ChatAttachment {
+                id: format!("{:x}", sha2::Sha256::digest(&bytes)),
+                filename: upload.filename.clone(),
+                media_type: upload.media_type.clone(),
+                data_url: upload.data_url.clone(),
+            };
+            let size = validate_chat_attachment(&attachment)?;
+            Ok((attachment, size))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let total_bytes = decoded_attachments
+        .iter()
+        .map(|(_, size)| *size)
+        .sum::<usize>();
+    if total_bytes > 24 * 1024 * 1024 {
+        return Err("combined image attachments must not exceed 24 MB".to_string());
+    }
+    let attachments = decoded_attachments
+        .into_iter()
+        .map(|(attachment, _)| attachment)
+        .collect::<Vec<_>>();
+    let (port, model_field) = mgr
+        .endpoint(input.slot_id)
+        .ok_or_else(|| format!("slot {} is not warm; warm it first", input.slot_id))?;
+    let supervision = input
+        .supervisor_slot_id
+        .map(|supervisor_slot_id| {
+            let (supervisor_port, supervisor_model) =
+                mgr.endpoint(supervisor_slot_id).ok_or_else(|| {
+                    format!("supervisor slot {supervisor_slot_id} is not warm; warm it first")
+                })?;
+            if supervisor_port == port || supervisor_model == model_field {
+                return Err(
+                    "supervisor slot must use a different warm model from the student slot"
+                        .to_string(),
+                );
+            }
+            if let (Some(student_size), Some(supervisor_size)) = (
+                model_size_billions(&model_field),
+                model_size_billions(&supervisor_model),
+            ) {
+                if student_size >= supervisor_size {
+                    return Err(
+                        "supervisor slot must use a larger model than the student slot".to_string(),
+                    );
+                }
+            }
+            let supervisor_base_url = format!("http://127.0.0.1:{supervisor_port}/v1");
+            Ok(json!({
+                "student": {
+                    "base_url": format!("http://127.0.0.1:{port}/v1"),
+                    "model": model_field.clone(),
+                },
+                "supervisor": {
+                    "base_url": supervisor_base_url,
+                    "model": supervisor_model.clone(),
+                    "system_prompt": SMALL_FIRST_SUPERVISOR_PROMPT,
+                    "max_output_tokens": 48,
+                },
+                "teacher": {
+                    "base_url": format!("http://127.0.0.1:{supervisor_port}/v1"),
+                    "model": supervisor_model,
+                },
+                "boundary_chars": 240,
+                "max_nudges": 2,
+            }))
+        })
+        .transpose()?;
+    let messages = vec![ChatMsg {
+        role: "user".to_string(),
+        content: input.prompt.to_string(),
+        attachments,
+    }];
+    let outbound = vec![
+        json!({ "role": "system", "content": system_prompt_for(&model_field) }),
+        openai_chat_message(&messages[0])?,
+    ];
+    let binding = RouteBinding {
+        route: "local".to_string(),
+        url: format!("http://127.0.0.1:{port}/v1/chat/completions"),
+        bearer: None,
+        model_field,
+    };
+    let mut request = sidecar_run_request(
+        app,
+        &messages,
+        &outbound,
+        &binding,
+        supervision.as_ref(),
+        Some(input.slot_id),
+        (input.session_id, input.run_id),
+    )?;
+    request["max_output_tokens"] = json!(input
+        .max_tokens
+        .unwrap_or(AGENT_CHAT_DEFAULT_MAX_TOKENS)
+        .clamp(1, CHAT_MAX_TOKENS));
+    request["max_tool_rounds"] = json!(MAX_TOOL_ROUNDS);
+    Ok(request)
 }
 
 fn cloud_route_binding() -> Option<RouteBinding> {
@@ -4001,6 +4131,31 @@ mod tests {
         let unsupervised = sidecar_tool_definitions(true);
         assert!(unsupervised.iter().any(|tool| {
             tool.get("name").and_then(Value::as_str) == Some("delegate_to_sidekick")
+        }));
+    }
+
+    #[test]
+    fn direct_tools_are_not_duplicated_inside_generic_wrappers() {
+        let tools = tool_schemas();
+        let direct = tools
+            .iter()
+            .filter_map(|tool| tool.pointer("/function/name").and_then(Value::as_str))
+            .filter(|name| !name.starts_with("understudy_"))
+            .collect::<std::collections::HashSet<_>>();
+        let wrapper = tools
+            .iter()
+            .find(|tool| {
+                tool.pointer("/function/name").and_then(Value::as_str)
+                    == Some("understudy_mcp_tool")
+            })
+            .expect("MCP wrapper exists");
+        let wrapped_names = wrapper
+            .pointer("/function/parameters/properties/tool_name/enum")
+            .and_then(Value::as_array)
+            .expect("wrapper names are enumerated");
+        assert!(wrapped_names.iter().all(|name| {
+            name.as_str()
+                .is_some_and(|name| !direct.contains(name))
         }));
     }
 

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -53,6 +53,16 @@ pub enum ChatEvent {
 pub struct ChatMsg {
     pub role: String,
     pub content: String,
+    #[serde(default)]
+    pub attachments: Vec<ChatAttachment>,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct ChatAttachment {
+    pub id: String,
+    pub filename: String,
+    pub media_type: String,
+    pub data_url: String,
 }
 
 #[derive(Serialize)]
@@ -1806,17 +1816,44 @@ fn approximate_messages_tokens(messages: &[Value]) -> u64 {
     messages
         .iter()
         .filter_map(|message| message.get("content"))
-        .map(|content| match content {
-            Value::String(text) => approximate_token_count(text),
-            other => approximate_token_count(&other.to_string()),
-        })
+        .map(approximate_content_tokens)
         .sum()
+}
+
+fn approximate_content_tokens(content: &Value) -> u64 {
+    match content {
+        Value::String(text) => approximate_token_count(text),
+        Value::Array(parts) => parts
+            .iter()
+            .map(|part| match part.get("type").and_then(Value::as_str) {
+                Some("text") => part
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(approximate_token_count)
+                    .unwrap_or(0),
+                Some("image_url") => 1_200,
+                _ => 0,
+            })
+            .sum(),
+        _ => 0,
+    }
 }
 
 fn chat_message_content(message: &Value) -> Option<String> {
     match message.get("content")? {
         Value::String(text) => Some(text.to_string()),
-        other => Some(other.to_string()),
+        Value::Array(parts) => Some(
+            parts
+                .iter()
+                .filter_map(|part| match part.get("type").and_then(Value::as_str) {
+                    Some("text") => part.get("text").and_then(Value::as_str).map(str::to_string),
+                    Some("image_url") => Some("[image attachment]".to_string()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join(" "),
+        ),
+        _ => None,
     }
 }
 
@@ -1920,7 +1957,65 @@ fn sidecar_provider_base_url(endpoint: &str) -> String {
         .to_string()
 }
 
-fn sidecar_runtime_messages(outbound: &[Value]) -> Result<Vec<Value>, String> {
+fn validate_chat_attachment(attachment: &ChatAttachment) -> Result<usize, String> {
+    use base64::Engine as _;
+    use sha2::Digest as _;
+
+    if attachment.filename.trim().is_empty() || attachment.filename.len() > 200 {
+        return Err("image filename must be between 1 and 200 bytes".to_string());
+    }
+    if !attachment.media_type.starts_with("image/") {
+        return Err("image media type must start with image/".to_string());
+    }
+    let prefix = format!("data:{};base64,", attachment.media_type);
+    let encoded = attachment
+        .data_url
+        .strip_prefix(&prefix)
+        .ok_or_else(|| "image data URL does not match its media type".to_string())?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| "image data URL contains invalid base64".to_string())?;
+    if bytes.is_empty() || bytes.len() > 8 * 1024 * 1024 {
+        return Err("image must be between 1 byte and 8 MB".to_string());
+    }
+    let digest = format!("{:x}", sha2::Sha256::digest(&bytes));
+    if digest != attachment.id {
+        return Err("image content hash does not match its id".to_string());
+    }
+    Ok(bytes.len())
+}
+
+fn openai_chat_message(message: &ChatMsg) -> Result<Value, String> {
+    if message.attachments.is_empty() {
+        return Ok(json!({ "role": message.role, "content": message.content }));
+    }
+    if message.role != "user" {
+        return Err("only user messages may contain image attachments".to_string());
+    }
+    if message.attachments.len() > 4 {
+        return Err("at most four image attachments are allowed per message".to_string());
+    }
+    let mut content = vec![json!({ "type": "text", "text": message.content })];
+    let mut total_bytes = 0usize;
+    for attachment in &message.attachments {
+        total_bytes = total_bytes.saturating_add(validate_chat_attachment(attachment)?);
+        if total_bytes > 24 * 1024 * 1024 {
+            return Err("combined image attachments must not exceed 24 MB".to_string());
+        }
+        content.push(json!({
+            "type": "image_url",
+            "image_url": { "url": attachment.data_url },
+        }));
+    }
+    Ok(json!({ "role": message.role, "content": content }))
+}
+
+fn sidecar_runtime_messages(original: &[ChatMsg], outbound: &[Value]) -> Result<Vec<Value>, String> {
+    let attachment_meta: HashMap<&str, &ChatAttachment> = original
+        .iter()
+        .flat_map(|message| message.attachments.iter())
+        .map(|attachment| (attachment.data_url.as_str(), attachment))
+        .collect();
     outbound
         .iter()
         .map(|message| {
@@ -1930,9 +2025,43 @@ fn sidecar_runtime_messages(outbound: &[Value]) -> Result<Vec<Value>, String> {
                 .ok_or_else(|| "conversation runtime message is missing role".to_string())?;
             let content = message
                 .get("content")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "conversation runtime message content must be text".to_string())?;
-            Ok(json!({ "role": role, "content": content }))
+                .ok_or_else(|| "conversation runtime message is missing content".to_string())?;
+            if let Some(text) = content.as_str() {
+                return Ok(json!({ "role": role, "content": text }));
+            }
+            if role != "user" {
+                return Err("only user runtime messages may contain multimodal parts".to_string());
+            }
+            let parts = content
+                .as_array()
+                .ok_or_else(|| "conversation runtime message content is invalid".to_string())?;
+            let mut text = String::new();
+            let mut attachments = Vec::new();
+            for part in parts {
+                match part.get("type").and_then(Value::as_str) {
+                    Some("text") => text.push_str(
+                        part.get("text").and_then(Value::as_str).unwrap_or_default(),
+                    ),
+                    Some("image_url") => {
+                        let data_url = part
+                            .pointer("/image_url/url")
+                            .and_then(Value::as_str)
+                            .ok_or_else(|| "runtime image is missing its data URL".to_string())?;
+                        let metadata = attachment_meta.get(data_url).ok_or_else(|| {
+                            "runtime image metadata does not match the submitted attachment"
+                                .to_string()
+                        })?;
+                        attachments.push(json!({
+                            "id": metadata.id,
+                            "filename": metadata.filename,
+                            "media_type": metadata.media_type,
+                            "data_url": metadata.data_url,
+                        }));
+                    }
+                    _ => return Err("conversation runtime message part is unsupported".to_string()),
+                }
+            }
+            Ok(json!({ "role": role, "content": text, "attachments": attachments }))
         })
         .collect()
 }
@@ -1961,13 +2090,14 @@ fn sidecar_tool_definitions() -> Vec<Value> {
 
 fn sidecar_run_request(
     app: &AppHandle,
+    original: &[ChatMsg],
     outbound: &[Value],
     binding: &RouteBinding,
     slot_id: Option<u32>,
     session_id: &str,
     run_id: &str,
 ) -> Result<Value, String> {
-    let messages = sidecar_runtime_messages(outbound)?;
+    let messages = sidecar_runtime_messages(original, outbound)?;
     let tool_executor_url = crate::server::info(app).map(|(base_url, _)| {
         let query = slot_id
             .map(|slot| format!("?slot_id={slot}"))
@@ -2523,6 +2653,13 @@ pub async fn chat_stream(
             _ => local_route_binding(&route, &mgr, slot_id)?,
         }
     };
+    if binding.route == "anthropic" && messages.iter().any(|message| !message.attachments.is_empty())
+    {
+        return Err(
+            "Image attachments currently require a local model or the Understudy gateway"
+                .to_string(),
+        );
+    }
 
     let mut outbound_messages = vec![json!({
         "role": "system",
@@ -2537,12 +2674,12 @@ pub async fn chat_stream(
     )
     .await;
     outbound_messages.extend(handoff_messages);
-    outbound_messages.extend(
-        messages
-            .iter()
-            .filter(|m| m.role != "system")
-            .map(|m| json!({ "role": m.role, "content": m.content })),
-    );
+    let projected_messages = messages
+        .iter()
+        .filter(|message| message.role != "system")
+        .map(openai_chat_message)
+        .collect::<Result<Vec<_>, _>>()?;
+    outbound_messages.extend(projected_messages);
     let (mut outbound_messages, compaction_reason, context_tokens_before) =
         compact_chat_messages(outbound_messages);
     let mut prompt_tokens = approximate_messages_tokens(&outbound_messages);
@@ -2590,6 +2727,7 @@ pub async fn chat_stream(
     if binding.route != "anthropic" {
         match sidecar_run_request(
             &app,
+            &messages,
             &outbound_messages,
             &binding,
             slot_id,
@@ -2914,6 +3052,7 @@ pub async fn benchmark_local_chat(
     let messages = vec![ChatMsg {
         role: "user".to_string(),
         content: prompt.clone(),
+        attachments: vec![],
     }];
     let sidekick_plan = if enable_parallel_sidekick {
         maybe_spawn_parallel_sidekick(app, "local", Some(slot_id), session_id, &messages, None)
@@ -3519,6 +3658,43 @@ fn finalize_tool_calls(mut tool_calls: Vec<ToolCallAcc>) -> Vec<ToolCallAcc> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn image_message() -> ChatMsg {
+        use base64::Engine as _;
+        use sha2::Digest as _;
+
+        let bytes = b"desktop-image-fixture";
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        ChatMsg {
+            role: "user".to_string(),
+            content: "inspect this".to_string(),
+            attachments: vec![ChatAttachment {
+                id: format!("{:x}", sha2::Sha256::digest(bytes)),
+                filename: "fixture.png".to_string(),
+                media_type: "image/png".to_string(),
+                data_url: format!("data:image/png;base64,{encoded}"),
+            }],
+        }
+    }
+
+    #[test]
+    fn image_projection_preserves_hash_metadata_and_bounded_token_estimate() {
+        let original = vec![image_message()];
+        let outbound = vec![openai_chat_message(&original[0]).unwrap()];
+        assert_eq!(outbound[0]["content"][1]["type"], "image_url");
+        assert_eq!(approximate_messages_tokens(&outbound), 1_202);
+
+        let projected = sidecar_runtime_messages(&original, &outbound).unwrap();
+        assert_eq!(projected[0]["content"], "inspect this");
+        assert_eq!(projected[0]["attachments"][0]["id"], original[0].attachments[0].id);
+        assert_eq!(projected[0]["attachments"][0]["filename"], "fixture.png");
+
+        let mut tampered = image_message();
+        tampered.attachments[0].id = "0".repeat(64);
+        assert!(openai_chat_message(&tampered)
+            .unwrap_err()
+            .contains("content hash"));
+    }
 
     #[test]
     fn sidekick_compaction_never_orphans_tool_replies() {

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -3149,6 +3149,186 @@ pub async fn chat_stream(
     Ok(())
 }
 
+struct PreparedBenchmarkRun {
+    started: Instant,
+    session_id: String,
+    capture_run_id: String,
+    messages: Vec<ChatMsg>,
+    outbound_messages: Vec<Value>,
+    binding: RouteBinding,
+    slot_id: Option<u32>,
+    allow_sidekick_tool: bool,
+    compacted: bool,
+    context_tokens_before: u64,
+}
+
+fn benchmark_sidecar_result(
+    prepared: &PreparedBenchmarkRun,
+    sidecar: crate::conversation_sidecar::SidecarRunResult,
+) -> BenchmarkChatResult {
+    let prompt_tokens = sidecar_usage_tokens(sidecar.usage.as_ref(), "prompt_tokens").unwrap_or(0);
+    let completion_tokens = sidecar_usage_tokens(sidecar.usage.as_ref(), "completion_tokens")
+        .unwrap_or_else(|| approximate_token_count(&sidecar.content));
+    let reasoning_tokens =
+        sidecar_usage_tokens(sidecar.usage.as_ref(), "reasoning_tokens").unwrap_or(0);
+    BenchmarkChatResult {
+        capture_run_id: prepared.capture_run_id.clone(),
+        status: if sidecar.content.trim().is_empty() {
+            "empty_final".to_string()
+        } else {
+            "ok".to_string()
+        },
+        runtime_backend: "pi".to_string(),
+        content: sidecar.content,
+        elapsed_ms: prepared.started.elapsed().as_millis() as u64,
+        tool_calls: sidecar.tool_calls,
+        prompt_tokens,
+        completion_tokens,
+        reasoning_tokens,
+        compacted: prepared.compacted || sidecar.compacted,
+        context_tokens_before: prepared
+            .context_tokens_before
+            .max(sidecar.context_tokens_before),
+    }
+}
+
+async fn benchmark_chat_native(
+    app: &AppHandle,
+    mgr: &Residency,
+    mut prepared: PreparedBenchmarkRun,
+) -> Result<BenchmarkChatResult, String> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let mut final_content = String::new();
+    let mut reasoning_tokens = 0u64;
+    let mut tool_count = 0u64;
+    let mut status = "tool_limit".to_string();
+    let mut repaired_empty_final = false;
+
+    for _round in 0..=BENCHMARK_MAX_TOOL_ROUNDS {
+        let result = nonstream_chat_once(
+            &client,
+            &prepared.binding.url,
+            prepared.binding.bearer.as_deref(),
+            &prepared.binding.model_field,
+            &prepared.outbound_messages,
+            BENCHMARK_MAX_TOKENS,
+            BENCHMARK_THINKING_BUDGET,
+            prepared.allow_sidekick_tool,
+        )
+        .await?;
+        final_content = result.content.clone();
+        reasoning_tokens += approximate_token_count(&result.reasoning);
+        let tool_calls = result.tool_calls;
+        if tool_calls.is_empty() {
+            if final_content.trim().is_empty() && !repaired_empty_final {
+                repaired_empty_final = true;
+                prepared
+                    .outbound_messages
+                    .push(benchmark_finalize_prompt(&result.reasoning));
+                continue;
+            }
+            if final_content.trim().is_empty() {
+                status = "empty_final".to_string();
+                break;
+            }
+            status = "ok".to_string();
+            break;
+        }
+        let assistant_tool_calls: Vec<Value> = tool_calls
+            .iter()
+            .map(|call| {
+                json!({
+                    "id": call.id,
+                    "type": "function",
+                    "function": { "name": call.name, "arguments": call.arguments },
+                })
+            })
+            .collect();
+        prepared.outbound_messages.push(json!({
+            "role": "assistant",
+            "content": final_content,
+            "tool_calls": assistant_tool_calls,
+        }));
+
+        for call in tool_calls {
+            let args = serde_json::from_str::<Value>(&call.arguments).unwrap_or_else(|_| json!({}));
+            let result = match tool_result(
+                app,
+                mgr,
+                prepared.slot_id,
+                &prepared.session_id,
+                &call.name,
+                &args,
+            )
+            .await
+            {
+                Ok(value) => value,
+                Err(err) => json!({ "error": err }),
+            };
+            tool_count += 1;
+            prepared.outbound_messages.push(json!({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": result.to_string(),
+            }));
+        }
+    }
+
+    Ok(BenchmarkChatResult {
+        capture_run_id: prepared.capture_run_id,
+        prompt_tokens: approximate_messages_tokens(&prepared.outbound_messages),
+        completion_tokens: final_content.split_whitespace().count() as u64,
+        reasoning_tokens,
+        content: final_content,
+        status,
+        runtime_backend: "native-rust".to_string(),
+        elapsed_ms: prepared.started.elapsed().as_millis() as u64,
+        tool_calls: tool_count,
+        compacted: prepared.compacted,
+        context_tokens_before: prepared.context_tokens_before,
+    })
+}
+
+async fn execute_prepared_benchmark(
+    app: &AppHandle,
+    mgr: &Residency,
+    prepared: PreparedBenchmarkRun,
+) -> Result<BenchmarkChatResult, String> {
+    let attempt = match sidecar_run_request(
+        app,
+        &prepared.messages,
+        &prepared.outbound_messages,
+        &prepared.binding,
+        None,
+        prepared.slot_id,
+        (&prepared.session_id, &prepared.capture_run_id),
+    ) {
+        Ok(mut request) => {
+            request["max_output_tokens"] = json!(BENCHMARK_MAX_TOKENS);
+            request["max_tool_rounds"] = json!(BENCHMARK_MAX_TOOL_ROUNDS);
+            request["tools"] = json!(sidecar_tool_definitions(prepared.allow_sidekick_tool));
+            crate::conversation_sidecar::try_run_chat_headless(app, request).await
+        }
+        Err(reason) => crate::conversation_sidecar::SidecarAttempt::NativeFallback(reason),
+    };
+    match attempt {
+        crate::conversation_sidecar::SidecarAttempt::Completed(sidecar) => {
+            Ok(benchmark_sidecar_result(&prepared, sidecar))
+        }
+        crate::conversation_sidecar::SidecarAttempt::FailedAfterOutput(reason) => Err(format!(
+            "conversation runtime stopped after the benchmark began: {reason}; native retry was suppressed"
+        )),
+        crate::conversation_sidecar::SidecarAttempt::NativeFallback(_)
+        | crate::conversation_sidecar::SidecarAttempt::NotSelected => {
+            benchmark_chat_native(app, mgr, prepared).await
+        }
+    }
+}
+
 pub async fn benchmark_local_chat(
     app: &AppHandle,
     mgr: &Residency,
@@ -3158,8 +3338,8 @@ pub async fn benchmark_local_chat(
     enable_parallel_sidekick: bool,
     allow_sidekick_tool: bool,
 ) -> Result<BenchmarkChatResult, String> {
-    let (session_id, capture_run_id) = identity;
     let started = Instant::now();
+    let (session_id, capture_run_id) = identity;
     let prompt = benchmark_prompt(prompt);
     let (port, model_field) = mgr
         .endpoint(slot_id)
@@ -3177,7 +3357,6 @@ pub async fn benchmark_local_chat(
             wait_ms: 0,
         }
     };
-    let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     let mut outbound_messages = vec![json!({
         "role": "system",
         "content": system_prompt_for(&model_field),
@@ -3194,7 +3373,7 @@ pub async fn benchmark_local_chat(
         .0,
     );
     outbound_messages.push(json!({ "role": "user", "content": prompt }));
-    let (mut outbound_messages, compaction_reason, context_tokens_before) =
+    let (outbound_messages, compaction_reason, context_tokens_before) =
         compact_chat_messages(outbound_messages);
     let compacted = compaction_reason.is_some();
     if let Some(reason) = compaction_reason.as_deref() {
@@ -3209,91 +3388,28 @@ pub async fn benchmark_local_chat(
             None,
         );
     }
-
-    let client = reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
-        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
-        .build()
-        .map_err(|e| e.to_string())?;
-    let mut final_content = String::new();
-    let mut reasoning_tokens = 0u64;
-    let mut tool_count = 0u64;
-    let mut status = "tool_limit".to_string();
-    let mut repaired_empty_final = false;
-
-    for _round in 0..=BENCHMARK_MAX_TOOL_ROUNDS {
-        let result = nonstream_chat_once(
-            &client,
-            &url,
-            None,
-            &model_field,
-            &outbound_messages,
-            BENCHMARK_MAX_TOKENS,
-            BENCHMARK_THINKING_BUDGET,
+    execute_prepared_benchmark(
+        app,
+        mgr,
+        PreparedBenchmarkRun {
+            started,
+            session_id: session_id.to_string(),
+            capture_run_id: capture_run_id.to_string(),
+            messages,
+            outbound_messages,
+            binding: RouteBinding {
+                route: "local".to_string(),
+                url: format!("http://127.0.0.1:{port}/v1/chat/completions"),
+                bearer: None,
+                model_field,
+            },
+            slot_id: Some(slot_id),
             allow_sidekick_tool,
-        )
-        .await?;
-        final_content = result.content.clone();
-        reasoning_tokens += approximate_token_count(&result.reasoning);
-        let tool_calls = result.tool_calls;
-        if tool_calls.is_empty() {
-            if final_content.trim().is_empty() && !repaired_empty_final {
-                repaired_empty_final = true;
-                outbound_messages.push(benchmark_finalize_prompt(&result.reasoning));
-                continue;
-            }
-            if final_content.trim().is_empty() {
-                status = "empty_final".to_string();
-                break;
-            }
-            status = "ok".to_string();
-            break;
-        }
-        let assistant_tool_calls: Vec<Value> = tool_calls
-            .iter()
-            .map(|call| {
-                json!({
-                    "id": call.id,
-                    "type": "function",
-                    "function": { "name": call.name, "arguments": call.arguments },
-                })
-            })
-            .collect();
-        outbound_messages.push(json!({
-            "role": "assistant",
-            "content": final_content,
-            "tool_calls": assistant_tool_calls,
-        }));
-
-        for call in tool_calls {
-            let args = serde_json::from_str::<Value>(&call.arguments).unwrap_or_else(|_| json!({}));
-            let result =
-                match tool_result(app, mgr, Some(slot_id), session_id, &call.name, &args).await {
-                    Ok(value) => value,
-                    Err(err) => json!({ "error": err }),
-                };
-            tool_count += 1;
-            outbound_messages.push(json!({
-                "role": "tool",
-                "tool_call_id": call.id,
-                "content": result.to_string(),
-            }));
-        }
-    }
-
-    Ok(BenchmarkChatResult {
-        capture_run_id: capture_run_id.to_string(),
-        prompt_tokens: approximate_messages_tokens(&outbound_messages),
-        completion_tokens: final_content.split_whitespace().count() as u64,
-        reasoning_tokens,
-        content: final_content,
-        status,
-        runtime_backend: "native-rust".to_string(),
-        elapsed_ms: started.elapsed().as_millis() as u64,
-        tool_calls: tool_count,
-        compacted,
-        context_tokens_before,
-    })
+            compacted,
+            context_tokens_before,
+        },
+    )
+    .await
 }
 
 pub async fn benchmark_gateway_chat(
@@ -3308,100 +3424,40 @@ pub async fn benchmark_gateway_chat(
     let started = Instant::now();
     let prompt = benchmark_prompt(prompt);
     let (base, key) = credentials().ok_or_else(|| "not signed in".to_string())?;
-    let url = format!("{}/v1/chat/completions", base.trim_end_matches('/'));
     let mut outbound_messages = vec![json!({
         "role": "system",
         "content": system_prompt_for(model_field),
     })];
     outbound_messages.extend(consume_sidekick_handoffs(app, session_id).0);
-    outbound_messages.push(json!({ "role": "user", "content": prompt }));
-    let (mut outbound_messages, compaction_reason, context_tokens_before) =
+    outbound_messages.push(json!({ "role": "user", "content": prompt.clone() }));
+    let (outbound_messages, compaction_reason, context_tokens_before) =
         compact_chat_messages(outbound_messages);
-    let compacted = compaction_reason.is_some();
-
-    let client = reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(CHAT_CONNECT_TIMEOUT_SECS))
-        .timeout(Duration::from_secs(CHAT_REQUEST_TIMEOUT_SECS))
-        .build()
-        .map_err(|e| e.to_string())?;
-    let mut final_content = String::new();
-    let mut reasoning_tokens = 0u64;
-    let mut tool_count = 0u64;
-    let mut status = "tool_limit".to_string();
-    let mut repaired_empty_final = false;
-
-    for _round in 0..=BENCHMARK_MAX_TOOL_ROUNDS {
-        let result = nonstream_chat_once(
-            &client,
-            &url,
-            Some(&key),
-            model_field,
-            &outbound_messages,
-            BENCHMARK_MAX_TOKENS,
-            BENCHMARK_THINKING_BUDGET,
+    execute_prepared_benchmark(
+        app,
+        mgr,
+        PreparedBenchmarkRun {
+            started,
+            session_id: session_id.to_string(),
+            capture_run_id: capture_run_id.to_string(),
+            messages: vec![ChatMsg {
+                role: "user".to_string(),
+                content: prompt,
+                attachments: vec![],
+            }],
+            outbound_messages,
+            binding: RouteBinding {
+                route: "cloud".to_string(),
+                url: format!("{}/v1/chat/completions", base.trim_end_matches('/')),
+                bearer: Some(key),
+                model_field: model_field.to_string(),
+            },
+            slot_id: None,
             allow_sidekick_tool,
-        )
-        .await?;
-        final_content = result.content.clone();
-        reasoning_tokens += approximate_token_count(&result.reasoning);
-        let tool_calls = result.tool_calls;
-        if tool_calls.is_empty() {
-            if final_content.trim().is_empty() && !repaired_empty_final {
-                repaired_empty_final = true;
-                outbound_messages.push(benchmark_finalize_prompt(&result.reasoning));
-                continue;
-            }
-            if final_content.trim().is_empty() {
-                status = "empty_final".to_string();
-                break;
-            }
-            status = "ok".to_string();
-            break;
-        }
-        let assistant_tool_calls: Vec<Value> = tool_calls
-            .iter()
-            .map(|call| {
-                json!({
-                    "id": call.id,
-                    "type": "function",
-                    "function": { "name": call.name, "arguments": call.arguments },
-                })
-            })
-            .collect();
-        outbound_messages.push(json!({
-            "role": "assistant",
-            "content": final_content,
-            "tool_calls": assistant_tool_calls,
-        }));
-
-        for call in tool_calls {
-            let args = serde_json::from_str::<Value>(&call.arguments).unwrap_or_else(|_| json!({}));
-            let result = match tool_result(app, mgr, None, session_id, &call.name, &args).await {
-                Ok(value) => value,
-                Err(err) => json!({ "error": err }),
-            };
-            tool_count += 1;
-            outbound_messages.push(json!({
-                "role": "tool",
-                "tool_call_id": call.id,
-                "content": result.to_string(),
-            }));
-        }
-    }
-
-    Ok(BenchmarkChatResult {
-        capture_run_id: capture_run_id.to_string(),
-        prompt_tokens: approximate_messages_tokens(&outbound_messages),
-        completion_tokens: final_content.split_whitespace().count() as u64,
-        reasoning_tokens,
-        content: final_content,
-        status,
-        runtime_backend: "native-rust".to_string(),
-        elapsed_ms: started.elapsed().as_millis() as u64,
-        tool_calls: tool_count,
-        compacted,
-        context_tokens_before,
-    })
+            compacted: compaction_reason.is_some(),
+            context_tokens_before,
+        },
+    )
+    .await
 }
 
 /// Agent-facing, non-streaming chat completion against one warm slot. The
@@ -3939,6 +3995,51 @@ mod tests {
         assert!(unsupervised.iter().any(|tool| {
             tool.get("name").and_then(Value::as_str) == Some("delegate_to_sidekick")
         }));
+    }
+
+    #[test]
+    fn benchmark_sidecar_result_preserves_exact_usage_and_compaction() {
+        let prepared = PreparedBenchmarkRun {
+            started: Instant::now() - Duration::from_millis(777),
+            session_id: "fusion-session".to_string(),
+            capture_run_id: "desktop-fusion-capture".to_string(),
+            messages: vec![],
+            outbound_messages: vec![],
+            binding: RouteBinding {
+                route: "local".to_string(),
+                url: "http://127.0.0.1:8091/v1/chat/completions".to_string(),
+                bearer: None,
+                model_field: "model-under-test".to_string(),
+            },
+            slot_id: Some(5),
+            allow_sidekick_tool: false,
+            compacted: true,
+            context_tokens_before: 12_000,
+        };
+        let result = benchmark_sidecar_result(
+            &prepared,
+            crate::conversation_sidecar::SidecarRunResult {
+                content: "measured answer".to_string(),
+                usage: Some(json!({
+                    "prompt_tokens": 321,
+                    "completion_tokens": 45,
+                    "reasoning_tokens": 9
+                })),
+                tool_calls: 2,
+                elapsed_ms: 777,
+                compacted: true,
+                context_tokens_before: 15_000,
+            },
+        );
+        assert_eq!(result.capture_run_id, "desktop-fusion-capture");
+        assert_eq!(result.runtime_backend, "pi");
+        assert_eq!(result.prompt_tokens, 321);
+        assert_eq!(result.completion_tokens, 45);
+        assert_eq!(result.reasoning_tokens, 9);
+        assert_eq!(result.tool_calls, 2);
+        assert!(result.elapsed_ms >= 777);
+        assert!(result.compacted);
+        assert_eq!(result.context_tokens_before, 15_000);
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -26,6 +26,9 @@ pub enum ChatEvent {
     Chunk {
         text: String,
     },
+    ReplaceChunk {
+        text: String,
+    },
     ReasoningChunk {
         text: String,
     },

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -67,8 +67,10 @@ pub struct ChatAttachment {
 
 #[derive(Serialize)]
 pub struct BenchmarkChatResult {
+    pub capture_run_id: String,
     pub content: String,
     pub status: String,
+    pub runtime_backend: String,
     pub elapsed_ms: u64,
     pub tool_calls: u64,
     pub prompt_tokens: u64,
@@ -2851,6 +2853,14 @@ pub async fn chat_stream(
                         let prompt_tokens =
                             sidecar_usage_tokens(sidecar.usage.as_ref(), "prompt_tokens")
                                 .unwrap_or(prompt_tokens);
+                        let runtime_compacted = compacted || sidecar.compacted;
+                        let runtime_compaction_reason = if sidecar.compacted {
+                            Some("runtime_compaction_boundary".to_string())
+                        } else {
+                            compaction_reason.clone()
+                        };
+                        let runtime_context_tokens_before =
+                            context_tokens_before.max(sidecar.context_tokens_before);
                         record_chat_run(
                             &app,
                             ChatRunInput {
@@ -2865,9 +2875,9 @@ pub async fn chat_stream(
                                 tool_calls: sidecar.tool_calls,
                                 sidekick_spawned: sidekick_plan.spawned,
                                 gateway_used: binding.route == "cloud",
-                                compacted,
-                                compaction_reason: compaction_reason.clone(),
-                                context_tokens_before: Some(context_tokens_before),
+                                compacted: runtime_compacted,
+                                compaction_reason: runtime_compaction_reason,
+                                context_tokens_before: Some(runtime_context_tokens_before),
                                 local_mem_gb,
                                 gateway_available,
                                 gateway_avoided: gateway_available && binding.route != "cloud",
@@ -3143,11 +3153,12 @@ pub async fn benchmark_local_chat(
     app: &AppHandle,
     mgr: &Residency,
     slot_id: u32,
-    session_id: &str,
+    identity: (&str, &str),
     prompt: &str,
     enable_parallel_sidekick: bool,
     allow_sidekick_tool: bool,
 ) -> Result<BenchmarkChatResult, String> {
+    let (session_id, capture_run_id) = identity;
     let started = Instant::now();
     let prompt = benchmark_prompt(prompt);
     let (port, model_field) = mgr
@@ -3271,11 +3282,13 @@ pub async fn benchmark_local_chat(
     }
 
     Ok(BenchmarkChatResult {
+        capture_run_id: capture_run_id.to_string(),
         prompt_tokens: approximate_messages_tokens(&outbound_messages),
         completion_tokens: final_content.split_whitespace().count() as u64,
         reasoning_tokens,
         content: final_content,
         status,
+        runtime_backend: "native-rust".to_string(),
         elapsed_ms: started.elapsed().as_millis() as u64,
         tool_calls: tool_count,
         compacted,
@@ -3290,6 +3303,7 @@ pub async fn benchmark_gateway_chat(
     prompt: &str,
     model_field: &str,
     allow_sidekick_tool: bool,
+    capture_run_id: &str,
 ) -> Result<BenchmarkChatResult, String> {
     let started = Instant::now();
     let prompt = benchmark_prompt(prompt);
@@ -3376,11 +3390,13 @@ pub async fn benchmark_gateway_chat(
     }
 
     Ok(BenchmarkChatResult {
+        capture_run_id: capture_run_id.to_string(),
         prompt_tokens: approximate_messages_tokens(&outbound_messages),
         completion_tokens: final_content.split_whitespace().count() as u64,
         reasoning_tokens,
         content: final_content,
         status,
+        runtime_backend: "native-rust".to_string(),
         elapsed_ms: started.elapsed().as_millis() as u64,
         tool_calls: tool_count,
         compacted,
@@ -3388,11 +3404,9 @@ pub async fn benchmark_gateway_chat(
     })
 }
 
-/// Agent-facing, non-streaming chat completion against one warm slot, served
-/// over the local API server. Reuses the benchmark chat plumbing
-/// (`nonstream_chat_once` + the local tool loop) — NOT the GUI `chat_stream`
-/// — but without the benchmark prompt wrapper, sidekick spawning, or
-/// persistence, and with an agent-sized token cap.
+/// Agent-facing, non-streaming chat completion against one warm slot. The
+/// canonical runtime is authoritative; the native loop remains a pre-output
+/// compatibility fallback for one release.
 pub async fn agent_chat(
     app: &AppHandle,
     mgr: &Residency,
@@ -3400,6 +3414,105 @@ pub async fn agent_chat(
     session_id: &str,
     prompt: &str,
     max_tokens: Option<u32>,
+    capture_run_id: Option<&str>,
+) -> Result<BenchmarkChatResult, String> {
+    let max_tokens = max_tokens
+        .unwrap_or(AGENT_CHAT_DEFAULT_MAX_TOKENS)
+        .clamp(1, CHAT_MAX_TOKENS);
+    let (port, model_field) = mgr
+        .endpoint(slot_id)
+        .ok_or_else(|| format!("slot {slot_id} is not warm; warm it first"))?;
+    let messages = vec![ChatMsg {
+        role: "user".to_string(),
+        content: prompt.to_string(),
+        attachments: vec![],
+    }];
+    let outbound = vec![
+        json!({ "role": "system", "content": system_prompt_for(&model_field) }),
+        json!({ "role": "user", "content": prompt }),
+    ];
+    let binding = RouteBinding {
+        route: "local".to_string(),
+        url: format!("http://127.0.0.1:{port}/v1/chat/completions"),
+        bearer: None,
+        model_field,
+    };
+    let run_id = match capture_run_id {
+        Some(value) if !value.trim().is_empty() && value.len() <= 200 => value.to_string(),
+        Some(_) => return Err("capture_run_id must contain 1 to 200 bytes".to_string()),
+        None => crate::conversation_runtime::new_run_id()?,
+    };
+    let attempt = match sidecar_run_request(
+        app,
+        &messages,
+        &outbound,
+        &binding,
+        None,
+        Some(slot_id),
+        (session_id, &run_id),
+    ) {
+        Ok(mut request) => {
+            request["max_output_tokens"] = json!(max_tokens);
+            request["max_tool_rounds"] = json!(BENCHMARK_MAX_TOOL_ROUNDS);
+            request["tools"] = json!(sidecar_tool_definitions(false));
+            crate::conversation_sidecar::try_run_chat_headless(app, request).await
+        }
+        Err(reason) => crate::conversation_sidecar::SidecarAttempt::NativeFallback(reason),
+    };
+    match attempt {
+        crate::conversation_sidecar::SidecarAttempt::Completed(sidecar) => {
+            let prompt_tokens =
+                sidecar_usage_tokens(sidecar.usage.as_ref(), "prompt_tokens").unwrap_or(0);
+            let completion_tokens =
+                sidecar_usage_tokens(sidecar.usage.as_ref(), "completion_tokens")
+                    .unwrap_or_else(|| approximate_token_count(&sidecar.content));
+            let reasoning_tokens =
+                sidecar_usage_tokens(sidecar.usage.as_ref(), "reasoning_tokens").unwrap_or(0);
+            Ok(BenchmarkChatResult {
+                capture_run_id: run_id,
+                status: if sidecar.content.trim().is_empty() {
+                    "empty_final".to_string()
+                } else {
+                    "ok".to_string()
+                },
+                runtime_backend: "pi".to_string(),
+                content: sidecar.content,
+                elapsed_ms: sidecar.elapsed_ms,
+                tool_calls: sidecar.tool_calls,
+                prompt_tokens,
+                completion_tokens,
+                reasoning_tokens,
+                compacted: sidecar.compacted,
+                context_tokens_before: sidecar.context_tokens_before,
+            })
+        }
+        crate::conversation_sidecar::SidecarAttempt::FailedAfterOutput(reason) => Err(format!(
+            "conversation runtime stopped after the headless turn began: {reason}; native retry was suppressed"
+        )),
+        crate::conversation_sidecar::SidecarAttempt::NativeFallback(_)
+        | crate::conversation_sidecar::SidecarAttempt::NotSelected => {
+            agent_chat_native(
+                app,
+                mgr,
+                slot_id,
+                session_id,
+                prompt,
+                Some(max_tokens),
+                &run_id,
+            )
+            .await
+        }
+    }
+}
+
+async fn agent_chat_native(
+    app: &AppHandle,
+    mgr: &Residency,
+    slot_id: u32,
+    session_id: &str,
+    prompt: &str,
+    max_tokens: Option<u32>,
+    capture_run_id: &str,
 ) -> Result<BenchmarkChatResult, String> {
     let started = Instant::now();
     let max_tokens = max_tokens
@@ -3486,11 +3599,13 @@ pub async fn agent_chat(
     }
 
     Ok(BenchmarkChatResult {
+        capture_run_id: capture_run_id.to_string(),
         prompt_tokens: approximate_messages_tokens(&outbound_messages),
         completion_tokens: final_content.split_whitespace().count() as u64,
         reasoning_tokens,
         content: final_content,
         status,
+        runtime_backend: "native-rust".to_string(),
         elapsed_ms: started.elapsed().as_millis() as u64,
         tool_calls: tool_count,
         compacted: false,

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -20,7 +20,7 @@ use crate::route_policy::{
     TOOL_DEPTH_ESCALATION_CALLS,
 };
 use crate::sidecar::{ServiceState, Services};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
@@ -3110,6 +3110,93 @@ pub fn set_sidekick_run_feedback(
     app.state::<crate::db::Db>()
         .set_sidekick_run_feedback(run_id, accepted)
         .map_err(|e| e.to_string())
+}
+
+/// Explicit human verdict on one local supervisor decision. `correct_action`
+/// is optional so a one-tap helpful/not-helpful label stays cheap, while a
+/// richer label remains available for evaluator and training exports.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SupervisorFeedbackRequest {
+    session_id: String,
+    run_id: Option<String>,
+    marker_id: Option<String>,
+    intervention_at: Option<u64>,
+    stage: String,
+    helpful: bool,
+    correct_action: Option<String>,
+    justification: Option<String>,
+}
+
+fn validate_correct_supervisor_action(
+    stage: &str,
+    helpful: bool,
+    correct_action: Option<&str>,
+) -> Result<(), String> {
+    let Some(correct_action) = correct_action else {
+        return Ok(());
+    };
+    if !matches!(correct_action, "continue" | "nudge" | "interrupt" | "stop") {
+        return Err(format!(
+            "unknown correct supervisor action: {correct_action}"
+        ));
+    }
+    let recorded_action = match stage {
+        "take_over" => "interrupt",
+        "nudge" => "nudge",
+        "continue" => "continue",
+        "stop" => "stop",
+        _ => return Err(format!("unknown supervisor stage: {stage}")),
+    };
+    if helpful != (correct_action == recorded_action) {
+        return Err(format!(
+            "correct_action {correct_action} is inconsistent with helpful={helpful} for {recorded_action}"
+        ));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn record_supervisor_feedback(
+    app: AppHandle,
+    feedback: SupervisorFeedbackRequest,
+) -> Result<(), String> {
+    if !matches!(
+        feedback.stage.as_str(),
+        "continue" | "nudge" | "take_over" | "stop"
+    ) {
+        return Err(format!("unknown supervisor stage: {}", feedback.stage));
+    }
+    if feedback.run_id.is_some() && feedback.marker_id.as_deref().is_none_or(str::is_empty) {
+        return Err("run-attributed supervisor feedback requires marker_id".to_string());
+    }
+    validate_correct_supervisor_action(
+        &feedback.stage,
+        feedback.helpful,
+        feedback.correct_action.as_deref(),
+    )?;
+    app.state::<crate::db::Db>()
+        .record_supervisor_feedback(&crate::db::SupervisorFeedbackInput {
+            session_id: feedback.session_id,
+            run_id: feedback.run_id,
+            marker_id: feedback.marker_id,
+            intervention_at: feedback.intervention_at,
+            stage: feedback.stage,
+            helpful: feedback.helpful,
+            correct_action: feedback.correct_action,
+            justification: feedback.justification,
+        })
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn supervisor_feedback_for_session(
+    app: AppHandle,
+    session_id: String,
+) -> Result<Vec<crate::db::SupervisorFeedbackRow>, String> {
+    app.state::<crate::db::Db>()
+        .list_supervisor_feedback_for_session(&session_id)
+        .map_err(|error| error.to_string())
 }
 
 #[tauri::command]

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -82,6 +82,7 @@ pub struct FusionBenchmarkCandidate {
 #[derive(serde::Deserialize)]
 pub struct RecordFusionBenchmarkRequest {
     pub run_id: String,
+    pub capture_run_id: Option<String>,
     pub task_id: String,
     pub mode: String,
     pub model: String,
@@ -358,6 +359,8 @@ pub struct EvalResultProvenance {
 pub struct EvalResultV1 {
     pub schema_version: &'static str,
     pub run_id: String,
+    /// Per-attempt canonical runtime id; unlike run_id, this is unique per row.
+    pub capture_run_id: Option<String>,
     pub task_id: String,
     pub split: String,
     pub score: Option<f64>,
@@ -391,6 +394,7 @@ pub(crate) fn eval_result_v1(row: &FusionBenchmarkRow) -> EvalResultV1 {
     EvalResultV1 {
         schema_version: "understudy.eval_result.v1",
         run_id: row.run_id.clone(),
+        capture_run_id: row.capture_run_id.clone(),
         task_id: row.task_id.clone(),
         split: row.split.clone().unwrap_or_else(|| "none".to_string()),
         score: row.score,
@@ -1791,6 +1795,7 @@ pub fn record_fusion_benchmark(
     }
     let input = FusionBenchmarkInput {
         run_id: result.run_id,
+        capture_run_id: result.capture_run_id,
         task_id: result.task_id,
         mode: result.mode,
         model: result.model,
@@ -2567,6 +2572,7 @@ async fn run_fusion_benchmark_inner(
                 });
             }
             if ready && !dry_run {
+                let capture_run_id = crate::conversation_runtime::new_run_id()?;
                 let before_sidekick_run_ids = app
                     .state::<crate::db::Db>()
                     .list_sidekick_runs(100)
@@ -2583,6 +2589,7 @@ async fn run_fusion_benchmark_inner(
                         task.prompt,
                         &effective_model,
                         allow_sidekick_tool,
+                        &capture_run_id,
                     )
                     .await
                 } else {
@@ -2591,7 +2598,7 @@ async fn run_fusion_benchmark_inner(
                         &app,
                         residency(&app),
                         slot_id,
-                        &run_id,
+                        (&run_id, &capture_run_id),
                         task.prompt,
                         needs_sidekick,
                         allow_sidekick_tool,
@@ -2624,6 +2631,7 @@ async fn run_fusion_benchmark_inner(
                         app.state::<crate::db::Db>()
                             .record_fusion_benchmark(&FusionBenchmarkInput {
                                 run_id: run_id.clone(),
+                                capture_run_id: Some(capture_run_id.clone()),
                                 task_id: task.id.to_string(),
                                 mode: mode.clone(),
                                 model: effective_model.clone(),
@@ -2692,6 +2700,7 @@ async fn run_fusion_benchmark_inner(
                 app.state::<crate::db::Db>()
                     .record_fusion_benchmark(&FusionBenchmarkInput {
                         run_id: run_id.clone(),
+                        capture_run_id: Some(result.capture_run_id.clone()),
                         task_id: task.id.to_string(),
                         mode: mode.clone(),
                         model: effective_model.clone(),
@@ -2741,9 +2750,11 @@ async fn run_fusion_benchmark_inner(
                     });
                 }
             } else if !ready && record_skips {
+                let capture_run_id = crate::conversation_runtime::new_run_id()?;
                 app.state::<crate::db::Db>()
                     .record_fusion_benchmark(&FusionBenchmarkInput {
                         run_id: run_id.clone(),
+                        capture_run_id: Some(capture_run_id),
                         task_id: task.id.to_string(),
                         mode: mode.clone(),
                         model: effective_model.clone(),
@@ -3388,6 +3399,7 @@ mod tests {
     fn benchmark_input(task_id: &str, score: Option<f64>, status: &str) -> FusionBenchmarkInput {
         FusionBenchmarkInput {
             run_id: "fusion-run-1".to_string(),
+            capture_run_id: Some(format!("desktop-{task_id}")),
             task_id: task_id.to_string(),
             mode: "sidekick-routing".to_string(),
             model: "gemma-4-e2b-it-qat-understudy".to_string(),

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -596,6 +596,11 @@ pub struct ChatRouteMetricGroup {
 #[derive(Serialize, Clone)]
 pub struct ChatRouteMetrics {
     pub schema_version: &'static str,
+    pub app_version: &'static str,
+    pub runtime_version: &'static str,
+    pub observed_row_limit: u32,
+    pub required_canonical_runtime_rows: u64,
+    pub remaining_canonical_runtime_rows: u64,
     pub canonical_runtime_rows: u64,
     pub pi_runtime_rows: u64,
     pub compatibility_fallback_rows: u64,
@@ -2330,13 +2335,26 @@ pub fn chat_session_save(
 
 #[tauri::command]
 pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRouteMetrics, String> {
+    let observed_row_limit = limit.unwrap_or(250).clamp(1, 500);
     let rows = app
         .state::<crate::db::Db>()
-        .list_chat_runs(limit.unwrap_or(250))
+        .list_chat_runs(observed_row_limit)
         .map_err(|e| e.to_string())?;
-    // Rows predating the canonical bridge have no run_id and inherited the
-    // native-rust column default during migration. Exclude those legacy rows
-    // or they permanently poison the rollout denominator.
+    Ok(chat_route_metrics_for_rows(rows, observed_row_limit))
+}
+
+fn chat_route_metrics_for_rows(rows: Vec<ChatRunRow>, observed_row_limit: u32) -> ChatRouteMetrics {
+    const REQUIRED_CANONICAL_RUNTIME_ROWS: u64 = 100;
+    // Count only the compatibility release cohort. Older development and
+    // migrated rows remain preserved in SQLite, but cannot poison or falsely
+    // satisfy the 100-run Rust deletion gate.
+    let rows: Vec<_> = rows
+        .into_iter()
+        .filter(|row| {
+            row.app_version == env!("CARGO_PKG_VERSION")
+                && row.runtime_version == crate::conversation_runtime::RUNTIME_VERSION
+        })
+        .collect();
     let canonical_runtime_rows = rows.iter().filter(|row| row.run_id.is_some()).count() as u64;
     let pi_runtime_rows = rows
         .iter()
@@ -2388,16 +2406,23 @@ pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRout
         });
     }
     out.sort_by_key(|g| std::cmp::Reverse(g.rows));
-    Ok(ChatRouteMetrics {
+    ChatRouteMetrics {
         schema_version: "understudy.chat_route_metrics.v1",
+        app_version: env!("CARGO_PKG_VERSION"),
+        runtime_version: crate::conversation_runtime::RUNTIME_VERSION,
+        observed_row_limit,
+        required_canonical_runtime_rows: REQUIRED_CANONICAL_RUNTIME_ROWS,
+        remaining_canonical_runtime_rows: REQUIRED_CANONICAL_RUNTIME_ROWS
+            .saturating_sub(canonical_runtime_rows),
         canonical_runtime_rows,
         pi_runtime_rows,
         compatibility_fallback_rows,
         pi_runtime_share,
-        compatibility_engine_delete_ready: canonical_runtime_rows >= 100
+        compatibility_engine_delete_ready: canonical_runtime_rows
+            >= REQUIRED_CANONICAL_RUNTIME_ROWS
             && compatibility_fallback_rows == 0,
         groups: out,
-    })
+    }
 }
 
 #[tauri::command]
@@ -3261,11 +3286,72 @@ pub fn server_info(app: AppHandle) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use super::{
-        eval_result_v1, eval_results_jsonl, export_packet_provenance, fusion_benchmark_score,
-        resolve_export_output_path_under, sha256_hex,
+        chat_route_metrics_for_rows, eval_result_v1, eval_results_jsonl, export_packet_provenance,
+        fusion_benchmark_score, resolve_export_output_path_under, sha256_hex,
     };
-    use crate::db::{Db, FusionBenchmarkInput};
+    use crate::db::{ChatRunRow, Db, FusionBenchmarkInput};
     use std::path::PathBuf;
+
+    fn migration_row(
+        runtime_backend: &str,
+        app_version: &str,
+        runtime_version: &str,
+    ) -> ChatRunRow {
+        ChatRunRow {
+            id: 1,
+            run_id: Some("run-1".to_string()),
+            runtime_backend: runtime_backend.to_string(),
+            app_version: app_version.to_string(),
+            runtime_version: runtime_version.to_string(),
+            session_id: "session-1".to_string(),
+            route: "local".to_string(),
+            model: "understudy-small".to_string(),
+            elapsed_ms: Some(1),
+            prompt_tokens: Some(1),
+            completion_tokens: Some(1),
+            tool_calls: 0,
+            sidekick_spawned: false,
+            gateway_used: false,
+            compacted: false,
+            compaction_reason: None,
+            context_tokens_before: None,
+            local_mem_gb: None,
+            gateway_available: false,
+            gateway_avoided: false,
+            status: "ok".to_string(),
+            error: None,
+            run_at: "2026-07-12T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn migration_gate_counts_only_the_current_release_cohort() {
+        let mut rows = vec![migration_row("native-rust", "legacy", "legacy"); 50];
+        rows.extend(vec![
+            migration_row(
+                "pi",
+                env!("CARGO_PKG_VERSION"),
+                crate::conversation_runtime::RUNTIME_VERSION,
+            );
+            100
+        ]);
+        let ready = chat_route_metrics_for_rows(rows.clone(), 250);
+        assert_eq!(ready.canonical_runtime_rows, 100);
+        assert_eq!(ready.pi_runtime_rows, 100);
+        assert_eq!(ready.compatibility_fallback_rows, 0);
+        assert_eq!(ready.remaining_canonical_runtime_rows, 0);
+        assert!(ready.compatibility_engine_delete_ready);
+
+        rows.push(migration_row(
+            "native-rust",
+            env!("CARGO_PKG_VERSION"),
+            crate::conversation_runtime::RUNTIME_VERSION,
+        ));
+        let fallback = chat_route_metrics_for_rows(rows, 250);
+        assert_eq!(fallback.canonical_runtime_rows, 101);
+        assert_eq!(fallback.compatibility_fallback_rows, 1);
+        assert!(!fallback.compatibility_engine_delete_ready);
+    }
 
     #[test]
     fn export_packet_provenance_hashes_and_summarizes_rows() {

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -589,6 +589,11 @@ pub struct ChatRouteMetricGroup {
 #[derive(Serialize, Clone)]
 pub struct ChatRouteMetrics {
     pub schema_version: &'static str,
+    pub canonical_runtime_rows: u64,
+    pub pi_runtime_rows: u64,
+    pub compatibility_fallback_rows: u64,
+    pub pi_runtime_share: Option<f64>,
+    pub compatibility_engine_delete_ready: bool,
     pub groups: Vec<ChatRouteMetricGroup>,
 }
 
@@ -2318,6 +2323,17 @@ pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRout
         .state::<crate::db::Db>()
         .list_chat_runs(limit.unwrap_or(250))
         .map_err(|e| e.to_string())?;
+    // Rows predating the canonical bridge have no run_id and inherited the
+    // native-rust column default during migration. Exclude those legacy rows
+    // or they permanently poison the rollout denominator.
+    let canonical_runtime_rows = rows.iter().filter(|row| row.run_id.is_some()).count() as u64;
+    let pi_runtime_rows = rows
+        .iter()
+        .filter(|row| row.run_id.is_some() && row.runtime_backend == "pi")
+        .count() as u64;
+    let compatibility_fallback_rows = canonical_runtime_rows.saturating_sub(pi_runtime_rows);
+    let pi_runtime_share = (canonical_runtime_rows > 0)
+        .then_some(pi_runtime_rows as f64 / canonical_runtime_rows as f64);
     let mut groups: std::collections::BTreeMap<(String, String), Vec<ChatRunRow>> =
         std::collections::BTreeMap::new();
     for row in rows {
@@ -2363,6 +2379,12 @@ pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRout
     out.sort_by_key(|g| std::cmp::Reverse(g.rows));
     Ok(ChatRouteMetrics {
         schema_version: "understudy.chat_route_metrics.v1",
+        canonical_runtime_rows,
+        pi_runtime_rows,
+        compatibility_fallback_rows,
+        pi_runtime_share,
+        compatibility_engine_delete_ready: canonical_runtime_rows >= 100
+            && compatibility_fallback_rows == 0,
         groups: out,
     })
 }

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -2254,6 +2254,64 @@ pub fn chat_runs(app: AppHandle, limit: Option<u32>) -> Result<Vec<ChatRunRow>, 
         .map_err(|e| e.to_string())
 }
 
+const DESKTOP_CHAT_SESSION_SCHEMA: &str = "understudy-desktop-chat-session-v1";
+const MAX_PERSISTED_CHAT_BYTES: usize = 48 * 1024 * 1024;
+const MAX_PERSISTED_CHAT_MESSAGES: usize = 500;
+
+#[derive(Serialize)]
+pub struct DesktopChatSession {
+    session_id: String,
+    messages: Value,
+    updated_at: String,
+}
+
+#[tauri::command]
+pub fn chat_session_latest(app: AppHandle) -> Result<Option<DesktopChatSession>, String> {
+    let Some(row) = app
+        .state::<crate::db::Db>()
+        .latest_chat_session(DESKTOP_CHAT_SESSION_SCHEMA)
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(None);
+    };
+    if row.schema != DESKTOP_CHAT_SESSION_SCHEMA {
+        return Ok(None);
+    }
+    let messages = serde_json::from_str(&row.messages)
+        .map_err(|error| format!("saved chat transcript is invalid: {error}"))?;
+    Ok(Some(DesktopChatSession {
+        session_id: row.session_id,
+        messages,
+        updated_at: row.updated_at,
+    }))
+}
+
+#[tauri::command]
+pub fn chat_session_save(
+    app: AppHandle,
+    session_id: String,
+    messages: Value,
+) -> Result<(), String> {
+    if session_id.trim().is_empty() || session_id.len() > 200 {
+        return Err("invalid chat session id".to_string());
+    }
+    let Some(items) = messages.as_array() else {
+        return Err("chat transcript must be an array".to_string());
+    };
+    if items.len() > MAX_PERSISTED_CHAT_MESSAGES {
+        return Err(format!(
+            "chat transcript exceeds {MAX_PERSISTED_CHAT_MESSAGES} messages"
+        ));
+    }
+    let encoded = serde_json::to_string(&messages).map_err(|error| error.to_string())?;
+    if encoded.len() > MAX_PERSISTED_CHAT_BYTES {
+        return Err("chat transcript exceeds the 48 MB local resume limit".to_string());
+    }
+    app.state::<crate::db::Db>()
+        .save_active_chat_session(&session_id, DESKTOP_CHAT_SESSION_SCHEMA, &encoded)
+        .map_err(|error| error.to_string())
+}
+
 #[tauri::command]
 pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRouteMetrics, String> {
     let rows = app

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -83,6 +83,7 @@ pub struct FusionBenchmarkCandidate {
 pub struct RecordFusionBenchmarkRequest {
     pub run_id: String,
     pub capture_run_id: Option<String>,
+    pub runtime_backend: Option<String>,
     pub task_id: String,
     pub mode: String,
     pub model: String,
@@ -361,6 +362,7 @@ pub struct EvalResultV1 {
     pub run_id: String,
     /// Per-attempt canonical runtime id; unlike run_id, this is unique per row.
     pub capture_run_id: Option<String>,
+    pub runtime_backend: Option<String>,
     pub task_id: String,
     pub split: String,
     pub score: Option<f64>,
@@ -395,6 +397,7 @@ pub(crate) fn eval_result_v1(row: &FusionBenchmarkRow) -> EvalResultV1 {
         schema_version: "understudy.eval_result.v1",
         run_id: row.run_id.clone(),
         capture_run_id: row.capture_run_id.clone(),
+        runtime_backend: Some(row.runtime_backend.clone()),
         task_id: row.task_id.clone(),
         split: row.split.clone().unwrap_or_else(|| "none".to_string()),
         score: row.score,
@@ -1796,6 +1799,9 @@ pub fn record_fusion_benchmark(
     let input = FusionBenchmarkInput {
         run_id: result.run_id,
         capture_run_id: result.capture_run_id,
+        runtime_backend: result
+            .runtime_backend
+            .unwrap_or_else(|| "external".to_string()),
         task_id: result.task_id,
         mode: result.mode,
         model: result.model,
@@ -2451,15 +2457,15 @@ async fn run_fusion_benchmark_inner(
         }
     }
 
-    let snapshot = residency(&app).snapshot();
+    let residency_manager = residency(&app);
+    let snapshot = residency_manager.snapshot();
     let warm_main = snapshot.slots.iter().find(|slot| slot.state == "running");
-    let warm_sidekick = snapshot.slots.iter().find(|slot| {
-        slot.state == "running"
-            && slot
-                .model_id
-                .as_deref()
-                .is_some_and(|id| id.contains("understudy-small") || id.contains("e2b"))
-    });
+    // Use the same endpoint selection as live chat. Model-name heuristics made
+    // valid small models such as LFM look unavailable to the benchmark even
+    // while the runtime was actively serving them.
+    let warm_sidekick = warm_main
+        .and_then(|main| residency_manager.sidekick_endpoint(Some(main.id)))
+        .and_then(|(slot_id, _, _, _)| snapshot.slots.iter().find(|slot| slot.id == slot_id));
     let candidate_main = if candidate == "local-fast" {
         warm_sidekick.or(warm_main)
     } else {
@@ -2632,6 +2638,7 @@ async fn run_fusion_benchmark_inner(
                             .record_fusion_benchmark(&FusionBenchmarkInput {
                                 run_id: run_id.clone(),
                                 capture_run_id: Some(capture_run_id.clone()),
+                                runtime_backend: "unknown".to_string(),
                                 task_id: task.id.to_string(),
                                 mode: mode.clone(),
                                 model: effective_model.clone(),
@@ -2701,6 +2708,7 @@ async fn run_fusion_benchmark_inner(
                     .record_fusion_benchmark(&FusionBenchmarkInput {
                         run_id: run_id.clone(),
                         capture_run_id: Some(result.capture_run_id.clone()),
+                        runtime_backend: result.runtime_backend.clone(),
                         task_id: task.id.to_string(),
                         mode: mode.clone(),
                         model: effective_model.clone(),
@@ -2755,6 +2763,7 @@ async fn run_fusion_benchmark_inner(
                     .record_fusion_benchmark(&FusionBenchmarkInput {
                         run_id: run_id.clone(),
                         capture_run_id: Some(capture_run_id),
+                        runtime_backend: "not-run".to_string(),
                         task_id: task.id.to_string(),
                         mode: mode.clone(),
                         model: effective_model.clone(),
@@ -3400,6 +3409,7 @@ mod tests {
         FusionBenchmarkInput {
             run_id: "fusion-run-1".to_string(),
             capture_run_id: Some(format!("desktop-{task_id}")),
+            runtime_backend: "pi".to_string(),
             task_id: task_id.to_string(),
             mode: "sidekick-routing".to_string(),
             model: "gemma-4-e2b-it-qat-understudy".to_string(),

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.2";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.3";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -37,6 +37,14 @@ pub(crate) enum RuntimeVerdict {
     Interrupt,
     Stop,
     Nudge,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TeacherOutputMode {
+    #[default]
+    Append,
+    Replace,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -110,6 +118,8 @@ pub(crate) enum RuntimeEvent {
         reason: String,
         teacher_model: String,
         from_partial_chars: u64,
+        #[serde(default)]
+        output_mode: TeacherOutputMode,
     },
     Cancellation {
         stage: String,
@@ -540,6 +550,7 @@ mod tests {
                     reason: "correct it".to_string(),
                     teacher_model: "teacher".to_string(),
                     from_partial_chars: 7,
+                    output_mode: TeacherOutputMode::Append,
                 },
             ),
         ];

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.1";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.2";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -1,0 +1,507 @@
+//! Canonical conversation evidence shared with the public TypeScript runtime.
+//!
+//! The CLI-owned Pi sidecar is the conversation authority. The desktop keeps
+//! this deliberately small consumer: deserialize envelopes, reject lossy or
+//! internally inconsistent traces, and persist one immutable JSONL journal per
+//! run. Provider orchestration remains outside Rust.
+
+use std::collections::{HashMap, HashSet};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager};
+
+pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.1";
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RuntimeRole {
+    User,
+    Student,
+    Teacher,
+    Primary,
+    Supervisor,
+    Tool,
+    System,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RuntimeVerdict {
+    Continue,
+    Interrupt,
+    Stop,
+    Nudge,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "event", content = "data", rename_all = "snake_case")]
+pub(crate) enum RuntimeEvent {
+    Message {
+        role: RuntimeRole,
+        text: String,
+        #[serde(default)]
+        model: Option<String>,
+    },
+    Delta {
+        role: RuntimeRole,
+        text: String,
+        #[serde(default)]
+        model: Option<String>,
+    },
+    ReasoningDelta {
+        role: RuntimeRole,
+        text: String,
+        #[serde(default)]
+        model: Option<String>,
+    },
+    ToolCall {
+        call_id: String,
+        name: String,
+        raw_arguments: String,
+        #[serde(default)]
+        parsed_arguments: Option<Value>,
+        #[serde(default)]
+        parse_error: Option<String>,
+    },
+    ToolResult {
+        call_id: String,
+        name: String,
+        ok: bool,
+        result: Value,
+    },
+    Usage {
+        role: RuntimeRole,
+        #[serde(default)]
+        model: Option<String>,
+        input_tokens: u64,
+        output_tokens: u64,
+        #[serde(default)]
+        reasoning_tokens: u64,
+        #[serde(default)]
+        cached_input_tokens: u64,
+        total_tokens: u64,
+        source: String,
+        complete: bool,
+    },
+    SupervisorVerdict {
+        verdict: RuntimeVerdict,
+        source: String,
+        #[serde(default)]
+        marker_id: Option<String>,
+        #[serde(default)]
+        reason: Option<String>,
+        #[serde(default)]
+        probabilities: Option<Value>,
+    },
+    StudentInterruption {
+        marker_id: String,
+        reason: String,
+        partial_text: String,
+        after_chars: u64,
+    },
+    TeacherContinuation {
+        marker_id: String,
+        reason: String,
+        teacher_model: String,
+        from_partial_chars: u64,
+    },
+    Cancellation {
+        stage: String,
+        reason: String,
+    },
+    Error {
+        stage: String,
+        code: String,
+        message: String,
+        recoverable: bool,
+    },
+    ImageAttachment {
+        attachment_id: String,
+        filename: String,
+        media_type: String,
+        byte_count: u64,
+    },
+    CompactionBoundary {
+        source_message_count: u64,
+        retained_message_count: u64,
+        estimated_tokens_before: u64,
+        estimated_tokens_after: u64,
+        summary_sha256: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub(crate) struct RuntimeEventEnvelope {
+    pub(crate) schema_version: String,
+    pub(crate) event_id: String,
+    pub(crate) run_id: String,
+    pub(crate) session_id: String,
+    pub(crate) runtime_id: String,
+    pub(crate) sequence: u64,
+    pub(crate) emitted_at: String,
+    #[serde(flatten)]
+    pub(crate) event: RuntimeEvent,
+}
+
+pub(crate) fn new_run_id() -> Result<String, String> {
+    let mut bytes = [0u8; 16];
+    getrandom::getrandom(&mut bytes).map_err(|error| format!("create run id: {error}"))?;
+    let random = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(format!("desktop-{random}"))
+}
+
+fn sha256(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn create_private_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path)
+        .map_err(|error| format!("create runtime event directory: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("secure runtime event directory: {error}"))?;
+    }
+    Ok(())
+}
+
+fn open_private_new(path: &Path) -> Result<File, String> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .map_err(|error| format!("create runtime event journal: {error}"))
+}
+
+pub(crate) fn persist_trace(
+    app: &AppHandle,
+    session_id: &str,
+    run_id: &str,
+    events: &[RuntimeEventEnvelope],
+) -> Result<PathBuf, String> {
+    validate_trace(events)?;
+    if events
+        .iter()
+        .any(|event| event.session_id != session_id || event.run_id != run_id)
+    {
+        return Err("runtime trace identity does not match its request".to_string());
+    }
+    let root = app
+        .state::<crate::db::Db>()
+        .data_dir()
+        .join("runtime-events")
+        .join(sha256(session_id));
+    create_private_dir(&root)?;
+    let path = root.join(format!("{}.jsonl", sha256(run_id)));
+    let mut file = open_private_new(&path)?;
+    for event in events {
+        let line = serde_json::to_string(event)
+            .map_err(|error| format!("serialize runtime event: {error}"))?;
+        file.write_all(line.as_bytes())
+            .and_then(|_| file.write_all(b"\n"))
+            .map_err(|error| format!("append runtime event: {error}"))?;
+    }
+    file.sync_all()
+        .map_err(|error| format!("sync runtime event journal: {error}"))?;
+    Ok(path)
+}
+
+fn required(value: &str, field: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        Err(format!("{field} must be a non-empty string"))
+    } else {
+        Ok(())
+    }
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), String> {
+    let Some(first) = events.first() else {
+        return Err("runtime trace must contain at least one event".to_string());
+    };
+    if first.sequence != 0 {
+        return Err("runtime trace sequence must start at zero".to_string());
+    }
+    required(&first.run_id, "run_id")?;
+    required(&first.session_id, "session_id")?;
+    required(&first.runtime_id, "runtime_id")?;
+
+    let mut event_ids = HashSet::new();
+    let mut pending_tools: HashMap<&str, &str> = HashMap::new();
+    let mut interrupt_markers = HashSet::new();
+    let mut interrupted_markers = HashSet::new();
+    let mut terminal_seen = false;
+
+    for (expected_sequence, envelope) in events.iter().enumerate() {
+        if terminal_seen {
+            return Err("events cannot follow a terminal cancellation/error".to_string());
+        }
+        if envelope.schema_version != EVENT_SCHEMA {
+            return Err(format!(
+                "unsupported runtime schema {}; expected {EVENT_SCHEMA}",
+                envelope.schema_version
+            ));
+        }
+        if envelope.run_id != first.run_id || envelope.session_id != first.session_id {
+            return Err("run_id and session_id must remain stable".to_string());
+        }
+        if envelope.runtime_id != first.runtime_id {
+            return Err("runtime_id must remain stable within one trace".to_string());
+        }
+        if envelope.sequence != expected_sequence as u64 {
+            return Err(format!(
+                "expected sequence {expected_sequence}, got {}",
+                envelope.sequence
+            ));
+        }
+        required(&envelope.event_id, "event_id")?;
+        required(&envelope.emitted_at, "emitted_at")?;
+        if envelope.event_id != format!("{}:{}", envelope.run_id, envelope.sequence) {
+            return Err(format!(
+                "event_id {} does not match its run and sequence",
+                envelope.event_id
+            ));
+        }
+        if !event_ids.insert(envelope.event_id.as_str()) {
+            return Err(format!("duplicate event_id {}", envelope.event_id));
+        }
+
+        match &envelope.event {
+            RuntimeEvent::Message { .. }
+            | RuntimeEvent::Delta { .. }
+            | RuntimeEvent::ReasoningDelta { .. } => {}
+            RuntimeEvent::ToolCall { call_id, name, .. } => {
+                required(call_id, "tool_call.call_id")?;
+                required(name, "tool_call.name")?;
+                if pending_tools.insert(call_id, name).is_some() {
+                    return Err(format!("duplicate pending tool call {call_id}"));
+                }
+            }
+            RuntimeEvent::ToolResult { call_id, name, .. } => {
+                let Some(expected_name) = pending_tools.remove(call_id.as_str()) else {
+                    return Err(format!("orphaned tool result {call_id}"));
+                };
+                if expected_name != name {
+                    return Err(format!(
+                        "tool result {call_id} changed name from {expected_name} to {name}"
+                    ));
+                }
+            }
+            RuntimeEvent::Usage {
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                source,
+                complete,
+                ..
+            } => {
+                if !matches!(source.as_str(), "provider" | "estimated" | "unavailable") {
+                    return Err(format!("unknown usage source {source}"));
+                }
+                if *complete && source == "unavailable" {
+                    return Err("complete usage cannot have unavailable source".to_string());
+                }
+                if *total_tokens < input_tokens.saturating_add(*output_tokens) {
+                    return Err("usage total cannot be less than input plus output".to_string());
+                }
+            }
+            RuntimeEvent::SupervisorVerdict {
+                verdict,
+                source,
+                marker_id,
+                reason,
+                ..
+            } => {
+                if !matches!(source.as_str(), "model" | "policy" | "human") {
+                    return Err(format!("unknown supervisor verdict source {source}"));
+                }
+                if matches!(verdict, RuntimeVerdict::Interrupt | RuntimeVerdict::Nudge)
+                    && reason
+                        .as_deref()
+                        .is_none_or(|value| value.trim().is_empty())
+                {
+                    return Err("interrupt/nudge verdict requires a reason".to_string());
+                }
+                if matches!(verdict, RuntimeVerdict::Interrupt) {
+                    let marker = marker_id
+                        .as_deref()
+                        .filter(|value| !value.trim().is_empty())
+                        .ok_or_else(|| "interrupt verdict requires marker_id".to_string())?;
+                    interrupt_markers.insert(marker);
+                }
+            }
+            RuntimeEvent::StudentInterruption {
+                marker_id, reason, ..
+            } => {
+                required(reason, "student_interruption.reason")?;
+                if !interrupt_markers.contains(marker_id.as_str()) {
+                    return Err(format!(
+                        "student interruption {marker_id} has no supervisor verdict"
+                    ));
+                }
+                interrupted_markers.insert(marker_id.as_str());
+            }
+            RuntimeEvent::TeacherContinuation {
+                marker_id,
+                reason,
+                teacher_model,
+                ..
+            } => {
+                required(reason, "teacher_continuation.reason")?;
+                required(teacher_model, "teacher_continuation.teacher_model")?;
+                if !interrupted_markers.contains(marker_id.as_str()) {
+                    return Err(format!(
+                        "teacher continuation {marker_id} has no student interruption"
+                    ));
+                }
+            }
+            RuntimeEvent::Cancellation { stage, reason } => {
+                required(stage, "cancellation.stage")?;
+                required(reason, "cancellation.reason")?;
+                terminal_seen = true;
+            }
+            RuntimeEvent::Error {
+                stage,
+                code,
+                message,
+                recoverable,
+            } => {
+                required(stage, "error.stage")?;
+                required(code, "error.code")?;
+                required(message, "error.message")?;
+                terminal_seen = !recoverable;
+            }
+            RuntimeEvent::ImageAttachment {
+                attachment_id,
+                filename,
+                media_type,
+                byte_count,
+            } => {
+                if !is_sha256(attachment_id) {
+                    return Err("image attachment id must be a lowercase SHA-256".to_string());
+                }
+                required(filename, "image_attachment.filename")?;
+                if !media_type.starts_with("image/") || *byte_count == 0 {
+                    return Err(
+                        "image attachment must have image/* media type and bytes".to_string()
+                    );
+                }
+            }
+            RuntimeEvent::CompactionBoundary {
+                source_message_count,
+                retained_message_count,
+                estimated_tokens_before,
+                estimated_tokens_after,
+                summary_sha256,
+            } => {
+                if retained_message_count > source_message_count
+                    || estimated_tokens_after > estimated_tokens_before
+                    || !is_sha256(summary_sha256)
+                {
+                    return Err("invalid compaction boundary".to_string());
+                }
+            }
+        }
+    }
+
+    if !pending_tools.is_empty() {
+        let mut calls = pending_tools.keys().copied().collect::<Vec<_>>();
+        calls.sort_unstable();
+        return Err(format!("orphaned tool calls without results: {calls:?}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn envelope(sequence: u64, event: RuntimeEvent) -> RuntimeEventEnvelope {
+        RuntimeEventEnvelope {
+            schema_version: EVENT_SCHEMA.to_string(),
+            event_id: format!("run-1:{sequence}"),
+            run_id: "run-1".to_string(),
+            session_id: "session-1".to_string(),
+            runtime_id: "pi-agent-session".to_string(),
+            sequence,
+            emitted_at: "2026-07-12T00:00:00Z".to_string(),
+            event,
+        }
+    }
+
+    #[test]
+    fn rejects_orphaned_tool_evidence() {
+        let events = vec![envelope(
+            0,
+            RuntimeEvent::ToolCall {
+                call_id: "call-1".to_string(),
+                name: "status".to_string(),
+                raw_arguments: "{}".to_string(),
+                parsed_arguments: Some(json!({})),
+                parse_error: None,
+            },
+        )];
+        assert!(validate_trace(&events)
+            .unwrap_err()
+            .contains("orphaned tool calls"));
+    }
+
+    #[test]
+    fn accepts_linked_supervisor_takeover() {
+        let events = vec![
+            envelope(
+                0,
+                RuntimeEvent::SupervisorVerdict {
+                    verdict: RuntimeVerdict::Interrupt,
+                    source: "model".to_string(),
+                    marker_id: Some("marker-1".to_string()),
+                    reason: Some("wrong tool".to_string()),
+                    probabilities: Some(json!({"interrupt": 0.9})),
+                },
+            ),
+            envelope(
+                1,
+                RuntimeEvent::StudentInterruption {
+                    marker_id: "marker-1".to_string(),
+                    reason: "wrong tool".to_string(),
+                    partial_text: "partial".to_string(),
+                    after_chars: 7,
+                },
+            ),
+            envelope(
+                2,
+                RuntimeEvent::TeacherContinuation {
+                    marker_id: "marker-1".to_string(),
+                    reason: "correct it".to_string(),
+                    teacher_model: "teacher".to_string(),
+                    from_partial_chars: 7,
+                },
+            ),
+        ];
+        validate_trace(&events).unwrap();
+    }
+}

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -223,6 +223,47 @@ pub(crate) fn persist_trace(
     Ok(path)
 }
 
+/// Load one immutable trace by public run id without exposing its hashed local
+/// path. Journals are partitioned by session hash, so lookup scans only the
+/// first-level runtime directories.
+pub(crate) fn load_persisted_trace(
+    app: &AppHandle,
+    run_id: &str,
+) -> Result<Option<Vec<RuntimeEventEnvelope>>, String> {
+    let root = app
+        .state::<crate::db::Db>()
+        .data_dir()
+        .join("runtime-events");
+    let filename = format!("{}.jsonl", sha256(run_id));
+    let directories = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("read runtime event root: {error}")),
+    };
+    for directory in directories.flatten() {
+        let path = directory.path().join(&filename);
+        if !path.is_file() {
+            continue;
+        }
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|error| format!("read persisted runtime trace: {error}"))?;
+        let events = raw
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                serde_json::from_str::<RuntimeEventEnvelope>(line)
+                    .map_err(|error| format!("parse persisted runtime trace: {error}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        validate_trace(&events)?;
+        if events.first().is_some_and(|event| event.run_id == run_id) {
+            return Ok(Some(events));
+        }
+        return Err("persisted runtime trace hash did not match run_id".to_string());
+    }
+    Ok(None)
+}
+
 fn required(value: &str, field: &str) -> Result<(), String> {
     if value.trim().is_empty() {
         Err(format!("{field} must be a non-empty string"))

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -1,0 +1,690 @@
+//! Desktop bridge to the CLI-owned Pi conversation runtime.
+//!
+//! A native retry is safe only before the sidecar emits user-visible output or
+//! starts a tool. After that boundary, failures are terminal for the turn so a
+//! tool or answer can never execute twice.
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+use std::time::{Duration, Instant};
+use tauri::ipc::Channel;
+use tauri::{AppHandle, Manager};
+
+use crate::chat::ChatEvent;
+use crate::conversation_runtime::{
+    RuntimeEvent, RuntimeEventEnvelope, EVENT_SCHEMA, RUNTIME_VERSION,
+};
+
+const RUNTIME_SETTING: &str = "conversation.runtime";
+const MAX_ERROR_BODY_BYTES: usize = 4_096;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[derive(Clone)]
+struct ActiveRunTarget {
+    run_id: String,
+    base_url: String,
+    token: String,
+}
+
+struct ActiveRun {
+    run_id: String,
+    target: Option<ActiveRunTarget>,
+    cancel_requested: bool,
+}
+
+static ACTIVE_RUNS: OnceLock<Mutex<HashMap<String, ActiveRun>>> = OnceLock::new();
+
+fn active_runs() -> &'static Mutex<HashMap<String, ActiveRun>> {
+    ACTIVE_RUNS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn locked<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+struct ActiveRunGuard {
+    session_id: String,
+    run_id: String,
+}
+
+impl ActiveRunGuard {
+    fn register(session_id: &str, run_id: &str) -> Result<Self, String> {
+        let mut runs = locked(active_runs());
+        if let Some(active) = runs.get(session_id) {
+            return Err(format!(
+                "session already has active conversation run {}",
+                active.run_id
+            ));
+        }
+        runs.insert(
+            session_id.to_string(),
+            ActiveRun {
+                run_id: run_id.to_string(),
+                target: None,
+                cancel_requested: false,
+            },
+        );
+        Ok(Self {
+            session_id: session_id.to_string(),
+            run_id: run_id.to_string(),
+        })
+    }
+
+    fn publish_target(&self, base_url: String, token: String) -> bool {
+        let mut runs = locked(active_runs());
+        let Some(active) = runs.get_mut(&self.session_id) else {
+            return false;
+        };
+        if active.run_id != self.run_id {
+            return false;
+        }
+        active.target = Some(ActiveRunTarget {
+            run_id: self.run_id.clone(),
+            base_url,
+            token,
+        });
+        active.cancel_requested
+    }
+}
+
+impl Drop for ActiveRunGuard {
+    fn drop(&mut self) {
+        let mut runs = locked(active_runs());
+        if runs
+            .get(&self.session_id)
+            .is_some_and(|active| active.run_id == self.run_id)
+        {
+            runs.remove(&self.session_id);
+        }
+    }
+}
+
+fn request_cancel(session_id: &str) -> Option<ActiveRunTarget> {
+    let mut runs = locked(active_runs());
+    let active = runs.get_mut(session_id)?;
+    active.cancel_requested = true;
+    active.target.clone()
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct CliRuntimeStatus {
+    installed: bool,
+    running: bool,
+    healthy: bool,
+    runtime_version: String,
+    event_schema: String,
+    detail: String,
+    #[serde(default)]
+    base_url: Option<String>,
+    #[serde(default)]
+    token_path: Option<String>,
+    #[serde(default)]
+    tool_token_path: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SidecarRunResult {
+    pub(crate) content: String,
+    pub(crate) usage: Option<Value>,
+    pub(crate) tool_calls: u64,
+    pub(crate) elapsed_ms: u64,
+}
+
+#[derive(Debug)]
+pub(crate) enum SidecarAttempt {
+    NotSelected,
+    Completed(SidecarRunResult),
+    NativeFallback(String),
+    FailedAfterOutput(String),
+}
+
+#[derive(Default)]
+struct SidecarAccumulator {
+    content: String,
+    tool_calls: u64,
+    emitted_output: bool,
+    terminal_error: Option<String>,
+    usage_input: u64,
+    usage_output: u64,
+    usage_total: u64,
+    usage_reasoning: u64,
+    usage_cached: u64,
+    usage_complete: bool,
+    usage_seen: bool,
+    pending_tools: HashMap<String, String>,
+}
+
+impl SidecarAccumulator {
+    fn observe(&mut self, envelope: &RuntimeEventEnvelope) -> Option<ChatEvent> {
+        match &envelope.event {
+            RuntimeEvent::Delta { text, .. } => {
+                self.content.push_str(text);
+                self.emitted_output |= !text.is_empty();
+                Some(ChatEvent::Chunk { text: text.clone() })
+            }
+            RuntimeEvent::ReasoningDelta { text, .. } => {
+                self.emitted_output |= !text.is_empty();
+                Some(ChatEvent::ReasoningChunk { text: text.clone() })
+            }
+            RuntimeEvent::ToolCall {
+                call_id,
+                name,
+                raw_arguments,
+                parsed_arguments,
+                parse_error,
+            } => {
+                self.tool_calls += 1;
+                self.emitted_output = true;
+                self.pending_tools.insert(call_id.clone(), name.clone());
+                let args = parsed_arguments.clone().unwrap_or_else(|| {
+                    serde_json::from_str(raw_arguments).unwrap_or_else(|_| {
+                        json!({
+                            "raw_arguments": raw_arguments,
+                            "parse_error": parse_error,
+                        })
+                    })
+                });
+                Some(ChatEvent::ToolCall {
+                    name: name.clone(),
+                    args,
+                })
+            }
+            RuntimeEvent::ToolResult {
+                call_id,
+                name,
+                ok,
+                result,
+            } => {
+                self.emitted_output = true;
+                self.pending_tools.remove(call_id);
+                Some(ChatEvent::ToolResult {
+                    name: name.clone(),
+                    ok: *ok,
+                    result: result.clone(),
+                })
+            }
+            RuntimeEvent::Usage {
+                input_tokens,
+                output_tokens,
+                reasoning_tokens,
+                cached_input_tokens,
+                total_tokens,
+                complete,
+                ..
+            } => {
+                self.usage_seen = true;
+                self.usage_input = self.usage_input.saturating_add(*input_tokens);
+                self.usage_output = self.usage_output.saturating_add(*output_tokens);
+                self.usage_reasoning = self.usage_reasoning.saturating_add(*reasoning_tokens);
+                self.usage_cached = self.usage_cached.saturating_add(*cached_input_tokens);
+                self.usage_total = self.usage_total.saturating_add(*total_tokens);
+                self.usage_complete |= *complete;
+                None
+            }
+            RuntimeEvent::Cancellation { reason, .. } => {
+                // A user cancellation is intentional and must never fall
+                // through to the compatibility engine, even before a token.
+                self.emitted_output = true;
+                self.terminal_error = Some(format!("conversation runtime cancelled: {reason}"));
+                None
+            }
+            RuntimeEvent::Error {
+                message,
+                recoverable,
+                ..
+            } => {
+                if !recoverable {
+                    self.terminal_error = Some(message.clone());
+                }
+                None
+            }
+            RuntimeEvent::SupervisorVerdict {
+                verdict,
+                reason,
+                marker_id,
+                ..
+            } => Some(ChatEvent::SidekickEvent {
+                mode: "supervision".to_string(),
+                stage: format!("{verdict:?}").to_lowercase(),
+                detail: format!(
+                    "run={}{} · {}",
+                    envelope.run_id,
+                    marker_id
+                        .as_deref()
+                        .map(|marker| format!(" marker={marker}"))
+                        .unwrap_or_default(),
+                    reason.as_deref().unwrap_or("supervisor verdict")
+                ),
+            }),
+            RuntimeEvent::StudentInterruption {
+                reason, marker_id, ..
+            } => Some(ChatEvent::SidekickEvent {
+                mode: "supervision".to_string(),
+                stage: "student_interrupted".to_string(),
+                detail: format!("run={} marker={} · {reason}", envelope.run_id, marker_id),
+            }),
+            RuntimeEvent::TeacherContinuation {
+                reason, marker_id, ..
+            } => Some(ChatEvent::SidekickEvent {
+                mode: "supervision".to_string(),
+                stage: "teacher_continuation".to_string(),
+                detail: format!("run={} marker={} · {reason}", envelope.run_id, marker_id),
+            }),
+            RuntimeEvent::Message { .. }
+            | RuntimeEvent::ImageAttachment { .. }
+            | RuntimeEvent::CompactionBoundary { .. } => None,
+        }
+    }
+
+    fn usage(&self) -> Option<Value> {
+        self.usage_seen.then(|| {
+            json!({
+                "prompt_tokens": self.usage_input,
+                "completion_tokens": self.usage_output,
+                "total_tokens": self.usage_total,
+                "cached_input_tokens": self.usage_cached,
+                "reasoning_tokens": self.usage_reasoning,
+                "complete": self.usage_complete,
+            })
+        })
+    }
+}
+
+fn parse_status(output: std::process::Output) -> Result<CliRuntimeStatus, String> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str::<CliRuntimeStatus>(&stdout).map_err(|error| {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = stderr.trim().lines().next().unwrap_or_default();
+        if detail.is_empty() {
+            format!("installed Understudy CLI does not expose the Pi runtime: {error}")
+        } else {
+            format!("Understudy CLI runtime status failed: {detail}")
+        }
+    })
+}
+
+fn runtime_selected(app: &AppHandle) -> bool {
+    if matches!(
+        std::env::var("UNDERSTUDY_CONVERSATION_RUNTIME").as_deref(),
+        Ok("native" | "rust" | "disabled")
+    ) {
+        return false;
+    }
+    !matches!(
+        app.state::<crate::db::Db>()
+            .setting_get(RUNTIME_SETTING)
+            .as_deref(),
+        Some("native" | "rust" | "disabled")
+    )
+}
+
+fn runtime_command(action: &str, app: &AppHandle) -> std::process::Command {
+    let mut command = crate::bin::command("understudy");
+    command.args(["runtime", action, "--json"]);
+    if let Some((base_url, token)) = crate::server::info(app) {
+        command.env("UNDERSTUDY_RUNTIME_TOOL_TOKEN", token);
+        command.env("UNDERSTUDY_RUNTIME_TOOL_BASE_URL", base_url);
+    }
+    if let Some(credentials) = crate::creds::resolve() {
+        command.env("UNDERSTUDY_RUNTIME_API_KEY", credentials.api_key);
+        command.env("UNDERSTUDY_RUNTIME_ALLOW_REMOTE", "1");
+    }
+    command
+}
+
+fn run_cli_status(action: &str, app: &AppHandle) -> Result<CliRuntimeStatus, String> {
+    runtime_command(action, app)
+        .output()
+        .map_err(|error| format!("Understudy CLI runtime {action} failed to start: {error}"))
+        .and_then(parse_status)
+}
+
+fn expected_tool_token(app: &AppHandle) -> Option<String> {
+    crate::server::info(app).map(|(_, token)| token)
+}
+
+fn tool_token_matches(status: &CliRuntimeStatus, app: &AppHandle) -> bool {
+    let Some(path) = status.tool_token_path.as_deref() else {
+        return false;
+    };
+    let Some(expected) = expected_tool_token(app) else {
+        return false;
+    };
+    std::fs::read_to_string(path)
+        .ok()
+        .is_some_and(|value| value.trim() == expected)
+}
+
+fn compatible(status: &CliRuntimeStatus, app: &AppHandle) -> bool {
+    status.installed
+        && status.running
+        && status.healthy
+        && status.event_schema == EVENT_SCHEMA
+        && status.runtime_version == RUNTIME_VERSION
+        && tool_token_matches(status, app)
+}
+
+fn ensure_ready(app: &AppHandle) -> Result<CliRuntimeStatus, String> {
+    if let Ok(status) = run_cli_status("status", app) {
+        if compatible(&status, app) {
+            return Ok(status);
+        }
+    }
+    let status = run_cli_status("start", app)?;
+    if !status.installed || !status.running || !status.healthy {
+        return Err(format!(
+            "conversation runtime is not ready: {}",
+            status.detail
+        ));
+    }
+    if status.event_schema != EVENT_SCHEMA || status.runtime_version != RUNTIME_VERSION {
+        return Err(format!(
+            "conversation runtime {} / {} is incompatible with desktop {} / {}; update the Understudy CLI",
+            status.runtime_version, status.event_schema, RUNTIME_VERSION, EVENT_SCHEMA
+        ));
+    }
+    if !tool_token_matches(&status, app) {
+        return Err("conversation runtime did not adopt the desktop tool credential".to_string());
+    }
+    Ok(status)
+}
+
+fn read_runtime_token(path: &Path) -> Result<String, String> {
+    let token = std::fs::read_to_string(path)
+        .map_err(|error| format!("read conversation runtime token: {error}"))?;
+    let token = token.trim();
+    if token.len() != 64 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("conversation runtime token is malformed".to_string());
+    }
+    Ok(token.to_string())
+}
+
+fn bounded_error_body(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(&bytes[..bytes.len().min(MAX_ERROR_BODY_BYTES)])
+        .trim()
+        .replace(['\r', '\n', '\t'], " ")
+}
+
+async fn execute_run(
+    app: &AppHandle,
+    request: Value,
+    on_event: &Channel<ChatEvent>,
+) -> Result<SidecarRunResult, (String, bool)> {
+    let started = Instant::now();
+    let run_id = request
+        .get("run_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            (
+                "conversation runtime request lost run_id".to_string(),
+                false,
+            )
+        })?
+        .to_string();
+    let session_id = request
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            (
+                "conversation runtime request lost session_id".to_string(),
+                false,
+            )
+        })?
+        .to_string();
+    let active = ActiveRunGuard::register(&session_id, &run_id).map_err(|error| (error, false))?;
+    let status = {
+        let app = app.clone();
+        tokio::task::spawn_blocking(move || ensure_ready(&app))
+            .await
+            .map_err(|error| {
+                (
+                    format!("conversation runtime start task failed: {error}"),
+                    false,
+                )
+            })?
+            .map_err(|error| (error, false))?
+    };
+    let base_url = status.base_url.ok_or_else(|| {
+        (
+            "conversation runtime did not publish a base URL".to_string(),
+            false,
+        )
+    })?;
+    let token_path = status.token_path.ok_or_else(|| {
+        (
+            "conversation runtime did not publish its token path".to_string(),
+            false,
+        )
+    })?;
+    let token = read_runtime_token(Path::new(&token_path)).map_err(|error| (error, false))?;
+    let client = reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .read_timeout(STREAM_IDLE_TIMEOUT)
+        .build()
+        .map_err(|error| (format!("build conversation runtime client: {error}"), false))?;
+    let response = client
+        .post(format!("{}/v1/runs", base_url.trim_end_matches('/')))
+        .bearer_auth(&token)
+        .json(&request)
+        .send()
+        .await
+        .map_err(|error| {
+            (
+                format!("conversation runtime request failed: {error}"),
+                false,
+            )
+        })?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.bytes().await.unwrap_or_default();
+        return Err((
+            format!(
+                "conversation runtime returned {status}: {}",
+                bounded_error_body(&body)
+            ),
+            false,
+        ));
+    }
+    if active.publish_target(base_url.clone(), token.clone()) {
+        cancel_target(ActiveRunTarget {
+            run_id: run_id.clone(),
+            base_url: base_url.clone(),
+            token: token.clone(),
+        })
+        .await
+        .map_err(|error| (error, false))?;
+    }
+
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+    let mut events = Vec::new();
+    let mut accumulator = SidecarAccumulator::default();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| {
+            (
+                format!("conversation runtime stream failed: {error}"),
+                accumulator.emitted_output,
+            )
+        })?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+        while let Some(newline) = buffer.find('\n') {
+            let line = buffer[..newline].trim().to_string();
+            buffer.drain(..=newline);
+            if line.is_empty() {
+                continue;
+            }
+            let envelope: RuntimeEventEnvelope = serde_json::from_str(&line).map_err(|error| {
+                (
+                    format!("conversation runtime emitted malformed evidence: {error}"),
+                    accumulator.emitted_output,
+                )
+            })?;
+            if let Some(event) = accumulator.observe(&envelope) {
+                let _ = on_event.send(event);
+            }
+            events.push(envelope);
+        }
+    }
+    if !buffer.trim().is_empty() {
+        let envelope: RuntimeEventEnvelope =
+            serde_json::from_str(buffer.trim()).map_err(|error| {
+                (
+                    format!("conversation runtime emitted malformed trailing evidence: {error}"),
+                    accumulator.emitted_output,
+                )
+            })?;
+        if let Some(event) = accumulator.observe(&envelope) {
+            let _ = on_event.send(event);
+        }
+        events.push(envelope);
+    }
+
+    let emitted_output = accumulator.emitted_output;
+    crate::conversation_runtime::validate_trace(&events).map_err(|error| {
+        (
+            format!("conversation runtime evidence failed validation: {error}"),
+            emitted_output,
+        )
+    })?;
+    crate::conversation_runtime::persist_trace(app, &session_id, &run_id, &events).map_err(
+        |error| {
+            (
+                format!("persist conversation runtime evidence: {error}"),
+                emitted_output,
+            )
+        },
+    )?;
+    if let Some(error) = accumulator.terminal_error {
+        return Err((error, emitted_output));
+    }
+    let usage = accumulator.usage();
+    Ok(SidecarRunResult {
+        content: accumulator.content,
+        usage,
+        tool_calls: accumulator.tool_calls,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+    })
+}
+
+async fn cancel_target(target: ActiveRunTarget) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|error| format!("build runtime cancellation client: {error}"))?;
+    let response = client
+        .delete(format!(
+            "{}/v1/runs/{}",
+            target.base_url.trim_end_matches('/'),
+            target.run_id
+        ))
+        .bearer_auth(target.token)
+        .send()
+        .await
+        .map_err(|error| format!("cancel conversation runtime: {error}"))?;
+    if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+        Ok(())
+    } else {
+        Err(format!(
+            "conversation runtime cancellation returned {}",
+            response.status()
+        ))
+    }
+}
+
+pub(crate) async fn try_run_chat(
+    app: &AppHandle,
+    request: Value,
+    on_event: &Channel<ChatEvent>,
+) -> SidecarAttempt {
+    if !runtime_selected(app) {
+        return SidecarAttempt::NotSelected;
+    }
+    match execute_run(app, request, on_event).await {
+        Ok(result) => SidecarAttempt::Completed(result),
+        Err((error, true)) => SidecarAttempt::FailedAfterOutput(error),
+        Err((error, false)) => SidecarAttempt::NativeFallback(error),
+    }
+}
+
+#[tauri::command]
+pub(crate) async fn conversation_runtime_start(app: AppHandle) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        run_cli_status("start", &app)
+            .and_then(|status| serde_json::to_value(status).map_err(|error| error.to_string()))
+    })
+    .await
+    .map_err(|error| format!("conversation runtime start task failed: {error}"))?
+}
+
+#[tauri::command]
+pub(crate) async fn conversation_runtime_repair(app: AppHandle) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        run_cli_status("repair", &app)
+            .and_then(|status| serde_json::to_value(status).map_err(|error| error.to_string()))
+    })
+    .await
+    .map_err(|error| format!("conversation runtime repair task failed: {error}"))?
+}
+
+#[tauri::command]
+pub(crate) async fn conversation_runtime_cancel(session_id: String) -> Result<Value, String> {
+    if session_id.trim().is_empty() || session_id.len() > 200 {
+        return Err("invalid conversation session id".to_string());
+    }
+    let target = request_cancel(&session_id);
+    if let Some(target) = target {
+        cancel_target(target).await?;
+        Ok(json!({ "status": "cancelling", "session_id": session_id }))
+    } else if locked(active_runs()).contains_key(&session_id) {
+        Ok(json!({ "status": "cancellation_queued", "session_id": session_id }))
+    } else {
+        Ok(json!({ "status": "idle", "session_id": session_id }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visible_output_closes_native_retry_boundary() {
+        let mut accumulator = SidecarAccumulator::default();
+        let envelope = RuntimeEventEnvelope {
+            schema_version: EVENT_SCHEMA.to_string(),
+            event_id: "run-1:0".to_string(),
+            run_id: "run-1".to_string(),
+            session_id: "session-1".to_string(),
+            runtime_id: "pi-agent-session".to_string(),
+            sequence: 0,
+            emitted_at: "2026-07-12T00:00:00Z".to_string(),
+            event: RuntimeEvent::Delta {
+                role: crate::conversation_runtime::RuntimeRole::Primary,
+                text: "visible".to_string(),
+                model: Some("local".to_string()),
+            },
+        };
+        assert!(matches!(
+            accumulator.observe(&envelope),
+            Some(ChatEvent::Chunk { .. })
+        ));
+        assert!(accumulator.emitted_output);
+    }
+
+    #[test]
+    fn cancellation_queues_during_startup_and_targets_the_exact_run() {
+        let session = "cancel-session-test";
+        let guard = ActiveRunGuard::register(session, "run-cancel-1").unwrap();
+        assert!(request_cancel(session).is_none());
+        assert!(guard.publish_target("http://127.0.0.1:1".to_string(), "token".to_string()));
+        let target = request_cancel(session).unwrap();
+        assert_eq!(target.run_id, "run-cancel-1");
+        drop(guard);
+        assert!(!locked(active_runs()).contains_key(session));
+    }
+}

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -295,6 +295,28 @@ impl SidecarAccumulator {
     }
 }
 
+fn publish_chat_event(
+    app: &AppHandle,
+    session_id: &str,
+    on_event: &Channel<ChatEvent>,
+    event: ChatEvent,
+) {
+    if let ChatEvent::SidekickEvent {
+        mode,
+        stage,
+        detail,
+    } = &event
+    {
+        if let Err(error) = app
+            .state::<crate::db::Db>()
+            .record_sidekick_event(session_id, mode, stage, detail)
+        {
+            eprintln!("understudy db: record supervision event failed: {error:#}");
+        }
+    }
+    let _ = on_event.send(event);
+}
+
 fn parse_status(output: std::process::Output) -> Result<CliRuntimeStatus, String> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     serde_json::from_str::<CliRuntimeStatus>(&stdout).map_err(|error| {
@@ -525,7 +547,7 @@ async fn execute_run(
                 )
             })?;
             if let Some(event) = accumulator.observe(&envelope) {
-                let _ = on_event.send(event);
+                publish_chat_event(app, &session_id, on_event, event);
             }
             events.push(envelope);
         }
@@ -539,7 +561,7 @@ async fn execute_run(
                 )
             })?;
         if let Some(event) = accumulator.observe(&envelope) {
-            let _ = on_event.send(event);
+            publish_chat_event(app, &session_id, on_event, event);
         }
         events.push(envelope);
     }

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -361,13 +361,16 @@ fn runtime_selected(app: &AppHandle) -> bool {
 fn runtime_command(action: &str, app: &AppHandle) -> std::process::Command {
     let mut command = crate::bin::command("understudy");
     command.args(["runtime", action, "--json"]);
+    // Every remote run still has to opt in on its authenticated request. Keep
+    // the process gate available from startup so adding a provider key later
+    // does not create a hidden restart requirement.
+    command.env("UNDERSTUDY_RUNTIME_ALLOW_REMOTE", "1");
     if let Some((base_url, token)) = crate::server::info(app) {
         command.env("UNDERSTUDY_RUNTIME_TOOL_TOKEN", token);
         command.env("UNDERSTUDY_RUNTIME_TOOL_BASE_URL", base_url);
     }
     if let Some(credentials) = crate::creds::resolve() {
         command.env("UNDERSTUDY_RUNTIME_API_KEY", credentials.api_key);
-        command.env("UNDERSTUDY_RUNTIME_ALLOW_REMOTE", "1");
     }
     command
 }

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -133,6 +133,8 @@ pub(crate) struct SidecarRunResult {
     pub(crate) usage: Option<Value>,
     pub(crate) tool_calls: u64,
     pub(crate) elapsed_ms: u64,
+    pub(crate) compacted: bool,
+    pub(crate) context_tokens_before: u64,
 }
 
 #[derive(Debug)]
@@ -156,6 +158,8 @@ struct SidecarAccumulator {
     usage_cached: u64,
     usage_complete: bool,
     usage_seen: bool,
+    compacted: bool,
+    context_tokens_before: u64,
     pending_tools: HashMap<String, String>,
 }
 
@@ -275,9 +279,16 @@ impl SidecarAccumulator {
                 stage: "teacher_continuation".to_string(),
                 detail: format!("run={} marker={} · {reason}", envelope.run_id, marker_id),
             }),
-            RuntimeEvent::Message { .. }
-            | RuntimeEvent::ImageAttachment { .. }
-            | RuntimeEvent::CompactionBoundary { .. } => None,
+            RuntimeEvent::CompactionBoundary {
+                estimated_tokens_before,
+                ..
+            } => {
+                self.compacted = true;
+                self.context_tokens_before =
+                    self.context_tokens_before.max(*estimated_tokens_before);
+                None
+            }
+            RuntimeEvent::Message { .. } | RuntimeEvent::ImageAttachment { .. } => None,
         }
     }
 
@@ -298,7 +309,7 @@ impl SidecarAccumulator {
 fn publish_chat_event(
     app: &AppHandle,
     session_id: &str,
-    on_event: &Channel<ChatEvent>,
+    on_event: Option<&Channel<ChatEvent>>,
     event: ChatEvent,
 ) {
     if let ChatEvent::SidekickEvent {
@@ -314,7 +325,9 @@ fn publish_chat_event(
             eprintln!("understudy db: record supervision event failed: {error:#}");
         }
     }
-    let _ = on_event.send(event);
+    if let Some(on_event) = on_event {
+        let _ = on_event.send(event);
+    }
 }
 
 fn parse_status(output: std::process::Output) -> Result<CliRuntimeStatus, String> {
@@ -435,7 +448,7 @@ fn bounded_error_body(bytes: &[u8]) -> String {
 async fn execute_run(
     app: &AppHandle,
     request: Value,
-    on_event: &Channel<ChatEvent>,
+    on_event: Option<&Channel<ChatEvent>>,
 ) -> Result<SidecarRunResult, (String, bool)> {
     let started = Instant::now();
     let run_id = request
@@ -590,6 +603,8 @@ async fn execute_run(
         usage,
         tool_calls: accumulator.tool_calls,
         elapsed_ms: started.elapsed().as_millis() as u64,
+        compacted: accumulator.compacted,
+        context_tokens_before: accumulator.context_tokens_before,
     })
 }
 
@@ -627,7 +642,18 @@ pub(crate) async fn try_run_chat(
     if !runtime_selected(app) {
         return SidecarAttempt::NotSelected;
     }
-    match execute_run(app, request, on_event).await {
+    match execute_run(app, request, Some(on_event)).await {
+        Ok(result) => SidecarAttempt::Completed(result),
+        Err((error, true)) => SidecarAttempt::FailedAfterOutput(error),
+        Err((error, false)) => SidecarAttempt::NativeFallback(error),
+    }
+}
+
+pub(crate) async fn try_run_chat_headless(app: &AppHandle, request: Value) -> SidecarAttempt {
+    if !runtime_selected(app) {
+        return SidecarAttempt::NotSelected;
+    }
+    match execute_run(app, request, None).await {
         Ok(result) => SidecarAttempt::Completed(result),
         Err((error, true)) => SidecarAttempt::FailedAfterOutput(error),
         Err((error, false)) => SidecarAttempt::NativeFallback(error),

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -179,15 +179,23 @@ struct SidecarAccumulator {
     compacted: bool,
     context_tokens_before: u64,
     pending_tools: HashMap<String, String>,
+    replace_next_teacher_delta: bool,
 }
 
 impl SidecarAccumulator {
     fn observe(&mut self, envelope: &RuntimeEventEnvelope) -> Option<ChatEvent> {
         match &envelope.event {
-            RuntimeEvent::Delta { text, .. } => {
+            RuntimeEvent::Delta { role, text, .. } => {
                 self.content.push_str(text);
                 self.emitted_output |= !text.is_empty();
-                Some(ChatEvent::Chunk { text: text.clone() })
+                if self.replace_next_teacher_delta
+                    && matches!(role, crate::conversation_runtime::RuntimeRole::Teacher)
+                {
+                    self.replace_next_teacher_delta = false;
+                    Some(ChatEvent::ReplaceChunk { text: text.clone() })
+                } else {
+                    Some(ChatEvent::Chunk { text: text.clone() })
+                }
             }
             RuntimeEvent::ReasoningDelta { text, .. } => {
                 self.emitted_output |= !text.is_empty();
@@ -291,12 +299,24 @@ impl SidecarAccumulator {
                 detail: format!("run={} marker={} · {reason}", envelope.run_id, marker_id),
             }),
             RuntimeEvent::TeacherContinuation {
-                reason, marker_id, ..
-            } => Some(ChatEvent::SidekickEvent {
-                mode: "supervision".to_string(),
-                stage: "teacher_continuation".to_string(),
-                detail: format!("run={} marker={} · {reason}", envelope.run_id, marker_id),
-            }),
+                reason,
+                marker_id,
+                output_mode,
+                ..
+            } => {
+                if matches!(
+                    output_mode,
+                    crate::conversation_runtime::TeacherOutputMode::Replace
+                ) {
+                    self.content.clear();
+                    self.replace_next_teacher_delta = true;
+                }
+                Some(ChatEvent::SidekickEvent {
+                    mode: "supervision".to_string(),
+                    stage: "teacher_continuation".to_string(),
+                    detail: format!("run={} marker={} · {reason}", envelope.run_id, marker_id),
+                })
+            }
             RuntimeEvent::CompactionBoundary {
                 estimated_tokens_before,
                 ..
@@ -851,28 +871,79 @@ pub(crate) async fn conversation_runtime_cancel(session_id: String) -> Result<Va
 mod tests {
     use super::*;
 
-    #[test]
-    fn visible_output_closes_native_retry_boundary() {
-        let mut accumulator = SidecarAccumulator::default();
-        let envelope = RuntimeEventEnvelope {
+    fn envelope(sequence: u64, event: RuntimeEvent) -> RuntimeEventEnvelope {
+        RuntimeEventEnvelope {
             schema_version: EVENT_SCHEMA.to_string(),
-            event_id: "run-1:0".to_string(),
+            event_id: format!("run-1:{sequence}"),
             run_id: "run-1".to_string(),
             session_id: "session-1".to_string(),
             runtime_id: "pi-agent-session".to_string(),
-            sequence: 0,
+            sequence,
             emitted_at: "2026-07-12T00:00:00Z".to_string(),
-            event: RuntimeEvent::Delta {
+            event,
+        }
+    }
+
+    #[test]
+    fn visible_output_closes_native_retry_boundary() {
+        let mut accumulator = SidecarAccumulator::default();
+        let envelope = envelope(
+            0,
+            RuntimeEvent::Delta {
                 role: crate::conversation_runtime::RuntimeRole::Primary,
                 text: "visible".to_string(),
                 model: Some("local".to_string()),
             },
-        };
+        );
         assert!(matches!(
             accumulator.observe(&envelope),
             Some(ChatEvent::Chunk { .. })
         ));
         assert!(accumulator.emitted_output);
+    }
+
+    #[test]
+    fn rejected_completed_output_is_replaced_by_teacher_delta() {
+        let mut accumulator = SidecarAccumulator::default();
+        accumulator.observe(&envelope(
+            0,
+            RuntimeEvent::Delta {
+                role: crate::conversation_runtime::RuntimeRole::Student,
+                text: "wrong".to_string(),
+                model: Some("student".to_string()),
+            },
+        ));
+        let continuation = accumulator.observe(&envelope(
+            1,
+            RuntimeEvent::TeacherContinuation {
+                marker_id: "run-1:intervention:0".to_string(),
+                reason: "wrong answer".to_string(),
+                teacher_model: "teacher".to_string(),
+                from_partial_chars: 5,
+                output_mode: crate::conversation_runtime::TeacherOutputMode::Replace,
+            },
+        ));
+        assert!(matches!(
+            continuation,
+            Some(ChatEvent::SidekickEvent { .. })
+        ));
+        assert!(accumulator.content.is_empty());
+        assert!(accumulator.replace_next_teacher_delta);
+
+        let replacement = accumulator.observe(&envelope(
+            2,
+            RuntimeEvent::Delta {
+                role: crate::conversation_runtime::RuntimeRole::Teacher,
+                text: "correct".to_string(),
+                model: Some("teacher".to_string()),
+            },
+        ));
+        assert!(matches!(
+            replacement,
+            Some(ChatEvent::ReplaceChunk { ref text }) if text == "correct"
+        ));
+        assert_eq!(accumulator.content, "correct");
+        assert!(!accumulator.replace_next_teacher_delta);
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -52,6 +52,8 @@ struct ActiveRunGuard {
     run_id: String,
 }
 
+pub(crate) struct AgentRunReservation(ActiveRunGuard);
+
 impl ActiveRunGuard {
     fn register(session_id: &str, run_id: &str) -> Result<Self, String> {
         let mut runs = locked(active_runs());
@@ -104,11 +106,27 @@ impl Drop for ActiveRunGuard {
     }
 }
 
+pub(crate) fn reserve_agent_run(
+    session_id: &str,
+    run_id: &str,
+) -> Result<AgentRunReservation, String> {
+    ActiveRunGuard::register(session_id, run_id).map(AgentRunReservation)
+}
+
 fn request_cancel(session_id: &str) -> Option<ActiveRunTarget> {
     let mut runs = locked(active_runs());
     let active = runs.get_mut(session_id)?;
     active.cancel_requested = true;
     active.target.clone()
+}
+
+fn request_cancel_run(run_id: &str) -> (bool, Option<ActiveRunTarget>) {
+    let mut runs = locked(active_runs());
+    let Some(active) = runs.values_mut().find(|active| active.run_id == run_id) else {
+        return (false, None);
+    };
+    active.cancel_requested = true;
+    (true, active.target.clone())
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -452,6 +470,8 @@ async fn execute_run(
     app: &AppHandle,
     request: Value,
     on_event: Option<&Channel<ChatEvent>>,
+    runtime_events: Option<&tokio::sync::mpsc::UnboundedSender<RuntimeEventEnvelope>>,
+    reservation: Option<AgentRunReservation>,
 ) -> Result<SidecarRunResult, (String, bool)> {
     let started = Instant::now();
     let run_id = request
@@ -474,7 +494,20 @@ async fn execute_run(
             )
         })?
         .to_string();
-    let active = ActiveRunGuard::register(&session_id, &run_id).map_err(|error| (error, false))?;
+    let active = match reservation {
+        Some(AgentRunReservation(active))
+            if active.session_id == session_id && active.run_id == run_id =>
+        {
+            active
+        }
+        Some(_) => {
+            return Err((
+                "conversation runtime reservation identity changed".to_string(),
+                false,
+            ));
+        }
+        None => ActiveRunGuard::register(&session_id, &run_id).map_err(|error| (error, false))?,
+    };
     let status = {
         let app = app.clone();
         tokio::task::spawn_blocking(move || ensure_ready(&app))
@@ -565,6 +598,9 @@ async fn execute_run(
             if let Some(event) = accumulator.observe(&envelope) {
                 publish_chat_event(app, &session_id, on_event, event);
             }
+            if let Some(runtime_events) = runtime_events {
+                let _ = runtime_events.send(envelope.clone());
+            }
             events.push(envelope);
         }
     }
@@ -578,6 +614,9 @@ async fn execute_run(
             })?;
         if let Some(event) = accumulator.observe(&envelope) {
             publish_chat_event(app, &session_id, on_event, event);
+        }
+        if let Some(runtime_events) = runtime_events {
+            let _ = runtime_events.send(envelope.clone());
         }
         events.push(envelope);
     }
@@ -645,7 +684,7 @@ pub(crate) async fn try_run_chat(
     if !runtime_selected(app) {
         return SidecarAttempt::NotSelected;
     }
-    match execute_run(app, request, Some(on_event)).await {
+    match execute_run(app, request, Some(on_event), None, None).await {
         Ok(result) => SidecarAttempt::Completed(result),
         Err((error, true)) => SidecarAttempt::FailedAfterOutput(error),
         Err((error, false)) => SidecarAttempt::NativeFallback(error),
@@ -656,11 +695,120 @@ pub(crate) async fn try_run_chat_headless(app: &AppHandle, request: Value) -> Si
     if !runtime_selected(app) {
         return SidecarAttempt::NotSelected;
     }
-    match execute_run(app, request, None).await {
+    match execute_run(app, request, None, None, None).await {
         Ok(result) => SidecarAttempt::Completed(result),
         Err((error, true)) => SidecarAttempt::FailedAfterOutput(error),
         Err((error, false)) => SidecarAttempt::NativeFallback(error),
     }
+}
+
+pub(crate) async fn ensure_agent_ready(app: AppHandle) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || ensure_ready(&app).map(|_| ()))
+        .await
+        .map_err(|error| format!("conversation runtime start task failed: {error}"))?
+}
+
+pub(crate) async fn execute_agent_run(
+    app: &AppHandle,
+    request: Value,
+    runtime_events: &tokio::sync::mpsc::UnboundedSender<RuntimeEventEnvelope>,
+    reservation: AgentRunReservation,
+) -> Result<SidecarRunResult, (String, bool)> {
+    let run_id = request
+        .get("run_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown-run")
+        .to_string();
+    let session_id = request
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown-session")
+        .to_string();
+    let (internal_tx, mut internal_rx) = tokio::sync::mpsc::unbounded_channel();
+    let app_for_run = app.clone();
+    let mut task = tokio::spawn(async move {
+        execute_run(
+            &app_for_run,
+            request,
+            None,
+            Some(&internal_tx),
+            Some(reservation),
+        )
+        .await
+    });
+    let mut observed = Vec::new();
+    let outcome = loop {
+        tokio::select! {
+            event = internal_rx.recv() => {
+                if let Some(event) = event {
+                    let _ = runtime_events.send(event.clone());
+                    observed.push(event);
+                }
+            }
+            result = &mut task => {
+                while let Ok(event) = internal_rx.try_recv() {
+                    let _ = runtime_events.send(event.clone());
+                    observed.push(event);
+                }
+                break result.map_err(|error| {
+                    (format!("conversation runtime task failed: {error}"), false)
+                })?;
+            }
+        }
+    };
+    match outcome {
+        Ok(result) => Ok(result),
+        Err((error, emitted_output)) => {
+            let terminal_seen = observed.last().is_some_and(|event| {
+                matches!(
+                    event.event,
+                    RuntimeEvent::Cancellation { .. } | RuntimeEvent::Error { .. }
+                )
+            });
+            if !terminal_seen {
+                let sequence = observed.last().map(|event| event.sequence + 1).unwrap_or(0);
+                let terminal = RuntimeEventEnvelope {
+                    schema_version: EVENT_SCHEMA.to_string(),
+                    event_id: format!("{run_id}:{sequence}"),
+                    run_id: run_id.clone(),
+                    session_id: session_id.clone(),
+                    runtime_id: observed
+                        .first()
+                        .map(|event| event.runtime_id.clone())
+                        .unwrap_or_else(|| "understudy-desktop-bridge-v1".to_string()),
+                    sequence,
+                    emitted_at: chrono::Utc::now().to_rfc3339(),
+                    event: RuntimeEvent::Error {
+                        stage: "desktop_bridge".to_string(),
+                        code: "desktop_runtime_bridge_error".to_string(),
+                        message: error.clone(),
+                        recoverable: false,
+                    },
+                };
+                let _ = runtime_events.send(terminal.clone());
+                observed.push(terminal);
+                if let Err(persist_error) =
+                    crate::conversation_runtime::persist_trace(app, &session_id, &run_id, &observed)
+                {
+                    eprintln!(
+                        "understudy desktop API: persist terminal bridge error failed: {persist_error}"
+                    );
+                }
+            }
+            Err((error, emitted_output))
+        }
+    }
+}
+
+pub(crate) async fn cancel_run_by_id(run_id: &str) -> Result<bool, String> {
+    let (found, target) = request_cancel_run(run_id);
+    if !found {
+        return Ok(false);
+    }
+    if let Some(target) = target {
+        cancel_target(target).await?;
+    }
+    Ok(true)
 }
 
 #[tauri::command]

--- a/apps/homescreen/src-tauri/src/custom_evals.rs
+++ b/apps/homescreen/src-tauri/src/custom_evals.rs
@@ -650,6 +650,10 @@ async fn run_custom_eval_inner(
             Some(&capture_run_id),
         )
         .await;
+        let runtime_backend = attempt
+            .as_ref()
+            .map(|result| result.runtime_backend.clone())
+            .unwrap_or_else(|_| "unknown".to_string());
         // Mirror the Fusion harness semantics: an executed non-ok attempt and
         // a failed request both count as scored failures (score 0) because a
         // gold answer exists for every example; the recorded status keeps the
@@ -704,6 +708,7 @@ async fn run_custom_eval_inner(
         db.record_fusion_benchmark(&FusionBenchmarkInput {
             run_id: run_id.clone(),
             capture_run_id: Some(capture_run_id),
+            runtime_backend,
             task_id: example.task_id.clone(),
             mode: CUSTOM_EVAL_MODE.to_string(),
             model: model.clone(),
@@ -1073,6 +1078,7 @@ mod tests {
             crate::db::FusionBenchmarkInput {
                 run_id: "custom-support-triage-1-99".into(),
                 capture_run_id: Some(format!("desktop-{task_id}")),
+                runtime_backend: "pi".into(),
                 task_id: task_id.into(),
                 mode: CUSTOM_EVAL_MODE.into(),
                 model: "gemma-4-e2b-it-qat-understudy".into(),

--- a/apps/homescreen/src-tauri/src/custom_evals.rs
+++ b/apps/homescreen/src-tauri/src/custom_evals.rs
@@ -229,8 +229,7 @@ type CsvRows = (Vec<(usize, ParsedExample)>, Vec<ImportRowError>);
 
 fn parse_csv_rows(content: &str) -> Result<CsvRows, String> {
     let records = parse_csv_records(content);
-    let is_blank =
-        |record: &[String]| record.iter().all(|cell| cell.trim().is_empty());
+    let is_blank = |record: &[String]| record.iter().all(|cell| cell.trim().is_empty());
     let header_idx = records
         .iter()
         .position(|record| !is_blank(record))
@@ -246,10 +245,11 @@ fn parse_csv_rows(content: &str) -> Result<CsvRows, String> {
     };
     let prompt_idx = column(&["input", "prompt"])
         .ok_or_else(|| "CSV header must include an 'input' or 'prompt' column".to_string())?;
-    let expected_idx = column(&["expected", "expected_output", "scoring_hint"]).ok_or_else(
-        || "CSV header must include an 'expected', 'expected_output', or 'scoring_hint' column"
-            .to_string(),
-    )?;
+    let expected_idx =
+        column(&["expected", "expected_output", "scoring_hint"]).ok_or_else(|| {
+            "CSV header must include an 'expected', 'expected_output', or 'scoring_hint' column"
+                .to_string()
+        })?;
     let id_idx = column(&["id", "task_id"]);
 
     let mut rows = vec![];
@@ -263,10 +263,7 @@ fn parse_csv_rows(content: &str) -> Result<CsvRows, String> {
         if record.len() < needed {
             errors.push(ImportRowError {
                 line,
-                reason: format!(
-                    "expected at least {needed} columns, found {}",
-                    record.len()
-                ),
+                reason: format!("expected at least {needed} columns, found {}", record.len()),
             });
             continue;
         }
@@ -642,6 +639,7 @@ async fn run_custom_eval_inner(
                 expected_signal: format!("{}: {}", rule.as_str(), example.expected),
             });
         }
+        let capture_run_id = crate::conversation_runtime::new_run_id()?;
         let attempt = crate::chat::agent_chat(
             &app,
             mgr.inner(),
@@ -649,6 +647,7 @@ async fn run_custom_eval_inner(
             &run_id,
             &example.prompt,
             None,
+            Some(&capture_run_id),
         )
         .await;
         // Mirror the Fusion harness semantics: an executed non-ok attempt and
@@ -668,8 +667,7 @@ async fn run_custom_eval_inner(
             Ok(result) if result.status == "ok" => {
                 match score_output(rule, &example.expected, &result.content) {
                     Ok(score) => {
-                        let note =
-                            format!("score={score}; output_chars={}", result.content.len());
+                        let note = format!("score={score}; output_chars={}", result.content.len());
                         (
                             "ok".to_string(),
                             Some(score),
@@ -705,6 +703,7 @@ async fn run_custom_eval_inner(
         };
         db.record_fusion_benchmark(&FusionBenchmarkInput {
             run_id: run_id.clone(),
+            capture_run_id: Some(capture_run_id),
             task_id: example.task_id.clone(),
             mode: CUSTOM_EVAL_MODE.to_string(),
             model: model.clone(),
@@ -818,7 +817,12 @@ mod tests {
     #[test]
     fn contains_rule_is_substring_match() {
         assert_eq!(
-            score_output(ScoringRule::Contains, "billing", "Route this to billing please").unwrap(),
+            score_output(
+                ScoringRule::Contains,
+                "billing",
+                "Route this to billing please"
+            )
+            .unwrap(),
             1.0
         );
         assert_eq!(
@@ -858,8 +862,7 @@ mod tests {
             "{\"input\": \"no expected here\"}\n",
             "{\"input\": \"numeric id\", \"scoring_hint\": \"hint\", \"task_id\": 7}\n",
         );
-        let (examples, errors) =
-            parse_examples(content, "jsonl", ScoringRule::Contains).unwrap();
+        let (examples, errors) = parse_examples(content, "jsonl", ScoringRule::Contains).unwrap();
         assert_eq!(examples.len(), 3);
         assert_eq!(examples[0].task_id, "row-1");
         assert_eq!(examples[0].prompt, "What is 2+2?");
@@ -1069,6 +1072,7 @@ mod tests {
         let row = |task_id: &str, score: Option<f64>, status: &str, elapsed: Option<u64>| {
             crate::db::FusionBenchmarkInput {
                 run_id: "custom-support-triage-1-99".into(),
+                capture_run_id: Some(format!("desktop-{task_id}")),
                 task_id: task_id.into(),
                 mode: CUSTOM_EVAL_MODE.into(),
                 model: "gemma-4-e2b-it-qat-understudy".into(),

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -23,6 +23,7 @@ pub struct FusionBenchmarkRow {
     pub run_id: String,
     /// Per-attempt id that joins this indexed row to canonical runtime JSONL.
     pub capture_run_id: Option<String>,
+    pub runtime_backend: String,
     pub task_id: String,
     pub mode: String,
     pub model: String,
@@ -51,6 +52,7 @@ pub struct FusionBenchmarkRow {
 pub struct FusionBenchmarkInput {
     pub run_id: String,
     pub capture_run_id: Option<String>,
+    pub runtime_backend: String,
     pub task_id: String,
     pub mode: String,
     pub model: String,
@@ -331,6 +333,7 @@ fn migrate(conn: &Connection) -> Result<()> {
                 id                  INTEGER PRIMARY KEY,
                 run_id              TEXT NOT NULL,
                 capture_run_id      TEXT,
+                runtime_backend     TEXT NOT NULL DEFAULT 'native-rust',
                 task_id             TEXT NOT NULL,
                 mode                TEXT NOT NULL,
                 model               TEXT NOT NULL,
@@ -499,6 +502,7 @@ fn migrate(conn: &Connection) -> Result<()> {
         "ALTER TABLE fusion_benchmarks ADD COLUMN harness_sha256 TEXT",
         "ALTER TABLE fusion_benchmarks ADD COLUMN split_sha256 TEXT",
         "ALTER TABLE fusion_benchmarks ADD COLUMN capture_run_id TEXT",
+        "ALTER TABLE fusion_benchmarks ADD COLUMN runtime_backend TEXT NOT NULL DEFAULT 'native-rust'",
         "ALTER TABLE sidekick_sessions ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE sidekick_sessions ADD COLUMN compacted_count INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE sidekick_sessions ADD COLUMN memory TEXT",
@@ -618,9 +622,10 @@ impl Db {
                 run_id, task_id, mode, model, elapsed_ms, prompt_tokens, completion_tokens,
                 sidekick_runs, sidekick_tool_calls, gateway_used, compacted, context_tokens_before,
                 local_mem_gb, score, status, notes, run_at,
-                cost_usd, cost_basis, split, harness_sha256, split_sha256, capture_run_id
+                cost_usd, cost_basis, split, harness_sha256, split_sha256, capture_run_id,
+                runtime_backend
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
-                       ?18, ?19, ?20, ?21, ?22, ?23)",
+                       ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
             rusqlite::params![
                 input.run_id,
                 input.task_id,
@@ -645,6 +650,7 @@ impl Db {
                 input.harness_sha256,
                 input.split_sha256,
                 input.capture_run_id,
+                input.runtime_backend,
             ],
         )?;
         Ok(())
@@ -853,7 +859,8 @@ impl Db {
                         ELSE 'ok'
                     END) AS status,
                     notes, run_at,
-                    cost_usd, cost_basis, split, harness_sha256, split_sha256, capture_run_id
+                    cost_usd, cost_basis, split, harness_sha256, split_sha256, capture_run_id,
+                    runtime_backend
              FROM fusion_benchmarks ORDER BY id DESC LIMIT ?1",
         )?;
         let rows = stmt.query_map([limit.clamp(1, 500) as i64], |r| {
@@ -882,6 +889,7 @@ impl Db {
                 harness_sha256: r.get(21)?,
                 split_sha256: r.get(22)?,
                 capture_run_id: r.get(23)?,
+                runtime_backend: r.get(24)?,
             })
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -1549,6 +1557,7 @@ mod tests {
         db.record_fusion_benchmark(&FusionBenchmarkInput {
             run_id: "run-1".into(),
             capture_run_id: Some("desktop-capture-1".into()),
+            runtime_backend: "pi".into(),
             task_id: "task-1".into(),
             mode: "sidekick-routing".into(),
             model: "model-x".into(),
@@ -1577,6 +1586,7 @@ mod tests {
         let row = &rows[0];
         assert_eq!(row.score, Some(0.0));
         assert_eq!(row.capture_run_id.as_deref(), Some("desktop-capture-1"));
+        assert_eq!(row.runtime_backend, "pi");
         assert_eq!(row.split.as_deref(), Some("none"));
         assert_eq!(row.cost_usd, None);
         assert_eq!(row.cost_basis.as_deref(), Some("local-zero-marginal-cost"));

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -120,6 +120,8 @@ pub struct FusionRouteDecisionInput {
 #[derive(Serialize, Clone)]
 pub struct ChatRunRow {
     pub id: u64,
+    pub run_id: Option<String>,
+    pub runtime_backend: String,
     pub session_id: String,
     pub route: String,
     pub model: String,
@@ -142,6 +144,8 @@ pub struct ChatRunRow {
 
 #[derive(Clone, Debug)]
 pub struct ChatRunInput {
+    pub run_id: String,
+    pub runtime_backend: String,
     pub session_id: String,
     pub route: String,
     pub model: String,
@@ -367,6 +371,8 @@ fn migrate(conn: &Connection) -> Result<()> {
             );
             CREATE TABLE IF NOT EXISTS chat_runs (
                 id                INTEGER PRIMARY KEY,
+                run_id            TEXT,
+                runtime_backend   TEXT NOT NULL DEFAULT 'native-rust',
                 session_id        TEXT NOT NULL,
                 route             TEXT NOT NULL,
                 model             TEXT NOT NULL,
@@ -463,6 +469,8 @@ fn migrate(conn: &Connection) -> Result<()> {
         "ALTER TABLE chat_runs ADD COLUMN local_mem_gb REAL",
         "ALTER TABLE chat_runs ADD COLUMN gateway_available INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE chat_runs ADD COLUMN gateway_avoided INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE chat_runs ADD COLUMN run_id TEXT",
+        "ALTER TABLE chat_runs ADD COLUMN runtime_backend TEXT NOT NULL DEFAULT 'native-rust'",
         "ALTER TABLE fusion_benchmarks ADD COLUMN compacted INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE fusion_benchmarks ADD COLUMN context_tokens_before INTEGER",
         "ALTER TABLE fusion_benchmarks ADD COLUMN local_mem_gb REAL",
@@ -694,11 +702,13 @@ impl Db {
         let conn = self.conn()?;
         conn.execute(
             "INSERT INTO chat_runs (
-                session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens, tool_calls,
+                run_id, runtime_backend, session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens, tool_calls,
                 sidekick_spawned, gateway_used, compacted, compaction_reason, context_tokens_before,
                 local_mem_gb, gateway_available, gateway_avoided, status, error, run_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
             rusqlite::params![
+                input.run_id,
+                input.runtime_backend,
                 input.session_id,
                 input.route,
                 input.model,
@@ -726,6 +736,8 @@ impl Db {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens,
+                    run_id,
+                    runtime_backend,
                     tool_calls, sidekick_spawned, gateway_used, compacted, compaction_reason,
                     context_tokens_before, local_mem_gb, gateway_available, gateway_avoided,
                     status, error, run_at
@@ -740,18 +752,20 @@ impl Db {
                 elapsed_ms: r.get::<_, Option<i64>>(4)?.map(|v| v as u64),
                 prompt_tokens: r.get::<_, Option<i64>>(5)?.map(|v| v as u64),
                 completion_tokens: r.get::<_, Option<i64>>(6)?.map(|v| v as u64),
-                tool_calls: r.get::<_, i64>(7)? as u64,
-                sidekick_spawned: r.get::<_, i64>(8)? != 0,
-                gateway_used: r.get::<_, i64>(9)? != 0,
-                compacted: r.get::<_, i64>(10)? != 0,
-                compaction_reason: r.get(11)?,
-                context_tokens_before: r.get::<_, Option<i64>>(12)?.map(|v| v as u64),
-                local_mem_gb: r.get(13)?,
-                gateway_available: r.get::<_, i64>(14)? != 0,
-                gateway_avoided: r.get::<_, i64>(15)? != 0,
-                status: r.get(16)?,
-                error: r.get(17)?,
-                run_at: r.get(18)?,
+                run_id: r.get(7)?,
+                runtime_backend: r.get(8)?,
+                tool_calls: r.get::<_, i64>(9)? as u64,
+                sidekick_spawned: r.get::<_, i64>(10)? != 0,
+                gateway_used: r.get::<_, i64>(11)? != 0,
+                compacted: r.get::<_, i64>(12)? != 0,
+                compaction_reason: r.get(13)?,
+                context_tokens_before: r.get::<_, Option<i64>>(14)?.map(|v| v as u64),
+                local_mem_gb: r.get(15)?,
+                gateway_available: r.get::<_, i64>(16)? != 0,
+                gateway_avoided: r.get::<_, i64>(17)? != 0,
+                status: r.get(18)?,
+                error: r.get(19)?,
+                run_at: r.get(20)?,
             })
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -766,6 +780,8 @@ impl Db {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens,
+                    run_id,
+                    runtime_backend,
                     tool_calls, sidekick_spawned, gateway_used, compacted, compaction_reason,
                     context_tokens_before, local_mem_gb, gateway_available, gateway_avoided,
                     status, error, run_at
@@ -784,18 +800,20 @@ impl Db {
                     elapsed_ms: r.get::<_, Option<i64>>(4)?.map(|v| v as u64),
                     prompt_tokens: r.get::<_, Option<i64>>(5)?.map(|v| v as u64),
                     completion_tokens: r.get::<_, Option<i64>>(6)?.map(|v| v as u64),
-                    tool_calls: r.get::<_, i64>(7)? as u64,
-                    sidekick_spawned: r.get::<_, i64>(8)? != 0,
-                    gateway_used: r.get::<_, i64>(9)? != 0,
-                    compacted: r.get::<_, i64>(10)? != 0,
-                    compaction_reason: r.get(11)?,
-                    context_tokens_before: r.get::<_, Option<i64>>(12)?.map(|v| v as u64),
-                    local_mem_gb: r.get(13)?,
-                    gateway_available: r.get::<_, i64>(14)? != 0,
-                    gateway_avoided: r.get::<_, i64>(15)? != 0,
-                    status: r.get(16)?,
-                    error: r.get(17)?,
-                    run_at: r.get(18)?,
+                    run_id: r.get(7)?,
+                    runtime_backend: r.get(8)?,
+                    tool_calls: r.get::<_, i64>(9)? as u64,
+                    sidekick_spawned: r.get::<_, i64>(10)? != 0,
+                    gateway_used: r.get::<_, i64>(11)? != 0,
+                    compacted: r.get::<_, i64>(12)? != 0,
+                    compaction_reason: r.get(13)?,
+                    context_tokens_before: r.get::<_, Option<i64>>(14)?.map(|v| v as u64),
+                    local_mem_gb: r.get(15)?,
+                    gateway_available: r.get::<_, i64>(16)? != 0,
+                    gateway_avoided: r.get::<_, i64>(17)? != 0,
+                    status: r.get(18)?,
+                    error: r.get(19)?,
+                    run_at: r.get(20)?,
                 })
             },
         )?;
@@ -1404,6 +1422,40 @@ mod tests {
         // file: duplicate columns must be tolerated, data preserved.
         let db = Db::open(dir.clone()).expect("re-open existing db");
         assert_eq!(db.setting_get("k").as_deref(), Some("v"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn chat_run_round_trips_canonical_identity_and_backend() {
+        let (dir, db) = temp_db("chat-runtime-identity");
+        db.record_chat_run(&ChatRunInput {
+            run_id: "desktop-run-1".into(),
+            runtime_backend: "pi".into(),
+            session_id: "session-1".into(),
+            route: "local".into(),
+            model: "understudy-small".into(),
+            elapsed_ms: Some(25),
+            prompt_tokens: Some(10),
+            completion_tokens: Some(4),
+            tool_calls: 1,
+            sidekick_spawned: false,
+            gateway_used: false,
+            compacted: false,
+            compaction_reason: None,
+            context_tokens_before: Some(10),
+            local_mem_gb: Some(2.0),
+            gateway_available: false,
+            gateway_avoided: false,
+            status: "ok".into(),
+            error: None,
+        })
+        .unwrap();
+        let rows = db.list_chat_runs(1).unwrap();
+        assert_eq!(rows[0].run_id.as_deref(), Some("desktop-run-1"));
+        assert_eq!(rows[0].runtime_backend, "pi");
+        let session_rows = db.list_chat_runs_for_session("session-1", 1).unwrap();
+        assert_eq!(session_rows[0].run_id.as_deref(), Some("desktop-run-1"));
+        assert_eq!(session_rows[0].runtime_backend, "pi");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -216,6 +216,32 @@ pub struct SidekickEventRow {
     pub created_at: String,
 }
 
+#[derive(Serialize, Clone, Debug)]
+pub struct SupervisorFeedbackRow {
+    pub id: u64,
+    pub session_id: String,
+    pub run_id: Option<String>,
+    pub marker_id: Option<String>,
+    pub intervention_at: Option<u64>,
+    pub stage: String,
+    pub helpful: bool,
+    pub correct_action: Option<String>,
+    pub justification: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct SupervisorFeedbackInput {
+    pub session_id: String,
+    pub run_id: Option<String>,
+    pub marker_id: Option<String>,
+    pub intervention_at: Option<u64>,
+    pub stage: String,
+    pub helpful: bool,
+    pub correct_action: Option<String>,
+    pub justification: Option<String>,
+}
+
 #[derive(Serialize, Clone)]
 pub struct SidekickSessionSummaryRow {
     pub session_key: String,
@@ -449,6 +475,18 @@ fn migrate(conn: &Connection) -> Result<()> {
                 detail     TEXT NOT NULL,
                 created_at TEXT NOT NULL
             );
+            CREATE TABLE IF NOT EXISTS supervisor_feedback (
+                id              INTEGER PRIMARY KEY,
+                session_id      TEXT NOT NULL,
+                run_id          TEXT,
+                marker_id       TEXT,
+                intervention_at INTEGER,
+                stage           TEXT NOT NULL,
+                helpful         INTEGER NOT NULL,
+                correct_action  TEXT,
+                justification   TEXT,
+                created_at      TEXT NOT NULL
+            );
             CREATE TABLE IF NOT EXISTS sidekick_sessions (
                 session_key TEXT PRIMARY KEY,
                 session_id  TEXT NOT NULL,
@@ -509,10 +547,18 @@ fn migrate(conn: &Connection) -> Result<()> {
         "ALTER TABLE fusion_route_decisions ADD COLUMN policy_class TEXT NOT NULL DEFAULT 'unknown'",
         "ALTER TABLE fusion_route_decisions ADD COLUMN signals TEXT",
         "ALTER TABLE fusion_route_decisions ADD COLUMN upgrade_sidekick INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE supervisor_feedback ADD COLUMN marker_id TEXT",
+        "ALTER TABLE supervisor_feedback ADD COLUMN intervention_at INTEGER",
+        "ALTER TABLE supervisor_feedback ADD COLUMN correct_action TEXT",
     ];
     for sql in ALTERS {
         apply_alter(conn, sql)?;
     }
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS supervisor_feedback_marker_id
+         ON supervisor_feedback(marker_id)",
+        [],
+    )?;
     Ok(())
 }
 
@@ -1141,6 +1187,72 @@ impl Db {
         Ok(())
     }
 
+    /// Persist an explicit human judgment about one supervisor decision.
+    /// Marker identity makes retries idempotent and keeps labels joined to the
+    /// exact interruption that the user saw.
+    pub fn record_supervisor_feedback(&self, input: &SupervisorFeedbackInput) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO supervisor_feedback (
+                session_id, run_id, marker_id, intervention_at, stage, helpful,
+                correct_action, justification, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(marker_id) DO UPDATE SET
+                session_id=excluded.session_id,
+                run_id=excluded.run_id,
+                intervention_at=excluded.intervention_at,
+                stage=excluded.stage,
+                helpful=excluded.helpful,
+                correct_action=CASE
+                    WHEN excluded.correct_action IS NOT NULL THEN excluded.correct_action
+                    WHEN excluded.helpful=supervisor_feedback.helpful THEN supervisor_feedback.correct_action
+                    ELSE NULL
+                END,
+                justification=COALESCE(excluded.justification, supervisor_feedback.justification),
+                created_at=excluded.created_at",
+            rusqlite::params![
+                input.session_id,
+                input.run_id,
+                input.marker_id,
+                input.intervention_at.map(|value| value as i64),
+                input.stage,
+                input.helpful as i64,
+                input.correct_action,
+                input.justification,
+                now_iso(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_supervisor_feedback_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<SupervisorFeedbackRow>> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, session_id, run_id, marker_id, intervention_at, stage,
+                    helpful, correct_action, justification, created_at
+             FROM supervisor_feedback WHERE session_id=?1 ORDER BY id",
+        )?;
+        let rows = stmt.query_map([session_id], |row| {
+            Ok(SupervisorFeedbackRow {
+                id: row.get::<_, i64>(0)? as u64,
+                session_id: row.get(1)?,
+                run_id: row.get(2)?,
+                marker_id: row.get(3)?,
+                intervention_at: row.get::<_, Option<i64>>(4)?.map(|value| value as u64),
+                stage: row.get(5)?,
+                helpful: row.get::<_, i64>(6)? != 0,
+                correct_action: row.get(7)?,
+                justification: row.get(8)?,
+                created_at: row.get(9)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
     pub fn sidekick_feedback_summary(&self, limit: u32) -> Result<SidekickFeedbackSummary> {
         let conn = self.conn()?;
         let (useful, misses): (i64, i64) = conn.query_row(
@@ -1643,6 +1755,58 @@ mod tests {
         // Handing claims back makes them consumable again (failed-turn path).
         db.unconsume_sidekick_handoffs(&all).unwrap();
         assert_eq!(db.consume_sidekick_handoffs("s", 5).unwrap().len(), 5);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn supervisor_feedback_is_idempotent_per_marker() {
+        let (dir, db) = temp_db("supervisor-feedback");
+        db.record_supervisor_feedback(&SupervisorFeedbackInput {
+            session_id: "session-1".into(),
+            run_id: Some("run-1".into()),
+            marker_id: Some("run-1:intervention:0".into()),
+            intervention_at: Some(42),
+            stage: "take_over".into(),
+            helpful: true,
+            correct_action: Some("interrupt".into()),
+            justification: None,
+        })
+        .unwrap();
+        db.record_supervisor_feedback(&SupervisorFeedbackInput {
+            session_id: "session-1".into(),
+            run_id: Some("run-1".into()),
+            marker_id: Some("run-1:intervention:0".into()),
+            intervention_at: Some(42),
+            stage: "take_over".into(),
+            helpful: false,
+            correct_action: Some("continue".into()),
+            justification: Some("changed after review".into()),
+        })
+        .unwrap();
+        // A repeated one-tap label must not erase the richer correction.
+        db.record_supervisor_feedback(&SupervisorFeedbackInput {
+            session_id: "session-1".into(),
+            run_id: Some("run-1".into()),
+            marker_id: Some("run-1:intervention:0".into()),
+            intervention_at: Some(42),
+            stage: "take_over".into(),
+            helpful: false,
+            correct_action: None,
+            justification: None,
+        })
+        .unwrap();
+        let rows = db
+            .list_supervisor_feedback_for_session("session-1")
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(!rows[0].helpful);
+        assert_eq!(rows[0].marker_id.as_deref(), Some("run-1:intervention:0"));
+        assert_eq!(rows[0].intervention_at, Some(42));
+        assert_eq!(rows[0].correct_action.as_deref(), Some("continue"));
+        assert_eq!(
+            rows[0].justification.as_deref(),
+            Some("changed after review")
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -166,6 +166,14 @@ pub struct ChatRunInput {
 }
 
 #[derive(Serialize, Clone)]
+pub struct ChatSessionRow {
+    pub session_id: String,
+    pub schema: String,
+    pub messages: String,
+    pub updated_at: String,
+}
+
+#[derive(Serialize, Clone)]
 pub struct SidekickRunRow {
     pub id: u64,
     pub session_id: String,
@@ -368,6 +376,12 @@ fn migrate(conn: &Connection) -> Result<()> {
                 content     TEXT NOT NULL,
                 route       TEXT,
                 created_at  TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS chat_sessions (
+                session_id TEXT PRIMARY KEY,
+                schema     TEXT NOT NULL,
+                messages   TEXT NOT NULL,
+                updated_at TEXT NOT NULL
             );
             CREATE TABLE IF NOT EXISTS chat_runs (
                 id                INTEGER PRIMARY KEY,
@@ -1000,6 +1014,44 @@ impl Db {
         Ok(())
     }
 
+    pub fn save_active_chat_session(
+        &self,
+        session_id: &str,
+        schema: &str,
+        messages: &str,
+    ) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO chat_sessions(session_id, schema, messages, updated_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(session_id) DO UPDATE SET
+                schema=excluded.schema,
+                messages=excluded.messages,
+                updated_at=excluded.updated_at",
+            rusqlite::params![session_id, schema, messages, now_iso()],
+        )?;
+        Ok(())
+    }
+
+    pub fn latest_chat_session(&self, schema: &str) -> Result<Option<ChatSessionRow>> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT session_id, schema, messages, updated_at
+             FROM chat_sessions WHERE schema=?1
+             ORDER BY updated_at DESC, rowid DESC LIMIT 1",
+        )?;
+        let mut rows = stmt.query([schema])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        Ok(Some(ChatSessionRow {
+            session_id: row.get(0)?,
+            schema: row.get(1)?,
+            messages: row.get(2)?,
+            updated_at: row.get(3)?,
+        }))
+    }
+
     // Mirrors the sidekick_runs column list; not restructured to avoid churn.
     #[allow(clippy::too_many_arguments)]
     pub fn record_sidekick_run(
@@ -1460,6 +1512,31 @@ mod tests {
     }
 
     #[test]
+    fn active_chat_session_preserves_history_and_selects_latest_schema() {
+        let (dir, db) = temp_db("active-chat-session");
+        db.save_active_chat_session("session-1", "desktop-chat-v1", "[]")
+            .unwrap();
+        db.save_active_chat_session(
+            "session-2",
+            "desktop-chat-v1",
+            r#"[{"role":"user","content":"resume me"}]"#,
+        )
+        .unwrap();
+        db.save_active_chat_session("legacy", "legacy-chat-v0", "[]")
+            .unwrap();
+        let row = db.latest_chat_session("desktop-chat-v1").unwrap().unwrap();
+        assert_eq!(row.session_id, "session-2");
+        assert!(row.messages.contains("resume me"));
+        let count: u64 = db
+            .conn()
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM chat_sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 3);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn fusion_benchmark_rows_round_trip_eval_result_columns() {
         let (dir, db) = temp_db("fusion-eval-cols");
         db.record_fusion_benchmark(&FusionBenchmarkInput {
@@ -1579,7 +1656,10 @@ mod tests {
         assert_eq!(evals[0].eval_id, "support-triage-1");
         assert_eq!(evals[0].scoring_rule, "contains");
         assert_eq!(evals[0].example_count, 2);
-        assert_eq!(evals[0].harness_sha256.as_deref(), Some("b".repeat(64).as_str()));
+        assert_eq!(
+            evals[0].harness_sha256.as_deref(),
+            Some("b".repeat(64).as_str())
+        );
 
         let fetched = db.get_custom_eval("support-triage-1").unwrap().unwrap();
         assert_eq!(fetched.name, "Support triage");
@@ -1608,7 +1688,12 @@ mod tests {
                 }],
             })
             .is_err());
-        assert_eq!(db.list_custom_eval_examples("support-triage-1").unwrap().len(), 2);
+        assert_eq!(
+            db.list_custom_eval_examples("support-triage-1")
+                .unwrap()
+                .len(),
+            2
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -127,6 +127,8 @@ pub struct ChatRunRow {
     pub id: u64,
     pub run_id: Option<String>,
     pub runtime_backend: String,
+    pub app_version: String,
+    pub runtime_version: String,
     pub session_id: String,
     pub route: String,
     pub model: String,
@@ -420,6 +422,8 @@ fn migrate(conn: &Connection) -> Result<()> {
                 id                INTEGER PRIMARY KEY,
                 run_id            TEXT,
                 runtime_backend   TEXT NOT NULL DEFAULT 'native-rust',
+                app_version       TEXT NOT NULL DEFAULT 'legacy',
+                runtime_version   TEXT NOT NULL DEFAULT 'legacy',
                 session_id        TEXT NOT NULL,
                 route             TEXT NOT NULL,
                 model             TEXT NOT NULL,
@@ -530,6 +534,8 @@ fn migrate(conn: &Connection) -> Result<()> {
         "ALTER TABLE chat_runs ADD COLUMN gateway_avoided INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE chat_runs ADD COLUMN run_id TEXT",
         "ALTER TABLE chat_runs ADD COLUMN runtime_backend TEXT NOT NULL DEFAULT 'native-rust'",
+        "ALTER TABLE chat_runs ADD COLUMN app_version TEXT NOT NULL DEFAULT 'legacy'",
+        "ALTER TABLE chat_runs ADD COLUMN runtime_version TEXT NOT NULL DEFAULT 'legacy'",
         "ALTER TABLE fusion_benchmarks ADD COLUMN compacted INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE fusion_benchmarks ADD COLUMN context_tokens_before INTEGER",
         "ALTER TABLE fusion_benchmarks ADD COLUMN local_mem_gb REAL",
@@ -774,13 +780,15 @@ impl Db {
         let conn = self.conn()?;
         conn.execute(
             "INSERT INTO chat_runs (
-                run_id, runtime_backend, session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens, tool_calls,
+                run_id, runtime_backend, app_version, runtime_version, session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens, tool_calls,
                 sidekick_spawned, gateway_used, compacted, compaction_reason, context_tokens_before,
                 local_mem_gb, gateway_available, gateway_avoided, status, error, run_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
             rusqlite::params![
                 input.run_id,
                 input.runtime_backend,
+                env!("CARGO_PKG_VERSION"),
+                crate::conversation_runtime::RUNTIME_VERSION,
                 input.session_id,
                 input.route,
                 input.model,
@@ -810,6 +818,8 @@ impl Db {
             "SELECT id, session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens,
                     run_id,
                     runtime_backend,
+                    app_version,
+                    runtime_version,
                     tool_calls, sidekick_spawned, gateway_used, compacted, compaction_reason,
                     context_tokens_before, local_mem_gb, gateway_available, gateway_avoided,
                     status, error, run_at
@@ -826,18 +836,20 @@ impl Db {
                 completion_tokens: r.get::<_, Option<i64>>(6)?.map(|v| v as u64),
                 run_id: r.get(7)?,
                 runtime_backend: r.get(8)?,
-                tool_calls: r.get::<_, i64>(9)? as u64,
-                sidekick_spawned: r.get::<_, i64>(10)? != 0,
-                gateway_used: r.get::<_, i64>(11)? != 0,
-                compacted: r.get::<_, i64>(12)? != 0,
-                compaction_reason: r.get(13)?,
-                context_tokens_before: r.get::<_, Option<i64>>(14)?.map(|v| v as u64),
-                local_mem_gb: r.get(15)?,
-                gateway_available: r.get::<_, i64>(16)? != 0,
-                gateway_avoided: r.get::<_, i64>(17)? != 0,
-                status: r.get(18)?,
-                error: r.get(19)?,
-                run_at: r.get(20)?,
+                app_version: r.get(9)?,
+                runtime_version: r.get(10)?,
+                tool_calls: r.get::<_, i64>(11)? as u64,
+                sidekick_spawned: r.get::<_, i64>(12)? != 0,
+                gateway_used: r.get::<_, i64>(13)? != 0,
+                compacted: r.get::<_, i64>(14)? != 0,
+                compaction_reason: r.get(15)?,
+                context_tokens_before: r.get::<_, Option<i64>>(16)?.map(|v| v as u64),
+                local_mem_gb: r.get(17)?,
+                gateway_available: r.get::<_, i64>(18)? != 0,
+                gateway_avoided: r.get::<_, i64>(19)? != 0,
+                status: r.get(20)?,
+                error: r.get(21)?,
+                run_at: r.get(22)?,
             })
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -854,6 +866,8 @@ impl Db {
             "SELECT id, session_id, route, model, elapsed_ms, prompt_tokens, completion_tokens,
                     run_id,
                     runtime_backend,
+                    app_version,
+                    runtime_version,
                     tool_calls, sidekick_spawned, gateway_used, compacted, compaction_reason,
                     context_tokens_before, local_mem_gb, gateway_available, gateway_avoided,
                     status, error, run_at
@@ -874,18 +888,20 @@ impl Db {
                     completion_tokens: r.get::<_, Option<i64>>(6)?.map(|v| v as u64),
                     run_id: r.get(7)?,
                     runtime_backend: r.get(8)?,
-                    tool_calls: r.get::<_, i64>(9)? as u64,
-                    sidekick_spawned: r.get::<_, i64>(10)? != 0,
-                    gateway_used: r.get::<_, i64>(11)? != 0,
-                    compacted: r.get::<_, i64>(12)? != 0,
-                    compaction_reason: r.get(13)?,
-                    context_tokens_before: r.get::<_, Option<i64>>(14)?.map(|v| v as u64),
-                    local_mem_gb: r.get(15)?,
-                    gateway_available: r.get::<_, i64>(16)? != 0,
-                    gateway_avoided: r.get::<_, i64>(17)? != 0,
-                    status: r.get(18)?,
-                    error: r.get(19)?,
-                    run_at: r.get(20)?,
+                    app_version: r.get(9)?,
+                    runtime_version: r.get(10)?,
+                    tool_calls: r.get::<_, i64>(11)? as u64,
+                    sidekick_spawned: r.get::<_, i64>(12)? != 0,
+                    gateway_used: r.get::<_, i64>(13)? != 0,
+                    compacted: r.get::<_, i64>(14)? != 0,
+                    compaction_reason: r.get(15)?,
+                    context_tokens_before: r.get::<_, Option<i64>>(16)?.map(|v| v as u64),
+                    local_mem_gb: r.get(17)?,
+                    gateway_available: r.get::<_, i64>(18)? != 0,
+                    gateway_avoided: r.get::<_, i64>(19)? != 0,
+                    status: r.get(20)?,
+                    error: r.get(21)?,
+                    run_at: r.get(22)?,
                 })
             },
         )?;
@@ -1632,6 +1648,11 @@ mod tests {
         let rows = db.list_chat_runs(1).unwrap();
         assert_eq!(rows[0].run_id.as_deref(), Some("desktop-run-1"));
         assert_eq!(rows[0].runtime_backend, "pi");
+        assert_eq!(rows[0].app_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            rows[0].runtime_version,
+            crate::conversation_runtime::RUNTIME_VERSION
+        );
         let session_rows = db.list_chat_runs_for_session("session-1", 1).unwrap();
         assert_eq!(session_rows[0].run_id.as_deref(), Some("desktop-run-1"));
         assert_eq!(session_rows[0].runtime_backend, "pi");

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -21,6 +21,8 @@ pub struct BenchRow {
 pub struct FusionBenchmarkRow {
     pub id: u64,
     pub run_id: String,
+    /// Per-attempt id that joins this indexed row to canonical runtime JSONL.
+    pub capture_run_id: Option<String>,
     pub task_id: String,
     pub mode: String,
     pub model: String,
@@ -48,6 +50,7 @@ pub struct FusionBenchmarkRow {
 #[derive(Clone, Debug)]
 pub struct FusionBenchmarkInput {
     pub run_id: String,
+    pub capture_run_id: Option<String>,
     pub task_id: String,
     pub mode: String,
     pub model: String,
@@ -327,6 +330,7 @@ fn migrate(conn: &Connection) -> Result<()> {
             CREATE TABLE IF NOT EXISTS fusion_benchmarks (
                 id                  INTEGER PRIMARY KEY,
                 run_id              TEXT NOT NULL,
+                capture_run_id      TEXT,
                 task_id             TEXT NOT NULL,
                 mode                TEXT NOT NULL,
                 model               TEXT NOT NULL,
@@ -494,6 +498,7 @@ fn migrate(conn: &Connection) -> Result<()> {
         "ALTER TABLE fusion_benchmarks ADD COLUMN split TEXT",
         "ALTER TABLE fusion_benchmarks ADD COLUMN harness_sha256 TEXT",
         "ALTER TABLE fusion_benchmarks ADD COLUMN split_sha256 TEXT",
+        "ALTER TABLE fusion_benchmarks ADD COLUMN capture_run_id TEXT",
         "ALTER TABLE sidekick_sessions ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE sidekick_sessions ADD COLUMN compacted_count INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE sidekick_sessions ADD COLUMN memory TEXT",
@@ -613,9 +618,9 @@ impl Db {
                 run_id, task_id, mode, model, elapsed_ms, prompt_tokens, completion_tokens,
                 sidekick_runs, sidekick_tool_calls, gateway_used, compacted, context_tokens_before,
                 local_mem_gb, score, status, notes, run_at,
-                cost_usd, cost_basis, split, harness_sha256, split_sha256
+                cost_usd, cost_basis, split, harness_sha256, split_sha256, capture_run_id
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
-                       ?18, ?19, ?20, ?21, ?22)",
+                       ?18, ?19, ?20, ?21, ?22, ?23)",
             rusqlite::params![
                 input.run_id,
                 input.task_id,
@@ -639,6 +644,7 @@ impl Db {
                 input.split,
                 input.harness_sha256,
                 input.split_sha256,
+                input.capture_run_id,
             ],
         )?;
         Ok(())
@@ -847,7 +853,7 @@ impl Db {
                         ELSE 'ok'
                     END) AS status,
                     notes, run_at,
-                    cost_usd, cost_basis, split, harness_sha256, split_sha256
+                    cost_usd, cost_basis, split, harness_sha256, split_sha256, capture_run_id
              FROM fusion_benchmarks ORDER BY id DESC LIMIT ?1",
         )?;
         let rows = stmt.query_map([limit.clamp(1, 500) as i64], |r| {
@@ -875,6 +881,7 @@ impl Db {
                 split: r.get(20)?,
                 harness_sha256: r.get(21)?,
                 split_sha256: r.get(22)?,
+                capture_run_id: r.get(23)?,
             })
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -1541,6 +1548,7 @@ mod tests {
         let (dir, db) = temp_db("fusion-eval-cols");
         db.record_fusion_benchmark(&FusionBenchmarkInput {
             run_id: "run-1".into(),
+            capture_run_id: Some("desktop-capture-1".into()),
             task_id: "task-1".into(),
             mode: "sidekick-routing".into(),
             model: "model-x".into(),
@@ -1568,6 +1576,7 @@ mod tests {
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
         assert_eq!(row.score, Some(0.0));
+        assert_eq!(row.capture_run_id.as_deref(), Some("desktop-capture-1"));
         assert_eq!(row.split.as_deref(), Some("none"));
         assert_eq!(row.cost_usd, None);
         assert_eq!(row.cost_basis.as_deref(), Some("local-zero-marginal-cost"));

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -192,6 +192,8 @@ pub fn run() {
             commands::sidekick_runs,
             commands::sidekick_metrics,
             commands::set_sidekick_run_feedback,
+            commands::record_supervisor_feedback,
+            commands::supervisor_feedback_for_session,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -179,6 +179,8 @@ pub fn run() {
             commands::export_automationbench_handoff,
             commands::chat_runs,
             commands::chat_route_metrics,
+            commands::chat_session_latest,
+            commands::chat_session_save,
             commands::run_fusion_benchmark,
             commands::run_fusion_benchmark_matrix,
             commands::run_fusion_benchmark_matrix_live,

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ mod bin;
 mod bootstrap;
 mod chat;
 mod commands;
+mod conversation_runtime;
+mod conversation_sidecar;
 mod creds;
 mod custom_evals;
 mod db;
@@ -196,6 +198,9 @@ pub fn run() {
             commands::get_setting,
             commands::set_setting,
             commands::server_info,
+            conversation_sidecar::conversation_runtime_start,
+            conversation_sidecar::conversation_runtime_repair,
+            conversation_sidecar::conversation_runtime_cancel,
             rlm::rlm_demo_catalog,
             rlm::rlm_plan,
             rlm::run_rlm_live,

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -259,7 +259,11 @@ pub fn snapshots() -> Vec<SnapshotInfo> {
 
 pub fn mlx_runtime_status() -> MlxRuntimeStatus {
     let command = crate::bin::mlx_server();
-    match crate::bin::command("mlx_vlm.server").arg("--help").output() {
+    match std::process::Command::new(&command)
+        .arg("--help")
+        .env("PATH", crate::bin::runtime_path())
+        .output()
+    {
         Ok(out) if out.status.success() => MlxRuntimeStatus {
             available: true,
             command,

--- a/apps/homescreen/src-tauri/src/rlm.rs
+++ b/apps/homescreen/src-tauri/src/rlm.rs
@@ -294,10 +294,10 @@ fn clamp_tokens(requested: Option<u32>, default: u32) -> u32 {
 
 pub(crate) fn plan_rlm_run(request: &RlmPlanRequest) -> Result<RlmPlan, String> {
     let task = demo_task(&request.task_id)?;
-    let quest_count = request
-        .quest_count
-        .unwrap_or(task.default_quests)
-        .clamp(task.min_quests, task.max_quests.min(task.units.len() as u32));
+    let quest_count = request.quest_count.unwrap_or(task.default_quests).clamp(
+        task.min_quests,
+        task.max_quests.min(task.units.len() as u32),
+    );
     let concurrency = request
         .concurrency
         .unwrap_or(RLM_DEFAULT_CONCURRENCY)
@@ -784,6 +784,7 @@ async fn bounded_agent_chat(
 ) -> QuestOutcome {
     let started = std::time::Instant::now();
     let residency = app.state::<Residency>();
+    let capture_run_id = crate::conversation_runtime::new_run_id().ok();
     let call = crate::chat::agent_chat(
         app,
         residency.inner(),
@@ -791,6 +792,7 @@ async fn bounded_agent_chat(
         session_id,
         prompt,
         Some(max_tokens),
+        capture_run_id.as_deref(),
     );
     match tokio::time::timeout(Duration::from_secs(timeout_secs), call).await {
         Err(_) => QuestOutcome {

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -946,7 +946,6 @@ fn tools() -> Vec<Value> {
             obj_schema(
                 json!({
                     "run_id": { "type": "string" },
-                    "capture_run_id": { "type": "string", "description": "Per-attempt id joining this row to canonical runtime evidence." },
                     "candidates": { "type": "array", "items": { "type": "string" } },
                     "domains": { "type": "array", "items": { "type": "string" } },
                     "num_examples": { "type": "integer", "minimum": 1 },
@@ -961,6 +960,8 @@ fn tools() -> Vec<Value> {
             obj_schema(
                 json!({
                     "run_id": { "type": "string" },
+                    "capture_run_id": { "type": "string", "description": "Per-attempt id joining this row to canonical runtime evidence." },
+                    "runtime_backend": { "type": "string", "description": "Runtime that executed the attempt, such as pi, native-rust, or external." },
                     "task_id": { "type": "string" },
                     "mode": { "type": "string" },
                     "model": { "type": "string" },
@@ -1426,6 +1427,14 @@ mod tests {
         assert_eq!(
             chat["inputSchema"]["properties"]["capture_run_id"]["maxLength"],
             200
+        );
+        let record = tools
+            .iter()
+            .find(|tool| tool["name"] == "record_fusion_benchmark")
+            .expect("record benchmark tool exists");
+        assert_eq!(
+            record["inputSchema"]["properties"]["runtime_backend"]["type"],
+            "string"
         );
         assert_eq!(required_of("fusion_route_recommendation"), ["prompt"]);
         assert_eq!(required_of("search_traces"), ["q"]);

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -98,6 +98,7 @@ pub fn router(ctx: Ctx) -> Router {
         // Stable versioned aliases for the CLI and third-party desktop agents.
         .route("/v1/capabilities", get(agent_capabilities))
         .route("/v1/status", get(status))
+        .route("/v1/metrics/chat-routes", get(chat_route_metrics))
         .route("/v1/models", get(models))
         .route("/v1/models/catalog", get(snapshots))
         .route("/v1/residency", get(residency))
@@ -272,9 +273,11 @@ fn agent_capabilities_value() -> Value {
             "model_inventory": true,
             "model_downloads": true,
             "model_residency": true,
+            "migration_observation": true,
         },
         "endpoints": {
             "status": "/v1/status",
+            "migration_status": "/v1/metrics/chat-routes",
             "models": "/v1/models",
             "model_catalog": "/v1/models/catalog",
             "residency": "/v1/residency",
@@ -1673,7 +1676,12 @@ mod tests {
         assert_eq!(capabilities["features"]["local_supervision"], true);
         assert_eq!(capabilities["features"]["persisted_run_events"], true);
         assert_eq!(capabilities["features"]["supervisor_feedback"], true);
+        assert_eq!(capabilities["features"]["migration_observation"], true);
         assert_eq!(capabilities["endpoints"]["status"], "/v1/status");
+        assert_eq!(
+            capabilities["endpoints"]["migration_status"],
+            "/v1/metrics/chat-routes"
+        );
         assert_eq!(
             capabilities["endpoints"]["start_turn"],
             "/v1/conversations/{session_id}/turns"

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -82,6 +82,10 @@ pub fn router(ctx: Ctx) -> Router {
         .route("/api/fusion/run-active", get(fusion_run_active))
         .route("/api/fusion/run-cancel", post(fusion_run_cancel))
         .route("/api/chat/completion", post(chat_completion))
+        .route(
+            "/api/conversation-runtime/tool",
+            post(conversation_runtime_tool),
+        )
         .route("/api/sidekick/metrics", get(sidekick_metrics))
         .route("/api/sidekick/sessions", get(sidekick_session_summaries))
         .route("/api/profile/:id", get(profile))
@@ -238,6 +242,63 @@ where
     F: FnOnce() -> Result<T, String> + Send + 'static,
 {
     blocking_status(f, StatusCode::BAD_REQUEST).await
+}
+
+#[derive(serde::Deserialize)]
+struct ConversationRuntimeToolQuery {
+    slot_id: Option<u32>,
+}
+
+#[derive(serde::Deserialize)]
+struct ConversationRuntimeToolRequest {
+    run_id: String,
+    session_id: String,
+    tool_call_id: String,
+    name: String,
+    arguments: Value,
+}
+
+/// Authenticated executor used by the CLI-owned runtime. Keeping this a thin
+/// adapter guarantees Pi and the one-release Rust fallback expose the exact
+/// same desktop tools and residency semantics.
+async fn conversation_runtime_tool(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Query(query): Query<ConversationRuntimeToolQuery>,
+    Json(request): Json<ConversationRuntimeToolRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    auth(&ctx, &h)
+        .map_err(|(status, error)| (status, Json(json!({ "ok": false, "error": error }))))?;
+    if request.run_id.trim().is_empty()
+        || request.session_id.trim().is_empty()
+        || request.tool_call_id.trim().is_empty()
+        || request.name.trim().is_empty()
+        || request.run_id.len() > 200
+        || request.session_id.len() > 200
+        || request.tool_call_id.len() > 500
+        || request.name.len() > 128
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "ok": false, "error": "invalid conversation runtime tool request" })),
+        ));
+    }
+    let result = crate::chat::tool_result(
+        &ctx.app,
+        ctx.app.state::<crate::residency::Residency>().inner(),
+        query.slot_id,
+        &request.session_id,
+        &request.name,
+        &request.arguments,
+    )
+    .await
+    .map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "ok": false, "error": error })),
+        )
+    })?;
+    Ok(Json(json!({ "ok": true, "result": result })))
 }
 
 /// `blocking`, with the caller's error status (trace lookups report 502).

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -485,6 +485,7 @@ struct ChatBody {
     prompt: String,
     session_id: Option<String>,
     max_tokens: Option<u32>,
+    capture_run_id: Option<String>,
 }
 
 async fn chat_completion(
@@ -504,6 +505,7 @@ async fn chat_completion(
         &session_id,
         &b.prompt,
         b.max_tokens,
+        b.capture_run_id.as_deref(),
     )
     .await
     .map(|r| Json(json!(r)))
@@ -944,6 +946,7 @@ fn tools() -> Vec<Value> {
             obj_schema(
                 json!({
                     "run_id": { "type": "string" },
+                    "capture_run_id": { "type": "string", "description": "Per-attempt id joining this row to canonical runtime evidence." },
                     "candidates": { "type": "array", "items": { "type": "string" } },
                     "domains": { "type": "array", "items": { "type": "string" } },
                     "num_examples": { "type": "integer", "minimum": 1 },
@@ -996,12 +999,13 @@ fn tools() -> Vec<Value> {
         // ----- chat -----
         (
             "chat_completion",
-            "Non-streaming chat completion against a warm residency slot (local tool loop included). Warm a slot first.",
+            "Non-streaming canonical-runtime chat completion against a warm residency slot. Returns capture_run_id for immutable evidence correlation; warm a slot first.",
             obj_schema(
                 json!({
                     "slot_id": { "type": "integer", "minimum": 1, "description": "A warm slot from residency." },
                     "prompt": { "type": "string" },
                     "session_id": { "type": "string" },
+                    "capture_run_id": { "type": "string", "minLength": 1, "maxLength": 200, "description": "Optional caller-owned per-attempt evidence id; generated when omitted." },
                     "max_tokens": { "type": "integer", "minimum": 1, "maximum": 8192, "description": "Completion cap; default 2048." }
                 }),
                 &["slot_id", "prompt"],
@@ -1143,6 +1147,7 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
                 .get("max_tokens")
                 .and_then(|v| v.as_u64())
                 .map(|x| x as u32);
+            let capture_run_id = args.get("capture_run_id").and_then(|v| v.as_str());
             let residency = app.state::<crate::residency::Residency>();
             json!(
                 crate::chat::agent_chat(
@@ -1151,7 +1156,8 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
                     slot_id,
                     &session_id,
                     &prompt,
-                    max_tokens
+                    max_tokens,
+                    capture_run_id
                 )
                 .await?
             )
@@ -1413,6 +1419,14 @@ mod tests {
         assert_eq!(required_of("start_model_download"), ["model_id"]);
         assert_eq!(required_of("cancel_model_download"), ["download_id"]);
         assert_eq!(required_of("chat_completion"), ["slot_id", "prompt"]);
+        let chat = tools
+            .iter()
+            .find(|tool| tool["name"] == "chat_completion")
+            .expect("chat completion tool exists");
+        assert_eq!(
+            chat["inputSchema"]["properties"]["capture_run_id"]["maxLength"],
+            200
+        );
         assert_eq!(required_of("fusion_route_recommendation"), ["prompt"]);
         assert_eq!(required_of("search_traces"), ["q"]);
         assert_eq!(required_of("open_trace"), ["id"]);

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -11,8 +11,9 @@
 // run on the Tauri async runtime.
 
 use axum::{
+    body::{Body, Bytes},
     extract::{Path, Query, Request, State},
-    http::{HeaderMap, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -24,6 +25,7 @@ use tauri::{AppHandle, Emitter, Manager};
 const DEFAULT_PORT: u16 = 17790;
 const TOKEN_KEY: &str = "server_token";
 const PORT_KEY: &str = "server_port";
+const AGENT_CHAT_BODY_LIMIT: usize = 44 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct Ctx {
@@ -93,6 +95,28 @@ pub fn router(ctx: Ctx) -> Router {
         .route("/api/traces/search", get(traces_search))
         .route("/api/traces/:id", get(traces_open))
         .route("/api/ui/focus", post(ui_focus))
+        // Stable versioned aliases for the CLI and third-party desktop agents.
+        .route("/v1/capabilities", get(agent_capabilities))
+        .route("/v1/status", get(status))
+        .route("/v1/models", get(models))
+        .route("/v1/models/catalog", get(snapshots))
+        .route("/v1/residency", get(residency))
+        .route("/v1/residency/slots", post(residency_add_slot))
+        .route("/v1/residency/assign", post(residency_assign))
+        .route("/v1/residency/warm", post(residency_warm))
+        .route("/v1/residency/cool", post(residency_cool))
+        .route("/v1/residency/remove", post(residency_remove))
+        .route("/v1/downloads", get(downloads_list).post(download_start))
+        .route("/v1/downloads/:id", get(download_status))
+        .route("/v1/downloads/:id/cancel", post(download_cancel))
+        .route(
+            "/v1/conversations/:session_id/turns",
+            post(agent_conversation_turn)
+                .layer(axum::extract::DefaultBodyLimit::max(AGENT_CHAT_BODY_LIMIT)),
+        )
+        .route("/v1/runs/:run_id/cancel", post(agent_run_cancel))
+        .route("/v1/runs/:run_id/events", get(agent_run_events))
+        .route("/v1/feedback/supervisor", post(agent_supervisor_feedback))
         // agent fronts
         .route("/mcp", post(mcp))
         .route("/.well-known/agent.json", get(a2a_card))
@@ -172,6 +196,7 @@ async fn serve(ctx: Ctx, port: u16) {
     };
     // The app is the canonical local daemon: advertise it in the agent card
     // once the server is actually reachable (never the token itself).
+    crate::agent_card::record_api_capability(port, &ctx.token);
     crate::agent_card::record_server_started(port, !ctx.token.is_empty());
     let _ = axum::serve(listener, router(ctx)).await;
 }
@@ -200,7 +225,251 @@ fn token_matches(provided: &str, expected: &str) -> bool {
         == 0
 }
 
+fn validate_agent_id(value: &str, label: &str) -> Result<(), (StatusCode, String)> {
+    if value.is_empty()
+        || value.len() > 200
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "{label} must be 1-200 ASCII letters, digits, dots, colons, underscores, or hyphens"
+            ),
+        ));
+    }
+    Ok(())
+}
+
 // ---------------- REST handlers ----------------
+
+async fn agent_capabilities(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    Ok(Json(agent_capabilities_value()))
+}
+
+fn agent_capabilities_value() -> Value {
+    json!({
+        "schema_version": "understudy.desktop_api.v2",
+        "api_version": "2.1.0",
+        "event_schema": crate::conversation_runtime::EVENT_SCHEMA,
+        "runtime": {
+            "id": "understudy-conversation-runtime",
+            "required_version": crate::conversation_runtime::RUNTIME_VERSION,
+        },
+        "features": {
+            "streaming_ndjson": true,
+            "inline_images": true,
+            "exact_run_cancellation": true,
+            "persisted_run_events": true,
+            "supervisor_feedback": true,
+            "local_supervision": true,
+            "fully_offline_local_models": true,
+            "model_inventory": true,
+            "model_downloads": true,
+            "model_residency": true,
+        },
+        "endpoints": {
+            "status": "/v1/status",
+            "models": "/v1/models",
+            "model_catalog": "/v1/models/catalog",
+            "residency": "/v1/residency",
+            "residency_add_slot": "/v1/residency/slots",
+            "residency_assign": "/v1/residency/assign",
+            "residency_warm": "/v1/residency/warm",
+            "residency_cool": "/v1/residency/cool",
+            "residency_remove": "/v1/residency/remove",
+            "downloads": "/v1/downloads",
+            "download_status": "/v1/downloads/{download_id}",
+            "download_cancel": "/v1/downloads/{download_id}/cancel",
+            "start_turn": "/v1/conversations/{session_id}/turns",
+            "cancel_run": "/v1/runs/{run_id}/cancel",
+            "run_events": "/v1/runs/{run_id}/events",
+            "supervisor_feedback": "/v1/feedback/supervisor",
+        }
+    })
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentConversationTurnBody {
+    slot_id: u32,
+    supervisor_slot_id: Option<u32>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    attachments: Vec<crate::chat::AgentChatAttachmentUpload>,
+    run_id: Option<String>,
+    max_tokens: Option<u32>,
+}
+
+async fn agent_conversation_turn(
+    State(ctx): State<Ctx>,
+    Path(session_id): Path<String>,
+    h: HeaderMap,
+    Json(body): Json<AgentConversationTurnBody>,
+) -> Result<Response, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    validate_agent_id(&session_id, "session_id")?;
+    if body.text.trim().is_empty() && body.attachments.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "text or at least one image attachment is required".to_string(),
+        ));
+    }
+    let run_id = match body.run_id {
+        Some(run_id) => run_id,
+        None => crate::conversation_runtime::new_run_id()
+            .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?,
+    };
+    validate_agent_id(&run_id, "run_id")?;
+    crate::conversation_sidecar::ensure_agent_ready(ctx.app.clone())
+        .await
+        .map_err(|error| (StatusCode::SERVICE_UNAVAILABLE, error))?;
+    let residency = ctx.app.state::<crate::residency::Residency>();
+    let request = crate::chat::agent_sidecar_request(
+        &ctx.app,
+        &residency,
+        crate::chat::AgentSidecarRequest {
+            slot_id: body.slot_id,
+            supervisor_slot_id: body.supervisor_slot_id,
+            session_id: &session_id,
+            run_id: &run_id,
+            prompt: body.text.trim(),
+            attachments: &body.attachments,
+            max_tokens: body.max_tokens,
+        },
+    )
+    .map_err(|error| (StatusCode::BAD_REQUEST, error))?;
+    let reservation = crate::conversation_sidecar::reserve_agent_run(&session_id, &run_id)
+        .map_err(|error| (StatusCode::CONFLICT, error))?;
+
+    let (events_tx, events_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::conversation_runtime::RuntimeEventEnvelope>();
+    let app = ctx.app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err((error, _)) =
+            crate::conversation_sidecar::execute_agent_run(&app, request, &events_tx, reservation)
+                .await
+        {
+            eprintln!("understudy desktop API conversation run failed: {error}");
+        }
+    });
+
+    let stream = futures_util::stream::unfold(events_rx, |mut receiver| async move {
+        let event = receiver.recv().await?;
+        let mut line = serde_json::to_vec(&event).unwrap_or_default();
+        line.push(b'\n');
+        Some((
+            Ok::<Bytes, std::convert::Infallible>(Bytes::from(line)),
+            receiver,
+        ))
+    });
+    let mut response = Response::new(Body::from_stream(stream));
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson; charset=utf-8"),
+    );
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response.headers_mut().insert(
+        "x-understudy-run-id",
+        HeaderValue::from_str(&run_id).map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                "run_id is not a valid header value".into(),
+            )
+        })?,
+    );
+    response.headers_mut().insert(
+        "x-understudy-session-id",
+        HeaderValue::from_str(&session_id).map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                "session_id is not a valid header value".into(),
+            )
+        })?,
+    );
+    Ok(response)
+}
+
+async fn agent_run_cancel(
+    State(ctx): State<Ctx>,
+    Path(run_id): Path<String>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    validate_agent_id(&run_id, "run_id")?;
+    let cancelled = crate::conversation_sidecar::cancel_run_by_id(&run_id)
+        .await
+        .map_err(|error| (StatusCode::BAD_GATEWAY, error))?;
+    if !cancelled {
+        return Err((StatusCode::NOT_FOUND, "active run not found".to_string()));
+    }
+    Ok(Json(json!({
+        "ok": true,
+        "status": "cancelling",
+        "run_id": run_id,
+    })))
+}
+
+async fn agent_run_events(
+    State(ctx): State<Ctx>,
+    Path(run_id): Path<String>,
+    h: HeaderMap,
+) -> Result<Response, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    validate_agent_id(&run_id, "run_id")?;
+    let app = ctx.app.clone();
+    let events = tokio::task::spawn_blocking(move || {
+        crate::conversation_runtime::load_persisted_trace(&app, &run_id)
+    })
+    .await
+    .map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("read run task failed: {error}"),
+        )
+    })?
+    .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error))?
+    .ok_or_else(|| (StatusCode::NOT_FOUND, "persisted run not found".to_string()))?;
+    let mut body = String::new();
+    for event in events {
+        body.push_str(&serde_json::to_string(&event).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("serialize persisted run: {error}"),
+            )
+        })?);
+        body.push('\n');
+    }
+    let mut response = Response::new(Body::from(body));
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson; charset=utf-8"),
+    );
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, no-store"),
+    );
+    Ok(response)
+}
+
+async fn agent_supervisor_feedback(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(feedback): Json<crate::commands::SupervisorFeedbackRequest>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    crate::commands::record_supervisor_feedback(ctx.app.clone(), feedback)
+        .map_err(|error| (StatusCode::BAD_REQUEST, error))?;
+    Ok(Json(json!({ "ok": true })))
+}
 
 async fn status(State(ctx): State<Ctx>, h: HeaderMap) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
@@ -1382,6 +1651,55 @@ mod tests {
         assert!(!token_matches(&token[..32], &token));
         assert!(!token_matches(&gen_token(), &token));
         assert!(!token_matches("", &token));
+    }
+
+    #[test]
+    fn agent_api_ids_are_bounded_before_reaching_runtime_state() {
+        assert!(validate_agent_id("session-1", "session_id").is_ok());
+        assert!(validate_agent_id("", "session_id").is_err());
+        assert!(validate_agent_id(&"x".repeat(201), "run_id").is_err());
+        assert!(validate_agent_id("bad/slash", "run_id").is_err());
+    }
+
+    #[test]
+    fn agent_capabilities_advertise_the_versioned_control_plane() {
+        let capabilities = agent_capabilities_value();
+        assert_eq!(capabilities["schema_version"], "understudy.desktop_api.v2");
+        assert_eq!(capabilities["api_version"], "2.1.0");
+        assert_eq!(
+            capabilities["event_schema"],
+            crate::conversation_runtime::EVENT_SCHEMA
+        );
+        assert_eq!(capabilities["features"]["local_supervision"], true);
+        assert_eq!(capabilities["features"]["persisted_run_events"], true);
+        assert_eq!(capabilities["features"]["supervisor_feedback"], true);
+        assert_eq!(capabilities["endpoints"]["status"], "/v1/status");
+        assert_eq!(
+            capabilities["endpoints"]["start_turn"],
+            "/v1/conversations/{session_id}/turns"
+        );
+    }
+
+    #[test]
+    fn agent_turn_body_accepts_camel_case_images_and_exact_run_id() {
+        let body: AgentConversationTurnBody = serde_json::from_value(json!({
+            "slotId": 3,
+            "supervisorSlotId": 9,
+            "text": "review this shelf",
+            "runId": "agent-run-3",
+            "maxTokens": 512,
+            "attachments": [{
+                "filename": "shelf.png",
+                "mediaType": "image/png",
+                "dataUrl": "data:image/png;base64,iVBORw0KGgo="
+            }]
+        }))
+        .unwrap();
+        assert_eq!(body.slot_id, 3);
+        assert_eq!(body.supervisor_slot_id, Some(9));
+        assert_eq!(body.run_id.as_deref(), Some("agent-run-3"));
+        assert_eq!(body.attachments.len(), 1);
+        assert_eq!(body.max_tokens, Some(512));
     }
 
     #[test]

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -1,0 +1,92 @@
+# Desktop runtime migration removal map
+
+Status: release gate, snapshot after `1c6261c` on 2026-07-12.
+
+The migration is successful only when the canonical conversation runtime owns
+conversation state and the native app becomes a thin authenticated adapter. The
+one-release Rust compatibility engine is temporary. New chat-harness behavior is
+frozen except for P0 reliability and release bugs.
+
+## Acceptance evidence
+
+Run the local readiness probe only after stopping the desktop app and its warm
+model processes:
+
+```sh
+npm run runtime:desktop-readiness -- --output .understudy/capture-evidence/desktop-runtime-readiness.json
+```
+
+The output is private, contains no token values, and is not packaged. It fails
+closed if app, runtime, or model RSS is unavailable. The 2026-07-12
+process-cold/filesystem-warm run on a 128 GB Apple Silicon development machine
+passed all gates:
+
+| Gate | Result | Ceiling |
+| --- | ---: | ---: |
+| Desktop HTTP ready | 209 ms | 2,500 ms |
+| Canonical runtime ready | 702 ms | 3,000 ms |
+| Both restored models ready | 2,790 ms | 45,000 ms |
+| Desktop + runtime RSS | 226.3 MB | 750 MB |
+| Restored model RSS | 16.68 GB | 32 GB |
+
+This is not a reboot-cold claim: macOS may retain model weights in its filesystem
+cache. Release qualification should repeat it on one clean install and one
+ordinary warm restart.
+
+## Deletion gate
+
+`chat_route_metrics` counts only rows with a canonical `run_id`; legacy rows
+cannot poison the denominator. Delete the compatibility engine only after one
+released version records a rolling window of at least 100 canonical runs with:
+
+- `compatibility_fallback_rows == 0`;
+- `pi_runtime_share == 1.0`;
+- no post-output runtime retry (already structurally prohibited);
+- green image, offline, tool, cancellation, supervision, restart, and compaction
+  conformance scenarios;
+- the readiness probe passing on release artifacts.
+
+The current development window is intentionally not eligible because mismatch
+and repair probes exercised the fallback.
+
+## Removable ownership
+
+The ranges below are a review map, not permission to delete them early. Line
+numbers are approximate anchors and must be replaced by the actual deletion
+diff. The conservative gross target is about 4,200 lines; the final claim is
+`git diff --numstat` from the post-release deletion PR.
+
+| Owner being replaced | Current anchors | Gross removable LOC | Replacement |
+| --- | --- | ---: | --- |
+| Legacy sidekick session, compaction, model loop, repo/skill tools | `chat.rs:129-464`, `712-1583` | ~1,200 | Pi supervision plus authenticated desktop tool executor |
+| Parallel-sidekick policy, handoff waiting, and duplicate state machine | `chat.rs:2394-2688`, sidekick portions of `route_policy.rs` | ~550 | Canonical supervisor verdict/interruption/continuation events |
+| Native streaming/tool-round fallback | `chat.rs:2935-3139`, `3503-3760` | ~470 | CLI-managed Pi runtime |
+| Native benchmark/headless model loops | `chat.rs:3142-3502` | ~360 | Headless canonical-runtime adapter |
+| Native prompt compaction/thinking parser | `chat.rs:1721-1777`, `1816-1917` | ~160 | Pi compaction and reasoning events |
+| Direct Anthropic stream translation | `anthropic.rs:130-429` | ~300 | Canonical provider adapter; key/catalog storage remains native |
+| Legacy sidekick SQLite rows, metrics, commands, and tests | sidekick-only portions of `db.rs:177-227`, `413-459`, `1055-1419`; `commands.rs` sidekick endpoints/accounting | ~650 | Canonical event ledger and correction-pair exporter |
+| Legacy Sidekick settings and visualization | `StatusPane.tsx` sidekick lane; `ChatPane.tsx` delegate tool card | ~350 | One supervisor/intervention surface |
+| Registrations, fixtures, and now-dead tests | `lib.rs`, route/benchmark tests | ~160 | Runtime conformance tests |
+| **Conservative gross target** |  | **~4,200** |  |
+
+## Required migration order
+
+1. Merge the canonical desktop bridge and release the compatibility build.
+2. Rebase cache-health onto it and align the desktop runtime compatibility
+   constant with the released CLI.
+3. Move `agent_chat`, custom eval, RLM, HTTP completion, and Fusion benchmark
+   callers to a headless canonical-runtime adapter. These are the remaining
+   callers keeping the native non-streaming loop alive.
+4. Route direct Anthropic through the canonical provider contract; retain only
+   local key presence and catalog management in Rust.
+5. Replace legacy parallel-sidekick metrics/UI with canonical intervention and
+   human-label evidence.
+6. Observe the deletion gate for one release, then remove the ranges above in a
+   dedicated PR. Do not retain two permanent conversation engines.
+
+## Explicitly retained native responsibilities
+
+The deletion target does not include Tauri windowing, local model download and
+residency, macOS lifecycle, SQLite indexing, user consent, authenticated
+loopback tool execution, or canonical JSONL validation. Those remain app-owned
+unless a later contract deliberately moves them.

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -50,6 +50,13 @@ through Pi and durably recorded why no background handoff ran
 (`benchmark_sidekick_score_low`). The benchmark readiness check now delegates
 sidekick selection to residency instead of rejecting valid warm models by name.
 
+Direct Anthropic chat now selects Pi's native `anthropic-messages` provider and
+uses the same authenticated tool/evidence path. The frozen local provider
+fixture proved two Messages API rounds, one matched tool call/result, exact
+provider usage, and no credential in the provider payload or canonical events.
+Runtime contract version `0.3.2` makes older sidecars fail closed before output,
+so the native Anthropic translator remains only as the one-release fallback.
+
 ## Deletion gate
 
 `chat_route_metrics` counts only rows with a canonical `run_id`; legacy rows
@@ -95,8 +102,8 @@ diff. The conservative gross target is about 4,200 lines; the final claim is
    completion, MCP completion, and specialized Fusion local/gateway benchmarks
    now use the canonical runtime with one consolidated pre-output, one-release
    fallback.
-4. Route direct Anthropic through the canonical provider contract; retain only
-   local key presence and catalog management in Rust.
+4. Direct Anthropic now uses Pi's canonical provider contract; retain only key
+   presence, catalog management, and the one-release fallback in Rust.
 5. Replace legacy parallel-sidekick metrics/UI with canonical intervention and
    human-label evidence.
 6. Observe the deletion gate for one release, then remove the ranges above in a

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -38,8 +38,17 @@ HTTP response returned the caller's `capture_run_id`, `runtime_backend: "pi"`,
 one tool call, and exact provider usage. The joined private JSONL contained one
 `status` call and one matching successful result under the same run/session
 identity, with mode `0600`. This proves HTTP, MCP, custom-eval, and RLM calls can
-use the same immutable evidence spine as GUI chat; Fusion's specialized
-sidekick/gateway benchmark paths remain native below.
+use the same immutable evidence spine as GUI chat.
+
+Fusion now uses that same canonical path for local and gateway benchmark
+attempts while preserving the existing routing and sidekick policy around it.
+The local `runtime-status-check` proof (`fusion-pi-proof-1783882706`) persisted
+`runtime_backend: "pi"`, one matched `residency` tool round, and exact summed
+provider usage (2,267 input and 185 output tokens) under capture id
+`desktop-839bd2b9189f996e99e12074e9bda426`. A parallel-mode proof also executed
+through Pi and durably recorded why no background handoff ran
+(`benchmark_sidekick_score_low`). The benchmark readiness check now delegates
+sidekick selection to residency instead of rejecting valid warm models by name.
 
 ## Deletion gate
 
@@ -69,7 +78,7 @@ diff. The conservative gross target is about 4,200 lines; the final claim is
 | Legacy sidekick session, compaction, model loop, repo/skill tools | `chat.rs:129-464`, `712-1583` | ~1,200 | Pi supervision plus authenticated desktop tool executor |
 | Parallel-sidekick policy, handoff waiting, and duplicate state machine | `chat.rs:2394-2688`, sidekick portions of `route_policy.rs` | ~550 | Canonical supervisor verdict/interruption/continuation events |
 | Native streaming/tool-round fallback | `chat.rs:2935-3139`, `3503-3760` | ~470 | CLI-managed Pi runtime |
-| Native benchmark/headless model loops | `chat.rs:3142-3502` | ~360 | Headless canonical-runtime adapter |
+| Native benchmark/headless model loops | consolidated compatibility fallback near `chat.rs:3150-3435` | ~360 | Headless canonical-runtime adapter |
 | Native prompt compaction/thinking parser | `chat.rs:1721-1777`, `1816-1917` | ~160 | Pi compaction and reasoning events |
 | Direct Anthropic stream translation | `anthropic.rs:130-429` | ~300 | Canonical provider adapter; key/catalog storage remains native |
 | Legacy sidekick SQLite rows, metrics, commands, and tests | sidekick-only portions of `db.rs:177-227`, `413-459`, `1055-1419`; `commands.rs` sidekick endpoints/accounting | ~650 | Canonical event ledger and correction-pair exporter |
@@ -83,9 +92,9 @@ diff. The conservative gross target is about 4,200 lines; the final claim is
 2. Rebase cache-health onto it and align the desktop runtime compatibility
    constant with the released CLI.
 3. Finish the headless migration. `agent_chat`, custom eval, RLM, HTTP
-   completion, and MCP completion now use the canonical runtime with a
-   pre-output one-release fallback. The specialized Fusion sidekick/gateway
-   benchmark callers still keep the native non-streaming loop alive.
+   completion, MCP completion, and specialized Fusion local/gateway benchmarks
+   now use the canonical runtime with one consolidated pre-output, one-release
+   fallback.
 4. Route direct Anthropic through the canonical provider contract; retain only
    local key presence and catalog management in Rust.
 5. Replace legacy parallel-sidekick metrics/UI with canonical intervention and

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -1,6 +1,6 @@
 # Desktop runtime migration removal map
 
-Status: release gate, snapshot after `1c6261c` on 2026-07-12.
+Status: release gate, snapshot after `79b9d25` on 2026-07-12.
 
 The migration is successful only when the canonical conversation runtime owns
 conversation state and the native app becomes a thin authenticated adapter. The
@@ -32,6 +32,14 @@ passed all gates:
 This is not a reboot-cold claim: macOS may retain model weights in its filesystem
 cache. Release qualification should repeat it on one clean install and one
 ordinary warm restart.
+
+The rebuilt debug app also passed a caller-correlated headless tool round. The
+HTTP response returned the caller's `capture_run_id`, `runtime_backend: "pi"`,
+one tool call, and exact provider usage. The joined private JSONL contained one
+`status` call and one matching successful result under the same run/session
+identity, with mode `0600`. This proves HTTP, MCP, custom-eval, and RLM calls can
+use the same immutable evidence spine as GUI chat; Fusion's specialized
+sidekick/gateway benchmark paths remain native below.
 
 ## Deletion gate
 
@@ -74,9 +82,10 @@ diff. The conservative gross target is about 4,200 lines; the final claim is
 1. Merge the canonical desktop bridge and release the compatibility build.
 2. Rebase cache-health onto it and align the desktop runtime compatibility
    constant with the released CLI.
-3. Move `agent_chat`, custom eval, RLM, HTTP completion, and Fusion benchmark
-   callers to a headless canonical-runtime adapter. These are the remaining
-   callers keeping the native non-streaming loop alive.
+3. Finish the headless migration. `agent_chat`, custom eval, RLM, HTTP
+   completion, and MCP completion now use the canonical runtime with a
+   pre-output one-release fallback. The specialized Fusion sidekick/gateway
+   benchmark callers still keep the native non-streaming loop alive.
 4. Route direct Anthropic through the canonical provider contract; retain only
    local key presence and catalog management in Rust.
 5. Replace legacy parallel-sidekick metrics/UI with canonical intervention and

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -59,9 +59,18 @@ so the native Anthropic translator remains only as the one-release fallback.
 
 ## Deletion gate
 
-`chat_route_metrics` counts only rows with a canonical `run_id`; legacy rows
-cannot poison the denominator. Delete the compatibility engine only after one
-released version records a rolling window of at least 100 canonical runs with:
+The release artifact exposes the gate directly:
+
+```sh
+understudy desktop migration-status --require-ready --json
+```
+
+The command exits `2` while observation is incomplete. The underlying
+versioned Desktop API cohorts rows by both app version and canonical-runtime
+version; legacy and development rows remain in SQLite but cannot poison or
+falsely satisfy the denominator. Delete the compatibility engine only after
+one released app/runtime cohort records a rolling window of at least 100
+canonical runs with:
 
 - `compatibility_fallback_rows == 0`;
 - `pi_runtime_share == 1.0`;

--- a/experiments/desktop-grocery-proof/run.mjs
+++ b/experiments/desktop-grocery-proof/run.mjs
@@ -37,16 +37,17 @@ export function scoreObject(actual, expected) {
 
 export function summarizeEvents(events, elapsedMs) {
   const outputByRole = {};
-  for (const event of events.filter(
-    (event) => event.event === "delta" && typeof event.data?.text === "string",
-  )) {
+  let output = "";
+  for (const event of events) {
+    if (event.event === "teacher_continuation" && event.data?.output_mode === "replace") {
+      output = "";
+      continue;
+    }
+    if (event.event !== "delta" || typeof event.data?.text !== "string") continue;
     const role = String(event.data?.role ?? "unknown");
     outputByRole[role] = `${outputByRole[role] ?? ""}${event.data.text}`;
+    output += event.data.text;
   }
-  const output = events
-    .filter((event) => event.event === "delta" && typeof event.data?.text === "string")
-    .map((event) => event.data.text)
-    .join("");
   const usage = {};
   for (const event of events.filter((event) => event.event === "usage")) {
     const role = String(event.data?.role ?? "unknown");

--- a/experiments/desktop-tool-proof/README.md
+++ b/experiments/desktop-tool-proof/README.md
@@ -1,0 +1,20 @@
+# Desktop strict-tool proof
+
+This no-spend local proof compares warm Desktop models on the exact same
+versioned tool-call inputs. It scores the canonical trace rather than trusting
+the final prose: one exact named tool, exact parsed arguments, one paired
+successful result, no orphan result, and the requested final output.
+
+```sh
+node experiments/desktop-tool-proof/run.mjs \
+  --candidate 4b:7 \
+  --candidate 12b:6 \
+  --candidate 26b:5 \
+  --repetitions 3
+```
+
+Evidence is written owner-only under
+`~/.understudy/proofs/tool-correctness/<proof-id>/`. The task-file SHA-256 is
+stored in every row and the summary. A tiny local slice proves integration and
+identifies failure modes; it is not sufficient by itself for a production
+replacement claim.

--- a/experiments/desktop-tool-proof/run.mjs
+++ b/experiments/desktop-tool-proof/run.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export function scoreToolTrace(events, task) {
+  const calls = events.filter((event) => event.event === "tool_call");
+  const results = events.filter((event) => event.event === "tool_result");
+  const call = calls[0]?.data ?? null;
+  const result = results.find((event) => event.data?.call_id === call?.call_id)?.data ?? null;
+  const output = events
+    .filter((event) => event.event === "delta" && typeof event.data?.text === "string")
+    .map((event) => event.data.text)
+    .join("")
+    .trim();
+  const checks = {
+    exactly_one_call: calls.length === 1,
+    exact_tool_name: call?.name === task.tool,
+    exact_arguments:
+      call?.parse_error == null && isDeepStrictEqual(call?.parsed_arguments, task.arguments),
+    paired_successful_result:
+      results.length === 1 && result?.name === task.tool && result?.ok === true,
+    exact_output: output === task.expected_output,
+  };
+  return {
+    strict_pass: Object.values(checks).every(Boolean),
+    checks,
+    output,
+    call_count: calls.length,
+    result_count: results.length,
+    called_tool: call?.name ?? null,
+    parsed_arguments: call?.parsed_arguments ?? null,
+    parse_error: call?.parse_error ?? null,
+    result_ok: result?.ok ?? false,
+    orphan_result_count: results.filter(
+      (candidate) => !calls.some((item) => item.data?.call_id === candidate.data?.call_id),
+    ).length,
+  };
+}
+
+export function summarizeRows(rows) {
+  const groups = new Map();
+  for (const row of rows) {
+    const selected = groups.get(row.candidate) ?? [];
+    selected.push(row);
+    groups.set(row.candidate, selected);
+  }
+  return Object.fromEntries([...groups].map(([candidate, selected]) => [candidate, {
+    slot_id: selected[0]?.slot_id ?? null,
+    strict_passes: selected.filter((row) => row.strict_pass).length,
+    attempts: selected.length,
+    strict_accuracy: selected.filter((row) => row.strict_pass).length / selected.length,
+    exact_name_rate: selected.filter((row) => row.checks.exact_tool_name).length / selected.length,
+    exact_arguments_rate: selected.filter((row) => row.checks.exact_arguments).length / selected.length,
+    successful_result_rate:
+      selected.filter((row) => row.checks.paired_successful_result).length / selected.length,
+    exact_output_rate: selected.filter((row) => row.checks.exact_output).length / selected.length,
+    parse_errors: selected.filter((row) => row.parse_error != null).length,
+    orphan_results: selected.reduce((sum, row) => sum + row.orphan_result_count, 0),
+    mean_latency_ms: Math.round(
+      selected.reduce((sum, row) => sum + row.elapsed_ms, 0) / selected.length,
+    ),
+    total_tokens: selected.reduce((sum, row) => sum + row.total_tokens, 0),
+    failures: selected
+      .filter((row) => !row.strict_pass)
+      .map((row) => ({
+        repetition: row.repetition,
+        task_id: row.task_id,
+        called_tool: row.called_tool,
+        parsed_arguments: row.parsed_arguments,
+        result_ok: row.result_ok,
+        output: row.output,
+        checks: row.checks,
+      })),
+  }]));
+}
+
+function parseArgs(argv) {
+  const options = {
+    candidates: [],
+    repetitions: 3,
+    maxTokens: 160,
+    outputRoot: join(homedir(), ".understudy", "proofs", "tool-correctness"),
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    const next = argv[index + 1];
+    if (value === "--candidate") {
+      const [label, rawSlot] = String(next).split(":");
+      options.candidates.push({ label, slotId: Number(rawSlot) });
+    } else if (value === "--repetitions") options.repetitions = Number(next);
+    else if (value === "--max-tokens") options.maxTokens = Number(next);
+    else if (value === "--output-root") options.outputRoot = resolve(next);
+    else throw new Error(`unknown argument: ${value}`);
+    index += 1;
+  }
+  if (options.candidates.length === 0) {
+    throw new Error("provide at least one --candidate label:slot");
+  }
+  const labels = new Set();
+  for (const candidate of options.candidates) {
+    if (!/^[a-z0-9][a-z0-9-]{0,39}$/.test(candidate.label) || labels.has(candidate.label)) {
+      throw new Error(`candidate label must be unique and URL-safe: ${candidate.label}`);
+    }
+    if (!Number.isInteger(candidate.slotId) || candidate.slotId <= 0) {
+      throw new Error(`candidate slot must be a positive integer: ${candidate.slotId}`);
+    }
+    labels.add(candidate.label);
+  }
+  if (!Number.isInteger(options.repetitions) || options.repetitions < 1 || options.repetitions > 20) {
+    throw new Error("repetitions must be an integer from 1 to 20");
+  }
+  if (!Number.isInteger(options.maxTokens) || options.maxTokens < 16 || options.maxTokens > 2_048) {
+    throw new Error("max-tokens must be an integer from 16 to 2048");
+  }
+  return options;
+}
+
+function readCapability() {
+  const path = process.env.UNDERSTUDY_DESKTOP_API_FILE
+    ?? join(homedir(), ".understudy", "desktop-api.json");
+  const metadata = statSync(path);
+  if (process.platform !== "win32" && (metadata.mode & 0o077) !== 0) {
+    throw new Error(`desktop capability permissions are broader than 0600: ${path}`);
+  }
+  const value = JSON.parse(readFileSync(path, "utf8"));
+  const url = new URL(value.base_url);
+  if (url.protocol !== "http:" || url.hostname !== "127.0.0.1") {
+    throw new Error("desktop capability is not a loopback HTTP endpoint");
+  }
+  if (typeof value.token !== "string" || value.token.length < 32) {
+    throw new Error("desktop capability has no valid bearer token");
+  }
+  return { baseUrl: url.origin, token: value.token };
+}
+
+async function apiFetch(capability, path, init = {}) {
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${capability.token}`);
+  if (init.body !== undefined) headers.set("content-type", "application/json");
+  return fetch(new URL(path, capability.baseUrl), { ...init, headers });
+}
+
+async function readNdjson(response) {
+  if (!response.body) return [];
+  const events = [];
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    while (buffer.includes("\n")) {
+      const newline = buffer.indexOf("\n");
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      if (line) events.push(JSON.parse(line));
+    }
+  }
+  buffer += decoder.decode();
+  if (buffer.trim()) events.push(JSON.parse(buffer));
+  return events;
+}
+
+function writeProofFile(path, data) {
+  writeFileSync(path, data, { flag: "wx", mode: 0o600 });
+}
+
+function eventTokens(events) {
+  return events
+    .filter((event) => event.event === "usage")
+    .reduce((sum, event) => sum + Number(event.data?.total_tokens ?? 0), 0);
+}
+
+export async function runProof(options = parseArgs(process.argv.slice(2))) {
+  const taskBytes = readFileSync(join(here, "tasks.json"));
+  const tasks = JSON.parse(taskBytes);
+  const suiteSha256 = createHash("sha256").update(taskBytes).digest("hex");
+  const startedAt = new Date();
+  const proofId = `tools-${suiteSha256.slice(0, 10)}-${startedAt.toISOString().replaceAll(/[-:.]/g, "")}`;
+  const outputDir = join(options.outputRoot, proofId);
+  mkdirSync(options.outputRoot, { recursive: true, mode: 0o700 });
+  mkdirSync(outputDir, { mode: 0o700 });
+  const capability = readCapability();
+  const capabilitiesResponse = await apiFetch(capability, "/v1/capabilities");
+  if (!capabilitiesResponse.ok) {
+    throw new Error(`capabilities returned ${capabilitiesResponse.status}`);
+  }
+  const capabilities = await capabilitiesResponse.json();
+  if (
+    capabilities.schema_version !== "understudy.desktop_api.v2"
+    || capabilities.features?.streaming_ndjson !== true
+    || capabilities.features?.persisted_run_events !== true
+  ) {
+    throw new Error("Understudy Desktop API v2 canonical streaming evidence is required");
+  }
+
+  const rows = [];
+  for (const candidate of options.candidates) {
+    for (let repetition = 1; repetition <= options.repetitions; repetition += 1) {
+      for (const task of tasks) {
+        const runId = `${proofId}-${candidate.label}-r${repetition}-${task.id}`;
+        const sessionId = runId;
+        const before = performance.now();
+        const response = await apiFetch(
+          capability,
+          `/v1/conversations/${encodeURIComponent(sessionId)}/turns`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              slotId: candidate.slotId,
+              text: task.prompt,
+              runId,
+              maxTokens: options.maxTokens,
+            }),
+          },
+        );
+        if (!response.ok) {
+          throw new Error(
+            `${candidate.label}/r${repetition}/${task.id} returned ${response.status}: ${await response.text()}`,
+          );
+        }
+        const events = await readNdjson(response);
+        const score = scoreToolTrace(events, task);
+        const row = {
+          proof_id: proofId,
+          suite_sha256: suiteSha256,
+          candidate: candidate.label,
+          slot_id: candidate.slotId,
+          repetition,
+          task_id: task.id,
+          expected_tool: task.tool,
+          expected_arguments: task.arguments,
+          run_id: runId,
+          session_id: sessionId,
+          elapsed_ms: Math.round(performance.now() - before),
+          total_tokens: eventTokens(events),
+          canonical_event_count: events.length,
+          ...score,
+        };
+        rows.push(row);
+        writeProofFile(
+          join(outputDir, `${candidate.label}-r${repetition}-${task.id}.events.jsonl`),
+          `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
+        );
+        process.stdout.write(
+          `${candidate.label.padEnd(10)} r${repetition} ${task.id.padEnd(22)} `
+          + `${score.strict_pass ? "PASS" : "FAIL"} tool=${score.called_tool ?? "none"}\n`,
+        );
+      }
+    }
+  }
+  const summary = {
+    format: "understudy.desktop_tool_proof.v1",
+    proof_id: proofId,
+    suite_sha256: suiteSha256,
+    started_at: startedAt.toISOString(),
+    completed_at: new Date().toISOString(),
+    api_version: capabilities.api_version,
+    event_schema: capabilities.event_schema,
+    task_count: tasks.length,
+    repetitions: options.repetitions,
+    run_count: rows.length,
+    candidates: summarizeRows(rows),
+  };
+  writeProofFile(
+    join(outputDir, "results.jsonl"),
+    `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
+  );
+  writeProofFile(join(outputDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  writeProofFile(join(outputDir, "tasks.json"), taskBytes);
+  process.stdout.write(`${JSON.stringify({ output_dir: outputDir, summary }, null, 2)}\n`);
+  return { outputDir, rows, summary };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  runProof().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/experiments/desktop-tool-proof/tasks.json
+++ b/experiments/desktop-tool-proof/tasks.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "status-empty",
+    "tool": "status",
+    "arguments": {},
+    "prompt": "Call the status tool exactly once with an empty object. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "residency-empty",
+    "tool": "residency",
+    "arguments": {},
+    "prompt": "Call the residency tool exactly once with an empty object. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "models-empty",
+    "tool": "list_models",
+    "arguments": {},
+    "prompt": "Call the list_models tool exactly once with an empty object. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "catalog-empty",
+    "tool": "list_snapshot_models",
+    "arguments": {},
+    "prompt": "Call the list_snapshot_models tool exactly once with an empty object. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "traces-limit",
+    "tool": "list_traces",
+    "arguments": { "limit": 1 },
+    "prompt": "Call the list_traces tool exactly once with limit 1. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "trace-search-required",
+    "tool": "search_traces",
+    "arguments": { "q": "runtime" },
+    "prompt": "Call the search_traces tool exactly once with q set to runtime. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "mcp-wrapper",
+    "tool": "understudy_mcp_tool",
+    "arguments": { "tool_name": "knowledge_dossiers", "arguments": {} },
+    "prompt": "Call the understudy_mcp_tool exactly once with tool_name knowledge_dossiers and arguments as an empty object. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "cli-wrapper",
+    "tool": "understudy_agent_tools",
+    "arguments": { "command": "version" },
+    "prompt": "Call the understudy_agent_tools tool exactly once with command version. If its result succeeds, reply with only OK. Do not call any other tool.",
+    "expected_output": "OK"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prepare": "npm run build",
     "package:smoke": "node scripts/package-smoke.mjs",
     "runtime:compaction-soak": "npm run build && node scripts/runtime-compaction-soak.mjs",
+    "runtime:desktop-readiness": "npm run build && node scripts/desktop-runtime-readiness.mjs",
     "skills:validate": "node scripts/validate-public-skills.mjs --repo",
     "test": "node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -37,22 +37,26 @@ shape:
 
 Rules for producers and consumers:
 
-1. **Rows are additive-extensible.** Producers may attach extra fields
+1. **Run and attempt identity are different.** `run_id` groups every row from
+   one benchmark invocation. `capture_run_id` identifies one task attempt and,
+   when present, joins it to immutable canonical conversation-runtime JSONL.
+   New Desktop benchmark rows always assign it; legacy rows may be null.
+2. **Rows are additive-extensible.** Producers may attach extra fields
    (`additionalProperties: true`); consumers must ignore fields they do not
    understand. Never change the meaning of an existing field — that requires
    `eval_result.v2`.
-2. **Most fields are nullable by design** so a producer can adopt the schema
+3. **Most fields are nullable by design** so a producer can adopt the schema
    today with whatever it can compute, and enrich rows over time. Only
    `schema_version`, `run_id`, `task_id`, and `status` are required.
-3. **A score of `0` is a scored failure**, never a missing value. Missing means
+4. **A score of `0` is a scored failure**, never a missing value. Missing means
    `score: null`. UI code must use null checks, not truthiness.
-4. **`status` semantics** (matching the desktop scorer): `ok` = executed and
+5. **`status` semantics** (matching the desktop scorer): `ok` = executed and
    scored; `error` = the attempt failed to execute; `skipped` = never executed;
    `unscored` = executed but no rubric/gold covers the task, so the row must be
    excluded from score averages rather than counted as 0.
-5. **Never invent prices.** `cost.usd` stays null unless a real price basis
+6. **Never invent prices.** `cost.usd` stays null unless a real price basis
    exists, and `cost.basis` must say what that basis is.
-6. **Provenance chains are optional but standardized**: `harness_sha256` and
+7. **Provenance chains are optional but standardized**: `harness_sha256` and
    `split_sha256` line up with the `harness_sha256` / `splits_sha256` hash
    chain the `capture-evidence` and `optimize-workload` skills already require
    in `baseline.json` and `claim.json`.

--- a/schemas/understudy.desktop_api.v2.openapi.json
+++ b/schemas/understudy.desktop_api.v2.openapi.json
@@ -64,6 +64,39 @@
         }
       }
     },
+    "/v1/metrics/chat-routes": {
+      "get": {
+        "operationId": "desktopMigrationStatus",
+        "summary": "Inspect the rolling Pi adoption and Rust fallback deletion gate",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 250
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rolling canonical-runtime adoption metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MigrationStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/v1/models": {
       "get": {
         "operationId": "desktopModels",
@@ -628,6 +661,80 @@
       "StatusDocument": {
         "type": "object",
         "description": "Desktop status is forward-compatible; clients should inspect only fields they understand.",
+        "additionalProperties": true
+      },
+      "MigrationStatus": {
+        "type": "object",
+        "required": [
+          "schema_version",
+          "app_version",
+          "runtime_version",
+          "observed_row_limit",
+          "required_canonical_runtime_rows",
+          "remaining_canonical_runtime_rows",
+          "canonical_runtime_rows",
+          "pi_runtime_rows",
+          "compatibility_fallback_rows",
+          "pi_runtime_share",
+          "compatibility_engine_delete_ready",
+          "groups"
+        ],
+        "properties": {
+          "schema_version": {
+            "const": "understudy.chat_route_metrics.v1"
+          },
+          "app_version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "runtime_version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "observed_row_limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500
+          },
+          "required_canonical_runtime_rows": {
+            "const": 100
+          },
+          "remaining_canonical_runtime_rows": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "canonical_runtime_rows": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "pi_runtime_rows": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "compatibility_fallback_rows": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "pi_runtime_share": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 1
+          },
+          "compatibility_engine_delete_ready": {
+            "type": "boolean"
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
         "additionalProperties": true
       },
       "ModelList": {

--- a/schemas/understudy.eval_result.v1.schema.json
+++ b/schemas/understudy.eval_result.v1.schema.json
@@ -21,6 +21,10 @@
       "minLength": 1,
       "description": "Per-attempt identifier that joins this row to immutable canonical conversation-runtime evidence. Unlike run_id, this value is unique for each task attempt."
     },
+    "runtime_backend": {
+      "type": ["string", "null"],
+      "description": "Conversation runtime that executed the attempt, such as pi, native-rust, external, or not-run."
+    },
     "task_id": {
       "type": "string",
       "minLength": 1,

--- a/schemas/understudy.eval_result.v1.schema.json
+++ b/schemas/understudy.eval_result.v1.schema.json
@@ -16,6 +16,11 @@
       "minLength": 1,
       "description": "Identifier of the run this row belongs to. All rows produced by one invocation of a harness share a run_id."
     },
+    "capture_run_id": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "Per-attempt identifier that joins this row to immutable canonical conversation-runtime evidence. Unlike run_id, this value is unique for each task attempt."
+    },
     "task_id": {
       "type": "string",
       "minLength": 1,

--- a/scripts/desktop-runtime-readiness.mjs
+++ b/scripts/desktop-runtime-readiness.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const appBinary = resolve(
+  process.env.UNDERSTUDY_DESKTOP_BINARY ||
+    join(
+      repoRoot,
+      "apps/homescreen/src-tauri/target/debug/bundle/macos/Understudy.app/Contents/MacOS/understudy",
+    ),
+);
+const cli = join(repoRoot, "dist/bin.js");
+const database =
+  process.env.UNDERSTUDY_DESKTOP_DB ||
+  join(homedir(), "Library/Application Support/com.homescreen.app/understudy.db");
+const baseUrl = process.env.UNDERSTUDY_DESKTOP_URL || "http://127.0.0.1:17790";
+const outputIndex = process.argv.indexOf("--output");
+const output = outputIndex >= 0 ? process.argv[outputIndex + 1] : undefined;
+
+if (process.argv.includes("--help")) {
+  process.stdout.write(
+    "usage: node scripts/desktop-runtime-readiness.mjs [--output <private-json>]\n" +
+      "\n" +
+      "Run after stopping Understudy and its warm model processes. The probe launches the\n" +
+      "debug app bundle, cold-starts the managed runtime, measures restored models, and\n" +
+      "leaves the measured app running. No provider calls are made.\n",
+  );
+  process.exit(0);
+}
+if (outputIndex >= 0 && !output) {
+  throw new Error("--output requires a path");
+}
+
+const thresholds = {
+  app_ready_ms: 2_500,
+  runtime_ready_ms: 3_000,
+  max_model_load_ms: 45_000,
+  app_plus_runtime_rss_mb: 750,
+  total_model_rss_gb: 32,
+};
+
+function run(program, args, options = {}) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${program} ${args.join(" ")} failed: ${(result.stderr || result.stdout || "unknown error").trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function sqlite(query) {
+  return run("sqlite3", ["-json", database, query]);
+}
+
+function sqliteRows(query) {
+  const raw = sqlite(query);
+  return raw ? JSON.parse(raw) : [];
+}
+
+function rssKb(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const result = spawnSync("ps", ["-o", "rss=", "-p", String(pid)], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return null;
+  const value = Number(result.stdout.trim());
+  return Number.isFinite(value) ? value : null;
+}
+
+function listenerPid(port) {
+  if (!Number.isInteger(port) || port <= 0) return null;
+  const result = spawnSync(
+    "lsof",
+    ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) return null;
+  const pid = Number(result.stdout.trim().split(/\s+/)[0]);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function processAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchWithTimeout(url, options = {}, timeoutMs = 1_000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function healthReady() {
+  try {
+    const response = await fetchWithTimeout(`${baseUrl}/health`, {}, 300);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(check, timeoutMs, label) {
+  const started = performance.now();
+  while (performance.now() - started < timeoutMs) {
+    const result = await check();
+    if (result) return { elapsed_ms: Math.round(performance.now() - started), result };
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  throw new Error(`${label} did not become ready within ${timeoutMs}ms`);
+}
+
+if (!existsSync(appBinary)) {
+  throw new Error(`desktop binary is missing: ${appBinary}`);
+}
+if (!existsSync(cli)) {
+  throw new Error(`built CLI is missing: ${cli}; run npm run build first`);
+}
+if (!existsSync(database)) {
+  throw new Error(`desktop database is missing: ${database}`);
+}
+if (await healthReady()) {
+  throw new Error(`desktop is already serving at ${baseUrl}; stop it before a cold readiness run`);
+}
+
+const warmBefore = sqliteRows(
+  "SELECT slot_id, model_id, port, server_pid, mem_gb FROM residency WHERE warm=1 ORDER BY slot_id",
+);
+const liveOrphans = warmBefore.filter((slot) => processAlive(Number(slot.server_pid)));
+if (liveOrphans.length > 0) {
+  throw new Error(
+    `warm model processes are still alive for slots ${liveOrphans.map((slot) => slot.slot_id).join(", ")}; stop them before measuring cold startup`,
+  );
+}
+
+// A cold runtime measurement must not reuse a managed sidecar from a prior app
+// process. Stopping it is local-only and does not delete sessions or evidence.
+spawnSync(process.execPath, [cli, "runtime", "stop", "--json"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+
+const launchStarted = performance.now();
+const app = spawn(appBinary, [], {
+  cwd: repoRoot,
+  detached: true,
+  stdio: "ignore",
+  env: {
+    ...process.env,
+    UNDERSTUDY_BIN: cli,
+  },
+});
+app.unref();
+
+let result;
+try {
+  const appReady = await waitFor(healthReady, 10_000, "desktop HTTP server");
+  const token = run("sqlite3", [database, "SELECT value FROM settings WHERE key='server_token'"]);
+  if (!/^[0-9a-f]{64}$/i.test(token)) {
+    throw new Error("desktop server token is missing or malformed");
+  }
+  const authorization = { authorization: `Bearer ${token}` };
+
+  const runtimeStarted = performance.now();
+  const runtimeRaw = run(
+    process.execPath,
+    [cli, "runtime", "start", "--json"],
+    {
+      env: {
+        ...process.env,
+        UNDERSTUDY_RUNTIME_TOOL_TOKEN: token,
+        UNDERSTUDY_RUNTIME_TOOL_BASE_URL: baseUrl,
+      },
+    },
+  );
+  const runtime = JSON.parse(runtimeRaw);
+  const runtimeReadyMs = Math.round(performance.now() - runtimeStarted);
+  if (!runtime.healthy || !runtime.running) {
+    throw new Error(`conversation runtime did not become healthy: ${runtime.detail}`);
+  }
+
+  const warmIds = new Set(warmBefore.map((slot) => Number(slot.slot_id)));
+  const modelReady = await waitFor(
+    async () => {
+      const response = await fetchWithTimeout(`${baseUrl}/api/residency`, {
+        headers: authorization,
+      });
+      if (!response.ok) throw new Error(`residency returned HTTP ${response.status}`);
+      const snapshot = await response.json();
+      const warm = snapshot.slots.filter((slot) => warmIds.has(Number(slot.id)));
+      if (warm.some((slot) => slot.state === "error")) {
+        throw new Error(
+          `restored model error in slots ${warm.filter((slot) => slot.state === "error").map((slot) => slot.id).join(", ")}`,
+        );
+      }
+      return warm.length === warmIds.size && warm.every((slot) => slot.state === "running")
+        ? snapshot
+        : null;
+    },
+    90_000,
+    "restored local models",
+  );
+  const modelsReadyFromLaunchMs = Math.round(performance.now() - launchStarted);
+
+  const warmAfter = sqliteRows(
+    "SELECT slot_id, model_id, port, server_pid, mem_gb FROM residency WHERE warm=1 ORDER BY slot_id",
+  );
+  const models = warmAfter.map((slot) => {
+    const persistedPid = Number(slot.server_pid);
+    const pid = processAlive(persistedPid) ? persistedPid : listenerPid(Number(slot.port));
+    const rss = rssKb(pid);
+    const view = modelReady.result.slots.find((candidate) => Number(candidate.id) === Number(slot.slot_id));
+    return {
+      slot_id: Number(slot.slot_id),
+      model_id: slot.model_id,
+      port: Number(slot.port),
+      pid,
+      load_ms: view?.load_ms ?? null,
+      declared_mem_gb: Number(slot.mem_gb),
+      rss_gb: rss === null ? null : rss / 1024 / 1024,
+    };
+  });
+  const appRssKb = rssKb(app.pid);
+  const runtimeRssKb = rssKb(Number(runtime.pid));
+  const appPlusRuntimeRssMb =
+    appRssKb === null || runtimeRssKb === null ? null : (appRssKb + runtimeRssKb) / 1024;
+  const totalModelRssGb = models.reduce((sum, model) => sum + (model.rss_gb ?? 0), 0);
+  const maxModelLoadMs = Math.max(0, ...models.map((model) => Number(model.load_ms) || 0));
+  const checks = {
+    app_ready: appReady.elapsed_ms <= thresholds.app_ready_ms,
+    runtime_ready: runtimeReadyMs <= thresholds.runtime_ready_ms,
+    models_ready: maxModelLoadMs <= thresholds.max_model_load_ms,
+    app_plus_runtime_memory:
+      appPlusRuntimeRssMb !== null && appPlusRuntimeRssMb <= thresholds.app_plus_runtime_rss_mb,
+    model_memory:
+      models.every((model) => model.rss_gb !== null) &&
+      totalModelRssGb <= thresholds.total_model_rss_gb,
+  };
+  result = {
+    schema_version: "understudy-desktop-runtime-readiness-v1",
+    generated_at: new Date().toISOString(),
+    measurement_class: "process-cold-filesystem-warm",
+    caveat:
+      "The app, sidecar, and model server processes were cold, but model weights may remain in the macOS filesystem cache. This is not a reboot-cold measurement.",
+    passed: Object.values(checks).every(Boolean),
+    thresholds,
+    checks,
+    app: {
+      pid: app.pid,
+      ready_ms: appReady.elapsed_ms,
+      rss_mb: appRssKb === null ? null : appRssKb / 1024,
+    },
+    runtime: {
+      pid: Number(runtime.pid),
+      runtime_version: runtime.runtime_version,
+      event_schema: runtime.event_schema,
+      ready_ms: runtimeReadyMs,
+      rss_mb: runtimeRssKb === null ? null : runtimeRssKb / 1024,
+    },
+    restored_models_ready_ms: modelsReadyFromLaunchMs,
+    residency_poll_ms: modelReady.elapsed_ms,
+    app_plus_runtime_rss_mb: appPlusRuntimeRssMb,
+    total_model_rss_gb: totalModelRssGb,
+    models,
+  };
+} catch (error) {
+  if (processAlive(app.pid)) process.kill(app.pid, "SIGTERM");
+  throw error;
+}
+
+const rendered = `${JSON.stringify(result, null, 2)}\n`;
+if (output) writeFileSync(resolve(output), rendered, { mode: 0o600 });
+process.stdout.write(rendered);
+if (!result.passed) process.exitCode = 1;

--- a/src/commands/desktop.ts
+++ b/src/commands/desktop.ts
@@ -19,6 +19,22 @@ interface RuntimeEvent {
   data?: Record<string, unknown>;
 }
 
+interface DesktopMigrationStatus {
+  schema_version?: string;
+  app_version?: string;
+  runtime_version?: string;
+  observed_row_limit?: number;
+  required_canonical_runtime_rows?: number;
+  remaining_canonical_runtime_rows?: number;
+  canonical_runtime_rows?: number;
+  pi_runtime_rows?: number;
+  compatibility_fallback_rows?: number;
+  pi_runtime_share?: number | null;
+  compatibility_engine_delete_ready?: boolean;
+}
+
+const REQUIRED_CANONICAL_RELEASE_RUNS = 100;
+
 function positiveInteger(value: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0) throw new Error("value must be a positive integer");
@@ -173,6 +189,55 @@ export function registerDesktopCommand(program: Command): void {
       const capability = await requireDesktopApi();
       const value = await desktopControlJson(capability, "/v1/status", "/api/status");
       printStructured(value, jsonRequested(this, opts.json));
+    });
+
+  desktop
+    .command("migration-status")
+    .description("Check the one-release Pi adoption gate before deleting the Rust fallback.")
+    .option("--limit <n>", "Most-recent canonical/fallback rows to inspect", positiveInteger, 250)
+    .option("--require-ready", "Exit non-zero until 100 canonical runs have zero fallbacks")
+    .option("--json", "Output JSON")
+    .action(async function (
+      this: Command,
+      opts: { limit: number; requireReady?: boolean; json?: boolean },
+    ) {
+      const capability = await requireDesktopApi();
+      const query = `?limit=${opts.limit}`;
+      const value = await desktopControlJson(
+        capability,
+        `/v1/metrics/chat-routes${query}`,
+        `/api/chat/route-metrics${query}`,
+      ) as DesktopMigrationStatus;
+      const required = Number(
+        value.required_canonical_runtime_rows ?? REQUIRED_CANONICAL_RELEASE_RUNS,
+      );
+      const canonical = Number(value.canonical_runtime_rows ?? 0);
+      const piRows = Number(value.pi_runtime_rows ?? 0);
+      const fallbacks = Number(value.compatibility_fallback_rows ?? 0);
+      const ready = value.compatibility_engine_delete_ready === true;
+      const remaining = Number(
+        value.remaining_canonical_runtime_rows ?? Math.max(0, required - canonical),
+      );
+      const output = {
+        ...value,
+        required_canonical_runtime_rows: required,
+        remaining_canonical_runtime_rows: remaining,
+        observed_row_limit: value.observed_row_limit ?? opts.limit,
+      };
+      const share = value.pi_runtime_share == null
+        ? "unavailable"
+        : `${(value.pi_runtime_share * 100).toFixed(1)}%`;
+      printStructured(
+        output,
+        jsonRequested(this, opts.json),
+        [
+          `Pi migration: ${ready ? "ready for Rust fallback deletion" : "observing compatibility release"}`,
+          `release cohort: app ${value.app_version ?? "unknown"}, runtime ${value.runtime_version ?? "unknown"}`,
+          `canonical runs: ${canonical}/${required} (${remaining} remaining)`,
+          `Pi runs: ${piRows} (${share}); compatibility fallbacks: ${fallbacks}`,
+        ].join("\n"),
+      );
+      if (opts.requireReady && !ready) process.exitCode = 2;
     });
 
   const models = desktop.command("model").description("Inspect Desktop model inventory.");

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.1";
+export const RUNTIME_VERSION = "0.3.2";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);
@@ -76,6 +76,12 @@ export const runtimeRequestSchema = z
     session_id: z.string().min(1).max(200),
     base_url: z.string().url(),
     model: z.string().min(1).max(500),
+    provider_kind: z
+      .enum(["openai-compatible", "anthropic"])
+      .default("openai-compatible"),
+    // Delivered only over the authenticated loopback request. The runtime
+    // consumes this in memory and must never copy it into canonical events.
+    provider_api_key: z.string().min(1).max(4_096).optional(),
     role: z.enum(["student", "teacher", "primary", "supervisor"]),
     messages: z.array(z.union([textMessageSchema, toolMessageSchema])).min(1),
     tools: z.array(toolSchema).max(128).optional(),
@@ -298,7 +304,12 @@ export function validateAttachmentBytes(attachment: {
 
 export function safeErrorMessage(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
-  return raw.replace(/[\r\n\t]+/g, " ").slice(0, 1_000) || "unknown error";
+  return (
+    raw
+      .replace(/\bsk[-_][A-Za-z0-9_-]{6,}\b/g, "[redacted]")
+      .replace(/[\r\n\t]+/g, " ")
+      .slice(0, 1_000) || "unknown error"
+  );
 }
 
 const EVENT_NAMES = new Set<RuntimeEventName>([

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.2";
+export const RUNTIME_VERSION = "0.3.3";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);
@@ -462,6 +462,12 @@ export function validateRuntimeTrace(values: readonly unknown[]): RuntimeEventEn
       const marker = requiredString(data, "marker_id", "teacher_continuation.marker_id");
       requiredString(data, "reason", "teacher_continuation.reason");
       requiredString(data, "teacher_model", "teacher_continuation.teacher_model");
+      if (
+        "output_mode" in data &&
+        !["append", "replace"].includes(String(data.output_mode))
+      ) {
+        throw new Error("teacher_continuation.output_mode must be append or replace");
+      }
       if (!interruptedMarkers.has(marker)) {
         throw new Error(`teacher continuation ${marker} has no student interruption`);
       }

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -480,6 +480,10 @@ export function teacherContinuationBoundary(partial: string, firstDelta: string)
   return " ";
 }
 
+export function teacherOutputMode(studentCompleted: boolean): "append" | "replace" {
+  return studentCompleted ? "replace" : "append";
+}
+
 async function createPiRuntimeSession(options: {
   request: RuntimeRunRequest;
   target: RuntimeProviderTarget;
@@ -856,6 +860,7 @@ async function runSupervisedStudentSegment(options: {
   markerId?: string;
   nextBoundaryOrdinal: number;
   terminal: boolean;
+  studentCompleted: boolean;
 }> {
   const { request, config, writer, messages, abortSignal } = options;
   const { session } = await createPiRuntimeSession({
@@ -947,11 +952,13 @@ async function runSupervisedStudentSegment(options: {
   const abort = () => void session.abort();
   abortSignal?.addEventListener("abort", abort, { once: true });
   let promptError: unknown;
+  let studentCompleted = false;
   try {
     await session.prompt(latest.content, {
       images: imageContent(latest),
       expandPromptTemplates: false,
     });
+    studentCompleted = !plannedAbort;
   } catch (error) {
     promptError = error;
   }
@@ -993,6 +1000,7 @@ async function runSupervisedStudentSegment(options: {
           },
           nextBoundaryOrdinal: boundaryOrdinal,
           terminal: true,
+          studentCompleted,
         };
       }
       if (finalDecision.verdict === "nudge" && !options.allowNudge) {
@@ -1034,6 +1042,7 @@ async function runSupervisedStudentSegment(options: {
     terminal: Boolean(
       abortSignal?.aborted || (!decision && promptError) || adapter.terminalEmitted(),
     ),
+    studentCompleted,
   };
 }
 
@@ -1045,12 +1054,17 @@ async function runTeacherContinuation(options: {
   partial: string;
   markerId: string;
   reason: string;
+  outputMode: "append" | "replace";
   abortSignal?: AbortSignal;
 }): Promise<void> {
-  const prompt =
-    "The partial assistant answer above was written by a smaller model that has been interrupted. " +
-    "Continue it seamlessly from the exact point it stopped. Correct the problem identified by the " +
-    "supervisor without repeating, rephrasing, or summarizing text already written.";
+  const supervisorReason =
+    `\n\nThe supervisor identified this specific problem:\n<supervisor_reason>\n${options.reason}\n</supervisor_reason>`;
+  const prompt = options.outputMode === "replace"
+    ? "The completed assistant answer above was rejected by a supervisor. Produce one complete corrected replacement answer that satisfies the original user request. Do not mention the rejected answer or the supervision process." +
+      supervisorReason
+    : "The partial assistant answer above was written by a smaller model that has been interrupted. " +
+      "Continue it seamlessly from the exact point it stopped without repeating, rephrasing, or summarizing text already written." +
+      supervisorReason;
   const messages: RuntimeInputMessage[] = [
     ...options.request.messages,
     { role: "assistant", content: options.partial },
@@ -1061,6 +1075,7 @@ async function runTeacherContinuation(options: {
     reason: options.reason,
     teacher_model: options.config.teacher.model,
     from_partial_chars: characterCount(options.partial),
+    output_mode: options.outputMode,
   });
   const { session } = await createPiRuntimeSession({
     request: options.request,
@@ -1074,8 +1089,10 @@ async function runTeacherContinuation(options: {
     role: "teacher",
     model: options.config.teacher.model,
     abortReason: () => options.abortSignal?.reason,
-    transformTextDelta: (delta, first) =>
-      first ? `${teacherContinuationBoundary(options.partial, delta)}${delta}` : delta,
+    transformTextDelta: (delta, first) => {
+      if (options.outputMode === "replace") return delta;
+      return first ? `${teacherContinuationBoundary(options.partial, delta)}${delta}` : delta;
+    },
   });
   const abort = () => void session.abort();
   options.abortSignal?.addEventListener("abort", abort, { once: true });
@@ -1178,6 +1195,7 @@ async function runPiSupervisedConversation(
       partial: totalPartial,
       markerId,
       reason,
+      outputMode: teacherOutputMode(segment.studentCompleted),
       abortSignal,
     });
     return;

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -15,6 +15,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@earendil-works/pi-ai";
+import { getModels, type Api, type Model } from "@earendil-works/pi-ai/compat";
 
 import {
   PI_RUNTIME_ID,
@@ -51,7 +52,24 @@ function modelFor(
   baseUrl: URL,
   maxTokens: number,
   contextWindow: number,
-) {
+  providerKind: RuntimeRunRequest["provider_kind"],
+): Model<Api> {
+  if (providerKind === "anthropic") {
+    const model = getModels("anthropic").find((candidate) => candidate.id === target.model);
+    if (!model) {
+      throw new Error(`Pi does not recognize Anthropic model ${target.model}`);
+    }
+    return {
+      ...model,
+      baseUrl: baseUrl.toString().replace(/\/$/, ""),
+      contextWindow,
+      maxTokens: Math.min(
+        model.maxTokens,
+        maxTokens,
+        Math.max(1, Math.floor(contextWindow / 2)),
+      ),
+    };
+  }
   return {
     id: target.model,
     name: target.model,
@@ -197,7 +215,7 @@ function runtimeInputTokenEstimate(message: RuntimeInputMessage): number {
 
 function seedHistory(
   manager: SessionManager,
-  model: string,
+  model: Model<Api>,
   messages: RuntimeInputMessage[],
 ): void {
   if (manager.getEntries().length > 0) return;
@@ -217,9 +235,9 @@ function seedHistory(
       manager.appendMessage({
         role: "assistant",
         content: [{ type: "text", text: message.content }],
-        api: "openai-completions",
-        provider: "understudy-runtime",
-        model,
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
         usage: zeroUsage(),
         stopReason: "stop",
         timestamp: Date.now() + index,
@@ -483,15 +501,23 @@ async function createPiRuntimeSession(options: {
     providerUrl,
     options.maxTokens ?? request.max_output_tokens,
     request.provider_context_window_tokens ?? request.context_window_tokens,
+    request.provider_kind,
   );
   const compaction = piCompactionSettings(
     request.context_window_tokens,
     request.max_output_tokens,
   );
   const authStorage = AuthStorage.inMemory();
+  const providerApiKey =
+    request.provider_api_key ??
+    process.env.UNDERSTUDY_RUNTIME_API_KEY ??
+    (request.provider_kind === "openai-compatible" ? "local-runtime" : undefined);
+  if (!providerApiKey) {
+    throw new Error("Anthropic API key is unavailable to the conversation runtime");
+  }
   authStorage.setRuntimeApiKey(
     selectedModel.provider,
-    process.env.UNDERSTUDY_RUNTIME_API_KEY ?? "local-runtime",
+    providerApiKey,
   );
   const modelRegistry = ModelRegistry.inMemory(authStorage);
   const settingsManager = SettingsManager.inMemory(
@@ -541,13 +567,13 @@ async function createPiRuntimeSession(options: {
   const sessionManager = persistent
     ? SessionManager.continueRecent(cwd, sessionDir)
     : SessionManager.inMemory(cwd);
-  seedHistory(sessionManager, target.model, messages);
+  seedHistory(sessionManager, selectedModel, messages);
   const tools = options.toolsEnabled === false ? [] : buildTools(request);
   const { session } = await createAgentSession({
     cwd,
     agentDir: join(root, "agent"),
     model: selectedModel,
-    thinkingLevel: "off",
+    thinkingLevel: request.provider_kind === "anthropic" ? "medium" : "off",
     tools: tools.map((tool) => tool.name),
     noTools: "all",
     customTools: tools,

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -20,6 +20,7 @@ import {
   runPiConversation,
   supervisorDecisionMarker,
   teacherContinuationBoundary,
+  teacherOutputMode,
 } from "../dist/runtime/conversation/pi-runtime.js";
 import {
   parseRuntimeRequest,
@@ -669,11 +670,13 @@ test("Pi runtime deterministically interrupts a student and continues with the t
   assert.equal(interruption.data.partial_text, "Paris is in Germany.");
   assert.equal(interruption.data.marker_id, verdict.data.marker_id);
   assert.equal(continuation.data.marker_id, verdict.data.marker_id);
+  assert.equal(continuation.data.output_mode, "append");
   assert.deepEqual(
     events.filter((event) => event.event === "usage").map((event) => event.data.role),
     ["supervisor", "student", "teacher"],
   );
   assert.match(JSON.stringify(requests.at(-1).messages), /Paris is in Germany/);
+  assert.match(JSON.stringify(requests.at(-1).messages), /wrong country/);
   validateRuntimeTrace(events);
   const rendered = events
     .filter((event) => event.event === "delta")
@@ -687,6 +690,11 @@ test("teacher continuation inserts only a missing word boundary", () => {
   assert.equal(teacherContinuationBoundary("inventory is 9. ", "but the price"), "");
   assert.equal(teacherContinuationBoundary("inventory is 9", ", but the price"), "");
   assert.equal(teacherContinuationBoundary("", "fresh answer"), "");
+});
+
+test("teacher output replaces only a completed rejected answer", () => {
+  assert.equal(teacherOutputMode(false), "append");
+  assert.equal(teacherOutputMode(true), "replace");
 });
 
 test("every supervisor decision gets a stable labelable marker", () => {

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -23,6 +23,7 @@ import {
 } from "../dist/runtime/conversation/pi-runtime.js";
 import {
   parseRuntimeRequest,
+  safeErrorMessage,
   validateRuntimeTrace,
 } from "../dist/runtime/conversation/contract.js";
 import {
@@ -122,6 +123,15 @@ test("command guard permits ordinary work and inert discussion of dangerous synt
   ]) {
     assert.deepEqual(classifyShellToolCall(tool, input), { decision: "allow" });
   }
+});
+
+test("runtime errors redact provider-shaped secrets", () => {
+  const anthropicShaped = ["sk", "ant", "api03", "fixturesecret"].join("-");
+  const understudyShaped = ["sk", "org", "fixturesecret"].join("_");
+  const message = safeErrorMessage(
+    new Error(`provider rejected ${anthropicShaped} and ${understudyShaped}`),
+  );
+  assert.equal(message, "provider rejected [redacted] and [redacted]");
 });
 
 test("CLI lifecycle installs, starts, diagnoses, and stops the packaged sidecar", async () => {
@@ -305,6 +315,124 @@ test("Pi runtime emits the same canonical basic-chat evidence", async () => {
   assert.ok(events.every((event) => event.runtime_id === "pi-agent-session"));
   assert.equal(events.at(-1).data.input_tokens, 4);
   assert.equal(events.at(-1).data.output_tokens, 4);
+  validateRuntimeTrace(events);
+});
+
+test("Pi runtime uses native Anthropic Messages without leaking the provider key", async () => {
+  const providerKey = "fixture-anthropic-secret";
+  const toolToken = "anthropic-tool-token-".padEnd(64, "a");
+  process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN = toolToken;
+  let providerCalls = 0;
+  let toolCalls = 0;
+  const server = createServer(async (request, response) => {
+    const body = await requestJson(request);
+    if (request.url === "/tool") {
+      toolCalls += 1;
+      assert.equal(request.headers.authorization, `Bearer ${toolToken}`);
+      assert.equal(body.name, "status");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, result: { status: "healthy" } }));
+      return;
+    }
+    providerCalls += 1;
+    assert.equal(request.url, "/v1/messages");
+    assert.equal(request.headers["x-api-key"], providerKey);
+    assert.equal(body.model, "claude-haiku-4-5");
+    assert.doesNotMatch(JSON.stringify(body), new RegExp(providerKey));
+    if (providerCalls === 2) assert.match(JSON.stringify(body.messages), /tool_result/);
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    const contentEvents =
+      providerCalls === 1
+        ? [
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block: { type: "tool_use", id: "toolu_fixture", name: "status", input: {} },
+            },
+            { type: "content_block_stop", index: 0 },
+          ]
+        : [
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block: { type: "text", text: "" },
+            },
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "Pi Anthropic tool fixture passed." },
+            },
+            { type: "content_block_stop", index: 0 },
+          ];
+    for (const event of [
+      {
+        type: "message_start",
+        message: {
+          id: `msg_anthropic_fixture_${providerCalls}`,
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-haiku-4-5",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: providerCalls === 1 ? 11 : 19, output_tokens: 1 },
+        },
+      },
+      ...contentEvents,
+      {
+        type: "message_delta",
+        delta: {
+          stop_reason: providerCalls === 1 ? "tool_use" : "end_turn",
+          stop_sequence: null,
+        },
+        usage: { output_tokens: providerCalls === 1 ? 4 : 6 },
+      },
+      { type: "message_stop" },
+    ]) {
+      response.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+    }
+    response.end();
+  });
+  await new Promise((accept) => server.listen(0, "127.0.0.1", accept));
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  const events = [];
+  try {
+    await runPiConversation(
+      {
+        run_id: "run-managed-pi-anthropic",
+        session_id: "session-managed-pi-anthropic",
+        base_url: `http://127.0.0.1:${address.port}`,
+        model: "claude-haiku-4-5",
+        provider_kind: "anthropic",
+        provider_api_key: providerKey,
+        role: "primary",
+        messages: basicChatFixture.messages,
+        tools: [
+          {
+            name: "status",
+            description: "Read runtime status.",
+            input_schema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ],
+        tool_executor_url: `http://127.0.0.1:${address.port}/tool`,
+        runtime_backend: "pi",
+      },
+      (event) => events.push(event),
+    );
+  } finally {
+    await new Promise((accept) => server.close(accept));
+    delete process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;
+  }
+  assert.equal(providerCalls, 2);
+  assert.equal(toolCalls, 1);
+  assert.deepEqual(
+    events.map((event) => event.event),
+    ["message", "usage", "tool_call", "tool_result", "delta", "usage"],
+  );
+  assert.equal(events.at(-1).data.input_tokens, 19);
+  assert.equal(events.at(-1).data.output_tokens, 6);
+  assert.doesNotMatch(JSON.stringify(events), new RegExp(providerKey));
   validateRuntimeTrace(events);
 });
 

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -83,6 +83,32 @@ before(async () => {
       response.end(JSON.stringify({ app: "running", repair_required: false }));
       return;
     }
+    if (
+      request.method === "GET"
+      && [
+        "/v1/metrics/chat-routes?limit=100",
+        "/v1/metrics/chat-routes?limit=99",
+      ].includes(request.url)
+    ) {
+      const ready = request.url.endsWith("=100");
+      controlCalls.push({ method: request.method, url: request.url });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        schema_version: "understudy.chat_route_metrics.v1",
+        app_version: "0.2.5",
+        runtime_version: "0.3.3",
+        observed_row_limit: ready ? 100 : 99,
+        required_canonical_runtime_rows: 100,
+        remaining_canonical_runtime_rows: ready ? 0 : 1,
+        canonical_runtime_rows: ready ? 100 : 99,
+        pi_runtime_rows: ready ? 100 : 98,
+        compatibility_fallback_rows: ready ? 0 : 1,
+        pi_runtime_share: ready ? 1 : 98 / 99,
+        compatibility_engine_delete_ready: ready,
+        groups: [],
+      }));
+      return;
+    }
     const controlValues = {
       "GET /v1/models": [{ id: "understudy-small", ready: true }],
       "GET /v1/models/catalog": [{ id: "understudy-small", tier: "small" }],
@@ -236,6 +262,7 @@ describe("desktop API CLI", () => {
       "/v1/downloads/{download_id}",
       "/v1/downloads/{download_id}/cancel",
       "/v1/feedback/supervisor",
+      "/v1/metrics/chat-routes",
       "/v1/models",
       "/v1/models/catalog",
       "/v1/residency",
@@ -265,6 +292,27 @@ describe("desktop API CLI", () => {
     const value = JSON.parse(result.stdout);
     assert.equal(value.schema_version, "understudy.desktop_api.v2");
     assert.equal(value.api_version, "2.1.0");
+  });
+
+  it("exposes a fail-closed release observation gate for Rust fallback deletion", async () => {
+    const ready = await runCli([
+      "desktop", "migration-status", "--limit", "100", "--require-ready", "--json",
+    ]);
+    assert.equal(ready.status, 0, ready.stderr);
+    const value = JSON.parse(ready.stdout);
+    assert.equal(value.canonical_runtime_rows, 100);
+    assert.equal(value.compatibility_fallback_rows, 0);
+    assert.equal(value.remaining_canonical_runtime_rows, 0);
+    assert.equal(value.compatibility_engine_delete_ready, true);
+
+    const observing = await runCli([
+      "desktop", "migration-status", "--limit", "99", "--require-ready", "--json",
+    ]);
+    assert.equal(observing.status, 2, observing.stderr);
+    const pending = JSON.parse(observing.stdout);
+    assert.equal(pending.compatibility_fallback_rows, 1);
+    assert.equal(pending.remaining_canonical_runtime_rows, 1);
+    assert.equal(pending.compatibility_engine_delete_ready, false);
   });
 
   it("operates model downloads and residency through versioned REST with one-release fallback", async () => {

--- a/tests/desktop-grocery-proof.test.mjs
+++ b/tests/desktop-grocery-proof.test.mjs
@@ -43,4 +43,19 @@ describe("desktop grocery proof", () => {
     assert.equal(summary.small_model_output_share, 0.5);
     assert.equal(summary.supervisor_token_overhead, 9 / 26);
   });
+
+  it("replaces a rejected completed answer while retaining role evidence", () => {
+    const events = [
+      { event: "delta", data: { role: "student", text: '{"answer":"wrong"}' } },
+      { event: "student_interruption", data: { partial_text: '{"answer":"wrong"}' } },
+      { event: "teacher_continuation", data: { output_mode: "replace" } },
+      { event: "delta", data: { role: "teacher", text: '{"answer":"correct"}' } },
+    ];
+    const summary = summarizeEvents(events, 42);
+    assert.equal(summary.output, '{"answer":"correct"}');
+    assert.deepEqual(summary.output_by_role, {
+      student: '{"answer":"wrong"}',
+      teacher: '{"answer":"correct"}',
+    });
+  });
 });

--- a/tests/desktop-tool-proof.test.mjs
+++ b/tests/desktop-tool-proof.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  scoreToolTrace,
+  summarizeRows,
+} from "../experiments/desktop-tool-proof/run.mjs";
+
+const task = {
+  tool: "list_traces",
+  arguments: { limit: 1 },
+  expected_output: "OK",
+};
+
+describe("desktop strict-tool proof", () => {
+  it("requires one exact call, paired result, arguments, and output", () => {
+    const events = [
+      {
+        event: "tool_call",
+        data: {
+          call_id: "call-1",
+          name: "list_traces",
+          parsed_arguments: { limit: 1 },
+          parse_error: null,
+        },
+      },
+      {
+        event: "tool_result",
+        data: { call_id: "call-1", name: "list_traces", ok: true },
+      },
+      { event: "delta", data: { text: "OK" } },
+    ];
+    const score = scoreToolTrace(events, task);
+    assert.equal(score.strict_pass, true);
+    assert.equal(score.orphan_result_count, 0);
+    assert.deepEqual(score.checks, {
+      exactly_one_call: true,
+      exact_tool_name: true,
+      exact_arguments: true,
+      paired_successful_result: true,
+      exact_output: true,
+    });
+  });
+
+  it("rejects wrappers, malformed arguments, duplicates, and orphan results", () => {
+    const score = scoreToolTrace([
+      {
+        event: "tool_call",
+        data: {
+          call_id: "call-1",
+          name: "understudy_mcp_tool",
+          parsed_arguments: { tool_name: "list_traces" },
+          parse_error: null,
+        },
+      },
+      { event: "tool_result", data: { call_id: "orphan", name: "list_traces", ok: true } },
+      { event: "delta", data: { text: "YES" } },
+    ], task);
+    assert.equal(score.strict_pass, false);
+    assert.equal(score.orphan_result_count, 1);
+    assert.equal(score.checks.exact_tool_name, false);
+    assert.equal(score.checks.exact_arguments, false);
+    assert.equal(score.checks.paired_successful_result, false);
+    assert.equal(score.checks.exact_output, false);
+  });
+
+  it("summarizes promotion evidence without hiding individual failures", () => {
+    const common = {
+      candidate: "12b",
+      slot_id: 6,
+      elapsed_ms: 100,
+      total_tokens: 20,
+      parse_error: null,
+      orphan_result_count: 0,
+      called_tool: "status",
+      parsed_arguments: {},
+      result_ok: true,
+      output: "OK",
+    };
+    const summary = summarizeRows([
+      {
+        ...common,
+        repetition: 1,
+        task_id: "a",
+        strict_pass: true,
+        checks: {
+          exactly_one_call: true,
+          exact_tool_name: true,
+          exact_arguments: true,
+          paired_successful_result: true,
+          exact_output: true,
+        },
+      },
+      {
+        ...common,
+        repetition: 1,
+        task_id: "b",
+        strict_pass: false,
+        checks: {
+          exactly_one_call: false,
+          exact_tool_name: false,
+          exact_arguments: false,
+          paired_successful_result: false,
+          exact_output: false,
+        },
+      },
+    ]);
+    assert.equal(summary["12b"].strict_passes, 1);
+    assert.equal(summary["12b"].attempts, 2);
+    assert.equal(summary["12b"].strict_accuracy, 0.5);
+    assert.equal(summary["12b"].failures.length, 1);
+  });
+});


### PR DESCRIPTION
## What changed

- make the CLI-owned Pi sidecar the default Desktop conversation runtime, with Rust fallback only before any visible output or tool boundary
- route GUI chat, headless Desktop API, image chat, exact cancellation, custom eval, RLM, Fusion, and direct Anthropic through the same canonical event contract
- restore the owner-only `understudy.desktop_api.v2` model, residency, download, streamed-turn, replay, cancellation, and supervisor-feedback APIs
- preserve caller-owned `run_id` / `capture_run_id`, exact usage, tool evidence, marker-linked supervision, and private append-only JSONL
- resolve the CLI-owned pinned MLX/VLM runtime and remove duplicate tool aliases from generic wrappers
- fix completed-answer rejection: teacher corrections now replace the rejected output, receive the supervisor reason, and stay distinct from true mid-stream append takeovers
- add a frozen no-spend strict-tool proof with suite hashes, exact calls, exact arguments, paired results, parse/orphan accounting, and per-candidate failure rows

## Root cause and impact

The supervisor correctly rejected a completed small-model answer, but the runtime concatenated the teacher JSON after the rejected JSON. The teacher prompt also omitted the supervisor's specific reason. That made a correct intervention unusable and understated supervisor precision.

Runtime 0.3.3 now emits `teacher_continuation.output_mode` as `append` or `replace`. Rust clears rejected content for replacement, the GUI replaces the visible answer on the first teacher delta, and benchmark consumers honor the same event.

## Local model evidence

Strict exposed-tool slice, 3 repetitions x 8 tasks per model:

- 4B: 24/24 strict
- dense 12B: 24/24 strict
- sparse-MoE 26B: 24/24 strict
- zero parse errors and zero orphan results for all three

This isolates strict tool syntax from model topology: the 12B failure was duplicate/ambiguous tool exposure, not a dense-vs-sparse-MoE limitation. The slice is deliberately narrow and is not a production promotion claim.

Three frozen grocery repetitions before this P0 found 4B direct 3/9, 26B 9/9, and supervised 4B 3/9 because the correct teacher answer was concatenated. After the fix:

- 4B direct: 3/9 exact
- 26B: 9/9 exact
- supervised 4B: 6/9 exact
- 3/3 cart errors correctly interrupted and corrected
- 3 codebase errors missed; 0 false positives
- 85% mean small-model output share, ~43.2% supervisor token overhead

The remaining gap is supervisor recall on a constrained reasoning task, not output assembly.

Earlier 12B grocery evidence remains: 12B direct 6/9, 26B 9/9, supervised 12B 9/9 with no interventions and ~47.8% supervisor overhead. Keep 12B experimental until a broader agentic frozen slice passes.

## Other live proofs

- native image upload -> local 26B VLM -> canonical image SHA-256 evidence
- exact-run cancellation preserves the partial and terminates canonically
- restart restores the active transcript and Pi session state
- authenticated Desktop status/residency tools produce paired canonical calls and results
- direct Anthropic Messages uses Pi, keeps provider secrets out of evidence, and records exact usage
- process-cold/filesystem-warm readiness passed local fail-closed ceilings

No paid provider calls or trace uploads.

## Verification

- `npm run check`: 205 tests plus typecheck, skill validation, and package smoke
- focused post-prompt-change runtime and grocery regressions: 31/31
- Rust: 128 passed, 1 intentionally ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- production Next build
- rebuilt Tauri debug app and live authenticated Desktop API proof

## Remaining before Rust deletion

- ship one compatibility release
- observe at least 100 canonical GUI/headless/Fusion runs with zero fallback rows
- then remove the mapped ~4,200 Rust conversation-harness LOC

## Stack order

Merge this before #148. Cache health is rebased on this branch and owns runtime contract 0.3.4.
