### PR TITLE
Add truthful native runtime reference adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Added
 
+- **Truthful native Rust migration baseline.** `understudy runtime conformance
+  --backend native` now uses the owner-only authenticated Desktop API to force
+  the one-release Rust fallback against a named warm slot. It passes only the
+  exact prompt-only case the legacy headless boundary actually supports and
+  records richer frozen scenarios as explicit gaps, preventing synthetic
+  wrapper events from overstating image, tool, cancellation, compaction,
+  restart, or supervision parity.
 - **Understudy Desktop agent control plane.** The public CLI now discovers the
   owner-only Desktop capability file and exposes a versioned OpenAPI 3.1
   contract for capabilities, models, downloads, residency, canonical turns,

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -3659,6 +3659,44 @@ pub async fn agent_chat(
     }
 }
 
+/// Execute the frozen one-release compatibility engine directly. This exists
+/// only so migration evidence can compare the legacy Rust baseline with the
+/// canonical runtime without making runtime unavailability part of the test.
+/// New product callers must continue to use `agent_chat`.
+pub(crate) async fn agent_chat_native_reference(
+    app: &AppHandle,
+    mgr: &Residency,
+    slot_id: u32,
+    session_id: &str,
+    prompt: &str,
+    max_tokens: Option<u32>,
+    capture_run_id: &str,
+) -> Result<BenchmarkChatResult, String> {
+    validate_native_reference_request(prompt, capture_run_id)?;
+    agent_chat_native(
+        app,
+        mgr,
+        slot_id,
+        session_id,
+        prompt,
+        max_tokens,
+        capture_run_id,
+    )
+    .await
+}
+
+fn validate_native_reference_request(prompt: &str, capture_run_id: &str) -> Result<(), String> {
+    if !capture_run_id.starts_with("conformance-native-basic-chat-")
+        || capture_run_id.len() > 200
+    {
+        return Err("native Rust reference requires the frozen basic-chat run identity".to_string());
+    }
+    if prompt != "Run the local fixture." {
+        return Err("native Rust reference requires the frozen basic-chat prompt".to_string());
+    }
+    Ok(())
+}
+
 async fn agent_chat_native(
     app: &AppHandle,
     mgr: &Residency,
@@ -4031,6 +4069,27 @@ fn finalize_tool_calls(mut tool_calls: Vec<ToolCallAcc>) -> Vec<ToolCallAcc> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_reference_is_restricted_to_the_frozen_basic_case() {
+        validate_native_reference_request(
+            "Run the local fixture.",
+            "conformance-native-basic-chat-test",
+        )
+        .unwrap();
+        assert!(validate_native_reference_request(
+            "Run an arbitrary local prompt.",
+            "conformance-native-basic-chat-test",
+        )
+        .unwrap_err()
+        .contains("frozen basic-chat prompt"));
+        assert!(validate_native_reference_request(
+            "Run the local fixture.",
+            "arbitrary-native-run",
+        )
+        .unwrap_err()
+        .contains("frozen basic-chat run identity"));
+    }
 
     fn image_message() -> (ChatMsg, String) {
         use base64::Engine as _;

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -531,10 +531,7 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
                 complete,
                 ..
             } => {
-                if model
-                    .as_deref()
-                    .is_none_or(|value| value.trim().is_empty())
-                {
+                if model.as_deref().is_none_or(|value| value.trim().is_empty()) {
                     return Err("usage requires model attribution".to_string());
                 }
                 if !matches!(source.as_str(), "provider" | "estimated" | "unavailable") {

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -789,6 +789,7 @@ struct ChatBody {
     session_id: Option<String>,
     max_tokens: Option<u32>,
     capture_run_id: Option<String>,
+    runtime_backend: Option<String>,
 }
 
 async fn chat_completion(
@@ -801,18 +802,44 @@ async fn chat_completion(
         .session_id
         .unwrap_or_else(|| format!("agent-{}", chrono::Utc::now().timestamp_millis()));
     let residency = ctx.app.state::<crate::residency::Residency>();
-    crate::chat::agent_chat(
-        &ctx.app,
-        &residency,
-        b.slot_id,
-        &session_id,
-        &b.prompt,
-        b.max_tokens,
-        b.capture_run_id.as_deref(),
-    )
-    .await
-    .map(|r| Json(json!(r)))
-    .map_err(|e| (StatusCode::BAD_REQUEST, e))
+    let result = match b.runtime_backend.as_deref() {
+        None | Some("pi") => {
+            crate::chat::agent_chat(
+                &ctx.app,
+                &residency,
+                b.slot_id,
+                &session_id,
+                &b.prompt,
+                b.max_tokens,
+                b.capture_run_id.as_deref(),
+            )
+            .await
+        }
+        Some("native-rust-reference") => {
+            let run_id = b.capture_run_id.as_deref().ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "native-rust-reference requires capture_run_id".to_string(),
+                )
+            })?;
+            crate::chat::agent_chat_native_reference(
+                &ctx.app,
+                &residency,
+                b.slot_id,
+                &session_id,
+                &b.prompt,
+                b.max_tokens,
+                run_id,
+            )
+            .await
+        }
+        Some(value) => Err(format!(
+            "runtime_backend must be pi or native-rust-reference, got {value}"
+        )),
+    };
+    result
+        .map(|r| Json(json!(r)))
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))
 }
 async fn dossiers(
     State(ctx): State<Ctx>,

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -68,7 +68,7 @@
     {
       "id": "native-runtime-deletion",
       "status": "planned",
-      "evidence": "Deletion waits for the full genuine-run observation gate and conformance proof from the canonical runtime."
+      "evidence": "Deletion waits for the full genuine-run observation gate and conformance proof from the canonical runtime. A separate authenticated native reference adapter now forces the prompt-only Rust headless boundary and reports all richer frozen scenarios as explicit gaps rather than overstating parity."
     }
   ]
 }

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -79,6 +79,22 @@ npm run runtime:desktop-readiness -- \
 understudy desktop migration-status --require-ready --json
 ```
 
+The one-release Rust fallback can be measured separately without making it a
+promotion gate:
+
+```sh
+understudy runtime conformance \
+  --backend native \
+  --slot <warm-desktop-slot> \
+  --model <exact-served-model-id> \
+  --output .understudy/capture-evidence/native-rust-reference.json
+```
+
+This reference is intentionally incomplete. It forces the existing
+prompt-only headless Rust boundary and fails richer scenarios before execution;
+do not interpret synthetic event projection or a loopback provider as proof of
+native image, tool, cancellation, restart, compaction, or supervision parity.
+
 The command exits `2` while observation is incomplete. The underlying
 versioned Desktop API cohorts rows by both app version and canonical-runtime
 version; legacy and development rows remain in SQLite but cannot poison or

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -23,12 +23,19 @@ import {
   RUNTIME_VERSION,
 } from "../runtime/conversation/contract.js";
 import {
+  executeFrozenNativeDesktopReferenceScenario,
   executeFrozenConformanceScenario,
   runConversationAdapterConformance,
   runConversationConformance,
 } from "../runtime/conversation/conformance.js";
 import { runPiConversation } from "../runtime/conversation/pi-runtime.js";
 import { runVercelConversation } from "../runtime/conversation/vercel-runtime.js";
+import {
+  desktopApiFetch,
+  requireDesktopApi,
+  responseError,
+  type DesktopApiCapability,
+} from "../internal/desktop-api.js";
 
 function emit(command: Command, payload: Record<string, unknown>, human: string): void {
   if (isJsonMode(command)) {
@@ -53,6 +60,90 @@ function persistImmutableReport(path: string, report: unknown): string {
     closeSync(descriptor);
   }
   return target;
+}
+
+function positiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("value must be a positive integer");
+  }
+  return parsed;
+}
+
+function requiredNonNegativeInteger(
+  value: Record<string, unknown>,
+  key: string,
+): number {
+  const candidate = value[key];
+  if (!Number.isInteger(candidate) || (candidate as number) < 0) {
+    throw new Error(`native Rust reference returned invalid ${key}`);
+  }
+  return candidate as number;
+}
+
+async function requireNativeReferenceSlot(
+  capability: DesktopApiCapability,
+  slotId: number,
+  model: string,
+  timeoutMs: number,
+): Promise<void> {
+  const response = await desktopApiFetch(capability, "/v1/residency", {
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) throw await responseError(response);
+  const value = await response.json() as { slots?: unknown };
+  const slots = Array.isArray(value.slots) ? value.slots : [];
+  const slot = slots.find(
+    (candidate): candidate is Record<string, unknown> =>
+      Boolean(candidate) &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      (candidate as Record<string, unknown>).id === slotId,
+  );
+  if (!slot) throw new Error(`desktop residency slot ${slotId} does not exist`);
+  if (slot.state !== "running") {
+    throw new Error(`desktop residency slot ${slotId} is ${String(slot.state ?? "not running")}`);
+  }
+  if (slot.model_id !== model) {
+    throw new Error(
+      `desktop residency slot ${slotId} serves ${String(slot.model_id)}, not requested ${model}`,
+    );
+  }
+}
+
+async function runNativeDesktopReferenceCompletion(
+  capability: DesktopApiCapability,
+  slotId: number,
+  timeoutMs: number,
+  request: { run_id: string; session_id: string; prompt: string; max_tokens: number },
+) {
+  const response = await desktopApiFetch(capability, "/api/chat/completion", {
+    method: "POST",
+    body: JSON.stringify({
+      slot_id: slotId,
+      prompt: request.prompt,
+      session_id: request.session_id,
+      capture_run_id: request.run_id,
+      max_tokens: request.max_tokens,
+      runtime_backend: "native-rust-reference",
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) throw await responseError(response);
+  const value = await response.json() as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("native Rust reference returned a malformed completion");
+  }
+  const row = value as Record<string, unknown>;
+  return {
+    capture_run_id: String(row.capture_run_id ?? ""),
+    content: String(row.content ?? ""),
+    status: String(row.status ?? ""),
+    runtime_backend: String(row.runtime_backend ?? ""),
+    prompt_tokens: requiredNonNegativeInteger(row, "prompt_tokens"),
+    completion_tokens: requiredNonNegativeInteger(row, "completion_tokens"),
+    reasoning_tokens: requiredNonNegativeInteger(row, "reasoning_tokens"),
+  };
 }
 
 async function startDeterministicSupervisorFixture(): Promise<{
@@ -351,9 +442,10 @@ export function registerRuntimeCommand(program: Command): void {
     .command("conformance")
     .description("Verify immutable evidence or execute every frozen input through one adapter.")
     .option("--fixtures <path>", "Use a specific conformance fixture directory")
-    .option("--backend <backend>", "Execute inputs through pi or vercel")
+    .option("--backend <backend>", "Execute inputs through pi, vercel, or native")
     .option("--base-url <url>", "OpenAI-compatible provider base URL")
     .option("--model <id>", "Provider model identifier")
+    .option("--slot <id>", "Warm desktop slot for the native Rust reference", positiveInteger)
     .option("--student-base-url <url>", "Student provider URL for the supervision scenario")
     .option("--student-model <id>", "Student model for the supervision scenario")
     .option("--supervisor-base-url <url>", "Supervisor provider URL for the supervision scenario")
@@ -386,6 +478,7 @@ export function registerRuntimeCommand(program: Command): void {
         backend?: string;
         baseUrl?: string;
         model?: string;
+        slot?: number;
         studentBaseUrl?: string;
         studentModel?: string;
         supervisorBaseUrl?: string;
@@ -415,13 +508,20 @@ export function registerRuntimeCommand(program: Command): void {
           }
           return;
         }
-        if (!["pi", "vercel"].includes(options.backend)) {
-          throw new Error("--backend must be pi or vercel");
+        if (!["pi", "vercel", "native"].includes(options.backend)) {
+          throw new Error("--backend must be pi, vercel, or native");
         }
-        if (!options.baseUrl || !options.model) {
-          throw new Error("--backend requires --base-url and --model");
+        const backend = options.backend as "pi" | "vercel" | "native";
+        if (backend === "native") {
+          if (!options.model) throw new Error("--backend native requires --model");
+          if (!options.slot) throw new Error("--backend native requires --slot");
+          if (options.baseUrl) {
+            throw new Error("--backend native uses the authenticated desktop API, not --base-url");
+          }
+          if (options.allowRemote) throw new Error("--backend native cannot use --allow-remote");
+        } else if (!options.baseUrl || !options.model) {
+          throw new Error("--backend pi or vercel requires --base-url and --model");
         }
-        const backend = options.backend as "pi" | "vercel";
         if (options.deterministicSupervisor && backend !== "pi") {
           throw new Error("--deterministic-supervisor requires --backend pi");
         }
@@ -449,6 +549,15 @@ export function registerRuntimeCommand(program: Command): void {
           throw new Error("--scenario-timeout-ms must be an integer from 1000 to 600000");
         }
         const invocationId = `${Date.now()}-${process.pid}`;
+        const nativeCapability = backend === "native" ? await requireDesktopApi() : undefined;
+        if (nativeCapability) {
+          await requireNativeReferenceSlot(
+            nativeCapability,
+            options.slot!,
+            options.model,
+            scenarioTimeoutMs,
+          );
+        }
         const supervisorFixture = options.deterministicSupervisor
           ? await startDeterministicSupervisorFixture()
           : undefined;
@@ -456,8 +565,8 @@ export function registerRuntimeCommand(program: Command): void {
           ? await startDeterministicMalformedToolFixture()
           : undefined;
         const supervisorTarget = supervisorFixture?.target ?? {
-          base_url: options.supervisorBaseUrl ?? options.baseUrl,
-          model: options.supervisorModel ?? options.model,
+          base_url: options.supervisorBaseUrl ?? options.baseUrl!,
+          model: options.supervisorModel ?? options.model!,
         };
         let report;
         try {
@@ -467,7 +576,7 @@ export function registerRuntimeCommand(program: Command): void {
               capabilities,
               metadata: {
                 backend,
-                runtime_id: RUNTIME_ID,
+                runtime_id: backend === "native" ? "native-rust-reference" : RUNTIME_ID,
                 runtime_version: RUNTIME_VERSION,
                 event_schema: EVENT_SCHEMA,
                 conformance_schema: CONFORMANCE_SCHEMA,
@@ -477,34 +586,57 @@ export function registerRuntimeCommand(program: Command): void {
                   transformers_offline: process.env.TRANSFORMERS_OFFLINE === "1",
                   hf_datasets_offline: process.env.HF_DATASETS_OFFLINE === "1",
                 },
-                provider: { base_url: options.baseUrl, model: options.model },
-                supervision: {
-                  student: {
-                    base_url: options.studentBaseUrl ?? options.baseUrl,
-                    model: options.studentModel ?? options.model,
-                  },
-                  supervisor: {
-                    ...supervisorTarget,
-                  },
-                  teacher: {
-                    base_url: options.teacherBaseUrl ?? options.baseUrl,
-                    model: options.teacherModel ?? options.model,
-                  },
-                },
-                supervisor_mode: options.deterministicSupervisor
-                  ? "deterministic_fixture"
-                  : "model",
-                malformed_tool_mode: options.deterministicMalformedTool
-                  ? "deterministic_fixture"
-                  : "model",
-                compaction_mode: options.deterministicCompaction
-                  ? "deterministic_fixture"
-                  : "model",
+                provider: backend === "native"
+                  ? {
+                      base_url: nativeCapability!.baseUrl,
+                      model: options.model,
+                      slot_id: options.slot,
+                    }
+                  : { base_url: options.baseUrl, model: options.model },
+                ...(backend === "native"
+                  ? { evidence_projection: "legacy_prompt_only_completion_summary" }
+                  : {
+                      supervision: {
+                        student: {
+                          base_url: options.studentBaseUrl ?? options.baseUrl,
+                          model: options.studentModel ?? options.model,
+                        },
+                        supervisor: {
+                          ...supervisorTarget,
+                        },
+                        teacher: {
+                          base_url: options.teacherBaseUrl ?? options.baseUrl,
+                          model: options.teacherModel ?? options.model,
+                        },
+                      },
+                      supervisor_mode: options.deterministicSupervisor
+                        ? "deterministic_fixture"
+                        : "model",
+                      malformed_tool_mode: options.deterministicMalformedTool
+                        ? "deterministic_fixture"
+                        : "model",
+                      compaction_mode: options.deterministicCompaction
+                        ? "deterministic_fixture"
+                        : "model",
+                    }),
                 scenario_timeout_ms: scenarioTimeoutMs,
                 tool_executor_configured: Boolean(options.toolExecutorUrl),
                 allow_remote: options.allowRemote ?? false,
               },
               async run(input) {
+                if (backend === "native") {
+                  return executeFrozenNativeDesktopReferenceScenario(input, {
+                    model: options.model!,
+                    invocation_id: invocationId,
+                    complete: (request) =>
+                      runNativeDesktopReferenceCompletion(
+                        nativeCapability!,
+                        options.slot!,
+                        scenarioTimeoutMs,
+                        request,
+                      ),
+                  });
+                }
                 return executeFrozenConformanceScenario(input, run, {
                   backend,
                   base_url: options.baseUrl!,

--- a/src/runtime/conversation/conformance.ts
+++ b/src/runtime/conversation/conformance.ts
@@ -5,9 +5,11 @@ import { fileURLToPath } from "node:url";
 
 import {
   CONFORMANCE_SCHEMA,
+  EVENT_SCHEMA,
   parseRuntimeInputFixture,
   validateRuntimeTrace,
   type EmitRuntimeEvent,
+  type RuntimeEventName,
   type RuntimeInputFixture,
 } from "./contract.js";
 
@@ -87,6 +89,27 @@ export type ExecutableConformanceOptions = {
   teacher?: RuntimeConformanceProviderTarget;
   malformed_tool?: RuntimeConformanceProviderTarget;
   deterministic_compaction?: boolean;
+};
+
+export type NativeDesktopReferenceResult = {
+  capture_run_id: string;
+  content: string;
+  status: string;
+  runtime_backend: string;
+  prompt_tokens: number;
+  completion_tokens: number;
+  reasoning_tokens: number;
+};
+
+export type NativeDesktopReferenceOptions = {
+  model: string;
+  invocation_id: string;
+  complete(request: {
+    run_id: string;
+    session_id: string;
+    prompt: string;
+    max_tokens: number;
+  }): Promise<NativeDesktopReferenceResult>;
 };
 
 export type RuntimeConformanceScenarioResult = {
@@ -451,6 +474,96 @@ export async function executeFrozenConformanceScenario(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * Exercise the legacy Rust fallback through its existing prompt-only headless
+ * boundary. Unsupported frozen scenarios fail before any request is sent; the
+ * reference report must expose those gaps instead of projecting richer
+ * canonical evidence around a narrower call.
+ */
+export async function executeFrozenNativeDesktopReferenceScenario(
+  input: RuntimeInputFixture,
+  options: NativeDesktopReferenceOptions,
+): Promise<readonly unknown[]> {
+  if (
+    input.fixture_id !== "basic-chat" ||
+    input.messages.length !== 1 ||
+    input.messages[0]?.role !== "user" ||
+    (input.messages[0].attachments?.length ?? 0) > 0 ||
+    input.tools.length > 0
+  ) {
+    throw new Error(
+      `native Rust reference does not expose canonical ${input.fixture_id} execution through its prompt-only headless boundary`,
+    );
+  }
+  const runId = `conformance-native-${input.fixture_id}-${options.invocation_id}`;
+  const sessionId = runId;
+  const prompt = input.messages[0].content;
+  const result = await options.complete({
+    run_id: runId,
+    session_id: sessionId,
+    prompt,
+    max_tokens: 256,
+  });
+  if (result.capture_run_id !== runId) {
+    throw new Error(
+      `native Rust reference changed run identity: expected ${runId}, got ${result.capture_run_id}`,
+    );
+  }
+  if (result.runtime_backend !== "native-rust") {
+    throw new Error(
+      `desktop did not force the native Rust reference; observed ${result.runtime_backend}`,
+    );
+  }
+  if (result.status !== "ok" || result.content.trim().length === 0) {
+    throw new Error(`native Rust reference ended with ${result.status || "unknown status"}`);
+  }
+  for (const [label, value] of Object.entries({
+    prompt_tokens: result.prompt_tokens,
+    completion_tokens: result.completion_tokens,
+    reasoning_tokens: result.reasoning_tokens,
+  })) {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new Error(`native Rust reference returned invalid ${label}`);
+    }
+  }
+  const emittedAt = new Date().toISOString();
+  const envelope = (
+    sequence: number,
+    event: RuntimeEventName,
+    data: Record<string, unknown>,
+  ) => ({
+    schema_version: EVENT_SCHEMA,
+    event_id: `${runId}:${sequence}`,
+    run_id: runId,
+    session_id: sessionId,
+    runtime_id: "native-rust-reference",
+    sequence,
+    emitted_at: emittedAt,
+    event,
+    data,
+  });
+  return [
+    envelope(0, "message", { role: "user", text: prompt }),
+    envelope(1, "delta", {
+      role: "primary",
+      text: result.content,
+      model: options.model,
+    }),
+    envelope(2, "usage", {
+      role: "primary",
+      model: options.model,
+      input_tokens: result.prompt_tokens,
+      output_tokens: result.completion_tokens,
+      reasoning_tokens: result.reasoning_tokens,
+      cached_input_tokens: 0,
+      total_tokens:
+        result.prompt_tokens + result.completion_tokens + result.reasoning_tokens,
+      source: "estimated",
+      complete: false,
+    }),
+  ];
 }
 
 /** Execute every frozen input through one real adapter and retain failures. */

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1114,6 +1114,19 @@ describe("understudy CLI", () => {
     assert.match(result.stderr, /requires --base-url and --model/);
   });
 
+  it("requires an explicit warm slot for the native Rust reference", () => {
+    const result = run([
+      "runtime",
+      "conformance",
+      "--backend",
+      "native",
+      "--model",
+      "understudy-reference-model",
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--backend native requires --slot/);
+  });
+
   it("rejects removed full runtime commands", () => {
     const result = run(["gateway", "--port", "23333"]);
     assert.notEqual(result.status, 0);

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -30,6 +30,7 @@ import {
 } from "../dist/runtime/conversation/contract.js";
 import {
   executeFrozenConformanceScenario,
+  executeFrozenNativeDesktopReferenceScenario,
   runConversationAdapterConformance,
   runConversationConformance,
   validateScenarioEvidence,
@@ -2569,6 +2570,171 @@ test("packaged immutable suite passes hashes and canonical trace gates", () => {
       "cancellation",
     ],
   );
+});
+
+test("native Rust reference wraps only the exact prompt-only boundary", async () => {
+  const calls = [];
+  const events = await executeFrozenNativeDesktopReferenceScenario(basicChatFixture, {
+    model: "understudy-reference-model",
+    invocation_id: "native-test",
+    async complete(request) {
+      calls.push(request);
+      return {
+        capture_run_id: request.run_id,
+        content: "The local fixture passed.",
+        status: "ok",
+        runtime_backend: "native-rust",
+        prompt_tokens: 4,
+        completion_tokens: 5,
+        reasoning_tokens: 0,
+      };
+    },
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].prompt, "Run the local fixture.");
+  assert.doesNotThrow(() => validateScenarioEvidence(basicChatFixture, events));
+  assert.equal(events[0].runtime_id, "native-rust-reference");
+  assert.equal(events[0].run_id, "conformance-native-basic-chat-native-test");
+  assert.equal(events[1].data.model, "understudy-reference-model");
+  assert.deepEqual(events[2].data, {
+    role: "primary",
+    model: "understudy-reference-model",
+    input_tokens: 4,
+    output_tokens: 5,
+    reasoning_tokens: 0,
+    cached_input_tokens: 0,
+    total_tokens: 9,
+    source: "estimated",
+    complete: false,
+  });
+
+  const image = JSON.parse(
+    readFileSync(
+      new URL(
+        "../schemas/conversation-runtime-conformance/inputs/offline-image.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  await assert.rejects(
+    () =>
+      executeFrozenNativeDesktopReferenceScenario(image, {
+        model: "understudy-reference-model",
+        invocation_id: "native-test",
+        async complete(request) {
+          calls.push(request);
+          throw new Error("must not execute");
+        },
+      }),
+    /does not expose canonical offline-image execution/,
+  );
+  assert.equal(calls.length, 1, "unsupported inputs must fail before the desktop call");
+});
+
+test("native CLI adapter forces the authenticated desktop reference and reports honest gaps", async () => {
+  const requests = [];
+  const token = "native-reference-test-token".padEnd(64, "x");
+  const server = createServer(async (request, response) => {
+    if (request.url === "/health") {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("ok");
+      return;
+    }
+    if (request.headers.authorization !== `Bearer ${token}`) {
+      response.writeHead(401);
+      response.end("unauthorized");
+      return;
+    }
+    if (request.method === "GET" && request.url === "/v1/residency") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        slots: [
+          { id: 7, model_id: "understudy-reference-model", state: "running" },
+        ],
+      }));
+      return;
+    }
+    if (request.method === "POST" && request.url === "/api/chat/completion") {
+      const body = await requestJson(request);
+      requests.push(body);
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        capture_run_id: body.capture_run_id,
+        content: "The local fixture passed.",
+        status: "ok",
+        runtime_backend: "native-rust",
+        prompt_tokens: 4,
+        completion_tokens: 5,
+        reasoning_tokens: 0,
+      }));
+      return;
+    }
+    response.writeHead(404);
+    response.end("not found");
+  });
+  const home = mkdtempSync(join(tmpdir(), "understudy-native-reference-"));
+  try {
+    await new Promise((accept) => server.listen(0, "127.0.0.1", accept));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const capabilityPath = join(home, "desktop-api.json");
+    writeFileSync(
+      capabilityPath,
+      JSON.stringify({
+        schema_version: "understudy.desktop_api.v2",
+        base_url: `http://127.0.0.1:${address.port}`,
+        token,
+        pid: process.pid,
+        app_version: "0.3.5",
+      }),
+      { mode: 0o600 },
+    );
+    const result = await runCli(
+      [
+        "runtime",
+        "conformance",
+        "--backend",
+        "native",
+        "--slot",
+        "7",
+        "--model",
+        "understudy-reference-model",
+        "--scenario-timeout-ms",
+        "5000",
+        "--json",
+      ],
+      { UNDERSTUDY_DESKTOP_API_FILE: capabilityPath },
+    );
+    assert.equal(result.code, 1, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.adapter_id, "native");
+    assert.equal(report.passed, false);
+    assert.equal(report.complete, false);
+    assert.equal(report.eligible_for_promotion, false);
+    assert.equal(report.metadata.runtime_id, "native-rust-reference");
+    assert.equal(report.metadata.evidence_projection, "legacy_prompt_only_completion_summary");
+    assert.deepEqual(
+      Object.fromEntries(report.scenarios.map((scenario) => [scenario.id, scenario.status])),
+      {
+        "basic-chat": "passed",
+        "offline-image": "failed",
+        "tool-round": "failed",
+        "malformed-tool-call": "failed",
+        "supervisor-takeover": "not_applicable",
+        "long-chat-compaction": "not_applicable",
+        "restart-resume": "not_applicable",
+        cancellation: "failed",
+      },
+    );
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].runtime_backend, "native-rust-reference");
+    assert.equal(requests[0].prompt, "Run the local fixture.");
+    assert.match(requests[0].capture_run_id, /^conformance-native-basic-chat-/);
+  } finally {
+    await new Promise((accept) => server.close(() => accept()));
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("remote model endpoints fail closed unless both gates are enabled", async () => {


### PR DESCRIPTION
## Summary

- add `understudy runtime conformance --backend native --slot … --model …` over the owner-only Desktop API
- force the one-release Rust fallback only for the exact frozen `basic-chat` identity and prompt
- verify the warm slot, served model, exact run id, native backend, bounded timeout, and estimated model attribution
- fail richer image/tool/malformed-tool/cancellation cases before Desktop execution and keep supervision/compaction/restart explicitly not applicable
- document that this is an incomplete migration baseline, never a promotion gate

This does not add supervision, image, tool, cancellation, compaction, or restart behavior to the legacy Rust harness. It makes the current gap measurable without synthetic parity.

## Verification

- `npm run check` (262 tests, 33 public skills, package smoke)
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` (163 passed, 4 opt-in real-data tests ignored)
- focused native Rust guard test after the final scope restriction
- end-to-end fake Desktop CLI test proves authentication, slot/model identity, force-native request, one real call, and the exact incomplete matrix
- `git diff --check`

`cargo fmt --check` still reports only the pre-existing unrelated formatting drift in `supervision_tiebreaker.rs`; touched Rust is formatted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->