### PR TITLE
Add approval-gated hosted grocery comparison

### DIFF
--- a/experiments/desktop-grocery-proof/DEMO.md
+++ b/experiments/desktop-grocery-proof/DEMO.md
@@ -2,9 +2,9 @@
 
 This script is for an engineering or applied-AI buyer evaluating whether a
 smaller open-weight model can safely handle part of an existing workload. It
-uses synthetic tasks and local models only. The purpose is to show the
-replacement loop and its evidence, not to claim production readiness from
-three examples.
+uses synthetic tasks and local models by default, with an optional explicitly
+approved hosted-incumbent route. The purpose is to show the replacement loop
+and its evidence, not to claim production readiness from three examples.
 
 ## Before the call
 
@@ -21,6 +21,11 @@ node experiments/desktop-grocery-proof/run.mjs \
 
 Keep the resulting proof directory open. Do not use customer prompts, traces,
 or credentials in the demo.
+
+If the buyer wants their hosted incumbent in the comparison, configure the
+fourth route before the call using the approval-gated command in `README.md`.
+Verify the model id and current token prices with them. Never improvise prices
+or infer consent from an existing key.
 
 Open `report.html` first. It is the buyer-facing decision packet; keep the
 JSONL files behind it for drill-down rather than making the terminal the demo.
@@ -46,11 +51,14 @@ support, cancellation, replay, and supervisor feedback.
 
 ## 3-8 minutes: show one runtime, multiple routes
 
-Explain the three frozen routes:
+Explain the three default frozen routes:
 
 1. E2B alone;
 2. 26B alone;
 3. E2B working first while 26B supervises.
+
+If configured, add the fourth route: the hosted incumbent, executed by Pi with
+the same run identity, canonical events, and deterministic scorer.
 
 The same three tasks run through every route: codebase analysis, cart
 substitution, and operations classification. The suite hash prevents a route
@@ -59,7 +67,7 @@ from receiving an easier slice.
 ```sh
 PROOF=$(find ~/.understudy/proofs/grocery-marketplace \
   -mindepth 1 -maxdepth 1 -type d | sort | tail -1)
-jq '{proof_id, suite_sha256, task_count, run_count, slots}' "$PROOF/summary.json"
+jq '{proof_id, suite_sha256, task_count, run_count, slots, incumbent}' "$PROOF/summary.json"
 ```
 
 ## 8-15 minutes: make the comparison legible
@@ -74,6 +82,7 @@ jq '.by_mode | with_entries(.value |= {
   mean_field_accuracy,
   mean_latency_ms,
   total_tokens,
+  cost_usd,
   supervisor_missed_errors,
   mean_small_model_output_share,
   mean_supervisor_token_overhead

--- a/experiments/desktop-grocery-proof/README.md
+++ b/experiments/desktop-grocery-proof/README.md
@@ -1,7 +1,7 @@
 # Desktop grocery-marketplace proof
 
-This local-only experiment sends one frozen synthetic slice through three
-routes behind the same authenticated Desktop API:
+By default this local-only experiment sends one frozen synthetic slice through
+three routes behind the same authenticated Desktop API:
 
 1. the small local model alone;
 2. the main local model alone;
@@ -19,6 +19,32 @@ node experiments/desktop-grocery-proof/run.mjs \
   --teacher-slot 5
 ```
 
+To compare a hosted incumbent on the identical slice, opt in explicitly. This
+fourth route uses Pi and the same canonical event contract; it does not add a
+second benchmark harness in Rust. The command requires the credential by
+environment-variable name, user-supplied token prices, a worst-case spend fuse,
+and `--confirm-spend` before any synthetic prompt leaves the machine:
+
+```sh
+export INCUMBENT_API_KEY='<set in the terminal, never in chat>'
+node experiments/desktop-grocery-proof/run.mjs \
+  --student-slot 9 \
+  --teacher-slot 5 \
+  --incumbent-base-url https://provider.example/v1 \
+  --incumbent-model incumbent-model-id \
+  --incumbent-provider-kind openai-compatible \
+  --incumbent-api-key-env INCUMBENT_API_KEY \
+  --incumbent-input-usd-per-million 2.50 \
+  --incumbent-output-usd-per-million 10.00 \
+  --budget-usd 0.10 \
+  --confirm-spend
+```
+
+The proof stores the model id, a SHA-256 of the base URL, the supplied price
+basis, conservative budget preflight, and provider-reported actual usage. It
+never stores the key or the cleartext remote URL. Omitting all incumbent flags
+retains the no-network three-route proof.
+
 Evidence is written owner-only beneath
 `~/.understudy/proofs/grocery-marketplace/<proof-id>/`: frozen tasks, one
 canonical event JSONL per run, scored results JSONL, and a summary. Every row
@@ -26,8 +52,8 @@ retains the exact `run_id` and frozen suite SHA-256.
 
 Each run also writes a self-contained `report.html` plus its structured
 `report.json` model. The report leads with a bounded route recommendation,
-quality/latency comparison, per-task decision, supervisor audit, caveats, and
-next pilot gate. The supervisor audit preserves each verdict reason and shows
+quality/latency/cost comparison, per-task decision, supervisor audit, caveats,
+and next pilot gate. The supervisor audit preserves each verdict reason and shows
 chosen-verdict first-token probability without presenting it as calibrated
 correctness. It contains no raw prompts or completions and makes no remote
 requests.

--- a/experiments/desktop-grocery-proof/report.mjs
+++ b/experiments/desktop-grocery-proof/report.mjs
@@ -5,6 +5,7 @@ const modeLabels = {
   small: "Small local",
   main: "Main local",
   supervised: "Small + supervisor",
+  hosted: "Hosted incumbent",
 };
 
 function escapeHtml(value) {
@@ -28,6 +29,11 @@ function signedPercent(value) {
 
 function integer(value) {
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(Number(value ?? 0));
+}
+
+function dollars(value) {
+  if (value == null) return null;
+  return `$${Number(value).toFixed(Number(value) < 0.01 ? 4 : 2)}`;
 }
 
 export function verdictProbabilityEvidence(verdict) {
@@ -93,13 +99,17 @@ function decisionForTask(task, rows) {
   const small = rows.find((row) => row.mode === "small");
   const main = rows.find((row) => row.mode === "main");
   const supervised = rows.find((row) => row.mode === "supervised");
-  if (!main?.score?.exact) {
+  const hosted = rows.find((row) => row.mode === "hosted");
+  const baseline = hosted ?? main;
+  const baselineName = hosted ? "hosted incumbent" : "main model";
+  if (!baseline?.score?.exact) {
     return {
       task_id: task.id,
       task_title: task.title,
       state: "expand",
       decision: "Expand the baseline",
-      reason: "The main route missed this task, so the slice cannot support a routing decision yet.",
+      reason: `The ${baselineName} missed this task, so the slice cannot support a routing decision yet.`,
+      baseline: hosted ? "hosted" : "main",
     };
   }
   if (small?.score?.exact) {
@@ -109,6 +119,7 @@ function decisionForTask(task, rows) {
       state: "pilot",
       decision: "Pilot the smaller model",
       reason: "The smaller route matched every required field; supervision also allowed it to continue.",
+      baseline: hosted ? "hosted" : "main",
     };
   }
   if (supervised?.supervisor_correct_intervention && supervised?.score?.exact) {
@@ -118,6 +129,7 @@ function decisionForTask(task, rows) {
       state: "supervise",
       decision: "Pilot with supervision",
       reason: "The smaller route missed, the supervisor interrupted correctly, and the teacher recovered the exact answer.",
+      baseline: hosted ? "hosted" : "main",
     };
   }
   if (supervised?.supervisor_missed_error) {
@@ -125,16 +137,18 @@ function decisionForTask(task, rows) {
       task_id: task.id,
       task_title: task.title,
       state: "hold",
-      decision: "Keep on the main model",
-      reason: "The smaller route missed and the supervisor allowed the error to pass.",
+      decision: hosted ? "Keep on the hosted incumbent" : "Keep on the main model",
+      reason: `The smaller route missed and the supervisor allowed the error to pass; retain the ${baselineName}.`,
+      baseline: hosted ? "hosted" : "main",
     };
   }
   return {
     task_id: task.id,
     task_title: task.title,
     state: "hold",
-    decision: "Keep on the main model",
+    decision: hosted ? "Keep on the hosted incumbent" : "Keep on the main model",
     reason: "This slice does not yet show a safe smaller or supervised route.",
+    baseline: hosted ? "hosted" : "main",
   };
 }
 
@@ -143,7 +157,12 @@ function recommendation(decisions) {
   const clauses = [];
   if (groups.pilot?.length) clauses.push(`pilot the smaller model on ${groups.pilot.map((row) => row.task_title).join(", ")}`);
   if (groups.supervise?.length) clauses.push(`pilot supervision on ${groups.supervise.map((row) => row.task_title).join(", ")}`);
-  if (groups.hold?.length) clauses.push(`keep ${groups.hold.map((row) => row.task_title).join(", ")} on the main model`);
+  if (groups.hold?.length) {
+    const baseline = groups.hold.some((row) => row.baseline === "hosted")
+      ? "hosted incumbent"
+      : "main model";
+    clauses.push(`keep ${groups.hold.map((row) => row.task_title).join(", ")} on the ${baseline}`);
+  }
   if (groups.expand?.length) clauses.push(`expand the baseline for ${groups.expand.map((row) => row.task_title).join(", ")}`);
   if (!clauses.length) return "Collect a larger frozen slice before choosing a route.";
   const sentence = clauses.join("; ");
@@ -168,7 +187,9 @@ export function buildReportModel(summary, rows, tasks) {
     task,
     rows.filter((row) => row.task_id === task.id),
   ));
-  const modes = ["small", "main", "supervised"].map((id) => ({
+  const modeIds = ["small", "main", "supervised"];
+  if (summary.by_mode.hosted) modeIds.push("hosted");
+  const modes = modeIds.map((id) => ({
     id,
     label: modeLabels[id],
     ...summary.by_mode[id],
@@ -176,6 +197,7 @@ export function buildReportModel(summary, rows, tasks) {
   const main = summary.by_mode.main;
   const small = summary.by_mode.small;
   const supervised = summary.by_mode.supervised;
+  const hosted = summary.by_mode.hosted ?? null;
   const smallLatency = Number(small.latency_reduction_vs_main ?? 0);
   const supervisedLatency = Number(supervised.latency_reduction_vs_main ?? 0);
   const judgments = rows
@@ -192,20 +214,31 @@ export function buildReportModel(summary, rows, tasks) {
       ...verdictProbabilityEvidence(verdict),
     })));
 
+  const executiveSummary = [
+    hosted
+      ? `The hosted incumbent passed ${hosted.exact_passes}/${hosted.task_count} tasks; the main local route passed ${main.exact_passes}/${main.task_count} on the identical slice.`
+      : `The main local route passed ${main.exact_passes}/${main.task_count} tasks and is the only clean baseline on this slice.`,
+    `The smaller route passed ${small.exact_passes}/${small.task_count} tasks at ${Math.abs(smallLatency * 100).toFixed(0)}% ${smallLatency >= 0 ? "lower" : "higher"} mean latency than main.`,
+    `Supervision corrected ${supervised.supervisor_correct_interventions} error, missed ${supervised.supervisor_missed_errors}, and ran at ${Math.abs(supervisedLatency * 100).toFixed(0)}% ${supervisedLatency >= 0 ? "lower" : "higher"} mean latency than main.`,
+  ];
+  if (hosted) {
+    executiveSummary.push(
+      `The hosted lane used ${hosted.total_tokens} provider-reported tokens${hosted.cost_usd == null ? "" : ` at ${dollars(hosted.cost_usd)} using the supplied price basis`}.`,
+    );
+  }
+  executiveSummary.push(
+    "This is integration evidence, not a production promotion claim; the next gate is a larger frozen slice from each real workflow cluster.",
+  );
+
   return {
-    schema_version: "understudy.desktop_grocery_buyer_report.v2",
+    schema_version: "understudy.desktop_grocery_buyer_report.v3",
     title: "Grocery AI routing decision",
     proof_id: summary.proof_id,
     suite_sha256: summary.suite_sha256,
     generated_at: summary.completed_at,
-    scope: `${summary.task_count} frozen synthetic tasks × 3 routes; ${summary.run_count} exact runs`,
+    scope: `${summary.task_count} frozen synthetic tasks × ${modes.length} routes; ${summary.run_count} exact runs`,
     recommendation: recommendation(decisions),
-    executive_summary: [
-      `The main local route passed ${main.exact_passes}/${main.task_count} tasks and is the only clean baseline on this slice.`,
-      `The smaller route passed ${small.exact_passes}/${small.task_count} tasks at ${Math.abs(smallLatency * 100).toFixed(0)}% ${smallLatency >= 0 ? "lower" : "higher"} mean latency than main.`,
-      `Supervision corrected ${supervised.supervisor_correct_interventions} error, missed ${supervised.supervisor_missed_errors}, and ran at ${Math.abs(supervisedLatency * 100).toFixed(0)}% ${supervisedLatency >= 0 ? "lower" : "higher"} mean latency than main.`,
-      "This is integration evidence, not a production promotion claim; the next gate is a larger frozen slice from each real workflow cluster.",
-    ],
+    executive_summary: executiveSummary,
     modes,
     decisions,
     supervision: {
@@ -221,7 +254,9 @@ export function buildReportModel(summary, rows, tasks) {
     next_steps: [
       "Freeze 30–50 representative examples for each workflow cluster before changing traffic.",
       "Require zero missed critical errors and report intervention precision, recall, latency, and token overhead.",
-      "Add the incumbent hosted route on the identical slice so cost and quality deltas become buyer-decision evidence.",
+      hosted
+        ? "Replace the synthetic slice with consented workflow examples and retain the same incumbent price basis."
+        : "Add the incumbent hosted route on the identical slice so cost and quality deltas become buyer-decision evidence.",
     ],
     further_questions: [
       "Does the smaller route remain exact on long-tail substitutions and policy exceptions?",
@@ -229,7 +264,9 @@ export function buildReportModel(summary, rows, tasks) {
       "What fallback rate and added latency are acceptable for the production workflow?",
     ],
     caveats: [
-      "Synthetic local tasks only; no customer prompts, production traffic, or remote judge were used.",
+      hosted
+        ? "Synthetic tasks only; the explicitly approved hosted lane sent those synthetic prompts to the configured incumbent."
+        : "Synthetic local tasks only; no customer prompts, production traffic, or remote judge were used.",
       "Three examples expose integration and failure modes but are too small for a replacement claim.",
       "Token counts are provider-reported by model role; dollar cost requires an explicit incumbent cost basis.",
       "Verdict confidence is the provider's first-token probability derived from logprobs; it is not a calibrated probability that the judgment is correct.",
@@ -238,11 +275,13 @@ export function buildReportModel(summary, rows, tasks) {
     chart_map: [
       {
         section: "Route comparison",
-        question: "How do exact quality and latency compare across the three routes?",
+        question: `How do exact quality and latency compare across the ${modes.length} routes?`,
         family: "comparison",
         type: "horizontal bar",
         fields: ["mode", "mean_field_accuracy", "mean_latency_ms"],
-        takeaway: "Main is the clean baseline; supervision improves quality but adds latency.",
+        takeaway: hosted
+          ? "The hosted incumbent and open-weight routes share one frozen slice and evidence contract."
+          : "Main is the clean baseline; supervision improves quality but adds latency.",
       },
     ],
   };
@@ -254,21 +293,25 @@ function routeCard(mode, maxLatency) {
   const routeNote = mode.id === "supervised"
     ? `${mode.supervisor_correct_interventions} corrected · ${mode.supervisor_missed_errors} missed`
     : `${mode.exact_passes}/${mode.task_count} exact`;
+  const cost = dollars(mode.cost_usd);
   return `<article class="route-card" data-source="summary.json">
     <header><h3>${escapeHtml(mode.label)}</h3><span>${escapeHtml(routeNote)}</span></header>
     <div class="measure"><div><span>Field accuracy</span><strong>${percent(mode.mean_field_accuracy)}</strong></div><div class="bar"><i style="width:${quality}%"></i></div></div>
     <div class="measure"><div><span>Mean latency</span><strong>${integer(mode.mean_latency_ms)} ms</strong></div><div class="bar latency"><i style="width:${latency}%"></i></div></div>
-    <footer>${integer(mode.total_tokens)} total tokens</footer>
+    <footer>${integer(mode.total_tokens)} total tokens${cost ? ` · ${escapeHtml(cost)}` : ""}</footer>
   </article>`;
 }
 
 function decisionCard(decision, rows) {
   const byMode = Object.fromEntries(rows.map((row) => [row.mode, row]));
   const result = (id) => byMode[id]?.score?.exact ? "Exact" : "Miss";
+  const hosted = byMode.hosted
+    ? `<span>Hosted <b>${result("hosted")}</b></span>`
+    : "";
   return `<article class="decision ${escapeHtml(decision.state)}" data-source="results.jsonl">
     <div class="decision-top"><div><span class="eyebrow">${escapeHtml(decision.task_id)}</span><h3>${escapeHtml(decision.task_title)}</h3></div><span class="pill">${escapeHtml(decision.decision)}</span></div>
     <p>${escapeHtml(decision.reason)}</p>
-    <div class="route-results"><span>Small <b>${result("small")}</b></span><span>Main <b>${result("main")}</b></span><span>Supervised <b>${result("supervised")}</b></span></div>
+    <div class="route-results"><span>Small <b>${result("small")}</b></span><span>Main <b>${result("main")}</b></span><span>Supervised <b>${result("supervised")}</b></span>${hosted}</div>
   </article>`;
 }
 
@@ -311,10 +354,12 @@ export function buildBuyerReport(summary, rows, tasks) {
   const main = summary.by_mode.main;
   const small = summary.by_mode.small;
   const supervised = summary.by_mode.supervised;
-  const routeHeading = main.exact_passes === main.task_count
-    ? "The main model is the clean baseline"
+  const hosted = summary.by_mode.hosted ?? null;
+  const baseline = hosted ?? main;
+  const routeHeading = baseline.exact_passes === baseline.task_count
+    ? hosted ? "The hosted incumbent is a clean baseline" : "The main model is the clean baseline"
     : "No route clears the frozen slice";
-  const routeIntro = `Exact field scoring shows the quality/latency tradeoff directly. The smaller model passes ${small.exact_passes}/${small.task_count}; supervision passes ${supervised.exact_passes}/${supervised.task_count} with ${supervised.supervisor_correct_interventions} correct intervention${supervised.supervisor_correct_interventions === 1 ? "" : "s"} and ${supervised.supervisor_missed_errors} missed error${supervised.supervisor_missed_errors === 1 ? "" : "s"}.`;
+  const routeIntro = `Exact field scoring shows the quality/latency tradeoff directly. The smaller model passes ${small.exact_passes}/${small.task_count}; supervision passes ${supervised.exact_passes}/${supervised.task_count} with ${supervised.supervisor_correct_interventions} correct intervention${supervised.supervisor_correct_interventions === 1 ? "" : "s"} and ${supervised.supervisor_missed_errors} missed error${supervised.supervisor_missed_errors === 1 ? "" : "s"}.${hosted ? ` The hosted incumbent passes ${hosted.exact_passes}/${hosted.task_count}.` : ""}`;
   const supervisionHeading = supervised.supervisor_correct_interventions > 0 && supervised.supervisor_missed_errors > 0
     ? `The supervisor helped ${supervised.supervisor_correct_interventions === 1 ? "once" : `${supervised.supervisor_correct_interventions} times`} and missed ${supervised.supervisor_missed_errors === 1 ? "once" : supervised.supervisor_missed_errors}`
     : supervised.supervisor_correct_interventions > 0
@@ -337,7 +382,7 @@ export function buildBuyerReport(summary, rows, tasks) {
     main { width:min(1040px,calc(100% - 32px)); margin:0 auto; padding:56px 0 80px; } h1,h2,h3,p { margin-top:0; } h1 { max-width:720px; font-size:clamp(42px,7vw,76px); line-height:.95; letter-spacing:-.055em; margin-bottom:24px; } h2 { font-size:clamp(27px,4vw,38px); line-height:1.1; letter-spacing:-.035em; margin-bottom:14px; } h3 { font-size:18px; line-height:1.25; margin-bottom:0; } section { margin-top:64px; } .kicker,.eyebrow { text-transform:uppercase; letter-spacing:.12em; font-size:12px; font-weight:750; color:var(--accent); }
     .scope { color:var(--muted); max-width:720px; } .recommendation { font-size:clamp(22px,3vw,32px); line-height:1.25; max-width:880px; margin:22px 0 0; }
     .summary { border-top:1px solid var(--line); border-bottom:1px solid var(--line); padding:28px 0; } .summary ul { margin:0; padding-left:22px; display:grid; gap:10px; }
-    .section-intro { color:var(--muted); max-width:760px; margin-bottom:24px; } .route-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:14px; }
+    .section-intro { color:var(--muted); max-width:760px; margin-bottom:24px; } .route-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; }
     .route-card,.decision,.audit,.judgment { background:var(--paper); border:1px solid var(--line); border-radius:16px; padding:20px; } .route-card header { display:flex; justify-content:space-between; gap:16px; align-items:baseline; margin-bottom:22px; } .route-card header span,.route-card footer { color:var(--muted); font-size:13px; }
     .measure { margin-top:14px; } .measure>div:first-child { display:flex; justify-content:space-between; gap:12px; font-size:13px; } .bar { height:10px; background:var(--open); border-radius:999px; overflow:hidden; margin-top:7px; } .bar i { display:block; height:100%; background:var(--olive); border-radius:inherit; } .bar.latency i { background:var(--blue); } .route-card footer { margin-top:20px; border-top:1px solid var(--line); padding-top:12px; }
     .decision-list { display:grid; gap:12px; } .decision-top { display:flex; justify-content:space-between; gap:18px; align-items:flex-start; } .decision p { color:var(--muted); margin:14px 0; } .pill { border:1px solid var(--line); border-radius:999px; padding:6px 10px; font-size:12px; font-weight:700; white-space:nowrap; } .decision.pilot .pill { color:var(--olive); } .decision.supervise .pill { color:var(--gold); } .decision.hold .pill { color:var(--accent); } .route-results { display:flex; gap:8px; flex-wrap:wrap; } .route-results span { background:var(--open); border-radius:8px; padding:6px 9px; font-size:12px; } .route-results b { margin-left:5px; }
@@ -352,7 +397,7 @@ export function buildBuyerReport(summary, rows, tasks) {
 <body>
 <main data-proof-id="${escapeHtml(model.proof_id)}">
   <header>
-    <div class="kicker">Understudy · frozen local proof</div>
+    <div class="kicker">Understudy · frozen comparison proof</div>
     <h1>${escapeHtml(model.title)}</h1>
     <p class="scope">${escapeHtml(model.scope)}</p>
     <p class="recommendation">${escapeHtml(model.recommendation)}</p>

--- a/experiments/desktop-grocery-proof/run.mjs
+++ b/experiments/desktop-grocery-proof/run.mjs
@@ -6,6 +6,8 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { validateRuntimeTrace } from "../../dist/runtime/conversation/contract.js";
+import { runPiConversation } from "../../dist/runtime/conversation/pi-runtime.js";
 import { renderExistingProof, writeBuyerReport } from "./report.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -53,10 +55,18 @@ export function summarizeEvents(events, elapsedMs) {
   const usage = {};
   for (const event of events.filter((event) => event.event === "usage")) {
     const role = String(event.data?.role ?? "unknown");
-    const row = usage[role] ?? { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+    const row = usage[role] ?? {
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      complete: true,
+      source: "provider",
+    };
     row.input_tokens += Number(event.data?.input_tokens ?? 0);
     row.output_tokens += Number(event.data?.output_tokens ?? 0);
     row.total_tokens += Number(event.data?.total_tokens ?? 0);
+    row.complete = row.complete && event.data?.complete === true;
+    if (event.data?.source !== "provider") row.source = String(event.data?.source ?? "unavailable");
     usage[role] = row;
   }
   const studentOutput = usage.student?.output_tokens ?? 0;
@@ -80,6 +90,114 @@ export function summarizeEvents(events, elapsedMs) {
   };
 }
 
+function isRemoteUrl(value) {
+  const { hostname } = new URL(value);
+  return !["127.0.0.1", "localhost", "::1", "[::1]"].includes(hostname);
+}
+
+function priceTokens(inputTokens, outputTokens, inputUsdPerMillion, outputUsdPerMillion) {
+  return ((inputTokens * inputUsdPerMillion) + (outputTokens * outputUsdPerMillion)) / 1_000_000;
+}
+
+export function incumbentBudgetPreflight(tasks, options) {
+  const inputTokens = tasks.reduce(
+    (sum, task) => sum + Math.ceil([...task.prompt].length / 4) + 2_048,
+    0,
+  );
+  const outputTokens = tasks.length * options.maxTokens;
+  const estimatedMaxCostUsd = priceTokens(
+    inputTokens,
+    outputTokens,
+    options.incumbentInputUsdPerMillion,
+    options.incumbentOutputUsdPerMillion,
+  );
+  return {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    estimated_max_cost_usd: estimatedMaxCostUsd,
+    budget_usd: options.budgetUsd,
+    within_budget: estimatedMaxCostUsd <= options.budgetUsd,
+    basis: "prompt chars / 4 + 2048 input-token overhead per task; max output tokens",
+  };
+}
+
+export async function runHostedIncumbent({ task, runId, sessionId, options }) {
+  const { remote } = validateIncumbentOptions(options);
+  const apiKey = options.incumbentApiKeyEnv
+    ? process.env[options.incumbentApiKeyEnv]
+    : undefined;
+  if (remote && !options.confirmSpend) {
+    throw new Error("remote incumbent comparison requires --confirm-spend");
+  }
+  if (remote && !apiKey) {
+    throw new Error(`remote incumbent credential is missing from ${options.incumbentApiKeyEnv}`);
+  }
+  const previousRemote = process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE;
+  if (remote) process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE = "1";
+  const events = [];
+  try {
+    await runPiConversation(
+      {
+        run_id: runId,
+        session_id: sessionId,
+        base_url: options.incumbentBaseUrl,
+        model: options.incumbentModel,
+        provider_kind: options.incumbentProviderKind,
+        provider_api_key: apiKey,
+        role: "primary",
+        messages: [{ role: "user", content: task.prompt }],
+        max_output_tokens: options.maxTokens,
+        max_tool_rounds: 0,
+        allow_remote: remote,
+        runtime_backend: "pi",
+      },
+      (event) => events.push(event),
+    );
+  } finally {
+    if (previousRemote === undefined) delete process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE;
+    else process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE = previousRemote;
+  }
+  validateRuntimeTrace(events);
+  return events;
+}
+
+export function validateIncumbentOptions(options) {
+  const incumbentEnabled = options.incumbentBaseUrl != null || options.incumbentModel != null;
+  if (incumbentEnabled && (!options.incumbentBaseUrl || !options.incumbentModel)) {
+    throw new Error("hosted incumbent comparison requires both --incumbent-base-url and --incumbent-model");
+  }
+  if (!["openai-compatible", "anthropic"].includes(options.incumbentProviderKind)) {
+    throw new Error("incumbentProviderKind must be openai-compatible or anthropic");
+  }
+  if (options.incumbentApiKeyEnv && !/^[A-Z][A-Z0-9_]*$/.test(options.incumbentApiKeyEnv)) {
+    throw new Error("incumbentApiKeyEnv must be an uppercase environment variable name");
+  }
+  if (incumbentEnabled && (!Number.isInteger(options.maxTokens) || options.maxTokens <= 0)) {
+    throw new Error("maxTokens must be a positive integer for an incumbent comparison");
+  }
+  const remote = incumbentEnabled && isRemoteUrl(options.incumbentBaseUrl);
+  if (remote) {
+    for (const [name, value] of Object.entries({
+      incumbentInputUsdPerMillion: options.incumbentInputUsdPerMillion,
+      incumbentOutputUsdPerMillion: options.incumbentOutputUsdPerMillion,
+    })) {
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`${name} must be a non-negative number for a remote incumbent`);
+      }
+    }
+    if (!Number.isFinite(options.budgetUsd) || options.budgetUsd <= 0) {
+      throw new Error("budgetUsd must be positive for a remote incumbent");
+    }
+    if (!options.incumbentApiKeyEnv) {
+      throw new Error("remote incumbent comparison requires --incumbent-api-key-env");
+    }
+    if (!options.confirmSpend) {
+      throw new Error("remote incumbent comparison requires --confirm-spend");
+    }
+  }
+  return { incumbentEnabled, remote };
+}
+
 function parseArgs(argv) {
   const options = {
     studentSlot: 9,
@@ -87,15 +205,36 @@ function parseArgs(argv) {
     maxTokens: 384,
     outputRoot: join(homedir(), ".understudy", "proofs", "grocery-marketplace"),
     reportFrom: null,
+    incumbentBaseUrl: null,
+    incumbentModel: null,
+    incumbentProviderKind: "openai-compatible",
+    incumbentApiKeyEnv: null,
+    incumbentInputUsdPerMillion: null,
+    incumbentOutputUsdPerMillion: null,
+    budgetUsd: null,
+    confirmSpend: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     const next = argv[index + 1];
+    if (value === "--confirm-spend") {
+      options.confirmSpend = true;
+      continue;
+    }
     if (value === "--student-slot") options.studentSlot = Number(next);
     else if (value === "--teacher-slot") options.teacherSlot = Number(next);
     else if (value === "--max-tokens") options.maxTokens = Number(next);
     else if (value === "--output-root") options.outputRoot = resolve(next);
     else if (value === "--report-from") options.reportFrom = resolve(next);
+    else if (value === "--incumbent-base-url") options.incumbentBaseUrl = next;
+    else if (value === "--incumbent-model") options.incumbentModel = next;
+    else if (value === "--incumbent-provider-kind") options.incumbentProviderKind = next;
+    else if (value === "--incumbent-api-key-env") options.incumbentApiKeyEnv = next;
+    else if (value === "--incumbent-input-usd-per-million") {
+      options.incumbentInputUsdPerMillion = Number(next);
+    } else if (value === "--incumbent-output-usd-per-million") {
+      options.incumbentOutputUsdPerMillion = Number(next);
+    } else if (value === "--budget-usd") options.budgetUsd = Number(next);
     else throw new Error(`unknown argument: ${value}`);
     index += 1;
   }
@@ -109,6 +248,7 @@ function parseArgs(argv) {
   if (options.studentSlot === options.teacherSlot) {
     throw new Error("student and teacher slots must be distinct");
   }
+  validateIncumbentOptions(options);
   return options;
 }
 
@@ -168,6 +308,18 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
   const tasksBytes = readFileSync(join(here, "tasks.json"));
   const tasks = JSON.parse(tasksBytes);
   const suiteHash = createHash("sha256").update(tasksBytes).digest("hex");
+  const {
+    incumbentEnabled,
+    remote: incumbentRemote,
+  } = validateIncumbentOptions(options);
+  const incumbentBudget = incumbentEnabled && incumbentRemote
+    ? incumbentBudgetPreflight(tasks, options)
+    : null;
+  if (incumbentBudget && !incumbentBudget.within_budget) {
+    throw new Error(
+      `incumbent worst-case cost $${incumbentBudget.estimated_max_cost_usd.toFixed(6)} exceeds budget $${options.budgetUsd.toFixed(6)}`,
+    );
+  }
   const startedAt = new Date();
   const proofId = `grocery-${suiteHash.slice(0, 10)}-${startedAt.toISOString().replaceAll(/[-:.]/g, "")}`;
   const outputDir = join(options.outputRoot, proofId);
@@ -198,30 +350,37 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
       supervisorSlotId: options.teacherSlot,
     },
   ];
+  if (incumbentEnabled) modes.push({ id: "hosted" });
   const rows = [];
+  let hostedCostUsd = 0;
   for (const mode of modes) {
     for (const task of tasks) {
       const runId = `${proofId}-${mode.id}-${task.id}`;
       const sessionId = `${proofId}-${mode.id}`;
       const before = performance.now();
-      const response = await apiFetch(
-        capability,
-        `/v1/conversations/${encodeURIComponent(sessionId)}/turns`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            slotId: mode.slotId,
-            supervisorSlotId: mode.supervisorSlotId,
-            text: task.prompt,
-            runId,
-            maxTokens: options.maxTokens,
-          }),
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`${mode.id}/${task.id} returned ${response.status}: ${await response.text()}`);
+      let events;
+      if (mode.id === "hosted") {
+        events = await runHostedIncumbent({ task, runId, sessionId, options });
+      } else {
+        const response = await apiFetch(
+          capability,
+          `/v1/conversations/${encodeURIComponent(sessionId)}/turns`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              slotId: mode.slotId,
+              supervisorSlotId: mode.supervisorSlotId,
+              text: task.prompt,
+              runId,
+              maxTokens: options.maxTokens,
+            }),
+          },
+        );
+        if (!response.ok) {
+          throw new Error(`${mode.id}/${task.id} returned ${response.status}: ${await response.text()}`);
+        }
+        events = await readNdjson(response);
       }
-      const events = await readNdjson(response);
       const evidence = summarizeEvents(events, Math.round(performance.now() - before));
       const parsed = extractJsonObject(evidence.output);
       const score = scoreObject(parsed, task.expected);
@@ -234,6 +393,32 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
       const intervened = evidence.verdicts.some(
         (verdict) => verdict.verdict === "nudge" || verdict.verdict === "interrupt",
       );
+      const hostedUsage = mode.id === "hosted" ? evidence.usage.primary : null;
+      if (
+        mode.id === "hosted"
+        && incumbentRemote
+        && (hostedUsage?.complete !== true || hostedUsage.source !== "provider")
+      ) {
+        throw new Error(
+          `hosted/${task.id} did not report complete provider usage; cannot enforce spend or report cost`,
+        );
+      }
+      const costUsd = mode.id === "hosted" && hostedUsage?.complete === true
+        ? priceTokens(
+          hostedUsage.input_tokens,
+          hostedUsage.output_tokens,
+          options.incumbentInputUsdPerMillion ?? 0,
+          options.incumbentOutputUsdPerMillion ?? 0,
+        )
+        : null;
+      if (mode.id === "hosted" && incumbentRemote) {
+        hostedCostUsd += costUsd;
+        if (hostedCostUsd > options.budgetUsd) {
+          throw new Error(
+            `hosted incumbent reported cost $${hostedCostUsd.toFixed(6)} exceeds budget $${options.budgetUsd.toFixed(6)}`,
+          );
+        }
+      }
       const row = {
         proof_id: proofId,
         suite_sha256: suiteHash,
@@ -242,8 +427,9 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
         task_id: task.id,
         task_title: task.title,
         mode: mode.id,
-        student_slot_id: options.studentSlot,
-        teacher_slot_id: options.teacherSlot,
+        student_slot_id: mode.id === "hosted" ? null : options.studentSlot,
+        teacher_slot_id: mode.id === "hosted" ? null : options.teacherSlot,
+        model: mode.id === "hosted" ? options.incumbentModel : null,
         parsed_output: parsed,
         score,
         student_parsed_output: studentParsed,
@@ -257,6 +443,10 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
           : null,
         supervisor_correct_intervention: mode.id === "supervised"
           ? intervened && !studentScore.exact && score.exact
+          : null,
+        cost_usd: costUsd,
+        cost_basis: mode.id === "hosted" && incumbentRemote
+          ? "provider usage × user-supplied token prices"
           : null,
         ...evidence,
       };
@@ -282,6 +472,10 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
       mean_field_accuracy: mean(selected.map((row) => row.score.field_accuracy)),
       mean_latency_ms: Math.round(mean(selected.map((row) => row.elapsed_ms))),
       total_tokens: tokens,
+      cost_usd: mode.id === "hosted"
+        && selected.every((row) => typeof row.cost_usd === "number")
+        ? selected.reduce((sum, row) => sum + row.cost_usd, 0)
+        : null,
       interventions: selected.filter((row) => row.supervisor_intervened).length,
       student_interruptions: selected.reduce((sum, row) => sum + row.student_interruptions, 0),
       supervisor_verdicts: selected.reduce((sum, row) => sum + row.verdicts.length, 0),
@@ -306,7 +500,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
   byMode.supervised.quality_delta_vs_main = byMode.supervised.mean_field_accuracy
     - byMode.main.mean_field_accuracy;
   const summary = {
-    format: "understudy.desktop_grocery_proof.v1",
+    format: "understudy.desktop_grocery_proof.v2",
     proof_id: proofId,
     suite_sha256: suiteHash,
     started_at: startedAt.toISOString(),
@@ -316,6 +510,15 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
     task_count: tasks.length,
     run_count: rows.length,
     slots: { student: options.studentSlot, teacher: options.teacherSlot },
+    incumbent: incumbentEnabled ? {
+      model: options.incumbentModel,
+      provider_kind: options.incumbentProviderKind,
+      remote: incumbentRemote,
+      base_url_sha256: createHash("sha256").update(options.incumbentBaseUrl).digest("hex"),
+      input_usd_per_million: options.incumbentInputUsdPerMillion,
+      output_usd_per_million: options.incumbentOutputUsdPerMillion,
+      budget: incumbentBudget,
+    } : null,
     report_file: "report.html",
     report_model_file: "report.json",
     by_mode: byMode,

--- a/tests/desktop-grocery-proof.test.mjs
+++ b/tests/desktop-grocery-proof.test.mjs
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { describe, it } from "node:test";
 
 import {
   extractJsonObject,
+  incumbentBudgetPreflight,
+  runHostedIncumbent,
   scoreObject,
   summarizeEvents,
+  validateIncumbentOptions,
 } from "../experiments/desktop-grocery-proof/run.mjs";
 import {
   buildBuyerReport,
@@ -64,6 +70,108 @@ describe("desktop grocery proof", () => {
       student: '{"answer":"wrong"}',
       teacher: '{"answer":"correct"}',
     });
+  });
+
+  it("fails closed when the hosted incumbent worst case exceeds its spend fuse", () => {
+    const tasks = [{ prompt: "x".repeat(400) }, { prompt: "y".repeat(800) }];
+    const preflight = incumbentBudgetPreflight(tasks, {
+      maxTokens: 384,
+      incumbentInputUsdPerMillion: 5,
+      incumbentOutputUsdPerMillion: 20,
+      budgetUsd: 0.001,
+    });
+    assert.equal(preflight.input_tokens, 4_396);
+    assert.equal(preflight.output_tokens, 768);
+    assert.ok(preflight.estimated_max_cost_usd > preflight.budget_usd);
+    assert.equal(preflight.within_budget, false);
+  });
+
+  it("does not let programmatic callers bypass remote approval and budget gates", () => {
+    assert.throws(
+      () => validateIncumbentOptions({
+        incumbentBaseUrl: "https://provider.invalid/v1",
+        incumbentModel: "hosted-model",
+        incumbentProviderKind: "openai-compatible",
+        incumbentApiKeyEnv: "HOSTED_API_KEY",
+        incumbentInputUsdPerMillion: 5,
+        incumbentOutputUsdPerMillion: 20,
+        budgetUsd: null,
+        confirmSpend: true,
+        maxTokens: 64,
+      }),
+      /budgetUsd must be positive/,
+    );
+    assert.throws(
+      () => validateIncumbentOptions({
+        incumbentBaseUrl: "https://provider.invalid/v1",
+        incumbentModel: "hosted-model",
+        incumbentProviderKind: "openai-compatible",
+        incumbentApiKeyEnv: "HOSTED_API_KEY",
+        incumbentInputUsdPerMillion: 5,
+        incumbentOutputUsdPerMillion: 20,
+        budgetUsd: 0.25,
+        confirmSpend: false,
+        maxTokens: 64,
+      }),
+      /requires --confirm-spend/,
+    );
+  });
+
+  it("runs a hosted candidate through Pi and emits canonical evidence without spend", async () => {
+    const runtimeHome = mkdtempSync(join(tmpdir(), "understudy-grocery-hosted-"));
+    const previousRuntimeHome = process.env.UNDERSTUDY_CONVERSATION_RUNTIME_HOME;
+    process.env.UNDERSTUDY_CONVERSATION_RUNTIME_HOME = runtimeHome;
+    let requestBody = null;
+    const server = createServer(async (request, response) => {
+      let raw = "";
+      for await (const chunk of request) raw += chunk;
+      requestBody = JSON.parse(raw);
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.write(`data: ${JSON.stringify({
+        id: "chatcmpl-grocery-hosted",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "hosted-fixture",
+        choices: [{ index: 0, delta: { role: "assistant", content: '{"answer":"ok"}' }, finish_reason: null }],
+      })}\n\n`);
+      response.write(`data: ${JSON.stringify({
+        id: "chatcmpl-grocery-hosted",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "hosted-fixture",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      })}\n\n`);
+      response.end("data: [DONE]\n\n");
+    });
+    await new Promise((accept) => server.listen(0, "127.0.0.1", accept));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    try {
+      const events = await runHostedIncumbent({
+        task: { prompt: "Return the frozen answer." },
+        runId: "grocery-hosted-fixture-run",
+        sessionId: "grocery-hosted-fixture-session",
+        options: {
+          incumbentBaseUrl: `http://127.0.0.1:${address.port}/v1`,
+          incumbentModel: "hosted-fixture",
+          incumbentProviderKind: "openai-compatible",
+          incumbentApiKeyEnv: null,
+          maxTokens: 64,
+          confirmSpend: false,
+        },
+      });
+      assert.deepEqual(events.map((event) => event.event), ["message", "delta", "usage"]);
+      assert.ok(events.every((event) => event.runtime_id === "pi-agent-session"));
+      assert.equal(summarizeEvents(events, 12).output, '{"answer":"ok"}');
+      assert.equal(requestBody.model, "hosted-fixture");
+      assert.equal(requestBody.max_tokens, 64);
+    } finally {
+      await new Promise((accept) => server.close(accept));
+      if (previousRuntimeHome === undefined) delete process.env.UNDERSTUDY_CONVERSATION_RUNTIME_HOME;
+      else process.env.UNDERSTUDY_CONVERSATION_RUNTIME_HOME = previousRuntimeHome;
+      rmSync(runtimeHome, { recursive: true, force: true });
+    }
   });
 
   it("labels logprobs honestly and derives bounded first-token probabilities", () => {
@@ -151,6 +259,58 @@ describe("desktop grocery proof", () => {
     assert.match(html, /The student selected the wrong constraint result/);
     assert.doesNotMatch(html, /private prompt/);
     assert.doesNotMatch(html, /https?:\/\//);
+  });
+
+  it("compares a hosted incumbent on the same frozen report contract", () => {
+    const tasks = [{ id: "cart", title: "Cart", prompt: "synthetic" }];
+    const metric = {
+      exact_passes: 1,
+      task_count: 1,
+      mean_field_accuracy: 1,
+      mean_latency_ms: 100,
+      total_tokens: 20,
+    };
+    const rows = ["small", "main", "supervised", "hosted"].map((mode) => ({
+      proof_id: "proof-hosted",
+      suite_sha256: "c".repeat(64),
+      task_id: "cart",
+      task_title: "Cart",
+      mode,
+      score: { exact: true, field_accuracy: 1 },
+      student_score: mode === "supervised" ? { exact: true } : null,
+      verdicts: mode === "supervised" ? [{ verdict: "continue" }] : [],
+    }));
+    const summary = {
+      proof_id: "proof-hosted",
+      suite_sha256: "c".repeat(64),
+      completed_at: "2026-07-12T00:00:00Z",
+      task_count: 1,
+      run_count: 4,
+      by_mode: {
+        small: { ...metric, latency_reduction_vs_main: 0.5 },
+        main: metric,
+        supervised: {
+          ...metric,
+          latency_reduction_vs_main: -0.1,
+          supervisor_verdicts: 1,
+          interventions: 0,
+          supervisor_correct_interventions: 0,
+          supervisor_missed_errors: 0,
+          supervisor_false_positives: 0,
+          mean_small_model_output_share: 1,
+          mean_supervisor_token_overhead: 0.1,
+        },
+        hosted: { ...metric, mean_latency_ms: 250, total_tokens: 30, cost_usd: 0.0042 },
+      },
+    };
+    const model = buildReportModel(summary, rows, tasks);
+    assert.equal(model.schema_version, "understudy.desktop_grocery_buyer_report.v3");
+    assert.deepEqual(model.modes.map((mode) => mode.id), ["small", "main", "supervised", "hosted"]);
+    assert.match(model.executive_summary.join(" "), /hosted incumbent passed 1\/1/i);
+    assert.match(model.executive_summary.join(" "), /\$0\.0042/);
+    const html = buildBuyerReport(summary, rows, tasks);
+    assert.match(html, /Hosted incumbent/);
+    assert.match(html, /Hosted <b>Exact<\/b>/);
   });
 
   it("escapes task labels in the portable report", () => {


### PR DESCRIPTION
## What changed

- adds an optional hosted-incumbent route to the frozen grocery proof through the canonical Pi conversation runtime
- keeps the default three-route proof fully local and no-network
- records provider usage, user-supplied token pricing, and a buyer-facing quality/latency/cost comparison without storing the credential or cleartext provider URL
- makes remote execution fail closed without explicit spend confirmation, a positive budget, current token prices, and complete provider usage

## Why

The buyer proof could compare small, main, and supervised local routes, but it could not put an existing hosted incumbent on the exact same frozen slice and runtime evidence contract. This adds that fourth route without expanding the Rust harness.

## Safety

- no provider call or spend was made while developing or testing this change
- the hosted path is tested against a loopback SSE fixture
- synthetic proof inputs only
- incomplete usage or a reported-cost budget overrun terminates the proof

## Validation

- `npm run check` (217 tests, 33 public skills, package smoke)
- focused conversation/runtime and grocery report suite (42 tests)
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->