### PR TITLE
Make supervisor confidence evidence explicit

### DIFF
--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -106,6 +106,8 @@ pub(crate) enum RuntimeEvent {
         reason: Option<String>,
         #[serde(default)]
         probabilities: Option<Value>,
+        #[serde(default)]
+        probability_kind: Option<String>,
     },
     StudentInterruption {
         marker_id: String,
@@ -289,6 +291,54 @@ fn is_sha256(value: &str) -> bool {
             .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
+fn validate_verdict_probabilities(
+    probabilities: &Option<Value>,
+    probability_kind: &Option<String>,
+) -> Result<(), String> {
+    let Some(probabilities) = probabilities else {
+        if probability_kind.is_some() {
+            return Err("supervisor verdict probability_kind requires probabilities".to_string());
+        }
+        return Ok(());
+    };
+    let Some(kind) = probability_kind.as_deref() else {
+        // Runtime 0.3.4 initially omitted the kind at the Rust bridge. Keep
+        // those already-persisted traces readable while requiring all new Pi
+        // evidence to carry an explicit interpretation.
+        return Ok(());
+    };
+    if kind != "logprob" {
+        return Err(format!(
+            "unknown supervisor verdict probability_kind {kind}"
+        ));
+    }
+    let values = probabilities
+        .as_object()
+        .ok_or_else(|| "supervisor verdict probabilities must be an object".to_string())?;
+    if values.is_empty() {
+        return Err("supervisor verdict probabilities cannot be empty".to_string());
+    }
+    for (verdict, value) in values {
+        if !matches!(
+            verdict.as_str(),
+            "continue" | "interrupt" | "stop" | "nudge"
+        ) {
+            return Err(format!(
+                "unknown supervisor verdict probability key {verdict}"
+            ));
+        }
+        let value = value
+            .as_f64()
+            .ok_or_else(|| format!("supervisor verdict probability {verdict} must be finite"))?;
+        if !value.is_finite() || value > 0.0 {
+            return Err(format!(
+                "supervisor verdict logprob {verdict} must be finite and at most zero"
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), String> {
     let Some(first) = events.first() else {
         return Err("runtime trace must contain at least one event".to_string());
@@ -384,7 +434,8 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
                 source,
                 marker_id,
                 reason,
-                ..
+                probabilities,
+                probability_kind,
             } => {
                 if !matches!(source.as_str(), "model" | "policy" | "human") {
                     return Err(format!("unknown supervisor verdict source {source}"));
@@ -403,6 +454,7 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
                         .ok_or_else(|| "interrupt verdict requires marker_id".to_string())?;
                     interrupt_markers.insert(marker);
                 }
+                validate_verdict_probabilities(probabilities, probability_kind)?;
             }
             RuntimeEvent::StudentInterruption {
                 marker_id, reason, ..
@@ -531,7 +583,8 @@ mod tests {
                     source: "model".to_string(),
                     marker_id: Some("marker-1".to_string()),
                     reason: Some("wrong tool".to_string()),
-                    probabilities: Some(json!({"interrupt": 0.9})),
+                    probabilities: Some(json!({"interrupt": -0.1})),
+                    probability_kind: Some("logprob".to_string()),
                 },
             ),
             envelope(
@@ -555,5 +608,26 @@ mod tests {
             ),
         ];
         validate_trace(&events).unwrap();
+        let serialized = serde_json::to_value(&events[0]).unwrap();
+        assert_eq!(serialized["data"]["probability_kind"], json!("logprob"));
+        assert_eq!(serialized["data"]["probabilities"]["interrupt"], -0.1);
+    }
+
+    #[test]
+    fn rejects_invalid_typed_verdict_probability_evidence() {
+        let invalid = vec![envelope(
+            0,
+            RuntimeEvent::SupervisorVerdict {
+                verdict: RuntimeVerdict::Continue,
+                source: "model".to_string(),
+                marker_id: Some("marker-1".to_string()),
+                reason: None,
+                probabilities: Some(json!({"continue": 0.9})),
+                probability_kind: Some("logprob".to_string()),
+            },
+        )];
+        assert!(validate_trace(&invalid)
+            .unwrap_err()
+            .contains("must be finite and at most zero"));
     }
 }

--- a/experiments/desktop-grocery-proof/DEMO.md
+++ b/experiments/desktop-grocery-proof/DEMO.md
@@ -108,6 +108,7 @@ Call out:
 
 - one exact `run_id` across the trace;
 - stable verdict/intervention marker IDs;
+- the supervisor's recorded reason and chosen-verdict first-token probability;
 - separate student and supervisor token counts;
 - the student partial and any teacher continuation remain separate;
 - a human can label a missed intervention without rewriting history.
@@ -115,6 +116,10 @@ Call out:
 The question changes from “should we trust small models?” to “which workload
 clusters have enough evidence to route, supervise, improve, or keep on the
 incumbent?”
+
+Do not call the first-token probability a calibrated correctness score. A
+confident missed error is evidence that the judge needs work, not evidence that
+the rejected student was safe.
 
 ## 22-27 minutes: show deployment safety
 

--- a/experiments/desktop-grocery-proof/README.md
+++ b/experiments/desktop-grocery-proof/README.md
@@ -27,7 +27,9 @@ retains the exact `run_id` and frozen suite SHA-256.
 Each run also writes a self-contained `report.html` plus its structured
 `report.json` model. The report leads with a bounded route recommendation,
 quality/latency comparison, per-task decision, supervisor audit, caveats, and
-next pilot gate. It contains no raw prompts or completions and makes no remote
+next pilot gate. The supervisor audit preserves each verdict reason and shows
+chosen-verdict first-token probability without presenting it as calibrated
+correctness. It contains no raw prompts or completions and makes no remote
 requests.
 
 To add the report to an older immutable proof without rerunning models:

--- a/experiments/desktop-grocery-proof/report.mjs
+++ b/experiments/desktop-grocery-proof/report.mjs
@@ -30,6 +30,65 @@ function integer(value) {
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(Number(value ?? 0));
 }
 
+export function verdictProbabilityEvidence(verdict) {
+  const raw = verdict?.probabilities;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      chosen_probability: null,
+      probabilities: null,
+      probability_kind: null,
+      source_probability_kind: verdict?.probability_kind ?? null,
+      inferred_source_kind: false,
+    };
+  }
+  const entries = Object.entries(raw)
+    .filter(([, value]) => typeof value === "number" && Number.isFinite(value));
+  if (!entries.length) {
+    return {
+      chosen_probability: null,
+      probabilities: null,
+      probability_kind: null,
+      source_probability_kind: verdict?.probability_kind ?? null,
+      inferred_source_kind: false,
+    };
+  }
+  const explicitKind = verdict?.probability_kind ?? null;
+  const legacyLogprob = explicitKind == null
+    && entries.some(([, value]) => value < 0)
+    && entries.every(([, value]) => value <= 0);
+  const isLogprob = explicitKind === "logprob" || legacyLogprob;
+  const probabilities = Object.fromEntries(entries.map(([name, value]) => [
+    name,
+    isLogprob ? Math.exp(value) : value,
+  ]));
+  if (Object.values(probabilities).some(
+    (value) => !Number.isFinite(value) || value < 0 || value > 1,
+  )) {
+    return {
+      chosen_probability: null,
+      probabilities: null,
+      probability_kind: null,
+      source_probability_kind: explicitKind,
+      inferred_source_kind: legacyLogprob,
+    };
+  }
+  return {
+    chosen_probability: probabilities[verdict?.verdict] ?? null,
+    probabilities,
+    probability_kind: isLogprob ? "first_token_probability_from_logprob" : explicitKind,
+    source_probability_kind: explicitKind ?? (legacyLogprob ? "logprob" : null),
+    inferred_source_kind: legacyLogprob,
+  };
+}
+
+function judgmentOutcome(row, verdict) {
+  if (row.supervisor_correct_intervention) return "correct intervention";
+  if (row.supervisor_missed_error) return "missed error";
+  if (row.supervisor_false_positive) return "false positive";
+  if (verdict.verdict === "continue" && row.student_score?.exact) return "correct continue";
+  return "review";
+}
+
 function decisionForTask(task, rows) {
   const small = rows.find((row) => row.mode === "small");
   const main = rows.find((row) => row.mode === "main");
@@ -119,9 +178,22 @@ export function buildReportModel(summary, rows, tasks) {
   const supervised = summary.by_mode.supervised;
   const smallLatency = Number(small.latency_reduction_vs_main ?? 0);
   const supervisedLatency = Number(supervised.latency_reduction_vs_main ?? 0);
+  const judgments = rows
+    .filter((row) => row.mode === "supervised")
+    .flatMap((row) => (row.verdicts ?? []).map((verdict, ordinal) => ({
+      task_id: row.task_id,
+      task_title: row.task_title,
+      marker_id: verdict.marker_id ?? null,
+      ordinal,
+      verdict: verdict.verdict,
+      reason: verdict.reason ?? null,
+      reason_recorded: typeof verdict.reason === "string" && verdict.reason.trim().length > 0,
+      outcome: judgmentOutcome(row, verdict),
+      ...verdictProbabilityEvidence(verdict),
+    })));
 
   return {
-    schema_version: "understudy.desktop_grocery_buyer_report.v1",
+    schema_version: "understudy.desktop_grocery_buyer_report.v2",
     title: "Grocery AI routing decision",
     proof_id: summary.proof_id,
     suite_sha256: summary.suite_sha256,
@@ -144,6 +216,7 @@ export function buildReportModel(summary, rows, tasks) {
       false_positives: supervised.supervisor_false_positives,
       small_model_output_share: supervised.mean_small_model_output_share,
       supervisor_token_overhead: supervised.mean_supervisor_token_overhead,
+      judgments,
     },
     next_steps: [
       "Freeze 30–50 representative examples for each workflow cluster before changing traffic.",
@@ -159,6 +232,7 @@ export function buildReportModel(summary, rows, tasks) {
       "Synthetic local tasks only; no customer prompts, production traffic, or remote judge were used.",
       "Three examples expose integration and failure modes but are too small for a replacement claim.",
       "Token counts are provider-reported by model role; dollar cost requires an explicit incumbent cost basis.",
+      "Verdict confidence is the provider's first-token probability derived from logprobs; it is not a calibrated probability that the judgment is correct.",
     ],
     sources: ["summary.json", "results.jsonl", "tasks.json", "*.events.jsonl"],
     chart_map: [
@@ -198,6 +272,27 @@ function decisionCard(decision, rows) {
   </article>`;
 }
 
+function judgmentCard(judgment) {
+  const confidence = judgment.chosen_probability == null
+    ? "Not available"
+    : percent(judgment.chosen_probability, 1);
+  const reason = judgment.reason_recorded
+    ? judgment.reason
+    : judgment.verdict === "continue"
+      ? "No reason required for a continue verdict."
+      : "No reason was recorded.";
+  const sourceNote = judgment.inferred_source_kind
+    ? "Legacy evidence: probability kind inferred from negative logprobs."
+    : judgment.probability_kind === "first_token_probability_from_logprob"
+      ? "Derived from the provider's first-token logprob."
+      : "Provider confidence was not available.";
+  return `<article class="judgment ${escapeHtml(judgment.outcome.replaceAll(" ", "-"))}" data-source="results.jsonl">
+    <div class="judgment-top"><div><span class="eyebrow">${escapeHtml(judgment.task_id)}</span><h3>${escapeHtml(judgment.verdict)}</h3></div><span class="pill">${escapeHtml(judgment.outcome)}</span></div>
+    <p>${escapeHtml(reason)}</p>
+    <footer><strong>${escapeHtml(confidence)}</strong> chosen-verdict first-token probability · ${escapeHtml(sourceNote)}</footer>
+  </article>`;
+}
+
 export function buildBuyerReport(summary, rows, tasks) {
   const model = buildReportModel(summary, rows, tasks);
   const maxLatency = Math.max(...model.modes.map((mode) => Number(mode.mean_latency_ms)));
@@ -211,6 +306,7 @@ export function buildBuyerReport(summary, rows, tasks) {
   const nextSteps = model.next_steps.map((item) => `<li>${escapeHtml(item)}</li>`).join("\n");
   const questions = model.further_questions.map((item) => `<li>${escapeHtml(item)}</li>`).join("\n");
   const caveats = model.caveats.map((item) => `<li>${escapeHtml(item)}</li>`).join("\n");
+  const judgmentCards = model.supervision.judgments.map(judgmentCard).join("\n");
   const shortHash = model.suite_sha256.slice(0, 16);
   const main = summary.by_mode.main;
   const small = summary.by_mode.small;
@@ -242,10 +338,11 @@ export function buildBuyerReport(summary, rows, tasks) {
     .scope { color:var(--muted); max-width:720px; } .recommendation { font-size:clamp(22px,3vw,32px); line-height:1.25; max-width:880px; margin:22px 0 0; }
     .summary { border-top:1px solid var(--line); border-bottom:1px solid var(--line); padding:28px 0; } .summary ul { margin:0; padding-left:22px; display:grid; gap:10px; }
     .section-intro { color:var(--muted); max-width:760px; margin-bottom:24px; } .route-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:14px; }
-    .route-card,.decision,.audit { background:var(--paper); border:1px solid var(--line); border-radius:16px; padding:20px; } .route-card header { display:flex; justify-content:space-between; gap:16px; align-items:baseline; margin-bottom:22px; } .route-card header span,.route-card footer { color:var(--muted); font-size:13px; }
+    .route-card,.decision,.audit,.judgment { background:var(--paper); border:1px solid var(--line); border-radius:16px; padding:20px; } .route-card header { display:flex; justify-content:space-between; gap:16px; align-items:baseline; margin-bottom:22px; } .route-card header span,.route-card footer { color:var(--muted); font-size:13px; }
     .measure { margin-top:14px; } .measure>div:first-child { display:flex; justify-content:space-between; gap:12px; font-size:13px; } .bar { height:10px; background:var(--open); border-radius:999px; overflow:hidden; margin-top:7px; } .bar i { display:block; height:100%; background:var(--olive); border-radius:inherit; } .bar.latency i { background:var(--blue); } .route-card footer { margin-top:20px; border-top:1px solid var(--line); padding-top:12px; }
     .decision-list { display:grid; gap:12px; } .decision-top { display:flex; justify-content:space-between; gap:18px; align-items:flex-start; } .decision p { color:var(--muted); margin:14px 0; } .pill { border:1px solid var(--line); border-radius:999px; padding:6px 10px; font-size:12px; font-weight:700; white-space:nowrap; } .decision.pilot .pill { color:var(--olive); } .decision.supervise .pill { color:var(--gold); } .decision.hold .pill { color:var(--accent); } .route-results { display:flex; gap:8px; flex-wrap:wrap; } .route-results span { background:var(--open); border-radius:8px; padding:6px 9px; font-size:12px; } .route-results b { margin-left:5px; }
     .audit { display:grid; grid-template-columns:repeat(6,minmax(0,1fr)); gap:10px; } .audit div { min-width:0; } .audit strong { display:block; font-size:24px; letter-spacing:-.03em; } .audit span { color:var(--muted); font-size:12px; }
+    .judgment-list { display:grid; gap:12px; margin-top:14px; } .judgment-top { display:flex; justify-content:space-between; gap:18px; align-items:flex-start; } .judgment h3 { text-transform:capitalize; } .judgment p { color:var(--muted); margin:14px 0; } .judgment footer { color:var(--muted); font-size:12px; } .judgment footer strong { color:var(--ink); font-size:15px; }
     .two-col { display:grid; grid-template-columns:1.2fr .8fr; gap:44px; } ol,ul { padding-left:22px; } li+li { margin-top:8px; } .caveat { color:var(--muted); font-size:14px; }
     .provenance { margin-top:64px; border-top:1px solid var(--line); padding-top:18px; display:flex; flex-wrap:wrap; gap:12px 24px; color:var(--muted); font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; }
     @media (max-width:760px) { main { padding-top:36px; } section { margin-top:48px; } .route-grid,.two-col { grid-template-columns:1fr; } .audit { grid-template-columns:repeat(2,minmax(0,1fr)); } .decision-top { flex-direction:column; } }
@@ -286,6 +383,7 @@ export function buildBuyerReport(summary, rows, tasks) {
       <div><strong>${percent(model.supervision.small_model_output_share)}</strong><span>small-model output</span></div>
       <div><strong>${percent(model.supervision.supervisor_token_overhead)}</strong><span>supervisor overhead</span></div>
     </div>
+    <div class="judgment-list" aria-label="Supervisor judgments with reasons and confidence">${judgmentCards}</div>
   </section>
 
   <section class="two-col" aria-label="Next steps and open questions">

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -474,6 +474,42 @@ export function validateRuntimeTrace(values: readonly unknown[]): RuntimeEventEn
       if (["interrupt", "nudge"].includes(verdict)) {
         requiredString(data, "reason", "supervisor_verdict.reason");
       }
+      if ("probabilities" in data && data.probabilities != null) {
+        const probabilities = record(
+          data.probabilities,
+          "supervisor_verdict.probabilities",
+        );
+        if (Object.keys(probabilities).length === 0) {
+          throw new Error("supervisor_verdict.probabilities cannot be empty");
+        }
+        for (const [name, value] of Object.entries(probabilities)) {
+          if (!["continue", "interrupt", "stop", "nudge"].includes(name)) {
+            throw new Error(`unknown supervisor verdict probability key ${name}`);
+          }
+          if (typeof value !== "number" || !Number.isFinite(value)) {
+            throw new Error(`supervisor_verdict.probabilities.${name} must be finite`);
+          }
+        }
+      }
+      if ("probability_kind" in data && data.probability_kind != null) {
+        const kind = requiredString(
+          data,
+          "probability_kind",
+          "supervisor_verdict.probability_kind",
+        );
+        if (kind !== "logprob") {
+          throw new Error(`unknown supervisor verdict probability_kind ${kind}`);
+        }
+        const probabilities = record(
+          data.probabilities,
+          "supervisor_verdict.probabilities",
+        );
+        for (const [name, value] of Object.entries(probabilities)) {
+          if ((value as number) > 0) {
+            throw new Error(`supervisor_verdict logprob ${name} must be at most zero`);
+          }
+        }
+      }
       if (verdict === "interrupt") {
         interruptMarkers.add(requiredString(data, "marker_id", "supervisor_verdict.marker_id"));
       }

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -789,6 +789,30 @@ test("every supervisor decision gets a stable labelable marker", () => {
   assert.equal(supervisorDecisionMarker("run-1", 3, 2, true), "run-1:intervention:2");
 });
 
+test("canonical verdict evidence rejects impossible positive logprobs", () => {
+  const verdict = {
+    schema_version: "understudy-conversation-runtime-event-v1",
+    event_id: "run-probability:0",
+    run_id: "run-probability",
+    session_id: "session-probability",
+    runtime_id: "pi-agent-session",
+    sequence: 0,
+    emitted_at: "2026-07-12T00:00:00Z",
+    event: "supervisor_verdict",
+    data: {
+      verdict: "continue",
+      source: "model",
+      marker_id: "run-probability:verdict:0",
+      probabilities: { continue: 0.9 },
+      probability_kind: "logprob",
+    },
+  };
+  assert.throws(
+    () => validateRuntimeTrace([verdict]),
+    /logprob continue must be at most zero/,
+  );
+});
+
 test("Pi supervision turns a user abort during a judge check into canonical cancellation", async () => {
   const server = createServer(async (request, response) => {
     const body = await requestJson(request);

--- a/tests/desktop-grocery-proof.test.mjs
+++ b/tests/desktop-grocery-proof.test.mjs
@@ -11,6 +11,7 @@ import {
 import {
   buildBuyerReport,
   buildReportModel,
+  verdictProbabilityEvidence,
 } from "../experiments/desktop-grocery-proof/report.mjs";
 
 describe("desktop grocery proof", () => {
@@ -65,6 +66,27 @@ describe("desktop grocery proof", () => {
     });
   });
 
+  it("labels logprobs honestly and derives bounded first-token probabilities", () => {
+    const explicit = verdictProbabilityEvidence({
+      verdict: "interrupt",
+      probability_kind: "logprob",
+      probabilities: { interrupt: -0.0704345703125, continue: -5.223102569580078 },
+    });
+    assert.equal(explicit.source_probability_kind, "logprob");
+    assert.equal(explicit.probability_kind, "first_token_probability_from_logprob");
+    assert.equal(explicit.inferred_source_kind, false);
+    assert.ok(explicit.chosen_probability > 0.93 && explicit.chosen_probability < 0.94);
+    assert.ok(Object.values(explicit.probabilities).every((value) => value >= 0 && value <= 1));
+
+    const legacy = verdictProbabilityEvidence({
+      verdict: "continue",
+      probabilities: { continue: -0.0034, stop: -6.1 },
+    });
+    assert.equal(legacy.source_probability_kind, "logprob");
+    assert.equal(legacy.inferred_source_kind, true);
+    assert.ok(legacy.chosen_probability > 0.99);
+  });
+
   it("turns exact route evidence into bounded buyer recommendations", () => {
     const tasks = [
       { id: "code", title: "Code review", prompt: "private prompt" },
@@ -85,6 +107,18 @@ describe("desktop grocery proof", () => {
       score: { exact: outcome[task.id][mode], field_accuracy: outcome[task.id][mode] ? 1 : 2 / 3 },
       supervisor_correct_intervention: mode === "supervised" && Boolean(outcome[task.id].corrected),
       supervisor_missed_error: mode === "supervised" && Boolean(outcome[task.id].missed),
+      student_score: mode === "supervised"
+        ? { exact: outcome[task.id].small, field_accuracy: outcome[task.id].small ? 1 : 2 / 3 }
+        : null,
+      verdicts: mode === "supervised" ? [{
+        verdict: outcome[task.id].corrected ? "interrupt" : "continue",
+        reason: outcome[task.id].corrected ? "The student selected the wrong constraint result." : null,
+        marker_id: `marker-${task.id}`,
+        probability_kind: "logprob",
+        probabilities: outcome[task.id].corrected
+          ? { interrupt: -0.01, continue: -5 }
+          : { continue: -0.01, interrupt: -5 },
+      }] : [],
     })));
     const summary = {
       proof_id: "proof-1",
@@ -102,10 +136,19 @@ describe("desktop grocery proof", () => {
     assert.deepEqual(model.decisions.map(({ state }) => state), ["hold", "supervise", "pilot"]);
     assert.match(model.recommendation, /pilot the smaller model on Ops classification/i);
     assert.match(model.recommendation, /keep Code review on the main model/i);
+    assert.deepEqual(
+      model.supervision.judgments.map(({ outcome: judgmentOutcome }) => judgmentOutcome),
+      ["missed error", "correct intervention", "correct continue"],
+    );
+    assert.ok(model.supervision.judgments.every(
+      (judgment) => judgment.chosen_probability > 0.98,
+    ));
 
     const html = buildBuyerReport(summary, rows, tasks);
     assert.match(html, /<h2 id="executive-summary">Executive Summary<\/h2>/);
     assert.match(html, /The supervisor helped once and missed once/);
+    assert.match(html, /chosen-verdict first-token probability/);
+    assert.match(html, /The student selected the wrong constraint result/);
     assert.doesNotMatch(html, /private prompt/);
     assert.doesNotMatch(html, /https?:\/\//);
   });


### PR DESCRIPTION
## What changed

- preserve `probability_kind` through the Rust Desktop bridge instead of dropping it during canonical event deserialization
- validate verdict probability evidence consistently in TypeScript and Rust while retaining already-persisted untyped 0.3.4 traces
- convert provider logprobs to bounded first-token probabilities in the grocery buyer report
- show every supervisor verdict, reason, confidence, and judged outcome in the buyer-facing audit
- state explicitly that first-token probability is not calibrated correctness

## Why

Real proof evidence stored negative logprob values under `probabilities`, while Desktop dropped the accompanying `probability_kind`. A reader could reasonably mistake those values for malformed probabilities. The aggregate report also showed only intervention counts, hiding the strongest judge-quality signal: the supervisor was highly confident on a missed error.

On the existing frozen proof, the corrected report exposes:

- missed code error: `continue`, 99.66% first-token probability
- correct cart intervention: `interrupt`, 93.20%
- correct operations continuation: `continue`, 99.92%

These are decision signals, not calibrated correctness claims.

## Verification

- `npm run check` (213 tests, public skill validation, package smoke)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (131 passed, one ignored)
- rendered the v2 report model in-memory from the existing immutable nine-run grocery proof; no model traffic or cohort rows were created
