### PR TITLE
Fail closed on desktop runtime deletion evidence

### DIFF
--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -62,15 +62,32 @@ so the native Anthropic translator remains only as the one-release fallback.
 The release artifact exposes the gate directly:
 
 ```sh
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
+understudy runtime conformance \
+  --backend pi \
+  --base-url <offline-mlx-vlm-base-url> \
+  --model <served-model-id> \
+  --capabilities compaction,restart,supervision \
+  --deterministic-supervisor \
+  --deterministic-malformed-tool \
+  --deterministic-compaction \
+  --tool-executor-url <authenticated-loopback-tool-executor-url> \
+  --require-complete \
+  --output .understudy/capture-evidence/desktop-runtime-conformance.json
+npm run runtime:desktop-readiness -- \
+  --output .understudy/capture-evidence/desktop-runtime-readiness.json
 understudy desktop migration-status --require-ready --json
 ```
 
 The command exits `2` while observation is incomplete. The underlying
 versioned Desktop API cohorts rows by both app version and canonical-runtime
 version; legacy and development rows remain in SQLite but cannot poison or
-falsely satisfy the denominator. Delete the compatibility engine only after
-one released app/runtime cohort records a rolling window of at least 100
-canonical runs with:
+falsely satisfy the denominator. The CLI additionally verifies that both
+owner-only evidence files match the live app/runtime versions, current event
+schema, and exact frozen-scenario hashes; missing or stale evidence fails
+closed even after the cohort reaches 100 runs. Delete the compatibility engine
+only after one released app/runtime cohort records a rolling window of at least
+100 canonical runs with:
 
 - `compatibility_fallback_rows == 0`;
 - `pi_runtime_share == 1.0`;

--- a/scripts/desktop-runtime-readiness.mjs
+++ b/scripts/desktop-runtime-readiness.mjs
@@ -178,6 +178,16 @@ try {
     throw new Error("desktop server token is missing or malformed");
   }
   const authorization = { authorization: `Bearer ${token}` };
+  const cohortResponse = await fetchWithTimeout(`${baseUrl}/v1/metrics/chat-routes?limit=1`, {
+    headers: authorization,
+  });
+  if (!cohortResponse.ok) {
+    throw new Error(`migration metrics returned HTTP ${cohortResponse.status}`);
+  }
+  const cohort = await cohortResponse.json();
+  if (typeof cohort.app_version !== "string" || cohort.app_version.length === 0) {
+    throw new Error("migration metrics did not report the desktop app version");
+  }
 
   const runtimeStarted = performance.now();
   const runtimeRaw = run(
@@ -264,6 +274,7 @@ try {
     thresholds,
     checks,
     app: {
+      version: cohort.app_version,
       pid: app.pid,
       ready_ms: appReady.elapsed_ms,
       rss_mb: appRssKb === null ? null : appRssKb / 1024,

--- a/src/commands/desktop.ts
+++ b/src/commands/desktop.ts
@@ -11,6 +11,11 @@ import {
   requireDesktopApi,
   responseError,
 } from "../internal/desktop-api.js";
+import {
+  DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE,
+  DEFAULT_DESKTOP_READINESS_EVIDENCE,
+  evaluateDesktopRuntimeReleaseEvidence,
+} from "../runtime/conversation/release-gate.js";
 
 interface RuntimeEvent {
   run_id?: string;
@@ -195,11 +200,27 @@ export function registerDesktopCommand(program: Command): void {
     .command("migration-status")
     .description("Check the one-release Pi adoption gate before deleting the Rust fallback.")
     .option("--limit <n>", "Most-recent canonical/fallback rows to inspect", positiveInteger, 250)
-    .option("--require-ready", "Exit non-zero until 100 canonical runs have zero fallbacks")
+    .option(
+      "--conformance-evidence <path>",
+      "Private executable Pi conformance report",
+      DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE,
+    )
+    .option(
+      "--readiness-evidence <path>",
+      "Private desktop startup and memory readiness report",
+      DEFAULT_DESKTOP_READINESS_EVIDENCE,
+    )
+    .option("--require-ready", "Exit non-zero until cohort and release evidence are ready")
     .option("--json", "Output JSON")
     .action(async function (
       this: Command,
-      opts: { limit: number; requireReady?: boolean; json?: boolean },
+      opts: {
+        limit: number;
+        conformanceEvidence: string;
+        readinessEvidence: string;
+        requireReady?: boolean;
+        json?: boolean;
+      },
     ) {
       const capability = await requireDesktopApi();
       const query = `?limit=${opts.limit}`;
@@ -214,15 +235,29 @@ export function registerDesktopCommand(program: Command): void {
       const canonical = Number(value.canonical_runtime_rows ?? 0);
       const piRows = Number(value.pi_runtime_rows ?? 0);
       const fallbacks = Number(value.compatibility_fallback_rows ?? 0);
-      const ready = value.compatibility_engine_delete_ready === true;
+      const cohortReady =
+        value.compatibility_engine_delete_ready === true &&
+        canonical >= required &&
+        piRows === canonical &&
+        fallbacks === 0;
       const remaining = Number(
         value.remaining_canonical_runtime_rows ?? Math.max(0, required - canonical),
       );
+      const releaseEvidence = evaluateDesktopRuntimeReleaseEvidence({
+        app_version: value.app_version ?? "unknown",
+        runtime_version: value.runtime_version ?? "unknown",
+        conformance_path: opts.conformanceEvidence,
+        readiness_path: opts.readinessEvidence,
+      });
+      const ready = cohortReady && releaseEvidence.ready;
       const output = {
         ...value,
         required_canonical_runtime_rows: required,
         remaining_canonical_runtime_rows: remaining,
         observed_row_limit: value.observed_row_limit ?? opts.limit,
+        release_cohort_ready: cohortReady,
+        release_evidence: releaseEvidence,
+        compatibility_engine_delete_ready: ready,
       };
       const share = value.pi_runtime_share == null
         ? "unavailable"
@@ -235,6 +270,9 @@ export function registerDesktopCommand(program: Command): void {
           `release cohort: app ${value.app_version ?? "unknown"}, runtime ${value.runtime_version ?? "unknown"}`,
           `canonical runs: ${canonical}/${required} (${remaining} remaining)`,
           `Pi runs: ${piRows} (${share}); compatibility fallbacks: ${fallbacks}`,
+          `conformance evidence: ${releaseEvidence.conformance.ready ? "ready" : "missing or stale"}`,
+          `startup/memory evidence: ${releaseEvidence.readiness.ready ? "ready" : "missing or stale"}`,
+          ...releaseEvidence.reasons.map((reason) => `blocked: ${reason}`),
         ].join("\n"),
       );
       if (opts.requireReady && !ready) process.exitCode = 2;

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -467,6 +467,16 @@ export function registerRuntimeCommand(program: Command): void {
               capabilities,
               metadata: {
                 backend,
+                runtime_id: RUNTIME_ID,
+                runtime_version: RUNTIME_VERSION,
+                event_schema: EVENT_SCHEMA,
+                conformance_schema: CONFORMANCE_SCHEMA,
+                network_mode: options.allowRemote ? "remote_allowed" : "offline",
+                offline_environment: {
+                  hf_hub_offline: process.env.HF_HUB_OFFLINE === "1",
+                  transformers_offline: process.env.TRANSFORMERS_OFFLINE === "1",
+                  hf_datasets_offline: process.env.HF_DATASETS_OFFLINE === "1",
+                },
                 provider: { base_url: options.baseUrl, model: options.model },
                 supervision: {
                   student: {

--- a/src/runtime/conversation/release-gate.ts
+++ b/src/runtime/conversation/release-gate.ts
@@ -1,0 +1,287 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  CONFORMANCE_SCHEMA,
+  EVENT_SCHEMA,
+  RUNTIME_VERSION,
+} from "./contract.js";
+import { loadConversationConformanceInputs } from "./conformance.js";
+
+export const DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE =
+  ".understudy/capture-evidence/desktop-runtime-conformance.json";
+export const DEFAULT_DESKTOP_READINESS_EVIDENCE =
+  ".understudy/capture-evidence/desktop-runtime-readiness.json";
+
+type EvidenceCheck = {
+  path: string;
+  ready: boolean;
+  generated_at?: string;
+  reasons: string[];
+};
+
+export type DesktopRuntimeReleaseEvidence = {
+  schema_version: "understudy.desktop_runtime_release_evidence.v1";
+  ready: boolean;
+  conformance: EvidenceCheck;
+  readiness: EvidenceCheck;
+  reasons: string[];
+};
+
+type ReleaseEvidenceOptions = {
+  app_version: string;
+  runtime_version: string;
+  conformance_path?: string;
+  readiness_path?: string;
+};
+
+const READINESS_THRESHOLDS = {
+  app_ready_ms: 2_500,
+  runtime_ready_ms: 3_000,
+  max_model_load_ms: 45_000,
+  app_plus_runtime_rss_mb: 750,
+  total_model_rss_gb: 32,
+} as const;
+const READINESS_CHECKS = [
+  "app_ready",
+  "runtime_ready",
+  "models_ready",
+  "app_plus_runtime_memory",
+  "model_memory",
+] as const;
+
+function readPrivateJson(path: string, label: string): {
+  path: string;
+  value?: Record<string, unknown>;
+  reasons: string[];
+} {
+  const absolute = resolve(path);
+  const reasons: string[] = [];
+  if (!existsSync(absolute)) {
+    return { path: absolute, reasons: [`${label} evidence is missing`] };
+  }
+  try {
+    const stat = statSync(absolute);
+    if (!stat.isFile()) reasons.push(`${label} evidence is not a regular file`);
+    if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+      reasons.push(`${label} evidence must be owner-only (0600)`);
+    }
+    const value = JSON.parse(readFileSync(absolute, "utf8")) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      reasons.push(`${label} evidence must be a JSON object`);
+      return { path: absolute, reasons };
+    }
+    return { path: absolute, value: value as Record<string, unknown>, reasons };
+  } catch (error) {
+    reasons.push(
+      `${label} evidence is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { path: absolute, reasons };
+  }
+}
+
+function validTimestamp(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function conformanceEvidence(
+  path: string,
+  runtimeVersion: string,
+): EvidenceCheck {
+  const loaded = readPrivateJson(path, "conformance");
+  const reasons = [...loaded.reasons];
+  const report = loaded.value;
+  if (!report) return { path: loaded.path, ready: false, reasons };
+
+  if (report.schema_version !== CONFORMANCE_SCHEMA) {
+    reasons.push(`conformance schema must be ${CONFORMANCE_SCHEMA}`);
+  }
+  const suite = loadConversationConformanceInputs();
+  if (report.suite_id !== suite.suite_id) {
+    reasons.push(`conformance suite must be ${suite.suite_id}`);
+  }
+  if (report.adapter_id !== "pi") reasons.push("conformance adapter must be pi");
+  if (report.passed !== true || report.complete !== true || report.eligible_for_promotion !== true) {
+    reasons.push("conformance report must be passed, complete, and eligible for promotion");
+  }
+  if (!validTimestamp(report.generated_at)) reasons.push("conformance generated_at is invalid");
+
+  const metadata = report.metadata && typeof report.metadata === "object"
+    ? report.metadata as Record<string, unknown>
+    : {};
+  if (metadata.runtime_version !== runtimeVersion) {
+    reasons.push(`conformance runtime version must match ${runtimeVersion}`);
+  }
+  if (metadata.runtime_version !== RUNTIME_VERSION) {
+    reasons.push(`conformance runtime version must match installed CLI ${RUNTIME_VERSION}`);
+  }
+  if (metadata.event_schema !== EVENT_SCHEMA) {
+    reasons.push(`conformance event schema must be ${EVENT_SCHEMA}`);
+  }
+  if (metadata.network_mode !== "offline") {
+    reasons.push("conformance network mode must be offline");
+  }
+  const provider = metadata.provider && typeof metadata.provider === "object"
+    ? metadata.provider as Record<string, unknown>
+    : {};
+  try {
+    const providerUrl = new URL(String(provider.base_url ?? ""));
+    if (!["127.0.0.1", "localhost", "::1"].includes(providerUrl.hostname)) {
+      reasons.push("conformance provider must be loopback-only");
+    }
+  } catch {
+    reasons.push("conformance provider URL is invalid");
+  }
+  const offline = metadata.offline_environment && typeof metadata.offline_environment === "object"
+    ? metadata.offline_environment as Record<string, unknown>
+    : {};
+  for (const name of ["hf_hub_offline", "transformers_offline", "hf_datasets_offline"]) {
+    if (offline[name] !== true) reasons.push(`conformance ${name} must be enabled`);
+  }
+
+  const scenarios = Array.isArray(report.scenarios)
+    ? report.scenarios.filter(
+        (value): value is Record<string, unknown> =>
+          Boolean(value) && typeof value === "object" && !Array.isArray(value),
+      )
+    : [];
+  if (scenarios.length !== suite.inputs.length) {
+    reasons.push(`conformance report must contain exactly ${suite.inputs.length} scenarios`);
+  }
+  for (const expected of suite.inputs) {
+    const matches = scenarios.filter((scenario) => scenario.id === expected.id);
+    if (matches.length !== 1) {
+      reasons.push(`conformance scenario ${expected.id} must appear exactly once`);
+      continue;
+    }
+    const scenario = matches[0];
+    if (scenario.status !== "passed") reasons.push(`conformance scenario ${expected.id} did not pass`);
+    if (scenario.fixture !== expected.fixture) {
+      reasons.push(`conformance scenario ${expected.id} fixture path is stale`);
+    }
+    if (scenario.fixture_sha256 !== expected.sha256) {
+      reasons.push(`conformance scenario ${expected.id} fixture hash is stale`);
+    }
+  }
+
+  return {
+    path: loaded.path,
+    ready: reasons.length === 0,
+    ...(validTimestamp(report.generated_at) ? { generated_at: report.generated_at } : {}),
+    reasons,
+  };
+}
+
+function readinessEvidence(
+  path: string,
+  appVersion: string,
+  runtimeVersion: string,
+): EvidenceCheck {
+  const loaded = readPrivateJson(path, "readiness");
+  const reasons = [...loaded.reasons];
+  const report = loaded.value;
+  if (!report) return { path: loaded.path, ready: false, reasons };
+
+  if (report.schema_version !== "understudy-desktop-runtime-readiness-v1") {
+    reasons.push("readiness schema must be understudy-desktop-runtime-readiness-v1");
+  }
+  if (report.passed !== true) reasons.push("readiness report did not pass");
+  if (!validTimestamp(report.generated_at)) reasons.push("readiness generated_at is invalid");
+  if (report.measurement_class !== "process-cold-filesystem-warm") {
+    reasons.push("readiness measurement class must be process-cold-filesystem-warm");
+  }
+
+  const app = report.app && typeof report.app === "object"
+    ? report.app as Record<string, unknown>
+    : {};
+  if (app.version !== appVersion) reasons.push(`readiness app version must match ${appVersion}`);
+  const runtime = report.runtime && typeof report.runtime === "object"
+    ? report.runtime as Record<string, unknown>
+    : {};
+  if (runtime.runtime_version !== runtimeVersion) {
+    reasons.push(`readiness runtime version must match ${runtimeVersion}`);
+  }
+  if (runtime.runtime_version !== RUNTIME_VERSION) {
+    reasons.push(`readiness runtime version must match installed CLI ${RUNTIME_VERSION}`);
+  }
+  if (runtime.event_schema !== EVENT_SCHEMA) {
+    reasons.push(`readiness event schema must be ${EVENT_SCHEMA}`);
+  }
+  const checks = report.checks && typeof report.checks === "object"
+    ? report.checks as Record<string, unknown>
+    : {};
+  for (const name of READINESS_CHECKS) {
+    if (checks[name] !== true) reasons.push(`readiness check ${name} must pass`);
+  }
+  const thresholds = report.thresholds && typeof report.thresholds === "object"
+    ? report.thresholds as Record<string, unknown>
+    : {};
+  for (const [name, ceiling] of Object.entries(READINESS_THRESHOLDS)) {
+    if (thresholds[name] !== ceiling) reasons.push(`readiness threshold ${name} must be ${ceiling}`);
+  }
+
+  const finite = (value: unknown): value is number =>
+    typeof value === "number" && Number.isFinite(value) && value >= 0;
+  if (!finite(app.ready_ms) || app.ready_ms > READINESS_THRESHOLDS.app_ready_ms) {
+    reasons.push("desktop startup measurement exceeds the release ceiling");
+  }
+  if (!finite(app.rss_mb)) reasons.push("desktop RSS measurement is missing");
+  if (!finite(runtime.ready_ms) || runtime.ready_ms > READINESS_THRESHOLDS.runtime_ready_ms) {
+    reasons.push("runtime startup measurement exceeds the release ceiling");
+  }
+  if (!finite(runtime.rss_mb)) reasons.push("runtime RSS measurement is missing");
+  if (
+    !finite(report.app_plus_runtime_rss_mb) ||
+    report.app_plus_runtime_rss_mb > READINESS_THRESHOLDS.app_plus_runtime_rss_mb
+  ) {
+    reasons.push("combined desktop/runtime RSS exceeds the release ceiling");
+  }
+  if (
+    !finite(report.total_model_rss_gb) ||
+    report.total_model_rss_gb > READINESS_THRESHOLDS.total_model_rss_gb
+  ) {
+    reasons.push("model RSS exceeds the release ceiling");
+  }
+  const models = Array.isArray(report.models)
+    ? report.models.filter(
+        (value): value is Record<string, unknown> =>
+          Boolean(value) && typeof value === "object" && !Array.isArray(value),
+      )
+    : [];
+  if (models.length === 0) reasons.push("readiness report contains no restored model measurements");
+  for (const model of models) {
+    if (!finite(model.load_ms) || model.load_ms > READINESS_THRESHOLDS.max_model_load_ms) {
+      reasons.push("a restored model load measurement exceeds the release ceiling");
+    }
+    if (!finite(model.rss_gb)) reasons.push("a restored model RSS measurement is missing");
+  }
+
+  return {
+    path: loaded.path,
+    ready: reasons.length === 0,
+    ...(validTimestamp(report.generated_at) ? { generated_at: report.generated_at } : {}),
+    reasons,
+  };
+}
+
+export function evaluateDesktopRuntimeReleaseEvidence(
+  options: ReleaseEvidenceOptions,
+): DesktopRuntimeReleaseEvidence {
+  const conformance = conformanceEvidence(
+    options.conformance_path ?? DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE,
+    options.runtime_version,
+  );
+  const readiness = readinessEvidence(
+    options.readiness_path ?? DEFAULT_DESKTOP_READINESS_EVIDENCE,
+    options.app_version,
+    options.runtime_version,
+  );
+  const reasons = [...conformance.reasons, ...readiness.reasons];
+  return {
+    schema_version: "understudy.desktop_runtime_release_evidence.v1",
+    ready: conformance.ready && readiness.ready,
+    conformance,
+    readiness,
+    reasons,
+  };
+}

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -2164,6 +2164,22 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       base_url: baseUrl,
       model: "conformance-cli",
     });
+    assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.4");
+    assert.equal(
+      cliReport.metadata.event_schema,
+      "understudy-conversation-runtime-event-v1",
+    );
+    assert.equal(
+      cliReport.metadata.conformance_schema,
+      "understudy-conversation-runtime-conformance-v1",
+    );
+    assert.equal(cliReport.metadata.network_mode, "offline");
+    assert.deepEqual(cliReport.metadata.offline_environment, {
+      hf_hub_offline: false,
+      transformers_offline: false,
+      hf_datasets_offline: false,
+    });
     assert.equal(cliReport.metadata.supervisor_mode, "deterministic_fixture");
     assert.equal(cliReport.metadata.malformed_tool_mode, "deterministic_fixture");
     assert.equal(cliReport.metadata.compaction_mode, "deterministic_fixture");

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -10,6 +10,8 @@ const cli = ["node", resolve("dist/bin.js")];
 const root = mkdtempSync(join(tmpdir(), "understudy-desktop-api-"));
 const capabilityPath = join(root, "desktop-api.json");
 const imagePath = join(root, "shelf.png");
+const conformanceEvidencePath = join(root, "desktop-runtime-conformance.json");
+const readinessEvidencePath = join(root, "desktop-runtime-readiness.json");
 const token = "desktop-api-test-token-".padEnd(64, "a");
 let server;
 let port;
@@ -50,7 +52,75 @@ function envelope(sequence, event, data) {
   };
 }
 
+function writeReleaseEvidence() {
+  const manifest = JSON.parse(readFileSync(
+    resolve("schemas/conversation-runtime-conformance/manifest.json"),
+    "utf8",
+  ));
+  writeFileSync(conformanceEvidencePath, `${JSON.stringify({
+    schema_version: "understudy-conversation-runtime-conformance-v1",
+    suite_id: manifest.suite_id,
+    adapter_id: "pi",
+    generated_at: "2026-07-12T20:00:00.000Z",
+    metadata: {
+      runtime_version: "0.3.4",
+      event_schema: "understudy-conversation-runtime-event-v1",
+      network_mode: "offline",
+      provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
+      offline_environment: {
+        hf_hub_offline: true,
+        transformers_offline: true,
+        hf_datasets_offline: true,
+      },
+    },
+    passed: true,
+    complete: true,
+    eligible_for_promotion: true,
+    scenarios: manifest.input_fixtures.map((fixture) => ({
+      id: fixture.id,
+      fixture: fixture.fixture,
+      fixture_sha256: fixture.fixture_sha256,
+      status: "passed",
+      event_count: 1,
+      output_chars: 0,
+    })),
+  }, null, 2)}\n`);
+  chmodSync(conformanceEvidencePath, 0o600);
+  writeFileSync(readinessEvidencePath, `${JSON.stringify({
+    schema_version: "understudy-desktop-runtime-readiness-v1",
+    generated_at: "2026-07-12T20:05:00.000Z",
+    measurement_class: "process-cold-filesystem-warm",
+    passed: true,
+    thresholds: {
+      app_ready_ms: 2500,
+      runtime_ready_ms: 3000,
+      max_model_load_ms: 45000,
+      app_plus_runtime_rss_mb: 750,
+      total_model_rss_gb: 32,
+    },
+    checks: {
+      app_ready: true,
+      runtime_ready: true,
+      models_ready: true,
+      app_plus_runtime_memory: true,
+      model_memory: true,
+    },
+    app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
+    runtime: {
+      runtime_version: "0.3.4",
+      event_schema: "understudy-conversation-runtime-event-v1",
+      ready_ms: 700,
+      rss_mb: 120,
+    },
+    app_plus_runtime_rss_mb: 220,
+    total_model_rss_gb: 4,
+    models: [{ model_id: "understudy-small", load_ms: 2000, rss_gb: 4 }],
+  }, null, 2)}\n`);
+  chmodSync(readinessEvidencePath, 0o600);
+}
+
 before(async () => {
+  writeReleaseEvidence();
   server = createServer(async (request, response) => {
     if (request.url === "/health") {
       response.writeHead(200);
@@ -95,8 +165,8 @@ before(async () => {
       response.writeHead(200, { "content-type": "application/json" });
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
-        app_version: "0.2.5",
-        runtime_version: "0.3.3",
+        app_version: "0.3.2",
+        runtime_version: "0.3.4",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,
@@ -296,23 +366,62 @@ describe("desktop API CLI", () => {
 
   it("exposes a fail-closed release observation gate for Rust fallback deletion", async () => {
     const ready = await runCli([
-      "desktop", "migration-status", "--limit", "100", "--require-ready", "--json",
+      "desktop", "migration-status", "--limit", "100", "--require-ready",
+      "--conformance-evidence", conformanceEvidencePath,
+      "--readiness-evidence", readinessEvidencePath,
+      "--json",
     ]);
     assert.equal(ready.status, 0, ready.stderr);
     const value = JSON.parse(ready.stdout);
     assert.equal(value.canonical_runtime_rows, 100);
     assert.equal(value.compatibility_fallback_rows, 0);
     assert.equal(value.remaining_canonical_runtime_rows, 0);
+    assert.equal(value.release_cohort_ready, true);
+    assert.equal(value.release_evidence.ready, true);
     assert.equal(value.compatibility_engine_delete_ready, true);
 
     const observing = await runCli([
-      "desktop", "migration-status", "--limit", "99", "--require-ready", "--json",
+      "desktop", "migration-status", "--limit", "99", "--require-ready",
+      "--conformance-evidence", conformanceEvidencePath,
+      "--readiness-evidence", readinessEvidencePath,
+      "--json",
     ]);
     assert.equal(observing.status, 2, observing.stderr);
     const pending = JSON.parse(observing.stdout);
     assert.equal(pending.compatibility_fallback_rows, 1);
     assert.equal(pending.remaining_canonical_runtime_rows, 1);
+    assert.equal(pending.release_evidence.ready, true);
     assert.equal(pending.compatibility_engine_delete_ready, false);
+
+    const missingEvidence = await runCli([
+      "desktop", "migration-status", "--limit", "100", "--require-ready",
+      "--conformance-evidence", join(root, "missing-conformance.json"),
+      "--readiness-evidence", readinessEvidencePath,
+      "--json",
+    ]);
+    assert.equal(missingEvidence.status, 2, missingEvidence.stderr);
+    const missing = JSON.parse(missingEvidence.stdout);
+    assert.equal(missing.release_cohort_ready, true);
+    assert.equal(missing.release_evidence.ready, false);
+    assert.equal(missing.compatibility_engine_delete_ready, false);
+    assert.match(missing.release_evidence.reasons.join("\n"), /conformance evidence is missing/);
+
+    const staleConformancePath = join(root, "stale-conformance.json");
+    const staleConformance = JSON.parse(readFileSync(conformanceEvidencePath, "utf8"));
+    staleConformance.scenarios[0].fixture_sha256 = "0".repeat(64);
+    writeFileSync(staleConformancePath, `${JSON.stringify(staleConformance, null, 2)}\n`);
+    chmodSync(staleConformancePath, 0o600);
+    const staleEvidence = await runCli([
+      "desktop", "migration-status", "--limit", "100", "--require-ready",
+      "--conformance-evidence", staleConformancePath,
+      "--readiness-evidence", readinessEvidencePath,
+      "--json",
+    ]);
+    assert.equal(staleEvidence.status, 2, staleEvidence.stderr);
+    const stale = JSON.parse(staleEvidence.stdout);
+    assert.equal(stale.release_cohort_ready, true);
+    assert.equal(stale.compatibility_engine_delete_ready, false);
+    assert.match(stale.release_evidence.reasons.join("\n"), /fixture hash is stale/);
   });
 
   it("operates model downloads and residency through versioned REST with one-release fallback", async () => {


### PR DESCRIPTION
## What changed
- require the 100-run Pi cohort plus current executable conformance and startup/memory evidence before the CLI reports Rust fallback deletion ready
- match exact frozen fixture hashes, app/runtime versions, event schema, loopback-only offline settings, fixed thresholds, and owner-only evidence files
- stamp executable conformance reports with runtime/network metadata and stamp readiness reports with the measured app version
- document the release-evidence commands

## Why
The Desktop API cohort flag could become true from 100 clean rows alone even if image, offline, tool, cancellation, supervision, restart, compaction, startup, or memory evidence was missing or stale. This makes the public deletion gate reflect the full migration definition of done.

## Validation
- `npm run check`
- focused conversation-runtime and desktop API suites
- live installed Desktop 0.3.2 probe: exits 2 at 1/100 and reports missing release evidence without counting synthetic traffic
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->