### PR TITLE
Certify the 6-bit sparse 26B tool path

### DIFF
--- a/experiments/desktop-tool-proof/RESULTS.md
+++ b/experiments/desktop-tool-proof/RESULTS.md
@@ -12,9 +12,9 @@ Status: local promotion evidence, not a production replacement claim
 - **Sparse 26B Understudy:** hold strict-tool certification. The matched BF16
   probe passes, so repair the 4-bit quantization path before promotion; do not
   normalize malformed tool names inside the runtime.
-- **Sparse 26B QAT 8-bit candidate:** pass the current strict-tool gate. Keep it
-  as the safe compressed 26B rung while mixed-precision work tries to recover
-  the 4-bit artifact's smaller footprint.
+- **Sparse 26B QAT 6-bit candidate:** pass the current strict-tool gate. It is
+  the smallest currently safe 26B rung; keep 8-bit as the higher-precision
+  reference while mixed allocation tries to approach the 4-bit footprint.
 
 ## Frozen comparison
 
@@ -66,7 +66,7 @@ itself sufficient to preserve this function-name token sequence.
 The one-task probe SHA-256 is
 `b5b607e19ed5fbba1a9c3be64abee439d7e783193ea33ed6d18149c76f1d91d6`.
 
-### 8-bit repair candidate
+### 6- and 8-bit repair candidates
 
 Changing the QAT 26B body from 4-bit to 8-bit, while preserving the checkpoint,
 group-size-32 conversion, automatic 8-bit router policy, template, tool schema,
@@ -87,6 +87,21 @@ The 8-bit result isolates the failing token sequence to the 4-bit body/expert
 path rather than the shared router policy or sparse-MoE architecture itself.
 It is promotion evidence for strict tool use, not yet for VLM, long-context, or
 general task quality.
+
+The uniform 6-bit body then preserved the same strict behavior while reducing
+the installed footprint by about 5.9 GB:
+
+- exact `two-step-catalog-models` probe: **10/10 strict**;
+- full frozen 17-task suite: **51/51 strict** across three repetitions;
+- parse, terminal, and orphan-result errors: **zero**;
+- mean full-suite end-to-end latency: **5,173 ms**;
+- installed size / Desktop residency estimate: **21.7 GB**;
+- provider spend and uploads: **none**.
+
+Owner-only 6-bit proof ids are `tools-b5b607e19e-20260713T011137245Z` for the
+10-attempt causal probe and `tools-2286836959-20260713T011234171Z` for the full
+suite. Together, the BF16, 8-bit, 6-bit, and 4-bit results place the observed
+strict-tool failure threshold between 4 and 6 body bits for this artifact.
 
 This is useful correction-pair material:
 
@@ -126,7 +141,7 @@ paths or trace data. They are not part of this repository.
    held-out slice.
 4. General task-quality comparison showing whether 12B adds enough value over
    the faster 4B to justify its memory and latency.
-5. For 26B, use the 8-bit candidate as the safe rung while protecting
+5. For 26B, use the 6-bit candidate as the safe rung while protecting
    tool-name-sensitive expert/body layers with mixed precision or tool-heavy
    calibration. Any smaller candidate must repeat the exact 10-run probe and
    the full 51-attempt strict gate.


### PR DESCRIPTION
Records the next precision rung: QAT 6-bit passes the formerly failing task 10/10 and the full strict suite 51/51 with zero parse, terminal, or orphan-result errors. At 21.7 GB and 5.17 s mean latency, it supersedes 8-bit as the smallest currently safe 26B strict-tool candidate; 4-bit remains held.\n\nValidation: `npm run check` (225 tests, 33 public skills, package smoke). Local-only, no provider spend or uploads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->