### PR TITLE
Isolate strict tool proofs from release metrics

### DIFF
--- a/experiments/desktop-tool-proof/README.md
+++ b/experiments/desktop-tool-proof/README.md
@@ -1,9 +1,12 @@
 # Desktop strict-tool proof
 
 This no-spend local proof compares warm Desktop models on the exact same
-versioned tool-call inputs. It scores the canonical trace rather than trusting
-the final prose: one exact named tool, exact parsed arguments, one paired
-successful result, no orphan result, and the requested final output.
+versioned tool-call inputs. By default it calls each warm model directly through
+Pi, using Desktop only for the authenticated read-only tool executor. Synthetic
+benchmark attempts therefore do not enter the genuine Desktop release cohort.
+It scores the canonical trace rather than trusting the final prose: one exact
+named tool, exact parsed arguments, one paired successful result, no orphan
+result, and the requested final output.
 
 ```sh
 node experiments/desktop-tool-proof/run.mjs \
@@ -12,6 +15,18 @@ node experiments/desktop-tool-proof/run.mjs \
   --candidate 26b:5 \
   --repetitions 3
 ```
+
+The direct runner resolves the selected slot from the authenticated residency
+surface and cross-checks its model path against the local agent card. Portable
+summary/results rows record the model id, Pi runtime, task hash, and exact
+tool-schema hash, never the capability token. Owner-only canonical event files
+preserve provider-emitted model fields and raw local tool results, so they can
+contain machine paths or local trace data and must not be uploaded. Run
+`npm run build` first when executing from a fresh source checkout.
+
+`--desktop-api` retains the end-to-end Desktop turn path for integration
+debugging. Do not use that mode for synthetic model comparisons during a release
+observation window because those turns are intentionally recorded by the app.
 
 Evidence is written owner-only under
 `~/.understudy/proofs/tool-correctness/<proof-id>/`. The task-file SHA-256 is

--- a/experiments/desktop-tool-proof/run.mjs
+++ b/experiments/desktop-tool-proof/run.mjs
@@ -7,11 +7,73 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 
+import { validateRuntimeTrace } from "../../dist/runtime/conversation/contract.js";
+import { runPiConversation } from "../../dist/runtime/conversation/pi-runtime.js";
+
 const here = dirname(fileURLToPath(import.meta.url));
+
+const directMcpToolNames = [
+  "status",
+  "residency",
+  "list_models",
+  "list_snapshot_models",
+  "list_traces",
+  "search_traces",
+  "open_trace",
+];
+
+const directWrapperTools = [
+  {
+    name: "understudy_mcp_tool",
+    description: "Call the local Understudy Desktop MCP tool surface.",
+    input_schema: {
+      type: "object",
+      properties: {
+        tool_name: {
+          type: "string",
+          enum: ["knowledge_dossiers", "local_benchmarks", "ui_focus"],
+        },
+        arguments: { type: "object" },
+      },
+      required: ["tool_name"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "understudy_agent_tools",
+    description: "Run a safe, read-only Understudy agent-tools CLI command.",
+    input_schema: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          enum: [
+            "version",
+            "spine",
+            "platforms",
+            "skills_list",
+            "skills_search",
+            "skills_inspect",
+            "doctor",
+            "models_pull_plan",
+          ],
+        },
+        query: { type: "string" },
+        name: { type: "string" },
+        model_id: { type: "string" },
+      },
+      required: ["command"],
+      additionalProperties: false,
+    },
+  },
+];
 
 export function scoreToolTrace(events, task) {
   const calls = events.filter((event) => event.event === "tool_call");
   const results = events.filter((event) => event.event === "tool_result");
+  const terminalError = events.find(
+    (event) => event.event === "error" || event.event === "cancellation",
+  );
   const call = calls[0]?.data ?? null;
   const result = results.find((event) => event.data?.call_id === call?.call_id)?.data ?? null;
   const output = events
@@ -20,6 +82,7 @@ export function scoreToolTrace(events, task) {
     .join("")
     .trim();
   const checks = {
+    terminal_error_free: terminalError == null,
     exactly_one_call: calls.length === 1,
     exact_tool_name: call?.name === task.tool,
     exact_arguments:
@@ -38,6 +101,9 @@ export function scoreToolTrace(events, task) {
     parsed_arguments: call?.parsed_arguments ?? null,
     parse_error: call?.parse_error ?? null,
     result_ok: result?.ok ?? false,
+    terminal_error: terminalError?.data?.message
+      ?? terminalError?.data?.reason
+      ?? (terminalError ? terminalError.event : null),
     orphan_result_count: results.filter(
       (candidate) => !calls.some((item) => item.data?.call_id === candidate.data?.call_id),
     ).length,
@@ -53,6 +119,8 @@ export function summarizeRows(rows) {
   }
   return Object.fromEntries([...groups].map(([candidate, selected]) => [candidate, {
     slot_id: selected[0]?.slot_id ?? null,
+    model_id: selected[0]?.model_id ?? null,
+    runtime_backend: selected[0]?.runtime_backend ?? null,
     strict_passes: selected.filter((row) => row.strict_pass).length,
     attempts: selected.length,
     strict_accuracy: selected.filter((row) => row.strict_pass).length / selected.length,
@@ -62,6 +130,7 @@ export function summarizeRows(rows) {
       selected.filter((row) => row.checks.paired_successful_result).length / selected.length,
     exact_output_rate: selected.filter((row) => row.checks.exact_output).length / selected.length,
     parse_errors: selected.filter((row) => row.parse_error != null).length,
+    terminal_errors: selected.filter((row) => row.terminal_error != null).length,
     orphan_results: selected.reduce((sum, row) => sum + row.orphan_result_count, 0),
     mean_latency_ms: Math.round(
       selected.reduce((sum, row) => sum + row.elapsed_ms, 0) / selected.length,
@@ -75,10 +144,49 @@ export function summarizeRows(rows) {
         called_tool: row.called_tool,
         parsed_arguments: row.parsed_arguments,
         result_ok: row.result_ok,
+        terminal_error: row.terminal_error,
         output: row.output,
         checks: row.checks,
       })),
   }]));
+}
+
+export function directToolDefinitions(mcpTools) {
+  const selected = directMcpToolNames.map((name) => {
+    const tool = mcpTools.find((candidate) => candidate.name === name);
+    if (!tool) throw new Error(`Desktop MCP is missing required direct-proof tool: ${name}`);
+    return {
+      name: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      input_schema: tool.inputSchema ?? { type: "object", properties: {} },
+    };
+  });
+  return [...selected, ...directWrapperTools];
+}
+
+export function resolveDirectCandidates(candidates, residency, agentCard) {
+  const warmModels = agentCard?.app?.warm_models;
+  if (!Array.isArray(warmModels)) {
+    throw new Error("agent card does not contain warm model paths");
+  }
+  return candidates.map((candidate) => {
+    const slot = residency?.slots?.find((row) => row.id === candidate.slotId);
+    if (!slot || slot.state !== "running" || !Number.isInteger(slot.port)) {
+      throw new Error(`candidate ${candidate.label} slot ${candidate.slotId} is not warm`);
+    }
+    const warm = warmModels.find(
+      (row) => row.id === slot.model_id && row.port === slot.port,
+    );
+    if (!warm || typeof warm.model_path !== "string" || !warm.model_path) {
+      throw new Error(`candidate ${candidate.label} has no attested warm model path`);
+    }
+    return {
+      ...candidate,
+      modelId: slot.model_id,
+      modelPath: warm.model_path,
+      baseUrl: `http://127.0.0.1:${slot.port}/v1`,
+    };
+  });
 }
 
 function parseArgs(argv) {
@@ -87,10 +195,19 @@ function parseArgs(argv) {
     repetitions: 3,
     maxTokens: 160,
     outputRoot: join(homedir(), ".understudy", "proofs", "tool-correctness"),
+    executionMode: "direct-pi",
   };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     const next = argv[index + 1];
+    if (value === "--desktop-api") {
+      options.executionMode = "desktop-api";
+      continue;
+    }
+    if (value === "--direct-runtime") {
+      options.executionMode = "direct-pi";
+      continue;
+    }
     if (value === "--candidate") {
       const [label, rawSlot] = String(next).split(":");
       options.candidates.push({ label, slotId: Number(rawSlot) });
@@ -147,6 +264,89 @@ async function apiFetch(capability, path, init = {}) {
   return fetch(new URL(path, capability.baseUrl), { ...init, headers });
 }
 
+function readAgentCard() {
+  const path = process.env.UNDERSTUDY_AGENT_CARD_FILE
+    ?? join(homedir(), ".understudy", "agent-card.json");
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+async function mcpRequest(capability, method, params) {
+  const response = await apiFetch(capability, "/mcp", {
+    method: "POST",
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  if (!response.ok) throw new Error(`Desktop MCP ${method} returned ${response.status}`);
+  const body = await response.json();
+  if (body.error) throw new Error(`Desktop MCP ${method} failed: ${body.error.message}`);
+  return body.result;
+}
+
+function modelSystemPrompt(modelId) {
+  const cards = JSON.parse(readFileSync(
+    resolve(here, "../../apps/homescreen/src-tauri/knowledge/model_cards.json"),
+    "utf8",
+  ));
+  const card = cards.find((candidate) => candidate.id === modelId);
+  const targetId = card?.alias_for ?? modelId;
+  return cards.find((candidate) => candidate.id === targetId)?.system_prompt
+    ?? cards.find((candidate) => candidate.id === "default")?.system_prompt
+    ?? "You are an AI assistant in the Understudy desktop app.";
+}
+
+async function loadDirectContext(capability, candidates) {
+  const [toolResult, residencyResult] = await Promise.all([
+    mcpRequest(capability, "tools/list", {}),
+    mcpRequest(capability, "tools/call", { name: "residency", arguments: {} }),
+  ]);
+  const tools = directToolDefinitions(toolResult?.tools ?? []);
+  const targets = resolveDirectCandidates(
+    candidates,
+    residencyResult?.structuredContent,
+    readAgentCard(),
+  );
+  return {
+    tools,
+    targets: new Map(targets.map((target) => [target.label, target])),
+    toolSchemaSha256: createHash("sha256").update(JSON.stringify(tools)).digest("hex"),
+  };
+}
+
+async function runDirectTurn(capability, context, candidate, task, runId, sessionId, maxTokens) {
+  const target = context.targets.get(candidate.label);
+  if (!target) throw new Error(`direct target is missing for ${candidate.label}`);
+  const previousToolToken = process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;
+  process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN = capability.token;
+  const events = [];
+  try {
+    await runPiConversation(
+      {
+        run_id: runId,
+        session_id: sessionId,
+        base_url: target.baseUrl,
+        model: target.modelPath,
+        provider_kind: "openai-compatible",
+        role: "primary",
+        messages: [
+          { role: "system", content: modelSystemPrompt(target.modelId) },
+          { role: "user", content: task.prompt },
+        ],
+        tools: context.tools,
+        tool_executor_url: `${capability.baseUrl}/api/conversation-runtime/tool?slot_id=${target.slotId}`,
+        max_output_tokens: maxTokens,
+        max_tool_rounds: 4,
+        allow_remote: false,
+        runtime_backend: "pi",
+      },
+      (event) => events.push(event),
+    );
+  } finally {
+    if (previousToolToken === undefined) delete process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;
+    else process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN = previousToolToken;
+  }
+  validateRuntimeTrace(events);
+  return { events, target };
+}
+
 async function readNdjson(response) {
   if (!response.body) return [];
   const events = [];
@@ -198,6 +398,9 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
   ) {
     throw new Error("Understudy Desktop API v2 canonical streaming evidence is required");
   }
+  const directContext = options.executionMode === "direct-pi"
+    ? await loadDirectContext(capability, options.candidates)
+    : null;
 
   const rows = [];
   for (const candidate of options.candidates) {
@@ -206,31 +409,49 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
         const runId = `${proofId}-${candidate.label}-r${repetition}-${task.id}`;
         const sessionId = runId;
         const before = performance.now();
-        const response = await apiFetch(
-          capability,
-          `/v1/conversations/${encodeURIComponent(sessionId)}/turns`,
-          {
-            method: "POST",
-            body: JSON.stringify({
-              slotId: candidate.slotId,
-              text: task.prompt,
-              runId,
-              maxTokens: options.maxTokens,
-            }),
-          },
-        );
-        if (!response.ok) {
-          throw new Error(
-            `${candidate.label}/r${repetition}/${task.id} returned ${response.status}: ${await response.text()}`,
+        let events;
+        let modelId = null;
+        if (directContext) {
+          const direct = await runDirectTurn(
+            capability,
+            directContext,
+            candidate,
+            task,
+            runId,
+            sessionId,
+            options.maxTokens,
           );
+          events = direct.events;
+          modelId = direct.target.modelId;
+        } else {
+          const response = await apiFetch(
+            capability,
+            `/v1/conversations/${encodeURIComponent(sessionId)}/turns`,
+            {
+              method: "POST",
+              body: JSON.stringify({
+                slotId: candidate.slotId,
+                text: task.prompt,
+                runId,
+                maxTokens: options.maxTokens,
+              }),
+            },
+          );
+          if (!response.ok) {
+            throw new Error(
+              `${candidate.label}/r${repetition}/${task.id} returned ${response.status}: ${await response.text()}`,
+            );
+          }
+          events = await readNdjson(response);
         }
-        const events = await readNdjson(response);
         const score = scoreToolTrace(events, task);
         const row = {
           proof_id: proofId,
           suite_sha256: suiteSha256,
           candidate: candidate.label,
           slot_id: candidate.slotId,
+          model_id: modelId,
+          runtime_backend: directContext ? "pi" : "desktop-api",
           repetition,
           task_id: task.id,
           expected_tool: task.tool,
@@ -255,7 +476,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
     }
   }
   const summary = {
-    format: "understudy.desktop_tool_proof.v1",
+    format: "understudy.desktop_tool_proof.v2",
     proof_id: proofId,
     suite_sha256: suiteSha256,
     started_at: startedAt.toISOString(),
@@ -265,6 +486,9 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
     task_count: tasks.length,
     repetitions: options.repetitions,
     run_count: rows.length,
+    execution_mode: options.executionMode,
+    release_cohort_eligible: false,
+    tool_schema_sha256: directContext?.toolSchemaSha256 ?? null,
     candidates: summarizeRows(rows),
   };
   writeProofFile(

--- a/tests/desktop-tool-proof.test.mjs
+++ b/tests/desktop-tool-proof.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  directToolDefinitions,
+  resolveDirectCandidates,
   scoreToolTrace,
   summarizeRows,
 } from "../experiments/desktop-tool-proof/run.mjs";
@@ -13,6 +15,70 @@ const task = {
 };
 
 describe("desktop strict-tool proof", () => {
+  it("builds the bounded direct tool set from the authenticated MCP contract", () => {
+    const names = [
+      "status",
+      "residency",
+      "list_models",
+      "list_snapshot_models",
+      "list_traces",
+      "search_traces",
+      "open_trace",
+    ];
+    const tools = directToolDefinitions(names.map((name) => ({
+      name,
+      description: `${name} description`,
+      inputSchema: { type: "object", properties: {} },
+    })));
+    assert.deepEqual(tools.map(({ name }) => name), [
+      ...names,
+      "understudy_mcp_tool",
+      "understudy_agent_tools",
+    ]);
+    assert.throws(
+      () => directToolDefinitions([]),
+      /missing required direct-proof tool: status/,
+    );
+  });
+
+  it("resolves only running slots with an attested local model path", () => {
+    const targets = resolveDirectCandidates(
+      [{ label: "12b", slotId: 6 }],
+      {
+        slots: [{
+          id: 6,
+          state: "running",
+          port: 8095,
+          model_id: "gemma-4-12b-it-qat-mlx-vlm-understudy",
+        }],
+      },
+      {
+        app: {
+          warm_models: [{
+            id: "gemma-4-12b-it-qat-mlx-vlm-understudy",
+            port: 8095,
+            model_path: "/models/12b",
+          }],
+        },
+      },
+    );
+    assert.deepEqual(targets, [{
+      label: "12b",
+      slotId: 6,
+      modelId: "gemma-4-12b-it-qat-mlx-vlm-understudy",
+      modelPath: "/models/12b",
+      baseUrl: "http://127.0.0.1:8095/v1",
+    }]);
+    assert.throws(
+      () => resolveDirectCandidates(
+        [{ label: "12b", slotId: 6 }],
+        { slots: [{ id: 6, state: "stopped", port: 8095 }] },
+        { app: { warm_models: [] } },
+      ),
+      /slot 6 is not warm/,
+    );
+  });
+
   it("requires one exact call, paired result, arguments, and output", () => {
     const events = [
       {
@@ -34,6 +100,7 @@ describe("desktop strict-tool proof", () => {
     assert.equal(score.strict_pass, true);
     assert.equal(score.orphan_result_count, 0);
     assert.deepEqual(score.checks, {
+      terminal_error_free: true,
       exactly_one_call: true,
       exact_tool_name: true,
       exact_arguments: true,
@@ -64,6 +131,16 @@ describe("desktop strict-tool proof", () => {
     assert.equal(score.checks.exact_output, false);
   });
 
+  it("separates terminal runtime errors from model tool-call mistakes", () => {
+    const score = scoreToolTrace([{
+      event: "error",
+      data: { message: "provider rejected the configured model field" },
+    }], task);
+    assert.equal(score.strict_pass, false);
+    assert.equal(score.checks.terminal_error_free, false);
+    assert.equal(score.terminal_error, "provider rejected the configured model field");
+  });
+
   it("summarizes promotion evidence without hiding individual failures", () => {
     const common = {
       candidate: "12b",
@@ -75,6 +152,7 @@ describe("desktop strict-tool proof", () => {
       called_tool: "status",
       parsed_arguments: {},
       result_ok: true,
+      terminal_error: null,
       output: "OK",
     };
     const summary = summarizeRows([
@@ -84,6 +162,7 @@ describe("desktop strict-tool proof", () => {
         task_id: "a",
         strict_pass: true,
         checks: {
+          terminal_error_free: true,
           exactly_one_call: true,
           exact_tool_name: true,
           exact_arguments: true,
@@ -97,6 +176,7 @@ describe("desktop strict-tool proof", () => {
         task_id: "b",
         strict_pass: false,
         checks: {
+          terminal_error_free: true,
           exactly_one_call: false,
           exact_tool_name: false,
           exact_arguments: false,
@@ -108,6 +188,7 @@ describe("desktop strict-tool proof", () => {
     assert.equal(summary["12b"].strict_passes, 1);
     assert.equal(summary["12b"].attempts, 2);
     assert.equal(summary["12b"].strict_accuracy, 0.5);
+    assert.equal(summary["12b"].terminal_errors, 0);
     assert.equal(summary["12b"].failures.length, 1);
   });
 });


### PR DESCRIPTION
## What changed

- makes direct Pi execution the safe default for synthetic strict-tool comparisons
- resolves warm candidates through authenticated residency and attests model paths against the local agent card
- reuses the bounded authenticated read-only Desktop tool executor without writing Desktop turn metrics
- records model ids, runtime backend, task/tool-schema hashes, and terminal runtime errors separately from model mistakes
- keeps `--desktop-api` as an explicit integration-debugging path

## Why

The previous proof sent synthetic benchmark turns through the Desktop conversation endpoint. During a release observation window those rows could contaminate the genuine cohort used to authorize Rust fallback deletion. The new default preserves canonical Pi evidence while keeping the release cohort unchanged.

## Local model evidence

On the frozen eight-task suite, three repetitions each:

- 4B Understudy: 24/24 strict passes, 1.455s mean
- 12B Understudy: 24/24 strict passes, 3.278s mean
- sparse 26B Understudy: 24/24 strict passes, 3.348s mean

All had zero parse errors and zero orphan results. The release cohort remained exactly 1/100. Raw canonical events remain owner-only under `~/.understudy/` and are not included here.

## Validation

- `npm run check` (220 tests, 33 public skills, package smoke)
- focused conversation/runtime and strict-tool suite (37 tests)
- live local direct-Pi proof (72 attempts, no provider spend)
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->