### PR TITLE
Prefer restored local models after cold launch

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -51,6 +51,7 @@ import {
   type ChatAttachmentUpload,
 } from "../lib/chat-attachments";
 import { modelShortName, type SnapshotAlias } from "../lib/model-aliases";
+import { resolveChatModelSelection } from "../lib/model-selection.mjs";
 import {
   SKIP_HINT_THRESHOLD,
   StreamPacer,
@@ -349,6 +350,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const observedResetToken = useRef(false);
   const dropInFlight = useRef(false);
   const dropRequestGeneration = useRef(0);
+  const selectedModelUserOwned = useRef(false);
   const streamPacer = useRef<StreamPacer | null>(null);
   const streamPacerGeneration = useRef(0);
 
@@ -412,8 +414,14 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
       const next = [...local, CLOUD_MODEL, ...anthropic];
       setChoices(next);
       setSelectedModel((current) => {
-        if (current && next.some((choice) => choice.id === current)) return current;
-        return local[0]?.id ?? CLOUD_MODEL.id;
+        const resolved = resolveChatModelSelection({
+          currentId: current,
+          choiceIds: next.map((choice) => choice.id),
+          preferredLocalId: local[0]?.id ?? null,
+          userSelected: selectedModelUserOwned.current,
+        });
+        selectedModelUserOwned.current = resolved.userSelected;
+        return resolved.selectedId;
       });
     } catch {
       setChoices([CLOUD_MODEL]);
@@ -1096,7 +1104,10 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
             <ModelPicker
               choices={choices}
               selected={selectedChoice}
-              onSelect={(id) => setSelectedModel(id)}
+              onSelect={(id) => {
+                selectedModelUserOwned.current = true;
+                setSelectedModel(id);
+              }}
               onConnectAnthropic={connectAnthropic}
             />
             <ModelCardDrawer

--- a/apps/homescreen/app/lib/model-selection.mjs
+++ b/apps/homescreen/app/lib/model-selection.mjs
@@ -1,0 +1,22 @@
+/**
+ * Resolve Chat's selected model while residency catches up after launch.
+ * Automatic cloud fallback is temporary; an explicit human choice is sticky.
+ */
+export function resolveChatModelSelection({
+  currentId,
+  choiceIds,
+  preferredLocalId,
+  userSelected,
+}) {
+  const currentExists = Boolean(currentId && choiceIds.includes(currentId));
+  if (userSelected && currentExists) {
+    return { selectedId: currentId, userSelected: true };
+  }
+  if (preferredLocalId && choiceIds.includes(preferredLocalId)) {
+    return { selectedId: preferredLocalId, userSelected: false };
+  }
+  if (currentExists) {
+    return { selectedId: currentId, userSelected: false };
+  }
+  return { selectedId: choiceIds[0] ?? null, userSelected: false };
+}

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -79,6 +79,10 @@ const streamPacerPath = new URL(
   "../apps/homescreen/app/lib/stream-pacer.mjs",
   import.meta.url,
 );
+const modelSelectionPath = new URL(
+  "../apps/homescreen/app/lib/model-selection.mjs",
+  import.meta.url,
+);
 const workloadDropRustPath = new URL(
   "../apps/homescreen/src-tauri/src/workload_drop.rs",
   import.meta.url,
@@ -132,6 +136,19 @@ test("reading pace is quiet, optional, and safe across teacher replacement", asy
   assert.match(pacer, /understudy\.pacing/);
   assert.match(pacer, /prefers-reduced-motion: reduce/);
   assert.match(pacer, /rejected student text can never survive in the hidden buffer/);
+});
+
+test("cold-start cloud fallback yields to local without overriding a human choice", async () => {
+  const [chat, selection] = await Promise.all([
+    readFile(chatPath, "utf8"),
+    readFile(modelSelectionPath, "utf8"),
+  ]);
+
+  assert.match(chat, /selectedModelUserOwned/);
+  assert.match(chat, /resolveChatModelSelection/);
+  assert.match(chat, /selectedModelUserOwned\.current = true/);
+  assert.match(selection, /if \(userSelected && currentExists\)/);
+  assert.match(selection, /preferredLocalId/);
 });
 
 test("desktop restores the reviewed persisted always-on-top pin", async () => {

--- a/tests/model-selection.test.mjs
+++ b/tests/model-selection.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveChatModelSelection } from "../apps/homescreen/app/lib/model-selection.mjs";
+
+const cloud = "cloud:glm-5.2";
+const local = "local:7";
+const anthropic = "anthropic:claude-opus";
+
+test("an automatic cold-start cloud fallback yields to the first warm local model", () => {
+  assert.deepEqual(
+    resolveChatModelSelection({
+      currentId: cloud,
+      choiceIds: [local, cloud],
+      preferredLocalId: local,
+      userSelected: false,
+    }),
+    { selectedId: local, userSelected: false },
+  );
+});
+
+test("an explicit cloud or Anthropic choice remains sticky while local models refresh", () => {
+  for (const selectedId of [cloud, anthropic]) {
+    assert.deepEqual(
+      resolveChatModelSelection({
+        currentId: selectedId,
+        choiceIds: [local, cloud, anthropic],
+        preferredLocalId: local,
+        userSelected: true,
+      }),
+      { selectedId, userSelected: true },
+    );
+  }
+});
+
+test("a disappeared explicit route falls back safely and releases the sticky choice", () => {
+  assert.deepEqual(
+    resolveChatModelSelection({
+      currentId: "local:missing",
+      choiceIds: [local, cloud],
+      preferredLocalId: local,
+      userSelected: true,
+    }),
+    { selectedId: local, userSelected: false },
+  );
+});
+
+test("cloud remains the automatic fallback while no local model is warm", () => {
+  assert.deepEqual(
+    resolveChatModelSelection({
+      currentId: cloud,
+      choiceIds: [cloud],
+      preferredLocalId: null,
+      userSelected: false,
+    }),
+    { selectedId: cloud, userSelected: false },
+  );
+});


### PR DESCRIPTION
## What changed

- makes the automatic cold-start cloud fallback yield to the first restored local model
- keeps an explicit human selection of GLM, Anthropic, or a local route sticky across residency refreshes
- releases a stale explicit choice safely if that route disappears
- adds direct selection-state tests and desktop integration assertions

## Why

Desktop restores model residency asynchronously. On a cold launch, Chat could select GLM during the short interval before the local slot became ready, then preserve that automatic fallback indefinitely. That violated the local-first default and made an accidental cloud request possible.

## Validation

- npm run check: 282 tests, 33 public skills, package smoke
- production Next build and typecheck
- reproduced against the exact signed 0.3.5 app with slot 7 restoring after the initial Chat render

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->