### PR TITLE
fix(desktop): reconcile local model processes

### DIFF
--- a/apps/homescreen/app/components/ModelsPane.tsx
+++ b/apps/homescreen/app/components/ModelsPane.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { curatedBenchmarks, curatedRoutes, type MarketEntry, type Provider } from "../lib/catalog";
 import { Button } from "./ui/Button";
+import { modelMemoryWarning } from "../lib/model-memory.mjs";
 
 type Dossier = {
   id: string;
@@ -172,6 +173,9 @@ export function ModelsPane() {
     snapshots.find((s) => s.name === selected) ??
     snapshots.find((s) => selectedLower === s.id.toLowerCase() || selectedLower === s.name.toLowerCase()) ??
     null;
+  const snapshotMemoryWarning = snapshot
+    ? modelMemoryWarning(snapshot.id, snapshot.approx_gb, null)
+    : null;
   const aaRow = aa?.find((a) => a.name.toLowerCase().includes(firstWord)) ?? null;
   const selectedRoute =
     marketRows.find((r) => r.display_name === selected) ??
@@ -231,6 +235,11 @@ export function ModelsPane() {
               <Tag>{snapshot.cached ? "cached" : "not cached"}</Tag>
               <Tag>{snapshot.manifest ? "manifest" : "manifest pending"}</Tag>
             </div>
+            {snapshotMemoryWarning && (
+              <div className="mb-2 text-[11px] leading-snug text-warn" role="note">
+                {snapshotMemoryWarning}
+              </div>
+            )}
             <pre className="whitespace-pre-wrap font-sans text-[13px] leading-relaxed text-ink">{snapshot.notes}</pre>
             <KV k="model id">{snapshot.id}</KV>
             {snapshot.short_name && <KV k="short name">{snapshot.short_name}</KV>}

--- a/apps/homescreen/app/components/ResidencyPanel.tsx
+++ b/apps/homescreen/app/components/ResidencyPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { StatusController, SlotView } from "../lib/useStatus";
 import { modelShortName, type SnapshotAlias } from "../lib/model-aliases";
+import { modelMemoryWarning } from "../lib/model-memory.mjs";
 
 type ModelInfo = { id: string; path: string; size_gb: number };
 
@@ -50,7 +51,14 @@ export function ResidencyPanel({ status }: { status: StatusController }) {
       {res.slots.length > 0 ? (
         <div className="model-list">
           {res.slots.map((s) => (
-            <SlotCard key={s.id} slot={s} models={models} snapshots={snapshots} call={call} />
+            <SlotCard
+              key={s.id}
+              slot={s}
+              models={models}
+              snapshots={snapshots}
+              residencyBudgetGb={res.usable_gb}
+              call={call}
+            />
           ))}
         </div>
       ) : (
@@ -64,16 +72,27 @@ function SlotCard({
   slot,
   models,
   snapshots,
+  residencyBudgetGb,
   call,
 }: {
   slot: SlotView;
   models: ModelInfo[] | null;
   snapshots: SnapshotAlias[];
+  residencyBudgetGb: number;
   call: (fn: string, args?: Record<string, unknown>) => Promise<void>;
 }) {
   const isWarm = slot.state === "running";
   const isLoading = slot.state === "loading";
   const thinkingLocked = isLoading;
+  const memoryWarning = slot.model_id
+    ? modelMemoryWarning(slot.model_id, slot.mem_gb, residencyBudgetGb)
+    : null;
+  const toggleWarm = () => {
+    if (!isWarm && memoryWarning && !window.confirm(`${memoryWarning}\n\nPrepare this model anyway?`)) {
+      return;
+    }
+    void call(isWarm ? "cool_slot" : "warm_slot", { slotId: slot.id });
+  };
   return (
     <div className="model-row" style={{ alignItems: "flex-start", flexDirection: "column", gap: 8, padding: "12px 0" }}>
       <div style={{ width: "100%", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
@@ -86,6 +105,11 @@ function SlotCard({
                 ? `${slot.model_id} · ${slot.mem_gb.toFixed(1)} GB${slot.port ? ` · :${slot.port}` : ""}${slot.load_ms ? ` · loaded ${(slot.load_ms / 1000).toFixed(1)}s` : ""}`
                 : "unassigned"}
             </div>
+            {memoryWarning && (
+              <div className="mt-1 max-w-[560px] text-[11px] leading-snug text-warn" role="note">
+                {memoryWarning}
+              </div>
+            )}
           </div>
         </div>
         <div style={{ display: "flex", gap: 6 }}>
@@ -93,7 +117,7 @@ function SlotCard({
             <button
               className={"btn" + (isWarm ? " ghost" : " primary")}
               disabled={isLoading}
-              onClick={() => call(isWarm ? "cool_slot" : "warm_slot", { slotId: slot.id })}
+              onClick={toggleWarm}
             >
               {isLoading ? "Warming…" : isWarm ? "Cool" : "Warm"}
             </button>

--- a/apps/homescreen/app/lib/model-memory.mjs
+++ b/apps/homescreen/app/lib/model-memory.mjs
@@ -1,0 +1,18 @@
+const SMALL_MODEL_MARKERS = ["understudy-small", "e2b"];
+
+export function modelMemoryWarning(modelId, modelMemoryGb, residencyBudgetGb) {
+  const normalized = modelId.toLowerCase();
+  if (SMALL_MODEL_MARKERS.some((marker) => normalized.includes(marker))) return null;
+  if (!Number.isFinite(modelMemoryGb) || modelMemoryGb < 6) return null;
+
+  const memory = modelMemoryGb.toFixed(1);
+  if (
+    residencyBudgetGb != null &&
+    Number.isFinite(residencyBudgetGb) &&
+    residencyBudgetGb > 0 &&
+    modelMemoryGb > residencyBudgetGb
+  ) {
+    return `Heavy for this Mac: ~${memory} GB model memory exceeds the ${residencyBudgetGb.toFixed(1)} GB residency budget. Preparing it may stop other models or fail.`;
+  }
+  return `Large local model: ~${memory} GB model memory. Preparing it may cool other warm models; the smallest certified rung is the safer default on constrained Macs.`;
+}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -234,8 +234,14 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
-        .run(|_app, event| {
+        .run(|app, event| {
             if let tauri::RunEvent::Exit = event {
+                // A normal quit owns server teardown. If the app crashes,
+                // residency restore reaps only exact orphaned path+port
+                // matches before it can warm another model.
+                if let Some(residency) = app.try_state::<residency::Residency>() {
+                    residency.shutdown();
+                }
                 // Graceful shutdown: the agent card must not keep
                 // advertising a dead pid as a healthy local daemon.
                 agent_card::mark_stopped();

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant, SystemTime};
-use sysinfo::System;
+use sysinfo::{Pid, Signal, System};
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::db::Db;
@@ -153,6 +153,103 @@ fn available_memory_gb() -> f32 {
     let mut system = System::new_all();
     system.refresh_memory();
     system.available_memory() as f32 / (1024.0 * 1024.0 * 1024.0)
+}
+
+fn command_has_value(args: &[String], flag_fragment: &str, value: &str) -> bool {
+    args.windows(2)
+        .any(|pair| pair[0].contains(flag_fragment) && pair[1] == value)
+}
+
+fn command_matches_persisted_slot(args: &[String], slot: &PersistedSlot) -> bool {
+    let Some(model_path) = slot.model_path.as_deref() else {
+        return false;
+    };
+    let Some(port) = slot.port else {
+        return false;
+    };
+    command_has_value(args, "model", model_path)
+        && command_has_value(args, "port", &port.to_string())
+}
+
+fn remaining_processes(pids: &[Pid]) -> Vec<Pid> {
+    let system = System::new_all();
+    pids.iter()
+        .copied()
+        .filter(|pid| system.process(*pid).is_some())
+        .collect()
+}
+
+fn wait_for_process_exit(pids: &[Pid], attempts: usize) -> Vec<Pid> {
+    let mut remaining = pids.to_vec();
+    for _ in 0..attempts {
+        if remaining.is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        remaining = remaining_processes(&remaining);
+    }
+    remaining
+}
+
+/// Kill only orphaned servers that match an exact persisted model path and
+/// reserved port. A second live Desktop instance must never kill the first
+/// instance's children; a crashed app's children are re-parented to launchd.
+fn reconcile_orphaned_servers(rows: &[PersistedSlot]) -> anyhow::Result<usize> {
+    let system = System::new_all();
+    let mut matched = Vec::new();
+    for (pid, process) in system.processes() {
+        let orphaned = process
+            .parent()
+            .map(|parent| parent.as_u32() == 1)
+            .unwrap_or(true);
+        if !orphaned {
+            continue;
+        }
+        let args: Vec<String> = process
+            .cmd()
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        if rows
+            .iter()
+            .any(|slot| command_matches_persisted_slot(&args, slot))
+        {
+            matched.push(*pid);
+        }
+    }
+    if matched.is_empty() {
+        return Ok(0);
+    }
+
+    for pid in &matched {
+        if let Some(process) = system.process(*pid) {
+            let _ = process.kill_with(Signal::Term);
+        }
+    }
+    let remaining = wait_for_process_exit(&matched, 20);
+    if !remaining.is_empty() {
+        let refreshed = System::new_all();
+        for pid in &remaining {
+            if let Some(process) = refreshed.process(*pid) {
+                let _ = process.kill();
+            }
+        }
+    }
+    let remaining = wait_for_process_exit(&remaining, 20);
+    if !remaining.is_empty() {
+        anyhow::bail!(
+            "refusing to restore model residency because orphaned server pid(s) {} did not exit",
+            remaining
+                .iter()
+                .map(|pid| pid.as_u32().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+    }
+    // Metal teardown can outlive process exit. Keep the same settle window as
+    // an in-app heavy-model eviction before any automatic re-warm.
+    std::thread::sleep(GPU_EVICTION_SETTLE_TIME);
+    Ok(matched.len())
 }
 
 fn append_mlx_cache_defaults(command: &mut Command, existing_flags: &[String]) {
@@ -538,6 +635,18 @@ impl Residency {
         self.cool_locked(&mut inner, slot_id)
     }
 
+    /// Graceful app exit must reap every server child. Do not mutate the
+    /// persisted warm preference: a normal relaunch may re-warm small models.
+    pub fn shutdown(&self) {
+        let mut inner = locked(&self.inner);
+        for resident in inner.iter_mut() {
+            if let Some(mut child) = resident.child.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
+
     fn cool_locked(&self, inner: &mut [Resident], slot_id: u32) -> anyhow::Result<()> {
         if let Some(r) = inner.iter_mut().find(|r| r.id == slot_id) {
             if let Some(child) = r.child.as_mut() {
@@ -691,6 +800,18 @@ impl Residency {
         let rows = app.state::<Db>().load_residency().unwrap_or_default();
         if rows.is_empty() {
             return;
+        }
+        match reconcile_orphaned_servers(&rows) {
+            Ok(0) => {}
+            Ok(count) => eprintln!(
+                "understudy residency: reaped {count} orphaned local model server(s) before restore"
+            ),
+            Err(err) => {
+                let reason = format!("local model process reconciliation failed: {err:#}");
+                eprintln!("understudy residency: {reason}");
+                emit_mlx_repair(app, &reason);
+                return;
+            }
         }
         let max_id = rows.iter().map(|r| r.slot_id).max().unwrap_or(0);
         // Next allocation hands out this value directly, so start one past
@@ -943,5 +1064,65 @@ mod tests {
         let snap = residency.snapshot();
         assert_eq!(snap.slots.len(), 1);
         assert!((snap.used_gb - 12.4).abs() < 0.001);
+    }
+
+    #[test]
+    fn orphan_reconciliation_requires_exact_model_and_port_arguments() {
+        let slot = PersistedSlot {
+            slot_id: 7,
+            model_id: Some("understudy-small".to_string()),
+            model_path: Some("/models/understudy-small".to_string()),
+            warm: true,
+            thinking: false,
+            port: Some(8096),
+            mem_gb: 4.0,
+            ordinal: 0,
+        };
+        assert!(command_matches_persisted_slot(
+            &[
+                "mlx_vlm.server".to_string(),
+                "--model".to_string(),
+                "/models/understudy-small".to_string(),
+                "--port".to_string(),
+                "8096".to_string(),
+            ],
+            &slot,
+        ));
+        assert!(!command_matches_persisted_slot(
+            &[
+                "mlx_vlm.server".to_string(),
+                "--model".to_string(),
+                "/models/understudy-small-copy".to_string(),
+                "--port".to_string(),
+                "8096".to_string(),
+            ],
+            &slot,
+        ));
+        assert!(!command_matches_persisted_slot(
+            &[
+                "mlx_vlm.server".to_string(),
+                "--model".to_string(),
+                "/models/understudy-small".to_string(),
+                "--port".to_string(),
+                "8097".to_string(),
+            ],
+            &slot,
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn graceful_shutdown_reaps_every_tracked_server_child() {
+        let residency = Residency::new(64);
+        let child = Command::new("sleep").arg("30").spawn().unwrap();
+        let pid = Pid::from_u32(child.id());
+        let mut running = resident(1, SlotState::Warm, 4.0);
+        running.child = Some(child);
+        locked(&residency.inner).push(running);
+
+        residency.shutdown();
+
+        assert!(locked(&residency.inner)[0].child.is_none());
+        assert!(System::new_all().process(pid).is_none());
     }
 }

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -189,8 +189,8 @@
     },
     {
       "id": "heavy-model-preflight-and-process-reconciliation",
-      "status": "partial",
-      "evidence": "Residency now fail-closes unsafe memory plans, cools before warming, serializes heavy experiments, waits for Metal teardown, and never auto-restores heavy models. It still needs a plain-language pre-warm warning and durable reconciliation of model-server ownership after an app crash so an orphan cannot overlap a newly launched server."
+      "status": "shipped",
+      "evidence": "Residency fail-closes unsafe memory plans, cools before warming, serializes heavy experiments, waits for Metal teardown, never auto-restores heavy models, reaps every tracked child on normal exit, and before restart kills only orphaned processes matching an exact persisted model path and reserved port. Model and residency views warn plainly before preparing large models and require confirmation at the warm action."
     },
     {
       "id": "legacy-desktop-retirement-guard",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -50,11 +50,19 @@ const statusPanePath = new URL(
   "../apps/homescreen/app/components/StatusPane.tsx",
   import.meta.url,
 );
+const modelsPanePath = new URL(
+  "../apps/homescreen/app/components/ModelsPane.tsx",
+  import.meta.url,
+);
 const rlmPanePath = new URL(
   "../apps/homescreen/app/components/RlmPane.tsx",
   import.meta.url,
 );
 const parityPath = new URL("../docs/desktop-product-parity.json", import.meta.url);
+const modelMemoryPath = new URL(
+  "../apps/homescreen/app/lib/model-memory.mjs",
+  import.meta.url,
+);
 
 test("public desktop preserves the reviewed Train interaction language", async () => {
   const [css, chat, sidebar] = await Promise.all([
@@ -141,6 +149,23 @@ test("desktop model downloads are app-owned, pausable, and resumable", async () 
   assert.match(statusPane, /busyActionLabel="Pause"/);
   assert.doesNotMatch(statusPane, /new Channel<DownloadEvent>/);
   assert.doesNotMatch(statusPane, /invoke\([^\n]*"download_snapshot_model"/);
+});
+
+test("large local models warn before consuming the residency budget", async () => {
+  const { modelMemoryWarning } = await import(modelMemoryPath);
+  const residencyPanel = await readFile(
+    new URL("../apps/homescreen/app/components/ResidencyPanel.tsx", import.meta.url),
+    "utf8",
+  );
+  const modelsPane = await readFile(modelsPanePath, "utf8");
+
+  assert.equal(modelMemoryWarning("understudy-small", 3.6, 2), null);
+  assert.equal(modelMemoryWarning("understudy-4b", 4.2, 8), null);
+  assert.match(modelMemoryWarning("understudy-26b", 15.8, 8), /exceeds the 8\.0 GB/);
+  assert.match(modelMemoryWarning("understudy-12b", 7.5, 40), /safer default/);
+  assert.match(residencyPanel, /Prepare this model anyway\?/);
+  assert.match(residencyPanel, /window\.confirm/);
+  assert.match(modelsPane, /snapshotMemoryWarning/);
 });
 
 test("Experiments is one guided review, strict compare, improve loop", async () => {


### PR DESCRIPTION
## Outcome
- reap every owned local model server on normal Desktop exit
- on restart, reap only orphaned servers matching the exact persisted model path and port before re-warming
- warn and require confirmation before preparing large local models
- mark the Train process-safety capability shipped in the parity ledger

## Verification
- `npm run check` (265 tests, 33 public skills, production build, package dry-run)
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml --lib` (166 passed, 4 explicit real-artifact tests ignored)
- `rustfmt --edition 2021 --check apps/homescreen/src-tauri/src/residency.rs`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->