### PR TITLE
Add truthful desktop model cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Added
 
+- **Truthful model cards in Chat.** One quiet info action beside the selected
+  model now shows its QAT source, MLX conversion, decode contract, scoped
+  certification, footprint, routing hints, and current slot state without
+  leaving the conversation. The four `-understudy` cards explicitly distinguish
+  compression and runtime certification from SFT or RL, and unknown provider or
+  local routes stay neutral instead of receiving invented provenance.
 - **Truthful native Rust migration baseline.** `understudy runtime conformance
   --backend native` now uses the owner-only authenticated Desktop API to force
   the one-release Rust fallback against a named warm slot. It passes only the

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -51,6 +51,7 @@ import {
   type ChatAttachmentUpload,
 } from "../lib/chat-attachments";
 import { modelShortName, type SnapshotAlias } from "../lib/model-aliases";
+import { ModelCardDrawer } from "./ModelCardDrawer";
 import type { FileUIPart } from "ai";
 
 type Role = "user" | "assistant";
@@ -124,6 +125,7 @@ type PersistedChatSession = {
 };
 type LocalModelChoice = {
   id: string;
+  modelId: string;
   label: string;
   detail: string;
   route: "local";
@@ -362,6 +364,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
         .filter((slot) => (slot.state === "running" || slot.state === "loading") && slot.model_id)
         .map<LocalModelChoice>((slot) => ({
           id: `local:${slot.id}`,
+          modelId: slot.model_id!,
           label: modelShortName(slot.model_id, snapshots) ?? `slot ${slot.id}`,
           detail: `${slot.model_id}${slot.port ? ` · :${slot.port}` : ""}${slot.state === "loading" ? " · loading" : ""}`,
           route: "local",
@@ -1039,6 +1042,17 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
               selected={selectedChoice}
               onSelect={(id) => setSelectedModel(id)}
               onConnectAnthropic={connectAnthropic}
+            />
+            <ModelCardDrawer
+              modelId={selectedChoice.route === "local" ? selectedChoice.modelId : selectedChoice.id}
+              label={selectedChoice.label}
+              route={selectedChoice.route}
+              runtime={{
+                slotId: selectedChoice.route === "local" ? selectedChoice.slotId : undefined,
+                active: selectedChoice.active,
+                loading: selectedChoice.route === "local" ? selectedChoice.loading : false,
+                thinking: selectedChoice.route === "local" ? selectedChoice.thinking : false,
+              }}
             />
             <PromptInputBody className="composer-row-body">
               <PromptInputTextarea

--- a/apps/homescreen/app/components/ModelCardDrawer.tsx
+++ b/apps/homescreen/app/components/ModelCardDrawer.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./base-ui/dialog";
-import { compactModelId, modelCardFor } from "../lib/model-cards";
+import { compactModelId, isDetailedModelCard, modelCardFor } from "../lib/model-cards";
 
 type ModelRoute = "local" | "cloud" | "anthropic";
 
@@ -32,7 +32,7 @@ export function ModelCardDrawer({
   runtime: ModelRuntimeContext;
 }) {
   const card = modelCardFor(modelId);
-  const isLocalCard = route === "local" && card?.provenance;
+  const localCard = route === "local" && isDetailedModelCard(card) ? card : null;
   const runtimeLabel = runtime.loading
     ? "Loading"
     : runtime.active
@@ -65,57 +65,57 @@ export function ModelCardDrawer({
           </div>
         </DialogHeader>
 
-        {isLocalCard ? (
+        {localCard ? (
           <div className="model-card-grid">
             <section className="model-card-section provenance">
               <h3>What this is</h3>
-              <ModelCardFact label="Base" value={card.provenance!.base_model} mono />
-              <ModelCardFact label="Source" value={card.provenance!.source_checkpoint} mono />
-              <ModelCardFact label="Conversion" value={card.provenance!.conversion} mono />
-              <ModelCardFact label="Training" value={card.provenance!.understudy_training} />
-              <ModelCardFact label="License" value={card.provenance!.license} />
+              <ModelCardFact label="Base" value={localCard.provenance.base_model} mono />
+              <ModelCardFact label="Source" value={localCard.provenance.source_checkpoint} mono />
+              <ModelCardFact label="Conversion" value={localCard.provenance.conversion} mono />
+              <ModelCardFact label="Training" value={localCard.provenance.understudy_training} />
+              <ModelCardFact label="License" value={localCard.provenance.license} />
             </section>
 
             <section className="model-card-section">
               <h3>How it runs</h3>
               <div className="model-card-decode">
-                <span><b>{card.decode_contract!.temperature}</b> temp</span>
-                <span><b>{card.decode_contract!.top_p}</b> top-p</span>
-                <span><b>{card.decode_contract!.top_k}</b> top-k</span>
+                <span><b>{localCard.decode_contract.temperature}</b> temp</span>
+                <span><b>{localCard.decode_contract.top_p}</b> top-p</span>
+                <span><b>{localCard.decode_contract.top_k}</b> top-k</span>
               </div>
-              <p>{card.decode_contract!.warning}</p>
+              <p>{localCard.decode_contract.warning}</p>
               <p className="model-card-mono">
-                Required: {card.decode_contract!.required_server_flags.join(" ")}
+                Required: {localCard.decode_contract.required_server_flags.join(" ")}
               </p>
             </section>
 
             <section className="model-card-section">
               <h3>What we verified</h3>
               <div className="model-card-certification">
-                <span>{card.certification!.status}</span>
-                <time>{card.certification!.certified_at}</time>
+                <span>{localCard.certification.status}</span>
+                <time>{localCard.certification.certified_at}</time>
               </div>
               <div className="model-card-checks">
-                {card.certification!.verified.map((item) => <span key={item}>{item}</span>)}
+                {localCard.certification.verified.map((item) => <span key={item}>{item}</span>)}
               </div>
-              <p>{card.certification!.scope}</p>
+              <p>{localCard.certification.scope}</p>
             </section>
 
             <section className="model-card-section">
               <h3>When to use it</h3>
-              <ModelCardFact label="Role" value={card.routing_hints!.role} />
+              <ModelCardFact label="Role" value={localCard.routing_hints.role} />
               <ModelCardFact
                 label="Escalate"
-                value={card.routing_hints!.escalate_when.join(" · ")}
+                value={localCard.routing_hints.escalate_when.join(" · ")}
               />
-              <ModelCardFact label="Next" value={card.routing_hints!.escalate_to} />
+              <ModelCardFact label="Next" value={localCard.routing_hints.escalate_to} />
               <ModelCardFact
                 label="Footprint"
-                value={`${card.footprint!.disk_gb} GB disk${
-                  card.footprint!.peak_runtime_memory_gb
-                    ? ` · ${card.footprint!.peak_runtime_memory_gb} GB measured peak`
+                value={`${localCard.footprint.disk_gb} GB disk${
+                  localCard.footprint.peak_runtime_memory_gb
+                    ? ` · ${localCard.footprint.peak_runtime_memory_gb} GB measured peak`
                     : ""
-                } · ${card.footprint!.runtime}`}
+                } · ${localCard.footprint.runtime}`}
               />
             </section>
           </div>

--- a/apps/homescreen/app/components/ModelCardDrawer.tsx
+++ b/apps/homescreen/app/components/ModelCardDrawer.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Info } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./base-ui/dialog";
+import { compactModelId, modelCardFor } from "../lib/model-cards";
+
+type ModelRoute = "local" | "cloud" | "anthropic";
+
+export type ModelRuntimeContext = {
+  slotId?: number;
+  active: boolean;
+  loading?: boolean;
+  thinking?: boolean;
+};
+
+export function ModelCardDrawer({
+  modelId,
+  label,
+  route,
+  runtime,
+}: {
+  modelId: string;
+  label: string;
+  route: ModelRoute;
+  runtime: ModelRuntimeContext;
+}) {
+  const card = modelCardFor(modelId);
+  const isLocalCard = route === "local" && card?.provenance;
+  const runtimeLabel = runtime.loading
+    ? "Loading"
+    : runtime.active
+      ? "Ready"
+      : "Unavailable";
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="model-card-trigger"
+          aria-label={`About ${label}`}
+          title={`About ${label}`}
+        >
+          <Info aria-hidden="true" />
+        </button>
+      </DialogTrigger>
+      <DialogContent className="model-card-dialog">
+        <DialogHeader className="model-card-header">
+          <div className="model-card-title-row">
+            <div>
+              <DialogTitle>{card?.alias ?? label}</DialogTitle>
+              <DialogDescription>{compactModelId(modelId)}</DialogDescription>
+            </div>
+            <div className="model-card-badges" aria-label="Current model state">
+              <span>{route}</span>
+              <span className={runtime.active ? "good" : ""}>{runtimeLabel}</span>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {isLocalCard ? (
+          <div className="model-card-grid">
+            <section className="model-card-section provenance">
+              <h3>What this is</h3>
+              <ModelCardFact label="Base" value={card.provenance!.base_model} mono />
+              <ModelCardFact label="Source" value={card.provenance!.source_checkpoint} mono />
+              <ModelCardFact label="Conversion" value={card.provenance!.conversion} mono />
+              <ModelCardFact label="Training" value={card.provenance!.understudy_training} />
+              <ModelCardFact label="License" value={card.provenance!.license} />
+            </section>
+
+            <section className="model-card-section">
+              <h3>How it runs</h3>
+              <div className="model-card-decode">
+                <span><b>{card.decode_contract!.temperature}</b> temp</span>
+                <span><b>{card.decode_contract!.top_p}</b> top-p</span>
+                <span><b>{card.decode_contract!.top_k}</b> top-k</span>
+              </div>
+              <p>{card.decode_contract!.warning}</p>
+              <p className="model-card-mono">
+                Required: {card.decode_contract!.required_server_flags.join(" ")}
+              </p>
+            </section>
+
+            <section className="model-card-section">
+              <h3>What we verified</h3>
+              <div className="model-card-certification">
+                <span>{card.certification!.status}</span>
+                <time>{card.certification!.certified_at}</time>
+              </div>
+              <div className="model-card-checks">
+                {card.certification!.verified.map((item) => <span key={item}>{item}</span>)}
+              </div>
+              <p>{card.certification!.scope}</p>
+            </section>
+
+            <section className="model-card-section">
+              <h3>When to use it</h3>
+              <ModelCardFact label="Role" value={card.routing_hints!.role} />
+              <ModelCardFact
+                label="Escalate"
+                value={card.routing_hints!.escalate_when.join(" · ")}
+              />
+              <ModelCardFact label="Next" value={card.routing_hints!.escalate_to} />
+              <ModelCardFact
+                label="Footprint"
+                value={`${card.footprint!.disk_gb} GB disk${
+                  card.footprint!.peak_runtime_memory_gb
+                    ? ` · ${card.footprint!.peak_runtime_memory_gb} GB measured peak`
+                    : ""
+                } · ${card.footprint!.runtime}`}
+              />
+            </section>
+          </div>
+        ) : (
+          <section className="model-card-section model-card-provider">
+            <h3>{route === "local" ? "Local snapshot" : "Provider route"}</h3>
+            <p>
+              {route === "local"
+                ? "This local model has no published Understudy model card yet. Its name and current runtime state are still shown here without inferring training or certification."
+                : "This model is served by the configured provider. Provenance, decode settings, and certification are determined by that route rather than a local Understudy snapshot."}
+            </p>
+          </section>
+        )}
+
+        <footer className="model-card-context">
+          <span>Current chat</span>
+          <strong>{route === "local" && runtime.slotId != null ? `Slot ${runtime.slotId}` : route}</strong>
+          {route === "local" && <strong>{runtime.thinking ? "Thinking on" : "Thinking off"}</strong>}
+          <span className="model-card-context-note">No frozen experiment is linked to this chat.</span>
+        </footer>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ModelCardFact({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <dl className="model-card-fact">
+      <dt>{label}</dt>
+      <dd className={mono ? "model-card-mono" : undefined}>{value}</dd>
+    </dl>
+  );
+}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2970,6 +2970,230 @@ select,
   padding-inline: 4px;
 }
 
+.model-card-trigger {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-2);
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.model-card-trigger:hover,
+.model-card-trigger:focus-visible {
+  background: color-mix(in srgb, var(--mb-cyan) 10%, transparent);
+  color: var(--mb-cyan);
+  outline: none;
+}
+
+.model-card-trigger svg {
+  width: 14px;
+  height: 14px;
+}
+
+.model-card-dialog {
+  width: min(720px, calc(100vw - 32px));
+  max-width: 720px !important;
+  max-height: calc(100vh - 32px);
+  gap: 12px !important;
+  overflow: auto;
+  border-color: color-mix(in srgb, var(--mb-cyan) 20%, rgba(255, 255, 255, 0.12)) !important;
+  background: color-mix(in srgb, var(--bg) 94%, #0a1e27) !important;
+  padding: 18px !important;
+}
+
+.model-card-title-row,
+.model-card-certification,
+.model-card-context,
+.model-card-badges,
+.model-card-decode,
+.model-card-checks {
+  display: flex;
+  align-items: center;
+}
+
+.model-card-title-row {
+  justify-content: space-between;
+  gap: 16px;
+  padding-right: 26px;
+}
+
+.model-card-title-row [data-slot="dialog-title"] {
+  color: var(--text);
+  font-size: 18px;
+}
+
+.model-card-title-row [data-slot="dialog-description"] {
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.model-card-badges,
+.model-card-checks {
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.model-card-badges span,
+.model-card-checks span {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 3px 7px;
+  color: var(--text-2);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.model-card-badges span.good,
+.model-card-checks span {
+  border-color: color-mix(in srgb, var(--mb-mint) 30%, transparent);
+  color: var(--mb-mint);
+}
+
+.model-card-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 8px;
+}
+
+.model-card-section {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.025);
+  padding: 11px 12px;
+}
+
+.model-card-section h3 {
+  margin: 0 0 8px;
+  color: var(--mb-cyan);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.model-card-section p {
+  margin: 7px 0 0;
+  color: var(--text-2);
+  font-size: 11px;
+  line-height: 1.42;
+}
+
+.model-card-fact {
+  display: grid;
+  grid-template-columns: 68px minmax(0, 1fr);
+  gap: 8px;
+  margin-top: 5px;
+  font-size: 10.5px;
+  line-height: 1.35;
+}
+
+.model-card-fact dt {
+  color: var(--text-3);
+}
+
+.model-card-fact dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.model-card-mono {
+  font-family: var(--font-mono);
+  font-size: 9.5px !important;
+}
+
+.model-card-decode {
+  gap: 7px;
+}
+
+.model-card-decode span {
+  flex: 1;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--mb-cyan) 7%, transparent);
+  padding: 6px;
+  color: var(--text-2);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-align: center;
+}
+
+.model-card-decode b {
+  display: block;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.model-card-certification {
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 7px;
+  color: var(--mb-mint);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.model-card-certification time {
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 400;
+}
+
+.model-card-provider {
+  min-height: 140px;
+}
+
+.model-card-context {
+  gap: 7px;
+  min-width: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  padding-top: 10px;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+}
+
+.model-card-context strong {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mb-mint) 10%, transparent);
+  padding: 3px 7px;
+  color: var(--mb-mint);
+  font-weight: 500;
+}
+
+.model-card-context-note {
+  margin-left: auto;
+  text-align: right;
+}
+
+@media (max-width: 660px) {
+  .model-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .model-card-context {
+    flex-wrap: wrap;
+  }
+
+  .model-card-context-note {
+    width: 100%;
+    margin-left: 0;
+    text-align: left;
+  }
+}
+
 .composer-row .ai-thinking-toggle {
   border-color: transparent;
   background: transparent;

--- a/apps/homescreen/app/lib/model-cards.ts
+++ b/apps/homescreen/app/lib/model-cards.ts
@@ -1,0 +1,74 @@
+import rawModelCards from "../../src-tauri/knowledge/model_cards.json";
+
+export type ModelCardProvenance = {
+  base_model: string;
+  source_checkpoint: string;
+  conversion: string;
+  understudy_training: string;
+  license: string;
+};
+
+export type ModelCardDecodeContract = {
+  temperature: number;
+  top_p: number;
+  top_k: number;
+  warning: string;
+  required_server_flags: string[];
+};
+
+export type ModelCardCertification = {
+  status: string;
+  scope: string;
+  verified: string[];
+  certified_at: string;
+};
+
+export type ModelCardFootprint = {
+  disk_gb: number;
+  peak_runtime_memory_gb?: number;
+  runtime: string;
+};
+
+export type ModelCardRoutingHints = {
+  role: string;
+  escalate_when: string[];
+  escalate_to: string;
+};
+
+export type PublicModelCard = {
+  id: string;
+  card_schema?: string;
+  alias?: string;
+  alias_for?: string;
+  provenance?: ModelCardProvenance;
+  decode_contract?: ModelCardDecodeContract;
+  certification?: ModelCardCertification;
+  footprint?: ModelCardFootprint;
+  routing_hints?: ModelCardRoutingHints;
+};
+
+const cards = rawModelCards as PublicModelCard[];
+const cardsById = new Map(cards.map((card) => [card.id.toLowerCase(), card]));
+
+export function normalizeModelCardId(modelId: string): string {
+  const withoutRoute = modelId.replace(/^(?:local|cloud|anthropic):/i, "");
+  return withoutRoute.split(/[\\/]/).filter(Boolean).at(-1)?.toLowerCase() ?? withoutRoute.toLowerCase();
+}
+
+export function modelCardFor(modelId: string): PublicModelCard | null {
+  let card = cardsById.get(normalizeModelCardId(modelId));
+  const visited = new Set<string>();
+  while (card?.alias_for && !visited.has(card.id)) {
+    visited.add(card.id);
+    card = cardsById.get(card.alias_for.toLowerCase());
+  }
+  return card ?? null;
+}
+
+export function compactModelId(modelId: string): string {
+  return normalizeModelCardId(modelId)
+    .replace(/^gemma-4-/, "")
+    .replace(/-it-qat-mlx-vlm(?:-4bit)?-understudy$/, "")
+    .replaceAll("-", " ")
+    .toUpperCase();
+}

--- a/apps/homescreen/app/lib/model-cards.ts
+++ b/apps/homescreen/app/lib/model-cards.ts
@@ -47,12 +47,31 @@ export type PublicModelCard = {
   routing_hints?: ModelCardRoutingHints;
 };
 
+export type DetailedPublicModelCard = PublicModelCard & {
+  provenance: ModelCardProvenance;
+  decode_contract: ModelCardDecodeContract;
+  certification: ModelCardCertification;
+  footprint: ModelCardFootprint;
+  routing_hints: ModelCardRoutingHints;
+};
+
 const cards = rawModelCards as PublicModelCard[];
 const cardsById = new Map(cards.map((card) => [card.id.toLowerCase(), card]));
 
 export function normalizeModelCardId(modelId: string): string {
   const withoutRoute = modelId.replace(/^(?:local|cloud|anthropic):/i, "");
-  return withoutRoute.split(/[\\/]/).filter(Boolean).at(-1)?.toLowerCase() ?? withoutRoute.toLowerCase();
+  const basename = withoutRoute.split(/[\\/]/).filter(Boolean).at(-1) ?? withoutRoute;
+  return basename.toLowerCase().replaceAll("-4-bit", "-4bit");
+}
+
+export function isDetailedModelCard(card: PublicModelCard | null): card is DetailedPublicModelCard {
+  return Boolean(
+    card?.provenance &&
+    card.decode_contract &&
+    card.certification &&
+    card.footprint &&
+    card.routing_hints,
+  );
 }
 
 export function modelCardFor(modelId: string): PublicModelCard | null {

--- a/apps/homescreen/src-tauri/knowledge/model_cards.json
+++ b/apps/homescreen/src-tauri/knowledge/model_cards.json
@@ -1,23 +1,168 @@
 [
   {
     "id": "default",
+    "card_schema": "understudy.model_card.v2",
     "system_prompt": "You are an AI assistant in the Understudy desktop app. Be direct, accurate, and useful. Do not claim to be an Understudy-trained model unless the selected model card explicitly says so."
   },
   {
     "id": "glm-5.2",
+    "card_schema": "understudy.model_card.v2",
+    "alias": "GLM 5.2",
     "system_prompt": "You are an AI assistant routed through the Understudy gateway. Be direct, accurate, and useful. Do not claim to be an Understudy-trained local model."
   },
   {
     "id": "gemma-4-e2b-it-qat-mlx-vlm-understudy",
-    "system_prompt": "You are an AI assistant created by understudylabs.com, an independent AI research and products company based in Oakland, CA. Luis Manrique and Aamir Poonawalla are cofounders.\n\nYou are a quantized and post-trained Gemma 4 E2B model. Your base pre-training was done by Google as part of the Gemma 4 series with a cutoff date of January 2025. Your Understudy post-training focused on speed and accuracy against tool calling and economically valuable knowledge work tasks."
+    "card_schema": "understudy.model_card.v2",
+    "alias": "Understudy Small",
+    "system_prompt": "You are a Gemma 4 E2B local model running in the Understudy desktop app. The checkpoint was converted from Google's QAT source to MLX 4-bit group-32 weights by Understudy. Do not claim Understudy SFT, RL, or other post-training; the Understudy work represented by this artifact is compression and serving certification.",
+    "provenance": {
+      "base_model": "google/gemma-4-E2B-it",
+      "source_checkpoint": "google/gemma-4-E2B-it-qat-q4_0-unquantized",
+      "conversion": "mlx_vlm convert -q --q-bits 4 --q-group-size 32",
+      "understudy_training": "None. Compression and serving certification only; no Understudy SFT or RL.",
+      "license": "Apache-2.0 (inherited from base)"
+    },
+    "decode_contract": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64,
+      "warning": "Sampling is part of the serving contract. Do not switch to greedy decoding to repair tool calls.",
+      "required_server_flags": ["--top-logprobs-k", "20"]
+    },
+    "certification": {
+      "status": "Serving contract verified",
+      "scope": "Generation, OpenAI/Pi compatibility, top-logprobs, and the tool-call serving path. This is not broad task-quality certification.",
+      "verified": ["generation", "OpenAI/Pi", "top-logprobs", "tool-call path"],
+      "certified_at": "2026-06-16"
+    },
+    "footprint": {
+      "disk_gb": 3.6,
+      "peak_runtime_memory_gb": 3.92,
+      "runtime": "mlx-vlm"
+    },
+    "routing_hints": {
+      "role": "Fast local worker",
+      "escalate_when": ["multi-step tool work", "high-stakes judgment", "the supervisor detects a likely error"],
+      "escalate_to": "Understudy Balanced or a configured supervisor"
+    }
   },
   {
     "id": "gemma-4-e2b-it-qat-mlx-vlm-4bit-understudy",
     "alias_for": "gemma-4-e2b-it-qat-mlx-vlm-understudy"
   },
   {
+    "id": "gemma-4-e4b-it-qat-mlx-vlm-understudy",
+    "card_schema": "understudy.model_card.v2",
+    "alias": "Understudy Balanced",
+    "system_prompt": "You are a Gemma 4 E4B local model running in the Understudy desktop app. The checkpoint was converted from Google's QAT source to MLX 4-bit group-32 weights by Understudy. Do not claim Understudy SFT, RL, or other post-training; the Understudy work represented by this artifact is compression and runtime certification.",
+    "provenance": {
+      "base_model": "google/gemma-4-E4B-it",
+      "source_checkpoint": "google/gemma-4-E4B-it-qat-q4_0-unquantized",
+      "conversion": "mlx_vlm convert -q --q-bits 4 --q-group-size 32",
+      "understudy_training": "None. Compression and runtime certification only; no Understudy SFT or RL.",
+      "license": "Apache-2.0 (inherited from base)"
+    },
+    "decode_contract": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64,
+      "warning": "Sampling is part of the serving contract. Do not switch to greedy decoding to repair tool calls.",
+      "required_server_flags": ["--top-logprobs-k", "20"]
+    },
+    "certification": {
+      "status": "Runtime compatible",
+      "scope": "8/8 frozen ConversationRuntime scenarios passed. Supervisor, malformed-tool, and compaction fixtures were deterministic; this is not broad task-quality certification.",
+      "verified": ["generation", "OpenAI/Pi", "top-logprobs", "tool-call path", "runtime 8/8"],
+      "certified_at": "2026-07-12"
+    },
+    "footprint": {
+      "disk_gb": 5.65,
+      "runtime": "mlx-vlm"
+    },
+    "routing_hints": {
+      "role": "Balanced local worker",
+      "escalate_when": ["high-stakes judgment", "repeated tool failure", "the supervisor requests takeover"],
+      "escalate_to": "Understudy Quality or a configured supervisor"
+    }
+  },
+  {
+    "id": "gemma-4-e4b-it-qat-mlx-vlm-4bit-understudy",
+    "alias_for": "gemma-4-e4b-it-qat-mlx-vlm-understudy"
+  },
+  {
+    "id": "gemma-4-12b-it-qat-mlx-vlm-understudy",
+    "card_schema": "understudy.model_card.v2",
+    "alias": "Understudy Quality",
+    "system_prompt": "You are a Gemma 4 12B local model running in the Understudy desktop app. The checkpoint was converted from Google's QAT source to MLX 4-bit group-32 weights by Understudy. Do not claim Understudy SFT, RL, or other post-training; the Understudy work represented by this artifact is compression and runtime certification.",
+    "provenance": {
+      "base_model": "google/gemma-4-12B-it",
+      "source_checkpoint": "google/gemma-4-12B-it-qat-q4_0-unquantized",
+      "conversion": "mlx_vlm convert -q --q-bits 4 --q-group-size 32",
+      "understudy_training": "None. Compression and runtime certification only; no Understudy SFT or RL.",
+      "license": "Apache-2.0 (inherited from base)"
+    },
+    "decode_contract": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64,
+      "warning": "Sampling is part of the serving contract. Do not switch to greedy decoding to repair tool calls.",
+      "required_server_flags": ["--top-logprobs-k", "20"]
+    },
+    "certification": {
+      "status": "Runtime compatible",
+      "scope": "8/8 frozen ConversationRuntime scenarios passed. Supervisor, malformed-tool, and compaction fixtures were deterministic; this is not broad task-quality certification.",
+      "verified": ["generation", "OpenAI/Pi", "top-logprobs", "tool-call path", "runtime 8/8"],
+      "certified_at": "2026-07-12"
+    },
+    "footprint": {
+      "disk_gb": 7.52,
+      "runtime": "mlx-vlm"
+    },
+    "routing_hints": {
+      "role": "Deeper local worker",
+      "escalate_when": ["strict tool correctness is required", "high-stakes judgment", "the supervisor requests takeover"],
+      "escalate_to": "A configured frontier supervisor"
+    }
+  },
+  {
+    "id": "gemma-4-12b-it-qat-mlx-vlm-4bit-understudy",
+    "alias_for": "gemma-4-12b-it-qat-mlx-vlm-understudy"
+  },
+  {
     "id": "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy",
-    "system_prompt": "You are an AI assistant created by understudylabs.com, an independent AI research and products company based in Oakland, CA. Luis Manrique and Aamir Poonawalla are cofounders.\n\nYou are a quantized and post-trained mixture of experts model. You employ a hybrid attention mechanism that interleaves local sliding window attention with full global attention, ensuring the final layer is always global. This hybrid design delivers the processing speed and low memory footprint of a lightweight model without sacrificing the deep awareness required for complex, long-context tasks.\n\nYour base pre-training was done by Google as part of the Gemma 4 series with a cutoff date of January 2025. Your post-training was conducted in June 2026 using the latest on-policy self-distillation and supervised fine-tuning methods on Understudy Labs' training cluster. Your post-training focused on speed and accuracy against tool calling and economically valuable knowledge work tasks."
+    "card_schema": "understudy.model_card.v2",
+    "alias": "Understudy Sparse",
+    "system_prompt": "You are a Gemma 4 26B-A4B local mixture-of-experts model running in the Understudy desktop app. The checkpoint was converted from Google's QAT source to MLX group-32 weights by Understudy, with 8-bit routers. Do not claim Understudy SFT, RL, or other post-training; the Understudy work represented by this artifact is compression and serving certification.",
+    "provenance": {
+      "base_model": "google/gemma-4-26B-A4B-it",
+      "source_checkpoint": "google/gemma-4-26B-A4B-it-qat-q4_0-unquantized",
+      "conversion": "MLX 4-bit group-32 experts with 8-bit routers",
+      "understudy_training": "None. Compression and serving certification only; no Understudy SFT or RL.",
+      "license": "Apache-2.0 (inherited from base)"
+    },
+    "decode_contract": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 64,
+      "warning": "Sampling is part of the serving contract. Do not switch to greedy decoding to repair tool calls.",
+      "required_server_flags": ["--top-logprobs-k", "20"]
+    },
+    "certification": {
+      "status": "Serving contract verified",
+      "scope": "Generation, OpenAI/Pi compatibility, top-logprobs without MTP, and the tool-call serving path. This is not broad task-quality certification.",
+      "verified": ["generation", "OpenAI/Pi", "top-logprobs", "tool-call path"],
+      "certified_at": "2026-06-16"
+    },
+    "footprint": {
+      "disk_gb": 16.0,
+      "peak_runtime_memory_gb": 17.0,
+      "runtime": "mlx-vlm"
+    },
+    "routing_hints": {
+      "role": "Heavy sparse local worker",
+      "escalate_when": ["strict tool correctness is required", "the task falls outside its certified serving scope", "the supervisor requests takeover"],
+      "escalate_to": "A configured frontier supervisor"
+    }
   },
   {
     "id": "gemma-4-26b-a4b-it-qat-mlx-vlm-4bit-understudy",
@@ -25,10 +170,14 @@
   },
   {
     "id": "gemma-4-e2b-it-mlx-vlm-4bit",
-    "system_prompt": "You are a Gemma 4 E2B local model running in the Understudy desktop app. Your base pre-training was done by Google as part of the Gemma 4 series with a cutoff date of January 2025. Do not claim Understudy post-training."
+    "card_schema": "understudy.model_card.v2",
+    "alias": "Gemma 4 E2B",
+    "system_prompt": "You are a Gemma 4 E2B local model running in the Understudy desktop app. Do not claim Understudy post-training."
   },
   {
     "id": "gemma-4-26b-a4b-it-mlx-vlm-4bit",
-    "system_prompt": "You are a Gemma 4 26B A4B local model running in the Understudy desktop app. Your base pre-training was done by Google as part of the Gemma 4 series with a cutoff date of January 2025. Do not claim Understudy post-training."
+    "card_schema": "understudy.model_card.v2",
+    "alias": "Gemma 4 26B-A4B",
+    "system_prompt": "You are a Gemma 4 26B-A4B local model running in the Understudy desktop app. Do not claim Understudy post-training."
   }
 ]

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -4071,6 +4071,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn public_model_cards_resolve_without_inventing_post_training() {
+        let alias_prompt = system_prompt_for(
+            "/tmp/models/gemma-4-e2b-it-qat-mlx-vlm-4-bit-understudy",
+        );
+        assert!(alias_prompt.contains("compression and serving certification"));
+        assert!(alias_prompt.contains("Do not claim Understudy SFT, RL"));
+        assert!(!alias_prompt.contains("quantized and post-trained"));
+
+        let sparse_prompt =
+            system_prompt_for("gemma-4-26b-a4b-it-qat-mlx-vlm-understudy");
+        assert!(sparse_prompt.contains("with 8-bit routers"));
+        assert!(!sparse_prompt.contains("self-distillation"));
+    }
+
+    #[test]
     fn native_reference_is_restricted_to_the_frozen_basic_case() {
         validate_native_reference_request(
             "Run the local fixture.",

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -174,8 +174,8 @@
     },
     {
       "id": "model-card-transparency",
-      "status": "planned",
-      "evidence": "The canonical model list still needs one compact drawer for provenance, decode contract, certification, footprint, routing hints, and active-experiment context sourced from public model manifests."
+      "status": "shipped",
+      "evidence": "Chat exposes one quiet model-info action beside the selected route. Its compact in-frame card resolves aliases from the same embedded public catalog used by the native runtime and shows exact QAT source, MLX group-32 conversion, the absence of Understudy SFT or RL, decode contract, scoped serving/runtime certification, footprint, escalation hints, exact slot state, thinking state, and an explicit no-linked-experiment state. Unknown local and provider routes fall back to neutral cards rather than inventing provenance or certification."
     },
     {
       "id": "reading-pace-streaming",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -258,8 +258,12 @@ test("chat exposes compact, truthful model cards from the canonical local catalo
   assert.match(drawer, /When to use it/);
   assert.match(drawer, /No frozen experiment is linked to this chat/);
   assert.doesNotMatch(drawer, /system_prompt/);
+  assert.match(drawer, /isDetailedModelCard\(card\)/);
+  assert.doesNotMatch(drawer, /decode_contract!|certification!|footprint!|routing_hints!/);
   assert.match(cardLib, /rawModelCards/);
   assert.match(cardLib, /while \(card\?\.alias_for/);
+  assert.match(cardLib, /replaceAll\("-4-bit", "-4bit"\)/);
+  assert.match(cardLib, /card\?\.provenance &&[\s\S]*?card\.routing_hints/);
 
   const ids = [
     "gemma-4-e2b-it-qat-mlx-vlm-understudy",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -54,6 +54,18 @@ const modelsPanePath = new URL(
   "../apps/homescreen/app/components/ModelsPane.tsx",
   import.meta.url,
 );
+const modelCardDrawerPath = new URL(
+  "../apps/homescreen/app/components/ModelCardDrawer.tsx",
+  import.meta.url,
+);
+const modelCardLibPath = new URL(
+  "../apps/homescreen/app/lib/model-cards.ts",
+  import.meta.url,
+);
+const modelCardsPath = new URL(
+  "../apps/homescreen/src-tauri/knowledge/model_cards.json",
+  import.meta.url,
+);
 const rlmPanePath = new URL(
   "../apps/homescreen/app/components/RlmPane.tsx",
   import.meta.url,
@@ -228,6 +240,56 @@ test("large local models warn before consuming the residency budget", async () =
   assert.match(modelsPane, /snapshotMemoryWarning/);
 });
 
+test("chat exposes compact, truthful model cards from the canonical local catalog", async () => {
+  const [chat, drawer, cardLib, modelCards, parity] = await Promise.all([
+    readFile(chatPath, "utf8"),
+    readFile(modelCardDrawerPath, "utf8"),
+    readFile(modelCardLibPath, "utf8"),
+    readFile(modelCardsPath, "utf8").then(JSON.parse),
+    readFile(parityPath, "utf8").then(JSON.parse),
+  ]);
+
+  assert.match(chat, /<ModelCardDrawer/);
+  assert.match(chat, /modelId: slot\.model_id!/);
+  assert.match(chat, /selectedChoice\.modelId/);
+  assert.match(drawer, /What this is/);
+  assert.match(drawer, /How it runs/);
+  assert.match(drawer, /What we verified/);
+  assert.match(drawer, /When to use it/);
+  assert.match(drawer, /No frozen experiment is linked to this chat/);
+  assert.doesNotMatch(drawer, /system_prompt/);
+  assert.match(cardLib, /rawModelCards/);
+  assert.match(cardLib, /while \(card\?\.alias_for/);
+
+  const ids = [
+    "gemma-4-e2b-it-qat-mlx-vlm-understudy",
+    "gemma-4-e4b-it-qat-mlx-vlm-understudy",
+    "gemma-4-12b-it-qat-mlx-vlm-understudy",
+    "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy",
+  ];
+  for (const id of ids) {
+    const card = modelCards.find((candidate) => candidate.id === id);
+    assert.ok(card, `missing public model card for ${id}`);
+    assert.equal(card.card_schema, "understudy.model_card.v2");
+    assert.match(card.provenance.source_checkpoint, /qat-q4_0-unquantized$/);
+    assert.match(card.provenance.understudy_training, /^None\./);
+    assert.equal(card.decode_contract.temperature, 1);
+    assert.equal(card.decode_contract.top_p, 0.95);
+    assert.equal(card.decode_contract.top_k, 64);
+    assert.deepEqual(card.decode_contract.required_server_flags, ["--top-logprobs-k", "20"]);
+    assert.match(card.certification.scope, /not broad task-quality certification/);
+    assert.doesNotMatch(card.system_prompt, /Your post-training was|quantized and post-trained/i);
+  }
+  assert.equal(
+    modelCards.find((card) => card.id === ids[3]).provenance.conversion,
+    "MLX 4-bit group-32 experts with 8-bit routers",
+  );
+  assert.equal(
+    parity.features.find((feature) => feature.id === "model-card-transparency")?.status,
+    "shipped",
+  );
+});
+
 test("Experiments is one guided review, strict compare, improve loop", async () => {
   const [review, compare, comparisonRules, reviewRust, proofRust, proofCli, rlmPane, css] = await Promise.all([
     readFile(reviewViewPath, "utf8"),
@@ -336,6 +398,10 @@ test("desktop migration claims stay tied to explicit product parity", async () =
   );
   assert.equal(
     parity.features.find((feature) => feature.id === "correction-pair-export-and-metrics")?.status,
+    "shipped",
+  );
+  assert.equal(
+    parity.features.find((feature) => feature.id === "model-card-transparency")?.status,
     "shipped",
   );
   assert.equal(


### PR DESCRIPTION
## What changed

- adds one compact model-info action beside the selected Chat route
- shows provenance, decode contract, scoped certification, footprint, routing hints, and current slot state in one frame
- replaces stale E2B/26B post-training claims with the actual QAT-to-MLX group-32 lineage
- adds E4B and 12B cards and neutral fallbacks for unknown local/provider routes
- marks model-card transparency shipped in the desktop parity ledger

## Why

The canonical OSS desktop still lacked the model-card transparency present in the Train merger inventory, while its embedded prompts incorrectly claimed Understudy SFT/RL work that did not occur. The UI and runtime now share one truthful embedded catalog.

## Validation

- full `npm run check`: 270 tests, 33 skills, package smoke
- production Next build
- full Rust suite: 168 passed, 4 ignored fixture-copy tests
- model-card runtime alias/factuality test
- local browser render at 1280×720: no scrolling, close works, focus returns to trigger
- exact release app built and launched; E4B remains warm in slot 7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->