### PR TITLE
Reject live model listeners in cold readiness probes

### DIFF
--- a/scripts/desktop-runtime-readiness.mjs
+++ b/scripts/desktop-runtime-readiness.mjs
@@ -144,10 +144,21 @@ if (await healthReady()) {
 const warmBefore = sqliteRows(
   "SELECT slot_id, model_id, port, server_pid, mem_gb FROM residency WHERE warm=1 ORDER BY slot_id",
 );
-const liveOrphans = warmBefore.filter((slot) => processAlive(Number(slot.server_pid)));
+// Older residency rows may have a null/stale persisted PID even while the
+// model server still owns its configured loopback port. A release readiness
+// claim must reject either form or it can accidentally measure a warm process.
+const liveOrphans = warmBefore
+  .map((slot) => {
+    const persistedPid = Number(slot.server_pid);
+    const livePid = processAlive(persistedPid)
+      ? persistedPid
+      : listenerPid(Number(slot.port));
+    return { ...slot, live_pid: livePid };
+  })
+  .filter((slot) => slot.live_pid !== null);
 if (liveOrphans.length > 0) {
   throw new Error(
-    `warm model processes are still alive for slots ${liveOrphans.map((slot) => slot.slot_id).join(", ")}; stop them before measuring cold startup`,
+    `warm model processes are still alive for slots ${liveOrphans.map((slot) => `${slot.slot_id} (pid ${slot.live_pid})`).join(", ")}; stop them before measuring cold startup`,
   );
 }
 


### PR DESCRIPTION
## What changed
- inspect each warm residency slot's configured loopback port when its persisted server PID is null or stale
- fail the cold-start readiness probe with the exact slot and live listener PID

## Why
Quitting Desktop left four MLX servers alive while their SQLite `server_pid` values were null. The previous preflight would have accepted those processes and produced a false process-cold measurement.

## Validation
- live regression: Desktop stopped, ports 8091/8095/8096/8092 remained live, probe rejected all four before launch
- full `npm run check`
- Desktop restored and healthy afterward
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->