### PR TITLE
feat(desktop): restore always-on-top pin

### DIFF
--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -233,6 +233,27 @@ select,
   background: var(--surface-2);
   color: var(--text);
 }
+.titlebar-pin {
+  position: fixed;
+  z-index: 30;
+  top: 9px;
+  left: calc(var(--traffic-left) + 76px);
+  display: inline-grid;
+  place-content: center;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: var(--r-control);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  color: var(--text-2);
+}
+.titlebar-pin:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.titlebar-pin.pinned {
+  color: var(--text);
+}
 .titlebar-qr {
   position: fixed;
   z-index: 30;

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { PanelLeftIcon, SquarePenIcon } from "lucide-react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { PanelLeftIcon, PinIcon, PinOffIcon, SquarePenIcon } from "lucide-react";
 import { Sidebar, type PaneId } from "./components/Sidebar";
 import { StatusPane } from "./components/StatusPane";
 import { ModelsPane } from "./components/ModelsPane";
@@ -20,6 +21,7 @@ export default function Page() {
   const [pane, setPane] = useState<PaneId>("chat");
   const [railOpen, setRailOpen] = useState(false);
   const [chatResetToken, setChatResetToken] = useState(0);
+  const [pinned, setPinned] = useState(false);
   const status = useStatus();
   const connected = status.snap?.connected ?? false;
 
@@ -64,6 +66,33 @@ export default function Page() {
   }, []);
 
   useEffect(() => {
+    let saved = false;
+    try {
+      saved = localStorage.getItem("understudy.alwaysOnTop") === "1";
+    } catch {
+      // Storage can be unavailable in browser-only development.
+    }
+    if (!saved) return;
+    setPinned(true);
+    getCurrentWindow()
+      .setAlwaysOnTop(true)
+      .catch(() => setPinned(false));
+  }, []);
+
+  const togglePin = () => {
+    const next = !pinned;
+    setPinned(next);
+    try {
+      localStorage.setItem("understudy.alwaysOnTop", next ? "1" : "0");
+    } catch {
+      // Best effort; the window behavior still works for this session.
+    }
+    getCurrentWindow()
+      .setAlwaysOnTop(next)
+      .catch(() => setPinned(!next));
+  };
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!event.metaKey || event.shiftKey || event.altKey || event.ctrlKey) return;
       if (event.key.toLowerCase() !== "n") return;
@@ -98,6 +127,20 @@ export default function Page() {
           <SquarePenIcon aria-hidden="true" size={15} strokeWidth={2} />
         </button>
       )}
+      <button
+        type="button"
+        className={"titlebar-pin" + (pinned ? " pinned" : "")}
+        aria-label={pinned ? "Unpin window (always on top)" : "Pin window always on top"}
+        aria-pressed={pinned}
+        title={pinned ? "Unpin window" : "Keep window on top"}
+        onClick={togglePin}
+      >
+        {pinned ? (
+          <PinOffIcon aria-hidden="true" size={15} strokeWidth={2} />
+        ) : (
+          <PinIcon aria-hidden="true" size={15} strokeWidth={2} />
+        )}
+      </button>
       <DownloadQrButton />
       <RuntimeRepairPrompt />
       <Sidebar

--- a/apps/homescreen/src-tauri/capabilities/default.json
+++ b/apps/homescreen/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-set-always-on-top",
     "opener:default"
   ]
 }

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -184,8 +184,8 @@
     },
     {
       "id": "always-on-top-window-pin",
-      "status": "planned",
-      "evidence": "The reviewed desktop supported a persisted, user-controlled always-on-top pin. The canonical shell does not yet expose it, despite the low implementation cost and usefulness while working alongside an editor or terminal."
+      "status": "shipped",
+      "evidence": "The canonical titlebar exposes the reviewed user-controlled always-on-top pin, persists the preference locally, restores it on launch, reports its pressed state accessibly, and reverts the UI if the native window operation fails."
     },
     {
       "id": "heavy-model-preflight-and-process-reconciliation",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -96,6 +96,22 @@ test("public desktop preserves the reviewed Train interaction language", async (
   assert.doesNotMatch(serving, /label: "Usage"/);
 });
 
+test("desktop restores the reviewed persisted always-on-top pin", async () => {
+  const [page, permissions] = await Promise.all([
+    readFile(new URL("../apps/homescreen/app/page.tsx", import.meta.url), "utf8"),
+    readFile(
+      new URL("../apps/homescreen/src-tauri/capabilities/default.json", import.meta.url),
+      "utf8",
+    ),
+  ]);
+
+  assert.match(page, /understudy\.alwaysOnTop/);
+  assert.match(page, /setAlwaysOnTop\(true\)/);
+  assert.match(page, /setAlwaysOnTop\(next\)/);
+  assert.match(page, /aria-pressed=\{pinned\}/);
+  assert.match(permissions, /core:window:allow-set-always-on-top/);
+});
+
 test("desktop has one managed runtime repair surface", async () => {
   const [page, prompt, repair] = await Promise.all([
     readFile(pagePath, "utf8"),


### PR DESCRIPTION
## Outcome
- restore the reviewed Train always-on-top titlebar control in the canonical OSS Desktop
- persist the preference locally and reapply it on launch
- expose accessible pressed state and fail back to the truthful UI state if the native call fails
- grant only the required Tauri window permission and mark the parity capability shipped

## Verification
- `npm run check` (266 tests, 33 public skills, package dry-run)
- production Next.js build
- focused desktop lineage test
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->