### PR TITLE
Continue locally when cloud supervision is offline

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -89,6 +89,11 @@ type ResidencySnapshot = {
 type SnapshotModel = SnapshotAlias;
 type ChatStatus = "ready" | "streaming" | "error";
 
+const CLOUD_SUPERVISOR_FALLBACK_NOTICE =
+  "Tried to hand off to a larger cloud model, but it is unavailable. Continuing with the local model.";
+const LOCAL_SUPERVISOR_FALLBACK_NOTICE =
+  "The supervising model is unavailable. Continuing with the selected local model.";
+
 const canonicalAttachment = async (file: FileUIPart): Promise<ChatAttachment> => {
   const mediaType = file.mediaType || "";
   if (!mediaType.startsWith("image/") || !file.url.startsWith(`data:${mediaType};base64,`)) {
@@ -518,6 +523,11 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
           return p;
         });
       } else if (msg.type === "SidekickEvent") {
+        if (msg.mode === "supervision" && msg.stage === "cloud_fallback_local") {
+          setNotice(CLOUD_SUPERVISOR_FALLBACK_NOTICE);
+        } else if (msg.mode === "supervision" && msg.stage === "supervisor_fallback_local") {
+          setNotice(LOCAL_SUPERVISOR_FALLBACK_NOTICE);
+        }
         setSidekickEvents((prev) => [
           {
             id: Date.now(),
@@ -642,6 +652,8 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
       latestSidekickEvent.stage === "interrupt" ||
       latestSidekickEvent.stage === "nudge" ||
       latestSidekickEvent.stage === "stop" ||
+      latestSidekickEvent.stage === "cloud_fallback_local" ||
+      latestSidekickEvent.stage === "supervisor_fallback_local" ||
       latestSidekickEvent.stage === "student_interrupted" ||
       latestSidekickEvent.stage === "teacher_continuation");
   const sidekickMonitorVisible =
@@ -766,6 +778,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
                 <div className="sidekick-active-title">
                   {latestSidekickEvent.stage === "compaction_boundary"
                     ? "Compaction boundary"
+                    : latestSidekickEvent.stage === "cloud_fallback_local"
+                      ? "Cloud supervisor unavailable"
+                    : latestSidekickEvent.stage === "supervisor_fallback_local"
+                      ? "Supervisor unavailable"
                     : latestSidekickEvent.stage === "route_applied"
                       ? "Route switched"
                     : latestSidekickEvent.stage === "student_interrupted"

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -112,6 +112,12 @@ pub(crate) enum RuntimeEvent {
         probabilities: Option<Value>,
         #[serde(default)]
         probability_kind: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        failure_kind: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        handoff_target: Option<String>,
     },
     StudentInterruption {
         marker_id: String,
@@ -440,6 +446,9 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
                 reason,
                 probabilities,
                 probability_kind,
+                error,
+                failure_kind,
+                handoff_target,
             } => {
                 if !matches!(source.as_str(), "model" | "policy" | "human") {
                     return Err(format!("unknown supervisor verdict source {source}"));
@@ -457,6 +466,33 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
                         .filter(|value| !value.trim().is_empty())
                         .ok_or_else(|| "interrupt verdict requires marker_id".to_string())?;
                     interrupt_markers.insert(marker);
+                }
+                if let Some(target) = handoff_target.as_deref() {
+                    if !matches!(target, "local" | "remote") {
+                        return Err(format!(
+                            "unknown supervisor verdict handoff_target {target}"
+                        ));
+                    }
+                }
+                if let Some(kind) = failure_kind.as_deref() {
+                    if !matches!(kind, "unavailable" | "invalid_response" | "policy_degrade") {
+                        return Err(format!("unknown supervisor verdict failure_kind {kind}"));
+                    }
+                    if error.as_deref().is_none_or(|value| value.trim().is_empty()) {
+                        return Err("supervisor verdict failure_kind requires error".to_string());
+                    }
+                    if kind == "unavailable" {
+                        if !matches!(verdict, RuntimeVerdict::Continue) {
+                            return Err(
+                                "an unavailable supervisor must degrade to continue".to_string()
+                            );
+                        }
+                        if handoff_target.is_none() {
+                            return Err(
+                                "an unavailable supervisor requires handoff_target".to_string()
+                            );
+                        }
+                    }
                 }
                 validate_verdict_probabilities(probabilities, probability_kind)?;
             }
@@ -589,6 +625,9 @@ mod tests {
                     reason: Some("wrong tool".to_string()),
                     probabilities: Some(json!({"interrupt": -0.1})),
                     probability_kind: Some("logprob".to_string()),
+                    error: None,
+                    failure_kind: None,
+                    handoff_target: Some("local".to_string()),
                 },
             ),
             envelope(
@@ -628,6 +667,9 @@ mod tests {
                 reason: None,
                 probabilities: Some(json!({"continue": 0.9})),
                 probability_kind: Some("logprob".to_string()),
+                error: None,
+                failure_kind: None,
+                handoff_target: Some("local".to_string()),
             },
         )];
         assert!(validate_trace(&invalid)

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -163,6 +163,11 @@ pub(crate) enum SidecarAttempt {
     FailedAfterOutput(String),
 }
 
+pub(crate) const CLOUD_SUPERVISOR_FALLBACK_NOTICE: &str =
+    "Tried to hand off to a larger cloud model, but it is unavailable. Continuing with the local model.";
+pub(crate) const LOCAL_SUPERVISOR_FALLBACK_NOTICE: &str =
+    "The supervising model is unavailable. Continuing with the selected local model.";
+
 #[derive(Default)]
 struct SidecarAccumulator {
     content: String,
@@ -277,20 +282,52 @@ impl SidecarAccumulator {
                 verdict,
                 reason,
                 marker_id,
+                error,
+                failure_kind,
+                handoff_target,
                 ..
-            } => Some(ChatEvent::SidekickEvent {
-                mode: "supervision".to_string(),
-                stage: format!("{verdict:?}").to_lowercase(),
-                detail: format!(
-                    "run={}{} · {}",
-                    envelope.run_id,
-                    marker_id
-                        .as_deref()
-                        .map(|marker| format!(" marker={marker}"))
-                        .unwrap_or_default(),
-                    reason.as_deref().unwrap_or("supervisor verdict")
-                ),
-            }),
+            } => {
+                let unavailable = failure_kind.as_deref() == Some("unavailable");
+                let (stage, summary) = if unavailable {
+                    if handoff_target.as_deref() == Some("remote") {
+                        ("cloud_fallback_local", CLOUD_SUPERVISOR_FALLBACK_NOTICE)
+                    } else {
+                        (
+                            "supervisor_fallback_local",
+                            LOCAL_SUPERVISOR_FALLBACK_NOTICE,
+                        )
+                    }
+                } else {
+                    (
+                        match verdict {
+                            crate::conversation_runtime::RuntimeVerdict::Continue => "continue",
+                            crate::conversation_runtime::RuntimeVerdict::Interrupt => "interrupt",
+                            crate::conversation_runtime::RuntimeVerdict::Stop => "stop",
+                            crate::conversation_runtime::RuntimeVerdict::Nudge => "nudge",
+                        },
+                        reason.as_deref().unwrap_or("supervisor verdict"),
+                    )
+                };
+                let error_detail = unavailable
+                    .then_some(error.as_deref())
+                    .flatten()
+                    .map(|value| format!(" · {value}"))
+                    .unwrap_or_default();
+                Some(ChatEvent::SidekickEvent {
+                    mode: "supervision".to_string(),
+                    stage: stage.to_string(),
+                    detail: format!(
+                        "run={}{} · {}{}",
+                        envelope.run_id,
+                        marker_id
+                            .as_deref()
+                            .map(|marker| format!(" marker={marker}"))
+                            .unwrap_or_default(),
+                        summary,
+                        error_detail,
+                    ),
+                })
+            }
             RuntimeEvent::StudentInterruption {
                 reason, marker_id, ..
             } => Some(ChatEvent::SidekickEvent {
@@ -900,6 +937,32 @@ mod tests {
             Some(ChatEvent::Chunk { .. })
         ));
         assert!(accumulator.emitted_output);
+    }
+
+    #[test]
+    fn failed_remote_supervisor_handoff_becomes_a_visible_local_fallback() {
+        let mut accumulator = SidecarAccumulator::default();
+        let event = accumulator.observe(&envelope(
+            0,
+            RuntimeEvent::SupervisorVerdict {
+                verdict: crate::conversation_runtime::RuntimeVerdict::Continue,
+                source: "model".to_string(),
+                marker_id: Some("run-1:verdict:0".to_string()),
+                reason: None,
+                probabilities: None,
+                probability_kind: None,
+                error: Some("request failed: offline".to_string()),
+                failure_kind: Some("unavailable".to_string()),
+                handoff_target: Some("remote".to_string()),
+            },
+        ));
+        assert!(matches!(
+            event,
+            Some(ChatEvent::SidekickEvent { ref stage, ref detail, .. })
+                if stage == "cloud_fallback_local"
+                    && detail.contains(CLOUD_SUPERVISOR_FALLBACK_NOTICE)
+        ));
+        assert!(!accumulator.emitted_output);
     }
 
     #[test]

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -1,0 +1,74 @@
+{
+  "manifest_version": 1,
+  "release_authority": "apps/homescreen",
+  "legacy_desktop_policy": "extraction_only",
+  "migration_complete": false,
+  "status_values": [
+    "shipped",
+    "partial",
+    "planned",
+    "retired"
+  ],
+  "features": [
+    {
+      "id": "canonical-conversation-runtime",
+      "status": "shipped",
+      "evidence": "Provider-neutral events, Pi and Vercel adapters, immutable run journals, and the one-release native fallback are present."
+    },
+    {
+      "id": "reviewed-desktop-shell",
+      "status": "shipped",
+      "evidence": "The public desktop owns the reviewed cyan and mint shell, compact composer, and four-item navigation."
+    },
+    {
+      "id": "offline-supervisor-fallback",
+      "status": "shipped",
+      "evidence": "A failed supervisor handoff is recorded canonically, attempted once, surfaced to the user, and degrades to continued local generation."
+    },
+    {
+      "id": "runtime-repair-experience",
+      "status": "partial",
+      "evidence": "CLI lifecycle and repair exist; the desktop still needs the reviewed contextual repair prompt on every relevant failure."
+    },
+    {
+      "id": "durable-image-and-chat-persistence",
+      "status": "partial",
+      "evidence": "Images and restart sessions work, but attachment bytes still need content-addressed local storage instead of transcript-embedded data URLs."
+    },
+    {
+      "id": "resumable-model-downloads",
+      "status": "partial",
+      "evidence": "First-use downloads work; background resume, cancellation, and repair-oriented progress remain to be unified."
+    },
+    {
+      "id": "supervision-review-desk",
+      "status": "planned",
+      "evidence": "Canonical verdicts exist; the one-frame review and human labeling workflow has not moved to the public desktop."
+    },
+    {
+      "id": "correction-pair-export-and-metrics",
+      "status": "planned",
+      "evidence": "Run evidence exists; correction export, intervention precision, false-positive, model-share, and overhead reporting remain."
+    },
+    {
+      "id": "remote-review-tiebreaker",
+      "status": "planned",
+      "evidence": "Remote review consent, stability checks, and judge-quality feedback have not moved to the canonical event workflow."
+    },
+    {
+      "id": "unified-experiment-hub",
+      "status": "partial",
+      "evidence": "GEPA, RLM, custom eval, and benchmark capabilities exist, but the reviewed benchmark, ledger, and comparison experience is not one coherent surface."
+    },
+    {
+      "id": "legacy-desktop-retirement-guard",
+      "status": "planned",
+      "evidence": "The public desktop is the release authority, but automation must still prevent new product work or releases from the legacy surface."
+    },
+    {
+      "id": "native-runtime-deletion",
+      "status": "planned",
+      "evidence": "Deletion waits for the full genuine-run observation gate and conformance proof from the canonical runtime."
+    }
+  ]
+}

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -501,6 +501,37 @@ export function validateRuntimeTrace(values: readonly unknown[]): RuntimeEventEn
       if (["interrupt", "nudge"].includes(verdict)) {
         requiredString(data, "reason", "supervisor_verdict.reason");
       }
+      if ("handoff_target" in data && data.handoff_target != null) {
+        const target = requiredString(
+          data,
+          "handoff_target",
+          "supervisor_verdict.handoff_target",
+        );
+        if (!["local", "remote"].includes(target)) {
+          throw new Error(`unknown supervisor verdict handoff_target ${target}`);
+        }
+      }
+      if ("failure_kind" in data && data.failure_kind != null) {
+        const failureKind = requiredString(
+          data,
+          "failure_kind",
+          "supervisor_verdict.failure_kind",
+        );
+        if (!["unavailable", "invalid_response", "policy_degrade"].includes(failureKind)) {
+          throw new Error(`unknown supervisor verdict failure_kind ${failureKind}`);
+        }
+        requiredString(data, "error", "supervisor_verdict.error");
+        if (failureKind === "unavailable") {
+          if (verdict !== "continue") {
+            throw new Error("an unavailable supervisor must degrade to continue");
+          }
+          requiredString(
+            data,
+            "handoff_target",
+            "supervisor_verdict.handoff_target",
+          );
+        }
+      }
       if ("probabilities" in data && data.probabilities != null) {
         const probabilities = record(
           data.probabilities,

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -631,8 +631,19 @@ type SupervisorDecision = {
   probabilities?: Record<string, number>;
   raw?: string;
   error?: string;
+  failureKind?: "unavailable" | "invalid_response" | "policy_degrade";
+  handoffTarget?: "local" | "remote";
   usage: Record<string, unknown>;
 };
+
+export function supervisorHandoffTarget(
+  target: RuntimeProviderTarget,
+): "local" | "remote" {
+  const hostname = new URL(target.base_url).hostname;
+  return ["127.0.0.1", "localhost", "::1", "[::1]"].includes(hostname)
+    ? "local"
+    : "remote";
+}
 
 function unavailableSupervisorUsage(model: string): Record<string, unknown> {
   return {
@@ -766,12 +777,14 @@ async function checkSupervisor(
   partial: string,
   signal?: AbortSignal,
 ): Promise<SupervisorDecision> {
-  const targetUrl = requireSafeProviderTargetUrl(config.supervisor, request.allow_remote);
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (process.env.UNDERSTUDY_RUNTIME_API_KEY) {
     headers.authorization = `Bearer ${process.env.UNDERSTUDY_RUNTIME_API_KEY}`;
   }
+  let handoffTarget: SupervisorDecision["handoffTarget"];
   try {
+    handoffTarget = supervisorHandoffTarget(config.supervisor);
+    const targetUrl = requireSafeProviderTargetUrl(config.supervisor, request.allow_remote);
     const response = await fetch(chatCompletionsUrl(targetUrl), {
       method: "POST",
       signal,
@@ -811,6 +824,8 @@ async function checkSupervisor(
     const complete = [input, output, total].every(Number.isFinite);
     return {
       ...parsed,
+      failureKind: parsed.error ? "invalid_response" : undefined,
+      handoffTarget,
       probabilities: verdictLogprobs(payload),
       usage: complete
         ? {
@@ -831,6 +846,8 @@ async function checkSupervisor(
     return {
       verdict: "continue",
       error: safeErrorMessage(error),
+      failureKind: "unavailable",
+      handoffTarget,
       usage: unavailableSupervisorUsage(config.supervisor.model),
     };
   }
@@ -853,6 +870,8 @@ function verdictEventData(
     after_chars: afterChars,
     raw: decision.raw,
     error: decision.error,
+    failure_kind: decision.failureKind,
+    handoff_target: decision.handoffTarget,
   };
 }
 
@@ -925,9 +944,12 @@ async function runSupervisedStudentSegment(options: {
           if (abortSignal?.aborted) return;
           if (result.verdict === "nudge" && !options.allowNudge) {
             result = {
+              ...result,
               verdict: "continue",
+              reason: undefined,
+              probabilities: undefined,
               error: "nudge budget exhausted; degraded to continue",
-              usage: result.usage,
+              failureKind: "policy_degrade",
             };
           }
           const intervention = result.verdict === "interrupt" || result.verdict === "nudge";
@@ -942,6 +964,12 @@ async function runSupervisedStudentSegment(options: {
             verdictEventData(result, thisBoundary, afterChars, currentMarker),
           );
           adapter.enqueue("usage", result.usage);
+          if (result.failureKind === "unavailable") {
+            // One failed handoff is enough evidence for this segment. Keep the
+            // student running, but do not repeatedly call an offline judge at
+            // every later boundary.
+            decision = result;
+          }
           if (result.verdict !== "continue") {
             decision = result;
             markerId = currentMarker;
@@ -1029,9 +1057,12 @@ async function runSupervisedStudentSegment(options: {
       }
       if (finalDecision.verdict === "nudge" && !options.allowNudge) {
         finalDecision = {
+          ...finalDecision,
           verdict: "continue",
+          reason: undefined,
+          probabilities: undefined,
           error: "nudge budget exhausted; degraded to continue",
-          usage: finalDecision.usage,
+          failureKind: "policy_degrade",
         };
       }
       const intervention =

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -19,6 +19,7 @@ import {
   piPreflightCompactionRequired,
   runPiConversation,
   supervisorDecisionMarker,
+  supervisorHandoffTarget,
   teacherContinuationBoundary,
   teacherOutputMode,
 } from "../dist/runtime/conversation/pi-runtime.js";
@@ -776,6 +777,116 @@ test("Pi runtime deterministically interrupts a student and continues with the t
     .map((event) => event.data.text)
     .join("");
   assert.doesNotMatch(rendered, /\w\.\w/);
+});
+
+test("Pi records a failed remote supervisor handoff and continues locally", async () => {
+  assert.equal(
+    supervisorHandoffTarget({
+      base_url: "https://offline-supervisor.example/v1",
+      model: "remote-supervisor",
+    }),
+    "remote",
+  );
+  const server = createServer(async (request, response) => {
+    const body = await requestJson(request);
+    assert.equal(body.model, "student-model");
+    sendFixtureSse(response, [
+      {
+        id: "chatcmpl-offline-supervisor-student",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "student-model",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: "assistant",
+              content: "The local model keeps working while the cloud supervisor is offline.",
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-offline-supervisor-student",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "student-model",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 12, total_tokens: 22 },
+      },
+    ]);
+  });
+  await new Promise((accept) => server.listen(0, "127.0.0.1", accept));
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  const localBaseUrl = `http://127.0.0.1:${address.port}/v1`;
+  const remoteBaseUrl = "https://offline-supervisor.example/v1";
+  const events = [];
+  const originalFetch = globalThis.fetch;
+  const previousAllowRemote = process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE;
+  process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE = "1";
+  globalThis.fetch = async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (url.startsWith(remoteBaseUrl)) {
+      throw new TypeError("fixture cloud supervisor is offline");
+    }
+    return originalFetch(input, init);
+  };
+  try {
+    await runPiConversation(
+      {
+        run_id: "run-offline-remote-supervisor",
+        session_id: "session-offline-remote-supervisor",
+        base_url: localBaseUrl,
+        model: "student-model",
+        role: "student",
+        allow_remote: true,
+        messages: [{ role: "user", content: "Keep answering if cloud review is unavailable." }],
+        tools: [],
+        runtime_backend: "pi",
+        supervision: {
+          student: { base_url: localBaseUrl, model: "student-model" },
+          supervisor: {
+            base_url: remoteBaseUrl,
+            model: "remote-supervisor",
+            system_prompt: "Judge the partial answer.",
+            max_output_tokens: 24,
+          },
+          teacher: { base_url: remoteBaseUrl, model: "remote-teacher" },
+          boundary_chars: 10,
+          max_nudges: 0,
+        },
+      },
+      (event) => events.push(event),
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousAllowRemote === undefined) {
+      delete process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE;
+    } else {
+      process.env.UNDERSTUDY_RUNTIME_ALLOW_REMOTE = previousAllowRemote;
+    }
+    await new Promise((accept) => server.close(accept));
+  }
+  validateRuntimeTrace(events);
+  const verdicts = events.filter((event) => event.event === "supervisor_verdict");
+  assert.equal(verdicts.length, 1, "offline supervisor is attempted only once per segment");
+  assert.equal(verdicts[0].data.verdict, "continue");
+  assert.equal(verdicts[0].data.failure_kind, "unavailable");
+  assert.equal(verdicts[0].data.handoff_target, "remote");
+  assert.match(verdicts[0].data.error, /cloud supervisor is offline/);
+  assert.equal(events.some((event) => event.event === "student_interruption"), false);
+  assert.equal(events.some((event) => event.event === "teacher_continuation"), false);
+  assert.equal(
+    events.filter((event) => event.event === "delta").map((event) => event.data.text).join(""),
+    "The local model keeps working while the cloud supervisor is offline.",
+  );
 });
 
 test("teacher continuation inserts only a missing word boundary", () => {

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 const cssPath = new URL("../apps/homescreen/app/globals.css", import.meta.url);
 const chatPath = new URL("../apps/homescreen/app/components/ChatPane.tsx", import.meta.url);
 const sidebarPath = new URL("../apps/homescreen/app/components/Sidebar.tsx", import.meta.url);
+const parityPath = new URL("../docs/desktop-product-parity.json", import.meta.url);
 
 test("public desktop preserves the reviewed Train interaction language", async () => {
   const [css, chat, sidebar] = await Promise.all([
@@ -19,6 +20,11 @@ test("public desktop preserves the reviewed Train interaction language", async (
   assert.match(css, /\.composer-row\s*\{/);
   assert.match(css, /\.persona-halo\.supervised/);
   assert.match(chat, /className="composer-row"/);
+  assert.match(
+    chat,
+    /Tried to hand off to a larger cloud model, but it is unavailable\. Continuing with the local model\./,
+  );
+  assert.match(chat, /msg\.stage === "cloud_fallback_local"/);
 
   const serving = sidebar.match(
     /const SERVING_NAV:[\s\S]*?= \[([\s\S]*?)\n\];/,
@@ -31,4 +37,29 @@ test("public desktop preserves the reviewed Train interaction language", async (
   assert.doesNotMatch(serving, /label: "Capture"/);
   assert.doesNotMatch(serving, /label: "Traces"/);
   assert.doesNotMatch(serving, /label: "Usage"/);
+});
+
+test("desktop migration claims stay tied to explicit product parity", async () => {
+  const parity = JSON.parse(await readFile(parityPath, "utf8"));
+  assert.equal(parity.release_authority, "apps/homescreen");
+  assert.equal(parity.legacy_desktop_policy, "extraction_only");
+  const ids = parity.features.map((feature) => feature.id);
+  assert.equal(new Set(ids).size, ids.length, "parity feature ids must remain unique");
+  for (const required of [
+    "offline-supervisor-fallback",
+    "supervision-review-desk",
+    "correction-pair-export-and-metrics",
+    "unified-experiment-hub",
+    "native-runtime-deletion",
+  ]) {
+    assert.ok(ids.includes(required), `parity manifest is missing ${required}`);
+  }
+  for (const feature of parity.features) {
+    assert.ok(parity.status_values.includes(feature.status), `${feature.id} has an unknown status`);
+    assert.ok(feature.evidence.length > 20, `${feature.id} needs concrete evidence`);
+  }
+  const actuallyComplete = parity.features.every((feature) =>
+    ["shipped", "retired"].includes(feature.status),
+  );
+  assert.equal(parity.migration_complete, actuallyComplete);
 });


### PR DESCRIPTION
## Outcome

When a remote supervisor is unavailable, the canonical Pi runtime now records the failed handoff once, continues the local student turn, and shows a clear non-blocking desktop notice.

## What changed

- distinguish unavailable, invalid-response, and policy-degrade supervisor outcomes in canonical verdict evidence
- record whether the attempted supervisor handoff was local or remote
- stop retrying an offline supervisor at every later boundary
- map failed remote supervision to the desktop notice while preserving the local response
- add a public product-parity manifest so visual shell work cannot be mistaken for a completed desktop migration

## Verification

- `npm run check` (232 tests, public skill validation, package smoke)
- `npm run build` in `apps/homescreen`
- `cargo test` in `apps/homescreen/src-tauri` (141 passed, 1 ignored)
- focused frozen Pi/Vercel conformance and offline-supervisor tests

No provider calls, uploads, model downloads, or customer data were used.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->