### PR TITLE
Resolve npm-linked CLI entries safely

### DIFF
--- a/apps/homescreen/src-tauri/src/bin.rs
+++ b/apps/homescreen/src-tauri/src/bin.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -11,17 +12,57 @@ pub fn resolve(name: &str) -> String {
         if let Some(candidate) = std::env::var_os("UNDERSTUDY_BIN") {
             let candidate = PathBuf::from(candidate);
             if candidate.is_file() {
-                return candidate.to_string_lossy().into_owned();
+                return canonical_candidate(&candidate)
+                    .unwrap_or(candidate)
+                    .to_string_lossy()
+                    .into_owned();
             }
         }
     }
-    if let Some(home) = std::env::var_os("HOME") {
-        let candidate = PathBuf::from(&home).join(".local/bin").join(name);
-        if candidate.is_file() {
+    let supplied = Path::new(name);
+    if supplied.components().count() > 1 {
+        return canonical_candidate(supplied)
+            .unwrap_or_else(|| supplied.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+    }
+    for directory in runtime_search_dirs() {
+        if let Some(candidate) = canonical_candidate(&directory.join(name)) {
             return candidate.to_string_lossy().into_owned();
         }
     }
     name.to_string()
+}
+
+fn canonical_candidate(candidate: &Path) -> Option<PathBuf> {
+    if !candidate.is_file() {
+        return None;
+    }
+    let resolved = candidate
+        .canonicalize()
+        .unwrap_or_else(|_| candidate.to_path_buf());
+    if resolved.extension().and_then(|value| value.to_str()) == Some("js")
+        || is_executable(&resolved)
+    {
+        Some(resolved)
+    } else {
+        None
+    }
+}
+
+#[cfg(unix)]
+fn is_executable(candidate: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    candidate
+        .metadata()
+        .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(candidate: &Path) -> bool {
+    candidate.is_file()
 }
 
 pub fn command(name: &str) -> Command {
@@ -43,27 +84,34 @@ pub fn command(name: &str) -> Command {
 }
 
 pub fn runtime_path() -> String {
-    let mut parts = vec![];
+    std::env::join_paths(runtime_search_dirs())
+        .unwrap_or_else(|_| OsString::from("/usr/bin:/bin"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn runtime_search_dirs() -> Vec<PathBuf> {
+    let mut parts = Vec::new();
     if let Some(home) = std::env::var_os("HOME") {
         let home = PathBuf::from(home);
-        parts.push(home.join(".local/bin").to_string_lossy().into_owned());
-        parts.push(home.join(".bun/bin").to_string_lossy().into_owned());
-        parts.push(home.join(".nvm/current/bin").to_string_lossy().into_owned());
+        parts.push(home.join(".local/bin"));
+        parts.push(home.join(".bun/bin"));
+        parts.push(home.join(".nvm/current/bin"));
     }
     parts.extend([
-        "/opt/homebrew/bin".to_string(),
-        "/opt/homebrew/sbin".to_string(),
-        "/usr/local/bin".to_string(),
-        "/usr/local/sbin".to_string(),
-        "/usr/bin".to_string(),
-        "/bin".to_string(),
-        "/usr/sbin".to_string(),
-        "/sbin".to_string(),
+        PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/opt/homebrew/sbin"),
+        PathBuf::from("/usr/local/bin"),
+        PathBuf::from("/usr/local/sbin"),
+        PathBuf::from("/usr/bin"),
+        PathBuf::from("/bin"),
+        PathBuf::from("/usr/sbin"),
+        PathBuf::from("/sbin"),
     ]);
-    if let Ok(existing) = std::env::var("PATH") {
-        parts.push(existing);
+    if let Some(existing) = std::env::var_os("PATH") {
+        parts.extend(std::env::split_paths(&existing));
     }
-    parts.join(":")
+    parts
 }
 
 pub fn moraine() -> String {
@@ -110,4 +158,58 @@ pub fn understudy() -> String {
 }
 pub fn uv() -> String {
     resolve("uv")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "understudy-bin-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("temp dir");
+        path
+    }
+
+    #[test]
+    fn npm_link_resolves_to_its_readable_javascript_entry() {
+        let dir = temp_dir("npm-link");
+        let target = dir.join("dist/bin.js");
+        fs::create_dir_all(target.parent().expect("parent")).expect("dist dir");
+        fs::write(&target, "#!/usr/bin/env node\n").expect("js entry");
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).expect("permissions");
+        let link = dir.join("understudy");
+        symlink(Path::new("dist/bin.js"), &link).expect("npm link");
+
+        assert_eq!(
+            canonical_candidate(&link),
+            Some(target.canonicalize().unwrap())
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn non_executable_shadow_is_skipped_but_an_executable_is_usable() {
+        let dir = temp_dir("shadow");
+        let candidate = dir.join("understudy");
+        fs::write(&candidate, "#!/bin/sh\n").expect("shim");
+        fs::set_permissions(&candidate, fs::Permissions::from_mode(0o644)).expect("permissions");
+        assert_eq!(canonical_candidate(&candidate), None);
+
+        fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).expect("permissions");
+        assert_eq!(
+            canonical_candidate(&candidate),
+            Some(candidate.canonicalize().unwrap())
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
 }


### PR DESCRIPTION
## What changed

- canonicalizes npm-linked CLI shims before launching them from Desktop
- runs readable JavaScript package entries through Node instead of requiring their source file to be executable
- skips non-executable shadow binaries and continues through the Finder-safe search path
- normalizes inherited PATH entries with the platform path APIs
- adds direct tests for npm links, unusable shadows, and executable shims

## Why

Desktop checks `~/.local/bin` before Homebrew so Finder launches can find the CLI. A local npm install can create an executable symlink whose target is a readable `dist/bin.js` without an executable bit. The shell could fall through to Homebrew, but Desktop attempted the shadow path directly and failed with `Permission denied`, blocking model repair and residency restoration.

## Validation

- cargo test: 171 passed, 4 real-evidence fixtures ignored
- signed production app build
- cold launch against the reproduced non-executable npm link: no repair banner
- E4B slot 7 restored in 2.6 seconds and Chat selected it locally
- codesign verification passed for the app bundle

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->