### PR TITLE
Ship an executable CLI entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "!**/*.py"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && node scripts/ensure-bin-mode.mjs",
     "clean": "rm -rf dist",
     "prepare": "npm run build",
     "package:smoke": "node scripts/package-smoke.mjs",

--- a/scripts/ensure-bin-mode.mjs
+++ b/scripts/ensure-bin-mode.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { chmodSync } from "node:fs";
+
+if (process.platform !== "win32") {
+  chmodSync(new URL("../dist/bin.js", import.meta.url), 0o755);
+}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -34,6 +34,7 @@ const forbiddenMemberParts = [
 ];
 
 const requiredPackageMembers = [
+  "dist/bin.js",
   ".agents/plugins/marketplace.json",
   ".codex-plugin/plugin.json",
   ".cursor-plugin/plugin.json",
@@ -95,6 +96,10 @@ for (const required of requiredPackageMembers) {
   if (!packagePaths.has(required)) {
     errors.push(`package/${required}: required package file missing`);
   }
+}
+const cliEntry = packageFiles.find((entry) => entry.path === "dist/bin.js");
+if (cliEntry && (!Number.isInteger(cliEntry.mode) || (cliEntry.mode & 0o111) === 0)) {
+  errors.push("package/dist/bin.js: CLI entry must be executable on Unix");
 }
 for (const entry of packageFiles) {
   const path = entry.path;


### PR DESCRIPTION
## Summary
- make the generated npm CLI entry executable on Unix
- fail package smoke when the packed binary loses execute bits
- preserve Windows compatibility through the Node filesystem API

## Verification
- `npm run check` (282 Node tests, 33 public skills, typecheck, package smoke)
- `npm pack --dry-run --json` reports `dist/bin.js` mode 493 / 0755
- normal shell resolution now selects Understudy CLI 0.6.4 instead of falling through to Homebrew 0.6.1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->