### PR TITLE
feat(desktop): persist chat images by content hash

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -42,6 +42,13 @@ import {
   ToolOutput,
   type ToolPart,
 } from "@/components/ai-elements/tool";
+import {
+  persistableChatMessages,
+  recentUniqueAttachmentRefs,
+  withHydratedAttachments,
+  type ChatAttachment,
+  type ChatAttachmentUpload,
+} from "../lib/chat-attachments";
 import { modelShortName, type SnapshotAlias } from "../lib/model-aliases";
 import type { FileUIPart } from "ai";
 
@@ -52,12 +59,6 @@ type ToolTrace = {
   input?: unknown;
   output?: unknown;
   errorText?: string;
-};
-type ChatAttachment = {
-  id: string;
-  filename: string;
-  media_type: string;
-  data_url: string;
 };
 type Msg = {
   role: Role;
@@ -94,24 +95,6 @@ const CLOUD_SUPERVISOR_FALLBACK_NOTICE =
 const LOCAL_SUPERVISOR_FALLBACK_NOTICE =
   "The supervising model is unavailable. Continuing with the selected local model.";
 
-const canonicalAttachment = async (file: FileUIPart): Promise<ChatAttachment> => {
-  const mediaType = file.mediaType || "";
-  if (!mediaType.startsWith("image/") || !file.url.startsWith(`data:${mediaType};base64,`)) {
-    throw new Error("Only valid image attachments are supported.");
-  }
-  const bytes = new Uint8Array(await (await fetch(file.url)).arrayBuffer());
-  if (bytes.byteLength === 0 || bytes.byteLength > 8 * 1024 * 1024) {
-    throw new Error("Each image must be between 1 byte and 8 MB.");
-  }
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
-  const id = Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
-  return {
-    id,
-    filename: file.filename || "image",
-    media_type: mediaType,
-    data_url: file.url,
-  };
-};
 type SidekickEvent = {
   id: number;
   session_id: string;
@@ -369,13 +352,35 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   useEffect(() => {
     let cancelled = false;
     invoke<PersistedChatSession | null>("chat_session_latest")
-      .then((saved) => {
+      .then(async (saved) => {
         if (cancelled || !saved) return;
+        const attachmentRefs = recentUniqueAttachmentRefs(saved.messages);
+        const hydrated =
+          attachmentRefs.length > 0
+            ? await invoke<Array<ChatAttachment & { dataUrl: string }>>(
+                "chat_attachments_hydrate",
+                {
+                  sessionId: saved.session_id,
+                  attachments: attachmentRefs,
+                },
+              ).catch((error) => {
+                if (!cancelled) {
+                  setNotice(`Some saved image previews could not be restored: ${String(error)}`);
+                }
+                return [];
+              })
+            : [];
+        if (cancelled) return;
+        if (hydrated.length < attachmentRefs.length) {
+          setNotice("Some saved image previews are unavailable; their history references were preserved.");
+        }
         setSessionId(saved.session_id);
-        setMessages(saved.messages);
+        setMessages(withHydratedAttachments(saved.messages, hydrated));
       })
-      .catch(() => {
-        // A corrupt or legacy session must never block a fresh local chat.
+      .catch((error) => {
+        // A corrupt or legacy session must never block a fresh local chat, but
+        // the user should know why the previous conversation is not visible.
+        if (!cancelled) setNotice(`Saved chat could not be restored: ${String(error)}`);
       })
       .finally(() => {
         if (!cancelled) setSessionHydrated(true);
@@ -388,7 +393,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   useEffect(() => {
     if (!sessionHydrated || streaming) return;
     const timer = window.setTimeout(() => {
-      invoke("chat_session_save", { sessionId, messages }).catch(() => {
+      invoke("chat_session_save", {
+        sessionId,
+        messages: persistableChatMessages(messages),
+      }).catch(() => {
         setNotice("This chat could not be saved for restart; the current turn is unaffected.");
       });
     }, 150);
@@ -433,14 +441,6 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     setErr(null);
     setNotice(null);
 
-    let attachments: ChatAttachment[];
-    try {
-      attachments = await Promise.all(files.map(canonicalAttachment));
-    } catch (error) {
-      setErr(String(error));
-      throw error;
-    }
-
     const choice = selectedChoice;
     if (choice.route === "local" && choice.slotId == null) {
       setErr("No local model is warm. Open Serving, warm a local model slot, then send again.");
@@ -449,6 +449,28 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     if (choice.route === "local" && !choice.active) {
       setErr("The selected local model is still loading. Try again in a moment.");
       return;
+    }
+
+    let attachments: ChatAttachment[] = [];
+    if (files.length > 0) {
+      const uploads: ChatAttachmentUpload[] = files.map((file) => ({
+        filename: file.filename || "image",
+        mediaType: file.mediaType || "",
+        dataUrl: file.url,
+      }));
+      try {
+        const stored = await invoke<Array<Omit<ChatAttachment, "previewUrl">>>(
+          "chat_attachments_store",
+          { sessionId, attachments: uploads },
+        );
+        attachments = stored.map((attachment, index) => ({
+          ...attachment,
+          previewUrl: files[index]?.url,
+        }));
+      } catch (error) {
+        setErr(`Could not attach image: ${String(error)}`);
+        throw error;
+      }
     }
 
     const toSend: Msg[] = [
@@ -584,6 +606,9 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
 
   const restartChat = () => {
     if (streaming) return;
+    void invoke("chat_attachments_delete_session", { sessionId }).catch(() => {
+      // Starting a fresh chat still succeeds; orphan cleanup is local and best-effort.
+    });
     setMessages([]);
     setInput("");
     setErr(null);
@@ -738,7 +763,11 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
                       <div className="chat-image-list">
                         {m.attachments.map((attachment) => (
                           <figure className="chat-image" key={attachment.id}>
-                            <img src={attachment.data_url} alt={attachment.filename} />
+                            {attachment.previewUrl ? (
+                              <img src={attachment.previewUrl} alt={attachment.filename} />
+                            ) : (
+                              <div className="chat-image-unavailable">Preview unavailable</div>
+                            )}
                             <figcaption>{attachment.filename}</figcaption>
                           </figure>
                         ))}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2453,6 +2453,16 @@ select,
   border-radius: var(--r-control);
   object-fit: contain;
 }
+.chat-image-unavailable {
+  display: grid;
+  min-height: 72px;
+  padding: 10px;
+  border: 1px dashed var(--border);
+  border-radius: var(--r-control);
+  color: var(--text-2);
+  font-size: 10px;
+  place-items: center;
+}
 .chat-image figcaption {
   color: var(--text-2);
   font-size: 10px;

--- a/apps/homescreen/app/lib/chat-attachments.ts
+++ b/apps/homescreen/app/lib/chat-attachments.ts
@@ -1,0 +1,52 @@
+export type ChatAttachment = {
+  id: string;
+  filename: string;
+  mediaType: string;
+  previewUrl?: string;
+};
+
+export type ChatAttachmentUpload = {
+  filename: string;
+  mediaType: string;
+  dataUrl: string;
+};
+
+type MessageWithAttachments = {
+  attachments?: ChatAttachment[];
+};
+
+export function persistableChatMessages<T extends MessageWithAttachments>(messages: T[]) {
+  return messages.map((message) => ({
+    ...message,
+    attachments: message.attachments?.map(({ previewUrl: _previewUrl, ...attachment }) => attachment),
+  }));
+}
+
+export function recentUniqueAttachmentRefs<T extends MessageWithAttachments>(
+  messages: T[],
+  limit = 40,
+) {
+  const byId = new Map<string, ChatAttachment>();
+  for (const message of messages) {
+    for (const attachment of message.attachments ?? []) {
+      if (!byId.has(attachment.id)) byId.set(attachment.id, attachment);
+    }
+  }
+  return [...byId.values()]
+    .slice(-limit)
+    .map(({ previewUrl: _previewUrl, ...attachment }) => attachment);
+}
+
+export function withHydratedAttachments<T extends MessageWithAttachments>(
+  messages: T[],
+  hydrated: Array<ChatAttachment & { dataUrl: string }>,
+) {
+  const previews = new Map(hydrated.map((attachment) => [attachment.id, attachment.dataUrl]));
+  return messages.map((message) => ({
+    ...message,
+    attachments: message.attachments?.map((attachment) => {
+      const previewUrl = previews.get(attachment.id);
+      return previewUrl ? { ...attachment, previewUrl } : attachment;
+    }),
+  }));
+}

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -57,24 +57,10 @@ pub struct ChatMsg {
     pub role: String,
     pub content: String,
     #[serde(default)]
-    pub attachments: Vec<ChatAttachment>,
+    pub attachments: Vec<crate::chat_attachments::ChatAttachmentRef>,
 }
 
-#[derive(Clone, Deserialize)]
-pub struct ChatAttachment {
-    pub id: String,
-    pub filename: String,
-    pub media_type: String,
-    pub data_url: String,
-}
-
-#[derive(Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct AgentChatAttachmentUpload {
-    pub(crate) filename: String,
-    pub(crate) media_type: String,
-    pub(crate) data_url: String,
-}
+pub(crate) type AgentChatAttachmentUpload = crate::chat_attachments::ChatAttachmentUpload;
 
 #[derive(Serialize)]
 pub struct BenchmarkChatResult {
@@ -2011,35 +1997,11 @@ fn sidecar_provider_base_url(endpoint: &str) -> String {
         .to_string()
 }
 
-fn validate_chat_attachment(attachment: &ChatAttachment) -> Result<usize, String> {
-    use base64::Engine as _;
-    use sha2::Digest as _;
-
-    if attachment.filename.trim().is_empty() || attachment.filename.len() > 200 {
-        return Err("image filename must be between 1 and 200 bytes".to_string());
-    }
-    if !attachment.media_type.starts_with("image/") {
-        return Err("image media type must start with image/".to_string());
-    }
-    let prefix = format!("data:{};base64,", attachment.media_type);
-    let encoded = attachment
-        .data_url
-        .strip_prefix(&prefix)
-        .ok_or_else(|| "image data URL does not match its media type".to_string())?;
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|_| "image data URL contains invalid base64".to_string())?;
-    if bytes.is_empty() || bytes.len() > 8 * 1024 * 1024 {
-        return Err("image must be between 1 byte and 8 MB".to_string());
-    }
-    let digest = format!("{:x}", sha2::Sha256::digest(&bytes));
-    if digest != attachment.id {
-        return Err("image content hash does not match its id".to_string());
-    }
-    Ok(bytes.len())
-}
-
-fn openai_chat_message(message: &ChatMsg) -> Result<Value, String> {
+fn openai_chat_message(
+    app: &AppHandle,
+    session_id: &str,
+    message: &ChatMsg,
+) -> Result<Value, String> {
     if message.attachments.is_empty() {
         return Ok(json!({ "role": message.role, "content": message.content }));
     }
@@ -2050,15 +2012,19 @@ fn openai_chat_message(message: &ChatMsg) -> Result<Value, String> {
         return Err("at most four image attachments are allowed per message".to_string());
     }
     let mut content = vec![json!({ "type": "text", "text": message.content })];
-    let mut total_bytes = 0usize;
+    let mut total_bytes = 0u64;
     for attachment in &message.attachments {
-        total_bytes = total_bytes.saturating_add(validate_chat_attachment(attachment)?);
+        crate::chat_attachments::validate_ref(attachment)?;
+        total_bytes = total_bytes.saturating_add(crate::chat_attachments::attachment_byte_count(
+            app, session_id, attachment,
+        )?);
         if total_bytes > 24 * 1024 * 1024 {
             return Err("combined image attachments must not exceed 24 MB".to_string());
         }
+        let data_url = crate::chat_attachments::resolve_data_url(app, session_id, attachment)?;
         content.push(json!({
             "type": "image_url",
-            "image_url": { "url": attachment.data_url },
+            "image_url": { "url": data_url },
         }));
     }
     Ok(json!({ "role": message.role, "content": content }))
@@ -2068,10 +2034,10 @@ fn sidecar_runtime_messages(
     original: &[ChatMsg],
     outbound: &[Value],
 ) -> Result<Vec<Value>, String> {
-    let attachment_meta: HashMap<&str, &ChatAttachment> = original
+    let attachment_meta: HashMap<&str, &crate::chat_attachments::ChatAttachmentRef> = original
         .iter()
         .flat_map(|message| message.attachments.iter())
-        .map(|attachment| (attachment.data_url.as_str(), attachment))
+        .map(|attachment| (attachment.id.as_str(), attachment))
         .collect();
     outbound
         .iter()
@@ -2104,15 +2070,17 @@ fn sidecar_runtime_messages(
                             .pointer("/image_url/url")
                             .and_then(Value::as_str)
                             .ok_or_else(|| "runtime image is missing its data URL".to_string())?;
-                        let metadata = attachment_meta.get(data_url).ok_or_else(|| {
+                        let id = crate::chat_attachments::data_url_content_id(data_url)
+                            .ok_or_else(|| "runtime image data URL is invalid".to_string())?;
+                        let metadata = attachment_meta.get(id.as_str()).ok_or_else(|| {
                             "runtime image metadata does not match the submitted attachment"
                                 .to_string()
                         })?;
                         attachments.push(json!({
-                            "id": metadata.id,
+                            "id": id,
                             "filename": metadata.filename,
                             "media_type": metadata.media_type,
-                            "data_url": metadata.data_url,
+                            "data_url": data_url,
                         }));
                     }
                     _ => return Err("conversation runtime message part is unsupported".to_string()),
@@ -2238,47 +2206,23 @@ pub(crate) fn agent_sidecar_request(
     mgr: &Residency,
     input: AgentSidecarRequest<'_>,
 ) -> Result<Value, String> {
-    use sha2::Digest as _;
-
-    if input.attachments.len() > 4 {
-        return Err("at most four image attachments are allowed per message".to_string());
-    }
-    let decoded_attachments = input
-        .attachments
+    crate::chat_attachments::validate_uploads(input.attachments)?;
+    let attachments = if input.attachments.is_empty() {
+        Vec::new()
+    } else {
+        crate::chat_attachments::store_uploads(app, input.session_id, input.attachments.to_vec())?
+    };
+    let total_bytes = attachments
         .iter()
-        .map(|upload| {
-            let prefix = format!("data:{};base64,", upload.media_type);
-            let encoded = upload
-                .data_url
-                .strip_prefix(&prefix)
-                .ok_or_else(|| "image data URL does not match its media type".to_string())?;
-            let bytes = {
-                use base64::Engine as _;
-                base64::engine::general_purpose::STANDARD
-                    .decode(encoded)
-                    .map_err(|_| "image data URL contains invalid base64".to_string())?
-            };
-            let attachment = ChatAttachment {
-                id: format!("{:x}", sha2::Sha256::digest(&bytes)),
-                filename: upload.filename.clone(),
-                media_type: upload.media_type.clone(),
-                data_url: upload.data_url.clone(),
-            };
-            let size = validate_chat_attachment(&attachment)?;
-            Ok((attachment, size))
+        .map(|attachment| {
+            crate::chat_attachments::attachment_byte_count(app, input.session_id, attachment)
         })
-        .collect::<Result<Vec<_>, String>>()?;
-    let total_bytes = decoded_attachments
-        .iter()
-        .map(|(_, size)| *size)
-        .sum::<usize>();
+        .collect::<Result<Vec<_>, String>>()?
+        .into_iter()
+        .sum::<u64>();
     if total_bytes > 24 * 1024 * 1024 {
         return Err("combined image attachments must not exceed 24 MB".to_string());
     }
-    let attachments = decoded_attachments
-        .into_iter()
-        .map(|(attachment, _)| attachment)
-        .collect::<Vec<_>>();
     let (port, model_field) = mgr
         .endpoint(input.slot_id)
         .ok_or_else(|| format!("slot {} is not warm; warm it first", input.slot_id))?;
@@ -2333,7 +2277,7 @@ pub(crate) fn agent_sidecar_request(
     }];
     let outbound = vec![
         json!({ "role": "system", "content": system_prompt_for(&model_field) }),
-        openai_chat_message(&messages[0])?,
+        openai_chat_message(app, input.session_id, &messages[0])?,
     ];
     let binding = RouteBinding {
         route: "local".to_string(),
@@ -2915,7 +2859,7 @@ pub async fn chat_stream(
     let projected_messages = messages
         .iter()
         .filter(|message| message.role != "system")
-        .map(openai_chat_message)
+        .map(|message| openai_chat_message(&app, &session_id, message))
         .collect::<Result<Vec<_>, _>>()?;
     outbound_messages.extend(projected_messages);
     let (mut outbound_messages, compaction_reason, context_tokens_before) =
@@ -4088,28 +4032,37 @@ fn finalize_tool_calls(mut tool_calls: Vec<ToolCallAcc>) -> Vec<ToolCallAcc> {
 mod tests {
     use super::*;
 
-    fn image_message() -> ChatMsg {
+    fn image_message() -> (ChatMsg, String) {
         use base64::Engine as _;
         use sha2::Digest as _;
 
-        let bytes = b"desktop-image-fixture";
+        let bytes = b"\x89PNG\r\n\x1a\ndesktop-image-fixture";
         let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
-        ChatMsg {
-            role: "user".to_string(),
-            content: "inspect this".to_string(),
-            attachments: vec![ChatAttachment {
-                id: format!("{:x}", sha2::Sha256::digest(bytes)),
-                filename: "fixture.png".to_string(),
-                media_type: "image/png".to_string(),
-                data_url: format!("data:image/png;base64,{encoded}"),
-            }],
-        }
+        (
+            ChatMsg {
+                role: "user".to_string(),
+                content: "inspect this".to_string(),
+                attachments: vec![crate::chat_attachments::ChatAttachmentRef {
+                    id: format!("{:x}", sha2::Sha256::digest(bytes)),
+                    filename: "fixture.png".to_string(),
+                    media_type: "image/png".to_string(),
+                }],
+            },
+            format!("data:image/png;base64,{encoded}"),
+        )
     }
 
     #[test]
     fn image_projection_preserves_hash_metadata_and_bounded_token_estimate() {
-        let original = vec![image_message()];
-        let outbound = vec![openai_chat_message(&original[0]).unwrap()];
+        let (message, data_url) = image_message();
+        let original = vec![message];
+        let outbound = vec![json!({
+            "role": "user",
+            "content": [
+                { "type": "text", "text": "inspect this" },
+                { "type": "image_url", "image_url": { "url": data_url } },
+            ],
+        })];
         assert_eq!(outbound[0]["content"][1]["type"], "image_url");
         assert_eq!(approximate_messages_tokens(&outbound), 1_202);
 
@@ -4121,11 +4074,11 @@ mod tests {
         );
         assert_eq!(projected[0]["attachments"][0]["filename"], "fixture.png");
 
-        let mut tampered = image_message();
+        let (mut tampered, _) = image_message();
         tampered.attachments[0].id = "0".repeat(64);
-        assert!(openai_chat_message(&tampered)
+        assert!(sidecar_runtime_messages(&[tampered], &outbound)
             .unwrap_err()
-            .contains("content hash"));
+            .contains("metadata does not match"));
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/chat_attachments.rs
+++ b/apps/homescreen/src-tauri/src/chat_attachments.rs
@@ -1,0 +1,533 @@
+//! Durable, local-only image attachments for desktop chat.
+//!
+//! The WebView sends image bytes once. We keep them under private app data and
+//! put only content-addressed references in chat history, avoiding giant base64
+//! rows in SQLite while still restoring image context after an app restart.
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+const MAX_ATTACHMENTS_PER_TURN: usize = 4;
+const MAX_ATTACHMENT_BYTES: usize = 8 * 1024 * 1024;
+const MAX_HYDRATE_ATTACHMENTS: usize = 40;
+const MAX_HYDRATE_ENCODED_BYTES: usize = 32 * 1024 * 1024;
+const MAX_FILENAME_CHARS: usize = 200;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatAttachmentRef {
+    pub id: String,
+    pub filename: String,
+    pub media_type: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatAttachmentUpload {
+    pub filename: String,
+    pub media_type: String,
+    pub data_url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HydratedChatAttachment {
+    pub id: String,
+    pub filename: String,
+    pub media_type: String,
+    pub data_url: String,
+}
+
+fn mime_extension(media_type: &str) -> Option<&'static str> {
+    match media_type {
+        "image/jpeg" => Some("jpg"),
+        "image/png" => Some("png"),
+        "image/webp" => Some("webp"),
+        "image/gif" => Some("gif"),
+        _ => None,
+    }
+}
+
+fn validate_session_id(session_id: &str) -> Result<(), String> {
+    if session_id.trim().is_empty() || session_id.len() > 200 {
+        return Err("image attachment requires a bounded chat session id".to_string());
+    }
+    Ok(())
+}
+
+fn session_component(session_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(session_id.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn attachment_root(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
+    validate_session_id(session_id)?;
+    Ok(app
+        .state::<crate::db::Db>()
+        .data_dir()
+        .join("chat-attachments")
+        .join(session_component(session_id)))
+}
+
+pub(crate) fn validate_ref(reference: &ChatAttachmentRef) -> Result<&'static str, String> {
+    if reference.id.len() != 64
+        || !reference
+            .id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err("image attachment has an invalid content id".to_string());
+    }
+    if reference.filename.is_empty() || reference.filename.chars().count() > MAX_FILENAME_CHARS {
+        return Err("image attachment has an invalid filename".to_string());
+    }
+    mime_extension(&reference.media_type)
+        .ok_or_else(|| format!("unsupported image type: {}", reference.media_type))
+}
+
+fn attachment_path(root: &Path, reference: &ChatAttachmentRef) -> Result<PathBuf, String> {
+    let extension = validate_ref(reference)?;
+    Ok(root.join(format!("{}.{}", reference.id, extension)))
+}
+
+fn decode_upload(upload: &ChatAttachmentUpload) -> Result<Vec<u8>, String> {
+    if upload.filename.is_empty() || upload.filename.chars().count() > MAX_FILENAME_CHARS {
+        return Err("image attachment has an invalid filename".to_string());
+    }
+    mime_extension(&upload.media_type)
+        .ok_or_else(|| format!("unsupported image type: {}", upload.media_type))?;
+    let prefix = format!("data:{};base64,", upload.media_type);
+    let encoded = upload
+        .data_url
+        .strip_prefix(&prefix)
+        .ok_or_else(|| "image attachment data does not match its media type".to_string())?;
+    if encoded.len() > (MAX_ATTACHMENT_BYTES * 4 / 3) + 8 {
+        return Err(format!(
+            "{} is larger than the 8 MB image limit",
+            upload.filename
+        ));
+    }
+    let bytes = STANDARD
+        .decode(encoded)
+        .map_err(|_| format!("{} is not valid base64 image data", upload.filename))?;
+    if bytes.is_empty() || bytes.len() > MAX_ATTACHMENT_BYTES {
+        return Err(format!(
+            "{} must be a non-empty image no larger than 8 MB",
+            upload.filename
+        ));
+    }
+    let signature_matches = match upload.media_type.as_str() {
+        "image/png" => bytes.starts_with(b"\x89PNG\r\n\x1a\n"),
+        "image/jpeg" => bytes.starts_with(&[0xff, 0xd8, 0xff]),
+        "image/gif" => bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a"),
+        "image/webp" => bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP",
+        _ => false,
+    };
+    if !signature_matches {
+        return Err(format!(
+            "{} does not contain valid {} image bytes",
+            upload.filename, upload.media_type
+        ));
+    }
+    Ok(bytes)
+}
+
+fn content_id(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+pub(crate) fn data_url_content_id(data_url: &str) -> Option<String> {
+    let (_, encoded) = data_url.split_once(',')?;
+    STANDARD
+        .decode(encoded)
+        .ok()
+        .map(|bytes| content_id(&bytes))
+}
+
+fn create_private_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path)
+        .map_err(|error| format!("create image attachment directory: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("secure image attachment directory: {error}"))?;
+    }
+    Ok(())
+}
+
+fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    if path.is_file() {
+        match std::fs::read(path) {
+            Ok(existing) if existing == bytes => return Ok(()),
+            Ok(_) | Err(_) => std::fs::remove_file(path)
+                .map_err(|error| format!("replace damaged image attachment: {error}"))?,
+        }
+    }
+    let temporary = path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temporary)
+        .map_err(|error| format!("create image attachment: {error}"))?;
+    if let Err(error) = file.write_all(bytes).and_then(|_| file.sync_all()) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(format!("write image attachment: {error}"));
+    }
+    drop(file);
+    if path.is_file() {
+        let _ = std::fs::remove_file(&temporary);
+        return Ok(());
+    }
+    std::fs::rename(&temporary, path).map_err(|error| {
+        let _ = std::fs::remove_file(&temporary);
+        format!("finish image attachment: {error}")
+    })
+}
+
+fn store_at(
+    root: &Path,
+    uploads: Vec<ChatAttachmentUpload>,
+) -> Result<Vec<ChatAttachmentRef>, String> {
+    if uploads.is_empty() || uploads.len() > MAX_ATTACHMENTS_PER_TURN {
+        return Err(format!(
+            "attach between 1 and {MAX_ATTACHMENTS_PER_TURN} images at a time"
+        ));
+    }
+    create_private_dir(root)?;
+    uploads
+        .into_iter()
+        .map(|upload| {
+            let bytes = decode_upload(&upload)?;
+            let reference = ChatAttachmentRef {
+                id: content_id(&bytes),
+                filename: upload.filename,
+                media_type: upload.media_type,
+            };
+            let path = attachment_path(root, &reference)?;
+            write_private_atomic(&path, &bytes)?;
+            Ok(reference)
+        })
+        .collect()
+}
+
+pub(crate) fn store_uploads(
+    app: &AppHandle,
+    session_id: &str,
+    uploads: Vec<ChatAttachmentUpload>,
+) -> Result<Vec<ChatAttachmentRef>, String> {
+    store_at(&attachment_root(app, session_id)?, uploads)
+}
+
+/// Convert the previous desktop schema, which embedded `data_url` bytes in
+/// SQLite, into bounded attachment references. This runs once when a v1 chat
+/// is reopened and the caller immediately saves the resulting v2 snapshot.
+pub(crate) fn migrate_legacy_messages(
+    app: &AppHandle,
+    session_id: &str,
+    messages: &Value,
+) -> Result<Value, String> {
+    migrate_legacy_at(&attachment_root(app, session_id)?, messages)
+}
+
+fn migrate_legacy_at(root: &Path, messages: &Value) -> Result<Value, String> {
+    let mut migrated = messages.clone();
+    let items = migrated
+        .as_array_mut()
+        .ok_or_else(|| "chat transcript must be an array".to_string())?;
+    for message in items {
+        let Some(attachments) = message.get_mut("attachments").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        if attachments.is_empty() {
+            continue;
+        }
+        let mut uploads = Vec::with_capacity(attachments.len());
+        let mut already_referenced = true;
+        for attachment in attachments.iter() {
+            let Some(object) = attachment.as_object() else {
+                return Err("saved image attachment is invalid".to_string());
+            };
+            let data_url = object
+                .get("data_url")
+                .or_else(|| object.get("dataUrl"))
+                .and_then(Value::as_str);
+            let Some(data_url) = data_url else {
+                continue;
+            };
+            already_referenced = false;
+            let filename = object
+                .get("filename")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "saved image attachment is missing its filename".to_string())?;
+            let media_type = object
+                .get("media_type")
+                .or_else(|| object.get("mediaType"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| "saved image attachment is missing its media type".to_string())?;
+            uploads.push(ChatAttachmentUpload {
+                filename: filename.to_string(),
+                media_type: media_type.to_string(),
+                data_url: data_url.to_string(),
+            });
+        }
+        if already_referenced {
+            continue;
+        }
+        if uploads.len() != attachments.len() {
+            return Err("saved chat mixes embedded images and attachment references".to_string());
+        }
+        *attachments = store_at(root, uploads)?
+            .into_iter()
+            .map(|reference| serde_json::to_value(reference).expect("attachment ref serializes"))
+            .collect();
+    }
+    Ok(migrated)
+}
+
+pub(crate) fn validate_uploads(uploads: &[ChatAttachmentUpload]) -> Result<(), String> {
+    if uploads.len() > MAX_ATTACHMENTS_PER_TURN {
+        return Err(format!(
+            "attach at most {MAX_ATTACHMENTS_PER_TURN} images at a time"
+        ));
+    }
+    for upload in uploads {
+        decode_upload(upload)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn resolve_data_url(
+    app: &AppHandle,
+    session_id: &str,
+    reference: &ChatAttachmentRef,
+) -> Result<String, String> {
+    let root = attachment_root(app, session_id)?;
+    let path = attachment_path(&root, reference)?;
+    let bytes = std::fs::read(&path).map_err(|error| {
+        format!(
+            "image attachment {} is unavailable: {error}",
+            reference.filename
+        )
+    })?;
+    if bytes.is_empty() || bytes.len() > MAX_ATTACHMENT_BYTES {
+        return Err(format!(
+            "image attachment {} is invalid",
+            reference.filename
+        ));
+    }
+    if content_id(&bytes) != reference.id {
+        return Err(format!(
+            "image attachment {} failed its integrity check",
+            reference.filename
+        ));
+    }
+    Ok(format!(
+        "data:{};base64,{}",
+        reference.media_type,
+        STANDARD.encode(bytes)
+    ))
+}
+
+pub(crate) fn attachment_byte_count(
+    app: &AppHandle,
+    session_id: &str,
+    reference: &ChatAttachmentRef,
+) -> Result<u64, String> {
+    let root = attachment_root(app, session_id)?;
+    let path = attachment_path(&root, reference)?;
+    let metadata = std::fs::metadata(&path).map_err(|error| {
+        format!(
+            "image attachment {} is unavailable: {error}",
+            reference.filename
+        )
+    })?;
+    if metadata.len() == 0 || metadata.len() > MAX_ATTACHMENT_BYTES as u64 {
+        return Err(format!(
+            "image attachment {} has an invalid size",
+            reference.filename
+        ));
+    }
+    Ok(metadata.len())
+}
+
+#[tauri::command]
+pub async fn chat_attachments_store(
+    app: AppHandle,
+    session_id: String,
+    attachments: Vec<ChatAttachmentUpload>,
+) -> Result<Vec<ChatAttachmentRef>, String> {
+    tauri::async_runtime::spawn_blocking(move || store_uploads(&app, &session_id, attachments))
+        .await
+        .map_err(|error| format!("store image attachment task failed: {error}"))?
+}
+
+#[tauri::command]
+pub async fn chat_attachments_hydrate(
+    app: AppHandle,
+    session_id: String,
+    attachments: Vec<ChatAttachmentRef>,
+) -> Result<Vec<HydratedChatAttachment>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        hydrate_attachments(&app, &session_id, attachments)
+    })
+    .await
+    .map_err(|error| format!("restore image attachment task failed: {error}"))?
+}
+
+fn hydrate_attachments(
+    app: &AppHandle,
+    session_id: &str,
+    attachments: Vec<ChatAttachmentRef>,
+) -> Result<Vec<HydratedChatAttachment>, String> {
+    if attachments.len() > MAX_HYDRATE_ATTACHMENTS {
+        return Err(format!(
+            "restore at most {MAX_HYDRATE_ATTACHMENTS} image previews at a time"
+        ));
+    }
+    let mut total = 0usize;
+    let mut hydrated = Vec::with_capacity(attachments.len());
+    for reference in attachments {
+        let Ok(data_url) = resolve_data_url(app, session_id, &reference) else {
+            continue;
+        };
+        if total.saturating_add(data_url.len()) > MAX_HYDRATE_ENCODED_BYTES {
+            break;
+        }
+        total += data_url.len();
+        hydrated.push(HydratedChatAttachment {
+            id: reference.id,
+            filename: reference.filename,
+            media_type: reference.media_type,
+            data_url,
+        });
+    }
+    Ok(hydrated)
+}
+
+#[tauri::command]
+pub fn chat_attachments_delete_session(app: AppHandle, session_id: String) -> Result<(), String> {
+    let root = attachment_root(&app, &session_id)?;
+    if root.exists() {
+        std::fs::remove_dir_all(&root)
+            .map_err(|error| format!("delete local chat images: {error}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn upload(data: &str) -> ChatAttachmentUpload {
+        ChatAttachmentUpload {
+            filename: "pixel.png".to_string(),
+            media_type: "image/png".to_string(),
+            data_url: format!("data:image/png;base64,{data}"),
+        }
+    }
+
+    #[test]
+    fn stores_content_addressed_images_without_rewriting_existing_bytes() {
+        let root = std::env::temp_dir().join(format!(
+            "understudy-chat-images-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let bytes = b"\x89PNG\r\n\x1a\n-bounded-test-bytes";
+        let encoded = STANDARD.encode(bytes);
+        validate_uploads(&[upload(&encoded)]).unwrap();
+        let first = store_at(&root, vec![upload(&encoded)]).unwrap();
+        let second = store_at(&root, vec![upload(&encoded)]).unwrap();
+        assert_eq!(first[0].id, second[0].id);
+        assert_eq!(
+            std::fs::read(attachment_path(&root, &first[0]).unwrap()).unwrap(),
+            bytes
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn reattachment_repairs_damaged_content_addressed_bytes() {
+        let root = std::env::temp_dir().join(format!(
+            "understudy-chat-images-repair-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let bytes = b"\x89PNG\r\n\x1a\n-repairable-test-bytes";
+        let encoded = STANDARD.encode(bytes);
+        let stored = store_at(&root, vec![upload(&encoded)]).unwrap();
+        let path = attachment_path(&root, &stored[0]).unwrap();
+        std::fs::write(&path, b"damaged").unwrap();
+        store_at(&root, vec![upload(&encoded)]).unwrap();
+        assert_eq!(std::fs::read(path).unwrap(), bytes);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_transcripts_migrate_bytes_out_of_sqlite_shape() {
+        let root = std::env::temp_dir().join(format!(
+            "understudy-chat-images-migration-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let bytes = b"\x89PNG\r\n\x1a\n-legacy-test-bytes";
+        let data_url = format!("data:image/png;base64,{}", STANDARD.encode(bytes));
+        let legacy = serde_json::json!([{
+            "role": "user",
+            "content": "review",
+            "attachments": [{
+                "id": "legacy-id-is-recomputed",
+                "filename": "legacy.png",
+                "media_type": "image/png",
+                "data_url": data_url,
+            }],
+        }]);
+        let migrated = migrate_legacy_at(&root, &legacy).unwrap();
+        let serialized = serde_json::to_string(&migrated).unwrap();
+        assert!(!serialized.contains("base64"));
+        let reference: ChatAttachmentRef =
+            serde_json::from_value(migrated[0]["attachments"][0].clone()).unwrap();
+        assert_eq!(
+            std::fs::read(attachment_path(&root, &reference).unwrap()).unwrap(),
+            bytes
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rejects_wrong_types_mismatched_data_and_oversized_batches() {
+        let mut wrong_type = upload("eA==");
+        wrong_type.media_type = "application/pdf".to_string();
+        assert!(decode_upload(&wrong_type).is_err());
+        let mut mismatch = upload("eA==");
+        mismatch.media_type = "image/jpeg".to_string();
+        assert!(decode_upload(&mismatch).is_err());
+        assert!(validate_uploads(&[mismatch]).is_err());
+        let root = std::env::temp_dir().join("understudy-chat-images-batch-test");
+        assert!(store_at(
+            &root,
+            (0..=MAX_ATTACHMENTS_PER_TURN)
+                .map(|_| upload("eA=="))
+                .collect()
+        )
+        .is_err());
+    }
+}

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -2309,7 +2309,8 @@ pub fn chat_runs(app: AppHandle, limit: Option<u32>) -> Result<Vec<ChatRunRow>, 
         .map_err(|e| e.to_string())
 }
 
-const DESKTOP_CHAT_SESSION_SCHEMA: &str = "understudy-desktop-chat-session-v1";
+const DESKTOP_CHAT_SESSION_SCHEMA: &str = "understudy-desktop-chat-session-v2";
+const LEGACY_DESKTOP_CHAT_SESSION_SCHEMA: &str = "understudy-desktop-chat-session-v1";
 const MAX_PERSISTED_CHAT_BYTES: usize = 48 * 1024 * 1024;
 const MAX_PERSISTED_CHAT_MESSAGES: usize = 500;
 
@@ -2322,22 +2323,34 @@ pub struct DesktopChatSession {
 
 #[tauri::command]
 pub fn chat_session_latest(app: AppHandle) -> Result<Option<DesktopChatSession>, String> {
-    let Some(row) = app
-        .state::<crate::db::Db>()
+    let db = app.state::<crate::db::Db>();
+    let row = db
         .latest_chat_session(DESKTOP_CHAT_SESSION_SCHEMA)
-        .map_err(|error| error.to_string())?
-    else {
-        return Ok(None);
+        .map_err(|error| error.to_string())?;
+    let (session_id, messages, updated_at) = if let Some(row) = row {
+        let messages = serde_json::from_str(&row.messages)
+            .map_err(|error| format!("saved chat transcript is invalid: {error}"))?;
+        (row.session_id, messages, row.updated_at)
+    } else {
+        let Some(legacy) = db
+            .latest_chat_session(LEGACY_DESKTOP_CHAT_SESSION_SCHEMA)
+            .map_err(|error| error.to_string())?
+        else {
+            return Ok(None);
+        };
+        let messages: Value = serde_json::from_str(&legacy.messages)
+            .map_err(|error| format!("saved legacy chat transcript is invalid: {error}"))?;
+        let messages =
+            crate::chat_attachments::migrate_legacy_messages(&app, &legacy.session_id, &messages)?;
+        let encoded = serde_json::to_string(&messages).map_err(|error| error.to_string())?;
+        db.save_active_chat_session(&legacy.session_id, DESKTOP_CHAT_SESSION_SCHEMA, &encoded)
+            .map_err(|error| error.to_string())?;
+        (legacy.session_id, messages, chrono::Utc::now().to_rfc3339())
     };
-    if row.schema != DESKTOP_CHAT_SESSION_SCHEMA {
-        return Ok(None);
-    }
-    let messages = serde_json::from_str(&row.messages)
-        .map_err(|error| format!("saved chat transcript is invalid: {error}"))?;
     Ok(Some(DesktopChatSession {
-        session_id: row.session_id,
+        session_id,
         messages,
-        updated_at: row.updated_at,
+        updated_at,
     }))
 }
 

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod agent_ops;
 mod bin;
 mod bootstrap;
 mod chat;
+mod chat_attachments;
 mod commands;
 mod conversation_runtime;
 mod conversation_sidecar;
@@ -183,6 +184,9 @@ pub fn run() {
             commands::chat_route_metrics,
             commands::chat_session_latest,
             commands::chat_session_save,
+            chat_attachments::chat_attachments_store,
+            chat_attachments::chat_attachments_hydrate,
+            chat_attachments::chat_attachments_delete_session,
             commands::run_fusion_benchmark,
             commands::run_fusion_benchmark_matrix,
             commands::run_fusion_benchmark_matrix_live,

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -32,8 +32,8 @@
     },
     {
       "id": "durable-image-and-chat-persistence",
-      "status": "partial",
-      "evidence": "Images and restart sessions work, but attachment bytes still need content-addressed local storage instead of transcript-embedded data URLs."
+      "status": "shipped",
+      "evidence": "Image bytes are validated and stored atomically with private permissions under content hashes; SQLite keeps references only, legacy data URLs migrate on reopen, and previews hydrate after restart."
     },
     {
       "id": "resumable-model-downloads",

--- a/docs/privacy-and-data-boundaries.md
+++ b/docs/privacy-and-data-boundaries.md
@@ -15,6 +15,7 @@ the CLI may send bounded product telemetry as documented in
 | Source snippets | code fragments, prompt builders, parser logic | do not print, upload, or commit without approval |
 | Prompt bodies | system prompts, messages, templates | local-only unless explicitly approved |
 | Completions | model outputs, judge outputs, failed rows | local-only unless explicitly approved |
+| Desktop chat images | screenshots and other supported image attachments | private app-data files addressed by content hash; SQLite stores references only |
 | Traces | request/response payloads, spans, usage rows | metadata-only by default |
 | Eval rows | JSONL, CSV, YAML, golden fixtures | local-only until a redaction and split plan exists |
 | Secrets | API keys, tokens, credentials, local env files | never ask for chat-pasted values; never print values |
@@ -51,6 +52,16 @@ completions, or tool payloads to stdout.
 Gateway probes are explicit live calls. BYOK provider keys are read only from an
 environment variable named by `--byok-env`; they are not requested in chat, not
 persisted, and not printed.
+
+## Desktop Chat Storage
+
+Desktop chat history stays under the operating system's private app-data
+directory. Image bytes are validated, capped at 8 MB each, written atomically
+with owner-only permissions on Unix, and referenced from SQLite by SHA-256
+content ID. Reopening a chat hydrates only bounded previews. Starting a new chat
+deletes the previous session's image directory on a best-effort basis; removing
+the desktop app-data directory deletes chat history and its attachments
+together.
 
 ## Never Collected By Default
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,6 +36,11 @@ contact channel listed on the organization profile.
 eventually contain private payloads. Do not commit it unless a specific public
 fixture is intentionally synthetic and reviewed.
 
+Desktop image attachments live under private app data, outside `.understudy/`.
+The app accepts only bounded PNG, JPEG, WebP, and GIF bytes with matching file
+signatures. Filenames never select filesystem paths: session directories are
+hashed and stored filenames are derived from verified SHA-256 content IDs.
+
 ## Agent Tool Execution
 
 The conversation runtime does not enable Pi's built-in Bash tool. It accepts

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -14,6 +14,14 @@ const runtimeRepairLibPath = new URL(
   "../apps/homescreen/app/lib/runtime-repair.ts",
   import.meta.url,
 );
+const attachmentLibPath = new URL(
+  "../apps/homescreen/app/lib/chat-attachments.ts",
+  import.meta.url,
+);
+const attachmentRustPath = new URL(
+  "../apps/homescreen/src-tauri/src/chat_attachments.rs",
+  import.meta.url,
+);
 const parityPath = new URL("../docs/desktop-product-parity.json", import.meta.url);
 
 test("public desktop preserves the reviewed Train interaction language", async () => {
@@ -67,6 +75,29 @@ test("desktop has one managed runtime repair surface", async () => {
   assert.doesNotMatch(repair, /understudy update/);
 });
 
+test("desktop persists image references instead of transcript-embedded bytes", async () => {
+  const [chat, attachmentLib, attachmentRust] = await Promise.all([
+    readFile(chatPath, "utf8"),
+    readFile(attachmentLibPath, "utf8"),
+    readFile(attachmentRustPath, "utf8"),
+  ]);
+
+  assert.match(chat, /"chat_attachments_store"/);
+  assert.match(chat, /"chat_attachments_hydrate"/);
+  assert.match(chat, /"chat_attachments_delete_session"/);
+  assert.match(chat, /persistableChatMessages\(messages\)/);
+  assert.match(attachmentLib, /previewUrl: _previewUrl/);
+  assert.match(
+    attachmentLib,
+    /return previewUrl \? \{ \.\.\.attachment, previewUrl \} : attachment;/,
+  );
+  assert.match(attachmentRust, /join\("chat-attachments"\)/);
+  assert.match(attachmentRust, /content_id\(&bytes\)/);
+  assert.match(attachmentRust, /from_mode\(0o700\)/);
+  assert.match(attachmentRust, /options\.mode\(0o600\)/);
+  assert.match(attachmentRust, /migrate_legacy_messages/);
+});
+
 test("desktop migration claims stay tied to explicit product parity", async () => {
   const parity = JSON.parse(await readFile(parityPath, "utf8"));
   assert.equal(parity.release_authority, "apps/homescreen");
@@ -76,6 +107,7 @@ test("desktop migration claims stay tied to explicit product parity", async () =
   for (const required of [
     "offline-supervisor-fallback",
     "runtime-repair-experience",
+    "durable-image-and-chat-persistence",
     "supervision-review-desk",
     "correction-pair-export-and-metrics",
     "unified-experiment-hub",
@@ -85,6 +117,10 @@ test("desktop migration claims stay tied to explicit product parity", async () =
   }
   assert.equal(
     parity.features.find((feature) => feature.id === "runtime-repair-experience")?.status,
+    "shipped",
+  );
+  assert.equal(
+    parity.features.find((feature) => feature.id === "durable-image-and-chat-persistence")?.status,
     "shipped",
   );
   for (const feature of parity.features) {


### PR DESCRIPTION
## Outcome

Completes the reviewed Train image/restart parity slice in the public desktop.

- validates PNG/JPEG/WebP/GIF bytes and 8 MB per-image bounds
- writes owner-private, atomic, content-addressed files under app data
- persists only attachment references in SQLite
- migrates legacy transcript-embedded data URLs on first reopen
- hydrates bounded previews after restart and drops unavailable images safely
- routes authenticated Desktop API image turns through the same store
- documents local storage and deletion boundaries

## Verification

- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (147 passed, 1 ignored)
- attachment tests: dedupe, corruption repair, legacy migration, invalid input
- desktop `npm run build`
- root `npm run check` (234 tests, skills validation, package smoke)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->