### PR TITLE
Resolve Desktop slot identities for conformance

### DIFF
--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -47,6 +47,9 @@ pub struct PersistedSlot {
 pub struct SlotView {
     pub id: u32,
     pub model_id: Option<String>,
+    /// Exact local provider identity. MLX accepts this weights path even when
+    /// a catalog alias differs from the id exposed by the server.
+    pub model_path: Option<String>,
     pub state: String, // running | loading | stopped | error
     pub port: Option<u16>,
     pub mem_gb: f32,
@@ -632,6 +635,7 @@ impl Residency {
             .map(|r| SlotView {
                 id: r.id,
                 model_id: r.model_id.clone(),
+                model_path: r.model_path.clone(),
                 state: r.state.as_str().to_string(),
                 port: r.port,
                 mem_gb: r.mem_gb,

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -1,6 +1,8 @@
 {
-  "manifest_version": 1,
+  "manifest_version": 2,
   "release_authority": "apps/homescreen",
+  "distribution_authority": "@understudylabs/understudy-agent-tools",
+  "external_research_bridge_policy": "documented_uv_bridge_only",
   "legacy_desktop_policy": "extraction_only",
   "migration_complete": false,
   "status_values": [
@@ -9,11 +11,111 @@
     "planned",
     "retired"
   ],
+  "legacy_inventory": {
+    "scope": "Final legacy production-only files absent from the canonical desktop tree.",
+    "audited_file_count": 30,
+    "disposition_values": [
+      "port_capability",
+      "superseded",
+      "retired"
+    ],
+    "groups": [
+      {
+        "disposition": "port_capability",
+        "target_feature": "drop-to-workload-compilation",
+        "files": [
+          "app/components/DropAnalysisCards.tsx"
+        ]
+      },
+      {
+        "disposition": "port_capability",
+        "target_feature": "model-card-transparency",
+        "files": [
+          "app/components/ModelCardDrawer.tsx",
+          "app/lib/model-cards.ts",
+          "app/lib/useActiveExperiment.ts"
+        ]
+      },
+      {
+        "disposition": "port_capability",
+        "target_feature": "reading-pace-streaming",
+        "files": [
+          "app/lib/stream-pacer.test.ts",
+          "app/lib/stream-pacer.ts"
+        ]
+      },
+      {
+        "disposition": "superseded",
+        "replacement": "The compact Review -> Compare -> Improve hub and CLI-owned evidence ledger.",
+        "files": [
+          "app/components/ExperimentsPane.tsx",
+          "app/lib/scatter-math.test.ts",
+          "app/lib/scatter-math.ts"
+        ]
+      },
+      {
+        "disposition": "superseded",
+        "replacement": "The authenticated Desktop API and the public CLI; no unauthenticated environment bridge.",
+        "files": [
+          "app/lib/env-bridge.test.ts",
+          "app/lib/env-bridge.ts"
+        ]
+      },
+      {
+        "disposition": "superseded",
+        "replacement": "Canonical Pi journals, the supervision review projection, and correction-pair export.",
+        "files": [
+          "app/lib/supervision-evidence.test.ts",
+          "app/lib/supervision-evidence.ts",
+          "app/lib/supervision-review.test.ts",
+          "src-tauri/src/supervision.rs"
+        ]
+      },
+      {
+        "disposition": "superseded",
+        "replacement": "Inline canonical runtime stages and quiet fallback notices.",
+        "files": [
+          "app/lib/sidekick-toasts.test.ts",
+          "app/lib/sidekick-toasts.ts"
+        ]
+      },
+      {
+        "disposition": "superseded",
+        "replacement": "CLI-owned frozen tool proof, immutable event evidence, Pi tool rounds, command guard, and SQLite chat persistence.",
+        "files": [
+          "src-tauri/src/bench.rs",
+          "src-tauri/src/capture.rs",
+          "src-tauri/src/chat_history.rs",
+          "src-tauri/src/executor.rs",
+          "src-tauri/src/tool_round.rs"
+        ]
+      },
+      {
+        "disposition": "retired",
+        "replacement": "Removed debug telemetry, duplicate charting, global toast, and content-bearing UI-state surfaces from the minimal local-first app.",
+        "files": [
+          "app/components/PerfOverlay.tsx",
+          "app/components/base-ui/sonner.tsx",
+          "app/components/ui/chart.tsx",
+          "app/lib/frame-stats.test.ts",
+          "app/lib/frame-stats.ts",
+          "app/lib/telemetry.ts",
+          "app/lib/ui-snapshot.ts",
+          "src-tauri/src/ui_state.rs"
+        ]
+      }
+    ]
+  },
   "features": [
     {
       "id": "canonical-conversation-runtime",
       "status": "shipped",
       "evidence": "Provider-neutral events, Pi and Vercel adapters, immutable run journals, and the one-release native fallback are present."
+    },
+    {
+      "id": "desktop-slot-provider-identity",
+      "status": "shipped",
+      "evidence": "Authenticated residency snapshots expose the exact local weights path and port. Pi and Vercel conformance can resolve those values from one warm slot and reject manual alias overrides, preventing catalog names from producing false runtime failures."
     },
     {
       "id": "reviewed-desktop-shell",
@@ -59,6 +161,36 @@
       "id": "unified-experiment-hub",
       "status": "shipped",
       "evidence": "Experiments presents one compact Review -> Compare -> Improve loop. The public CLI owns the fixed 17-task regression suite and 30-task promotion suite, direct Pi execution, serial residency isolation, exact trace scoring, suite and tool-schema hashes, owner-only canonical event evidence, and immutable failed-case improvement packets. Desktop is a bounded adapter: it preflights two distinct warm models, fixes promotion at three repetitions, reports strict model misses separately from terminal runtime errors, and refuses promotion when task bytes, result rows, event files, permissions, hashes, or attempt counts are incomplete. No cloud call or upload occurs."
+    },
+    {
+      "id": "experiment-ledger-first-run",
+      "status": "shipped",
+      "evidence": "A clean install offers one local Create ledger action. It idempotently creates the canonical index.jsonl and append-only rounds.jsonl without truncating a partially initialized ledger, then opens the empty experiment view."
+    },
+    {
+      "id": "drop-to-workload-compilation",
+      "status": "planned",
+      "evidence": "The legacy drop analyzer was coupled to an unauthenticated Python environment bridge, private workflow links, and duplicate chart dependencies. Preserve the user outcome by routing a local file or directory into the public CLI workload compiler and bounded result cards; do not port that bridge or UI wholesale."
+    },
+    {
+      "id": "model-card-transparency",
+      "status": "planned",
+      "evidence": "The canonical model list still needs one compact drawer for provenance, decode contract, certification, footprint, routing hints, and active-experiment context sourced from public model manifests."
+    },
+    {
+      "id": "reading-pace-streaming",
+      "status": "planned",
+      "evidence": "The tested reading-rate buffer and skip affordance remain absent. Port only after a small usability check proves that display pacing reduces disorientation without making local answers feel artificially slow; retain an immediate-display escape hatch."
+    },
+    {
+      "id": "always-on-top-window-pin",
+      "status": "planned",
+      "evidence": "The reviewed desktop supported a persisted, user-controlled always-on-top pin. The canonical shell does not yet expose it, despite the low implementation cost and usefulness while working alongside an editor or terminal."
+    },
+    {
+      "id": "heavy-model-preflight-and-process-reconciliation",
+      "status": "partial",
+      "evidence": "Residency now fail-closes unsafe memory plans, cools before warming, serializes heavy experiments, waits for Metal teardown, and never auto-restores heavy models. It still needs a plain-language pre-warm warning and durable reconciliation of model-server ownership after an app crash so an orphan cannot overlap a newly launched server."
     },
     {
       "id": "legacy-desktop-retirement-guard",

--- a/schemas/understudy.desktop_api.v2.openapi.json
+++ b/schemas/understudy.desktop_api.v2.openapi.json
@@ -819,6 +819,13 @@
                     "null"
                   ]
                 },
+                "model_path": {
+                  "description": "Exact local weights path accepted by the slot's provider server.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "state": {
                   "type": "string",
                   "enum": [

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -33,6 +33,7 @@ import { runVercelConversation } from "../runtime/conversation/vercel-runtime.js
 import {
   desktopApiFetch,
   requireDesktopApi,
+  resolveDesktopSlotProviderTarget,
   responseError,
   type DesktopApiCapability,
 } from "../internal/desktop-api.js";
@@ -445,7 +446,11 @@ export function registerRuntimeCommand(program: Command): void {
     .option("--backend <backend>", "Execute inputs through pi, vercel, or native")
     .option("--base-url <url>", "OpenAI-compatible provider base URL")
     .option("--model <id>", "Provider model identifier")
-    .option("--slot <id>", "Warm desktop slot for the native Rust reference", positiveInteger)
+    .option(
+      "--slot <id>",
+      "Warm desktop slot (auto-resolves the exact local Pi/Vercel provider identity)",
+      positiveInteger,
+    )
     .option("--student-base-url <url>", "Student provider URL for the supervision scenario")
     .option("--student-model <id>", "Student model for the supervision scenario")
     .option("--supervisor-base-url <url>", "Supervisor provider URL for the supervision scenario")
@@ -519,7 +524,11 @@ export function registerRuntimeCommand(program: Command): void {
             throw new Error("--backend native uses the authenticated desktop API, not --base-url");
           }
           if (options.allowRemote) throw new Error("--backend native cannot use --allow-remote");
-        } else if (!options.baseUrl || !options.model) {
+        } else if (options.slot && (options.baseUrl || options.model)) {
+          throw new Error(
+            "--slot resolves --base-url and --model from Desktop; do not combine them",
+          );
+        } else if (!options.slot && (!options.baseUrl || !options.model)) {
           throw new Error("--backend pi or vercel requires --base-url and --model");
         }
         if (options.deterministicSupervisor && backend !== "pi") {
@@ -554,10 +563,22 @@ export function registerRuntimeCommand(program: Command): void {
           await requireNativeReferenceSlot(
             nativeCapability,
             options.slot!,
-            options.model,
+            options.model!,
             scenarioTimeoutMs,
           );
         }
+        const desktopSlotCapability = backend !== "native" && options.slot
+          ? await requireDesktopApi()
+          : undefined;
+        const desktopSlotTarget = desktopSlotCapability
+          ? await resolveDesktopSlotProviderTarget(
+              desktopSlotCapability,
+              options.slot!,
+              scenarioTimeoutMs,
+            )
+          : undefined;
+        const providerBaseUrl = desktopSlotTarget?.baseUrl ?? options.baseUrl!;
+        const providerModel = desktopSlotTarget?.model ?? options.model!;
         const supervisorFixture = options.deterministicSupervisor
           ? await startDeterministicSupervisorFixture()
           : undefined;
@@ -565,8 +586,8 @@ export function registerRuntimeCommand(program: Command): void {
           ? await startDeterministicMalformedToolFixture()
           : undefined;
         const supervisorTarget = supervisorFixture?.target ?? {
-          base_url: options.supervisorBaseUrl ?? options.baseUrl!,
-          model: options.supervisorModel ?? options.model!,
+          base_url: options.supervisorBaseUrl ?? providerBaseUrl,
+          model: options.supervisorModel ?? providerModel,
         };
         let report;
         try {
@@ -592,21 +613,31 @@ export function registerRuntimeCommand(program: Command): void {
                       model: options.model,
                       slot_id: options.slot,
                     }
-                  : { base_url: options.baseUrl, model: options.model },
+                  : {
+                      base_url: providerBaseUrl,
+                      model: providerModel,
+                      ...(desktopSlotTarget
+                        ? {
+                            slot_id: desktopSlotTarget.slotId,
+                            artifact_id: desktopSlotTarget.artifactId,
+                            identity_source: "desktop_residency_model_path",
+                          }
+                        : {}),
+                    },
                 ...(backend === "native"
                   ? { evidence_projection: "legacy_prompt_only_completion_summary" }
                   : {
                       supervision: {
                         student: {
-                          base_url: options.studentBaseUrl ?? options.baseUrl,
-                          model: options.studentModel ?? options.model,
+                          base_url: options.studentBaseUrl ?? providerBaseUrl,
+                          model: options.studentModel ?? providerModel,
                         },
                         supervisor: {
                           ...supervisorTarget,
                         },
                         teacher: {
-                          base_url: options.teacherBaseUrl ?? options.baseUrl,
-                          model: options.teacherModel ?? options.model,
+                          base_url: options.teacherBaseUrl ?? providerBaseUrl,
+                          model: options.teacherModel ?? providerModel,
                         },
                       },
                       supervisor_mode: options.deterministicSupervisor
@@ -639,22 +670,22 @@ export function registerRuntimeCommand(program: Command): void {
                 }
                 return executeFrozenConformanceScenario(input, run, {
                   backend,
-                  base_url: options.baseUrl!,
-                  model: options.model!,
+                  base_url: providerBaseUrl,
+                  model: providerModel,
                   invocation_id: invocationId,
                   scenario_timeout_ms: scenarioTimeoutMs,
                   tool_executor_url: options.toolExecutorUrl,
                   allow_remote: options.allowRemote,
                   student: {
-                    base_url: options.studentBaseUrl ?? options.baseUrl!,
-                    model: options.studentModel ?? options.model!,
+                    base_url: options.studentBaseUrl ?? providerBaseUrl,
+                    model: options.studentModel ?? providerModel,
                   },
                   supervisor: {
                     ...supervisorTarget,
                   },
                   teacher: {
-                    base_url: options.teacherBaseUrl ?? options.baseUrl!,
-                    model: options.teacherModel ?? options.model!,
+                    base_url: options.teacherBaseUrl ?? providerBaseUrl,
+                    model: options.teacherModel ?? providerModel,
                   },
                   malformed_tool: malformedToolFixture?.target,
                   deterministic_compaction: options.deterministicCompaction,

--- a/src/internal/desktop-api.ts
+++ b/src/internal/desktop-api.ts
@@ -43,6 +43,13 @@ export interface DesktopApiCapability {
   path: string;
 }
 
+export interface DesktopSlotProviderTarget {
+  slotId: number;
+  artifactId: string;
+  baseUrl: string;
+  model: string;
+}
+
 export function desktopApiPath(): string {
   return process.env.UNDERSTUDY_DESKTOP_API_FILE ??
     join(homedir(), ".understudy", "desktop-api.json");
@@ -143,6 +150,60 @@ export async function desktopApiFetchCompat(
   const response = await desktopApiFetch(capability, versionedPath, init);
   if (response.status !== 404) return response;
   return desktopApiFetch(capability, legacyPath, init);
+}
+
+/**
+ * Resolve one live Desktop residency slot into the exact OpenAI-compatible
+ * provider identity used by the app. MLX accepts the weights path reliably;
+ * a catalog/artifact alias may not match the model id exposed by the server.
+ */
+export async function resolveDesktopSlotProviderTarget(
+  capability: DesktopApiCapability,
+  slotId: number,
+  timeoutMs: number = 1_500,
+): Promise<DesktopSlotProviderTarget> {
+  const response = await desktopApiFetchCompat(
+    capability,
+    "/v1/residency",
+    "/api/residency",
+    { signal: AbortSignal.timeout(timeoutMs) },
+  );
+  if (!response.ok) throw await responseError(response);
+  const value = await response.json() as { slots?: unknown };
+  const slots = Array.isArray(value.slots) ? value.slots : [];
+  const slot = slots.find(
+    (candidate): candidate is Record<string, unknown> =>
+      Boolean(candidate) &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      (candidate as Record<string, unknown>).id === slotId,
+  );
+  if (!slot) throw new Error(`desktop residency slot ${slotId} does not exist`);
+  if (slot.state !== "running") {
+    throw new Error(`desktop residency slot ${slotId} is ${String(slot.state ?? "not running")}`);
+  }
+  if (
+    typeof slot.port !== "number" ||
+    !Number.isInteger(slot.port) ||
+    slot.port < 1 ||
+    slot.port > 65_535
+  ) {
+    throw new Error(`desktop residency slot ${slotId} has no valid provider port`);
+  }
+  if (typeof slot.model_path !== "string" || slot.model_path.trim() === "") {
+    throw new Error(
+      `desktop residency slot ${slotId} does not expose its exact model path; update Understudy Desktop`,
+    );
+  }
+  if (typeof slot.model_id !== "string" || slot.model_id.trim() === "") {
+    throw new Error(`desktop residency slot ${slotId} has no assigned model id`);
+  }
+  return {
+    slotId,
+    artifactId: slot.model_id,
+    baseUrl: `http://127.0.0.1:${slot.port}/v1`,
+    model: slot.model_path,
+  };
 }
 
 export async function responseError(response: Response): Promise<Error> {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1114,6 +1114,23 @@ describe("understudy CLI", () => {
     assert.match(result.stderr, /requires --base-url and --model/);
   });
 
+  it("does not let manual aliases override a desktop slot identity", () => {
+    const result = run([
+      "runtime",
+      "conformance",
+      "--backend",
+      "pi",
+      "--slot",
+      "7",
+      "--base-url",
+      "http://127.0.0.1:8096/v1",
+      "--model",
+      "understudy-small",
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--slot resolves --base-url and --model/);
+  });
+
   it("requires an explicit warm slot for the native Rust reference", () => {
     const result = run([
       "runtime",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -14,6 +14,10 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 
+import {
+  resolveDesktopSlotProviderTarget,
+} from "../dist/internal/desktop-api.js";
+
 const cli = ["node", resolve("dist/bin.js")];
 const root = mkdtempSync(join(tmpdir(), "understudy-desktop-api-"));
 const capabilityPath = join(root, "desktop-api.json");
@@ -193,7 +197,13 @@ before(async () => {
       "GET /v1/models": [{ id: "understudy-small", ready: true }],
       "GET /v1/models/catalog": [{ id: "understudy-small", tier: "small" }],
       "GET /v1/residency": {
-        slots: [{ id: 7, state: "running", model_id: "understudy-small" }],
+        slots: [{
+          id: 7,
+          state: "running",
+          model_id: "understudy-small",
+          model_path: "/models/understudy-small",
+          port: 8096,
+        }],
         used_gb: 2,
         usable_gb: 8,
       },
@@ -449,6 +459,10 @@ describe("desktop API CLI", () => {
         "cancellation", "error", "image_attachment", "compaction_boundary",
       ],
     );
+    assert.deepEqual(
+      contract.components.schemas.ResidencySnapshot.properties.slots.items.properties.model_path.type,
+      ["string", "null"],
+    );
     const pairSchema = JSON.parse(readFileSync(
       resolve("schemas/understudy.correction_pair.v1.schema.json"),
       "utf8",
@@ -619,6 +633,26 @@ describe("desktop API CLI", () => {
       model_id: "understudy-small",
     });
     assert.equal(mcpCalls.length, 0, "the public CLI must not tunnel stable controls through MCP");
+  });
+
+  it("resolves a warm slot to its exact local provider identity", async () => {
+    const target = await resolveDesktopSlotProviderTarget(
+      {
+        schemaVersion: "understudy.desktop_api.v2",
+        baseUrl: `http://127.0.0.1:${port}`,
+        token,
+        pid: process.pid,
+        appVersion: "test",
+        path: capabilityPath,
+      },
+      7,
+    );
+    assert.deepEqual(target, {
+      slotId: 7,
+      artifactId: "understudy-small",
+      baseUrl: "http://127.0.0.1:8096/v1",
+      model: "/models/understudy-small",
+    });
   });
 
   it("streams canonical image-chat events with caller-owned identity", async () => {

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -209,6 +209,8 @@ test("remote review is opt-in, CLI-owned, and never replaces the human label", a
 test("desktop migration claims stay tied to explicit product parity", async () => {
   const parity = JSON.parse(await readFile(parityPath, "utf8"));
   assert.equal(parity.release_authority, "apps/homescreen");
+  assert.equal(parity.distribution_authority, "@understudylabs/understudy-agent-tools");
+  assert.equal(parity.external_research_bridge_policy, "documented_uv_bridge_only");
   assert.equal(parity.legacy_desktop_policy, "extraction_only");
   const ids = parity.features.map((feature) => feature.id);
   assert.equal(new Set(ids).size, ids.length, "parity feature ids must remain unique");
@@ -221,6 +223,12 @@ test("desktop migration claims stay tied to explicit product parity", async () =
     "correction-pair-export-and-metrics",
     "remote-review-tiebreaker",
     "unified-experiment-hub",
+    "experiment-ledger-first-run",
+    "drop-to-workload-compilation",
+    "model-card-transparency",
+    "reading-pace-streaming",
+    "always-on-top-window-pin",
+    "heavy-model-preflight-and-process-reconciliation",
     "native-runtime-deletion",
   ]) {
     assert.ok(ids.includes(required), `parity manifest is missing ${required}`);
@@ -252,6 +260,21 @@ test("desktop migration claims stay tied to explicit product parity", async () =
   for (const feature of parity.features) {
     assert.ok(parity.status_values.includes(feature.status), `${feature.id} has an unknown status`);
     assert.ok(feature.evidence.length > 20, `${feature.id} needs concrete evidence`);
+  }
+  const dispositionGroups = parity.legacy_inventory.groups;
+  const legacyFiles = dispositionGroups.flatMap((group) => group.files);
+  assert.equal(legacyFiles.length, parity.legacy_inventory.audited_file_count);
+  assert.equal(new Set(legacyFiles).size, legacyFiles.length, "legacy files need one disposition");
+  for (const group of dispositionGroups) {
+    assert.ok(
+      parity.legacy_inventory.disposition_values.includes(group.disposition),
+      `unknown legacy disposition ${group.disposition}`,
+    );
+    if (group.disposition === "port_capability") {
+      assert.ok(ids.includes(group.target_feature), `${group.target_feature} needs a parity feature`);
+    } else {
+      assert.ok(group.replacement.length > 20, `${group.disposition} needs a replacement rationale`);
+    }
   }
   const actuallyComplete = parity.features.every((feature) =>
     ["shipped", "retired"].includes(feature.status),


### PR DESCRIPTION
## What changed
- resolve Pi and Vercel conformance targets from one authenticated warm Desktop slot
- use the exact MLX weights path and reject manual alias overrides
- expose the exact path in the authenticated residency contract
- turn the Train migration claim into a 30-file disposition ledger with explicit remaining product gaps

## Verification
- npm run check: 264 tests passed
- cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml --lib: 164 passed, 4 ignored
- rustfmt --check on the changed Rust file
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->