### PR TITLE
Make Pi deletion gate a truthful rolling window

### DIFF
--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -604,6 +604,8 @@ pub struct ChatRouteMetrics {
     pub canonical_runtime_rows: u64,
     pub pi_runtime_rows: u64,
     pub compatibility_fallback_rows: u64,
+    pub consecutive_pi_rows: u64,
+    pub remaining_consecutive_pi_rows: u64,
     pub pi_runtime_share: Option<f64>,
     pub compatibility_engine_delete_ready: bool,
     pub groups: Vec<ChatRouteMetricGroup>,
@@ -2415,22 +2417,31 @@ pub fn chat_route_metrics(app: AppHandle, limit: Option<u32>) -> Result<ChatRout
 
 fn chat_route_metrics_for_rows(rows: Vec<ChatRunRow>, observed_row_limit: u32) -> ChatRouteMetrics {
     const REQUIRED_CANONICAL_RUNTIME_ROWS: u64 = 100;
-    // Count only the compatibility release cohort. Older development and
-    // migrated rows remain preserved in SQLite, but cannot poison or falsely
-    // satisfy the 100-run Rust deletion gate.
+    // The deletion cohort is the latest 100 canonical turns from this exact
+    // app/runtime release. Older development rows remain preserved in SQLite,
+    // while an early compatibility probe naturally ages out only after 100
+    // newer Pi turns. `list_chat_runs` supplies newest-first rows.
     let rows: Vec<_> = rows
         .into_iter()
         .filter(|row| {
             row.app_version == env!("CARGO_PKG_VERSION")
                 && row.runtime_version == crate::conversation_runtime::RUNTIME_VERSION
+                && row.run_id.is_some()
         })
+        .take(REQUIRED_CANONICAL_RUNTIME_ROWS as usize)
         .collect();
-    let canonical_runtime_rows = rows.iter().filter(|row| row.run_id.is_some()).count() as u64;
+    let canonical_runtime_rows = rows.len() as u64;
     let pi_runtime_rows = rows
         .iter()
-        .filter(|row| row.run_id.is_some() && row.runtime_backend == "pi")
+        .filter(|row| row.runtime_backend == "pi")
         .count() as u64;
     let compatibility_fallback_rows = canonical_runtime_rows.saturating_sub(pi_runtime_rows);
+    let consecutive_pi_rows = rows
+        .iter()
+        .take_while(|row| row.runtime_backend == "pi")
+        .count() as u64;
+    let remaining_consecutive_pi_rows =
+        REQUIRED_CANONICAL_RUNTIME_ROWS.saturating_sub(consecutive_pi_rows);
     let pi_runtime_share = (canonical_runtime_rows > 0)
         .then_some(pi_runtime_rows as f64 / canonical_runtime_rows as f64);
     let mut groups: std::collections::BTreeMap<(String, String), Vec<ChatRunRow>> =
@@ -2487,6 +2498,8 @@ fn chat_route_metrics_for_rows(rows: Vec<ChatRunRow>, observed_row_limit: u32) -
         canonical_runtime_rows,
         pi_runtime_rows,
         compatibility_fallback_rows,
+        consecutive_pi_rows,
+        remaining_consecutive_pi_rows,
         pi_runtime_share,
         compatibility_engine_delete_ready: canonical_runtime_rows
             >= REQUIRED_CANONICAL_RUNTIME_ROWS
@@ -3395,32 +3408,60 @@ mod tests {
     }
 
     #[test]
-    fn migration_gate_counts_only_the_current_release_cohort() {
-        let mut rows = vec![migration_row("native-rust", "legacy", "legacy"); 50];
-        rows.extend(vec![
-            migration_row(
-                "pi",
-                env!("CARGO_PKG_VERSION"),
-                crate::conversation_runtime::RUNTIME_VERSION,
-            );
-            100
-        ]);
+    fn migration_gate_uses_the_latest_hundred_current_release_turns() {
+        let pi = migration_row(
+            "pi",
+            env!("CARGO_PKG_VERSION"),
+            crate::conversation_runtime::RUNTIME_VERSION,
+        );
+        let fallback = migration_row(
+            "native-rust",
+            env!("CARGO_PKG_VERSION"),
+            crate::conversation_runtime::RUNTIME_VERSION,
+        );
+        let mut rows = vec![pi.clone(); 100];
+        rows.extend(vec![fallback.clone(); 2]);
+        rows.extend(vec![migration_row("native-rust", "legacy", "legacy"); 50]);
+
         let ready = chat_route_metrics_for_rows(rows.clone(), 250);
         assert_eq!(ready.canonical_runtime_rows, 100);
         assert_eq!(ready.pi_runtime_rows, 100);
         assert_eq!(ready.compatibility_fallback_rows, 0);
+        assert_eq!(ready.consecutive_pi_rows, 100);
+        assert_eq!(ready.remaining_consecutive_pi_rows, 0);
         assert_eq!(ready.remaining_canonical_runtime_rows, 0);
         assert!(ready.compatibility_engine_delete_ready);
 
-        rows.push(migration_row(
+        rows.insert(0, fallback);
+        let blocked = chat_route_metrics_for_rows(rows, 250);
+        assert_eq!(blocked.canonical_runtime_rows, 100);
+        assert_eq!(blocked.pi_runtime_rows, 99);
+        assert_eq!(blocked.compatibility_fallback_rows, 1);
+        assert_eq!(blocked.consecutive_pi_rows, 0);
+        assert_eq!(blocked.remaining_consecutive_pi_rows, 100);
+        assert!(!blocked.compatibility_engine_delete_ready);
+    }
+
+    #[test]
+    fn migration_gate_reports_the_clean_pi_streak_separately_from_volume() {
+        let pi = migration_row(
+            "pi",
+            env!("CARGO_PKG_VERSION"),
+            crate::conversation_runtime::RUNTIME_VERSION,
+        );
+        let fallback = migration_row(
             "native-rust",
             env!("CARGO_PKG_VERSION"),
             crate::conversation_runtime::RUNTIME_VERSION,
-        ));
-        let fallback = chat_route_metrics_for_rows(rows, 250);
-        assert_eq!(fallback.canonical_runtime_rows, 101);
-        assert_eq!(fallback.compatibility_fallback_rows, 1);
-        assert!(!fallback.compatibility_engine_delete_ready);
+        );
+        let rows = vec![pi, fallback.clone(), fallback];
+        let metrics = chat_route_metrics_for_rows(rows, 250);
+        assert_eq!(metrics.canonical_runtime_rows, 3);
+        assert_eq!(metrics.pi_runtime_rows, 1);
+        assert_eq!(metrics.compatibility_fallback_rows, 2);
+        assert_eq!(metrics.remaining_canonical_runtime_rows, 97);
+        assert_eq!(metrics.consecutive_pi_rows, 1);
+        assert_eq!(metrics.remaining_consecutive_pi_rows, 99);
     }
 
     #[test]

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -1,6 +1,6 @@
 # Desktop runtime migration removal map
 
-Status: release gate, snapshot after `79b9d25` on 2026-07-12.
+Status: release gate, refreshed after `ca01b04` on 2026-07-13.
 
 The migration is successful only when the canonical conversation runtime owns
 conversation state and the native app becomes a thin authenticated adapter. The
@@ -99,14 +99,17 @@ do not interpret synthetic event projection or a loopback provider as proof of
 native image, tool, cancellation, restart, compaction, or supervision parity.
 
 The command exits `2` while observation is incomplete. The underlying
-versioned Desktop API cohorts rows by both app version and canonical-runtime
-version; legacy and development rows remain in SQLite but cannot poison or
-falsely satisfy the denominator. The CLI additionally verifies that both
+versioned Desktop API evaluates the newest 100 canonical turns for the exact
+app and runtime versions. Legacy rows remain in SQLite but cannot falsely
+satisfy the denominator, and an early fallback probe ages out only after 100
+newer Pi turns. The API reports both total window coverage and the clean Pi
+streak so "remaining" cannot hide a fallback inside an otherwise full window.
+The CLI additionally verifies that both
 owner-only evidence files match the live app/runtime versions, current event
 schema, and exact frozen-scenario hashes; missing or stale evidence fails
 closed even after the cohort reaches 100 runs. Delete the compatibility engine
-only after one released app/runtime cohort records a rolling window of at least
-100 canonical runs with:
+only after one released app/runtime cohort records a rolling window of exactly
+the latest 100 canonical runs with:
 
 - `compatibility_fallback_rows == 0`;
 - `pi_runtime_share == 1.0`;
@@ -115,8 +118,10 @@ only after one released app/runtime cohort records a rolling window of at least
   conformance scenarios;
 - the readiness probe passing on release artifacts.
 
-The current development window is intentionally not eligible because mismatch
-and repair probes exercised the fallback.
+The 2026-07-13 installed-app proof recorded the first 0.3.5 Pi-backed GUI turn.
+Two earlier 0.3.5 compatibility probes remain preserved, so 99 newer clean Pi
+turns are required before the rolling window can become eligible. Do not
+manufacture those rows; they are release-adoption evidence.
 
 ## Removable ownership
 

--- a/src/commands/desktop.ts
+++ b/src/commands/desktop.ts
@@ -60,6 +60,8 @@ interface DesktopMigrationStatus {
   canonical_runtime_rows?: number;
   pi_runtime_rows?: number;
   compatibility_fallback_rows?: number;
+  consecutive_pi_rows?: number;
+  remaining_consecutive_pi_rows?: number;
   pi_runtime_share?: number | null;
   compatibility_engine_delete_ready?: boolean;
 }
@@ -478,13 +480,19 @@ export function registerDesktopCommand(program: Command): void {
       const canonical = Number(value.canonical_runtime_rows ?? 0);
       const piRows = Number(value.pi_runtime_rows ?? 0);
       const fallbacks = Number(value.compatibility_fallback_rows ?? 0);
+      const consecutivePiRows = Number(value.consecutive_pi_rows ?? piRows);
       const cohortReady =
         value.compatibility_engine_delete_ready === true &&
         canonical >= required &&
         piRows === canonical &&
-        fallbacks === 0;
+        fallbacks === 0 &&
+        consecutivePiRows >= required;
       const remaining = Number(
         value.remaining_canonical_runtime_rows ?? Math.max(0, required - canonical),
+      );
+      const remainingConsecutive = Number(
+        value.remaining_consecutive_pi_rows
+          ?? Math.max(0, required - consecutivePiRows),
       );
       const releaseEvidence = evaluateDesktopRuntimeReleaseEvidence({
         app_version: value.app_version ?? "unknown",
@@ -497,6 +505,8 @@ export function registerDesktopCommand(program: Command): void {
         ...value,
         required_canonical_runtime_rows: required,
         remaining_canonical_runtime_rows: remaining,
+        consecutive_pi_rows: consecutivePiRows,
+        remaining_consecutive_pi_rows: remainingConsecutive,
         observed_row_limit: value.observed_row_limit ?? opts.limit,
         release_cohort_ready: cohortReady,
         release_evidence: releaseEvidence,
@@ -513,6 +523,7 @@ export function registerDesktopCommand(program: Command): void {
           `release cohort: app ${value.app_version ?? "unknown"}, runtime ${value.runtime_version ?? "unknown"}`,
           `canonical runs: ${canonical}/${required} (${remaining} remaining)`,
           `Pi runs: ${piRows} (${share}); compatibility fallbacks: ${fallbacks}`,
+          `clean Pi streak: ${consecutivePiRows}/${required} (${remainingConsecutive} remaining)`,
           `conformance evidence: ${releaseEvidence.conformance.ready ? "ready" : "missing or stale"}`,
           `startup/memory evidence: ${releaseEvidence.readiness.ready ? "ready" : "missing or stale"}`,
           ...releaseEvidence.reasons.map((reason) => `blocked: ${reason}`),

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -187,6 +187,8 @@ before(async () => {
         canonical_runtime_rows: ready ? 100 : 99,
         pi_runtime_rows: ready ? 100 : 98,
         compatibility_fallback_rows: ready ? 0 : 1,
+        consecutive_pi_rows: ready ? 100 : 98,
+        remaining_consecutive_pi_rows: ready ? 0 : 2,
         pi_runtime_share: ready ? 1 : 98 / 99,
         compatibility_engine_delete_ready: ready,
         groups: [],
@@ -503,6 +505,8 @@ describe("desktop API CLI", () => {
     assert.equal(value.canonical_runtime_rows, 100);
     assert.equal(value.compatibility_fallback_rows, 0);
     assert.equal(value.remaining_canonical_runtime_rows, 0);
+    assert.equal(value.consecutive_pi_rows, 100);
+    assert.equal(value.remaining_consecutive_pi_rows, 0);
     assert.equal(value.release_cohort_ready, true);
     assert.equal(value.release_evidence.ready, true);
     assert.equal(value.compatibility_engine_delete_ready, true);
@@ -517,6 +521,8 @@ describe("desktop API CLI", () => {
     const pending = JSON.parse(observing.stdout);
     assert.equal(pending.compatibility_fallback_rows, 1);
     assert.equal(pending.remaining_canonical_runtime_rows, 1);
+    assert.equal(pending.consecutive_pi_rows, 98);
+    assert.equal(pending.remaining_consecutive_pi_rows, 2);
     assert.equal(pending.release_evidence.ready, true);
     assert.equal(pending.compatibility_engine_delete_ready, false);
 


### PR DESCRIPTION
## Summary
- evaluate Rust-deletion evidence over the latest 100 canonical turns from the exact app/runtime release
- report clean consecutive Pi streak separately from total cohort coverage
- let deliberate early fallback probes age out after 100 newer Pi turns
- document the first installed 0.3.5 Pi-backed GUI turn without manufacturing adoption rows

## Live evidence
- installed Desktop turn `desktop-322db53d1aa924de144c237da68e5be0`
- `runtime_backend=pi`, app/runtime 0.3.5, local E4B route, status `ok`
- current truthful state: 1-turn clean Pi streak; 99 newer clean turns required

## Verification
- 172 Rust tests passed; 4 real-artifact fixtures ignored
- Rust clippy with warnings denied
- 282 Node tests and 33 public skills passed
- package, privacy, typecheck, and diff checks passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->