### PR TITLE
Compile dropped workloads locally in Desktop

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -305,6 +305,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const [droppedWorkload, setDroppedWorkload] = useState<DroppedWorkload | null>(null);
   const observedResetToken = useRef(false);
   const dropInFlight = useRef(false);
+  const dropRequestGeneration = useRef(0);
 
   const refreshModels = async () => {
     try {
@@ -398,13 +399,15 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
           return;
         }
         dropInFlight.current = true;
+        const requestGeneration = dropRequestGeneration.current + 1;
+        dropRequestGeneration.current = requestGeneration;
         setDropRunning(true);
         setDroppedWorkload(null);
         setErr(null);
         setNotice("Creating a local metadata-only Workload Card…");
         void invoke<DroppedWorkload>("compile_dropped_workload", { path: paths[0] })
           .then((result) => {
-            if (disposed) return;
+            if (disposed || dropRequestGeneration.current !== requestGeneration) return;
             setDroppedWorkload(result);
             setNotice(
               result.truncated
@@ -413,9 +416,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
             );
           })
           .catch((error) => {
-            if (!disposed) setErr(String(error));
+            if (!disposed && dropRequestGeneration.current === requestGeneration) setErr(String(error));
           })
           .finally(() => {
+            if (dropRequestGeneration.current !== requestGeneration) return;
             dropInFlight.current = false;
             if (!disposed) setDropRunning(false);
           });
@@ -699,6 +703,8 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     setNotice(null);
     setSessionId(crypto.randomUUID());
     setAssistantSpeaking(false);
+    dropRequestGeneration.current += 1;
+    dropInFlight.current = false;
     setDroppedWorkload(null);
     setDropRunning(false);
     setPersonaReady(false);

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import {
   Conversation,
   ConversationContent,
@@ -89,6 +90,19 @@ type ResidencySnapshot = {
 };
 type SnapshotModel = SnapshotAlias;
 type ChatStatus = "ready" | "streaming" | "error";
+type DroppedWorkload = {
+  source_name: string;
+  source_path: string;
+  source_type: "file" | "directory";
+  scanned_file_count: number;
+  source_count: number;
+  total_bytes: number;
+  source_kinds: Record<string, number>;
+  truncated: boolean;
+  local_only: true;
+  payload_read: false;
+  workload_card_path: string;
+};
 
 const CLOUD_SUPERVISOR_FALLBACK_NOTICE =
   "Tried to hand off to a larger cloud model, but it is unavailable. Continuing with the local model.";
@@ -148,6 +162,12 @@ const CLOUD_MODEL: ModelChoice = {
   slotId: null,
   active: true,
 };
+
+function compactBytes(bytes: number): string {
+  if (bytes < 1_024) return `${bytes} B`;
+  if (bytes < 1_024 * 1_024) return `${(bytes / 1_024).toFixed(1)} KB`;
+  return `${(bytes / (1_024 * 1_024)).toFixed(1)} MB`;
+}
 
 function cleanReasoningText(text: string) {
   return text
@@ -280,7 +300,11 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const [introThinking, setIntroThinking] = useState(true);
   const [sidekickEvents, setSidekickEvents] = useState<SidekickEvent[]>([]);
   const [sessionHydrated, setSessionHydrated] = useState(false);
+  const [dropHovering, setDropHovering] = useState(false);
+  const [dropRunning, setDropRunning] = useState(false);
+  const [droppedWorkload, setDroppedWorkload] = useState<DroppedWorkload | null>(null);
   const observedResetToken = useRef(false);
+  const dropInFlight = useRef(false);
 
   const refreshModels = async () => {
     try {
@@ -347,6 +371,66 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     refreshModels();
     const timer = window.setInterval(refreshModels, 2500);
     return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    void getCurrentWebview()
+      .onDragDropEvent((event) => {
+        if (event.payload.type === "enter" || event.payload.type === "over") {
+          setDropHovering(true);
+          return;
+        }
+        if (event.payload.type === "leave") {
+          setDropHovering(false);
+          return;
+        }
+
+        setDropHovering(false);
+        const paths = event.payload.paths;
+        if (paths.length !== 1) {
+          setErr("Drop one file or folder at a time so each Workload Card has a clear source.");
+          return;
+        }
+        if (dropInFlight.current) {
+          setNotice("The current dropped workload is still being compiled locally.");
+          return;
+        }
+        dropInFlight.current = true;
+        setDropRunning(true);
+        setDroppedWorkload(null);
+        setErr(null);
+        setNotice("Creating a local metadata-only Workload Card…");
+        void invoke<DroppedWorkload>("compile_dropped_workload", { path: paths[0] })
+          .then((result) => {
+            if (disposed) return;
+            setDroppedWorkload(result);
+            setNotice(
+              result.truncated
+                ? "Workload draft created at the safety limit; no file contents were read."
+                : "Workload draft created locally; no file contents were read.",
+            );
+          })
+          .catch((error) => {
+            if (!disposed) setErr(String(error));
+          })
+          .finally(() => {
+            dropInFlight.current = false;
+            if (!disposed) setDropRunning(false);
+          });
+      })
+      .then((stop) => {
+        if (disposed) stop();
+        else unlisten = stop;
+      })
+      .catch((error) => {
+        if (!disposed) setNotice(`File and folder drop is unavailable: ${String(error)}`);
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   }, []);
 
   useEffect(() => {
@@ -615,6 +699,8 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     setNotice(null);
     setSessionId(crypto.randomUUID());
     setAssistantSpeaking(false);
+    setDroppedWorkload(null);
+    setDropRunning(false);
     setPersonaReady(false);
     setIntroThinking(true);
     setPersonaCycle((value) => value + 1);
@@ -707,9 +793,16 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
       className={
         "chat ai-chat" +
         (messages.length > 0 ? " has-messages" : "") +
+        (dropRunning || droppedWorkload ? " has-workload" : "") +
         (streaming ? " is-streaming" : "")
       }
     >
+      {dropHovering && (
+        <div className="workload-drop-overlay" role="status">
+          <div className="workload-drop-overlay-title">Drop one file or folder</div>
+          <div>Metadata only · stays on this Mac</div>
+        </div>
+      )}
       <div className={"persona-stage" + (personaReady ? " persona-ready" : "")} aria-hidden="true">
         <img
           key={`stamp-${personaCycle}`}
@@ -832,6 +925,53 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
                 <div className="sidekick-active-task">{latestSidekickEvent.detail}</div>
               </div>
             </div>
+          )}
+          {(dropRunning || droppedWorkload) && (
+            <section className="workload-draft" aria-live="polite">
+              {dropRunning || !droppedWorkload ? (
+                <div className="workload-draft-loading">
+                  <span />
+                  Building a bounded local Workload Card…
+                </div>
+              ) : (
+                <>
+                  <div className="workload-draft-copy">
+                    <div className="workload-draft-kicker">Workload draft</div>
+                    <div className="workload-draft-title" title={droppedWorkload.source_path}>
+                      {droppedWorkload.source_name}
+                    </div>
+                    <div className="workload-draft-meta">
+                      <span>{droppedWorkload.source_type}</span>
+                      <span>{droppedWorkload.source_count} source{droppedWorkload.source_count === 1 ? "" : "s"}</span>
+                      <span>{compactBytes(droppedWorkload.total_bytes)}</span>
+                      <span>contents unread</span>
+                      {droppedWorkload.truncated && <span>safety limit reached</span>}
+                    </div>
+                    <div className="workload-draft-kinds">
+                      {Object.entries(droppedWorkload.source_kinds).map(([kind, count]) => (
+                        <span key={kind}>{kind.replaceAll("-", " ")} · {count}</span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="workload-draft-actions">
+                    <button
+                      type="button"
+                      className="btn primary"
+                      onClick={() => {
+                        setInput(
+                          `Review this local metadata-only Workload Card and propose the smallest useful benchmark: ${droppedWorkload.workload_card_path}`,
+                        );
+                      }}
+                    >
+                      Review next steps
+                    </button>
+                    <button type="button" className="btn ghost" onClick={() => setDroppedWorkload(null)}>
+                      Dismiss
+                    </button>
+                  </div>
+                </>
+              )}
+            </section>
           )}
           {err && <div className="chat-err">{err}</div>}
           {notice && !err && <div className="chat-runtime-notice">{notice}</div>}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -1910,6 +1910,7 @@ select,
 
 /* ---------- Chat pane ---------- */
 .chat {
+  position: relative;
   max-width: 1080px;
   margin: 0 auto;
   height: 100%;
@@ -2000,6 +2001,19 @@ select,
   height: 48px;
   flex: 0 0 48px;
   min-height: 48px;
+}
+.ai-chat.has-workload .persona-stage {
+  height: 48px;
+  flex: 0 0 48px;
+  min-height: 48px;
+}
+.ai-chat.has-workload .persona-halo {
+  width: 42px;
+  height: 42px;
+}
+.ai-chat.has-workload .persona-stamp {
+  width: 34px;
+  height: 34px;
 }
 .ai-chat.has-messages .persona-halo {
   width: 42px;
@@ -2383,6 +2397,110 @@ select,
   font-size: 11px;
   line-height: 1.4;
   padding: 5px 0;
+}
+.workload-drop-overlay {
+  position: absolute;
+  z-index: 50;
+  inset: calc(var(--titlebar-h) + 8px) 24px 24px;
+  display: grid;
+  place-content: center;
+  gap: 6px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 70%, var(--border));
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 11px;
+  text-align: center;
+  backdrop-filter: blur(18px);
+  pointer-events: none;
+}
+.workload-drop-overlay-title {
+  color: var(--mb-cyan);
+  font-family: var(--sans);
+  font-size: 18px;
+  font-weight: 650;
+}
+.workload-draft {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(680px, 92%);
+  margin: 0 auto;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 26%, var(--border));
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 12%);
+}
+.workload-draft-copy {
+  min-width: 0;
+}
+.workload-draft-kicker {
+  margin-bottom: 3px;
+  color: var(--mb-cyan);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.workload-draft-title {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.workload-draft-meta,
+.workload-draft-kinds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 10px;
+  margin-top: 6px;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+.workload-draft-meta span:not(:last-child)::after {
+  content: " ·";
+  margin-left: 8px;
+}
+.workload-draft-kinds span {
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-2);
+}
+.workload-draft-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 6px;
+}
+.workload-draft-loading {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--text-2);
+  font-size: 12px;
+}
+.workload-draft-loading span {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--mb-cyan);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--mb-cyan) 70%, transparent);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+@media (max-width: 720px) {
+  .workload-draft {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .workload-draft-actions {
+    justify-content: flex-end;
+  }
 }
 .runtime-repair-prompt {
   position: fixed;

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ mod supervision_export;
 mod supervision_review;
 mod supervision_tiebreaker;
 mod tool_proof;
+mod workload_drop;
 
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -216,6 +217,7 @@ pub fn run() {
             tool_proof::desktop_tool_proof_run,
             tool_proof::desktop_tool_proof_list,
             tool_proof::desktop_tool_proof_prepare,
+            workload_drop::compile_dropped_workload,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -1,0 +1,109 @@
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+fn validate_compile_result(value: Value) -> Result<Value, String> {
+    if !value.is_object() {
+        return Err("The Understudy CLI returned an invalid workload result.".into());
+    }
+    if value.get("local_only").and_then(Value::as_bool) != Some(true)
+        || value.get("payload_read").and_then(Value::as_bool) != Some(false)
+    {
+        return Err(
+            "The workload compiler did not preserve the local metadata-only boundary.".into(),
+        );
+    }
+    for field in ["source_name", "source_type", "workload_card_path"] {
+        if value.get(field).and_then(Value::as_str).is_none() {
+            return Err(format!("The workload compiler omitted {field}."));
+        }
+    }
+    Ok(value)
+}
+
+fn bounded_detail(stderr: &[u8]) -> String {
+    let detail = String::from_utf8_lossy(stderr).trim().to_string();
+    if detail.is_empty() {
+        return "No diagnostic was returned.".into();
+    }
+    detail.chars().take(800).collect()
+}
+
+fn compile(path: String) -> Result<Value, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("Drop one local file or folder.".into());
+    }
+    let canonical = PathBuf::from(trimmed)
+        .canonicalize()
+        .map_err(|error| format!("The dropped path is unavailable: {error}"))?;
+    if !canonical.is_file() && !canonical.is_dir() {
+        return Err("The dropped item must be a file or folder.".into());
+    }
+
+    // The public CLI owns discovery, privacy boundaries, scan limits, and the
+    // durable Workload Card. Desktop only passes one exact local path and
+    // renders the bounded JSON result.
+    let output = crate::bin::command("understudy")
+        .args(["capture-import", "compile", "--source"])
+        .arg(&canonical)
+        .arg("--json")
+        .output()
+        .map_err(|error| {
+            format!(
+                "Could not run the Understudy CLI ({error}). Open Status to repair the CLI, then drop the item again."
+            )
+        })?;
+    if !output.status.success() {
+        return Err(format!(
+            "The Understudy CLI could not compile this item. {}",
+            bounded_detail(&output.stderr)
+        ));
+    }
+    let value = serde_json::from_slice::<Value>(&output.stdout)
+        .map_err(|_| "The Understudy CLI returned malformed workload JSON.".to_string())?;
+    validate_compile_result(value)
+}
+
+#[tauri::command]
+pub async fn compile_dropped_workload(path: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || compile(path))
+        .await
+        .map_err(|error| format!("The workload compiler stopped unexpectedly: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_only_local_metadata_results() {
+        let valid = json!({
+            "source_name": "fixture.jsonl",
+            "source_type": "file",
+            "workload_card_path": "/tmp/workload-card.json",
+            "local_only": true,
+            "payload_read": false
+        });
+        assert!(validate_compile_result(valid).is_ok());
+
+        let unsafe_result = json!({
+            "source_name": "fixture.jsonl",
+            "source_type": "file",
+            "workload_card_path": "/tmp/workload-card.json",
+            "local_only": false,
+            "payload_read": true
+        });
+        assert!(validate_compile_result(unsafe_result)
+            .unwrap_err()
+            .contains("metadata-only"));
+    }
+
+    #[test]
+    fn bounds_cli_failure_details() {
+        let input = vec![b'x'; 2_000];
+        assert_eq!(bounded_detail(&input).chars().count(), 800);
+        assert_eq!(bounded_detail(b"\n"), "No diagnostic was returned.");
+    }
+}

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -11,7 +11,7 @@ for:
 | --- | --- | --- |
 | Public spine | `spine`, `skills` | Kept in TypeScript. |
 | Local workload discovery | `demo scan`, `demo plan`, `workload-discovery scan`, `workload-discovery plan` | Restored as metadata-only `capture-evidence check` and `capture-evidence workload-card`; old `understand` remains a compatibility alias. |
-| Capture/import | `capture-import scan`, `capture-import preview`, `capture-import workload-card` | Restored in TypeScript as metadata-only local scan, bounded preview, and workload-card artifacts. |
+| Capture/import | `capture-import scan`, `capture-import preview`, `capture-import workload-card`, `capture-import compile` | Restored in TypeScript as metadata-only local scan, bounded preview, exact file/folder compilation, and workload-card artifacts. |
 | Route decision | `route-decision plan --workload-card ...` | Restored in TypeScript. Emits the JSON contract from `docs/route-decision-packet-template.md` with conservative evaluate-first routes only. |
 | Value report | `value report` | Restored in TypeScript. Emits conservative value reports only from measured evidence or explicit overrides. |
 | Validate/optimize proof gates | Python helper scripts under `skills/optimize-workload/scripts/` | Restored as deterministic TypeScript gates plus `uv`-orchestrated optimizer adapters. Python remains runtime-only for GEPA/DSPy packages. |
@@ -46,6 +46,7 @@ understudy routes clear classify --project rehearsal
 understudy routes rollback classify --project rehearsal
 understudy setup-code --client openai --file src/client.ts --json
 understudy capture-import scan --repo .
+understudy capture-import compile --source ./local-file-or-folder --json
 understudy capture-import preview --repo . --limit 10
 understudy capture-import workload-card --repo .
 understudy capture-evidence check --repo .
@@ -78,9 +79,13 @@ or read prompt/eval payloads. They write metadata artifacts to:
 
 The capture/import commands are also local-only and metadata-first. `scan`
 records candidate paths, kinds, extensions, byte sizes, and detection evidence
-for likely eval fixtures, golden fixtures, `.jsonl`, `.csv`, prompt files, app
-routes, and provider traces. It does not persist file contents, prompts,
-messages, completions, traces, or secret values.
+for likely eval fixtures, golden fixtures, structured data, documents,
+spreadsheets, source files, media, app routes, and provider traces. `compile`
+accepts one exact file or directory, scans at most 5,000 files, records at most
+1,000 source entries, and writes an isolated Workload Card under
+`~/.understudy/capture-imports/` for desktop or CLI review without modifying the
+dropped source. Neither command persists file contents, prompts, messages, completions,
+traces, or secret values.
 
 ```text
 .understudy/capture-import/capture-sources.json

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -169,8 +169,8 @@
     },
     {
       "id": "drop-to-workload-compilation",
-      "status": "planned",
-      "evidence": "The legacy drop analyzer was coupled to an unauthenticated Python environment bridge, private workflow links, and duplicate chart dependencies. Preserve the user outcome by routing a local file or directory into the public CLI workload compiler and bounded result cards; do not port that bridge or UI wholesale."
+      "status": "shipped",
+      "evidence": "Chat accepts one native file or directory drop and passes the exact canonical path to the public capture-import compiler through a thin Tauri command. The CLI performs metadata-only discovery with 5,000-file and 1,000-source ceilings, ignores dependency/build directories and symlinks, writes a private isolated Workload Card under ~/.understudy without modifying the source, and returns a bounded summary. Desktop rejects results that do not attest local_only=true and payload_read=false, renders one compact draft card, and never restores the unauthenticated environment bridge, private workflow links, charts, or drop-action protocol."
     },
     {
       "id": "model-card-transparency",

--- a/src/capture-import.ts
+++ b/src/capture-import.ts
@@ -402,7 +402,10 @@ export function compileCaptureImport(
     throw new Error(`Capture/import source must be a file or directory: ${source}`);
   }
   const repo = sourceStat.isDirectory() ? source : dirname(source);
-  const dropId = createHash("sha256").update(source).digest("hex").slice(0, 12);
+  const dropId = createHash("sha256")
+    .update(`${source}\0${now.toISOString()}`)
+    .digest("hex")
+    .slice(0, 12);
   const outputDir = join(resolve(outputRootInput), dropId);
   const manifest = scanCaptureImport(repo, now, source, outputDir);
   const card = buildWorkloadCard(repo, now, outputDir);
@@ -443,7 +446,10 @@ function collectSources(
   const walked = walkBounded(inputSource, MAX_SCAN_FILES);
   const files = walked.files
     .map((path) => ({ absolutePath: path, relativePath: relative(repo, path) }))
-    .filter(({ relativePath }) => !relativePath.startsWith(".."))
+    .filter(({ relativePath }) =>
+      relativePath !== ".." &&
+      !relativePath.startsWith("../") &&
+      !relativePath.startsWith("..\\"))
     .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
 
   const sources: CaptureSource[] = [];

--- a/src/capture-import.ts
+++ b/src/capture-import.ts
@@ -1,5 +1,7 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { basename, extname, join, relative, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { globalConfigDir } from "./config/paths.js";
 
 export type CaptureSourceKind =
   | "eval-fixture"
@@ -8,7 +10,12 @@ export type CaptureSourceKind =
   | "csv-data"
   | "prompt-file"
   | "app-route"
-  | "provider-trace";
+  | "provider-trace"
+  | "document"
+  | "spreadsheet"
+  | "source-file"
+  | "media-file"
+  | "local-file";
 
 export type CaptureSource = {
   id: string;
@@ -31,9 +38,32 @@ export type RedactionManifest = {
 export type CaptureScanManifest = {
   generated_at: string;
   repo: string;
+  input_source: string;
+  input_kind: "file" | "directory";
+  scanned_file_count: number;
+  scan_file_limit: number;
+  scan_source_limit: number;
+  truncated: boolean;
   source_count: number;
   sources: CaptureSource[];
   redaction_manifest_path: string;
+};
+
+export type CaptureCompileResult = {
+  generated_at: string;
+  source_name: string;
+  source_path: string;
+  source_type: "file" | "directory";
+  scanned_file_count: number;
+  source_count: number;
+  total_bytes: number;
+  source_kinds: Partial<Record<CaptureSourceKind, number>>;
+  truncated: boolean;
+  local_only: true;
+  payload_read: false;
+  artifact_root: string;
+  manifest_path: string;
+  workload_card_path: string;
 };
 
 export type CapturePreview = {
@@ -142,18 +172,56 @@ const kindOrder: CaptureSourceKind[] = [
   "prompt-file",
   "app-route",
   "provider-trace",
+  "document",
+  "spreadsheet",
+  "source-file",
+  "media-file",
+  "local-file",
 ];
+
+const MAX_SCAN_FILES = 5_000;
+const MAX_CAPTURE_SOURCES = 1_000;
 
 export function artifactDir(repo: string): string {
   return join(repo, ".understudy", "capture-import");
 }
 
-export function scanCaptureImport(repoInput: string, now = new Date()): CaptureScanManifest {
-  const repo = resolve(repoInput);
-  const sources = collectSources(repo);
+export function scanCaptureImport(
+  repoInput: string,
+  now = new Date(),
+  sourceInput?: string,
+  outputDirInput?: string,
+): CaptureScanManifest {
+  const repoResolved = resolve(repoInput);
+  if (!existsSync(repoResolved)) {
+    throw new Error(`Repository path does not exist: ${repoResolved}`);
+  }
+  const repo = repoResolved;
+  const sourceResolved = resolve(sourceInput ?? repo);
+  if (!existsSync(sourceResolved)) {
+    throw new Error(`Capture/import source does not exist: ${sourceResolved}`);
+  }
+  const inputSource = sourceResolved;
+  const canonicalRepo = realpathSync(repo);
+  const canonicalSource = realpathSync(inputSource);
+  const sourceRelativeToRepo = relative(canonicalRepo, canonicalSource);
+  if (
+    sourceRelativeToRepo === ".." ||
+    sourceRelativeToRepo.startsWith("../") ||
+    sourceRelativeToRepo.startsWith("..\\") ||
+    resolve(canonicalRepo, sourceRelativeToRepo) !== canonicalSource
+  ) {
+    throw new Error(`Capture/import source must be inside the repository root: ${inputSource}`);
+  }
+  const inputStat = statSync(inputSource);
+  if (!inputStat.isFile() && !inputStat.isDirectory()) {
+    throw new Error(`Capture/import source must be a file or directory: ${inputSource}`);
+  }
+  const collected = collectSources(repo, inputSource, sourceInput !== undefined);
   const generated_at = now.toISOString();
-  const outputDir = artifactDir(repo);
-  mkdirSync(outputDir, { recursive: true });
+  const outputDir = outputDirInput ? resolve(outputDirInput) : artifactDir(repo);
+  mkdirSync(outputDir, { recursive: true, mode: 0o700 });
+  setPrivateMode(outputDir, 0o700);
 
   const redactionManifest: RedactionManifest = {
     generated_at,
@@ -164,7 +232,7 @@ export function scanCaptureImport(repoInput: string, now = new Date()): CaptureS
       "Do not read or persist prompts, completions, traces, examples, customer data, or secrets.",
       "Keep artifacts local under .understudy/capture-import.",
     ],
-    source_count: sources.length,
+    source_count: collected.sources.length,
     payload_fields_omitted: ["contents", "prompt", "completion", "messages", "input", "output", "trace"],
   };
 
@@ -174,17 +242,24 @@ export function scanCaptureImport(repoInput: string, now = new Date()): CaptureS
   const manifest: CaptureScanManifest = {
     generated_at,
     repo,
-    source_count: sources.length,
-    sources,
-    redaction_manifest_path: relative(repo, redactionPath),
+    input_source: inputSource,
+    input_kind: inputStat.isFile() ? "file" : "directory",
+    scanned_file_count: collected.scannedFileCount,
+    scan_file_limit: MAX_SCAN_FILES,
+    scan_source_limit: MAX_CAPTURE_SOURCES,
+    truncated: collected.truncated,
+    source_count: collected.sources.length,
+    sources: collected.sources,
+    redaction_manifest_path: artifactReference(repo, redactionPath),
   };
   writeJson(join(outputDir, "capture-sources.json"), manifest);
   return manifest;
 }
 
-export function readCaptureManifest(repoInput: string): CaptureScanManifest {
+export function readCaptureManifest(repoInput: string, outputDirInput?: string): CaptureScanManifest {
   const repo = resolve(repoInput);
-  const manifestPath = join(artifactDir(repo), "capture-sources.json");
+  const outputDir = outputDirInput ? resolve(outputDirInput) : artifactDir(repo);
+  const manifestPath = join(outputDir, "capture-sources.json");
   if (!existsSync(manifestPath)) {
     throw new Error(`Missing capture/import scan manifest: ${relative(process.cwd(), manifestPath)}`);
   }
@@ -212,9 +287,10 @@ export function previewCaptureImport(repoInput: string, sourceId: string, limit:
   return preview;
 }
 
-export function buildWorkloadCard(repoInput: string, now = new Date()): WorkloadCard {
+export function buildWorkloadCard(repoInput: string, now = new Date(), outputDirInput?: string): WorkloadCard {
   const repo = resolve(repoInput);
-  const manifest = readCaptureManifest(repo);
+  const outputDir = outputDirInput ? resolve(outputDirInput) : artifactDir(repo);
+  const manifest = readCaptureManifest(repo, outputDir);
   const source_kinds = Object.fromEntries(kindOrder.map((kind) => [kind, 0])) as Record<CaptureSourceKind, number>;
   for (const source of manifest.sources) {
     source_kinds[source.kind] += 1;
@@ -222,10 +298,10 @@ export function buildWorkloadCard(repoInput: string, now = new Date()): Workload
   const card: WorkloadCard = {
     schema_version: "understudy.workload_card.v1",
     workload_id: "capture-import",
-    workload_name: null,
+    workload_name: basename(manifest.input_source),
     owner: null,
     candidate_id: "metadata-discovery",
-    source_path: null,
+    source_path: manifest.input_source,
     mode: "local-only",
     workload_shape: ["metadata-discovered"],
     value_lens: ["quality", "cost", "latency"],
@@ -300,27 +376,86 @@ export function buildWorkloadCard(repoInput: string, now = new Date()): Workload
         "Run optimize-workload only after the workload contract is hash-bound.",
       ],
       evidence_paths: [
-        ".understudy/capture-import/capture-sources.json",
-        ".understudy/capture-import/redaction-manifest.json",
+        artifactReference(repo, join(outputDir, "capture-sources.json")),
+        artifactReference(repo, join(outputDir, "redaction-manifest.json")),
       ],
-      capture_sources: ".understudy/capture-import/capture-sources.json",
-      redaction_manifest: ".understudy/capture-import/redaction-manifest.json",
+      capture_sources: artifactReference(repo, join(outputDir, "capture-sources.json")),
+      redaction_manifest: artifactReference(repo, join(outputDir, "redaction-manifest.json")),
     },
   };
-  writeJson(join(artifactDir(repo), "workload-card.json"), card);
+  writeJson(join(outputDir, "workload-card.json"), card);
   return card;
 }
 
-function collectSources(repo: string): CaptureSource[] {
-  const files = walk(repo)
+export function compileCaptureImport(
+  sourceInput: string,
+  now = new Date(),
+  outputRootInput = join(globalConfigDir(), "capture-imports"),
+): CaptureCompileResult {
+  const sourceResolved = resolve(sourceInput);
+  if (!existsSync(sourceResolved)) {
+    throw new Error(`Capture/import source does not exist: ${sourceResolved}`);
+  }
+  const source = sourceResolved;
+  const sourceStat = statSync(source);
+  if (!sourceStat.isFile() && !sourceStat.isDirectory()) {
+    throw new Error(`Capture/import source must be a file or directory: ${source}`);
+  }
+  const repo = sourceStat.isDirectory() ? source : dirname(source);
+  const dropId = createHash("sha256").update(source).digest("hex").slice(0, 12);
+  const outputDir = join(resolve(outputRootInput), dropId);
+  const manifest = scanCaptureImport(repo, now, source, outputDir);
+  const card = buildWorkloadCard(repo, now, outputDir);
+  const sourceKinds = Object.fromEntries(
+    Object.entries(card.discovery.source_kinds).filter(([, count]) => count > 0),
+  ) as Partial<Record<CaptureSourceKind, number>>;
+  return {
+    generated_at: now.toISOString(),
+    source_name: basename(source),
+    source_path: source,
+    source_type: sourceStat.isFile() ? "file" : "directory",
+    scanned_file_count: manifest.scanned_file_count,
+    source_count: manifest.source_count,
+    total_bytes: manifest.sources.reduce((total, item) => total + item.bytes, 0),
+    source_kinds: sourceKinds,
+    truncated: manifest.truncated,
+    local_only: true,
+    payload_read: false,
+    artifact_root: outputDir,
+    manifest_path: join(outputDir, "capture-sources.json"),
+    workload_card_path: join(outputDir, "workload-card.json"),
+  };
+}
+
+function artifactReference(repo: string, path: string): string {
+  const repoRelative = relative(repo, path);
+  if (repoRelative === ".." || repoRelative.startsWith("../") || repoRelative.startsWith("..\\")) {
+    return path;
+  }
+  return repoRelative;
+}
+
+function collectSources(
+  repo: string,
+  inputSource: string,
+  includeUnknownFiles: boolean,
+): { sources: CaptureSource[]; scannedFileCount: number; truncated: boolean } {
+  const walked = walkBounded(inputSource, MAX_SCAN_FILES);
+  const files = walked.files
     .map((path) => ({ absolutePath: path, relativePath: relative(repo, path) }))
     .filter(({ relativePath }) => !relativePath.startsWith(".."))
     .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
 
   const sources: CaptureSource[] = [];
+  let sourceLimitReached = false;
   for (const file of files) {
-    const detection = detectKind(file.relativePath);
+    const detection = detectKind(file.relativePath) ??
+      (includeUnknownFiles ? { kind: "local-file" as const, evidence: ["explicit:path-drop"] } : null);
     if (!detection) {
+      continue;
+    }
+    if (sources.length >= MAX_CAPTURE_SOURCES) {
+      sourceLimitReached = true;
       continue;
     }
     const stat = statSync(file.absolutePath);
@@ -333,7 +468,11 @@ function collectSources(repo: string): CaptureSource[] {
       evidence: detection.evidence,
     });
   }
-  return sources;
+  return {
+    sources,
+    scannedFileCount: files.length,
+    truncated: walked.truncated || sourceLimitReached,
+  };
 }
 
 function detectKind(path: string): { kind: CaptureSourceKind; evidence: string[] } | null {
@@ -361,29 +500,67 @@ function detectKind(path: string): { kind: CaptureSourceKind; evidence: string[]
   if (/trace|span|otel|openai|anthropic|provider/.test(normalized) && [".json", ".jsonl", ".ndjson"].includes(ext)) {
     return { kind: "provider-trace", evidence: ["path:trace-or-provider"] };
   }
+  if ([".pdf", ".doc", ".docx", ".rtf", ".txt", ".md", ".markdown"].includes(ext)) {
+    return { kind: "document", evidence: [`extension:${ext}`] };
+  }
+  if ([".xlsx", ".xls", ".ods", ".tsv"].includes(ext)) {
+    return { kind: "spreadsheet", evidence: [`extension:${ext}`] };
+  }
+  if ([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rs", ".go", ".java", ".kt", ".swift", ".rb", ".php", ".c", ".cc", ".cpp", ".h", ".hpp"].includes(ext)) {
+    return { kind: "source-file", evidence: [`extension:${ext}`] };
+  }
+  if ([".png", ".jpg", ".jpeg", ".gif", ".webp", ".heic", ".wav", ".mp3", ".m4a", ".mp4", ".mov"].includes(ext)) {
+    return { kind: "media-file", evidence: [`extension:${ext}`] };
+  }
   return null;
 }
 
-function walk(root: string): string[] {
+function walkBounded(root: string, maxFiles: number): { files: string[]; truncated: boolean } {
   if (!existsSync(root)) {
-    throw new Error(`Repository path does not exist: ${root}`);
+    throw new Error(`Capture/import source does not exist: ${root}`);
   }
-  const entries = readdirSync(root, { withFileTypes: true });
+  const rootStat = statSync(root);
+  if (rootStat.isFile()) {
+    return { files: [root], truncated: false };
+  }
+  if (!rootStat.isDirectory()) {
+    throw new Error(`Capture/import source must be a file or directory: ${root}`);
+  }
   const files: string[] = [];
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      if (!ignoredDirs.has(entry.name)) {
-        files.push(...walk(join(root, entry.name)));
+  const pending = [root];
+  while (pending.length > 0) {
+    const directory = pending.pop()!;
+    const entries = readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name));
+    const childDirectories: string[] = [];
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!ignoredDirs.has(entry.name)) {
+          childDirectories.push(join(directory, entry.name));
+        }
+        continue;
       }
-      continue;
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (files.length >= maxFiles) {
+        return { files, truncated: true };
+      }
+      files.push(join(directory, entry.name));
     }
-    if (entry.isFile()) {
-      files.push(join(root, entry.name));
+    for (const child of childDirectories.reverse()) {
+      pending.push(child);
     }
   }
-  return files;
+  return { files, truncated: false };
 }
 
 function writeJson(path: string, payload: unknown): void {
-  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  setPrivateMode(path, 0o600);
+}
+
+function setPrivateMode(path: string, mode: number): void {
+  if (process.platform === "win32") return;
+  chmodSync(path, mode);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runUnderstandCheck, runUnderstandWorkloadCard } from "./understand.js";
-import { buildWorkloadCard, previewCaptureImport, scanCaptureImport } from "./capture-import.js";
+import { buildWorkloadCard, compileCaptureImport, previewCaptureImport, scanCaptureImport } from "./capture-import.js";
 import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
 import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
@@ -299,9 +299,10 @@ function registerCaptureImportCommands(program: Command): void {
     .command("scan")
     .description("Scan a local repo for capture/import source metadata")
     .option("--repo <path>", "Repository to scan", ".")
+    .option("--source <path>", "Exact file or directory to scan inside the repository")
     .option("--json", "Output JSON")
-    .action((options: { repo: string; json?: boolean }) => {
-      const manifest = scanCaptureImport(options.repo);
+    .action((options: { repo: string; source?: string; json?: boolean }) => {
+      const manifest = scanCaptureImport(options.repo, new Date(), options.source);
       if (commandJsonEnabled(program, options)) {
         console.log(JSON.stringify(manifest, null, 2));
         return;
@@ -309,6 +310,23 @@ function registerCaptureImportCommands(program: Command): void {
       console.log(`capture-import scan: ${manifest.source_count} metadata-only sources`);
       console.log(`manifest: ${relative(process.cwd(), join(resolve(options.repo), ".understudy/capture-import/capture-sources.json"))}`);
       console.log(`redaction: ${manifest.redaction_manifest_path}`);
+    });
+
+  captureImport
+    .command("compile")
+    .description("Compile one dropped local file or directory into a metadata-only Workload Card")
+    .requiredOption("--source <path>", "Local file or directory to compile")
+    .option("--output-root <path>", "Private local artifact root; defaults under ~/.understudy")
+    .option("--json", "Output JSON")
+    .action((options: { source: string; outputRoot?: string; json?: boolean }) => {
+      const result = compileCaptureImport(options.source, new Date(), options.outputRoot);
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`capture-import compile: ${result.source_count} source(s) from ${result.source_name}`);
+      console.log(`workload card: ${result.workload_card_path}`);
+      console.log("payload_read: false");
     });
 
   captureImport

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -1599,6 +1599,70 @@ describe("understudy CLI", () => {
       assert.equal(packet.schema_version, "understudy.route_decision_packet.v1");
       assert.equal(packet.constraints.data_class, "source-metadata-only");
     }));
+
+  it("compiles one dropped file into an isolated metadata-only Workload Card", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-drop-file-"));
+    try {
+      const source = join(root, "customer-payload.unknown");
+      writeFileSync(source, "payload must stay unread\n");
+      const outputRoot = join(root, "artifacts");
+      const result = run(["capture-import", "compile", "--source", source, "--output-root", outputRoot, "--json"]);
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(!result.stdout.includes("payload must stay unread"));
+
+      const compiled = JSON.parse(result.stdout);
+      assert.equal(compiled.source_name, "customer-payload.unknown");
+      assert.equal(compiled.source_type, "file");
+      assert.equal(compiled.source_count, 1);
+      assert.equal(compiled.source_kinds["local-file"], 1);
+      assert.equal(compiled.local_only, true);
+      assert.equal(compiled.payload_read, false);
+      assert.match(compiled.workload_card_path, /artifacts\/[a-f0-9]{12}\/workload-card\.json$/);
+
+      const card = JSON.parse(readFileSync(compiled.workload_card_path, "utf8"));
+      assert.equal(card.schema_version, "understudy.workload_card.v1");
+      assert.equal(card.mode, "local-only");
+      assert.equal(card.source_path, source);
+      assert.equal(card.evaluation_inputs[0].kind, "local-file");
+      if (process.platform !== "win32") {
+        assert.equal(statSync(compiled.artifact_root).mode & 0o777, 0o700);
+        assert.equal(statSync(compiled.workload_card_path).mode & 0o777, 0o600);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds a dropped directory and classifies broad local source material", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-drop-directory-"));
+    try {
+      mkdirSync(join(root, "node_modules"), { recursive: true });
+      writeFileSync(join(root, "00-brief.pdf"), "not read");
+      writeFileSync(join(root, "01-scores.xlsx"), "not read");
+      writeFileSync(join(root, "02-worker.rs"), "not read");
+      writeFileSync(join(root, "03-raw.unknown"), "not read");
+      writeFileSync(join(root, "node_modules", "ignored.ts"), "not scanned");
+      for (let index = 0; index < 1_001; index += 1) {
+        writeFileSync(join(root, `sample-${String(index).padStart(4, "0")}.txt`), "x");
+      }
+
+      const outputRoot = join(root, "artifacts");
+      const result = run(["capture-import", "compile", "--source", root, "--output-root", outputRoot, "--json"]);
+      assert.equal(result.status, 0, result.stderr);
+      const compiled = JSON.parse(result.stdout);
+      assert.equal(compiled.source_type, "directory");
+      assert.equal(compiled.scanned_file_count, 1_005);
+      assert.equal(compiled.source_count, 1_000);
+      assert.equal(compiled.truncated, true);
+      assert.ok(compiled.source_kinds.document > 0);
+      assert.equal(compiled.source_kinds.spreadsheet, 1);
+      assert.equal(compiled.source_kinds["source-file"], 1);
+      assert.equal(compiled.source_kinds["local-file"], 1);
+      assert.ok(!result.stdout.includes("node_modules"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("two-phase email login", () => {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1628,6 +1628,10 @@ describe("understudy CLI", () => {
         assert.equal(statSync(compiled.artifact_root).mode & 0o777, 0o700);
         assert.equal(statSync(compiled.workload_card_path).mode & 0o777, 0o600);
       }
+
+      const repeated = run(["capture-import", "compile", "--source", source, "--output-root", outputRoot, "--json"]);
+      assert.equal(repeated.status, 0, repeated.stderr);
+      assert.notEqual(JSON.parse(repeated.stdout).artifact_root, compiled.artifact_root);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -169,6 +169,8 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
 
   assert.match(chat, /getCurrentWebview\(\)\s*\.onDragDropEvent/);
   assert.match(chat, /"compile_dropped_workload"/);
+  assert.match(chat, /dropRequestGeneration\.current !== requestGeneration/);
+  assert.match(chat, /dropRequestGeneration\.current \+= 1/);
   assert.match(chat, /Drop one file or folder/);
   assert.match(chat, /Metadata only · stays on this Mac/);
   assert.match(chat, /Review next steps/);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -63,6 +63,11 @@ const modelMemoryPath = new URL(
   "../apps/homescreen/app/lib/model-memory.mjs",
   import.meta.url,
 );
+const workloadDropRustPath = new URL(
+  "../apps/homescreen/src-tauri/src/workload_drop.rs",
+  import.meta.url,
+);
+const captureImportPath = new URL("../src/capture-import.ts", import.meta.url);
 
 test("public desktop preserves the reviewed Train interaction language", async () => {
   const [css, chat, sidebar] = await Promise.all([
@@ -152,6 +157,33 @@ test("desktop persists image references instead of transcript-embedded bytes", a
   assert.match(attachmentRust, /from_mode\(0o700\)/);
   assert.match(attachmentRust, /options\.mode\(0o600\)/);
   assert.match(attachmentRust, /migrate_legacy_messages/);
+});
+
+test("desktop compiles one dropped path through the bounded public CLI", async () => {
+  const [chat, bridge, compiler, parity] = await Promise.all([
+    readFile(chatPath, "utf8"),
+    readFile(workloadDropRustPath, "utf8"),
+    readFile(captureImportPath, "utf8"),
+    readFile(parityPath, "utf8").then(JSON.parse),
+  ]);
+
+  assert.match(chat, /getCurrentWebview\(\)\s*\.onDragDropEvent/);
+  assert.match(chat, /"compile_dropped_workload"/);
+  assert.match(chat, /Drop one file or folder/);
+  assert.match(chat, /Metadata only · stays on this Mac/);
+  assert.match(chat, /Review next steps/);
+  assert.doesNotMatch(chat, /\/analyze-drop|\/drop-act/);
+  assert.match(bridge, /CLI owns discovery, privacy boundaries, scan limits/);
+  assert.match(bridge, /"capture-import", "compile", "--source"/);
+  assert.match(bridge, /value\.get\("local_only"\)/);
+  assert.match(bridge, /value\.get\("payload_read"\)/);
+  assert.match(compiler, /const MAX_SCAN_FILES = 5_000/);
+  assert.match(compiler, /const MAX_CAPTURE_SOURCES = 1_000/);
+  assert.match(compiler, /payload_read: false/);
+  assert.equal(
+    parity.features.find((feature) => feature.id === "drop-to-workload-compilation")?.status,
+    "shipped",
+  );
 });
 
 test("desktop model downloads are app-owned, pausable, and resumable", async () => {


### PR DESCRIPTION
## What changed

- add `understudy capture-import compile --source <path>` for one exact file or directory
- bound metadata discovery to 5,000 files and 1,000 source records without reading payloads
- write owner-only Workload Card artifacts under `~/.understudy/capture-imports/`
- connect native Tauri file/folder drops to the public CLI through a thin adapter
- render one compact Workload draft card in Chat; do not restore the legacy environment bridge or analytics wall

## Why

This preserves the useful Train outcome in the canonical OSS desktop while keeping discovery, privacy rules, and durable artifacts owned by the public CLI.

## Validation

- `npm run check` (269 tests)
- `cargo test` (168 passed, 4 fixture-dependent tests ignored)
- desktop Next production build
- targeted 1,001-file bounded directory test
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->