### PR TITLE
fix(runtime): auto-wire desktop slot tools

### DIFF
--- a/apps/homescreen/src-tauri/gen/schemas/capabilities.json
+++ b/apps/homescreen/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Capability for the main window","local":true,"windows":["main"],"permissions":["core:default","core:window:allow-start-dragging","opener:default"]}}
+{"default":{"identifier":"default","description":"Capability for the main window","local":true,"windows":["main"],"permissions":["core:default","core:window:allow-start-dragging","core:window:allow-set-always-on-top","opener:default"]}}

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -115,7 +115,7 @@
     {
       "id": "desktop-slot-provider-identity",
       "status": "shipped",
-      "evidence": "Authenticated residency snapshots expose the exact local weights path and port. Pi and Vercel conformance can resolve those values from one warm slot and reject manual alias overrides, preventing catalog names from producing false runtime failures."
+      "evidence": "Authenticated residency snapshots expose the exact local weights path and port. Pi and Vercel conformance resolve those values plus the slot-bound Desktop tool executor from one warm slot, inject its private bearer only in memory for the run, and reject manual alias overrides, preventing catalog names from producing false runtime failures."
     },
     {
       "id": "reviewed-desktop-shell",

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -65,19 +65,22 @@ The release artifact exposes the gate directly:
 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
 understudy runtime conformance \
   --backend pi \
-  --base-url <offline-mlx-vlm-base-url> \
-  --model <served-model-id> \
+  --slot <warm-desktop-slot> \
   --capabilities compaction,restart,supervision \
   --deterministic-supervisor \
   --deterministic-malformed-tool \
   --deterministic-compaction \
-  --tool-executor-url <authenticated-loopback-tool-executor-url> \
   --require-complete \
   --output .understudy/capture-evidence/desktop-runtime-conformance.json
 npm run runtime:desktop-readiness -- \
   --output .understudy/capture-evidence/desktop-runtime-readiness.json
 understudy desktop migration-status --require-ready --json
 ```
+
+For Pi or Vercel, `--slot` resolves the exact local weights path and serving
+port from the authenticated Desktop capability. It also wires the slot-bound
+tool executor and its bearer token in memory for the duration of the run; the
+token is neither printed nor persisted in conformance evidence.
 
 The one-release Rust fallback can be measured separately without making it a
 promotion gate:

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -579,6 +579,13 @@ export function registerRuntimeCommand(program: Command): void {
           : undefined;
         const providerBaseUrl = desktopSlotTarget?.baseUrl ?? options.baseUrl!;
         const providerModel = desktopSlotTarget?.model ?? options.model!;
+        const desktopToolExecutor = desktopSlotCapability && !options.toolExecutorUrl
+          ? {
+              url: `${desktopSlotCapability.baseUrl}/api/conversation-runtime/tool?slot_id=${options.slot}`,
+              token: desktopSlotCapability.token,
+            }
+          : undefined;
+        const toolExecutorUrl = options.toolExecutorUrl ?? desktopToolExecutor?.url;
         const supervisorFixture = options.deterministicSupervisor
           ? await startDeterministicSupervisorFixture()
           : undefined;
@@ -589,6 +596,10 @@ export function registerRuntimeCommand(program: Command): void {
           base_url: options.supervisorBaseUrl ?? providerBaseUrl,
           model: options.supervisorModel ?? providerModel,
         };
+        const previousToolToken = process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;
+        if (desktopToolExecutor) {
+          process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN = desktopToolExecutor.token;
+        }
         let report;
         try {
           report = await runConversationAdapterConformance(
@@ -651,7 +662,12 @@ export function registerRuntimeCommand(program: Command): void {
                         : "model",
                     }),
                 scenario_timeout_ms: scenarioTimeoutMs,
-                tool_executor_configured: Boolean(options.toolExecutorUrl),
+                tool_executor_configured: Boolean(toolExecutorUrl),
+                tool_executor_source: desktopToolExecutor
+                  ? "desktop_authenticated_slot"
+                  : toolExecutorUrl
+                    ? "explicit"
+                    : "none",
                 allow_remote: options.allowRemote ?? false,
               },
               async run(input) {
@@ -674,7 +690,7 @@ export function registerRuntimeCommand(program: Command): void {
                   model: providerModel,
                   invocation_id: invocationId,
                   scenario_timeout_ms: scenarioTimeoutMs,
-                  tool_executor_url: options.toolExecutorUrl,
+                  tool_executor_url: toolExecutorUrl,
                   allow_remote: options.allowRemote,
                   student: {
                     base_url: options.studentBaseUrl ?? providerBaseUrl,
@@ -697,6 +713,13 @@ export function registerRuntimeCommand(program: Command): void {
         } finally {
           await supervisorFixture?.close();
           await malformedToolFixture?.close();
+          if (desktopToolExecutor) {
+            if (previousToolToken === undefined) {
+              delete process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;
+            } else {
+              process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN = previousToolToken;
+            }
+          }
         }
         const outputPath = options.output
           ? persistImmutableReport(options.output, report)

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -1694,8 +1694,32 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
   const restartRequestsByModel = new Map();
   const traces = new Map();
   const provider = createServer(async (request, response) => {
+    if (request.url === "/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    if (request.url === "/v1/residency") {
+      assert.equal(request.headers.authorization, `Bearer ${toolToken}`);
+      const address = provider.address();
+      assert.ok(address && typeof address !== "string");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        slots: [{
+          id: 7,
+          state: "running",
+          model_id: "conformance-slot-artifact",
+          model_path: "/models/conformance-slot-weights",
+          port: address.port,
+        }],
+      }));
+      return;
+    }
     const body = await requestJson(request);
-    if (request.url === "/tool") {
+    if (
+      request.url === "/tool" ||
+      request.url === "/api/conversation-runtime/tool?slot_id=7"
+    ) {
       assert.equal(request.headers.authorization, `Bearer ${toolToken}`);
       toolRequests.push(body);
       response.writeHead(200, { "content-type": "application/json" });
@@ -2349,6 +2373,48 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
     const persisted = JSON.parse(readFileSync(persistedPath, "utf8"));
     assert.equal(persisted.suite_id, cliReport.suite_id);
     assert.equal(persisted.generated_at, cliReport.generated_at);
+
+    const capabilityPath = join(runtimeHome, "desktop-api-slot-conformance.json");
+    writeFileSync(capabilityPath, JSON.stringify({
+      schema_version: "understudy.desktop_api.v2",
+      base_url: `http://127.0.0.1:${address.port}`,
+      token: toolToken,
+      pid: process.pid,
+      app_version: "0.3.5",
+    }), { mode: 0o600 });
+    const slotCli = await runCli([
+      "runtime",
+      "conformance",
+      "--backend",
+      "pi",
+      "--slot",
+      "7",
+      "--deterministic-supervisor",
+      "--deterministic-malformed-tool",
+      "--deterministic-compaction",
+      "--scenario-timeout-ms",
+      "5000",
+      "--require-complete",
+      "--output",
+      join(runtimeHome, "slot-live-conformance.json"),
+      "--json",
+    ], {
+      UNDERSTUDY_DESKTOP_API_FILE: capabilityPath,
+      UNDERSTUDY_RUNTIME_TOOL_TOKEN: "",
+    });
+    assert.equal(slotCli.code, 0, `stdout:\n${slotCli.stdout}\nstderr:\n${slotCli.stderr}`);
+    const slotReport = JSON.parse(slotCli.stdout);
+    assert.equal(slotReport.complete, true);
+    assert.equal(slotReport.eligible_for_promotion, true);
+    assert.equal(slotReport.metadata.tool_executor_configured, true);
+    assert.equal(slotReport.metadata.tool_executor_source, "desktop_authenticated_slot");
+    assert.deepEqual(slotReport.metadata.provider, {
+      base_url: `http://127.0.0.1:${address.port}/v1`,
+      model: "/models/conformance-slot-weights",
+      slot_id: 7,
+      artifact_id: "conformance-slot-artifact",
+      identity_source: "desktop_residency_model_path",
+    });
   } finally {
     await new Promise((accept) => provider.close(accept));
     delete process.env.UNDERSTUDY_RUNTIME_TOOL_TOKEN;


### PR DESCRIPTION
## Outcome
- make one authenticated `--slot` sufficient for local Pi/Vercel conformance
- resolve the exact model path, port, and slot-bound Desktop tool executor together
- inject the private bearer only in memory for the run and restore the caller environment afterward
- simplify the official runtime deletion-gate command and record the executor source in evidence
- include the generated Tauri capability snapshot for the merged window-pin permission

## Verification
- `npm run check` (266 tests, 33 public skills, package dry-run)
- full frozen mock conformance with an empty input tool-token environment and slot-discovered authenticated tool execution
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->