### PR TITLE
Port replacement-safe reading pace streaming

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -51,6 +51,11 @@ import {
   type ChatAttachmentUpload,
 } from "../lib/chat-attachments";
 import { modelShortName, type SnapshotAlias } from "../lib/model-aliases";
+import {
+  SKIP_HINT_THRESHOLD,
+  StreamPacer,
+  pacingEnabled,
+} from "../lib/stream-pacer.mjs";
 import { ModelCardDrawer } from "./ModelCardDrawer";
 import type { FileUIPart } from "ai";
 
@@ -339,9 +344,34 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const [dropHovering, setDropHovering] = useState(false);
   const [dropRunning, setDropRunning] = useState(false);
   const [droppedWorkload, setDroppedWorkload] = useState<DroppedWorkload | null>(null);
+  const [pacingMessageIndex, setPacingMessageIndex] = useState<number | null>(null);
+  const [pacedRevealed, setPacedRevealed] = useState<number | null>(null);
   const observedResetToken = useRef(false);
   const dropInFlight = useRef(false);
   const dropRequestGeneration = useRef(0);
+  const streamPacer = useRef<StreamPacer | null>(null);
+  const streamPacerGeneration = useRef(0);
+
+  const resetStreamPacer = () => {
+    streamPacerGeneration.current += 1;
+    streamPacer.current?.dispose();
+    streamPacer.current = null;
+    setPacingMessageIndex(null);
+    setPacedRevealed(null);
+  };
+
+  const startStreamPacer = (messageIndex: number) => {
+    resetStreamPacer();
+    if (!pacingEnabled()) return null;
+    const generation = streamPacerGeneration.current;
+    const pacer = new StreamPacer((revealed: number) => {
+      if (streamPacerGeneration.current === generation) setPacedRevealed(revealed);
+    });
+    streamPacer.current = pacer;
+    setPacingMessageIndex(messageIndex);
+    setPacedRevealed(0);
+    return pacer;
+  };
 
   const refreshModels = async () => {
     try {
@@ -392,6 +422,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   };
 
   const stopStreaming = () => {
+    streamPacer.current?.skip();
     void invoke<{ status: string }>("conversation_runtime_cancel", { sessionId })
       .then((result) => {
         if (result.status === "idle") {
@@ -408,7 +439,11 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   useEffect(() => {
     refreshModels();
     const timer = window.setInterval(refreshModels, 2500);
-    return () => window.clearInterval(timer);
+    return () => {
+      window.clearInterval(timer);
+      streamPacerGeneration.current += 1;
+      streamPacer.current?.dispose();
+    };
   }, []);
 
   useEffect(() => {
@@ -602,6 +637,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
       ...messages,
       { role: "user", content: clean, model: choice.label, attachments },
     ];
+    const turnPacer = startStreamPacer(toSend.length);
     setMessages([...toSend, { role: "assistant", content: "", reasoning: "", model: choice.label }]);
     setStreaming(true);
     setAssistantSpeaking(false);
@@ -612,6 +648,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
         setNotice(msg.message);
       } else if (msg.type === "Chunk") {
         setAssistantSpeaking(true);
+        turnPacer?.append(msg.text);
         setMessages((prev) => {
           if (prev.length === 0) return prev;
           const p = [...prev];
@@ -621,6 +658,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
         });
       } else if (msg.type === "ReplaceChunk") {
         setAssistantSpeaking(true);
+        turnPacer?.replace(msg.text);
         setMessages((prev) => {
           if (prev.length === 0) return prev;
           const p = [...prev];
@@ -687,10 +725,12 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
           ...prev.filter((event) => event.session_id === sessionId),
         ].slice(0, 12));
       } else if (msg.type === "Error") {
+        turnPacer?.skip();
         setErr(msg.message);
         setStreaming(false);
         setAssistantSpeaking(false);
       } else if (msg.type === "Done") {
+        turnPacer?.finish();
         setStreaming(false);
         setAssistantSpeaking(false);
       }
@@ -710,6 +750,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
         onEvent: ch,
       });
     } catch (e: unknown) {
+      turnPacer?.skip();
       setErr(String(e));
       setStreaming(false);
       setAssistantSpeaking(false);
@@ -731,6 +772,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
 
   const restartChat = () => {
     if (streaming) return;
+    resetStreamPacer();
     void invoke("chat_attachments_delete_session", { sessionId }).catch(() => {
       // Starting a fresh chat still succeeds; orphan cleanup is local and best-effort.
     });
@@ -886,6 +928,9 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
             messages.map((m, i) => {
               const isLastAssistant = m.role === "assistant" && i === messages.length - 1;
               const isActiveAssistant = isLastAssistant && streaming;
+              const isPacedAssistant = m.role === "assistant" && i === pacingMessageIndex && pacedRevealed !== null;
+              const shownContent = isPacedAssistant ? m.content.slice(0, pacedRevealed) : m.content;
+              const pacedBacklog = isPacedAssistant ? Math.max(0, m.content.length - pacedRevealed) : 0;
               const reasoningText = cleanReasoningText(m.reasoning ?? "");
               return (
                 <Message
@@ -920,7 +965,18 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
                       </div>
                     )}
                     {m.role === "assistant" ? (
-                      <MessageResponse>{m.content || (isActiveAssistant ? "..." : "")}</MessageResponse>
+                      <div className="paced-answer">
+                        <MessageResponse>{shownContent || (isActiveAssistant ? "..." : "")}</MessageResponse>
+                        {pacedBacklog > SKIP_HINT_THRESHOLD && (
+                          <button
+                            type="button"
+                            className="paced-answer-skip"
+                            onClick={() => streamPacer.current?.skip()}
+                          >
+                            Show full answer
+                          </button>
+                        )}
+                      </div>
                     ) : (
                       m.content
                     )}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2387,6 +2387,26 @@ select,
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+.paced-answer {
+  min-width: 0;
+}
+.paced-answer-skip {
+  margin-top: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  padding: 2px 0;
+}
+.paced-answer-skip:hover,
+.paced-answer-skip:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
 .chat-err {
   color: var(--error);
   font-size: 12px;

--- a/apps/homescreen/app/lib/stream-pacer.mjs
+++ b/apps/homescreen/app/lib/stream-pacer.mjs
@@ -82,6 +82,7 @@ export class StreamPacer {
   #state = initialDrainState();
   #done = false;
   #skipped = false;
+  #disposed = false;
   #timer = null;
   #lastTick = 0;
   #onUpdate;
@@ -107,7 +108,7 @@ export class StreamPacer {
   }
 
   append(chunk) {
-    if (!chunk) return;
+    if (this.#disposed || !chunk) return;
     this.#text += chunk;
     if (this.#skipped) {
       this.#revealAll();
@@ -121,6 +122,7 @@ export class StreamPacer {
    * cursor so rejected student text can never survive in the hidden buffer.
    */
   replace(text) {
+    if (this.#disposed) return;
     this.#teardown();
     this.#text = text;
     this.#done = false;
@@ -134,6 +136,7 @@ export class StreamPacer {
   }
 
   finish() {
+    if (this.#disposed) return;
     this.#done = true;
     this.#state.holdMs = 0;
     if (this.#skipped) {
@@ -145,6 +148,7 @@ export class StreamPacer {
 
   /** Reveal everything received now and keep later chunks immediate. */
   skip() {
+    if (this.#disposed) return;
     this.#skipped = true;
     this.#done = true;
     this.#teardown();
@@ -152,6 +156,7 @@ export class StreamPacer {
   }
 
   reset() {
+    if (this.#disposed) return;
     this.#teardown();
     this.#text = "";
     this.#done = false;
@@ -161,6 +166,7 @@ export class StreamPacer {
 
   dispose() {
     this.#teardown();
+    this.#disposed = true;
   }
 
   #revealAll() {

--- a/apps/homescreen/app/lib/stream-pacer.mjs
+++ b/apps/homescreen/app/lib/stream-pacer.mjs
@@ -1,0 +1,206 @@
+// Reading-pace display smoothing for streamed answers.
+//
+// Incoming chunks remain the source of truth in ChatPane. This module only
+// controls how much of the latest answer is visible, so persistence, tool
+// evidence, and supervision journals never wait on the display animation.
+
+/** Brisk reading speed in characters per second. */
+export const BASE_RATE = 70;
+/** Buffer length at which the catch-up multiplier reaches 2x. */
+export const CATCHUP_DIVISOR = 400;
+/** Catch-up cap, also used after the runtime emits Done. */
+export const MAX_MULTIPLIER = 8;
+export const SENTENCE_PAUSE_MS = 120;
+export const PARAGRAPH_PAUSE_MS = 250;
+/** Only show the escape hatch when the hidden backlog is meaningful. */
+export const SKIP_HINT_THRESHOLD = 300;
+export const TICK_MS = 30;
+
+export function initialDrainState() {
+  return { revealed: 0, fractional: 0, holdMs: 0 };
+}
+
+export function effectiveRate(bufferLength, done) {
+  if (done) return BASE_RATE * MAX_MULTIPLIER;
+  const multiplier = Math.min(
+    MAX_MULTIPLIER,
+    1 + Math.max(0, bufferLength) / CATCHUP_DIVISOR,
+  );
+  return BASE_RATE * multiplier;
+}
+
+export function pauseAfter(text, index) {
+  if (index >= text.length - 1) return 0;
+  const character = text[index];
+  if (character === "\n" && index > 0 && text[index - 1] === "\n") {
+    return PARAGRAPH_PAUSE_MS;
+  }
+  const closesSentence =
+    /[.!?]/.test(character) ||
+    (/["')\]]/.test(character) && index > 0 && /[.!?]/.test(text[index - 1]));
+  if (closesSentence && /\s/.test(text[index + 1])) return SENTENCE_PAUSE_MS;
+  return 0;
+}
+
+/**
+ * Advance one display tick. The full received text is immutable input; only
+ * the returned reveal cursor is display state.
+ */
+export function stepDrain(text, done, state, dtMs) {
+  let { revealed, fractional, holdMs } = state;
+  let remainingMs = Math.max(0, dtMs);
+
+  if (holdMs > 0) {
+    const consumed = Math.min(holdMs, remainingMs);
+    holdMs -= consumed;
+    remainingMs -= consumed;
+    if (remainingMs <= 0) return { revealed, fractional, holdMs };
+  }
+  if (revealed >= text.length) {
+    return { revealed: text.length, fractional: 0, holdMs: 0 };
+  }
+
+  const rate = effectiveRate(text.length - revealed, done);
+  let budget = fractional + (rate * remainingMs) / 1000;
+  while (budget >= 1 && revealed < text.length) {
+    budget -= 1;
+    revealed += 1;
+    const pause = pauseAfter(text, revealed - 1);
+    if (pause > 0) {
+      return { revealed, fractional: 0, holdMs: pause };
+    }
+  }
+  return {
+    revealed,
+    fractional: revealed >= text.length ? 0 : budget,
+    holdMs: 0,
+  };
+}
+
+export class StreamPacer {
+  #text = "";
+  #state = initialDrainState();
+  #done = false;
+  #skipped = false;
+  #timer = null;
+  #lastTick = 0;
+  #onUpdate;
+
+  constructor(onUpdate) {
+    this.#onUpdate = onUpdate;
+  }
+
+  get received() {
+    return this.#text;
+  }
+
+  get revealed() {
+    return this.#state.revealed;
+  }
+
+  get bufferLength() {
+    return this.#text.length - this.#state.revealed;
+  }
+
+  get draining() {
+    return this.#timer !== null;
+  }
+
+  append(chunk) {
+    if (!chunk) return;
+    this.#text += chunk;
+    if (this.#skipped) {
+      this.#revealAll();
+      return;
+    }
+    this.#ensureLoop();
+  }
+
+  /**
+   * Teacher continuation replacement is not an append. Reset the reveal
+   * cursor so rejected student text can never survive in the hidden buffer.
+   */
+  replace(text) {
+    this.#teardown();
+    this.#text = text;
+    this.#done = false;
+    this.#state = initialDrainState();
+    if (this.#skipped) {
+      this.#revealAll();
+      return;
+    }
+    this.#onUpdate(0);
+    this.#ensureLoop();
+  }
+
+  finish() {
+    this.#done = true;
+    this.#state.holdMs = 0;
+    if (this.#skipped) {
+      this.#revealAll();
+      return;
+    }
+    this.#ensureLoop();
+  }
+
+  /** Reveal everything received now and keep later chunks immediate. */
+  skip() {
+    this.#skipped = true;
+    this.#done = true;
+    this.#teardown();
+    this.#revealAll();
+  }
+
+  reset() {
+    this.#teardown();
+    this.#text = "";
+    this.#done = false;
+    this.#skipped = false;
+    this.#state = initialDrainState();
+  }
+
+  dispose() {
+    this.#teardown();
+  }
+
+  #revealAll() {
+    this.#state = {
+      revealed: this.#text.length,
+      fractional: 0,
+      holdMs: 0,
+    };
+    this.#onUpdate(this.#state.revealed);
+  }
+
+  #ensureLoop() {
+    if (this.#timer !== null || this.#state.revealed >= this.#text.length) return;
+    this.#lastTick = performance.now();
+    this.#timer = setInterval(() => this.#tick(), TICK_MS);
+  }
+
+  #tick() {
+    const now = performance.now();
+    const elapsedMs = Math.min(now - this.#lastTick, 250);
+    this.#lastTick = now;
+    this.#state = stepDrain(this.#text, this.#done, this.#state, elapsedMs);
+    this.#onUpdate(this.#state.revealed);
+    if (this.#state.revealed >= this.#text.length) this.#teardown();
+  }
+
+  #teardown() {
+    if (this.#timer !== null) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+  }
+}
+
+/** Developer escape hatch; reduced-motion users always get immediate text. */
+export function pacingEnabled() {
+  try {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return false;
+    return window.localStorage.getItem("understudy.pacing") !== "off";
+  } catch {
+    return true;
+  }
+}

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -179,8 +179,8 @@
     },
     {
       "id": "reading-pace-streaming",
-      "status": "planned",
-      "evidence": "The tested reading-rate buffer and skip affordance remain absent. Port only after a small usability check proves that display pacing reduces disorientation without making local answers feel artificially slow; retain an immediate-display escape hatch."
+      "status": "shipped",
+      "evidence": "Chat keeps the full canonical stream as its persistence and evidence source while revealing only the latest answer at a brisk reading rate with bounded elastic catch-up. Direct simulations show a 20-character-per-second provider stays within two characters of live display, while a 1,000-character local burst drains within two seconds after Done. A visible Show full answer escape hatch appears only beyond a 300-character backlog, reduced-motion and understudy.pacing=off disable pacing, and teacher ReplaceChunk events reset the hidden buffer so rejected student text cannot leak into the correction."
     },
     {
       "id": "always-on-top-window-pin",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -75,6 +75,10 @@ const modelMemoryPath = new URL(
   "../apps/homescreen/app/lib/model-memory.mjs",
   import.meta.url,
 );
+const streamPacerPath = new URL(
+  "../apps/homescreen/app/lib/stream-pacer.mjs",
+  import.meta.url,
+);
 const workloadDropRustPath = new URL(
   "../apps/homescreen/src-tauri/src/workload_drop.rs",
   import.meta.url,
@@ -111,6 +115,23 @@ test("public desktop preserves the reviewed Train interaction language", async (
   assert.doesNotMatch(serving, /label: "Capture"/);
   assert.doesNotMatch(serving, /label: "Traces"/);
   assert.doesNotMatch(serving, /label: "Usage"/);
+});
+
+test("reading pace is quiet, optional, and safe across teacher replacement", async () => {
+  const [chat, css, pacer] = await Promise.all([
+    readFile(chatPath, "utf8"),
+    readFile(cssPath, "utf8"),
+    readFile(streamPacerPath, "utf8"),
+  ]);
+
+  assert.match(chat, /turnPacer\?\.replace\(msg\.text\)/);
+  assert.match(chat, /Show full answer/);
+  assert.match(chat, /pacedBacklog > SKIP_HINT_THRESHOLD/);
+  assert.match(chat, /turnPacer\?\.skip\(\)/);
+  assert.match(css, /\.paced-answer-skip/);
+  assert.match(pacer, /understudy\.pacing/);
+  assert.match(pacer, /prefers-reduced-motion: reduce/);
+  assert.match(pacer, /rejected student text can never survive in the hidden buffer/);
 });
 
 test("desktop restores the reviewed persisted always-on-top pin", async () => {
@@ -290,6 +311,10 @@ test("chat exposes compact, truthful model cards from the canonical local catalo
   );
   assert.equal(
     parity.features.find((feature) => feature.id === "model-card-transparency")?.status,
+    "shipped",
+  );
+  assert.equal(
+    parity.features.find((feature) => feature.id === "reading-pace-streaming")?.status,
     "shipped",
   );
 });

--- a/tests/stream-pacer.test.mjs
+++ b/tests/stream-pacer.test.mjs
@@ -104,4 +104,6 @@ test("teacher replacement drops the rejected text and skip stays immediate", () 
   assert.equal(pacer.received, "final teacher answer");
   assert.equal(pacer.revealed, "final teacher answer".length);
   pacer.dispose();
+  pacer.append(" ignored late event");
+  assert.equal(pacer.received, "final teacher answer");
 });

--- a/tests/stream-pacer.test.mjs
+++ b/tests/stream-pacer.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BASE_RATE,
+  CATCHUP_DIVISOR,
+  MAX_MULTIPLIER,
+  PARAGRAPH_PAUSE_MS,
+  SENTENCE_PAUSE_MS,
+  StreamPacer,
+  effectiveRate,
+  initialDrainState,
+  pauseAfter,
+  stepDrain,
+} from "../apps/homescreen/app/lib/stream-pacer.mjs";
+
+const filler = (length) => "x".repeat(length);
+
+test("the catch-up curve is bounded and Done drains at 8x", () => {
+  assert.equal(effectiveRate(0, false), BASE_RATE);
+  assert.equal(effectiveRate(CATCHUP_DIVISOR, false), BASE_RATE * 2);
+  assert.equal(effectiveRate(1_000_000, false), BASE_RATE * MAX_MULTIPLIER);
+  assert.equal(effectiveRate(1, true), BASE_RATE * MAX_MULTIPLIER);
+});
+
+test("sentence and paragraph pauses apply only before more text", () => {
+  assert.equal(pauseAfter("Done. Next", 4), SENTENCE_PAUSE_MS);
+  assert.equal(pauseAfter("one\n\ntwo", 4), PARAGRAPH_PAUSE_MS);
+  assert.equal(pauseAfter("The end.", 7), 0);
+  assert.equal(pauseAfter("3.14", 1), 0);
+});
+
+test("drain math carries fractions, pauses, and never passes the buffer", () => {
+  const text = filler(1_000);
+  let ticked = initialDrainState();
+  for (let index = 0; index < 10; index += 1) {
+    ticked = stepDrain(text, false, ticked, 30);
+  }
+  const oneShot = stepDrain(text, false, initialDrainState(), 300);
+  assert.ok(Math.abs(ticked.revealed - oneShot.revealed) <= 2);
+
+  const sentence = stepDrain(`Hi. ${filler(200)}`, false, initialDrainState(), 1_000);
+  assert.equal(sentence.revealed, 3);
+  assert.equal(sentence.holdMs, SENTENCE_PAUSE_MS);
+
+  const complete = stepDrain(filler(10), true, initialDrainState(), 60_000);
+  assert.deepEqual(complete, { revealed: 10, fractional: 0, holdMs: 0 });
+});
+
+function simulateStream({ total, sourceCharsPerSecond, sourceDurationMs }) {
+  const tickMs = 30;
+  let received = 0;
+  let state = initialDrainState();
+  let maxLag = 0;
+  for (let elapsed = tickMs; elapsed <= sourceDurationMs; elapsed += tickMs) {
+    received = Math.min(total, Math.floor((sourceCharsPerSecond * elapsed) / 1_000));
+    state = stepDrain(filler(received), false, state, tickMs);
+    maxLag = Math.max(maxLag, received - state.revealed);
+  }
+  let catchupMs = 0;
+  while (state.revealed < total && catchupMs < 10_000) {
+    state = stepDrain(filler(total), true, state, tickMs);
+    catchupMs += tickMs;
+  }
+  return { maxLag, catchupMs, revealed: state.revealed };
+}
+
+test("a slow provider remains effectively live instead of feeling throttled", () => {
+  const result = simulateStream({
+    total: 100,
+    sourceCharsPerSecond: 20,
+    sourceDurationMs: 5_000,
+  });
+  assert.ok(result.maxLag <= 2, `slow-stream lag was ${result.maxLag} characters`);
+  assert.equal(result.revealed, 100);
+  assert.ok(result.catchupMs <= 30);
+});
+
+test("a 1,000-character local burst catches up within two seconds after Done", () => {
+  const result = simulateStream({
+    total: 1_000,
+    sourceCharsPerSecond: 1_000,
+    sourceDurationMs: 1_000,
+  });
+  assert.ok(result.maxLag > 300, "the fast source should exercise the escape hatch");
+  assert.equal(result.revealed, 1_000);
+  assert.ok(result.catchupMs <= 2_000, `catch-up took ${result.catchupMs}ms`);
+});
+
+test("teacher replacement drops the rejected text and skip stays immediate", () => {
+  const updates = [];
+  const pacer = new StreamPacer((revealed) => updates.push(revealed));
+  pacer.append("rejected student answer");
+  pacer.replace("teacher correction");
+  assert.equal(pacer.received, "teacher correction");
+  assert.equal(pacer.revealed, 0);
+  assert.equal(updates.at(-1), 0);
+
+  pacer.skip();
+  assert.equal(pacer.revealed, "teacher correction".length);
+  pacer.append(" continues");
+  assert.equal(pacer.revealed, "teacher correction continues".length);
+  pacer.replace("final teacher answer");
+  assert.equal(pacer.received, "final teacher answer");
+  assert.equal(pacer.revealed, "final teacher answer".length);
+  pacer.dispose();
+});


### PR DESCRIPTION
## What changed

- ports the reviewed Train reading-rate stream buffer into the canonical public desktop
- keeps the full runtime stream as persistence and evidence while pacing only the visible answer
- resets the hidden buffer on teacher replacement so rejected student text cannot leak into the correction
- flushes safely on stop and error, and offers one quiet Show full answer action only for meaningful backlog
- disables pacing for reduced-motion users and supports the local understudy.pacing=off escape hatch
- records the capability as shipped in the public parity ledger

## Why

Fast local models can dump an answer faster than a person can orient to it. The original Train implementation solved that display problem but did not understand the canonical supervisor ReplaceChunk event. This port preserves the calmer reading experience without compromising supervision correctness or canonical evidence.

## Validation

- npm run check: 277 tests, 33 public skills, package smoke
- cargo test: 169 passed, 4 real-evidence fixtures ignored
- production Next build
- signed Tauri app build with strict codesign verification
- native visual smoke with a warm local E4B model, including the backlog threshold and full-answer affordance
- simulations: 20 chars/sec stays within 2 chars of live; 1,000-char burst catches up within 2 seconds after Done

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->