### PR TITLE
Desktop: unify the experiment comparison flow

### DIFF
--- a/apps/homescreen/app/components/ExperimentCompareView.tsx
+++ b/apps/homescreen/app/components/ExperimentCompareView.tsx
@@ -249,7 +249,7 @@ export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
         </div>
         <nav>
           <button type="button" onClick={onReview}>Review decisions</button>
-          <button type="button" disabled={!latest} onClick={() => void exportEvidence()}>
+          <button type="button" disabled={!latest || phase !== "idle"} onClick={() => void exportEvidence()}>
             {phase === "exporting" ? "Exporting…" : "Export evidence"}
           </button>
         </nav>

--- a/apps/homescreen/app/components/ExperimentCompareView.tsx
+++ b/apps/homescreen/app/components/ExperimentCompareView.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { Channel, invoke } from "@tauri-apps/api/core";
+import { useEffect, useMemo, useState } from "react";
+import {
+  comparisonNextAction,
+  listMatchedComparisons,
+} from "../lib/experiment-comparison.mjs";
+
+type BenchmarkCandidate = {
+  id: string;
+  label: string;
+  route: string;
+  model_hint: string;
+  description: string;
+};
+
+type BenchmarkSuite = {
+  id: string;
+  label: string;
+  description: string;
+  task_ids: string[];
+};
+
+type BenchmarkMatrix = {
+  schema_version: string;
+  suites: BenchmarkSuite[];
+  candidates: BenchmarkCandidate[];
+};
+
+type PlanRow = {
+  task_id: string;
+  mode: string;
+  model: string;
+  ready: boolean;
+  reason: string;
+};
+
+type MatrixRun = {
+  run_id: string;
+  suite: string;
+  dry_run: boolean;
+  rows: number;
+  candidates: Array<{ candidate: string; run: { rows: PlanRow[] } }>;
+};
+
+type BenchmarkRow = {
+  id: number;
+  run_id: string;
+  capture_run_id?: string | null;
+  runtime_backend: string;
+  task_id: string;
+  mode: string;
+  model: string;
+  elapsed_ms?: number | null;
+  prompt_tokens?: number | null;
+  completion_tokens?: number | null;
+  score?: number | null;
+  status: string;
+  cost_usd?: number | null;
+  harness_sha256?: string | null;
+  split_sha256?: string | null;
+};
+
+type ComparisonCandidate = {
+  candidate_id: string;
+  label: string;
+  run_id: string;
+  rows: number;
+  executed: number;
+  ok_rows: number;
+  error_rows: number;
+  skipped_rows: number;
+  terminal_rows: number;
+  score_coverage: number;
+  capture_coverage: number;
+  avg_score: number | null;
+  avg_latency_ms: number | null;
+  avg_tokens: number | null;
+  cost_usd: number | null;
+  models: string[];
+  task_mode_keys: string[];
+  runtime_backends: string[];
+};
+
+type MatchedComparison = {
+  parent_run_id: string;
+  newest_id: number;
+  candidates: ComparisonCandidate[];
+  matched_slice: boolean;
+  harness_sha256: string | null;
+  split_sha256: string | null;
+  promotion_ready: boolean;
+  blockers: string[];
+  winner_id: string | null;
+};
+
+type BenchmarkEvent =
+  | { type: "RunStarted"; run_id: string; rows: number }
+  | { type: "RowStarted"; task_id: string; candidate: string }
+  | { type: "RowFinished"; task_id: string; candidate: string; status: string }
+  | { type: "RunFinished"; run_id: string; rows: number }
+  | { type: "Error"; message: string };
+
+const LOCAL_CANDIDATES = ["local-main", "local-fast"];
+const DIRECT_MODE = ["main-only"];
+const VISIBLE_SUITES = new Set(["local-fusion-smoke", "local-comparison"]);
+
+function fmtPercent(value: number | null) {
+  return value == null ? "—" : `${Math.round(value * 100)}%`;
+}
+
+function fmtNumber(value: number | null, suffix = "") {
+  return value == null ? "—" : `${Math.round(value).toLocaleString()}${suffix}`;
+}
+
+function shortModel(value: string | undefined) {
+  if (!value) return "not recorded";
+  const tail = value.split("/").at(-1) ?? value;
+  return tail.length > 30 ? `${tail.slice(0, 29)}…` : tail;
+}
+
+function comparisonStatus(comparison: MatchedComparison | null) {
+  if (!comparison) return "no evidence";
+  if (comparison.promotion_ready) return "promotion-grade";
+  if (comparison.matched_slice) return "directional";
+  return "not comparable";
+}
+
+export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
+  const [matrix, setMatrix] = useState<BenchmarkMatrix | null>(null);
+  const [rows, setRows] = useState<BenchmarkRow[]>([]);
+  const [suite, setSuite] = useState("local-fusion-smoke");
+  const [phase, setPhase] = useState<"idle" | "preflight" | "running" | "exporting">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState({ done: 0, total: 0, label: "" });
+  const [exportPath, setExportPath] = useState<string | null>(null);
+
+  const localCandidateRows = useMemo(
+    () => matrix?.candidates.filter((candidate) => LOCAL_CANDIDATES.includes(candidate.id)) ?? [],
+    [matrix],
+  );
+  const comparisons = useMemo(
+    () => listMatchedComparisons(rows, localCandidateRows) as MatchedComparison[],
+    [rows, localCandidateRows],
+  );
+  const latest = comparisons[0] ?? null;
+  const next = comparisonNextAction(latest) as { title: string; body: string };
+  const visibleSuites = matrix?.suites.filter((item) => VISIBLE_SUITES.has(item.id)) ?? [];
+
+  const refresh = async () => {
+    const [nextMatrix, nextRows] = await Promise.all([
+      invoke<BenchmarkMatrix>("fusion_benchmark_matrix"),
+      invoke<BenchmarkRow[]>("fusion_benchmark_results", { limit: 500 }),
+    ]);
+    setMatrix(nextMatrix);
+    setRows(nextRows);
+  };
+
+  useEffect(() => {
+    void refresh().catch((cause) => setError(String(cause)));
+  }, []);
+
+  const runComparison = async () => {
+    if (phase !== "idle") return;
+    setPhase("preflight");
+    setError(null);
+    setExportPath(null);
+    setProgress({ done: 0, total: 0, label: "Checking both local models…" });
+    const request = {
+      suite,
+      candidates: LOCAL_CANDIDATES,
+      modes: DIRECT_MODE,
+      dry_run: true,
+      record_skips: false,
+    };
+    try {
+      const plan = await invoke<MatrixRun>("run_fusion_benchmark_matrix", { request });
+      const planRows = plan.candidates.flatMap((candidate) => candidate.run.rows);
+      const blockers = [...new Set(planRows.filter((row) => !row.ready).map((row) => row.reason))];
+      if (blockers.length) {
+        throw new Error(`Load distinct main and fast local models first (${blockers.join(", ")}).`);
+      }
+      const models = plan.candidates.map((candidate) => ({
+        candidate: candidate.candidate,
+        models: [...new Set(candidate.run.rows.map((row) => row.model))],
+      }));
+      const mainModel = models.find((row) => row.candidate === "local-main")?.models[0];
+      const fastModel = models.find((row) => row.candidate === "local-fast")?.models[0];
+      if (!mainModel || !fastModel || mainModel === fastModel) {
+        throw new Error("Load a distinct fast model; this plan would compare the same model twice.");
+      }
+
+      setPhase("running");
+      const channel = new Channel<BenchmarkEvent>();
+      channel.onmessage = (event) => {
+        if (event.type === "RunStarted") {
+          setProgress({ done: 0, total: event.rows, label: "Running the same frozen slice…" });
+        } else if (event.type === "RowStarted") {
+          setProgress((current) => ({ ...current, label: `${event.candidate} · ${event.task_id}` }));
+        } else if (event.type === "RowFinished") {
+          setProgress((current) => ({ ...current, done: Math.min(current.total, current.done + 1) }));
+        } else if (event.type === "Error") {
+          setError(event.message);
+        }
+      };
+      await invoke<MatrixRun>("run_fusion_benchmark_matrix_live", {
+        request: { ...request, dry_run: false, record_skips: true },
+        onEvent: channel,
+      });
+      await refresh();
+      setProgress((current) => ({ ...current, done: current.total, label: "Comparison captured." }));
+    } catch (cause) {
+      setError(String(cause));
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  const exportEvidence = async () => {
+    if (phase !== "idle") return;
+    setPhase("exporting");
+    setError(null);
+    try {
+      const result = await invoke<{ path: string }>("export_fusion_benchmark_comparison", {
+        request: { limit: 500, output_path: null },
+      });
+      setExportPath(result.path);
+    } catch (cause) {
+      setError(String(cause));
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  const progressPercent = progress.total ? Math.round((progress.done / progress.total) * 100) : 0;
+
+  return (
+    <main className="experiment-compare">
+      <header className="experiment-compare-topbar">
+        <div>
+          <span>Experiments</span>
+          <strong>Model comparison</strong>
+        </div>
+        <div className="experiment-loop" aria-label="Experiment loop">
+          <button type="button" onClick={onReview}>1 · Review</button>
+          <b>2 · Compare</b>
+          <span>3 · Improve</span>
+        </div>
+        <nav>
+          <button type="button" onClick={onReview}>Review decisions</button>
+          <button type="button" disabled={!latest} onClick={() => void exportEvidence()}>
+            {phase === "exporting" ? "Exporting…" : "Export evidence"}
+          </button>
+        </nav>
+      </header>
+
+      <section className="experiment-compare-body">
+        <article className="experiment-run-card">
+          <div className="experiment-kicker">One fair question</div>
+          <h2>Can the fast local model replace the main model?</h2>
+          <p>Same frozen tasks, direct model calls, no cloud traffic, and one shared run identity.</p>
+          <label>
+            <span>Difficulty</span>
+            <select value={suite} onChange={(event) => setSuite(event.target.value)} disabled={phase !== "idle"}>
+              {visibleSuites.map((item) => (
+                <option value={item.id} key={item.id}>{item.label}</option>
+              ))}
+            </select>
+          </label>
+          <button className="experiment-run-primary" type="button" disabled={phase !== "idle" || !matrix} onClick={() => void runComparison()}>
+            {phase === "preflight" ? "Checking models…" : phase === "running" ? "Comparing…" : "Compare local models"}
+          </button>
+          <small>Preflight fails closed if the models are missing, identical, or not warm.</small>
+
+          {(phase === "running" || progress.total > 0) && (
+            <div className="experiment-live-progress">
+              <div><span>{progress.label}</span><em>{progress.done}/{progress.total}</em></div>
+              <i><b style={{ width: `${progressPercent}%` }} /></i>
+            </div>
+          )}
+
+          <div className="experiment-ledger">
+            <div><strong>Recent matched runs</strong><span>{comparisons.length}</span></div>
+            {comparisons.slice(0, 3).map((comparison) => (
+              <div className="experiment-ledger-row" key={comparison.parent_run_id}>
+                <span>{comparison.parent_run_id}</span>
+                <em>{comparisonStatus(comparison)}</em>
+              </div>
+            ))}
+            {!comparisons.length && <p>No comparison evidence yet.</p>}
+          </div>
+        </article>
+
+        <article className="experiment-result-card">
+          <header>
+            <div>
+              <span>Latest evidence</span>
+              <strong>{latest?.parent_run_id ?? "No matched run yet"}</strong>
+            </div>
+            <em className={latest?.promotion_ready ? "ready" : latest?.matched_slice ? "directional" : "blocked"}>
+              {comparisonStatus(latest)}
+            </em>
+          </header>
+
+          {latest ? (
+            <>
+              <div className="experiment-candidates">
+                {latest.candidates.map((candidate) => (
+                  <section className={candidate.candidate_id === latest.winner_id ? "winner" : ""} key={candidate.candidate_id}>
+                    <header>
+                      <div><span>{candidate.candidate_id === "local-fast" ? "Candidate" : "Baseline"}</span><strong>{candidate.label}</strong></div>
+                      {candidate.candidate_id === latest.winner_id && <em>best on slice</em>}
+                    </header>
+                    <code>{shortModel(candidate.models[0])}</code>
+                    <dl>
+                      <div><dt>Quality</dt><dd>{fmtPercent(candidate.avg_score)}</dd></div>
+                      <div><dt>Latency</dt><dd>{fmtNumber(candidate.avg_latency_ms, " ms")}</dd></div>
+                      <div><dt>Tokens</dt><dd>{fmtNumber(candidate.avg_tokens)}</dd></div>
+                      <div><dt>Captured</dt><dd>{fmtPercent(candidate.capture_coverage)}</dd></div>
+                    </dl>
+                    <small>{candidate.ok_rows} ok · {candidate.error_rows} errors · {candidate.skipped_rows} skipped</small>
+                  </section>
+                ))}
+              </div>
+              <div className="experiment-evidence-gate">
+                <div><span>Same task + mode slice</span><strong>{latest.matched_slice ? "yes" : "no"}</strong></div>
+                <div><span>Canonical capture coverage</span><strong>{latest.candidates.every((candidate) => candidate.capture_coverage === 1) ? "100%" : "incomplete"}</strong></div>
+                <div><span>Matching immutable hashes</span><strong>{latest.harness_sha256 && latest.split_sha256 ? "yes" : "missing"}</strong></div>
+              </div>
+              {latest.blockers.length > 0 && <p className="experiment-directional-note">{latest.blockers[0]}</p>}
+            </>
+          ) : (
+            <div className="experiment-empty-result">
+              <strong>Start with the local smoke.</strong>
+              <p>Four direct rows answer the first question without uploading data or contacting a cloud model.</p>
+            </div>
+          )}
+        </article>
+      </section>
+
+      <footer className="experiment-next-action">
+        <div><span>Next</span><strong>{next.title}</strong><p>{next.body}</p></div>
+        <span className={latest?.promotion_ready ? "ready" : "closed"}>
+          {latest?.promotion_ready ? "ready for improvement handoff" : "promotion gate closed"}
+        </span>
+      </footer>
+
+      {(error || exportPath) && (
+        <div className={`experiment-notice${error ? " error" : ""}`} role={error ? "alert" : "status"}>
+          {error ?? `Evidence exported to ${exportPath}`}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/homescreen/app/components/RlmPane.tsx
+++ b/apps/homescreen/app/components/RlmPane.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
 import type { ResidencySnapshot } from "../lib/useStatus";
+import { ExperimentCompareView } from "./ExperimentCompareView";
 import { SupervisionReviewView } from "./SupervisionReviewView";
 
 type RlmTask = {
@@ -120,7 +121,10 @@ function shortModel(model: string | null): string {
 
 /** The human-facing Experiments job starts with trustworthy intervention labels. */
 export function RlmPane() {
-  return <SupervisionReviewView />;
+  const [view, setView] = useState<"review" | "compare">("review");
+  return view === "review"
+    ? <SupervisionReviewView onCompare={() => setView("compare")} />
+    : <ExperimentCompareView onReview={() => setView("review")} />;
 }
 
 // Kept during the one-release migration window for extraction and conformance

--- a/apps/homescreen/app/components/SupervisionReviewView.tsx
+++ b/apps/homescreen/app/components/SupervisionReviewView.tsx
@@ -40,7 +40,7 @@ function groupForMarker(groups: ReviewEvidenceGroup[], marker: string | null) {
   );
 }
 
-export function SupervisionReviewView() {
+export function SupervisionReviewView({ onCompare }: { onCompare?: () => void }) {
   const [queue, setQueue] = useState<SupervisionReviewQueue | null>(null);
   const [activeMarker, setActiveMarker] = useState<string | null>(null);
   const [showReviewed, setShowReviewed] = useState(false);
@@ -262,6 +262,11 @@ export function SupervisionReviewView() {
             Review past decisions
           </button>
         )}
+        {onCompare && (
+          <button type="button" onClick={onCompare}>
+            Compare local models
+          </button>
+        )}
       </div>
     );
   }
@@ -291,6 +296,7 @@ export function SupervisionReviewView() {
         <nav aria-label="Review queue">
           <button type="button" disabled={saving || visibleGroups.length < 2} onClick={() => move(-1)}>Previous</button>
           <button type="button" disabled={saving || visibleGroups.length < 2} onClick={() => move(1)}>Skip</button>
+          {onCompare && <button type="button" onClick={onCompare}>Compare</button>}
           <button type="button" aria-expanded={showDetails} onClick={() => setShowDetails((value) => !value)}>Details</button>
         </nav>
       </header>

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -3308,8 +3308,273 @@ select,
 .supervision-review-state button { padding: 9px 12px; }
 .supervision-review-state.error { color: var(--error); }
 
+/* ---------- Experiments: compact compare + evidence ledger ---------- */
+.content:has(.experiment-compare) {
+  overflow: hidden;
+  padding: calc(var(--titlebar-h) + 14px) 24px 18px;
+}
+
+.experiment-compare {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 14px;
+  width: min(1160px, 100%);
+  height: 100%;
+  margin: 0 auto;
+  color: var(--text);
+}
+
+.experiment-compare button {
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-2);
+  font: 500 11px/1.2 var(--mono);
+  cursor: pointer;
+}
+.experiment-compare button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--mb-cyan) 42%, var(--border-strong));
+  background: var(--hover);
+  color: var(--text);
+}
+.experiment-compare button:disabled { opacity: 0.42; cursor: not-allowed; }
+
+.experiment-compare-topbar {
+  display: grid;
+  grid-template-columns: 1fr minmax(280px, 0.9fr) 1fr;
+  align-items: center;
+  gap: 20px;
+  min-height: 40px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.experiment-compare-topbar > div:first-child { display: flex; align-items: baseline; gap: 10px; }
+.experiment-compare-topbar > div:first-child span,
+.experiment-kicker,
+.experiment-result-card > header span,
+.experiment-candidates header span,
+.experiment-next-action span {
+  color: var(--text-3);
+  font: 10px/1.3 var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.experiment-compare-topbar > div:first-child strong { font: 500 14px/1.2 var(--mono); }
+.experiment-compare-topbar nav { display: flex; justify-content: flex-end; gap: 7px; }
+.experiment-compare-topbar nav button { padding: 7px 10px; }
+
+.experiment-loop {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-3);
+  font: 9px/1.2 var(--mono);
+}
+.experiment-loop button,
+.experiment-loop b,
+.experiment-loop span { padding: 7px 10px; text-align: center; }
+.experiment-loop button { border: 0; border-radius: 999px; font-size: 9px; }
+.experiment-loop b { background: color-mix(in srgb, var(--mb-cyan) 15%, transparent); color: var(--text); font-weight: 500; }
+
+.experiment-compare-body {
+  display: grid;
+  grid-template-columns: minmax(250px, 0.7fr) minmax(0, 1.3fr);
+  gap: 12px;
+  min-height: 0;
+}
+.experiment-run-card,
+.experiment-result-card {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 86%, transparent);
+}
+.experiment-run-card {
+  display: flex;
+  flex-direction: column;
+  padding: clamp(16px, 2.4vw, 26px);
+  border-top: 2px solid var(--mb-mint);
+}
+.experiment-run-card h2 {
+  max-width: 380px;
+  margin: 10px 0 8px;
+  font-size: clamp(19px, 2.4vw, 28px);
+  font-weight: 500;
+  line-height: 1.12;
+  letter-spacing: -0.035em;
+}
+.experiment-run-card > p {
+  margin: 0 0 18px;
+  color: var(--text-2);
+  font-size: 11px;
+  line-height: 1.5;
+}
+.experiment-run-card > label { display: grid; gap: 7px; margin-bottom: 9px; }
+.experiment-run-card > label span { color: var(--text-3); font: 9px/1.2 var(--mono); text-transform: uppercase; letter-spacing: 0.07em; }
+.experiment-run-card select {
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font: 11px/1.2 var(--mono);
+}
+.experiment-run-primary {
+  min-height: 42px;
+  padding: 10px 12px;
+  border-color: color-mix(in srgb, var(--mb-cyan) 54%, var(--border)) !important;
+  background: color-mix(in srgb, var(--mb-cyan) 17%, transparent) !important;
+  color: var(--text) !important;
+}
+.experiment-run-card > small { margin-top: 8px; color: var(--text-3); font: 9px/1.4 var(--mono); }
+
+.experiment-live-progress { margin-top: 15px; }
+.experiment-live-progress > div { display: flex; justify-content: space-between; gap: 8px; color: var(--text-2); font: 9px/1.3 var(--mono); }
+.experiment-live-progress em { color: var(--mb-cyan); font-style: normal; }
+.experiment-live-progress i { display: block; height: 3px; margin-top: 7px; overflow: hidden; border-radius: 99px; background: var(--border); }
+.experiment-live-progress i b { display: block; height: 100%; background: var(--mb-cyan); transition: width 180ms ease; }
+
+.experiment-ledger {
+  display: grid;
+  gap: 1px;
+  margin-top: auto;
+  padding-top: 17px;
+  border-top: 1px solid var(--border);
+}
+.experiment-ledger > div:first-child,
+.experiment-ledger-row { display: flex; align-items: center; justify-content: space-between; gap: 9px; }
+.experiment-ledger > div:first-child { margin-bottom: 4px; color: var(--text-3); font: 9px/1.3 var(--mono); }
+.experiment-ledger > div:first-child strong { color: var(--text-2); font-weight: 500; }
+.experiment-ledger-row { min-width: 0; padding: 5px 0; color: var(--text-3); font: 9px/1.2 var(--mono); }
+.experiment-ledger-row span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.experiment-ledger-row em { flex: 0 0 auto; color: var(--text-2); font-style: normal; }
+.experiment-ledger > p { margin: 6px 0 0; color: var(--text-3); font: 9px/1.4 var(--mono); }
+
+.experiment-result-card {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+  border-top: 2px solid var(--mb-cyan);
+}
+.experiment-result-card > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.experiment-result-card > header > div { display: grid; gap: 3px; min-width: 0; }
+.experiment-result-card > header strong { overflow: hidden; font: 500 12px/1.3 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.experiment-result-card > header > em {
+  padding: 4px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-3);
+  font: 8px/1.2 var(--mono);
+  font-style: normal;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.experiment-result-card > header > em.ready { border-color: color-mix(in srgb, var(--mb-mint) 45%, var(--border)); color: var(--mb-mint); }
+.experiment-result-card > header > em.directional { border-color: color-mix(in srgb, var(--c-warn) 45%, var(--border)); color: var(--c-warn); }
+
+.experiment-candidates {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  min-height: 0;
+  padding: 14px;
+}
+.experiment-candidates > section {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg) 48%, transparent);
+}
+.experiment-candidates > section.winner { border-color: color-mix(in srgb, var(--mb-mint) 42%, var(--border)); }
+.experiment-candidates header { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
+.experiment-candidates header > div { display: grid; gap: 3px; }
+.experiment-candidates header strong { font-size: 15px; font-weight: 500; }
+.experiment-candidates header em { color: var(--mb-mint); font: 8px/1.2 var(--mono); font-style: normal; }
+.experiment-candidates code { margin: 12px 0; overflow: hidden; color: var(--text-3); font: 9px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.experiment-candidates dl { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; margin: auto 0 10px; }
+.experiment-candidates dl > div { padding: 8px; border: 1px solid var(--border); margin: -1px 0 0 -1px; }
+.experiment-candidates dt { color: var(--text-3); font: 8px/1.2 var(--mono); text-transform: uppercase; letter-spacing: 0.05em; }
+.experiment-candidates dd { margin: 4px 0 0; color: var(--text); font: 500 16px/1.1 var(--mono); }
+.experiment-candidates > section > small { color: var(--text-3); font: 8px/1.3 var(--mono); }
+
+.experiment-evidence-gate {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--border);
+}
+.experiment-evidence-gate > div { display: grid; gap: 4px; padding: 10px 13px; border-right: 1px solid var(--border); }
+.experiment-evidence-gate > div:last-child { border-right: 0; }
+.experiment-evidence-gate span { color: var(--text-3); font: 8px/1.3 var(--mono); }
+.experiment-evidence-gate strong { color: var(--text-2); font: 500 10px/1.2 var(--mono); }
+.experiment-directional-note { margin: 0; padding: 9px 13px; border-top: 1px solid var(--border); color: var(--c-warn); font: 9px/1.4 var(--mono); }
+.experiment-empty-result { align-self: center; max-width: 360px; margin: auto; padding: 30px; text-align: center; }
+.experiment-empty-result strong { font-size: 20px; font-weight: 500; }
+.experiment-empty-result p { margin: 10px 0 0; color: var(--text-2); font-size: 11px; line-height: 1.55; }
+
+.experiment-next-action {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 20px;
+  min-height: 76px;
+  padding: 12px 15px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 24%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+.experiment-next-action > div { display: grid; grid-template-columns: auto 1fr; gap: 3px 10px; align-items: baseline; }
+.experiment-next-action strong { font-size: 14px; font-weight: 500; }
+.experiment-next-action p { grid-column: 2; margin: 0; color: var(--text-3); font-size: 10px; line-height: 1.4; }
+.experiment-next-action > span:last-child {
+  min-width: 150px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-3);
+  font: 8px/1.2 var(--mono);
+  letter-spacing: 0.05em;
+  text-align: center;
+  text-transform: uppercase;
+}
+.experiment-next-action > span:last-child.ready {
+  border-color: color-mix(in srgb, var(--mb-mint) 44%, var(--border));
+  color: var(--mb-mint);
+}
+.experiment-notice {
+  position: absolute;
+  right: 0;
+  bottom: 88px;
+  max-width: 560px;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, var(--mb-mint) 38%, var(--border));
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text-2);
+  font: 9px/1.4 var(--mono);
+  overflow-wrap: anywhere;
+}
+.experiment-notice.error { border-color: color-mix(in srgb, var(--error) 45%, var(--border)); color: var(--error); }
+
 @media (max-width: 900px) {
-  .content:has(.supervision-review) { overflow-y: auto; }
+  .content:has(.supervision-review),
+  .content:has(.experiment-compare) { overflow-y: auto; }
   .supervision-review { height: auto; min-height: 100%; }
   .supervision-review-topbar { grid-template-columns: 1fr auto; }
   .supervision-review-progress { display: none; }
@@ -3317,4 +3582,10 @@ select,
   .supervision-review-card { min-height: 220px; }
   .supervision-review-labeler { grid-template-columns: 1fr; }
   .supervision-review-alternatives { grid-template-columns: 1fr 1fr; }
+  .experiment-compare { height: auto; min-height: 100%; }
+  .experiment-compare-topbar { grid-template-columns: 1fr auto; }
+  .experiment-loop { display: none; }
+  .experiment-compare-body { grid-template-columns: 1fr; }
+  .experiment-run-card,
+  .experiment-result-card { min-height: 440px; }
 }

--- a/apps/homescreen/app/lib/experiment-comparison.d.mts
+++ b/apps/homescreen/app/lib/experiment-comparison.d.mts
@@ -1,0 +1,46 @@
+export type ComparisonProjectionCandidate = {
+  candidate_id: string;
+  label: string;
+  run_id: string;
+  rows: number;
+  executed: number;
+  ok_rows: number;
+  error_rows: number;
+  skipped_rows: number;
+  terminal_rows: number;
+  score_coverage: number;
+  capture_coverage: number;
+  avg_score: number | null;
+  avg_latency_ms: number | null;
+  avg_tokens: number | null;
+  cost_usd: number | null;
+  models: string[];
+  task_mode_keys: string[];
+  runtime_backends: string[];
+};
+
+export type MatchedComparisonProjection = {
+  parent_run_id: string;
+  newest_id: number;
+  candidates: ComparisonProjectionCandidate[];
+  matched_slice: boolean;
+  harness_sha256: string | null;
+  split_sha256: string | null;
+  promotion_ready: boolean;
+  blockers: string[];
+  winner_id: string | null;
+};
+
+export function identifyCandidateRun(
+  runId: string,
+  candidates: Array<{ id: string }>,
+): { candidate_id: string; parent_run_id: string } | null;
+
+export function listMatchedComparisons(
+  rows: Array<Record<string, unknown>>,
+  candidates: Array<{ id: string; label: string }>,
+): MatchedComparisonProjection[];
+
+export function comparisonNextAction(
+  comparison: MatchedComparisonProjection | null,
+): { title: string; body: string };

--- a/apps/homescreen/app/lib/experiment-comparison.mjs
+++ b/apps/homescreen/app/lib/experiment-comparison.mjs
@@ -1,0 +1,171 @@
+/**
+ * Pure projection from the existing Fusion benchmark ledger into the compact
+ * Experiments comparison. Keeping this outside React makes the evidence rules
+ * independently testable and prevents the UI from inventing promotion claims.
+ */
+
+const TERMINAL = new Set(["ok", "error", "skipped", "tool_limit", "timeout", "cancelled"]);
+
+/** @param {string} runId @param {Array<{id: string}>} candidates */
+export function identifyCandidateRun(runId, candidates) {
+  const match = [...candidates]
+    .sort((left, right) => right.id.length - left.id.length)
+    .find((candidate) => runId.endsWith(`-${candidate.id}`));
+  if (!match) return null;
+  return {
+    candidate_id: match.id,
+    parent_run_id: runId.slice(0, -(match.id.length + 1)),
+  };
+}
+
+/** @param {number[]} values */
+function average(values) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+}
+
+/** @param {Array<string | null | undefined>} values */
+function exactSharedValue(values) {
+  if (!values.length || values.some((value) => !value)) return null;
+  const unique = new Set(values);
+  return unique.size === 1 ? values[0] : null;
+}
+
+/** @param {Array<Record<string, any>>} rows @param {{id: string, label: string}} candidate */
+function summarizeCandidate(rows, candidate) {
+  const executed = rows.filter((row) => row.status !== "skipped");
+  const scored = executed.filter((row) => typeof row.score === "number");
+  const latency = executed.flatMap((row) => typeof row.elapsed_ms === "number" ? [row.elapsed_ms] : []);
+  const tokens = executed.flatMap((row) =>
+    typeof row.prompt_tokens === "number" && typeof row.completion_tokens === "number"
+      ? [row.prompt_tokens + row.completion_tokens]
+      : [],
+  );
+  const knownCosts = executed.flatMap((row) => typeof row.cost_usd === "number" ? [row.cost_usd] : []);
+  return {
+    candidate_id: candidate.id,
+    label: candidate.label,
+    run_id: rows[0]?.run_id ?? "",
+    rows: rows.length,
+    executed: executed.length,
+    ok_rows: rows.filter((row) => row.status === "ok").length,
+    error_rows: rows.filter((row) => row.status !== "ok" && row.status !== "skipped").length,
+    skipped_rows: rows.filter((row) => row.status === "skipped").length,
+    terminal_rows: rows.filter((row) => TERMINAL.has(row.status)).length,
+    score_coverage: executed.length ? scored.length / executed.length : 0,
+    capture_coverage: executed.length
+      ? executed.filter((row) => typeof row.capture_run_id === "string" && row.capture_run_id.length > 0).length / executed.length
+      : 0,
+    avg_score: average(scored.map((row) => row.score)),
+    avg_latency_ms: average(latency),
+    avg_tokens: average(tokens),
+    cost_usd: knownCosts.length === executed.length ? knownCosts.reduce((sum, value) => sum + value, 0) : null,
+    models: [...new Set(executed.map((row) => row.model).filter(Boolean))].sort(),
+    task_mode_keys: [...new Set(rows.map((row) => `${row.task_id}:${row.mode}`))].sort(),
+    runtime_backends: [...new Set(executed.map((row) => row.runtime_backend).filter(Boolean))].sort(),
+  };
+}
+
+/** @param {Array<Record<string, any>>} rows @param {Array<{id: string, label: string}>} candidates */
+export function listMatchedComparisons(rows, candidates) {
+  const byParent = new Map();
+  for (const row of rows) {
+    const identity = identifyCandidateRun(row.run_id, candidates);
+    if (!identity) continue;
+    const group = byParent.get(identity.parent_run_id) ?? { newest_id: -1, by_candidate: new Map() };
+    group.newest_id = Math.max(group.newest_id, Number(row.id) || 0);
+    group.by_candidate.set(
+      identity.candidate_id,
+      [...(group.by_candidate.get(identity.candidate_id) ?? []), row],
+    );
+    byParent.set(identity.parent_run_id, group);
+  }
+
+  return [...byParent.entries()]
+    .filter(([, group]) => group.by_candidate.size >= 2)
+    .map(([parentRunId, group]) => {
+      const summaries = candidates
+        .filter((candidate) => group.by_candidate.has(candidate.id))
+        .map((candidate) => summarizeCandidate(group.by_candidate.get(candidate.id), candidate));
+      const firstKeys = summaries[0]?.task_mode_keys ?? [];
+      const matchedSlice = summaries.length >= 2
+        && firstKeys.length > 0
+        && summaries.every((candidate) => JSON.stringify(candidate.task_mode_keys) === JSON.stringify(firstKeys));
+      const allRows = [...group.by_candidate.values()].flat();
+      const harnessSha256 = exactSharedValue(allRows.map((row) => row.harness_sha256));
+      const splitSha256 = exactSharedValue(allRows.map((row) => row.split_sha256));
+      const blockers = [];
+      if (!matchedSlice) blockers.push("Candidates did not run the identical task and mode slice.");
+      if (!harnessSha256 || !splitSha256) blockers.push("Immutable suite hashes are missing or do not match.");
+      if (summaries.some((candidate) => candidate.terminal_rows !== candidate.rows)) {
+        blockers.push("At least one row is not terminal.");
+      }
+      if (summaries.some((candidate) => candidate.error_rows > 0 || candidate.skipped_rows > 0)) {
+        blockers.push("Errors or skipped rows must be resolved before promotion.");
+      }
+      if (summaries.some((candidate) => candidate.score_coverage !== 1)) {
+        blockers.push("Every executed row needs a score.");
+      }
+      if (summaries.some((candidate) => candidate.capture_coverage !== 1)) {
+        blockers.push("Every executed row needs a canonical capture_run_id.");
+      }
+
+      const rankable = matchedSlice
+        && summaries.every((candidate) => candidate.avg_score !== null)
+        && summaries.every((candidate) => candidate.error_rows === 0 && candidate.skipped_rows === 0);
+      const ranked = rankable
+        ? [...summaries].sort((left, right) =>
+            (right.avg_score - left.avg_score)
+            || ((left.avg_latency_ms ?? Infinity) - (right.avg_latency_ms ?? Infinity))
+            || ((left.avg_tokens ?? Infinity) - (right.avg_tokens ?? Infinity)),
+          )
+        : [];
+      return {
+        parent_run_id: parentRunId,
+        newest_id: group.newest_id,
+        candidates: summaries,
+        matched_slice: matchedSlice,
+        harness_sha256: harnessSha256,
+        split_sha256: splitSha256,
+        promotion_ready: blockers.length === 0,
+        blockers,
+        winner_id: ranked[0]?.candidate_id ?? null,
+      };
+    })
+    .sort((left, right) => right.newest_id - left.newest_id);
+}
+
+/** @param {ReturnType<typeof listMatchedComparisons>[number] | null} comparison */
+export function comparisonNextAction(comparison) {
+  if (!comparison) {
+    return {
+      title: "Run one matched local comparison",
+      body: "The app will preflight both warm models, then run the same frozen questions through each route.",
+    };
+  }
+  if (!comparison.matched_slice) {
+    return { title: "Rerun the same frozen slice", body: comparison.blockers[0] };
+  }
+  const operationalBlocker = comparison.blockers.find((blocker) =>
+    blocker.startsWith("Errors") || blocker.startsWith("At least one") || blocker.startsWith("Every executed"),
+  );
+  if (operationalBlocker) {
+    return { title: "Fix the incomplete evidence, then rerun", body: operationalBlocker };
+  }
+  if (!comparison.promotion_ready) {
+    return {
+      title: "Treat this result as directional",
+      body: "The slice matches, but promotion waits for immutable matching suite hashes.",
+    };
+  }
+  const winner = comparison.candidates.find((candidate) => candidate.candidate_id === comparison.winner_id);
+  if (winner?.candidate_id === "local-fast") {
+    return {
+      title: "Challenge the fast model on a harder slice",
+      body: "It won this promotion-grade comparison; increase difficulty before changing the default route.",
+    };
+  }
+  return {
+    title: "Improve the fast model on its misses",
+    body: "Keep the main model as fallback and use the failed fast-model rows for prompt repair or targeted training data.",
+  };
+}

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -53,7 +53,7 @@
     {
       "id": "remote-review-tiebreaker",
       "status": "partial",
-      "evidence": "The public CLI and desktop now provide destination-bound opt-in GLM 5.2 review over bounded pre-intervention evidence, exact served-model validation, private content-addressed analysis caching, offline-safe fallback, and explicit human judge-quality feedback. A frozen fail-closed promotion suite is public and dry-run verified; a fresh live 10+ case provider run is still required before recommending the advisory by default."
+      "evidence": "The public CLI and desktop provide destination-bound opt-in GLM 5.2 review over bounded pre-intervention evidence, exact served-model validation, private content-addressed analysis caching, offline-safe fallback, and explicit human judge-quality feedback. The 2026-07-13 frozen 10-case live qualification completed with 100% contract and route validity, but only 70% action accuracy and two high-confidence wrong actions, so the recorded recommendation is do_not_enable and the advisory remains off by default pending prompt-policy repair and requalification."
     },
     {
       "id": "unified-experiment-hub",

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -58,7 +58,7 @@
     {
       "id": "unified-experiment-hub",
       "status": "partial",
-      "evidence": "GEPA, RLM, custom eval, and benchmark capabilities exist, but the reviewed benchmark, ledger, and comparison experience is not one coherent surface."
+      "evidence": "Experiments now presents one compact Review -> Compare -> Improve loop. Compare preflights two distinct warm local models, runs an identical direct frozen slice without cloud traffic, projects the existing benchmark ledger into quality, latency, token, capture, and failure evidence, and refuses promotion without matching immutable hashes and complete capture IDs. The improvement handoff and canonical immutable hash writer still need to move behind the shared CLI/runtime before this feature is shipped."
     },
     {
       "id": "legacy-desktop-retirement-guard",

--- a/docs/dev-run/supervision-tiebreaker-qualification.md
+++ b/docs/dev-run/supervision-tiebreaker-qualification.md
@@ -1,0 +1,42 @@
+# Supervision tiebreaker qualification
+
+Status: `do_not_enable` after the first promotion-sized live run on 2026-07-13.
+
+The GLM 5.2 advisory is operationally sound but not yet trustworthy enough to
+reduce human labeling. Keep it destination-bound, opt-in, and advisory-only;
+the human label remains final.
+
+## Frozen evidence
+
+- suite SHA-256: `faf8f7d21fa8c9fcbceb17e6cf184eb6a7f18c5cfc1307092628d5155b1e0c6d`
+- prompt SHA-256: `ba32dcc1a9900c363122c231c5970245ce97c7b99826e2b0bbb8c16a21e321de`
+- requested model: `glm-5.2`
+- exact served model: `zai-org/glm-5.2`
+- cases: 10 across the frozen validation and test splits
+- conservative command fuse: `$0.20`; actual provider cost was not returned
+- immutable local artifact root: `~/.understudy/evals/supervision-tiebreaker/`
+
+## Result
+
+| Gate | Result | Promotion bar |
+| --- | ---: | ---: |
+| Contract validity | 100% | 100% |
+| Route validity | 100% | 100% |
+| Action accuracy | 70% | at least 85% |
+| Assessment accuracy | 90% | at least 85% |
+| Reason-quality accuracy | 90% | at least 75% |
+| High-confidence wrong actions | 2 | 0 |
+
+Three action decisions missed. GLM chose `continue` instead of `stop` for a
+correctly formatted completed answer, `nudge` instead of `continue` for an
+on-track partial, and `interrupt` instead of `unclear` when the evidence was
+insufficient. The first two misses were high-confidence.
+
+## Next rung
+
+This failure shape is prompt-policy calibration before it is model training:
+the response contract, route, assessment, and reason classification already
+work. Use the three frozen misses as GEPA-style prompt feedback, preserve the
+test split, rerun the same fail-closed suite, and do not enable the advisory by
+default until every promotion gate passes. Fine-tuning becomes justified only
+if prompt optimization plateaus on repeated held-out runs.

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -135,15 +135,18 @@ test("desktop model downloads are app-owned, pausable, and resumable", async () 
   assert.doesNotMatch(statusPane, /invoke\([^\n]*"download_snapshot_model"/);
 });
 
-test("Experiments starts with canonical one-frame intervention review", async () => {
-  const [review, reviewRust, rlmPane, css] = await Promise.all([
+test("Experiments is one guided review, compare, improve loop", async () => {
+  const [review, compare, comparisonRules, reviewRust, rlmPane, css] = await Promise.all([
     readFile(reviewViewPath, "utf8"),
+    readFile(new URL("../apps/homescreen/app/components/ExperimentCompareView.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../apps/homescreen/app/lib/experiment-comparison.mjs", import.meta.url), "utf8"),
     readFile(reviewRustPath, "utf8"),
     readFile(rlmPanePath, "utf8"),
     readFile(cssPath, "utf8"),
   ]);
 
-  assert.match(rlmPane, /return <SupervisionReviewView \/>/);
+  assert.match(rlmPane, /<SupervisionReviewView onCompare=/);
+  assert.match(rlmPane, /<ExperimentCompareView onReview=/);
   assert.match(review, /"supervision_review_queue"/);
   assert.match(review, /"record_supervisor_feedback"/);
   assert.match(review, /1 · Small model/);
@@ -153,7 +156,15 @@ test("Experiments starts with canonical one-frame intervention review", async ()
   assert.match(reviewRust, /RuntimeEvent::StudentInterruption/);
   assert.match(reviewRust, /RuntimeEvent::TeacherContinuation/);
   assert.match(reviewRust, /load_recent_persisted_traces/);
+  assert.match(compare, /LOCAL_CANDIDATES = \["local-main", "local-fast"\]/);
+  assert.match(compare, /DIRECT_MODE = \["main-only"\]/);
+  assert.match(compare, /compare the same model twice/);
+  assert.match(compare, /run_fusion_benchmark_matrix_live/);
+  assert.doesNotMatch(compare, /gateway-supervised/);
+  assert.match(comparisonRules, /Immutable suite hashes are missing or do not match/);
+  assert.match(comparisonRules, /canonical capture_run_id/);
   assert.match(css, /\.content:has\(\.supervision-review\)\s*\{[\s\S]*?overflow: hidden/);
+  assert.match(css, /\.content:has\(\.experiment-compare\)\s*\{[\s\S]*?overflow: hidden/);
   assert.match(css, /grid-template-rows: auto minmax\(0, 1fr\) auto/);
 });
 

--- a/tests/experiment-hub.test.mjs
+++ b/tests/experiment-hub.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  comparisonNextAction,
+  identifyCandidateRun,
+  listMatchedComparisons,
+} from "../apps/homescreen/app/lib/experiment-comparison.mjs";
+
+const candidates = [
+  { id: "local-main", label: "Local main" },
+  { id: "local-fast", label: "Local fast" },
+];
+
+function row(id, candidate, task, mode, score, overrides = {}) {
+  return {
+    id,
+    run_id: `compare-1-${candidate}`,
+    capture_run_id: `capture-${id}`,
+    runtime_backend: "pi",
+    task_id: task,
+    mode,
+    model: candidate,
+    elapsed_ms: candidate === "local-fast" ? 100 : 300,
+    prompt_tokens: 10,
+    completion_tokens: candidate === "local-fast" ? 8 : 12,
+    score,
+    status: "ok",
+    cost_usd: null,
+    harness_sha256: "harness-a",
+    split_sha256: "split-a",
+    ...overrides,
+  };
+}
+
+test("candidate identity preserves the exact parent run id", () => {
+  assert.deepEqual(
+    identifyCandidateRun("compare-1-local-fast", candidates),
+    { candidate_id: "local-fast", parent_run_id: "compare-1" },
+  );
+  assert.equal(identifyCandidateRun("unrelated-run", candidates), null);
+});
+
+test("a fully captured same-hash slice is promotion-ready and rankable", () => {
+  const comparison = listMatchedComparisons([
+    row(1, "local-main", "task-a", "main-only", 0.8),
+    row(2, "local-main", "task-b", "main-only", 0.8),
+    row(3, "local-fast", "task-a", "main-only", 1),
+    row(4, "local-fast", "task-b", "main-only", 1),
+  ], candidates)[0];
+  assert.equal(comparison.matched_slice, true);
+  assert.equal(comparison.promotion_ready, true);
+  assert.equal(comparison.winner_id, "local-fast");
+  assert.equal(comparison.candidates[1].capture_coverage, 1);
+  assert.match(comparisonNextAction(comparison).title, /harder slice/i);
+});
+
+test("matching visible rows stay directional when immutable hashes are absent", () => {
+  const comparison = listMatchedComparisons([
+    row(1, "local-main", "task-a", "main-only", 1, { harness_sha256: null, split_sha256: null }),
+    row(2, "local-fast", "task-a", "main-only", 1, { harness_sha256: null, split_sha256: null }),
+  ], candidates)[0];
+  assert.equal(comparison.matched_slice, true);
+  assert.equal(comparison.promotion_ready, false);
+  assert.match(comparison.blockers.join(" "), /suite hashes/i);
+  assert.match(comparisonNextAction(comparison).title, /directional/i);
+});
+
+test("skips, missing capture ids, and mismatched task slices block promotion", () => {
+  const comparison = listMatchedComparisons([
+    row(1, "local-main", "task-a", "main-only", 1),
+    row(2, "local-main", "task-b", "main-only", 1),
+    row(3, "local-fast", "task-a", "main-only", null, {
+      capture_run_id: null,
+      status: "skipped",
+    }),
+  ], candidates)[0];
+  assert.equal(comparison.matched_slice, false);
+  assert.equal(comparison.promotion_ready, false);
+  assert.equal(comparison.winner_id, null);
+  assert.match(comparison.blockers.join(" "), /identical task and mode slice/i);
+  assert.match(comparison.blockers.join(" "), /skipped rows/i);
+});
+
+test("the newest matched parent run wins over older ledger rows", () => {
+  const rows = [
+    row(1, "local-main", "task-a", "main-only", 1, { run_id: "older-local-main" }),
+    row(2, "local-fast", "task-a", "main-only", 1, { run_id: "older-local-fast" }),
+    row(7, "local-main", "task-a", "main-only", 1, { run_id: "newer-local-main" }),
+    row(8, "local-fast", "task-a", "main-only", 1, { run_id: "newer-local-fast" }),
+  ];
+  const comparisons = listMatchedComparisons(rows, candidates);
+  assert.equal(comparisons[0].parent_run_id, "newer");
+  assert.equal(comparisons[1].parent_run_id, "older");
+});


### PR DESCRIPTION
## What changed
- make Experiments one guided Review -> Compare -> Improve loop
- add a one-click, local-only matched main-vs-fast model comparison
- project the benchmark ledger into quality, latency, token, capture, and failure evidence
- fail promotion closed without identical slices, immutable hashes, terminal rows, and complete capture IDs
- preserve the existing intervention review as the default first step

## Product boundary
- no provider calls or uploads
- no new Rust harness or datastore
- improvement handoff and canonical hash writing remain explicitly partial

## Verification
- `npm run check` (252 tests, 33 skills, package smoke)
- `node --test tests/experiment-hub.test.mjs tests/desktop-ui-lineage.test.mjs`
- `npm run build` in `apps/homescreen`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->