### PR TITLE
Prompt Desktop users to update the CLI

### DIFF
--- a/apps/homescreen/app/components/StatusPane.tsx
+++ b/apps/homescreen/app/components/StatusPane.tsx
@@ -8,6 +8,7 @@ type ToolStatus = {
   id: string;
   label: string;
   installed: boolean;
+  update_available: boolean;
   command: string;
   detail: string;
 };
@@ -440,10 +441,10 @@ export function StatusPane({ status }: { status: StatusController }) {
                   ? bootstrap.understudy.detail || bootstrap.understudy.command
                   : "Installs the understudy CLI and public agent skills."
               }
-              done={bootstrap.understudy.installed}
+              done={bootstrap.understudy.installed && !bootstrap.understudy.update_available}
               busy={action === "install_understudy_agent_tools"}
-              action={bootstrap.understudy.installed ? undefined : () => runInstall("install_understudy_agent_tools")}
-              actionLabel="Install"
+              action={bootstrap.understudy.installed && !bootstrap.understudy.update_available ? undefined : () => runInstall("install_understudy_agent_tools")}
+              actionLabel={bootstrap.understudy.update_available ? "Update" : "Install"}
             />
             <SetupRow
               title="Moraine traces"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -18,9 +18,14 @@ pub struct ToolStatus {
     pub id: String,
     pub label: String,
     pub installed: bool,
+    pub update_available: bool,
     pub command: String,
     pub detail: String,
 }
+
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.1";
+const UNDERSTUDY_INSTALLER_URL: &str =
+    "https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {
@@ -93,12 +98,7 @@ pub fn status() -> BootstrapStatus {
     let snapshots = models::snapshots();
     BootstrapStatus {
         uv: command_status("uv", "uv", bin::uv(), &["--version"]),
-        understudy: command_status(
-            "understudy",
-            "Understudy agent tools",
-            bin::understudy(),
-            &["--version"],
-        ),
+        understudy: understudy_status(),
         moraine: command_status("moraine", "Moraine CLI", bin::moraine(), &["--version"]),
         moraine_mcp: command_status(
             "moraine_mcp",
@@ -133,12 +133,42 @@ pub fn install_mlx_runtime() -> Result<String, String> {
 }
 
 pub fn install_understudy_agent_tools() -> Result<String, String> {
-    let out = Command::new("npm")
-        .args(["install", "-g", "@understudylabs/understudy-agent-tools"])
+    let script = std::env::temp_dir().join(format!(
+        "understudy-agent-tools-install-{}.sh",
+        std::process::id()
+    ));
+    let download = Command::new("curl")
+        .args([
+            "--proto",
+            "=https",
+            "--tlsv1.2",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            UNDERSTUDY_INSTALLER_URL,
+            "--output",
+        ])
+        .arg(&script)
         .env("PATH", bin::runtime_path())
         .output()
-        .map_err(|e| format!("npm install failed to start: {e}"))?;
-    command_output(out)
+        .map_err(|e| format!("Understudy installer download failed to start: {e}"))?;
+    if let Err(error) = command_output(download) {
+        let _ = std::fs::remove_file(&script);
+        return Err(error);
+    }
+
+    let installed = Command::new("sh")
+        .arg(&script)
+        .args(["--noninteractive", "--agents", "none", "--keep-login"])
+        .env("UNDERSTUDY_NONINTERACTIVE", "1")
+        .env("UNDERSTUDY_AGENT_PLATFORMS", "none")
+        .env("UNDERSTUDY_KEEP_LOGIN", "1")
+        .env("PATH", bin::runtime_path())
+        .output()
+        .map_err(|e| format!("Understudy installer failed to start: {e}"));
+    let _ = std::fs::remove_file(&script);
+    installed.and_then(command_output)
 }
 
 pub async fn download_model(
@@ -484,6 +514,7 @@ fn command_status(id: &str, label: &str, command: String, args: &[&str]) -> Tool
             id: id.to_string(),
             label: label.to_string(),
             installed: true,
+            update_available: false,
             command,
             detail: String::from_utf8_lossy(&out.stdout).trim().to_string(),
         },
@@ -491,6 +522,7 @@ fn command_status(id: &str, label: &str, command: String, args: &[&str]) -> Tool
             id: id.to_string(),
             label: label.to_string(),
             installed: false,
+            update_available: false,
             command,
             detail: String::from_utf8_lossy(&out.stderr).trim().to_string(),
         },
@@ -498,10 +530,50 @@ fn command_status(id: &str, label: &str, command: String, args: &[&str]) -> Tool
             id: id.to_string(),
             label: label.to_string(),
             installed: false,
+            update_available: false,
             command,
             detail: err.to_string(),
         },
     }
+}
+
+fn understudy_status() -> ToolStatus {
+    let mut status = command_status(
+        "understudy",
+        "Understudy agent tools",
+        bin::understudy(),
+        &["--version"],
+    );
+    if status.installed
+        && parse_version(&status.detail)
+            .zip(parse_version(MIN_UNDERSTUDY_CLI_VERSION))
+            .is_none_or(|(installed, required)| installed < required)
+    {
+        status.update_available = true;
+        status.detail = format!(
+            "{} installed · update required (Desktop needs {}+)",
+            status.detail, MIN_UNDERSTUDY_CLI_VERSION
+        );
+    }
+    status
+}
+
+fn parse_version(value: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = value
+        .split_whitespace()
+        .next()?
+        .trim_start_matches('v')
+        .split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts
+        .next()?
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
 }
 
 fn mlx_status() -> ToolStatus {
@@ -510,6 +582,7 @@ fn mlx_status() -> ToolStatus {
         id: "mlx".to_string(),
         label: "MLX serving runtime".to_string(),
         installed: runtime.available,
+        update_available: false,
         command: runtime.command,
         detail: runtime.detail,
     }
@@ -522,5 +595,25 @@ fn command_output(out: std::process::Output) -> Result<String, String> {
         Ok(format!("{stdout}{stderr}"))
     } else {
         Err(format!("{stdout}{stderr}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_version_check_is_fail_closed_and_tracks_the_package_release() {
+        assert_eq!(parse_version("0.6.0"), Some((0, 6, 0)));
+        assert_eq!(parse_version("v0.6.1"), Some((0, 6, 1)));
+        assert_eq!(parse_version("0.6.1-beta.1"), Some((0, 6, 1)));
+        assert_eq!(parse_version("unknown"), None);
+
+        let package: serde_json::Value =
+            serde_json::from_str(include_str!("../../../../package.json")).unwrap();
+        assert_eq!(
+            package.get("version").and_then(serde_json::Value::as_str),
+            Some(MIN_UNDERSTUDY_CLI_VERSION)
+        );
     }
 }

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -3031,7 +3031,7 @@ pub async fn chat_stream(
                     crate::conversation_sidecar::SidecarAttempt::NativeFallback(reason) => {
                         let _ = on_event.send(ChatEvent::Notice {
                             message: format!(
-                                "Canonical runtime unavailable ({reason}). Continuing with the local compatibility engine."
+                                "Canonical runtime unavailable ({reason}). Continuing with the local compatibility engine. Open Status → First-run setup to update Understudy agent tools."
                             ),
                         });
                     }
@@ -3075,7 +3075,7 @@ pub async fn chat_stream(
             Err(reason) => {
                 let _ = on_event.send(ChatEvent::Notice {
                     message: format!(
-                        "Canonical runtime could not accept this turn ({reason}). Continuing with the local compatibility engine."
+                        "Canonical runtime could not accept this turn ({reason}). Continuing with the local compatibility engine. Open Status → First-run setup to update Understudy agent tools."
                     ),
                 });
             }


### PR DESCRIPTION
## Summary
- detect an installed but incompatible Understudy CLI and show Update instead of ready
- replace the broken unpublished npm-package install path with the supported public installer
- preserve login, install CLI-only, and tell fallback users exactly where to repair

## Validation
- npm run check (208 tests; skills and package smoke)
- cargo test (130 passed; 1 ignored real-database fixture)
- cargo clippy --all-targets -- -D warnings
- bun run build
- live preflight reproduced installed CLI 0.6.0 vs required 0.6.1/runtime 0.3.4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->