### PR TITLE
Unify the public desktop with the reviewed Train UI

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -30,10 +30,8 @@ import {
   PromptInputActionMenuContent,
   PromptInputActionMenuTrigger,
   PromptInputBody,
-  PromptInputFooter,
   PromptInputSubmit,
   PromptInputTextarea,
-  PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
 import { Persona, type PersonaState } from "@/components/ai-elements/persona";
 import {
@@ -687,7 +685,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
           key={personaCycle}
           variant="halo"
           state={personaState}
-          className="persona-halo"
+          className={
+            "persona-halo" +
+            (streaming && latestSidekickEvent?.mode === "supervision" ? " supervised" : "")
+          }
           onReady={() => setPersonaReady(true)}
         />
         {showSidekickPersona && (
@@ -803,41 +804,39 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
           onSubmit={(message) => send(message.text, message.files)}
           className="border-rule bg-card"
         >
-          <PromptInputBody>
-            <PromptInputTextarea
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="Ask Understudy..."
-              disabled={streaming}
+          <div className="composer-row">
+            <PromptInputActionMenu>
+              <PromptInputActionMenuTrigger tooltip="Add image or file" />
+              <PromptInputActionMenuContent>
+                <PromptInputActionAddAttachments label="Add image or file" />
+              </PromptInputActionMenuContent>
+            </PromptInputActionMenu>
+            <ModelPicker
+              choices={choices}
+              selected={selectedChoice}
+              onSelect={(id) => setSelectedModel(id)}
+              onConnectAnthropic={connectAnthropic}
             />
-          </PromptInputBody>
-          <PromptInputFooter>
-            <PromptInputTools>
-              <PromptInputActionMenu>
-                <PromptInputActionMenuTrigger tooltip="Add image or file" />
-                <PromptInputActionMenuContent>
-                  <PromptInputActionAddAttachments label="Add image or file" />
-                </PromptInputActionMenuContent>
-              </PromptInputActionMenu>
-              <ModelPicker
-                choices={choices}
-                selected={selectedChoice}
-                onSelect={(id) => setSelectedModel(id)}
-                onConnectAnthropic={connectAnthropic}
-              />
-              <ThinkingToggle
-                selected={selectedChoice}
+            <PromptInputBody className="composer-row-body">
+              <PromptInputTextarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Ask Understudy..."
                 disabled={streaming}
-                loading={selectedChoice.route === "local" && thinkingPending?.slotId === selectedChoice.slotId}
-                onToggle={setThinking}
               />
-            </PromptInputTools>
+            </PromptInputBody>
+            <ThinkingToggle
+              selected={selectedChoice}
+              disabled={streaming}
+              loading={selectedChoice.route === "local" && thinkingPending?.slotId === selectedChoice.slotId}
+              onToggle={setThinking}
+            />
             <PromptInputSubmit
               status={streaming ? "streaming" : err ? "error" : "ready"}
               onStop={stopStreaming}
               disabled={!streaming && (!input.trim() || (selectedChoice.route === "local" && !selectedChoice.active))}
             />
-          </PromptInputFooter>
+          </div>
         </PromptInput>
       </div>
     </div>

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -42,14 +42,9 @@ const ICONS: Record<PaneId, ReactNode> = {
     </svg>
   ),
   rlm: (
-    // Fan-out tree: one root, three workers, one reduce.
     <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <circle cx="8" cy="2.8" r="1.6" stroke="currentColor" strokeWidth="1.2" />
-      <circle cx="3" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.2" />
-      <circle cx="8" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.2" />
-      <circle cx="13" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.2" />
-      <circle cx="8" cy="13.2" r="1.6" stroke="currentColor" strokeWidth="1.2" />
-      <path d="M7 4 4 6.7M8 4.4V6.5M9 4l3 2.7M4 9.2l3 2.8M8 9.5v2.1M12 9.2l-3 2.8" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+      <path d="M6.5 2h3M8 2v4.2l4 6.3c.5.8 0 1.5-.9 1.5H4.9c-.9 0-1.4-.7-.9-1.5l4-6.3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M5.5 10.5h5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" opacity=".72" />
     </svg>
   ),
   "training-evals": (
@@ -108,20 +103,13 @@ const ICONS: Record<PaneId, ReactNode> = {
 const SERVING_NAV: { id: PaneId; label: string }[] = [
   { id: "chat", label: "Chat" },
   { id: "status", label: "Status" },
-  { id: "capture", label: "Capture" },
   { id: "models", label: "Models" },
-  { id: "rlm", label: "RLM" },
-  { id: "traces", label: "Traces" },
-  { id: "usage", label: "Usage" },
+  { id: "rlm", label: "Experiments" },
 ];
 
+// Keep the implementation available to agents and deep links while the human
+// navigation stays focused on the four product-level jobs reviewed in Train.
 const TRAINING_NAV: { id: PaneId; label: string }[] = [
-  { id: "training-evals", label: "Evals" },
-  { id: "training-optimization", label: "Optimization" },
-  { id: "training-datasets", label: "Datasets" },
-  { id: "training-finetuning", label: "Fine-tuning" },
-  { id: "training-rl", label: "RL" },
-  { id: "training-jobs", label: "Jobs" },
 ];
 
 export function Sidebar({
@@ -147,7 +135,7 @@ export function Sidebar({
         </div>
       ))}
 
-      <div className="nav-section">Training</div>
+      {TRAINING_NAV.length > 0 && <div className="nav-section">Training</div>}
       {TRAINING_NAV.map((n) => (
         <div
           key={n.id}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -29,7 +29,8 @@
   --color-popover-foreground: var(--c-ink);
   --color-border: var(--c-rule);
   --color-input: var(--c-card);
-  --color-ring: var(--c-stamp);
+  /* The reviewed Train desktop uses cyan for model focus and activity. */
+  --color-ring: color-mix(in srgb, #67e8f9 55%, rgba(255,255,255,0.25));
   --color-primary: var(--c-stamp);
   --color-primary-foreground: var(--c-paper);
   --color-secondary: var(--c-hover);
@@ -1916,6 +1917,9 @@ select,
   height: min(52vh, 420px);
   opacity: 0;
   transform: scale(0.96);
+  /* understudy-fast family tint from the merged Train desktop. */
+  --pc-tint: #67e8f9;
+  filter: drop-shadow(0 0 22px color-mix(in srgb, var(--pc-tint) 34%, transparent));
   transition: width 260ms cubic-bezier(0.2, 0.7, 0.2, 1),
     height 260ms cubic-bezier(0.2, 0.7, 0.2, 1),
     opacity 300ms cubic-bezier(0.2, 0.7, 0.2, 1),
@@ -2683,3 +2687,121 @@ select,
 }
 .gepa-subscores td.up { color: var(--c-ok); }
 .gepa-subscores td.down { color: var(--c-bad); }
+
+/* --------------------------------------------------------------------------
+ * Reviewed Train desktop treatment
+ *
+ * Ported from understudy-agent@3f025022 after the public desktop runtime moved
+ * to this repository. Keep the visual language here so release builds do not
+ * regress to the pre-Train terracotta composer while the canonical Pi runtime
+ * and residency guard remain owned by understudy-agent-tools.
+ * -------------------------------------------------------------------------- */
+:root {
+  --mb-cyan: #67e8f9;
+  --mb-mint: #9edbd3;
+}
+
+.ai-chat-composer {
+  width: min(560px, 88%);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ai-chat-composer form {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.14) !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.ai-chat-composer form:focus-within {
+  border-color: color-mix(in srgb, var(--mb-cyan) 50%, rgba(255, 255, 255, 0.2)) !important;
+  box-shadow: 0 0 24px -10px color-mix(in srgb, var(--mb-cyan) 35%, transparent);
+}
+
+.composer-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+}
+
+.composer-row [data-slot="input-group"],
+.composer-row [data-slot="prompt-input-body"] {
+  width: auto;
+  min-width: 80px;
+  flex: 1 1 auto;
+}
+
+.composer-row textarea {
+  width: 100%;
+  min-width: 0;
+  min-height: 24px;
+  max-height: 120px;
+  padding: 9px 4px;
+}
+
+.composer-row .ai-model-trigger {
+  max-width: 132px;
+  border: 0;
+  background: transparent;
+  padding-inline: 4px;
+}
+
+.composer-row .ai-thinking-toggle {
+  border-color: transparent;
+  background: transparent;
+  padding-inline: 6px;
+}
+
+.composer-row > button:first-child {
+  color: var(--text-2);
+}
+
+.composer-row > button:first-child:hover {
+  color: var(--text);
+}
+
+.ai-chat-composer textarea {
+  caret-color: var(--mb-cyan);
+}
+
+.ai-chat-composer button[type="submit"] {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mb-cyan) 20%, transparent);
+  color: var(--mb-cyan);
+  transition: background 140ms ease, opacity 140ms ease;
+}
+
+.ai-chat-composer button[type="submit"]:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--mb-cyan) 32%, transparent);
+}
+
+.ai-chat-composer button[type="submit"]:disabled {
+  opacity: 0.35;
+}
+
+/* Mint identifies the smaller worker; cyan remains the supervising route. */
+.sidekick-persona-halo {
+  --pc-tint: var(--mb-mint);
+  filter: drop-shadow(0 0 14px color-mix(in srgb, var(--pc-tint) 34%, transparent));
+}
+
+.persona-halo.supervised {
+  --pc-tint: var(--mb-mint);
+  filter: drop-shadow(0 0 22px color-mix(in srgb, var(--pc-tint) 34%, transparent));
+}
+
+.persona-halo.supervised::after {
+  content: "";
+  position: absolute;
+  inset: -7px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 45%, transparent);
+  border-radius: 999px;
+  pointer-events: none;
+}

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -33,11 +33,14 @@ export default function Page() {
       "status",
       "chat",
       "models",
-      "capture",
       "account",
+      "rlm",
+    ];
+    const hidden = [
+      "capture",
       "usage",
       "traces",
-      "rlm",
+      "training",
       "training-evals",
       "training-optimization",
       "training-datasets",
@@ -46,10 +49,11 @@ export default function Page() {
       "training-jobs",
     ];
     const u = listen<{ pane?: string }>("server-focus", (e) => {
+      const requested = e.payload?.pane;
       const p = (
-        e.payload?.pane === "marketplace" ? "models" :
-        e.payload?.pane === "training" ? "training-jobs" :
-        e.payload?.pane
+        requested === "marketplace" ? "models" :
+        requested && hidden.includes(requested) ? "status" :
+        requested
       ) as PaneId;
       if (p && (valid as string[]).includes(p)) setPane(p);
     });

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const cssPath = new URL("../apps/homescreen/app/globals.css", import.meta.url);
+const chatPath = new URL("../apps/homescreen/app/components/ChatPane.tsx", import.meta.url);
+const sidebarPath = new URL("../apps/homescreen/app/components/Sidebar.tsx", import.meta.url);
+
+test("public desktop preserves the reviewed Train interaction language", async () => {
+  const [css, chat, sidebar] = await Promise.all([
+    readFile(cssPath, "utf8"),
+    readFile(chatPath, "utf8"),
+    readFile(sidebarPath, "utf8"),
+  ]);
+
+  assert.match(css, /understudy-agent@3f025022/);
+  assert.match(css, /--mb-cyan:\s*#67e8f9/);
+  assert.match(css, /--mb-mint:\s*#9edbd3/);
+  assert.match(css, /\.composer-row\s*\{/);
+  assert.match(css, /\.persona-halo\.supervised/);
+  assert.match(chat, /className="composer-row"/);
+
+  const serving = sidebar.match(
+    /const SERVING_NAV:[\s\S]*?= \[([\s\S]*?)\n\];/,
+  )?.[1];
+  assert.ok(serving, "SERVING_NAV remains statically auditable");
+  assert.match(serving, /label: "Chat"/);
+  assert.match(serving, /label: "Status"/);
+  assert.match(serving, /label: "Models"/);
+  assert.match(serving, /label: "Experiments"/);
+  assert.doesNotMatch(serving, /label: "Capture"/);
+  assert.doesNotMatch(serving, /label: "Traces"/);
+  assert.doesNotMatch(serving, /label: "Usage"/);
+});


### PR DESCRIPTION
## Summary
- restore the reviewed cyan/mint model language from the merged Train desktop (`understudy-agent@3f025022`)
- restore a single-row composer while preserving current model selection, thinking, image upload, cancellation, and canonical runtime behavior
- reduce human navigation to Chat, Status, Models, and Experiments; keep deeper CLI/agent implementation intact
- tint active supervision mint with a cyan supervisor ring
- add a lineage regression test so the public release cannot silently fall back to the pre-Train UI again

## Why
The public desktop runtime moved to `understudy-agent-tools`, but the full reviewed Train frontend did not. This combines the current guarded Pi runtime and residency protection with the UI already reviewed and built from the Train merge.

## Verification
- `npm run check` (230 tests, 0 failures)
- `bun run build` in `apps/homescreen`
- isolated Tauri preview with an empty model home
- confirmed no MLX/VLM listeners during visual comparison
- `git diff --check`

No provider calls or model loads were performed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->