### PR TITLE
Add certified mixed-bit Gemma MoE recipe

### DIFF
--- a/experiments/desktop-tool-proof/README.md
+++ b/experiments/desktop-tool-proof/README.md
@@ -34,6 +34,20 @@ node experiments/desktop-tool-proof/run.mjs \
 Filtered proofs hash and persist only the selected task subset, so they cannot
 be confused with evidence from the full frozen suite.
 
+For Gemma 4 MoE compression repair, the local converter preserves QAT's
+group-size-32 contract, keeps routers at 8-bit, and protects an explicit layer
+set at 6-bit while leaving the remaining body at 4-bit:
+
+```bash
+python experiments/desktop-tool-proof/convert-gemma4-moe-mixed.py \
+  --source <qat-bf16-source> \
+  --output <candidate-output> \
+  --protected-layers 15-29
+```
+
+Every generated artifact is a candidate until it passes both the exact
+10-attempt causal probe and the full 51-attempt strict suite.
+
 The direct runner resolves the selected slot from the authenticated residency
 surface and cross-checks its model path against the local agent card. Portable
 summary/results rows record the model id, Pi runtime, task hash, and exact

--- a/experiments/desktop-tool-proof/RESULTS.md
+++ b/experiments/desktop-tool-proof/RESULTS.md
@@ -12,9 +12,9 @@ Status: local promotion evidence, not a production replacement claim
 - **Sparse 26B Understudy:** hold strict-tool certification. The matched BF16
   probe passes, so repair the 4-bit quantization path before promotion; do not
   normalize malformed tool names inside the runtime.
-- **Sparse 26B QAT 6-bit candidate:** pass the current strict-tool gate. It is
-  the smallest currently safe 26B rung; keep 8-bit as the higher-precision
-  reference while mixed allocation tries to approach the 4-bit footprint.
+- **Sparse 26B QAT mixed 4/6-bit candidate:** pass the current strict-tool gate.
+  It is the smallest currently safe 26B rung; keep uniform 6-bit and 8-bit as
+  higher-precision references for broader promotion work.
 
 ## Frozen comparison
 
@@ -103,6 +103,29 @@ Owner-only 6-bit proof ids are `tools-b5b607e19e-20260713T011137245Z` for the
 suite. Together, the BF16, 8-bit, 6-bit, and 4-bit results place the observed
 strict-tool failure threshold between 4 and 6 body bits for this artifact.
 
+### Mixed 4/6-bit layer ablation
+
+A QAT-aware mixed recipe recovered most of the 4-bit footprint without hiding
+the failure in the runtime. All candidates kept group size 32, routers at
+8-bit, embeddings/head at 6-bit, and the unprotected body at 4-bit:
+
+| Protected 6-bit layers | Installed size | Exact probe |
+| --- | ---: | ---: |
+| 0–7 | 17.5 GB | 1/10 |
+| 0–14 | about 19 GB | 8/10 |
+| **15–29** | **18.8 GB** | **10/10** |
+
+The late-half candidate then passed the full 17-task suite **51/51** across
+three repetitions with zero parse, terminal, or orphan-result errors. Mean
+end-to-end latency was **4,348 ms**. Its quantized module allocation is 149 at
+4-bit, 148 at 6-bit, and 30 router modules at 8-bit.
+
+Owner-only proof ids are `tools-b5b607e19e-20260713T012832871Z` for the exact
+probe and `tools-2286836959-20260713T012949919Z` for the full suite. This result
+also corrects the earlier generalization from broad tool-trigger analysis:
+early-layer protection helps general triggering, but this exact punctuation
+regression is late-half sensitive.
+
 This is useful correction-pair material:
 
 - rejected: colon-suffixed tool names;
@@ -141,7 +164,6 @@ paths or trace data. They are not part of this repository.
    held-out slice.
 4. General task-quality comparison showing whether 12B adds enough value over
    the faster 4B to justify its memory and latency.
-5. For 26B, use the 6-bit candidate as the safe rung while protecting
-   tool-name-sensitive expert/body layers with mixed precision or tool-heavy
-   calibration. Any smaller candidate must repeat the exact 10-run probe and
-   the full 51-attempt strict gate.
+5. For 26B, use the late-half mixed 4/6-bit candidate as the safe strict-tool
+   rung. It still needs frozen VLM, long-context, and broader quality evidence
+   before publication or default routing.

--- a/experiments/desktop-tool-proof/convert-gemma4-moe-mixed.py
+++ b/experiments/desktop-tool-proof/convert-gemma4-moe-mixed.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Build a QAT-aware mixed-bit Gemma 4 MoE candidate for local certification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+LAYER_PATTERN = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
+
+
+def parse_layers(value: str) -> set[int]:
+    layers: set[int] = set()
+    for part in value.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if "-" in token:
+            start_text, end_text = token.split("-", 1)
+            start, end = int(start_text), int(end_text)
+            if start > end:
+                raise argparse.ArgumentTypeError(f"invalid layer range: {token}")
+            layers.update(range(start, end + 1))
+        else:
+            layers.add(int(token))
+    if not layers or min(layers) < 0:
+        raise argparse.ArgumentTypeError("protected layers must be non-negative")
+    return layers
+
+
+def build_predicate(
+    protected_layers: set[int],
+    *,
+    group_size: int,
+    low_bits: int,
+    high_bits: int,
+    router_bits: int,
+    skip_multimodal_module,
+):
+    def predicate(path, module):
+        if skip_multimodal_module(path) or not hasattr(module, "to_quantized"):
+            return False
+        weight = getattr(module, "weight", None)
+        if weight is None or len(weight.shape) < 2 or weight.shape[1] % group_size != 0:
+            return False
+        if "router.proj" in path:
+            return {"group_size": group_size, "bits": router_bits}
+        if "embed_tokens" in path or "lm_head" in path:
+            return {"group_size": group_size, "bits": high_bits}
+        match = LAYER_PATTERN.search(path)
+        bits = high_bits if match and int(match.group(1)) in protected_layers else low_bits
+        return {"group_size": group_size, "bits": bits}
+
+    return predicate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--protected-layers", type=parse_layers, default=parse_layers("15-29"))
+    parser.add_argument("--group-size", type=int, default=32)
+    parser.add_argument("--low-bits", type=int, default=4)
+    parser.add_argument("--high-bits", type=int, default=6)
+    parser.add_argument("--router-bits", type=int, default=8)
+    args = parser.parse_args()
+
+    if not args.source.is_dir():
+        parser.error(f"source is not a directory: {args.source}")
+    if args.output.exists():
+        parser.error(f"output already exists: {args.output}")
+    if args.group_size != 32:
+        parser.error("Gemma QAT candidates require group size 32")
+    if not 2 <= args.low_bits < args.high_bits <= args.router_bits <= 8:
+        parser.error("expected 2 <= low bits < high bits <= router bits <= 8")
+
+    from mlx_vlm.convert import convert
+    from mlx_vlm.utils import skip_multimodal_module
+
+    protected_layers = sorted(args.protected_layers)
+    convert(
+        str(args.source),
+        str(args.output),
+        quantize=True,
+        q_group_size=args.group_size,
+        q_bits=args.low_bits,
+        dtype="bfloat16",
+        quant_predicate=build_predicate(
+            set(protected_layers),
+            group_size=args.group_size,
+            low_bits=args.low_bits,
+            high_bits=args.high_bits,
+            router_bits=args.router_bits,
+            skip_multimodal_module=skip_multimodal_module,
+        ),
+    )
+    manifest = {
+        "format": "understudy.local_mixed_quantization.v1",
+        "source": str(args.source.resolve()),
+        "output": str(args.output.resolve()),
+        "group_size": args.group_size,
+        "low_bits": args.low_bits,
+        "high_bits": args.high_bits,
+        "router_bits": args.router_bits,
+        "protected_layers": protected_layers,
+        "promotion_status": "candidate_requires_strict_tool_certification",
+    }
+    (args.output / "understudy.quantization.json").write_text(
+        json.dumps(manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a QAT-aware Gemma 4 MoE converter that keeps group size 32, routers at 8-bit, a selected layer range at 6-bit, and the remaining body at 4-bit. The proven late-half recipe (`15-29`) produces an 18.8 GB 26B candidate that passes the exact regression probe 10/10 and the full strict suite 51/51 with zero parse, terminal, or orphan-result errors. Failed early-half ablations are recorded to prevent regression to the wrong sensitivity assumption.\n\nValidation: live BF16→mixed conversion; exact and full direct-Pi proofs; converter predicate/argument smokes; `npm run check` (225 tests, 33 public skills, package smoke). No provider spend or uploads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->