### PR TITLE
Add exact task probes to tool certification

### DIFF
--- a/experiments/desktop-tool-proof/README.md
+++ b/experiments/desktop-tool-proof/README.md
@@ -22,6 +22,18 @@ node experiments/desktop-tool-proof/run.mjs \
   --repetitions 3
 ```
 
+For a causal probe against an exact frozen task, repeat `--task-id` as needed:
+
+```bash
+node experiments/desktop-tool-proof/run.mjs \
+  --candidate 26b-bf16:9 \
+  --task-id two-step-catalog-models \
+  --repetitions 3
+```
+
+Filtered proofs hash and persist only the selected task subset, so they cannot
+be confused with evidence from the full frozen suite.
+
 The direct runner resolves the selected slot from the authenticated residency
 surface and cross-checks its model path against the local agent card. Portable
 summary/results rows record the model id, Pi runtime, task hash, and exact

--- a/experiments/desktop-tool-proof/RESULTS.md
+++ b/experiments/desktop-tool-proof/RESULTS.md
@@ -9,9 +9,9 @@ Status: local promotion evidence, not a production replacement claim
   long-context, and broader task-quality certification.
 - **12B Understudy:** pass the current strict-tool gate. The evidence does not
   support changing this artifact to a sparse MoE for tool correctness.
-- **Sparse 26B Understudy:** hold strict-tool certification. Fix the checkpoint,
-  chat template, or tool-call renderer before promotion; do not normalize
-  malformed tool names inside the runtime.
+- **Sparse 26B Understudy:** hold strict-tool certification. The matched BF16
+  probe passes, so repair the 4-bit quantization path before promotion; do not
+  normalize malformed tool names inside the runtime.
 
 ## Frozen comparison
 
@@ -43,6 +43,25 @@ list_models:
 The arguments, call count, order, and final `OK` text were otherwise correct.
 The executor rejected both calls because the colon-suffixed tools do not exist.
 The 4B and 12B artifacts emitted the exact names on every repetition.
+
+### Causal BF16 probe
+
+The matching QAT BF16 26B artifact passed only this frozen task 3/3 through the
+same Pi runtime, tool schema, prompt, and decode path. Both 4-bit 26B artifacts
+failed the task 3/3: the correct group-size-32 Understudy artifact and the older
+group-size-64 conversion. This isolates the new failure to 4-bit quantization
+fidelity rather than sparse-MoE reasoning or the chat template. Group size 32
+remains required—it fixed the earlier QAT block-size mismatch—but is not by
+itself sufficient to preserve this function-name token sequence.
+
+| 26B causal probe | Quantization | Strict |
+| --- | --- | ---: |
+| QAT BF16 | none | 3/3 |
+| QAT MLX 4-bit Understudy | group size 32 | 0/3 |
+| QAT MLX 4-bit legacy | group size 64 | 0/3 |
+
+The one-task probe SHA-256 is
+`b5b607e19ed5fbba1a9c3be64abee439d7e783193ea33ed6d18149c76f1d91d6`.
 
 This is useful correction-pair material:
 
@@ -82,3 +101,5 @@ paths or trace data. They are not part of this repository.
    held-out slice.
 4. General task-quality comparison showing whether 12B adds enough value over
    the faster 4B to justify its memory and latency.
+5. For 26B, protect the tool-name-sensitive layers with mixed precision or
+   tool-heavy calibration, then repeat the full 17-task strict gate.

--- a/experiments/desktop-tool-proof/run.mjs
+++ b/experiments/desktop-tool-proof/run.mjs
@@ -78,14 +78,14 @@ export function expectedCallsForTask(task) {
 
 export function selectTasks(tasks, taskIds = []) {
   if (taskIds.length === 0) return tasks;
+  if (new Set(taskIds).size !== taskIds.length) {
+    throw new Error("task-id values must be unique");
+  }
   const selected = taskIds.map((taskId) => {
     const task = tasks.find((candidate) => candidate.id === taskId);
     if (!task) throw new Error(`unknown task-id: ${taskId}`);
     return task;
   });
-  if (new Set(taskIds).size !== taskIds.length) {
-    throw new Error("task-id values must be unique");
-  }
   return selected;
 }
 

--- a/experiments/desktop-tool-proof/run.mjs
+++ b/experiments/desktop-tool-proof/run.mjs
@@ -76,6 +76,19 @@ export function expectedCallsForTask(task) {
   return [];
 }
 
+export function selectTasks(tasks, taskIds = []) {
+  if (taskIds.length === 0) return tasks;
+  const selected = taskIds.map((taskId) => {
+    const task = tasks.find((candidate) => candidate.id === taskId);
+    if (!task) throw new Error(`unknown task-id: ${taskId}`);
+    return task;
+  });
+  if (new Set(taskIds).size !== taskIds.length) {
+    throw new Error("task-id values must be unique");
+  }
+  return selected;
+}
+
 export function scoreToolTrace(events, task) {
   const calls = events.filter((event) => event.event === "tool_call");
   const results = events.filter((event) => event.event === "tool_result");
@@ -232,6 +245,7 @@ function parseArgs(argv) {
     timeoutMs: 30_000,
     outputRoot: join(homedir(), ".understudy", "proofs", "tool-correctness"),
     executionMode: "direct-pi",
+    taskIds: [],
   };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
@@ -250,6 +264,7 @@ function parseArgs(argv) {
     } else if (value === "--repetitions") options.repetitions = Number(next);
     else if (value === "--max-tokens") options.maxTokens = Number(next);
     else if (value === "--timeout-ms") options.timeoutMs = Number(next);
+    else if (value === "--task-id") options.taskIds.push(String(next));
     else if (value === "--output-root") options.outputRoot = resolve(next);
     else throw new Error(`unknown argument: ${value}`);
     index += 1;
@@ -427,8 +442,11 @@ function eventTokens(events) {
 }
 
 export async function runProof(options = parseArgs(process.argv.slice(2))) {
-  const taskBytes = readFileSync(join(here, "tasks.json"));
-  const tasks = JSON.parse(taskBytes);
+  const sourceTaskBytes = readFileSync(join(here, "tasks.json"));
+  const tasks = selectTasks(JSON.parse(sourceTaskBytes), options.taskIds);
+  const taskBytes = options.taskIds.length === 0
+    ? sourceTaskBytes
+    : Buffer.from(`${JSON.stringify(tasks, null, 2)}\n`);
   const suiteSha256 = createHash("sha256").update(taskBytes).digest("hex");
   const startedAt = new Date();
   const proofId = `tools-${suiteSha256.slice(0, 10)}-${startedAt.toISOString().replaceAll(/[-:.]/g, "")}`;

--- a/tests/desktop-tool-proof.test.mjs
+++ b/tests/desktop-tool-proof.test.mjs
@@ -5,6 +5,7 @@ import {
   directToolDefinitions,
   resolveDirectCandidates,
   scoreToolTrace,
+  selectTasks,
   summarizeRows,
 } from "../experiments/desktop-tool-proof/run.mjs";
 
@@ -15,6 +16,13 @@ const task = {
 };
 
 describe("desktop strict-tool proof", () => {
+  it("selects an exact ordered subset for causal probes", () => {
+    const tasks = [{ id: "one" }, { id: "two" }];
+    assert.deepEqual(selectTasks(tasks, ["two"]), [{ id: "two" }]);
+    assert.throws(() => selectTasks(tasks, ["missing"]), /unknown task-id: missing/);
+    assert.throws(() => selectTasks(tasks, ["one", "one"]), /must be unique/);
+  });
+
   it("builds the bounded direct tool set from the authenticated MCP contract", () => {
     const names = [
       "status",

--- a/tests/desktop-tool-proof.test.mjs
+++ b/tests/desktop-tool-proof.test.mjs
@@ -21,6 +21,7 @@ describe("desktop strict-tool proof", () => {
     assert.deepEqual(selectTasks(tasks, ["two"]), [{ id: "two" }]);
     assert.throws(() => selectTasks(tasks, ["missing"]), /unknown task-id: missing/);
     assert.throws(() => selectTasks(tasks, ["one", "one"]), /must be unique/);
+    assert.throws(() => selectTasks(tasks, ["missing", "missing"]), /must be unique/);
   });
 
   it("builds the bounded direct tool set from the authenticated MCP contract", () => {


### PR DESCRIPTION
Adds repeatable `--task-id` filtering for causal strict-tool probes, hashes/persists only the selected frozen subset, and tests invalid/duplicate ids. Records the matched 26B result: QAT BF16 passes the failing ordered two-call task 3/3 while both 4-bit variants fail 3/3, isolating a remaining quantization-fidelity defect.\n\nValidation: `npm run check` (225 tests, 33 public skills, package smoke); no provider spend or uploads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->