### PR TITLE
Record legacy desktop retirement

### DIFF
--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -62,8 +62,8 @@
     },
     {
       "id": "legacy-desktop-retirement-guard",
-      "status": "planned",
-      "evidence": "The public desktop is the release authority, but automation must still prevent new product work or releases from the legacy surface."
+      "status": "shipped",
+      "evidence": "The legacy desktop source is explicitly extraction-only: its stale npm package is private, both archived Tauri apps have bundling disabled, and a trusted-base PR guard rejects additions or modifications while allowing deletion or auditable shelving. The public apps/homescreen remains the sole desktop release authority."
     },
     {
       "id": "native-runtime-deletion",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -187,6 +187,10 @@ test("desktop migration claims stay tied to explicit product parity", async () =
     parity.features.find((feature) => feature.id === "correction-pair-export-and-metrics")?.status,
     "shipped",
   );
+  assert.equal(
+    parity.features.find((feature) => feature.id === "legacy-desktop-retirement-guard")?.status,
+    "shipped",
+  );
   for (const feature of parity.features) {
     assert.ok(parity.status_values.includes(feature.status), `${feature.id} has an unknown status`);
     assert.ok(feature.evidence.length > 20, `${feature.id} needs concrete evidence`);


### PR DESCRIPTION
## What changed

- mark the legacy desktop retirement guard as shipped in the public parity manifest
- describe the concrete enforcement: private npm package, disabled Tauri bundling, and trusted-base rejection of additions or modifications
- add a lineage assertion so the public migration claim cannot silently regress

## Evidence

The private source enforcement landed in understudy-agent PR 573 before this claim changed.

## Validation

- TypeScript build and typecheck passed
- all 236 Node tests passed
- 33 public skills validated
- package/privacy smoke passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->