### PR TITLE
Preserve native local model context windows

### DIFF
--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -2153,6 +2153,16 @@ fn sidecar_tool_definitions(allow_sidekick_delegation: bool) -> Vec<Value> {
         .collect()
 }
 
+const LOCAL_LOGICAL_CONTEXT_WINDOW_TOKENS: u64 = 32_768;
+
+fn local_context_windows(binding: &RouteBinding) -> Option<(u64, u64)> {
+    if binding.route != "local" {
+        return None;
+    }
+    let provider = crate::models::context_window_tokens(&binding.model_field)?;
+    Some((provider.min(LOCAL_LOGICAL_CONTEXT_WINDOW_TOKENS), provider))
+}
+
 fn sidecar_run_request(
     app: &AppHandle,
     original: &[ChatMsg],
@@ -2190,6 +2200,10 @@ fn sidecar_run_request(
         request["provider_api_key"] = json!(binding.bearer.as_deref().ok_or_else(|| {
             "Anthropic route lost its in-memory provider credential".to_string()
         })?);
+    }
+    if let Some((logical, provider)) = local_context_windows(binding) {
+        request["context_window_tokens"] = json!(logical);
+        request["provider_context_window_tokens"] = json!(provider);
     }
     if let Some(url) = tool_executor_url {
         request["tool_executor_url"] = json!(url);
@@ -4156,10 +4170,9 @@ mod tests {
             .pointer("/function/parameters/properties/tool_name/enum")
             .and_then(Value::as_array)
             .expect("wrapper names are enumerated");
-        assert!(wrapped_names.iter().all(|name| {
-            name.as_str()
-                .is_some_and(|name| !direct.contains(name))
-        }));
+        assert!(wrapped_names
+            .iter()
+            .all(|name| { name.as_str().is_some_and(|name| !direct.contains(name)) }));
     }
 
     #[test]
@@ -4217,6 +4230,36 @@ mod tests {
             sidecar_provider_base_url("https://gateway.example/v1/chat/completions"),
             "https://gateway.example/v1"
         );
+    }
+
+    #[test]
+    fn local_runtime_separates_logical_and_native_provider_windows() {
+        let dir = std::env::temp_dir().join(format!(
+            "understudy-chat-context-window-test-{}",
+            std::process::id(),
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("config.json"),
+            r#"{"text_config":{"max_position_embeddings":262144}}"#,
+        )
+        .unwrap();
+        let local = RouteBinding {
+            route: "local".to_string(),
+            url: "http://127.0.0.1:8091/v1/chat/completions".to_string(),
+            bearer: None,
+            model_field: dir.to_string_lossy().into_owned(),
+        };
+        assert_eq!(local_context_windows(&local), Some((32_768, 262_144)));
+        let cloud = RouteBinding {
+            route: "cloud".to_string(),
+            url: "https://gateway.example/v1/chat/completions".to_string(),
+            bearer: Some("fixture".to_string()),
+            model_field: local.model_field.clone(),
+        };
+        assert_eq!(local_context_windows(&cloud), None);
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -55,6 +55,10 @@ pub(crate) enum RuntimeEvent {
         text: String,
         #[serde(default)]
         model: Option<String>,
+        #[serde(default)]
+        logical_context_window_tokens: Option<u64>,
+        #[serde(default)]
+        provider_context_window_tokens: Option<u64>,
     },
     Delta {
         role: RuntimeRole,

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -60,6 +60,8 @@ pub struct MlxRuntimeStatus {
 /// The port the MLX server binds — matches Understudy's configured local base URL.
 pub const MLX_PORT: u16 = 8089;
 pub const LOCAL_BASE_URL: &str = "http://127.0.0.1:8089/v1";
+const MIN_CONTEXT_WINDOW_TOKENS: u64 = 1_024;
+const MAX_CONTEXT_WINDOW_TOKENS: u64 = 2_000_000;
 
 /// Marker dropped at the start of a snapshot download and removed only after
 /// every file has landed and verified. While it exists the snapshot must not
@@ -76,6 +78,26 @@ pub fn models_dir() -> Option<PathBuf> {
     }
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".understudy").join("models"))
+}
+
+/// Read the provider's native attention window from a local MLX model config.
+/// The conversation runtime keeps this separate from its smaller logical
+/// compaction boundary so long inputs remain possible without letting every
+/// multi-turn session grow raw KV state to the model maximum.
+pub fn context_window_tokens(model_path: &str) -> Option<u64> {
+    let raw = std::fs::read_to_string(Path::new(model_path).join("config.json")).ok()?;
+    let config: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    [
+        "/text_config/max_position_embeddings",
+        "/max_position_embeddings",
+        "/model_config/max_position_embeddings",
+        "/text_config/context_length",
+        "/context_length",
+        "/n_ctx",
+    ]
+    .into_iter()
+    .find_map(|pointer| config.pointer(pointer).and_then(serde_json::Value::as_u64))
+    .filter(|tokens| (MIN_CONTEXT_WINDOW_TOKENS..=MAX_CONTEXT_WINDOW_TOKENS).contains(tokens))
 }
 
 /// Live model catalog served by the snapshot service.
@@ -326,6 +348,48 @@ mod tests {
         std::fs::remove_file(dir.join(INCOMPLETE_MARKER)).unwrap();
         assert!(snapshot_ready(&dir));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reads_nested_and_top_level_native_context_windows() {
+        let nested = temp_snapshot_dir("nested-context-window");
+        std::fs::write(
+            nested.join("config.json"),
+            r#"{"text_config":{"max_position_embeddings":262144}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            context_window_tokens(nested.to_str().unwrap()),
+            Some(262_144)
+        );
+        let top_level = temp_snapshot_dir("top-level-context-window");
+        std::fs::write(
+            top_level.join("config.json"),
+            r#"{"max_position_embeddings":131072}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            context_window_tokens(top_level.to_str().unwrap()),
+            Some(131_072),
+        );
+        let _ = std::fs::remove_dir_all(nested);
+        let _ = std::fs::remove_dir_all(top_level);
+    }
+
+    #[test]
+    fn rejects_missing_malformed_and_implausible_context_windows() {
+        let missing = temp_snapshot_dir("missing-context-window");
+        std::fs::write(missing.join("config.json"), "{}").unwrap();
+        assert_eq!(context_window_tokens(missing.to_str().unwrap()), None);
+        let too_large = temp_snapshot_dir("large-context-window");
+        std::fs::write(
+            too_large.join("config.json"),
+            r#"{"max_position_embeddings":3000000}"#,
+        )
+        .unwrap();
+        assert_eq!(context_window_tokens(too_large.to_str().unwrap()), None);
+        let _ = std::fs::remove_dir_all(missing);
+        let _ = std::fs::remove_dir_all(too_large);
     }
 
     #[test]

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -104,6 +104,16 @@ export const runtimeRequestSchema = z
   })
   .strict()
   .superRefine((request, context) => {
+    if (
+      request.provider_context_window_tokens != null &&
+      request.provider_context_window_tokens < request.context_window_tokens
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["provider_context_window_tokens"],
+        message: "provider context window must be at least the logical context window",
+      });
+    }
     if (request.supervision && request.runtime_backend !== "pi") {
       context.addIssue({
         code: z.ZodIssueCode.custom,
@@ -399,6 +409,23 @@ export function validateRuntimeTrace(values: readonly unknown[]): RuntimeEventEn
     if (["message", "delta", "reasoning_delta"].includes(event)) {
       requiredString(data, "role", `${event}.role`);
       if (typeof data.text !== "string") throw new Error(`${event}.text must be a string`);
+      if (event === "message" && "logical_context_window_tokens" in data) {
+        const logical = nonNegativeInteger(
+          data,
+          "logical_context_window_tokens",
+          "message.logical_context_window_tokens",
+        );
+        const provider = nonNegativeInteger(
+          data,
+          "provider_context_window_tokens",
+          "message.provider_context_window_tokens",
+        );
+        if (logical < 1_024 || provider < logical) {
+          throw new Error(
+            "message context windows require provider >= logical >= 1024 tokens",
+          );
+        }
+      }
     } else if (event === "tool_call") {
       const callId = requiredString(data, "call_id", "tool_call.call_id");
       const name = requiredString(data, "name", "tool_call.name");

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -352,7 +352,14 @@ async function emitInputEvidence(
       byte_count: bytes.byteLength,
     });
   }
-  await writer.emit("message", { role: "user", text: latest.content, model: null });
+  await writer.emit("message", {
+    role: "user",
+    text: latest.content,
+    model: null,
+    logical_context_window_tokens: request.context_window_tokens,
+    provider_context_window_tokens:
+      request.provider_context_window_tokens ?? request.context_window_tokens,
+  });
 }
 
 function attachCanonicalAdapter(

--- a/src/runtime/conversation/vercel-runtime.ts
+++ b/src/runtime/conversation/vercel-runtime.ts
@@ -160,7 +160,14 @@ async function emitInputEvidence(
       byte_count: bytes.byteLength,
     });
   }
-  await writer.emit("message", { role: "user", text: latest.content, model: null });
+  await writer.emit("message", {
+    role: "user",
+    text: latest.content,
+    model: null,
+    logical_context_window_tokens: request.context_window_tokens,
+    provider_context_window_tokens:
+      request.provider_context_window_tokens ?? request.context_window_tokens,
+  });
 }
 
 export async function runVercelConversation(

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -322,6 +322,8 @@ test("Vercel runtime emits canonical input, delta, and provider usage", async ()
     events.map((event) => event.sequence),
     [0, 1, 2],
   );
+  assert.equal(events[0].data.logical_context_window_tokens, 32_768);
+  assert.equal(events[0].data.provider_context_window_tokens, 32_768);
   assert.deepEqual(
     {
       input_tokens: events[2].data.input_tokens,
@@ -401,6 +403,8 @@ test("Pi runtime emits the same canonical basic-chat evidence", async () => {
     ["message", "delta", "usage"],
   );
   assert.ok(events.every((event) => event.runtime_id === "pi-agent-session"));
+  assert.equal(events[0].data.logical_context_window_tokens, 32_768);
+  assert.equal(events[0].data.provider_context_window_tokens, 32_768);
   assert.equal(events.at(-1).data.input_tokens, 4);
   assert.equal(events.at(-1).data.output_tokens, 4);
   validateRuntimeTrace(events);
@@ -605,6 +609,8 @@ test("Pi runtime recovers from an unexpected provider context overflow", async (
     await new Promise((accept) => server.close(accept));
   }
   validateRuntimeTrace(events);
+  assert.equal(events[0].data.logical_context_window_tokens, 2_048);
+  assert.equal(events[0].data.provider_context_window_tokens, 32_768);
   assert.ok(calls >= 3, `expected overflow, summary, and retry calls; saw ${calls}`);
   assert.equal(events.some((event) => event.event === "error"), false);
   assert.ok(events.some((event) => event.event === "compaction_boundary"));
@@ -2327,6 +2333,22 @@ test("Pi compaction budgets cannot outgrow small local conversations", () => {
   });
   assert.equal(piPreflightCompactionRequired(800, 100, 1_024, 128), true);
   assert.equal(piPreflightCompactionRequired(700, 100, 1_024, 128), false);
+});
+
+test("runtime context evidence rejects a provider window below the logical window", () => {
+  assert.throws(
+    () => parseRuntimeRequest({
+      run_id: "bad-context-run",
+      session_id: "bad-context-session",
+      base_url: "http://127.0.0.1:1/v1",
+      model: "local-model",
+      role: "primary",
+      messages: [{ role: "user", content: "hello" }],
+      context_window_tokens: 32_768,
+      provider_context_window_tokens: 16_384,
+    }),
+    /provider context window must be at least the logical context window/,
+  );
 });
 
 test("deterministic compaction is restricted to its frozen Pi gate", () => {


### PR DESCRIPTION
## Summary
- read each local model native context window from its config
- keep the app multi-turn compaction target at 32k without imposing a server-side KV cap
- record logical and provider context windows in canonical Pi/Vercel evidence
- reject impossible evidence where the provider window is smaller than the logical window

## Verification
- `npm run check` (229 tests; package and skill smoke pass)
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml --lib` (140 passed, 1 ignored)
- `cargo clippy --manifest-path apps/homescreen/src-tauri/Cargo.toml --lib -- -D warnings`
- `git diff --check`

No model processes or provider calls were started.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->