### PR TITLE
feat(desktop): unify runtime health and repair

### DIFF
--- a/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
+++ b/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { WrenchIcon, XIcon } from "lucide-react";
+import {
+  CONVERSATION_RUNTIME_REPAIR_REQUEST,
+  MLX_REPAIR_REQUEST,
+  isConversationRuntimeError,
+  isMissingMlxVlmError,
+  promptForHealth,
+  promptForRuntimeRequest,
+  type DesktopHealth,
+  type RepairPrompt,
+  type RuntimeRepairRequest,
+} from "../lib/runtime-repair";
+
+const HEALTH_REFRESH_MS = 15 * 60 * 1_000;
+
+export function RuntimeRepairPrompt() {
+  const [prompt, setPrompt] = useState<RepairPrompt | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refreshHealth = useCallback(async () => {
+    try {
+      const health = await invoke<DesktopHealth>("desktop_health");
+      setPrompt(promptForHealth(health));
+    } catch {
+      // Health is best-effort. Offline startup and the native runtime fallback
+      // must remain available even if the aggregate check itself fails.
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshHealth();
+    const timer = window.setInterval(() => void refreshHealth(), HEALTH_REFRESH_MS);
+    const unlisten = listen<RuntimeRepairRequest>("runtime-repair-needed", (event) => {
+      setPrompt(promptForRuntimeRequest(event.payload));
+    });
+    const onError = (event: ErrorEvent) => {
+      const error = event.error ?? event.message;
+      if (isMissingMlxVlmError(error)) setPrompt(promptForRuntimeRequest(MLX_REPAIR_REQUEST));
+      else if (isConversationRuntimeError(error)) {
+        setPrompt(promptForRuntimeRequest(CONVERSATION_RUNTIME_REPAIR_REQUEST));
+      }
+    };
+    const onRejection = (event: PromiseRejectionEvent) => {
+      if (isMissingMlxVlmError(event.reason)) {
+        setPrompt(promptForRuntimeRequest(MLX_REPAIR_REQUEST));
+      } else if (isConversationRuntimeError(event.reason)) {
+        setPrompt(promptForRuntimeRequest(CONVERSATION_RUNTIME_REPAIR_REQUEST));
+      }
+    };
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+    return () => {
+      window.clearInterval(timer);
+      void unlisten.then((remove) => remove());
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+    };
+  }, [refreshHealth]);
+
+  const repair = async () => {
+    if (!prompt || busy) return;
+    if (prompt.runtime === "desktop") {
+      await openUrl(prompt.command);
+      return;
+    }
+    const command =
+      prompt.runtime === "cli"
+        ? "install_understudy_agent_tools"
+        : prompt.runtime === "conversation-runtime"
+          ? "conversation_runtime_repair"
+          : "install_mlx_runtime";
+    setBusy(true);
+    try {
+      await invoke(command);
+      await refreshHealth();
+    } catch (error) {
+      setPrompt((current) =>
+        current
+          ? {
+              ...current,
+              reason: `${String(error)} Run ${current.command} in Terminal.`,
+            }
+          : current,
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!prompt) return null;
+  return (
+    <aside className="runtime-repair-prompt" aria-live="polite" aria-label={prompt.title}>
+      <WrenchIcon className="runtime-repair-icon" size={17} aria-hidden="true" />
+      <div className="runtime-repair-copy">
+        <strong>{prompt.title}</strong>
+        <span>{prompt.reason}</span>
+        <code>{prompt.command}</code>
+      </div>
+      <button type="button" className="runtime-repair-action" disabled={busy} onClick={repair}>
+        {busy ? "Repairing…" : prompt.actionLabel}
+      </button>
+      <button
+        type="button"
+        className="runtime-repair-dismiss"
+        aria-label="Dismiss repair prompt"
+        onClick={() => setPrompt(null)}
+      >
+        <XIcon size={14} aria-hidden="true" />
+      </button>
+    </aside>
+  );
+}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2358,10 +2358,82 @@ select,
   padding: 6px 0;
 }
 .chat-runtime-notice {
-  color: var(--text-muted);
+  color: var(--text-2);
   font-size: 11px;
   line-height: 1.4;
   padding: 5px 0;
+}
+.runtime-repair-prompt {
+  position: fixed;
+  z-index: 80;
+  top: 42px;
+  right: 16px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+  width: min(520px, calc(100vw - 32px));
+  padding: 10px 10px 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--border));
+  border-radius: var(--r-control);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 24%);
+  backdrop-filter: blur(16px);
+}
+.runtime-repair-icon {
+  color: var(--accent);
+}
+.runtime-repair-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.runtime-repair-copy strong {
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+}
+.runtime-repair-copy span,
+.runtime-repair-copy code {
+  overflow: hidden;
+  color: var(--text-2);
+  font-size: 10px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.runtime-repair-copy code {
+  color: var(--accent);
+}
+.runtime-repair-action,
+.runtime-repair-dismiss {
+  border: 1px solid var(--border);
+  border-radius: var(--r-control);
+  background: var(--elevated);
+  color: var(--text);
+}
+.runtime-repair-action {
+  min-height: 30px;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 10px;
+  white-space: nowrap;
+}
+.runtime-repair-action:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.runtime-repair-action:disabled {
+  opacity: 0.6;
+}
+.runtime-repair-dismiss {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  place-items: center;
+}
+.runtime-repair-dismiss:hover {
+  color: var(--accent);
 }
 .chat-image-list {
   display: flex;
@@ -2382,7 +2454,7 @@ select,
   object-fit: contain;
 }
 .chat-image figcaption {
-  color: var(--text-muted);
+  color: var(--text-2);
   font-size: 10px;
   margin-top: 3px;
 }

--- a/apps/homescreen/app/lib/runtime-repair.ts
+++ b/apps/homescreen/app/lib/runtime-repair.ts
@@ -1,0 +1,119 @@
+export type RuntimeRepairRequest = {
+  runtime: string;
+  reason: string;
+  command: string;
+};
+
+export type VersionHealth = {
+  id: string;
+  label: string;
+  available: boolean;
+  installed_version?: string | null;
+  latest_version?: string | null;
+  update_available?: boolean | null;
+  detail: string;
+};
+
+export type DesktopHealth = {
+  checked_at: string;
+  online: boolean;
+  desktop: VersionHealth;
+  cli: VersionHealth;
+  mlx_vlm: VersionHealth;
+  conversation_runtime: VersionHealth;
+};
+
+export type RepairPrompt = RuntimeRepairRequest & {
+  title: string;
+  actionLabel: string;
+};
+
+export const CLI_INSTALL_COMMAND =
+  "curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh | bash -s -- --yes";
+
+export const MLX_REPAIR_REQUEST: RuntimeRepairRequest = {
+  runtime: "mlx-vlm",
+  reason: "The local model runtime is missing or unhealthy.",
+  command: "understudy models runtime repair",
+};
+
+export const CONVERSATION_RUNTIME_REPAIR_REQUEST: RuntimeRepairRequest = {
+  runtime: "conversation-runtime",
+  reason: "The managed conversation runtime is missing, stale, or unhealthy.",
+  command: "understudy runtime repair",
+};
+
+export function isMissingMlxVlmError(error: unknown): boolean {
+  const text = String(error).toLowerCase();
+  return (
+    text.includes("mlx-vlm") ||
+    text.includes("mlx_vlm") ||
+    (text.includes("local model server") &&
+      (text.includes("not found") ||
+        text.includes("no such file") ||
+        text.includes("did not become ready")))
+  );
+}
+
+export function isConversationRuntimeError(error: unknown): boolean {
+  const text = String(error).toLowerCase();
+  return (
+    text.includes("conversation runtime") ||
+    text.includes("vercel-ai-sdk") ||
+    text.includes("understudy-conversation-runtime-event")
+  );
+}
+
+export function promptForRuntimeRequest(request: RuntimeRepairRequest): RepairPrompt {
+  return {
+    ...request,
+    title: request.runtime === "mlx-vlm" ? "Local models need repair" : "Runtime needs repair",
+    actionLabel: "Repair with CLI",
+  };
+}
+
+export function promptForHealth(health: DesktopHealth): RepairPrompt | null {
+  if (!health.cli.available) {
+    return {
+      runtime: "cli",
+      title: "Understudy CLI is missing",
+      reason: "Install the public CLI so the desktop can diagnose and repair its runtimes.",
+      command: CLI_INSTALL_COMMAND,
+      actionLabel: "Install CLI",
+    };
+  }
+  if (health.cli.update_available === true) {
+    const versions = health.cli.latest_version
+      ? `${health.cli.installed_version ?? "installed"} → ${health.cli.latest_version}`
+      : health.cli.detail;
+    return {
+      runtime: "cli",
+      title: "Understudy CLI update available",
+      reason: versions,
+      command: CLI_INSTALL_COMMAND,
+      actionLabel: "Update CLI",
+    };
+  }
+  if (!health.mlx_vlm.available) {
+    return promptForRuntimeRequest({
+      ...MLX_REPAIR_REQUEST,
+      reason: health.mlx_vlm.detail || MLX_REPAIR_REQUEST.reason,
+    });
+  }
+  if (!health.conversation_runtime.available) {
+    return promptForRuntimeRequest({
+      ...CONVERSATION_RUNTIME_REPAIR_REQUEST,
+      reason: health.conversation_runtime.detail || CONVERSATION_RUNTIME_REPAIR_REQUEST.reason,
+    });
+  }
+  if (health.desktop.update_available === true) {
+    return {
+      runtime: "desktop",
+      title: "Understudy Desktop update available",
+      reason: `${health.desktop.installed_version ?? "installed"} → ${health.desktop.latest_version ?? "latest"}`,
+      command: "https://github.com/understudylabs/understudy-agent-tools/releases/latest",
+      actionLabel: "Open download",
+    };
+  }
+  return null;
+}

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -13,6 +13,7 @@ import { UsagePane } from "./components/UsagePane";
 import { DownloadQrButton } from "./components/DownloadQrButton";
 import { isTrainingPane, TrainingPane } from "./components/TrainingPane";
 import { RlmPane } from "./components/RlmPane";
+import { RuntimeRepairPrompt } from "./components/RuntimeRepairPrompt";
 import { useStatus } from "./lib/useStatus";
 
 export default function Page() {
@@ -98,6 +99,7 @@ export default function Page() {
         </button>
       )}
       <DownloadQrButton />
+      <RuntimeRepairPrompt />
       <Sidebar
         active={pane}
         onSelect={(next) => {

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -41,6 +41,27 @@ pub struct BootstrapStatus {
 }
 
 #[derive(Serialize, Clone)]
+pub struct VersionHealth {
+    pub id: String,
+    pub label: String,
+    pub available: bool,
+    pub installed_version: Option<String>,
+    pub latest_version: Option<String>,
+    pub update_available: Option<bool>,
+    pub detail: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct DesktopHealth {
+    pub checked_at: String,
+    pub online: bool,
+    pub desktop: VersionHealth,
+    pub cli: VersionHealth,
+    pub mlx_vlm: VersionHealth,
+    pub conversation_runtime: VersionHealth,
+}
+
+#[derive(Serialize, Clone)]
 #[serde(tag = "type")]
 pub enum DownloadEvent {
     Log {
@@ -125,10 +146,10 @@ pub fn install_uv() -> Result<String, String> {
 }
 
 pub fn install_mlx_runtime() -> Result<String, String> {
-    let out = bin::command("uv")
-        .args(["tool", "install", "mlx-vlm"])
+    let out = bin::command("understudy")
+        .args(["models", "runtime", "repair", "--json"])
         .output()
-        .map_err(|e| format!("uv not found: {e}"))?;
+        .map_err(|e| format!("Understudy CLI not found: {e}"))?;
     command_output(out)
 }
 
@@ -169,6 +190,161 @@ pub fn install_understudy_agent_tools() -> Result<String, String> {
         .map_err(|e| format!("Understudy installer failed to start: {e}"));
     let _ = std::fs::remove_file(&script);
     installed.and_then(command_output)
+}
+
+/// Aggregate bounded public update checks and local runtime diagnostics for
+/// the desktop repair surface. Network failure only leaves latest versions
+/// unknown; local availability and repair remain fully functional offline.
+pub async fn desktop_health(app: &AppHandle) -> DesktopHealth {
+    let cli_local = command_version(bin::command("understudy").arg("--version").output());
+    let mlx_status = models::mlx_runtime_status();
+    let mlx_local = mlx_status
+        .available
+        .then_some(mlx_status.installed_version.clone())
+        .flatten();
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(3))
+        .read_timeout(Duration::from_secs(5))
+        .user_agent("Understudy-Desktop/health-check")
+        .build();
+
+    let (cli_latest, desktop_latest, desktop_url) = if let Ok(client) = client {
+        let cli = fetch_json(
+            &client,
+            "https://raw.githubusercontent.com/understudylabs/understudy-agent-tools/main/package.json",
+        );
+        let desktop = fetch_json(
+            &client,
+            "https://api.github.com/repos/understudylabs/understudy-agent-tools/releases/latest",
+        );
+        let (cli, desktop) = tokio::join!(cli, desktop);
+        (
+            cli.ok().and_then(|value| json_string(&value, &["version"])),
+            desktop
+                .as_ref()
+                .ok()
+                .and_then(|value| json_string(value, &["tag_name"]))
+                .and_then(|tag| extract_version(&tag)),
+            desktop
+                .ok()
+                .and_then(|value| json_string(&value, &["html_url"])),
+        )
+    } else {
+        (None, None, None)
+    };
+
+    let mut cli_health = version_health(
+        "cli",
+        "Understudy CLI",
+        cli_local,
+        cli_latest,
+        "Run the official agent-tools installer to repair or update.".to_string(),
+    );
+    if cli_health.available && !mlx_status.managed {
+        cli_health.update_available = Some(true);
+        cli_health.detail =
+            "Installed CLI lacks the managed MLX/VLM lifecycle; update it before repairing local models."
+                .to_string();
+    }
+    DesktopHealth {
+        checked_at: chrono::Utc::now().to_rfc3339(),
+        online: cli_health.latest_version.is_some() || desktop_latest.is_some(),
+        desktop: version_health(
+            "desktop",
+            "Desktop app",
+            Some(env!("CARGO_PKG_VERSION").to_string()),
+            desktop_latest,
+            desktop_url.unwrap_or_else(|| {
+                "https://github.com/understudylabs/understudy-agent-tools/releases/latest"
+                    .to_string()
+            }),
+        ),
+        cli: cli_health,
+        mlx_vlm: version_health(
+            "mlx-vlm",
+            "Local model runtime",
+            mlx_local,
+            None,
+            mlx_status.detail,
+        ),
+        conversation_runtime: crate::conversation_sidecar::health(app),
+    }
+}
+
+async fn fetch_json(client: &reqwest::Client, url: &str) -> Result<serde_json::Value, String> {
+    client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .error_for_status()
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+fn json_string(value: &serde_json::Value, path: &[&str]) -> Option<String> {
+    path.iter()
+        .try_fold(value, |current, key| current.get(*key))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn command_version(output: std::io::Result<std::process::Output>) -> Option<String> {
+    let output = output.ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    extract_version(&String::from_utf8_lossy(&output.stdout))
+        .or_else(|| extract_version(&String::from_utf8_lossy(&output.stderr)))
+}
+
+fn version_health(
+    id: &str,
+    label: &str,
+    installed: Option<String>,
+    latest: Option<String>,
+    detail: String,
+) -> VersionHealth {
+    VersionHealth {
+        id: id.to_string(),
+        label: label.to_string(),
+        available: installed.is_some(),
+        update_available: match (&installed, &latest) {
+            (Some(local), Some(remote)) => version_is_newer(remote, local),
+            _ => None,
+        },
+        installed_version: installed,
+        latest_version: latest,
+        detail,
+    }
+}
+
+fn extract_version(value: &str) -> Option<String> {
+    value
+        .split(|character: char| !(character.is_ascii_digit() || character == '.'))
+        .find(|part| {
+            let pieces: Vec<&str> = part.split('.').collect();
+            pieces.len() >= 2 && pieces.iter().all(|piece| piece.parse::<u64>().is_ok())
+        })
+        .map(str::to_string)
+}
+
+fn version_is_newer(candidate: &str, current: &str) -> Option<bool> {
+    fn numbers(value: &str) -> Option<Vec<u64>> {
+        extract_version(value)?
+            .split('.')
+            .map(str::parse)
+            .collect::<Result<Vec<_>, _>>()
+            .ok()
+    }
+    let mut candidate = numbers(candidate)?;
+    let mut current = numbers(current)?;
+    let length = candidate.len().max(current.len());
+    candidate.resize(length, 0);
+    current.resize(length, 0);
+    Some(candidate > current)
 }
 
 pub async fn download_model(
@@ -615,5 +791,17 @@ mod tests {
             package.get("version").and_then(serde_json::Value::as_str),
             Some(MIN_UNDERSTUDY_CLI_VERSION)
         );
+    }
+
+    #[test]
+    fn public_update_versions_compare_without_string_ordering() {
+        assert_eq!(
+            extract_version("understudy 0.6.10"),
+            Some("0.6.10".to_string())
+        );
+        assert_eq!(extract_version("v0.7.0-beta.1"), Some("0.7.0".to_string()));
+        assert_eq!(version_is_newer("0.6.10", "0.6.9"), Some(true));
+        assert_eq!(version_is_newer("0.6.1", "0.6.1"), Some(false));
+        assert_eq!(version_is_newer("not-a-version", "0.6.1"), None);
     }
 }

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -1168,18 +1168,27 @@ pub fn bootstrap_status() -> crate::bootstrap::BootstrapStatus {
 }
 
 #[tauri::command]
+pub async fn desktop_health(app: AppHandle) -> crate::bootstrap::DesktopHealth {
+    crate::bootstrap::desktop_health(&app).await
+}
+
+#[tauri::command]
 pub fn install_uv() -> Result<String, String> {
     crate::bootstrap::install_uv()
 }
 
 #[tauri::command]
-pub fn install_mlx_runtime() -> Result<String, String> {
-    crate::bootstrap::install_mlx_runtime()
+pub async fn install_mlx_runtime() -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(crate::bootstrap::install_mlx_runtime)
+        .await
+        .map_err(|e| format!("install_mlx_runtime task failed: {e}"))?
 }
 
 #[tauri::command]
-pub fn install_understudy_agent_tools() -> Result<String, String> {
-    crate::bootstrap::install_understudy_agent_tools()
+pub async fn install_understudy_agent_tools() -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(crate::bootstrap::install_understudy_agent_tools)
+        .await
+        .map_err(|e| format!("install_understudy_agent_tools task failed: {e}"))?
 }
 
 #[tauri::command]

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Manager};
 
+use crate::bootstrap::VersionHealth;
 use crate::chat::ChatEvent;
 use crate::conversation_runtime::{
     RuntimeEvent, RuntimeEventEnvelope, EVENT_SCHEMA, RUNTIME_VERSION,
@@ -416,6 +417,49 @@ fn parse_status(output: std::process::Output) -> Result<CliRuntimeStatus, String
             format!("Understudy CLI runtime status failed: {detail}")
         }
     })
+}
+
+pub(crate) fn health(app: &AppHandle) -> VersionHealth {
+    match run_cli_status("status", app) {
+        Ok(status) => {
+            let schema_matches = status.event_schema == EVENT_SCHEMA;
+            let version_matches = status.runtime_version == RUNTIME_VERSION;
+            let ready = compatible(&status, app);
+            let detail = if ready {
+                status.detail
+            } else if !schema_matches {
+                format!(
+                    "runtime schema {} is incompatible with {}; native fallback remains active",
+                    status.event_schema, EVENT_SCHEMA
+                )
+            } else if !version_matches {
+                format!(
+                    "runtime {} does not match required {}; update or repair the CLI; native fallback remains active",
+                    status.runtime_version, RUNTIME_VERSION
+                )
+            } else {
+                format!("{}; native fallback remains active", status.detail)
+            };
+            VersionHealth {
+                id: "conversation-runtime".to_string(),
+                label: "Conversation runtime".to_string(),
+                available: ready,
+                installed_version: status.installed.then_some(status.runtime_version),
+                latest_version: Some(RUNTIME_VERSION.to_string()),
+                update_available: Some(!schema_matches || !version_matches),
+                detail,
+            }
+        }
+        Err(error) => VersionHealth {
+            id: "conversation-runtime".to_string(),
+            label: "Conversation runtime".to_string(),
+            available: false,
+            installed_version: None,
+            latest_version: Some(RUNTIME_VERSION.to_string()),
+            update_available: None,
+            detail: format!("{error}; native fallback remains active"),
+        },
+    }
 }
 
 fn runtime_selected(app: &AppHandle) -> bool {

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -140,6 +140,7 @@ pub fn run() {
             commands::mlx_runtime_status,
             commands::set_app_icon,
             commands::bootstrap_status,
+            commands::desktop_health,
             commands::install_uv,
             commands::install_mlx_runtime,
             commands::install_understudy_agent_tools,

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -54,7 +54,28 @@ pub struct SnapshotInfo {
 pub struct MlxRuntimeStatus {
     pub available: bool,
     pub command: String,
+    pub installed_version: Option<String>,
+    pub managed: bool,
     pub detail: String,
+}
+
+#[derive(Deserialize)]
+struct ManagedMlxRuntimeStatus {
+    healthy: bool,
+    runtime_version: String,
+    server_binary: String,
+    detail: String,
+}
+
+fn parse_managed_mlx_status(raw: &str) -> Result<MlxRuntimeStatus, serde_json::Error> {
+    let status = serde_json::from_str::<ManagedMlxRuntimeStatus>(raw)?;
+    Ok(MlxRuntimeStatus {
+        available: status.healthy,
+        command: status.server_binary,
+        installed_version: Some(status.runtime_version),
+        managed: true,
+        detail: status.detail,
+    })
 }
 
 /// The port the MLX server binds — matches Understudy's configured local base URL.
@@ -280,26 +301,33 @@ pub fn snapshots() -> Vec<SnapshotInfo> {
 }
 
 pub fn mlx_runtime_status() -> MlxRuntimeStatus {
-    let command = crate::bin::mlx_server();
-    match std::process::Command::new(&command)
-        .arg("--help")
-        .env("PATH", crate::bin::runtime_path())
+    let fallback_command = crate::bin::mlx_server();
+    match crate::bin::command("understudy")
+        .args(["models", "runtime", "status", "--json"])
         .output()
     {
-        Ok(out) if out.status.success() => MlxRuntimeStatus {
-            available: true,
-            command,
-            detail: "mlx_vlm.server is available".to_string(),
+        // `models runtime status` may exit non-zero while unhealthy but still
+        // emits the complete JSON diagnosis. Parse stdout regardless of exit.
+        Ok(out) => match parse_managed_mlx_status(&String::from_utf8_lossy(&out.stdout)) {
+            Ok(status) => status,
+            Err(error) => MlxRuntimeStatus {
+                available: false,
+                command: fallback_command,
+                installed_version: None,
+                managed: false,
+                detail: format!(
+                    "Understudy CLI does not expose a compatible managed MLX/VLM runtime ({error}); update the CLI, then run `understudy models runtime repair`"
+                ),
+            },
         },
-        Ok(out) => MlxRuntimeStatus {
+        Err(error) => MlxRuntimeStatus {
             available: false,
-            command,
-            detail: String::from_utf8_lossy(&out.stderr).trim().to_string(),
-        },
-        Err(err) => MlxRuntimeStatus {
-            available: false,
-            command,
-            detail: err.to_string(),
+            command: fallback_command,
+            installed_version: None,
+            managed: false,
+            detail: format!(
+                "Understudy CLI is unavailable ({error}); install or update it, then run `understudy models runtime repair`"
+            ),
         },
     }
 }
@@ -321,6 +349,19 @@ fn dir_size_gb(p: &Path) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn managed_mlx_status_preserves_cli_binary_and_version() {
+        let status = parse_managed_mlx_status(
+            r#"{"healthy":true,"runtime_version":"0.6.4+abc","server_binary":"/managed/mlx_vlm.server","detail":"ready"}"#,
+        )
+        .unwrap();
+        assert!(status.available);
+        assert!(status.managed);
+        assert_eq!(status.command, "/managed/mlx_vlm.server");
+        assert_eq!(status.installed_version.as_deref(), Some("0.6.4+abc"));
+        assert_eq!(status.detail, "ready");
+    }
 
     fn temp_snapshot_dir(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -131,6 +131,17 @@ fn expand_home(value: &str) -> String {
     value.to_string()
 }
 
+fn emit_mlx_repair(app: &AppHandle, reason: &str) {
+    let _ = app.emit(
+        "runtime-repair-needed",
+        serde_json::json!({
+            "runtime": "mlx-vlm",
+            "reason": reason,
+            "command": "understudy models runtime repair",
+        }),
+    );
+}
+
 fn estimated_runtime_gb(weights_gb: f32) -> f32 {
     weights_gb * RUNTIME_WEIGHT_MULTIPLIER + RUNTIME_SERVER_OVERHEAD_GB
 }
@@ -370,6 +381,14 @@ impl Residency {
     /// Warm a slot: enforce a conservative runtime budget, spawn mlx_vlm.server,
     /// and poll until ready. Heavy checkpoints are exclusive by construction.
     pub fn warm(&self, app: &AppHandle, slot_id: u32) -> anyhow::Result<()> {
+        let runtime = crate::models::mlx_runtime_status();
+        if !runtime.available {
+            emit_mlx_repair(app, &runtime.detail);
+            anyhow::bail!(
+                "mlx-vlm is required to run local models but is unavailable: {}",
+                runtime.detail
+            );
+        }
         // 1. Validate without changing state. A rejected preflight must never
         // leave a slot stuck in Loading.
         let (model_id, model_path, mem_gb, thinking) = {
@@ -452,7 +471,9 @@ impl Residency {
                 let snapshot = self.snapshot_from(&inner);
                 drop(inner);
                 let _ = app.emit("residency-changed", snapshot);
-                anyhow::bail!("failed to start local model server: {err}");
+                let reason = format!("failed to start local model server: {err}");
+                emit_mlx_repair(app, &reason);
+                anyhow::bail!(reason);
             }
         };
         {
@@ -489,6 +510,12 @@ impl Residency {
             let snapshot = residency.snapshot_from(&inner);
             drop(inner);
             let _ = app.emit("residency-changed", snapshot);
+            if !ready {
+                emit_mlx_repair(
+                    &app,
+                    "local model server did not become ready before the startup timeout",
+                );
+            }
             // Persist + benchmark record.
             if ready {
                 residency.persist(&app);

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -27,8 +27,8 @@
     },
     {
       "id": "runtime-repair-experience",
-      "status": "partial",
-      "evidence": "CLI lifecycle and repair exist; the desktop still needs the reviewed contextual repair prompt on every relevant failure."
+      "status": "shipped",
+      "evidence": "Desktop health checks cover CLI, MLX/VLM, ConversationRuntime, and desktop versions; contextual failures offer the single managed CLI repair path while offline operation remains available."
     },
     {
       "id": "durable-image-and-chat-persistence",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -5,6 +5,15 @@ import test from "node:test";
 const cssPath = new URL("../apps/homescreen/app/globals.css", import.meta.url);
 const chatPath = new URL("../apps/homescreen/app/components/ChatPane.tsx", import.meta.url);
 const sidebarPath = new URL("../apps/homescreen/app/components/Sidebar.tsx", import.meta.url);
+const pagePath = new URL("../apps/homescreen/app/page.tsx", import.meta.url);
+const runtimeRepairPromptPath = new URL(
+  "../apps/homescreen/app/components/RuntimeRepairPrompt.tsx",
+  import.meta.url,
+);
+const runtimeRepairLibPath = new URL(
+  "../apps/homescreen/app/lib/runtime-repair.ts",
+  import.meta.url,
+);
 const parityPath = new URL("../docs/desktop-product-parity.json", import.meta.url);
 
 test("public desktop preserves the reviewed Train interaction language", async () => {
@@ -39,6 +48,25 @@ test("public desktop preserves the reviewed Train interaction language", async (
   assert.doesNotMatch(serving, /label: "Usage"/);
 });
 
+test("desktop has one managed runtime repair surface", async () => {
+  const [page, prompt, repair] = await Promise.all([
+    readFile(pagePath, "utf8"),
+    readFile(runtimeRepairPromptPath, "utf8"),
+    readFile(runtimeRepairLibPath, "utf8"),
+  ]);
+
+  assert.match(page, /<RuntimeRepairPrompt\s*\/>/);
+  assert.match(prompt, /invoke<DesktopHealth>\("desktop_health"\)/);
+  assert.match(prompt, /listen<RuntimeRepairRequest>\("runtime-repair-needed"/);
+  assert.match(prompt, /"install_understudy_agent_tools"/);
+  assert.match(prompt, /"install_mlx_runtime"/);
+  assert.match(prompt, /"conversation_runtime_repair"/);
+  assert.match(repair, /understudy models runtime repair/);
+  assert.match(repair, /understudy runtime repair/);
+  assert.match(repair, /install\.sh \| bash -s -- --yes/);
+  assert.doesNotMatch(repair, /understudy update/);
+});
+
 test("desktop migration claims stay tied to explicit product parity", async () => {
   const parity = JSON.parse(await readFile(parityPath, "utf8"));
   assert.equal(parity.release_authority, "apps/homescreen");
@@ -47,6 +75,7 @@ test("desktop migration claims stay tied to explicit product parity", async () =
   assert.equal(new Set(ids).size, ids.length, "parity feature ids must remain unique");
   for (const required of [
     "offline-supervisor-fallback",
+    "runtime-repair-experience",
     "supervision-review-desk",
     "correction-pair-export-and-metrics",
     "unified-experiment-hub",
@@ -54,6 +83,10 @@ test("desktop migration claims stay tied to explicit product parity", async () =
   ]) {
     assert.ok(ids.includes(required), `parity manifest is missing ${required}`);
   }
+  assert.equal(
+    parity.features.find((feature) => feature.id === "runtime-repair-experience")?.status,
+    "shipped",
+  );
   for (const feature of parity.features) {
     assert.ok(parity.status_values.includes(feature.status), `${feature.id} has an unknown status`);
     assert.ok(feature.evidence.length > 20, `${feature.id} needs concrete evidence`);


### PR DESCRIPTION
## Outcome

Ports the reviewed Train runtime-repair flow into the public desktop while keeping the CLI as the single lifecycle owner.

- checks desktop, CLI, managed MLX/VLM, and ConversationRuntime health
- offers one quiet contextual repair prompt on startup or relevant failures
- routes MLX/VLM repair through `understudy models runtime repair`
- preserves offline operation and the one-release native conversation fallback
- marks the runtime-repair parity checkpoint shipped

## Verification

- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (143 passed, 1 ignored)
- desktop `npm run build`
- root `npm run check` (233 tests, skills validation, package smoke)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->