### PR TITLE
Promote strict Desktop experiment evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,10 @@ understudy desktop supervisor-feedback --session my-task --run-id my-task-1 \
 understudy desktop supervisor-feedback --session my-task --run-id my-task-1 \
   --marker my-task-1:verdict:0 --stage stop --correct-action interrupt
 understudy desktop supervision export --reviewed-only --json
+understudy desktop tool-proof run --suite core \
+  --candidate local-main:7 --candidate local-fast:6 --repetitions 1
+understudy desktop tool-proof list --json
+understudy desktop tool-proof prepare --proof <proof-id> --json
 ```
 
 The CLI reads the private mode-0600 `~/.understudy/desktop-api.json`, verifies
@@ -503,6 +507,11 @@ missing or estimated usage is counted as excluded rather than treated as zero.
 The export also reports incomplete interventions and any journal or intervention
 rows omitted by its bounded recent-evidence window, so aggregates are never
 presented as all-time metrics when the safety cap was reached.
+The strict tool proof is also local-only: Pi runs each selected model serially,
+the CLI restores the previous residency set in a `finally` path, and promotion
+requires the frozen 30-task suite repeated three times with complete owner-only
+result and canonical-event evidence. Failed exact calls can be projected into
+an immutable GEPA-first improvement packet without uploading local traces.
 
 ## The skill tree
 

--- a/apps/homescreen/app/components/ExperimentCompareView.tsx
+++ b/apps/homescreen/app/components/ExperimentCompareView.tsx
@@ -1,110 +1,73 @@
 "use client";
 
-import { Channel, invoke } from "@tauri-apps/api/core";
+import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useMemo, useState } from "react";
 import {
-  comparisonNextAction,
-  listMatchedComparisons,
+  projectToolProof,
+  toolProofNextAction,
+  type ToolProofProjection,
 } from "../lib/experiment-comparison.mjs";
 
-type BenchmarkCandidate = {
-  id: string;
-  label: string;
-  route: string;
-  model_hint: string;
-  description: string;
-};
-
-type BenchmarkSuite = {
-  id: string;
-  label: string;
-  description: string;
-  task_ids: string[];
-};
-
-type BenchmarkMatrix = {
-  schema_version: string;
-  suites: BenchmarkSuite[];
-  candidates: BenchmarkCandidate[];
-};
-
 type PlanRow = {
-  task_id: string;
-  mode: string;
   model: string;
   ready: boolean;
   reason: string;
 };
 
 type MatrixRun = {
-  run_id: string;
-  suite: string;
-  dry_run: boolean;
-  rows: number;
   candidates: Array<{ candidate: string; run: { rows: PlanRow[] } }>;
 };
 
-type BenchmarkRow = {
-  id: number;
-  run_id: string;
-  capture_run_id?: string | null;
-  runtime_backend: string;
-  task_id: string;
-  mode: string;
-  model: string;
-  elapsed_ms?: number | null;
-  prompt_tokens?: number | null;
-  completion_tokens?: number | null;
-  score?: number | null;
-  status: string;
-  cost_usd?: number | null;
-  harness_sha256?: string | null;
-  split_sha256?: string | null;
+type ResidencySnapshot = {
+  slots: Array<{ id: number; model_id?: string | null; state: string }>;
 };
 
-type ComparisonCandidate = {
-  candidate_id: string;
-  label: string;
-  run_id: string;
-  rows: number;
-  executed: number;
-  ok_rows: number;
-  error_rows: number;
-  skipped_rows: number;
-  terminal_rows: number;
-  score_coverage: number;
-  capture_coverage: number;
-  avg_score: number | null;
-  avg_latency_ms: number | null;
-  avg_tokens: number | null;
-  cost_usd: number | null;
-  models: string[];
-  task_mode_keys: string[];
-  runtime_backends: string[];
+type ToolProofCandidate = {
+  slot_id: number | null;
+  model_id: string | null;
+  strict_passes: number;
+  attempts: number;
+  strict_accuracy: number;
+  terminal_errors: number;
+  mean_latency_ms: number;
+  total_tokens: number;
+  failures: Array<Record<string, unknown>>;
 };
 
-type MatchedComparison = {
-  parent_run_id: string;
-  newest_id: number;
-  candidates: ComparisonCandidate[];
-  matched_slice: boolean;
-  harness_sha256: string | null;
-  split_sha256: string | null;
-  promotion_ready: boolean;
-  blockers: string[];
-  winner_id: string | null;
+type ToolProof = {
+  output_dir: string;
+  summary: {
+    proof_id: string;
+    suite: "core" | "hard";
+    source_task_file: string;
+    suite_sha256: string;
+    tool_schema_sha256: string | null;
+    task_count: number;
+    repetitions: number;
+    run_count: number;
+    completed_at: string;
+    candidates: Record<string, ToolProofCandidate>;
+  };
+  evidence: {
+    complete: boolean;
+    private_files: boolean;
+    suite_hash_matches: boolean;
+    result_rows: number;
+    event_files: number;
+    expected_rows: number;
+  };
 };
 
-type BenchmarkEvent =
-  | { type: "RunStarted"; run_id: string; rows: number }
-  | { type: "RowStarted"; task_id: string; candidate: string }
-  | { type: "RowFinished"; task_id: string; candidate: string; status: string }
-  | { type: "RunFinished"; run_id: string; rows: number }
-  | { type: "Error"; message: string };
+type ToolProofList = { proofs: ToolProof[] };
 
-const LOCAL_CANDIDATES = ["local-main", "local-fast"];
-const DIRECT_MODE = ["main-only"];
-const VISIBLE_SUITES = new Set(["local-fusion-smoke", "local-comparison"]);
+const LOCAL_CANDIDATES = ["local-main", "local-fast"] as const;
+const PREFLIGHT_REQUEST = {
+  suite: "local-fusion-smoke",
+  candidates: LOCAL_CANDIDATES,
+  modes: ["main-only"],
+  dry_run: true,
+  record_skips: false,
+};
 
 function fmtPercent(value: number | null) {
   return value == null ? "—" : `${Math.round(value * 100)}%`;
@@ -114,102 +77,90 @@ function fmtNumber(value: number | null, suffix = "") {
   return value == null ? "—" : `${Math.round(value).toLocaleString()}${suffix}`;
 }
 
-function shortModel(value: string | undefined) {
+function shortModel(value: string | null | undefined) {
   if (!value) return "not recorded";
   const tail = value.split("/").at(-1) ?? value;
   return tail.length > 30 ? `${tail.slice(0, 29)}…` : tail;
 }
 
-function comparisonStatus(comparison: MatchedComparison | null) {
-  if (!comparison) return "no evidence";
-  if (comparison.promotion_ready) return "promotion-grade";
-  if (comparison.matched_slice) return "directional";
-  return "not comparable";
+function proofStatus(proof: ToolProofProjection | null) {
+  if (!proof) return "no evidence";
+  if (proof.promotion_ready) return "promotion-grade";
+  if (proof.evidence_complete) return "directional";
+  return "evidence blocked";
+}
+
+function isMatchedProof(proof: ToolProof) {
+  return LOCAL_CANDIDATES.every((candidate) => proof.summary.candidates[candidate]);
 }
 
 export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
-  const [matrix, setMatrix] = useState<BenchmarkMatrix | null>(null);
-  const [rows, setRows] = useState<BenchmarkRow[]>([]);
-  const [suite, setSuite] = useState("local-fusion-smoke");
-  const [phase, setPhase] = useState<"idle" | "preflight" | "running" | "exporting">("idle");
+  const [proofs, setProofs] = useState<ToolProof[]>([]);
+  const [suite, setSuite] = useState<"core" | "hard">("core");
+  const [phase, setPhase] = useState<"idle" | "preflight" | "running" | "preparing">("idle");
   const [error, setError] = useState<string | null>(null);
-  const [progress, setProgress] = useState({ done: 0, total: 0, label: "" });
-  const [exportPath, setExportPath] = useState<string | null>(null);
+  const [noticePath, setNoticePath] = useState<string | null>(null);
 
-  const localCandidateRows = useMemo(
-    () => matrix?.candidates.filter((candidate) => LOCAL_CANDIDATES.includes(candidate.id)) ?? [],
-    [matrix],
-  );
-  const comparisons = useMemo(
-    () => listMatchedComparisons(rows, localCandidateRows) as MatchedComparison[],
-    [rows, localCandidateRows],
-  );
-  const latest = comparisons[0] ?? null;
-  const next = comparisonNextAction(latest) as { title: string; body: string };
-  const visibleSuites = matrix?.suites.filter((item) => VISIBLE_SUITES.has(item.id)) ?? [];
+  const matchedProofs = useMemo(() => proofs.filter(isMatchedProof), [proofs]);
+  const latest = matchedProofs[0] ?? null;
+  const projected = projectToolProof(latest) as ToolProofProjection | null;
+  const next = toolProofNextAction(projected) as { title: string; body: string };
+  const failureCount = projected?.candidates.reduce(
+    (sum, candidate) => sum + Math.max(0, candidate.attempts - candidate.strict_passes),
+    0,
+  ) ?? 0;
 
   const refresh = async () => {
-    const [nextMatrix, nextRows] = await Promise.all([
-      invoke<BenchmarkMatrix>("fusion_benchmark_matrix"),
-      invoke<BenchmarkRow[]>("fusion_benchmark_results", { limit: 500 }),
-    ]);
-    setMatrix(nextMatrix);
-    setRows(nextRows);
+    const list = await invoke<ToolProofList>("desktop_tool_proof_list");
+    setProofs(list.proofs);
   };
 
   useEffect(() => {
     void refresh().catch((cause) => setError(String(cause)));
   }, []);
 
+  const resolveCandidateSlots = async () => {
+    const [plan, residency] = await Promise.all([
+      invoke<MatrixRun>("run_fusion_benchmark_matrix", { request: PREFLIGHT_REQUEST }),
+      invoke<ResidencySnapshot>("get_residency"),
+    ]);
+    const planRows = plan.candidates.flatMap((candidate) => candidate.run.rows);
+    const blockers = [...new Set(planRows.filter((row) => !row.ready).map((row) => row.reason))];
+    if (blockers.length) {
+      throw new Error(`Load distinct main and fast local models first (${blockers.join(", ")}).`);
+    }
+    const models = new Map(plan.candidates.map((candidate) => [
+      candidate.candidate,
+      [...new Set(candidate.run.rows.map((row) => row.model))][0],
+    ]));
+    const mainModel = models.get("local-main");
+    const fastModel = models.get("local-fast");
+    if (!mainModel || !fastModel || mainModel === fastModel) {
+      throw new Error("Load a distinct fast model; this plan would compare the same model twice.");
+    }
+    return LOCAL_CANDIDATES.map((label) => {
+      const model = models.get(label);
+      const slot = residency.slots.find((candidate) =>
+        candidate.state === "running" && candidate.model_id === model,
+      );
+      if (!slot) throw new Error(`${label} is not attached to a warm Desktop slot.`);
+      return { label, slotId: slot.id };
+    });
+  };
+
   const runComparison = async () => {
     if (phase !== "idle") return;
     setPhase("preflight");
     setError(null);
-    setExportPath(null);
-    setProgress({ done: 0, total: 0, label: "Checking both local models…" });
-    const request = {
-      suite,
-      candidates: LOCAL_CANDIDATES,
-      modes: DIRECT_MODE,
-      dry_run: true,
-      record_skips: false,
-    };
+    setNoticePath(null);
     try {
-      const plan = await invoke<MatrixRun>("run_fusion_benchmark_matrix", { request });
-      const planRows = plan.candidates.flatMap((candidate) => candidate.run.rows);
-      const blockers = [...new Set(planRows.filter((row) => !row.ready).map((row) => row.reason))];
-      if (blockers.length) {
-        throw new Error(`Load distinct main and fast local models first (${blockers.join(", ")}).`);
-      }
-      const models = plan.candidates.map((candidate) => ({
-        candidate: candidate.candidate,
-        models: [...new Set(candidate.run.rows.map((row) => row.model))],
-      }));
-      const mainModel = models.find((row) => row.candidate === "local-main")?.models[0];
-      const fastModel = models.find((row) => row.candidate === "local-fast")?.models[0];
-      if (!mainModel || !fastModel || mainModel === fastModel) {
-        throw new Error("Load a distinct fast model; this plan would compare the same model twice.");
-      }
-
+      const candidates = await resolveCandidateSlots();
       setPhase("running");
-      const channel = new Channel<BenchmarkEvent>();
-      channel.onmessage = (event) => {
-        if (event.type === "RunStarted") {
-          setProgress({ done: 0, total: event.rows, label: "Running the same frozen slice…" });
-        } else if (event.type === "RowStarted") {
-          setProgress((current) => ({ ...current, label: `${event.candidate} · ${event.task_id}` }));
-        } else if (event.type === "RowFinished") {
-          setProgress((current) => ({ ...current, done: Math.min(current.total, current.done + 1) }));
-        } else if (event.type === "Error") {
-          setError(event.message);
-        }
-      };
-      await invoke<MatrixRun>("run_fusion_benchmark_matrix_live", {
-        request: { ...request, dry_run: false, record_skips: true },
-        onEvent: channel,
+      const result = await invoke<ToolProof>("desktop_tool_proof_run", {
+        request: { suite, candidates },
       });
+      setNoticePath(result.output_dir);
       await refresh();
-      setProgress((current) => ({ ...current, done: current.total, label: "Comparison captured." }));
     } catch (cause) {
       setError(String(cause));
     } finally {
@@ -217,15 +168,16 @@ export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
     }
   };
 
-  const exportEvidence = async () => {
-    if (phase !== "idle") return;
-    setPhase("exporting");
+  const prepareImprovement = async () => {
+    if (phase !== "idle" || !projected) return;
+    setPhase("preparing");
     setError(null);
+    setNoticePath(null);
     try {
-      const result = await invoke<{ path: string }>("export_fusion_benchmark_comparison", {
-        request: { limit: 500, output_path: null },
+      const result = await invoke<{ path: string }>("desktop_tool_proof_prepare", {
+        proofId: projected.proof_id,
       });
-      setExportPath(result.path);
+      setNoticePath(result.path);
     } catch (cause) {
       setError(String(cause));
     } finally {
@@ -233,7 +185,7 @@ export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
     }
   };
 
-  const progressPercent = progress.total ? Math.round((progress.done / progress.total) * 100) : 0;
+  const plannedRows = suite === "hard" ? 180 : 34;
 
   return (
     <main className="experiment-compare">
@@ -249,8 +201,12 @@ export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
         </div>
         <nav>
           <button type="button" onClick={onReview}>Review decisions</button>
-          <button type="button" disabled={!latest || phase !== "idle"} onClick={() => void exportEvidence()}>
-            {phase === "exporting" ? "Exporting…" : "Export evidence"}
+          <button
+            type="button"
+            disabled={!projected?.evidence_complete || failureCount === 0 || phase !== "idle"}
+            onClick={() => void prepareImprovement()}
+          >
+            {phase === "preparing" ? "Preparing…" : "Prepare improvement"}
           </button>
         </nav>
       </header>
@@ -259,36 +215,38 @@ export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
         <article className="experiment-run-card">
           <div className="experiment-kicker">One fair question</div>
           <h2>Can the fast local model replace the main model?</h2>
-          <p>Same frozen tasks, direct model calls, no cloud traffic, and one shared run identity.</p>
+          <p>Exact Pi tool traces, frozen tasks, no cloud traffic, and private immutable evidence.</p>
           <label>
-            <span>Difficulty</span>
-            <select value={suite} onChange={(event) => setSuite(event.target.value)} disabled={phase !== "idle"}>
-              {visibleSuites.map((item) => (
-                <option value={item.id} key={item.id}>{item.label}</option>
-              ))}
+            <span>Evidence level</span>
+            <select value={suite} onChange={(event) => setSuite(event.target.value as "core" | "hard")} disabled={phase !== "idle"}>
+              <option value="core">Quick · 17 tasks × 1</option>
+              <option value="hard">Promotion · 30 tasks × 3</option>
             </select>
           </label>
-          <button className="experiment-run-primary" type="button" disabled={phase !== "idle" || !matrix} onClick={() => void runComparison()}>
+          <button className="experiment-run-primary" type="button" disabled={phase !== "idle"} onClick={() => void runComparison()}>
             {phase === "preflight" ? "Checking models…" : phase === "running" ? "Comparing…" : "Compare local models"}
           </button>
-          <small>Preflight fails closed if the models are missing, identical, or not warm.</small>
+          <small>Models run one at a time and residency is restored afterward to protect unified memory.</small>
 
-          {(phase === "running" || progress.total > 0) && (
+          {phase === "running" && (
             <div className="experiment-live-progress">
-              <div><span>{progress.label}</span><em>{progress.done}/{progress.total}</em></div>
-              <i><b style={{ width: `${progressPercent}%` }} /></i>
+              <div><span>Capturing strict canonical traces…</span><em>{plannedRows} rows</em></div>
+              <i><b className="indeterminate" /></i>
             </div>
           )}
 
           <div className="experiment-ledger">
-            <div><strong>Recent matched runs</strong><span>{comparisons.length}</span></div>
-            {comparisons.slice(0, 3).map((comparison) => (
-              <div className="experiment-ledger-row" key={comparison.parent_run_id}>
-                <span>{comparison.parent_run_id}</span>
-                <em>{comparisonStatus(comparison)}</em>
-              </div>
-            ))}
-            {!comparisons.length && <p>No comparison evidence yet.</p>}
+            <div><strong>Recent strict proofs</strong><span>{matchedProofs.length}</span></div>
+            {matchedProofs.slice(0, 3).map((proof) => {
+              const row = projectToolProof(proof) as ToolProofProjection;
+              return (
+                <div className="experiment-ledger-row" key={row.proof_id}>
+                  <span>{row.proof_id}</span>
+                  <em>{proofStatus(row)}</em>
+                </div>
+              );
+            })}
+            {!matchedProofs.length && <p>No matched local proof yet.</p>}
           </div>
         </article>
 
@@ -296,44 +254,44 @@ export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
           <header>
             <div>
               <span>Latest evidence</span>
-              <strong>{latest?.parent_run_id ?? "No matched run yet"}</strong>
+              <strong>{projected?.proof_id ?? "No matched proof yet"}</strong>
             </div>
-            <em className={latest?.promotion_ready ? "ready" : latest?.matched_slice ? "directional" : "blocked"}>
-              {comparisonStatus(latest)}
+            <em className={projected?.promotion_ready ? "ready" : projected?.evidence_complete ? "directional" : "blocked"}>
+              {proofStatus(projected)}
             </em>
           </header>
 
-          {latest ? (
+          {projected && latest ? (
             <>
               <div className="experiment-candidates">
-                {latest.candidates.map((candidate) => (
-                  <section className={candidate.candidate_id === latest.winner_id ? "winner" : ""} key={candidate.candidate_id}>
+                {projected.candidates.map((candidate) => (
+                  <section className={candidate.candidate_id === projected.winner_id ? "winner" : ""} key={candidate.candidate_id}>
                     <header>
-                      <div><span>{candidate.candidate_id === "local-fast" ? "Candidate" : "Baseline"}</span><strong>{candidate.label}</strong></div>
-                      {candidate.candidate_id === latest.winner_id && <em>best on slice</em>}
+                      <div><span>{candidate.candidate_id === "local-fast" ? "Candidate" : "Baseline"}</span><strong>{candidate.candidate_id === "local-fast" ? "Local fast" : "Local main"}</strong></div>
+                      {candidate.candidate_id === projected.winner_id && <em>best strict result</em>}
                     </header>
-                    <code>{shortModel(candidate.models[0])}</code>
+                    <code>{shortModel(candidate.model_id)}</code>
                     <dl>
-                      <div><dt>Quality</dt><dd>{fmtPercent(candidate.avg_score)}</dd></div>
-                      <div><dt>Latency</dt><dd>{fmtNumber(candidate.avg_latency_ms, " ms")}</dd></div>
-                      <div><dt>Tokens</dt><dd>{fmtNumber(candidate.avg_tokens)}</dd></div>
-                      <div><dt>Captured</dt><dd>{fmtPercent(candidate.capture_coverage)}</dd></div>
+                      <div><dt>Strict</dt><dd>{fmtPercent(candidate.strict_accuracy)}</dd></div>
+                      <div><dt>Latency</dt><dd>{fmtNumber(candidate.mean_latency_ms, " ms")}</dd></div>
+                      <div><dt>Tokens / task</dt><dd>{fmtNumber(candidate.attempts ? candidate.total_tokens / candidate.attempts : null)}</dd></div>
+                      <div><dt>Runtime errors</dt><dd>{candidate.terminal_errors}</dd></div>
                     </dl>
-                    <small>{candidate.ok_rows} ok · {candidate.error_rows} errors · {candidate.skipped_rows} skipped</small>
+                    <small>{candidate.strict_passes}/{candidate.attempts} exact · {candidate.attempts - candidate.strict_passes} misses</small>
                   </section>
                 ))}
               </div>
               <div className="experiment-evidence-gate">
-                <div><span>Same task + mode slice</span><strong>{latest.matched_slice ? "yes" : "no"}</strong></div>
-                <div><span>Canonical capture coverage</span><strong>{latest.candidates.every((candidate) => candidate.capture_coverage === 1) ? "100%" : "incomplete"}</strong></div>
-                <div><span>Matching immutable hashes</span><strong>{latest.harness_sha256 && latest.split_sha256 ? "yes" : "missing"}</strong></div>
+                <div><span>Frozen suite hash</span><strong>{latest.evidence.suite_hash_matches ? "matched" : "failed"}</strong></div>
+                <div><span>Canonical event files</span><strong>{latest.evidence.event_files}/{latest.evidence.expected_rows}</strong></div>
+                <div><span>Private evidence set</span><strong>{latest.evidence.complete ? "complete" : "incomplete"}</strong></div>
               </div>
-              {latest.blockers.length > 0 && <p className="experiment-directional-note">{latest.blockers[0]}</p>}
+              {projected.blockers.length > 0 && <p className="experiment-directional-note">{projected.blockers[0]}</p>}
             </>
           ) : (
             <div className="experiment-empty-result">
-              <strong>Start with the local smoke.</strong>
-              <p>Four direct rows answer the first question without uploading data or contacting a cloud model.</p>
+              <strong>Start with the quick proof.</strong>
+              <p>Seventeen strict tool tasks reveal malformed calls, extra calls, bad arguments, failed results, and wrong final output.</p>
             </div>
           )}
         </article>
@@ -341,14 +299,14 @@ export function ExperimentCompareView({ onReview }: { onReview: () => void }) {
 
       <footer className="experiment-next-action">
         <div><span>Next</span><strong>{next.title}</strong><p>{next.body}</p></div>
-        <span className={latest?.promotion_ready ? "ready" : "closed"}>
-          {latest?.promotion_ready ? "ready for improvement handoff" : "promotion gate closed"}
+        <span className={projected?.promotion_ready ? "ready" : "closed"}>
+          {projected?.promotion_ready ? "promotion evidence complete" : "promotion gate closed"}
         </span>
       </footer>
 
-      {(error || exportPath) && (
+      {(error || noticePath) && (
         <div className={`experiment-notice${error ? " error" : ""}`} role={error ? "alert" : "status"}>
-          {error ?? `Evidence exported to ${exportPath}`}
+          {error ?? `Private evidence: ${noticePath}`}
         </div>
       )}
     </main>

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -3440,6 +3440,14 @@ select,
 .experiment-live-progress em { color: var(--mb-cyan); font-style: normal; }
 .experiment-live-progress i { display: block; height: 3px; margin-top: 7px; overflow: hidden; border-radius: 99px; background: var(--border); }
 .experiment-live-progress i b { display: block; height: 100%; background: var(--mb-cyan); transition: width 180ms ease; }
+.experiment-live-progress i b.indeterminate {
+  width: 34%;
+  animation: experiment-progress 1.15s ease-in-out infinite alternate;
+}
+@keyframes experiment-progress {
+  from { transform: translateX(-20%); }
+  to { transform: translateX(210%); }
+}
 
 .experiment-ledger {
   display: grid;

--- a/apps/homescreen/app/lib/experiment-comparison.d.mts
+++ b/apps/homescreen/app/lib/experiment-comparison.d.mts
@@ -44,3 +44,35 @@ export function listMatchedComparisons(
 export function comparisonNextAction(
   comparison: MatchedComparisonProjection | null,
 ): { title: string; body: string };
+
+export type ToolProofProjection = {
+  proof_id: string;
+  suite: "core" | "hard";
+  suite_sha256: string;
+  tool_schema_sha256: string | null;
+  task_count: number;
+  repetitions: number;
+  expected_attempts: number;
+  output_dir: string;
+  evidence_complete: boolean;
+  promotion_ready: boolean;
+  blockers: string[];
+  candidates: Array<{
+    candidate_id: "local-main" | "local-fast";
+    slot_id: number | null;
+    model_id: string | null;
+    strict_passes: number;
+    attempts: number;
+    strict_accuracy: number;
+    terminal_errors: number;
+    mean_latency_ms: number;
+    total_tokens: number;
+    failures: Array<Record<string, unknown>>;
+  }>;
+  winner_id: "local-main" | "local-fast" | null;
+};
+
+export function projectToolProof(proof: Record<string, unknown> | null): ToolProofProjection | null;
+export function toolProofNextAction(
+  proof: ToolProofProjection | null,
+): { title: string; body: string };

--- a/apps/homescreen/app/lib/experiment-comparison.mjs
+++ b/apps/homescreen/app/lib/experiment-comparison.mjs
@@ -169,3 +169,89 @@ export function comparisonNextAction(comparison) {
     body: "Keep the main model as fallback and use the failed fast-model rows for prompt repair or targeted training data.",
   };
 }
+
+/**
+ * Project the CLI-owned strict Pi proof into the one-screen product decision.
+ * Strict failures are quality evidence; infrastructure errors and missing
+ * artifacts are promotion blockers.
+ * @param {Record<string, any> | null} proof
+ */
+export function projectToolProof(proof) {
+  if (!proof) return null;
+  const summary = proof.summary ?? {};
+  const candidates = ["local-main", "local-fast"].flatMap((id) => {
+    const row = summary.candidates?.[id];
+    return row ? [{ candidate_id: id, ...row }] : [];
+  });
+  const expectedAttempts = Number(summary.task_count ?? 0) * Number(summary.repetitions ?? 0);
+  const blockers = [];
+  if (candidates.length !== 2) blockers.push("The proof does not contain both local candidates.");
+  if (proof.evidence?.complete !== true) {
+    blockers.push("Immutable task, result, and canonical event evidence is incomplete.");
+  }
+  if (candidates.some((candidate) => candidate.attempts !== expectedAttempts)) {
+    blockers.push("Candidate attempt counts do not match the frozen suite.");
+  }
+  if (candidates.some((candidate) => candidate.terminal_errors > 0)) {
+    blockers.push("Runtime errors must be resolved before comparing model quality.");
+  }
+  const isPromotionSlice = summary.suite === "hard"
+    && summary.source_task_file === "tasks-hard.json"
+    && summary.task_count === 30
+    && summary.repetitions === 3;
+  if (!isPromotionSlice) blockers.push("Promotion requires the full 30-task hard suite repeated three times.");
+  const ranked = [...candidates].sort((left, right) =>
+    (right.strict_accuracy - left.strict_accuracy)
+    || (left.mean_latency_ms - right.mean_latency_ms)
+    || (left.total_tokens - right.total_tokens),
+  );
+  return {
+    proof_id: summary.proof_id,
+    suite: summary.suite,
+    suite_sha256: summary.suite_sha256,
+    tool_schema_sha256: summary.tool_schema_sha256,
+    task_count: summary.task_count,
+    repetitions: summary.repetitions,
+    expected_attempts: expectedAttempts,
+    output_dir: proof.output_dir,
+    evidence_complete: proof.evidence?.complete === true,
+    promotion_ready: blockers.length === 0,
+    blockers,
+    candidates,
+    winner_id: ranked[0]?.candidate_id ?? null,
+  };
+}
+
+/** @param {ReturnType<typeof projectToolProof>} proof */
+export function toolProofNextAction(proof) {
+  if (!proof) {
+    return {
+      title: "Run the quick local proof",
+      body: "Compare both warm models on 17 frozen strict tool tasks before spending time on repair.",
+    };
+  }
+  const infrastructureBlocker = proof.blockers.find((blocker) =>
+    blocker.startsWith("Immutable")
+    || blocker.startsWith("Candidate")
+    || blocker.startsWith("Runtime"),
+  );
+  if (infrastructureBlocker) {
+    return { title: "Fix the evidence path, then rerun", body: infrastructureBlocker };
+  }
+  if (!proof.promotion_ready) {
+    return {
+      title: "Run the hard proof",
+      body: "The quick result is directional. Promotion needs all 30 hard tasks, three repetitions, and matching immutable hashes.",
+    };
+  }
+  if (proof.winner_id === "local-fast") {
+    return {
+      title: "Review fast-model promotion",
+      body: "The fast model won a complete strict proof. Keep the main route as fallback while the promoted lane accumulates live evidence.",
+    };
+  }
+  return {
+    title: "Prepare the fast-model improvement packet",
+    body: "Use exact failed calls for GEPA prompt and policy repair first; escalate to training only if the error cluster persists.",
+  };
+}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ mod sidecar;
 mod supervision_export;
 mod supervision_review;
 mod supervision_tiebreaker;
+mod tool_proof;
 
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -212,6 +213,9 @@ pub fn run() {
             supervision_tiebreaker::supervision_tiebreaker_set_enabled,
             supervision_tiebreaker::supervision_tiebreaker_analyze,
             supervision_tiebreaker::record_tiebreaker_feedback,
+            tool_proof::desktop_tool_proof_run,
+            tool_proof::desktop_tool_proof_list,
+            tool_proof::desktop_tool_proof_prepare,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/tool_proof.rs
+++ b/apps/homescreen/src-tauri/src/tool_proof.rs
@@ -1,0 +1,168 @@
+//! Thin native bridge to the CLI-owned strict local tool proof.
+//!
+//! The CLI owns suite bytes, Pi execution, residency isolation, scoring,
+//! evidence permissions, and improvement packets. Native code only validates
+//! the bounded desktop request and launches the installed public CLI.
+
+use std::process::Stdio;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolProofCandidate {
+    label: String,
+    slot_id: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolProofRunRequest {
+    suite: String,
+    candidates: Vec<ToolProofCandidate>,
+}
+
+fn run_cli_json(args: &[String]) -> Result<Value, String> {
+    let output = crate::bin::command("understudy")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| {
+            format!(
+                "strict tool proof could not start: {error}. Repair the CLI with `understudy runtime repair`"
+            )
+        })?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        let detail: String = detail.trim().chars().take(2_000).collect();
+        return Err(if detail.is_empty() {
+            format!("strict tool proof exited with {}", output.status)
+        } else {
+            detail
+        });
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("strict tool proof returned invalid JSON: {error}"))
+}
+
+fn proof_args(request: ToolProofRunRequest) -> Result<Vec<String>, String> {
+    if !matches!(request.suite.as_str(), "core" | "hard") {
+        return Err("tool-proof suite must be core or hard".to_string());
+    }
+    if request.candidates.len() != 2 {
+        return Err("tool proof requires exactly the main and fast local candidates".to_string());
+    }
+    let mut labels = request
+        .candidates
+        .iter()
+        .map(|candidate| candidate.label.as_str())
+        .collect::<Vec<_>>();
+    labels.sort_unstable();
+    if labels != ["local-fast", "local-main"] {
+        return Err("tool proof candidates must be local-main and local-fast".to_string());
+    }
+    if request.candidates[0].slot_id == 0
+        || request.candidates[1].slot_id == 0
+        || request.candidates[0].slot_id == request.candidates[1].slot_id
+    {
+        return Err("tool proof candidates need distinct positive Desktop slots".to_string());
+    }
+    let repetitions = if request.suite == "hard" { "3" } else { "1" };
+    let mut args = vec![
+        "desktop".to_string(),
+        "tool-proof".to_string(),
+        "run".to_string(),
+        "--suite".to_string(),
+        request.suite,
+        "--repetitions".to_string(),
+        repetitions.to_string(),
+        "--max-tokens".to_string(),
+        "160".to_string(),
+        "--timeout-ms".to_string(),
+        "30000".to_string(),
+    ];
+    for candidate in request.candidates {
+        args.push("--candidate".to_string());
+        args.push(format!("{}:{}", candidate.label, candidate.slot_id));
+    }
+    args.push("--json".to_string());
+    Ok(args)
+}
+
+#[tauri::command]
+pub async fn desktop_tool_proof_run(request: ToolProofRunRequest) -> Result<Value, String> {
+    let args = proof_args(request)?;
+    tauri::async_runtime::spawn_blocking(move || run_cli_json(&args))
+        .await
+        .map_err(|error| format!("strict tool proof task failed: {error}"))?
+}
+
+#[tauri::command]
+pub async fn desktop_tool_proof_list() -> Result<Value, String> {
+    let args = vec![
+        "desktop".to_string(),
+        "tool-proof".to_string(),
+        "list".to_string(),
+        "--limit".to_string(),
+        "20".to_string(),
+        "--json".to_string(),
+    ];
+    tauri::async_runtime::spawn_blocking(move || run_cli_json(&args))
+        .await
+        .map_err(|error| format!("strict tool proof list task failed: {error}"))?
+}
+
+#[tauri::command]
+pub async fn desktop_tool_proof_prepare(proof_id: String) -> Result<Value, String> {
+    if proof_id.is_empty()
+        || proof_id.len() > 120
+        || !proof_id
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        return Err("strict tool proof id is invalid".to_string());
+    }
+    let args = vec![
+        "desktop".to_string(),
+        "tool-proof".to_string(),
+        "prepare".to_string(),
+        "--proof".to_string(),
+        proof_id,
+        "--json".to_string(),
+    ];
+    tauri::async_runtime::spawn_blocking(move || run_cli_json(&args))
+        .await
+        .map_err(|error| format!("strict tool improvement task failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_request_is_bounded_and_uses_the_promotion_repetition_count() {
+        let args = proof_args(ToolProofRunRequest {
+            suite: "hard".to_string(),
+            candidates: vec![
+                ToolProofCandidate {
+                    label: "local-main".to_string(),
+                    slot_id: 3,
+                },
+                ToolProofCandidate {
+                    label: "local-fast".to_string(),
+                    slot_id: 7,
+                },
+            ],
+        })
+        .unwrap();
+        assert!(args.windows(2).any(|pair| pair == ["--repetitions", "3"]));
+        assert!(proof_args(ToolProofRunRequest {
+            suite: "other".to_string(),
+            candidates: vec![],
+        })
+        .is_err());
+    }
+}

--- a/apps/homescreen/src-tauri/src/tool_proof.rs
+++ b/apps/homescreen/src-tauri/src/tool_proof.rs
@@ -92,6 +92,16 @@ fn proof_args(request: ToolProofRunRequest) -> Result<Vec<String>, String> {
     Ok(args)
 }
 
+fn valid_proof_id(value: &str) -> bool {
+    let mut characters = value.chars();
+    let Some(first) = characters.next() else {
+        return false;
+    };
+    value.len() <= 120
+        && (first.is_ascii_lowercase() || first.is_ascii_digit())
+        && characters.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+}
+
 #[tauri::command]
 pub async fn desktop_tool_proof_run(request: ToolProofRunRequest) -> Result<Value, String> {
     let args = proof_args(request)?;
@@ -117,12 +127,7 @@ pub async fn desktop_tool_proof_list() -> Result<Value, String> {
 
 #[tauri::command]
 pub async fn desktop_tool_proof_prepare(proof_id: String) -> Result<Value, String> {
-    if proof_id.is_empty()
-        || proof_id.len() > 120
-        || !proof_id
-            .chars()
-            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
-    {
+    if !valid_proof_id(&proof_id) {
         return Err("strict tool proof id is invalid".to_string());
     }
     let args = vec![
@@ -164,5 +169,8 @@ mod tests {
             candidates: vec![],
         })
         .is_err());
+        assert!(valid_proof_id("tools-hard-20260713"));
+        assert!(!valid_proof_id("--help"));
+        assert!(!valid_proof_id("-tools-hard"));
     }
 }

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -57,8 +57,8 @@
     },
     {
       "id": "unified-experiment-hub",
-      "status": "partial",
-      "evidence": "Experiments now presents one compact Review -> Compare -> Improve loop. Compare preflights two distinct warm local models, runs an identical direct frozen slice without cloud traffic, projects the existing benchmark ledger into quality, latency, token, capture, and failure evidence, and refuses promotion without matching immutable hashes and complete capture IDs. The improvement handoff and canonical immutable hash writer still need to move behind the shared CLI/runtime before this feature is shipped."
+      "status": "shipped",
+      "evidence": "Experiments presents one compact Review -> Compare -> Improve loop. The public CLI owns the fixed 17-task regression suite and 30-task promotion suite, direct Pi execution, serial residency isolation, exact trace scoring, suite and tool-schema hashes, owner-only canonical event evidence, and immutable failed-case improvement packets. Desktop is a bounded adapter: it preflights two distinct warm models, fixes promotion at three repetitions, reports strict model misses separately from terminal runtime errors, and refuses promotion when task bytes, result rows, event files, permissions, hashes, or attempt counts are incomplete. No cloud call or upload occurs."
     },
     {
       "id": "legacy-desktop-retirement-guard",

--- a/experiments/desktop-tool-proof/README.md
+++ b/experiments/desktop-tool-proof/README.md
@@ -14,6 +14,24 @@ Each attempt has a 30-second terminal timeout by default so a slow local tool or
 model becomes explicit cancellation evidence instead of hanging the suite; use
 `--timeout-ms` only when deliberately testing a slower environment.
 
+The supported product path is the Desktop **Experiments** screen or the public
+CLI. The quick proof uses the 17-task core suite once; the promotion proof uses
+all 30 hard tasks three times:
+
+```sh
+understudy desktop tool-proof run \
+  --suite core \
+  --candidate local-main:7 \
+  --candidate local-fast:6 \
+  --repetitions 1
+understudy desktop tool-proof list --json
+understudy desktop tool-proof prepare --proof <proof-id> --json
+```
+
+`prepare` creates an immutable owner-only packet containing only the failed
+strict rows and recommends GEPA prompt/policy repair first. It performs no
+upload and does not silently start training.
+
 ```sh
 node experiments/desktop-tool-proof/run.mjs \
   --candidate 4b:7 \
@@ -22,7 +40,8 @@ node experiments/desktop-tool-proof/run.mjs \
   --repetitions 3
 ```
 
-Direct-Pi proofs manage residency exclusively by default: the harness snapshots
+The direct runner remains available for harness development. Direct-Pi proofs
+manage residency exclusively by default: the harness snapshots
 the current warm set, cools and verifies every non-candidate slot, warms one
 candidate, runs its frozen rows, cools it, and restores the prior set in a
 `finally` path. This makes repeated comparisons sequential instead of stacking

--- a/experiments/desktop-tool-proof/run.mjs
+++ b/experiments/desktop-tool-proof/run.mjs
@@ -576,6 +576,8 @@ function eventTokens(events) {
 }
 
 export async function runProof(options = parseArgs(process.argv.slice(2))) {
+  const reportProgress = options.onProgress ?? ((line) => process.stdout.write(line));
+  const reportResult = options.reportResult ?? true;
   const suite = options.suite ?? "core";
   const sourceTaskFile = resolveSuiteFile(suite);
   const sourceTaskBytes = readFileSync(join(here, sourceTaskFile));
@@ -682,6 +684,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
             repetition,
             task_id: task.id,
             expected_calls: expectedCallsForTask(task),
+            expected_output: task.expected_output,
             run_id: runId,
             session_id: sessionId,
             elapsed_ms: Math.round(performance.now() - before),
@@ -694,7 +697,7 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
             join(outputDir, `${candidate.label}-r${repetition}-${task.id}.events.jsonl`),
             `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
           );
-          process.stdout.write(
+          reportProgress(
             `${candidate.label.padEnd(10)} r${repetition} ${task.id.padEnd(22)} `
             + `${score.strict_pass ? "PASS" : "FAIL"} tools=${score.call_sequence
               .map(({ tool }) => tool)
@@ -737,7 +740,9 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
   );
   writeProofFile(join(outputDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
   writeProofFile(join(outputDir, "tasks.json"), taskBytes);
-  process.stdout.write(`${JSON.stringify({ output_dir: outputDir, summary }, null, 2)}\n`);
+  if (reportResult) {
+    process.stdout.write(`${JSON.stringify({ output_dir: outputDir, summary }, null, 2)}\n`);
+  }
   return { outputDir, rows, summary };
 }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "skills",
     "schemas",
     "docs",
+    "experiments/desktop-tool-proof",
     "README.md",
     "AGENTS.md",
     "LICENSE",

--- a/src/commands/desktop.ts
+++ b/src/commands/desktop.ts
@@ -35,6 +35,13 @@ import {
   TIEBREAKER_EVAL_SUITE_PATH,
   runTiebreakerEval,
 } from "../supervision/tiebreaker-eval.js";
+import {
+  DEFAULT_TOOL_PROOF_ROOT,
+  listDesktopToolProofs,
+  prepareDesktopToolProofImprovement,
+  runDesktopToolProof,
+  type ToolProofCandidate,
+} from "../desktop/tool-proof.js";
 
 interface RuntimeEvent {
   run_id?: string;
@@ -95,6 +102,22 @@ function nonNegativeNumber(value: string): number {
 
 function collect(value: string, previous: string[]): string[] {
   return [...previous, value];
+}
+
+function toolProofCandidate(value: string): ToolProofCandidate {
+  const [label, rawSlot, ...extra] = value.split(":");
+  const slotId = Number(rawSlot);
+  if (extra.length || !label || !Number.isInteger(slotId) || slotId <= 0) {
+    throw new Error("candidate must be label:slot-id");
+  }
+  return { label, slotId };
+}
+
+function collectToolProofCandidate(
+  value: string,
+  previous: ToolProofCandidate[],
+): ToolProofCandidate[] {
+  return [...previous, toolProofCandidate(value)];
 }
 
 async function readStandardInput(): Promise<string> {
@@ -314,6 +337,106 @@ export function registerDesktopCommand(program: Command): void {
       const capability = await requireDesktopApi();
       const value = await desktopControlJson(capability, "/v1/status", "/api/status");
       printStructured(value, jsonRequested(this, opts.json));
+    });
+
+  const toolProof = desktop
+    .command("tool-proof")
+    .description("Run or inspect the frozen local strict tool-call proof through Pi.");
+
+  toolProof
+    .command("run")
+    .description("Compare one or more Desktop model slots on the exact same frozen tool traces.")
+    .requiredOption(
+      "--candidate <label:slot-id>",
+      "Candidate label and Desktop slot; repeat for a matched comparison",
+      collectToolProofCandidate,
+      [],
+    )
+    .addOption(new Option("--suite <suite>").choices(["core", "hard"]).default("core"))
+    .option("--repetitions <n>", "Attempts per frozen task", positiveInteger, 3)
+    .option("--max-tokens <n>", "Maximum output tokens per attempt", positiveInteger, 160)
+    .option("--timeout-ms <n>", "Terminal timeout per attempt", positiveInteger, 30_000)
+    .option("--task-id <id>", "Run an exact frozen task; repeat to select an ordered subset", collect, [])
+    .option("--output-root <path>", "Owner-only proof root", DEFAULT_TOOL_PROOF_ROOT)
+    .option("--prewarmed", "Do not manage exclusive residency (diagnostic only)")
+    .option("--desktop-api", "Route turns through the Desktop API instead of direct Pi")
+    .option("--json", "Output JSON")
+    .action(async function (this: Command, opts: {
+      candidate: ToolProofCandidate[];
+      suite: "core" | "hard";
+      repetitions: number;
+      maxTokens: number;
+      timeoutMs: number;
+      taskId: string[];
+      outputRoot: string;
+      prewarmed?: boolean;
+      desktopApi?: boolean;
+      json?: boolean;
+    }) {
+      const json = jsonRequested(this, opts.json);
+      const result = await runDesktopToolProof({
+        candidates: opts.candidate,
+        suite: opts.suite,
+        repetitions: opts.repetitions,
+        maxTokens: opts.maxTokens,
+        timeoutMs: opts.timeoutMs,
+        outputRoot: opts.outputRoot,
+        taskIds: opts.taskId,
+        manageResidency: opts.prewarmed !== true,
+        executionMode: opts.desktopApi ? "desktop-api" : "direct-pi",
+        onProgress: json ? () => {} : (line) => process.stdout.write(line),
+      });
+      printStructured(
+        result,
+        json,
+        [
+          `proof: ${result.summary.proof_id}`,
+          `suite: ${result.summary.suite} (${result.summary.suite_sha256})`,
+          ...Object.entries(result.summary.candidates).map(([candidate, row]) =>
+            `${candidate}: ${row.strict_passes}/${row.attempts} strict; ${row.mean_latency_ms} ms mean`,
+          ),
+          `evidence: ${result.output_dir}`,
+          "uploads performed: false",
+        ].join("\n"),
+      );
+    });
+
+  toolProof
+    .command("list")
+    .description("List private immutable strict-tool summaries without reading raw tool results.")
+    .option("--limit <n>", "Most recent proofs", positiveInteger, 20)
+    .option("--root <path>", "Owner-only proof root", DEFAULT_TOOL_PROOF_ROOT)
+    .option("--json", "Output JSON")
+    .action(function (this: Command, opts: { limit: number; root: string; json?: boolean }) {
+      const proofs = listDesktopToolProofs(resolve(opts.root), opts.limit);
+      printStructured(
+        { schema_version: "understudy.desktop_tool_proof_list.v1", proofs },
+        jsonRequested(this, opts.json),
+        proofs.length
+          ? proofs.map((proof) => `${proof.summary.proof_id} · ${proof.summary.suite} · ${proof.summary.completed_at}`).join("\n")
+          : "No strict-tool proofs yet.",
+      );
+    });
+
+  toolProof
+    .command("prepare")
+    .description("Create an immutable local improvement packet from a strict tool-proof's failures.")
+    .requiredOption("--proof <id>", "Strict tool-proof id")
+    .option("--root <path>", "Owner-only proof root", DEFAULT_TOOL_PROOF_ROOT)
+    .option("--json", "Output JSON")
+    .action(function (this: Command, opts: { proof: string; root: string; json?: boolean }) {
+      const result = prepareDesktopToolProofImprovement(opts.proof, resolve(opts.root));
+      printStructured(
+        result,
+        jsonRequested(this, opts.json),
+        [
+          `proof: ${result.packet.proof_id}`,
+          `failures: ${result.packet.failure_count}`,
+          `method: ${result.packet.recommended_method}`,
+          `packet: ${result.path}`,
+          "uploads performed: false",
+        ].join("\n"),
+      );
     });
 
   desktop

--- a/src/desktop/tool-proof.ts
+++ b/src/desktop/tool-proof.ts
@@ -1,0 +1,354 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export interface ToolProofCandidate {
+  label: string;
+  slotId: number;
+}
+
+export interface RunToolProofOptions {
+  candidates: ToolProofCandidate[];
+  suite: "core" | "hard";
+  repetitions: number;
+  maxTokens: number;
+  timeoutMs: number;
+  outputRoot?: string;
+  taskIds?: string[];
+  manageResidency: boolean;
+  executionMode?: "direct-pi" | "desktop-api";
+  onProgress?: (line: string) => void;
+}
+
+export interface ToolProofCandidateSummary {
+  slot_id: number | null;
+  model_id: string | null;
+  runtime_backend: string | null;
+  strict_passes: number;
+  attempts: number;
+  strict_accuracy: number;
+  exact_call_count_rate: number;
+  exact_name_rate: number;
+  exact_arguments_rate: number;
+  successful_result_rate: number;
+  exact_output_rate: number;
+  parse_errors: number;
+  terminal_errors: number;
+  orphan_results: number;
+  mean_latency_ms: number;
+  total_tokens: number;
+  failures: Array<Record<string, unknown>>;
+}
+
+export interface ToolProofSummary {
+  format: "understudy.desktop_tool_proof.v3";
+  proof_id: string;
+  suite: "core" | "hard";
+  source_task_file: string;
+  suite_sha256: string;
+  started_at: string;
+  completed_at: string;
+  api_version: string;
+  event_schema: string;
+  task_count: number;
+  repetitions: number;
+  run_count: number;
+  timeout_ms: number;
+  execution_mode: string;
+  residency_mode: string;
+  release_cohort_eligible: false;
+  tool_schema_sha256: string | null;
+  candidates: Record<string, ToolProofCandidateSummary>;
+}
+
+export interface ToolProofResult {
+  output_dir: string;
+  summary: ToolProofSummary;
+  evidence: ToolProofEvidenceAudit;
+}
+
+export interface ToolProofEvidenceAudit {
+  private_files: boolean;
+  suite_hash_matches: boolean;
+  result_rows: number;
+  event_files: number;
+  expected_rows: number;
+  complete: boolean;
+}
+
+export interface ToolProofImprovementResult {
+  path: string;
+  packet: {
+    format: "understudy.desktop_tool_improvement.v1";
+    proof_id: string;
+    suite: "core" | "hard";
+    suite_sha256: string;
+    tool_schema_sha256: string | null;
+    objective: "maximize_strict_tool_correctness";
+    recommended_method: "gepa_prompt_policy_first" | "no_repair_needed";
+    failure_count: number;
+    failures: Array<Record<string, unknown>>;
+    uploads_performed: false;
+  };
+}
+
+type RunnerModule = {
+  runProof(options: Record<string, unknown>): Promise<{
+    outputDir: string;
+    rows: Array<Record<string, unknown>>;
+    summary: ToolProofSummary;
+  }>;
+};
+
+export const DEFAULT_TOOL_PROOF_ROOT = join(
+  homedir(),
+  ".understudy",
+  "proofs",
+  "tool-correctness",
+);
+
+function validateCandidates(candidates: ToolProofCandidate[]): void {
+  if (candidates.length < 1) throw new Error("provide at least one tool-proof candidate");
+  const labels = new Set<string>();
+  const slots = new Set<number>();
+  for (const candidate of candidates) {
+    if (!/^[a-z0-9][a-z0-9-]{0,39}$/.test(candidate.label) || labels.has(candidate.label)) {
+      throw new Error(`candidate label must be unique and URL-safe: ${candidate.label}`);
+    }
+    if (!Number.isInteger(candidate.slotId) || candidate.slotId <= 0 || slots.has(candidate.slotId)) {
+      throw new Error(`candidate slot must be a unique positive integer: ${candidate.slotId}`);
+    }
+    labels.add(candidate.label);
+    slots.add(candidate.slotId);
+  }
+}
+
+export async function runDesktopToolProof(options: RunToolProofOptions): Promise<ToolProofResult> {
+  validateCandidates(options.candidates);
+  if (!Number.isInteger(options.repetitions) || options.repetitions < 1 || options.repetitions > 20) {
+    throw new Error("repetitions must be an integer from 1 to 20");
+  }
+  if (!Number.isInteger(options.maxTokens) || options.maxTokens < 16 || options.maxTokens > 2_048) {
+    throw new Error("maxTokens must be an integer from 16 to 2048");
+  }
+  if (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1_000 || options.timeoutMs > 300_000) {
+    throw new Error("timeoutMs must be an integer from 1000 to 300000");
+  }
+  const runnerUrl = new URL("../../experiments/desktop-tool-proof/run.mjs", import.meta.url);
+  const runner = await import(runnerUrl.href) as RunnerModule;
+  const result = await runner.runProof({
+    candidates: options.candidates,
+    suite: options.suite,
+    repetitions: options.repetitions,
+    maxTokens: options.maxTokens,
+    timeoutMs: options.timeoutMs,
+    outputRoot: resolve(options.outputRoot ?? DEFAULT_TOOL_PROOF_ROOT),
+    taskIds: options.taskIds ?? [],
+    executionMode: options.executionMode ?? "direct-pi",
+    manageResidency: options.manageResidency,
+    onProgress: options.onProgress,
+    reportResult: false,
+  });
+  return auditToolProof(result.outputDir, result.summary);
+}
+
+function isSummary(value: unknown): value is ToolProofSummary {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const row = value as Record<string, unknown>;
+  return row.format === "understudy.desktop_tool_proof.v3"
+    && typeof row.proof_id === "string"
+    && (row.suite === "core" || row.suite === "hard")
+    && typeof row.suite_sha256 === "string"
+    && typeof row.completed_at === "string"
+    && row.candidates != null
+    && typeof row.candidates === "object";
+}
+
+export function listDesktopToolProofs(
+  root = DEFAULT_TOOL_PROOF_ROOT,
+  limit = 20,
+): ToolProofResult[] {
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch (cause) {
+    const code = (cause as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return [];
+    throw cause;
+  }
+  return entries.flatMap((entry) => {
+    const outputDir = join(root, entry);
+    const path = join(outputDir, "summary.json");
+    try {
+      const metadata = statSync(path);
+      if (process.platform !== "win32" && (metadata.mode & 0o077) !== 0) return [];
+      const summary = JSON.parse(readFileSync(path, "utf8")) as unknown;
+      return isSummary(summary) ? [auditToolProof(outputDir, summary)] : [];
+    } catch {
+      return [];
+    }
+  }).sort((left, right) =>
+    right.summary.completed_at.localeCompare(left.summary.completed_at)
+  ).slice(0, limit);
+}
+
+function isPrivateFile(path: string): boolean {
+  try {
+    const metadata = statSync(path);
+    return metadata.isFile() && (process.platform === "win32" || (metadata.mode & 0o077) === 0);
+  } catch {
+    return false;
+  }
+}
+
+function auditToolProof(outputDir: string, summary: ToolProofSummary): ToolProofResult {
+  const summaryPath = join(outputDir, "summary.json");
+  const resultsPath = join(outputDir, "results.jsonl");
+  const tasksPath = join(outputDir, "tasks.json");
+  const requiredFiles = [summaryPath, resultsPath, tasksPath];
+  let rows: Array<Record<string, unknown>> = [];
+  let suiteHashMatches = false;
+  try {
+    const taskBytes = readFileSync(tasksPath);
+    suiteHashMatches = createHash("sha256").update(taskBytes).digest("hex") === summary.suite_sha256;
+    rows = readFileSync(resultsPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+  } catch {
+    rows = [];
+  }
+  let eventFiles: string[] = [];
+  try {
+    eventFiles = readdirSync(outputDir)
+      .filter((entry) => entry.endsWith(".events.jsonl"))
+      .map((entry) => join(outputDir, entry));
+  } catch {
+    eventFiles = [];
+  }
+  const expectedRows = Number.isInteger(summary.run_count) ? summary.run_count : 0;
+  const rowsConsistent = expectedRows > 0
+    && rows.length === expectedRows
+    && rows.every((row) =>
+      row.proof_id === summary.proof_id
+      && row.suite === summary.suite
+      && row.suite_sha256 === summary.suite_sha256
+      && typeof row.canonical_event_count === "number"
+      && row.canonical_event_count > 0,
+    );
+  const privateFiles = [...requiredFiles, ...eventFiles].every(isPrivateFile);
+  const complete = privateFiles
+    && suiteHashMatches
+    && rowsConsistent
+    && eventFiles.length === expectedRows
+    && typeof summary.tool_schema_sha256 === "string"
+    && summary.tool_schema_sha256.length === 64;
+  return {
+    output_dir: outputDir,
+    summary,
+    evidence: {
+      private_files: privateFiles,
+      suite_hash_matches: suiteHashMatches,
+      result_rows: rows.length,
+      event_files: eventFiles.length,
+      expected_rows: expectedRows,
+      complete,
+    },
+  };
+}
+
+export function prepareDesktopToolProofImprovement(
+  proofId: string,
+  root = DEFAULT_TOOL_PROOF_ROOT,
+): ToolProofImprovementResult {
+  if (!/^[a-z0-9][a-z0-9-]{0,119}$/.test(proofId)) {
+    throw new Error("proof id is invalid");
+  }
+  const outputDir = join(resolve(root), proofId);
+  const summaryPath = join(outputDir, "summary.json");
+  const resultsPath = join(outputDir, "results.jsonl");
+  const tasksPath = join(outputDir, "tasks.json");
+  const summaryMetadata = statSync(summaryPath);
+  const resultsMetadata = statSync(resultsPath);
+  const tasksMetadata = statSync(tasksPath);
+  if (
+    process.platform !== "win32"
+    && (
+      (summaryMetadata.mode & 0o077) !== 0
+      || (resultsMetadata.mode & 0o077) !== 0
+      || (tasksMetadata.mode & 0o077) !== 0
+    )
+  ) {
+    throw new Error("proof evidence permissions are broader than 0600");
+  }
+  const summary = JSON.parse(readFileSync(summaryPath, "utf8")) as unknown;
+  if (!isSummary(summary) || summary.proof_id !== proofId) {
+    throw new Error("proof summary is invalid or does not match its directory");
+  }
+  if (!auditToolProof(outputDir, summary).evidence.complete) {
+    throw new Error("proof evidence is incomplete or does not match its immutable hashes");
+  }
+  const rows = readFileSync(resultsPath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line, index) => {
+      const value = JSON.parse(line) as unknown;
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(`proof result ${index + 1} is not an object`);
+      }
+      return value as Record<string, unknown>;
+    });
+  const taskOutputById = new Map<string, unknown>();
+  const tasks = JSON.parse(readFileSync(tasksPath, "utf8")) as unknown;
+  if (!Array.isArray(tasks)) throw new Error("proof tasks are invalid");
+  for (const task of tasks) {
+    if (!task || typeof task !== "object" || Array.isArray(task)) continue;
+    const candidate = task as Record<string, unknown>;
+    if (typeof candidate.id === "string") {
+      taskOutputById.set(candidate.id, candidate.expected_output ?? null);
+    }
+  }
+  const failures = rows.filter((row) => row.strict_pass !== true).map((row) => ({
+    candidate: row.candidate,
+    model_id: row.model_id,
+    repetition: row.repetition,
+    task_id: row.task_id,
+    expected_calls: row.expected_calls,
+    observed_call_sequence: row.call_sequence,
+    expected_output: row.expected_output ?? taskOutputById.get(String(row.task_id)) ?? null,
+    observed_output: row.output,
+    checks: row.checks,
+    terminal_error: row.terminal_error,
+  }));
+  const packet: ToolProofImprovementResult["packet"] = {
+    format: "understudy.desktop_tool_improvement.v1",
+    proof_id: summary.proof_id,
+    suite: summary.suite,
+    suite_sha256: summary.suite_sha256,
+    tool_schema_sha256: summary.tool_schema_sha256,
+    objective: "maximize_strict_tool_correctness",
+    recommended_method: failures.length ? "gepa_prompt_policy_first" : "no_repair_needed",
+    failure_count: failures.length,
+    failures,
+    uploads_performed: false,
+  };
+  const path = join(outputDir, "improvement.json");
+  try {
+    writeFileSync(path, `${JSON.stringify(packet, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+    const metadata = statSync(path);
+    if (process.platform !== "win32" && (metadata.mode & 0o077) !== 0) {
+      throw new Error("improvement evidence permissions are broader than 0600");
+    }
+    const existing = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (JSON.stringify(existing) !== JSON.stringify(packet)) {
+      throw new Error("refusing to replace immutable improvement evidence");
+    }
+  }
+  return { path, packet };
+}

--- a/tests/desktop-tool-proof.test.mjs
+++ b/tests/desktop-tool-proof.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import {
@@ -11,6 +14,10 @@ import {
   selectTasks,
   summarizeRows,
 } from "../experiments/desktop-tool-proof/run.mjs";
+import {
+  listDesktopToolProofs,
+  prepareDesktopToolProofImprovement,
+} from "../dist/desktop/tool-proof.js";
 
 const task = {
   tool: "list_traces",
@@ -19,6 +26,128 @@ const task = {
 };
 
 describe("desktop strict-tool proof", () => {
+  it("lists only owner-only valid summaries in newest-first order", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-tool-proof-list-"));
+    const summary = (proofId, completedAt) => ({
+      format: "understudy.desktop_tool_proof.v3",
+      proof_id: proofId,
+      suite: "hard",
+      suite_sha256: "a".repeat(64),
+      completed_at: completedAt,
+      run_count: 0,
+      tool_schema_sha256: null,
+      candidates: { fast: { strict_passes: 1, attempts: 1 } },
+    });
+    for (const [id, completedAt, mode] of [
+      ["older", "2026-07-12T00:00:00.000Z", 0o600],
+      ["newer", "2026-07-13T00:00:00.000Z", 0o600],
+      ["broad", "2026-07-14T00:00:00.000Z", 0o644],
+    ]) {
+      const dir = join(root, id);
+      mkdirSync(dir, { mode: 0o700 });
+      const path = join(dir, "summary.json");
+      writeFileSync(path, `${JSON.stringify(summary(id, completedAt))}\n`, { mode });
+      chmodSync(path, mode);
+    }
+    assert.deepEqual(
+      listDesktopToolProofs(root, 20).map((proof) => proof.summary.proof_id),
+      ["newer", "older"],
+    );
+  });
+
+  it("prepares an immutable local improvement packet from failed strict rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-tool-proof-improve-"));
+    const proofId = "tools-hard-20260713";
+    const dir = join(root, proofId);
+    mkdirSync(dir, { mode: 0o700 });
+    const tasks = [{
+      id: "exact-list",
+      calls: [{ tool: "list_traces", arguments: { limit: 1 } }],
+      expected_output: "OK",
+    }];
+    const taskBytes = `${JSON.stringify(tasks)}\n`;
+    const suiteSha256 = createHash("sha256").update(taskBytes).digest("hex");
+    const summary = {
+      format: "understudy.desktop_tool_proof.v3",
+      proof_id: proofId,
+      suite: "hard",
+      suite_sha256: suiteSha256,
+      completed_at: "2026-07-13T00:00:00.000Z",
+      tool_schema_sha256: "c".repeat(64),
+      run_count: 1,
+      candidates: { fast: { strict_passes: 0, attempts: 1 } },
+    };
+    const failed = {
+      candidate: "fast",
+      model_id: "model-understudy",
+      repetition: 1,
+      task_id: "exact-list",
+      expected_calls: tasks[0].calls,
+      call_sequence: [{ tool: "list_traces", arguments: { limit: 2 }, parse_error: null }],
+      output: "NO_TOOL",
+      checks: { exact_arguments: false, exact_output: false },
+      terminal_error: null,
+      strict_pass: false,
+      proof_id: proofId,
+      suite: "hard",
+      suite_sha256: suiteSha256,
+      canonical_event_count: 1,
+    };
+    for (const [filename, value] of [
+      ["summary.json", `${JSON.stringify(summary)}\n`],
+      ["tasks.json", taskBytes],
+      ["results.jsonl", `${JSON.stringify(failed)}\n`],
+    ]) {
+      writeFileSync(join(dir, filename), value, { mode: 0o600 });
+    }
+    writeFileSync(join(dir, "fast-r1-exact-list.events.jsonl"), "{}\n", { mode: 0o600 });
+    const first = prepareDesktopToolProofImprovement(proofId, root);
+    const second = prepareDesktopToolProofImprovement(proofId, root);
+    assert.deepEqual(second, first);
+    assert.equal(first.packet.failure_count, 1);
+    assert.equal(first.packet.recommended_method, "gepa_prompt_policy_first");
+    assert.deepEqual(first.packet.failures, [{
+      candidate: "fast",
+      model_id: "model-understudy",
+      repetition: 1,
+      task_id: "exact-list",
+      expected_calls: tasks[0].calls,
+      observed_call_sequence: failed.call_sequence,
+      expected_output: "OK",
+      observed_output: "NO_TOOL",
+      checks: failed.checks,
+      terminal_error: null,
+    }]);
+    assert.equal(JSON.parse(readFileSync(first.path, "utf8")).uploads_performed, false);
+    assert.equal(statSync(first.path).mode & 0o777, 0o600);
+  });
+
+  it("rejects improvement evidence with broad permissions", () => {
+    if (process.platform === "win32") return;
+    const root = mkdtempSync(join(tmpdir(), "understudy-tool-proof-permissions-"));
+    const proofId = "tools-broad-20260713";
+    const dir = join(root, proofId);
+    mkdirSync(dir, { mode: 0o700 });
+    const summary = {
+      format: "understudy.desktop_tool_proof.v3",
+      proof_id: proofId,
+      suite: "core",
+      suite_sha256: "d".repeat(64),
+      completed_at: "2026-07-13T00:00:00.000Z",
+      tool_schema_sha256: null,
+      candidates: {},
+    };
+    writeFileSync(join(dir, "summary.json"), JSON.stringify(summary), { mode: 0o600 });
+    writeFileSync(join(dir, "tasks.json"), "[]\n", { mode: 0o600 });
+    const resultsPath = join(dir, "results.jsonl");
+    writeFileSync(resultsPath, "", { mode: 0o644 });
+    chmodSync(resultsPath, 0o644);
+    assert.throws(
+      () => prepareDesktopToolProofImprovement(proofId, root),
+      /permissions are broader than 0600/,
+    );
+  });
+
   it("selects an exact ordered subset for causal probes", () => {
     const tasks = [{ id: "one" }, { id: "two" }];
     assert.deepEqual(selectTasks(tasks, ["two"]), [{ id: "two" }]);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -38,6 +38,14 @@ const tiebreakerCliPath = new URL(
   "../src/supervision/tiebreaker.ts",
   import.meta.url,
 );
+const toolProofRustPath = new URL(
+  "../apps/homescreen/src-tauri/src/tool_proof.rs",
+  import.meta.url,
+);
+const toolProofCliPath = new URL(
+  "../src/desktop/tool-proof.ts",
+  import.meta.url,
+);
 const statusPanePath = new URL(
   "../apps/homescreen/app/components/StatusPane.tsx",
   import.meta.url,
@@ -135,12 +143,14 @@ test("desktop model downloads are app-owned, pausable, and resumable", async () 
   assert.doesNotMatch(statusPane, /invoke\([^\n]*"download_snapshot_model"/);
 });
 
-test("Experiments is one guided review, compare, improve loop", async () => {
-  const [review, compare, comparisonRules, reviewRust, rlmPane, css] = await Promise.all([
+test("Experiments is one guided review, strict compare, improve loop", async () => {
+  const [review, compare, comparisonRules, reviewRust, proofRust, proofCli, rlmPane, css] = await Promise.all([
     readFile(reviewViewPath, "utf8"),
     readFile(new URL("../apps/homescreen/app/components/ExperimentCompareView.tsx", import.meta.url), "utf8"),
     readFile(new URL("../apps/homescreen/app/lib/experiment-comparison.mjs", import.meta.url), "utf8"),
     readFile(reviewRustPath, "utf8"),
+    readFile(toolProofRustPath, "utf8"),
+    readFile(toolProofCliPath, "utf8"),
     readFile(rlmPanePath, "utf8"),
     readFile(cssPath, "utf8"),
   ]);
@@ -157,12 +167,19 @@ test("Experiments is one guided review, compare, improve loop", async () => {
   assert.match(reviewRust, /RuntimeEvent::TeacherContinuation/);
   assert.match(reviewRust, /load_recent_persisted_traces/);
   assert.match(compare, /LOCAL_CANDIDATES = \["local-main", "local-fast"\]/);
-  assert.match(compare, /DIRECT_MODE = \["main-only"\]/);
+  assert.match(compare, /modes: \["main-only"\]/);
   assert.match(compare, /compare the same model twice/);
-  assert.match(compare, /run_fusion_benchmark_matrix_live/);
+  assert.match(compare, /"desktop_tool_proof_run"/);
+  assert.match(compare, /"desktop_tool_proof_list"/);
+  assert.match(compare, /"desktop_tool_proof_prepare"/);
   assert.doesNotMatch(compare, /gateway-supervised/);
-  assert.match(comparisonRules, /Immutable suite hashes are missing or do not match/);
-  assert.match(comparisonRules, /canonical capture_run_id/);
+  assert.match(comparisonRules, /full 30-task hard suite repeated three times/);
+  assert.match(comparisonRules, /canonical event evidence is incomplete/);
+  assert.match(proofRust, /CLI owns suite bytes, Pi execution, residency isolation, scoring/);
+  assert.match(proofRust, /"--repetitions"/);
+  assert.match(proofCli, /suite_hash_matches/);
+  assert.match(proofCli, /eventFiles\.length === expectedRows/);
+  assert.match(proofCli, /gepa_prompt_policy_first/);
   assert.match(css, /\.content:has\(\.supervision-review\)\s*\{[\s\S]*?overflow: hidden/);
   assert.match(css, /\.content:has\(\.experiment-compare\)\s*\{[\s\S]*?overflow: hidden/);
   assert.match(css, /grid-template-rows: auto minmax\(0, 1fr\) auto/);

--- a/tests/experiment-hub.test.mjs
+++ b/tests/experiment-hub.test.mjs
@@ -5,6 +5,8 @@ import {
   comparisonNextAction,
   identifyCandidateRun,
   listMatchedComparisons,
+  projectToolProof,
+  toolProofNextAction,
 } from "../apps/homescreen/app/lib/experiment-comparison.mjs";
 
 const candidates = [
@@ -92,4 +94,75 @@ test("the newest matched parent run wins over older ledger rows", () => {
   const comparisons = listMatchedComparisons(rows, candidates);
   assert.equal(comparisons[0].parent_run_id, "newer");
   assert.equal(comparisons[1].parent_run_id, "older");
+});
+
+function strictProof(overrides = {}) {
+  return {
+    output_dir: "/private/proof",
+    evidence: { complete: true },
+    summary: {
+      proof_id: "tools-hard-one",
+      suite: "hard",
+      source_task_file: "tasks-hard.json",
+      suite_sha256: "a".repeat(64),
+      tool_schema_sha256: "b".repeat(64),
+      task_count: 30,
+      repetitions: 3,
+      candidates: {
+        "local-main": {
+          model_id: "main-model",
+          attempts: 90,
+          strict_passes: 81,
+          strict_accuracy: 0.9,
+          terminal_errors: 0,
+          mean_latency_ms: 400,
+          total_tokens: 9000,
+          failures: [{}],
+        },
+        "local-fast": {
+          model_id: "fast-model",
+          attempts: 90,
+          strict_passes: 84,
+          strict_accuracy: 0.9333,
+          terminal_errors: 0,
+          mean_latency_ms: 200,
+          total_tokens: 7000,
+          failures: [{}],
+        },
+      },
+      ...overrides,
+    },
+  };
+}
+
+test("a complete three-repetition strict proof is promotion-grade", () => {
+  const proof = projectToolProof(strictProof());
+  assert.equal(proof.promotion_ready, true);
+  assert.equal(proof.winner_id, "local-fast");
+  assert.equal(proof.expected_attempts, 90);
+  assert.match(toolProofNextAction(proof).title, /promotion/i);
+});
+
+test("a perfect quick proof still requires the hard frozen suite", () => {
+  const proof = projectToolProof(strictProof({
+    suite: "core",
+    source_task_file: "tasks.json",
+    task_count: 17,
+    repetitions: 1,
+    candidates: {
+      "local-main": { attempts: 17, strict_passes: 17, strict_accuracy: 1, terminal_errors: 0, mean_latency_ms: 400, total_tokens: 1000, failures: [] },
+      "local-fast": { attempts: 17, strict_passes: 17, strict_accuracy: 1, terminal_errors: 0, mean_latency_ms: 200, total_tokens: 800, failures: [] },
+    },
+  }));
+  assert.equal(proof.promotion_ready, false);
+  assert.match(proof.blockers.join(" "), /30-task hard suite/i);
+  assert.match(toolProofNextAction(proof).title, /hard proof/i);
+});
+
+test("terminal errors block promotion instead of counting as model misses", () => {
+  const source = strictProof();
+  source.summary.candidates["local-fast"].terminal_errors = 1;
+  const proof = projectToolProof(source);
+  assert.equal(proof.promotion_ready, false);
+  assert.match(toolProofNextAction(proof).title, /evidence path/i);
 });


### PR DESCRIPTION
## What changed

- promotes the existing Pi strict-tool proof into the packaged public CLI
- gives Desktop a bounded bridge for quick and promotion comparisons
- audits suite bytes, result rows, canonical event files, permissions, and hashes before promotion
- creates immutable GEPA-first improvement packets from failed strict rows
- replaces the scoreless Fusion comparison UI with strict correctness, latency, token, and runtime-error evidence

## Why

The previous main-only Fusion slice persisted no quality score, so the UI correctly failed closed but could never produce promotion-grade evidence. The existing strict proof already had the right frozen suites and exact trace semantics; this makes it the shared CLI/runtime source of truth instead of adding another benchmark harness.

## Validation

- npm run check: 258 tests, 33 public skills, package smoke green
- cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml --lib: 162 passed, 4 ignored fixture tests
- npm run build in apps/homescreen: production Next build green
- npm pack --dry-run --json: strict runner and both frozen suites packaged
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->