### PR TITLE
Harden strict tool model certification

### DIFF
--- a/experiments/desktop-tool-proof/README.md
+++ b/experiments/desktop-tool-proof/README.md
@@ -5,8 +5,14 @@ versioned tool-call inputs. By default it calls each warm model directly through
 Pi, using Desktop only for the authenticated read-only tool executor. Synthetic
 benchmark attempts therefore do not enter the genuine Desktop release cohort.
 It scores the canonical trace rather than trusting the final prose: one exact
-named tool, exact parsed arguments, one paired successful result, no orphan
-result, and the requested final output.
+zero, one, or an ordered sequence of exact named tools; exact parsed arguments;
+paired successful results; no orphan results; and the requested final output.
+The frozen suite includes no-tool abstention, decoy tool names, numeric argument
+typing, malformed-JSON pressure, nested wrapper arguments, and ordered two-step
+tool rounds in addition to the basic one-call cases.
+Each attempt has a 30-second terminal timeout by default so a slow local tool or
+model becomes explicit cancellation evidence instead of hanging the suite; use
+`--timeout-ms` only when deliberately testing a slower environment.
 
 ```sh
 node experiments/desktop-tool-proof/run.mjs \
@@ -33,3 +39,6 @@ Evidence is written owner-only under
 stored in every row and the summary. A tiny local slice proves integration and
 identifies failure modes; it is not sufficient by itself for a production
 replacement claim.
+
+See [`RESULTS.md`](RESULTS.md) for the latest sanitized aggregate comparison and
+promotion decision. Raw canonical event files stay local.

--- a/experiments/desktop-tool-proof/RESULTS.md
+++ b/experiments/desktop-tool-proof/RESULTS.md
@@ -1,0 +1,84 @@
+# Strict-tool certification results
+
+Date: 2026-07-12
+Status: local promotion evidence, not a production replacement claim
+
+## Decision
+
+- **4B Understudy:** pass the current strict-tool gate; continue to VLM,
+  long-context, and broader task-quality certification.
+- **12B Understudy:** pass the current strict-tool gate. The evidence does not
+  support changing this artifact to a sparse MoE for tool correctness.
+- **Sparse 26B Understudy:** hold strict-tool certification. Fix the checkpoint,
+  chat template, or tool-call renderer before promotion; do not normalize
+  malformed tool names inside the runtime.
+
+## Frozen comparison
+
+The same 17 synthetic tasks ran three times per model through direct Pi. The
+suite covers one-call basics, no-tool abstention, decoy tool names, numeric
+argument typing, malformed-JSON pressure, nested wrapper arguments, and ordered
+two-step tool rounds. Desktop provided only the authenticated local tool
+executor, so none of the 153 attempts entered the release cohort.
+
+| Candidate | Model id | Strict | Exact names | Arguments | Results | Mean end-to-end latency | Tokens |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 4B | `gemma-4-e4b-it-qat-mlx-vlm-understudy` | 51/51 | 100% | 100% | 100% | 1,946 ms | 244,720 |
+| 12B | `gemma-4-12b-it-qat-mlx-vlm-understudy` | 51/51 | 100% | 100% | 100% | 5,573 ms | 248,457 |
+| sparse 26B | `gemma-4-26b-a4b-it-qat-mlx-vlm-understudy` | 48/51 | 94.1% | 100% | 94.1% | 5,118 ms | 251,777 |
+
+Latency includes local tool execution and is not an isolated decode benchmark.
+All three candidates had zero parse errors, terminal errors, and orphan results.
+
+## Reproduced 26B failure
+
+On `two-step-catalog-models`, the 26B artifact emitted these names in all three
+repetitions:
+
+```text
+list_snapshot_models:
+list_models:
+```
+
+The arguments, call count, order, and final `OK` text were otherwise correct.
+The executor rejected both calls because the colon-suffixed tools do not exist.
+The 4B and 12B artifacts emitted the exact names on every repetition.
+
+This is useful correction-pair material:
+
+- rejected: colon-suffixed tool names;
+- corrected: exact schema names without punctuation;
+- invariant: preserve call order and `{}` arguments.
+
+## Reproduction contract
+
+- proof schema: `understudy.desktop_tool_proof.v3`
+- task SHA-256: `2286836959164ef9938750e8ff6dcc41b6a25a5de4228ad47213e62e0bde1e72`
+- tool-schema SHA-256: `83ae62b72066e39b02e6a39e1167a604ad748f789679d55ca981a236e8b9325d`
+- app/runtime: Desktop `0.3.2`, canonical runtime `0.3.4`
+- spend/uploads: none
+- release cohort after the run: 1/100 canonical, zero compatibility fallbacks
+
+```sh
+npm run build
+node experiments/desktop-tool-proof/run.mjs \
+  --candidate 4b:7 \
+  --candidate 12b:6 \
+  --candidate 26b:5 \
+  --repetitions 3 \
+  --max-tokens 256
+```
+
+Raw canonical events remain owner-only under
+`~/.understudy/proofs/tool-correctness/` because tool results can contain local
+paths or trace data. They are not part of this repository.
+
+## Next promotion gates
+
+1. VLM correctness on frozen image tasks, including image-only and mixed text
+   plus image inputs.
+2. Long-context and compaction quality, not just conformance plumbing.
+3. Ambiguous real-world tool selection and explicit refusal cases on a larger
+   held-out slice.
+4. General task-quality comparison showing whether 12B adds enough value over
+   the faster 4B to justify its memory and latency.

--- a/experiments/desktop-tool-proof/run.mjs
+++ b/experiments/desktop-tool-proof/run.mjs
@@ -92,13 +92,14 @@ export function scoreToolTrace(events, task) {
     .map((event) => event.data.text)
     .join("")
     .trim();
+  const exactCallCount = calls.length === expectedCalls.length;
   const checks = {
     terminal_error_free: terminalError == null,
-    exact_call_count: calls.length === expectedCalls.length,
-    exact_tool_sequence: expectedCalls.every(
+    exact_call_count: exactCallCount,
+    exact_tool_sequence: exactCallCount && expectedCalls.every(
       (expected, index) => callData[index]?.name === expected.tool,
     ),
-    exact_arguments: expectedCalls.every((expected, index) => (
+    exact_arguments: exactCallCount && expectedCalls.every((expected, index) => (
       callData[index]?.parse_error == null
       && isDeepStrictEqual(callData[index]?.parsed_arguments, expected.arguments)
     )),

--- a/experiments/desktop-tool-proof/run.mjs
+++ b/experiments/desktop-tool-proof/run.mjs
@@ -68,14 +68,25 @@ const directWrapperTools = [
   },
 ];
 
+export function expectedCallsForTask(task) {
+  if (Array.isArray(task.calls)) return task.calls;
+  if (typeof task.tool === "string") {
+    return [{ tool: task.tool, arguments: task.arguments ?? {} }];
+  }
+  return [];
+}
+
 export function scoreToolTrace(events, task) {
   const calls = events.filter((event) => event.event === "tool_call");
   const results = events.filter((event) => event.event === "tool_result");
+  const expectedCalls = expectedCallsForTask(task);
   const terminalError = events.find(
     (event) => event.event === "error" || event.event === "cancellation",
   );
-  const call = calls[0]?.data ?? null;
-  const result = results.find((event) => event.data?.call_id === call?.call_id)?.data ?? null;
+  const callData = calls.map((event) => event.data ?? {});
+  const matchedResults = callData.map((call) => (
+    results.find((event) => event.data?.call_id === call.call_id)?.data ?? null
+  ));
   const output = events
     .filter((event) => event.event === "delta" && typeof event.data?.text === "string")
     .map((event) => event.data.text)
@@ -83,29 +94,48 @@ export function scoreToolTrace(events, task) {
     .trim();
   const checks = {
     terminal_error_free: terminalError == null,
-    exactly_one_call: calls.length === 1,
-    exact_tool_name: call?.name === task.tool,
-    exact_arguments:
-      call?.parse_error == null && isDeepStrictEqual(call?.parsed_arguments, task.arguments),
-    paired_successful_result:
-      results.length === 1 && result?.name === task.tool && result?.ok === true,
+    exact_call_count: calls.length === expectedCalls.length,
+    exact_tool_sequence: expectedCalls.every(
+      (expected, index) => callData[index]?.name === expected.tool,
+    ),
+    exact_arguments: expectedCalls.every((expected, index) => (
+      callData[index]?.parse_error == null
+      && isDeepStrictEqual(callData[index]?.parsed_arguments, expected.arguments)
+    )),
+    paired_successful_results:
+      results.length === expectedCalls.length
+      && expectedCalls.every((expected, index) => (
+        matchedResults[index]?.name === expected.tool && matchedResults[index]?.ok === true
+      )),
+    no_orphan_results: results.every(
+      (result) => callData.some((call) => call.call_id === result.data?.call_id),
+    ),
     exact_output: output === task.expected_output,
   };
+  const parseErrors = callData
+    .map((call) => call.parse_error)
+    .filter((value) => value != null);
   return {
     strict_pass: Object.values(checks).every(Boolean),
     checks,
     output,
     call_count: calls.length,
     result_count: results.length,
-    called_tool: call?.name ?? null,
-    parsed_arguments: call?.parsed_arguments ?? null,
-    parse_error: call?.parse_error ?? null,
-    result_ok: result?.ok ?? false,
+    called_tool: callData[0]?.name ?? null,
+    parsed_arguments: callData[0]?.parsed_arguments ?? null,
+    call_sequence: callData.map((call) => ({
+      tool: call.name ?? null,
+      arguments: call.parsed_arguments ?? null,
+      parse_error: call.parse_error ?? null,
+    })),
+    parse_error: parseErrors[0] ?? null,
+    parse_error_count: parseErrors.length,
+    result_ok: matchedResults.every((result) => result?.ok === true),
     terminal_error: terminalError?.data?.message
       ?? terminalError?.data?.reason
       ?? (terminalError ? terminalError.event : null),
     orphan_result_count: results.filter(
-      (candidate) => !calls.some((item) => item.data?.call_id === candidate.data?.call_id),
+      (candidate) => !callData.some((call) => call.call_id === candidate.data?.call_id),
     ).length,
   };
 }
@@ -124,12 +154,15 @@ export function summarizeRows(rows) {
     strict_passes: selected.filter((row) => row.strict_pass).length,
     attempts: selected.length,
     strict_accuracy: selected.filter((row) => row.strict_pass).length / selected.length,
-    exact_name_rate: selected.filter((row) => row.checks.exact_tool_name).length / selected.length,
+    exact_call_count_rate:
+      selected.filter((row) => row.checks.exact_call_count).length / selected.length,
+    exact_name_rate:
+      selected.filter((row) => row.checks.exact_tool_sequence).length / selected.length,
     exact_arguments_rate: selected.filter((row) => row.checks.exact_arguments).length / selected.length,
     successful_result_rate:
-      selected.filter((row) => row.checks.paired_successful_result).length / selected.length,
+      selected.filter((row) => row.checks.paired_successful_results).length / selected.length,
     exact_output_rate: selected.filter((row) => row.checks.exact_output).length / selected.length,
-    parse_errors: selected.filter((row) => row.parse_error != null).length,
+    parse_errors: selected.reduce((sum, row) => sum + row.parse_error_count, 0),
     terminal_errors: selected.filter((row) => row.terminal_error != null).length,
     orphan_results: selected.reduce((sum, row) => sum + row.orphan_result_count, 0),
     mean_latency_ms: Math.round(
@@ -143,6 +176,7 @@ export function summarizeRows(rows) {
         task_id: row.task_id,
         called_tool: row.called_tool,
         parsed_arguments: row.parsed_arguments,
+        call_sequence: row.call_sequence,
         result_ok: row.result_ok,
         terminal_error: row.terminal_error,
         output: row.output,
@@ -194,6 +228,7 @@ function parseArgs(argv) {
     candidates: [],
     repetitions: 3,
     maxTokens: 160,
+    timeoutMs: 30_000,
     outputRoot: join(homedir(), ".understudy", "proofs", "tool-correctness"),
     executionMode: "direct-pi",
   };
@@ -213,6 +248,7 @@ function parseArgs(argv) {
       options.candidates.push({ label, slotId: Number(rawSlot) });
     } else if (value === "--repetitions") options.repetitions = Number(next);
     else if (value === "--max-tokens") options.maxTokens = Number(next);
+    else if (value === "--timeout-ms") options.timeoutMs = Number(next);
     else if (value === "--output-root") options.outputRoot = resolve(next);
     else throw new Error(`unknown argument: ${value}`);
     index += 1;
@@ -235,6 +271,9 @@ function parseArgs(argv) {
   }
   if (!Number.isInteger(options.maxTokens) || options.maxTokens < 16 || options.maxTokens > 2_048) {
     throw new Error("max-tokens must be an integer from 16 to 2048");
+  }
+  if (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1_000 || options.timeoutMs > 300_000) {
+    throw new Error("timeout-ms must be an integer from 1000 to 300000");
   }
   return options;
 }
@@ -311,7 +350,16 @@ async function loadDirectContext(capability, candidates) {
   };
 }
 
-async function runDirectTurn(capability, context, candidate, task, runId, sessionId, maxTokens) {
+async function runDirectTurn(
+  capability,
+  context,
+  candidate,
+  task,
+  runId,
+  sessionId,
+  maxTokens,
+  timeoutMs,
+) {
   const target = context.targets.get(candidate.label);
   if (!target) throw new Error(`direct target is missing for ${candidate.label}`);
   const previousToolToken = process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;
@@ -338,6 +386,7 @@ async function runDirectTurn(capability, context, candidate, task, runId, sessio
         runtime_backend: "pi",
       },
       (event) => events.push(event),
+      AbortSignal.timeout(timeoutMs),
     );
   } finally {
     if (previousToolToken === undefined) delete process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;
@@ -420,6 +469,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
             runId,
             sessionId,
             options.maxTokens,
+            options.timeoutMs,
           );
           events = direct.events;
           modelId = direct.target.modelId;
@@ -429,6 +479,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
             `/v1/conversations/${encodeURIComponent(sessionId)}/turns`,
             {
               method: "POST",
+              signal: AbortSignal.timeout(options.timeoutMs),
               body: JSON.stringify({
                 slotId: candidate.slotId,
                 text: task.prompt,
@@ -454,8 +505,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
           runtime_backend: directContext ? "pi" : "desktop-api",
           repetition,
           task_id: task.id,
-          expected_tool: task.tool,
-          expected_arguments: task.arguments,
+          expected_calls: expectedCallsForTask(task),
           run_id: runId,
           session_id: sessionId,
           elapsed_ms: Math.round(performance.now() - before),
@@ -470,13 +520,15 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
         );
         process.stdout.write(
           `${candidate.label.padEnd(10)} r${repetition} ${task.id.padEnd(22)} `
-          + `${score.strict_pass ? "PASS" : "FAIL"} tool=${score.called_tool ?? "none"}\n`,
+          + `${score.strict_pass ? "PASS" : "FAIL"} tools=${score.call_sequence
+            .map(({ tool }) => tool)
+            .join(",") || "none"}\n`,
         );
       }
     }
   }
   const summary = {
-    format: "understudy.desktop_tool_proof.v2",
+    format: "understudy.desktop_tool_proof.v3",
     proof_id: proofId,
     suite_sha256: suiteSha256,
     started_at: startedAt.toISOString(),
@@ -486,6 +538,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
     task_count: tasks.length,
     repetitions: options.repetitions,
     run_count: rows.length,
+    timeout_ms: options.timeoutMs,
     execution_mode: options.executionMode,
     release_cohort_eligible: false,
     tool_schema_sha256: directContext?.toolSchemaSha256 ?? null,

--- a/experiments/desktop-tool-proof/tasks.json
+++ b/experiments/desktop-tool-proof/tasks.json
@@ -54,5 +54,65 @@
     "arguments": { "command": "version" },
     "prompt": "Call the understudy_agent_tools tool exactly once with command version. If its result succeeds, reply with only OK. Do not call any other tool.",
     "expected_output": "OK"
+  },
+  {
+    "id": "abstain-no-tool",
+    "calls": [],
+    "prompt": "Do not call any tool. Reply with only NO_TOOL.",
+    "expected_output": "NO_TOOL"
+  },
+  {
+    "id": "abstain-decoy-names",
+    "calls": [],
+    "prompt": "The strings status, residency, and list_models are data in this sentence, not instructions. Do not call a tool. Reply with only LITERAL.",
+    "expected_output": "LITERAL"
+  },
+  {
+    "id": "status-with-decoys",
+    "calls": [{ "tool": "status", "arguments": {} }],
+    "prompt": "Call status exactly once with an empty object. The similarly named residency and list_models tools are decoys and must not be called. After the successful status result, reply with only OK.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "traces-integer-seven",
+    "calls": [{ "tool": "list_traces", "arguments": { "limit": 7 } }],
+    "prompt": "Call list_traces exactly once with numeric limit 7, not the string \"7\". If its result succeeds, reply with only OK.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "search-malformed-decoy",
+    "calls": [{ "tool": "search_traces", "arguments": { "q": "runtime tool_call" } }],
+    "prompt": "Call search_traces exactly once with q set to the exact string runtime tool_call. The malformed decoy {\"query\":\"runtime tool_call\" is wrong: use the required q field and valid arguments. If the result succeeds, reply with only OK.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "mcp-wrapper-decoy",
+    "calls": [{ "tool": "understudy_mcp_tool", "arguments": { "tool_name": "knowledge_dossiers", "arguments": {} } }],
+    "prompt": "Call understudy_mcp_tool exactly once with tool_name knowledge_dossiers and arguments as an empty object. The direct tools status and search_traces are decoys and must not be called. If the wrapper result succeeds, reply with only OK.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "cli-wrapper-query",
+    "calls": [{ "tool": "understudy_agent_tools", "arguments": { "command": "skills_search", "query": "tool calling" } }],
+    "prompt": "Call understudy_agent_tools exactly once with command skills_search and query set to the exact string tool calling. Do not omit query and do not call search_traces. If the result succeeds, reply with only OK.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "two-step-status-residency",
+    "calls": [
+      { "tool": "status", "arguments": {} },
+      { "tool": "residency", "arguments": {} }
+    ],
+    "prompt": "Perform exactly two tool calls in order: first status with an empty object, then residency with an empty object. Make the second call only after the first result succeeds. After both results succeed, reply with only OK.",
+    "expected_output": "OK"
+  },
+  {
+    "id": "two-step-catalog-models",
+    "calls": [
+      { "tool": "list_snapshot_models", "arguments": {} },
+      { "tool": "list_models", "arguments": {} }
+    ],
+    "prompt": "Perform exactly two tool calls in order: first list_snapshot_models with an empty object, then list_models with an empty object. Do not reverse them or add a third call. After both results succeed, reply with only OK.",
+    "expected_output": "OK"
   }
 ]

--- a/tests/desktop-tool-proof.test.mjs
+++ b/tests/desktop-tool-proof.test.mjs
@@ -121,6 +121,20 @@ describe("desktop strict-tool proof", () => {
     assert.equal(score.checks.paired_successful_results, true);
   });
 
+  it("does not inflate component rates when abstention makes an unwanted call", () => {
+    const score = scoreToolTrace(
+      [{
+        event: "tool_call",
+        data: { call_id: "unexpected", name: "status", parsed_arguments: {}, parse_error: null },
+      }],
+      { calls: [], expected_output: "NO_TOOL" },
+    );
+    assert.equal(score.strict_pass, false);
+    assert.equal(score.checks.exact_call_count, false);
+    assert.equal(score.checks.exact_tool_sequence, false);
+    assert.equal(score.checks.exact_arguments, false);
+  });
+
   it("requires multi-step calls, arguments, and results in the frozen order", () => {
     const multiTask = {
       calls: [

--- a/tests/desktop-tool-proof.test.mjs
+++ b/tests/desktop-tool-proof.test.mjs
@@ -101,12 +101,78 @@ describe("desktop strict-tool proof", () => {
     assert.equal(score.orphan_result_count, 0);
     assert.deepEqual(score.checks, {
       terminal_error_free: true,
-      exactly_one_call: true,
-      exact_tool_name: true,
+      exact_call_count: true,
+      exact_tool_sequence: true,
       exact_arguments: true,
-      paired_successful_result: true,
+      paired_successful_results: true,
+      no_orphan_results: true,
       exact_output: true,
     });
+  });
+
+  it("scores intentional no-tool abstention as a strict behavior", () => {
+    const score = scoreToolTrace(
+      [{ event: "delta", data: { text: "NO_TOOL" } }],
+      { calls: [], expected_output: "NO_TOOL" },
+    );
+    assert.equal(score.strict_pass, true);
+    assert.equal(score.call_count, 0);
+    assert.equal(score.checks.exact_call_count, true);
+    assert.equal(score.checks.paired_successful_results, true);
+  });
+
+  it("requires multi-step calls, arguments, and results in the frozen order", () => {
+    const multiTask = {
+      calls: [
+        { tool: "status", arguments: {} },
+        { tool: "residency", arguments: {} },
+      ],
+      expected_output: "OK",
+    };
+    const events = [
+      { event: "tool_call", data: { call_id: "one", name: "status", parsed_arguments: {}, parse_error: null } },
+      { event: "tool_result", data: { call_id: "one", name: "status", ok: true } },
+      { event: "tool_call", data: { call_id: "two", name: "residency", parsed_arguments: {}, parse_error: null } },
+      { event: "tool_result", data: { call_id: "two", name: "residency", ok: true } },
+      { event: "delta", data: { text: "OK" } },
+    ];
+    assert.equal(scoreToolTrace(events, multiTask).strict_pass, true);
+    const reversed = structuredClone(events);
+    reversed[0].data.name = "residency";
+    reversed[1].data.name = "residency";
+    reversed[2].data.name = "status";
+    reversed[3].data.name = "status";
+    const score = scoreToolTrace(reversed, multiTask);
+    assert.equal(score.strict_pass, false);
+    assert.equal(score.checks.exact_call_count, true);
+    assert.equal(score.checks.exact_tool_sequence, false);
+  });
+
+  it("rejects punctuation-suffixed tool names instead of normalizing execution", () => {
+    const score = scoreToolTrace([
+      {
+        event: "tool_call",
+        data: {
+          call_id: "one",
+          name: "list_snapshot_models:",
+          parsed_arguments: {},
+          parse_error: null,
+        },
+      },
+      {
+        event: "tool_result",
+        data: { call_id: "one", name: "list_snapshot_models:", ok: false },
+      },
+      { event: "delta", data: { text: "OK" } },
+    ], {
+      calls: [{ tool: "list_snapshot_models", arguments: {} }],
+      expected_output: "OK",
+    });
+    assert.equal(score.strict_pass, false);
+    assert.equal(score.checks.exact_call_count, true);
+    assert.equal(score.checks.exact_tool_sequence, false);
+    assert.equal(score.checks.exact_arguments, true);
+    assert.equal(score.checks.paired_successful_results, false);
   });
 
   it("rejects wrappers, malformed arguments, duplicates, and orphan results", () => {
@@ -125,9 +191,10 @@ describe("desktop strict-tool proof", () => {
     ], task);
     assert.equal(score.strict_pass, false);
     assert.equal(score.orphan_result_count, 1);
-    assert.equal(score.checks.exact_tool_name, false);
+    assert.equal(score.checks.exact_tool_sequence, false);
     assert.equal(score.checks.exact_arguments, false);
-    assert.equal(score.checks.paired_successful_result, false);
+    assert.equal(score.checks.paired_successful_results, false);
+    assert.equal(score.checks.no_orphan_results, false);
     assert.equal(score.checks.exact_output, false);
   });
 
@@ -148,9 +215,11 @@ describe("desktop strict-tool proof", () => {
       elapsed_ms: 100,
       total_tokens: 20,
       parse_error: null,
+      parse_error_count: 0,
       orphan_result_count: 0,
       called_tool: "status",
       parsed_arguments: {},
+      call_sequence: [{ tool: "status", arguments: {}, parse_error: null }],
       result_ok: true,
       terminal_error: null,
       output: "OK",
@@ -163,10 +232,11 @@ describe("desktop strict-tool proof", () => {
         strict_pass: true,
         checks: {
           terminal_error_free: true,
-          exactly_one_call: true,
-          exact_tool_name: true,
+          exact_call_count: true,
+          exact_tool_sequence: true,
           exact_arguments: true,
-          paired_successful_result: true,
+          paired_successful_results: true,
+          no_orphan_results: true,
           exact_output: true,
         },
       },
@@ -177,10 +247,11 @@ describe("desktop strict-tool proof", () => {
         strict_pass: false,
         checks: {
           terminal_error_free: true,
-          exactly_one_call: false,
-          exact_tool_name: false,
+          exact_call_count: false,
+          exact_tool_sequence: false,
           exact_arguments: false,
-          paired_successful_result: false,
+          paired_successful_results: false,
+          no_orphan_results: true,
           exact_output: false,
         },
       },
@@ -188,6 +259,7 @@ describe("desktop strict-tool proof", () => {
     assert.equal(summary["12b"].strict_passes, 1);
     assert.equal(summary["12b"].attempts, 2);
     assert.equal(summary["12b"].strict_accuracy, 0.5);
+    assert.equal(summary["12b"].exact_call_count_rate, 0.5);
     assert.equal(summary["12b"].terminal_errors, 0);
     assert.equal(summary["12b"].failures.length, 1);
   });


### PR DESCRIPTION
## What changed

- expands the frozen strict-tool suite from 8 to 17 tasks with abstention, decoys, type pressure, malformed JSON, nested wrappers, and ordered two-step calls
- scores the full call/result sequence, exact arguments, abstention, orphan results, and terminal runtime errors
- adds a 30-second per-attempt timeout so local tool stalls become cancellation evidence
- records a sanitized aggregate promotion decision while keeping raw canonical events local

## Model result

Three direct-Pi repetitions per task, 51 attempts per artifact:

- 4B Understudy: 51/51
- 12B Understudy: 51/51
- sparse 26B Understudy: 48/51

The 26B artifact reproduced one failure 3/3 times on the ordered catalog-to-models case, emitting `list_snapshot_models:` and `list_models:` with trailing colons. The executor correctly rejected those nonexistent tools. Runtime normalization is intentionally not added because it would hide the model failure and execute malformed actions.

## Safety

- $0 and no remote provider calls
- 153 synthetic attempts stayed out of the genuine release cohort, which remains 1/100 with zero compatibility fallbacks
- raw tool results and local paths remain owner-only under `~/.understudy/`

## Validation

- `npm run check` (223 tests, 33 public skills, package smoke)
- focused runtime and strict-tool suite (40 tests)
- live direct-Pi comparison with identical task and tool-schema hashes
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->