### PR TITLE
Make buyer report refreshes immutable

### DIFF
--- a/experiments/desktop-grocery-proof/DEMO.md
+++ b/experiments/desktop-grocery-proof/DEMO.md
@@ -22,13 +22,26 @@ node experiments/desktop-grocery-proof/run.mjs \
 Keep the resulting proof directory open. Do not use customer prompts, traces,
 or credentials in the demo.
 
+If reusing an existing proof, derive a report with the current renderer instead
+of trusting a report file produced by older code:
+
+```sh
+PROOF=~/.understudy/proofs/grocery-marketplace/<proof-id>
+REPORT=$(node experiments/desktop-grocery-proof/run.mjs \
+  --report-from "$PROOF" | jq -r .outputDir)
+```
+
+This does not run a model, contact a provider, alter the proof, or add a
+migration-cohort turn.
+
 If the buyer wants their hosted incumbent in the comparison, configure the
 fourth route before the call using the approval-gated command in `README.md`.
 Verify the model id and current token prices with them. Never improvise prices
 or infer consent from an existing key.
 
-Open `report.html` first. It is the buyer-facing decision packet; keep the
-JSONL files behind it for drill-down rather than making the terminal the demo.
+Open the fresh proof's `report.html`, or `$REPORT/report.html` when reusing
+evidence. It is the buyer-facing decision packet; keep the JSONL files behind
+it for drill-down rather than making the terminal the demo.
 
 ## 0-3 minutes: state the decision
 

--- a/experiments/desktop-grocery-proof/README.md
+++ b/experiments/desktop-grocery-proof/README.md
@@ -58,12 +58,22 @@ chosen-verdict first-token probability without presenting it as calibrated
 correctness. It contains no raw prompts or completions and makes no remote
 requests.
 
-To add the report to an older immutable proof without rerunning models:
+To render the current buyer report from older immutable evidence without
+rerunning models:
 
 ```sh
 node experiments/desktop-grocery-proof/run.mjs \
   --report-from ~/.understudy/proofs/grocery-marketplace/<proof-id>
 ```
+
+The command never edits the source proof. It writes a content-addressed,
+owner-only report package beneath
+`~/.understudy/reports/grocery-marketplace/`, including the current
+`report.html`, structured `report.json`, and a manifest binding source-file and
+renderer hashes. Repeating the command is idempotent; a changed source or
+renderer produces a new package rather than overwriting evidence. Use
+`--report-output-root <path>` only when automation needs a different local
+destination.
 
 For a buyer-facing walkthrough, use the
 [30-minute grocery-platform demo](DEMO.md). It keeps the measured judge miss in

--- a/experiments/desktop-grocery-proof/report.mjs
+++ b/experiments/desktop-grocery-proof/report.mjs
@@ -1,5 +1,20 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPORT_PACKAGE_SCHEMA = "understudy.desktop_grocery_report_package.v1";
+const DEFAULT_REPORT_ROOT = join(homedir(), ".understudy", "reports", "grocery-marketplace");
 
 const modeLabels = {
   small: "Small local",
@@ -34,6 +49,48 @@ function integer(value) {
 function dollars(value) {
   if (value == null) return null;
   return `$${Number(value).toFixed(Number(value) < 0.01 ? 4 : 2)}`;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function assertOwnerOnly(path) {
+  if (process.platform === "win32") return;
+  if ((statSync(path).mode & 0o077) !== 0) {
+    throw new Error(`derived buyer report permissions are broader than owner-only: ${path}`);
+  }
+}
+
+function validateProofSource(summary, rows, tasks, tasksBytes) {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,199}$/.test(summary?.proof_id ?? "")) {
+    throw new Error("source proof_id must be a safe path segment");
+  }
+  if (!/^[a-f0-9]{64}$/.test(summary?.suite_sha256 ?? "")) {
+    throw new Error("source suite_sha256 must be a lowercase SHA-256 digest");
+  }
+  if (sha256(tasksBytes) !== summary.suite_sha256) {
+    throw new Error("source tasks.json does not match suite_sha256");
+  }
+  if (!Array.isArray(tasks) || summary.task_count !== tasks.length) {
+    throw new Error("source task_count does not match tasks.json");
+  }
+  if (!Array.isArray(rows) || summary.run_count !== rows.length) {
+    throw new Error("source run_count does not match results.jsonl");
+  }
+  const taskIds = new Set(tasks.map((task) => task?.id));
+  if (taskIds.size !== tasks.length || taskIds.has(undefined)) {
+    throw new Error("source tasks.json has missing or duplicate task ids");
+  }
+  for (const row of rows) {
+    if (
+      row?.proof_id !== summary.proof_id
+      || row?.suite_sha256 !== summary.suite_sha256
+      || !taskIds.has(row?.task_id)
+    ) {
+      throw new Error("source results.jsonl does not match proof, suite, or task identity");
+    }
+  }
 }
 
 export function verdictProbabilityEvidence(verdict) {
@@ -463,10 +520,114 @@ function readJsonl(path) {
     .map((line) => JSON.parse(line));
 }
 
-export function renderExistingProof(path) {
-  const outputDir = resolve(path);
-  const summary = JSON.parse(readFileSync(join(outputDir, "summary.json"), "utf8"));
-  const rows = readJsonl(join(outputDir, "results.jsonl"));
-  const tasks = JSON.parse(readFileSync(join(outputDir, "tasks.json"), "utf8"));
-  return { outputDir, ...writeBuyerReport(outputDir, summary, rows, tasks) };
+function validateReportPackage(outputDir, expectedManifest) {
+  const manifestPath = join(outputDir, "manifest.json");
+  const modelPath = join(outputDir, "report.json");
+  const reportPath = join(outputDir, "report.html");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (
+    manifest.schema_version !== expectedManifest.schema_version
+    || JSON.stringify(manifest.source) !== JSON.stringify(expectedManifest.source)
+    || JSON.stringify(manifest.renderer) !== JSON.stringify(expectedManifest.renderer)
+  ) {
+    throw new Error(`derived buyer report identity mismatch: ${outputDir}`);
+  }
+  const modelBytes = readFileSync(modelPath);
+  const reportBytes = readFileSync(reportPath);
+  if (
+    sha256(modelBytes) !== manifest.files.report_json_sha256
+    || sha256(reportBytes) !== manifest.files.report_html_sha256
+  ) {
+    throw new Error(`derived buyer report content hash mismatch: ${outputDir}`);
+  }
+  for (const path of [outputDir, manifestPath, modelPath, reportPath]) assertOwnerOnly(path);
+  return {
+    outputDir,
+    manifestPath,
+    modelPath,
+    reportPath,
+    manifest,
+    model: JSON.parse(modelBytes.toString("utf8")),
+  };
+}
+
+export function renderExistingProof(path, { outputRoot = DEFAULT_REPORT_ROOT } = {}) {
+  const sourceDir = resolve(path);
+  const summaryBytes = readFileSync(join(sourceDir, "summary.json"));
+  const resultsBytes = readFileSync(join(sourceDir, "results.jsonl"));
+  const tasksBytes = readFileSync(join(sourceDir, "tasks.json"));
+  const summary = JSON.parse(summaryBytes.toString("utf8"));
+  const rows = readJsonl(join(sourceDir, "results.jsonl"));
+  const tasks = JSON.parse(tasksBytes.toString("utf8"));
+  validateProofSource(summary, rows, tasks, tasksBytes);
+  const model = buildReportModel(summary, rows, tasks);
+  const modelBytes = Buffer.from(`${JSON.stringify(model, null, 2)}\n`);
+  const reportBytes = Buffer.from(buildBuyerReport(summary, rows, tasks));
+  const rendererHash = sha256(readFileSync(fileURLToPath(import.meta.url)));
+  const source = {
+    proof_id: summary.proof_id,
+    suite_sha256: summary.suite_sha256,
+    summary_sha256: sha256(summaryBytes),
+    results_sha256: sha256(resultsBytes),
+    tasks_sha256: sha256(tasksBytes),
+  };
+  const sourceBundleHash = sha256(Object.values(source).join("\n"));
+  const renderer = {
+    report_schema_version: model.schema_version,
+    renderer_sha256: rendererHash,
+  };
+  const manifest = {
+    schema_version: REPORT_PACKAGE_SCHEMA,
+    source,
+    renderer,
+    files: {
+      report_json_sha256: sha256(modelBytes),
+      report_html_sha256: sha256(reportBytes),
+    },
+  };
+  const packageId = [
+    summary.proof_id,
+    model.schema_version.replaceAll(/[^a-zA-Z0-9.-]/g, "-"),
+    sourceBundleHash.slice(0, 12),
+    rendererHash.slice(0, 12),
+  ].join("-");
+  const reportRoot = resolve(outputRoot);
+  const outputDir = join(reportRoot, packageId);
+  mkdirSync(reportRoot, { recursive: true, mode: 0o700 });
+  assertOwnerOnly(reportRoot);
+  const expectedManifest = { schema_version: REPORT_PACKAGE_SCHEMA, source, renderer };
+  if (existsSync(outputDir)) {
+    return {
+      sourceDir,
+      reused: true,
+      ...validateReportPackage(outputDir, expectedManifest),
+    };
+  }
+
+  const temporaryDir = mkdtempSync(join(reportRoot, `.${packageId}.tmp-`));
+  try {
+    writeFileSync(join(temporaryDir, "report.json"), modelBytes, { flag: "wx", mode: 0o600 });
+    writeFileSync(join(temporaryDir, "report.html"), reportBytes, { flag: "wx", mode: 0o600 });
+    writeFileSync(
+      join(temporaryDir, "manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    renameSync(temporaryDir, outputDir);
+  } catch (error) {
+    rmSync(temporaryDir, { recursive: true, force: true });
+    if (existsSync(outputDir)) {
+      return {
+        sourceDir,
+        reused: true,
+        ...validateReportPackage(outputDir, expectedManifest),
+      };
+    }
+    throw error;
+  }
+  return {
+    sourceDir,
+    reused: false,
+    ...validateReportPackage(outputDir, expectedManifest),
+  };
 }

--- a/experiments/desktop-grocery-proof/report.mjs
+++ b/experiments/desktop-grocery-proof/report.mjs
@@ -513,11 +513,25 @@ export function writeBuyerReport(outputDir, summary, rows, tasks) {
   return { modelPath, reportPath, model };
 }
 
-function readJsonl(path) {
-  return readFileSync(path, "utf8")
+function parseJsonlBytes(bytes) {
+  return bytes.toString("utf8")
     .split("\n")
     .filter((line) => line.trim())
     .map((line) => JSON.parse(line));
+}
+
+export function readImmutableProofSource(sourceDir, readSource = readFileSync) {
+  const summaryBytes = readSource(join(sourceDir, "summary.json"));
+  const resultsBytes = readSource(join(sourceDir, "results.jsonl"));
+  const tasksBytes = readSource(join(sourceDir, "tasks.json"));
+  return {
+    summaryBytes,
+    resultsBytes,
+    tasksBytes,
+    summary: JSON.parse(summaryBytes.toString("utf8")),
+    rows: parseJsonlBytes(resultsBytes),
+    tasks: JSON.parse(tasksBytes.toString("utf8")),
+  };
 }
 
 function validateReportPackage(outputDir, expectedManifest) {
@@ -553,12 +567,14 @@ function validateReportPackage(outputDir, expectedManifest) {
 
 export function renderExistingProof(path, { outputRoot = DEFAULT_REPORT_ROOT } = {}) {
   const sourceDir = resolve(path);
-  const summaryBytes = readFileSync(join(sourceDir, "summary.json"));
-  const resultsBytes = readFileSync(join(sourceDir, "results.jsonl"));
-  const tasksBytes = readFileSync(join(sourceDir, "tasks.json"));
-  const summary = JSON.parse(summaryBytes.toString("utf8"));
-  const rows = readJsonl(join(sourceDir, "results.jsonl"));
-  const tasks = JSON.parse(tasksBytes.toString("utf8"));
+  const {
+    summaryBytes,
+    resultsBytes,
+    tasksBytes,
+    summary,
+    rows,
+    tasks,
+  } = readImmutableProofSource(sourceDir);
   validateProofSource(summary, rows, tasks, tasksBytes);
   const model = buildReportModel(summary, rows, tasks);
   const modelBytes = Buffer.from(`${JSON.stringify(model, null, 2)}\n`);

--- a/experiments/desktop-grocery-proof/run.mjs
+++ b/experiments/desktop-grocery-proof/run.mjs
@@ -205,6 +205,7 @@ function parseArgs(argv) {
     maxTokens: 384,
     outputRoot: join(homedir(), ".understudy", "proofs", "grocery-marketplace"),
     reportFrom: null,
+    reportOutputRoot: null,
     incumbentBaseUrl: null,
     incumbentModel: null,
     incumbentProviderKind: "openai-compatible",
@@ -226,6 +227,7 @@ function parseArgs(argv) {
     else if (value === "--max-tokens") options.maxTokens = Number(next);
     else if (value === "--output-root") options.outputRoot = resolve(next);
     else if (value === "--report-from") options.reportFrom = resolve(next);
+    else if (value === "--report-output-root") options.reportOutputRoot = resolve(next);
     else if (value === "--incumbent-base-url") options.incumbentBaseUrl = next;
     else if (value === "--incumbent-model") options.incumbentModel = next;
     else if (value === "--incumbent-provider-kind") options.incumbentProviderKind = next;
@@ -247,6 +249,9 @@ function parseArgs(argv) {
   }
   if (options.studentSlot === options.teacherSlot) {
     throw new Error("student and teacher slots must be distinct");
+  }
+  if (options.reportOutputRoot && !options.reportFrom) {
+    throw new Error("--report-output-root requires --report-from");
   }
   validateIncumbentOptions(options);
   return options;
@@ -539,7 +544,9 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
   const options = parseArgs(process.argv.slice(2));
   const operation = options.reportFrom
-    ? Promise.resolve().then(() => renderExistingProof(options.reportFrom))
+    ? Promise.resolve().then(() => renderExistingProof(options.reportFrom, {
+      outputRoot: options.reportOutputRoot ?? undefined,
+    }))
     : runProof(options);
   operation.then((result) => {
     if (options.reportFrom) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,6 +3,15 @@
 Versioned JSON Schemas for artifacts that cross surface boundaries (desktop
 app, skills, CLI, ladder). One spine, adopted everywhere.
 
+## `understudy.desktop_grocery_report_package.v1`
+
+[`understudy.desktop_grocery_report_package.v1.schema.json`](understudy.desktop_grocery_report_package.v1.schema.json)
+binds a derived buyer report to the immutable grocery proof and exact renderer
+that produced it. The manifest hashes `summary.json`, `results.jsonl`,
+`tasks.json`, `report.json`, `report.html`, and the renderer source. Refreshing
+an old proof therefore creates a new owner-only package instead of rewriting
+evidence or silently presenting a stale report.
+
 ## `understudy.desktop_api.v2`
 
 [`understudy.desktop_api.v2.openapi.json`](understudy.desktop_api.v2.openapi.json)

--- a/schemas/understudy.desktop_grocery_report_package.v1.schema.json
+++ b/schemas/understudy.desktop_grocery_report_package.v1.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.understudylabs.com/understudy.desktop_grocery_report_package.v1.schema.json",
+  "title": "Understudy desktop grocery report package v1",
+  "type": "object",
+  "required": ["schema_version", "source", "renderer", "files"],
+  "properties": {
+    "schema_version": {
+      "const": "understudy.desktop_grocery_report_package.v1"
+    },
+    "source": {
+      "type": "object",
+      "required": [
+        "proof_id",
+        "suite_sha256",
+        "summary_sha256",
+        "results_sha256",
+        "tasks_sha256"
+      ],
+      "properties": {
+        "proof_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+        },
+        "suite_sha256": { "$ref": "#/$defs/sha256" },
+        "summary_sha256": { "$ref": "#/$defs/sha256" },
+        "results_sha256": { "$ref": "#/$defs/sha256" },
+        "tasks_sha256": { "$ref": "#/$defs/sha256" }
+      },
+      "additionalProperties": false
+    },
+    "renderer": {
+      "type": "object",
+      "required": ["report_schema_version", "renderer_sha256"],
+      "properties": {
+        "report_schema_version": { "type": "string", "minLength": 1 },
+        "renderer_sha256": { "$ref": "#/$defs/sha256" }
+      },
+      "additionalProperties": false
+    },
+    "files": {
+      "type": "object",
+      "required": ["report_json_sha256", "report_html_sha256"],
+      "properties": {
+        "report_json_sha256": { "$ref": "#/$defs/sha256" },
+        "report_html_sha256": { "$ref": "#/$defs/sha256" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/desktop-grocery-proof.test.mjs
+++ b/tests/desktop-grocery-proof.test.mjs
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -17,6 +25,7 @@ import {
 import {
   buildBuyerReport,
   buildReportModel,
+  renderExistingProof,
   verdictProbabilityEvidence,
 } from "../experiments/desktop-grocery-proof/report.mjs";
 
@@ -348,5 +357,113 @@ describe("desktop grocery proof", () => {
     assert.equal(result.status, 1);
     assert.match(result.stderr, /ENOENT/);
     assert.doesNotMatch(result.stderr, /\n\s+at /);
+  });
+
+  it("refreshes a stale immutable proof into an owner-only derived report package", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-grocery-report-refresh-"));
+    const sourceDir = join(root, "proof");
+    const reportRoot = join(root, "reports");
+    mkdirSync(sourceDir, { mode: 0o700 });
+    const tasks = [{ id: "ops", title: "Ops classification", prompt: "private synthetic prompt" }];
+    const tasksBytes = Buffer.from(`${JSON.stringify(tasks)}\n`);
+    const suiteHash = createHash("sha256").update(tasksBytes).digest("hex");
+    const metric = {
+      exact_passes: 1,
+      task_count: 1,
+      mean_field_accuracy: 1,
+      mean_latency_ms: 100,
+      total_tokens: 20,
+    };
+    const rows = ["small", "main", "supervised"].map((mode) => ({
+      proof_id: "proof-refresh",
+      suite_sha256: suiteHash,
+      task_id: "ops",
+      task_title: "Ops classification",
+      mode,
+      score: { exact: true, field_accuracy: 1 },
+      student_score: mode === "supervised" ? { exact: true, field_accuracy: 1 } : null,
+      verdicts: mode === "supervised" ? [{ verdict: "continue", marker_id: "marker-ops" }] : [],
+    }));
+    const summary = {
+      proof_id: "proof-refresh",
+      suite_sha256: suiteHash,
+      completed_at: "2026-07-12T00:00:00Z",
+      task_count: 1,
+      run_count: 3,
+      by_mode: {
+        small: { ...metric, latency_reduction_vs_main: 0 },
+        main: metric,
+        supervised: {
+          ...metric,
+          latency_reduction_vs_main: 0,
+          supervisor_verdicts: 1,
+          interventions: 0,
+          supervisor_correct_interventions: 0,
+          supervisor_missed_errors: 0,
+          supervisor_false_positives: 0,
+          mean_small_model_output_share: 1,
+          mean_supervisor_token_overhead: 0,
+        },
+      },
+    };
+    try {
+      writeFileSync(join(sourceDir, "summary.json"), `${JSON.stringify(summary)}\n`, { mode: 0o600 });
+      writeFileSync(
+        join(sourceDir, "results.jsonl"),
+        `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
+        { mode: 0o600 },
+      );
+      writeFileSync(join(sourceDir, "tasks.json"), tasksBytes, { mode: 0o600 });
+      writeFileSync(join(sourceDir, "report.json"), '{"schema_version":"stale.v1"}\n', { mode: 0o600 });
+      writeFileSync(join(sourceDir, "report.html"), "stale report", { mode: 0o600 });
+
+      const first = renderExistingProof(sourceDir, { outputRoot: reportRoot });
+      assert.equal(first.reused, false);
+      assert.equal(first.sourceDir, sourceDir);
+      assert.notEqual(first.outputDir, sourceDir);
+      assert.equal(first.model.schema_version, "understudy.desktop_grocery_buyer_report.v3");
+      assert.equal(JSON.parse(readFileSync(join(sourceDir, "report.json"), "utf8")).schema_version, "stale.v1");
+      assert.match(readFileSync(first.reportPath, "utf8"), /Ops classification/);
+      assert.doesNotMatch(readFileSync(first.reportPath, "utf8"), /private synthetic prompt/);
+      assert.equal(first.manifest.source.proof_id, "proof-refresh");
+      assert.equal(first.manifest.renderer.report_schema_version, first.model.schema_version);
+      const packageSchema = JSON.parse(readFileSync(
+        new URL("../schemas/understudy.desktop_grocery_report_package.v1.schema.json", import.meta.url),
+        "utf8",
+      ));
+      assert.equal(packageSchema.properties.schema_version.const, first.manifest.schema_version);
+      assert.deepEqual(packageSchema.required, ["schema_version", "source", "renderer", "files"]);
+      for (const value of [
+        first.manifest.source.suite_sha256,
+        first.manifest.source.summary_sha256,
+        first.manifest.source.results_sha256,
+        first.manifest.source.tasks_sha256,
+        first.manifest.renderer.renderer_sha256,
+        first.manifest.files.report_json_sha256,
+        first.manifest.files.report_html_sha256,
+      ]) {
+        assert.match(value, /^[a-f0-9]{64}$/);
+      }
+      for (const path of [first.outputDir, first.manifestPath, first.modelPath, first.reportPath]) {
+        if (process.platform !== "win32") assert.equal(statSync(path).mode & 0o077, 0);
+      }
+
+      const second = renderExistingProof(sourceDir, { outputRoot: reportRoot });
+      assert.equal(second.reused, true);
+      assert.equal(second.outputDir, first.outputDir);
+      assert.deepEqual(second.manifest, first.manifest);
+
+      writeFileSync(
+        join(sourceDir, "summary.json"),
+        `${JSON.stringify({ ...summary, proof_id: "../../escape" })}\n`,
+        { mode: 0o600 },
+      );
+      assert.throws(
+        () => renderExistingProof(sourceDir, { outputRoot: reportRoot }),
+        /proof_id must be a safe path segment/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/desktop-grocery-proof.test.mjs
+++ b/tests/desktop-grocery-proof.test.mjs
@@ -25,6 +25,7 @@ import {
 import {
   buildBuyerReport,
   buildReportModel,
+  readImmutableProofSource,
   renderExistingProof,
   verdictProbabilityEvidence,
 } from "../experiments/desktop-grocery-proof/report.mjs";
@@ -357,6 +358,29 @@ describe("desktop grocery proof", () => {
     assert.equal(result.status, 1);
     assert.match(result.stderr, /ENOENT/);
     assert.doesNotMatch(result.stderr, /\n\s+at /);
+  });
+
+  it("parses report rows from the exact results bytes read for provenance", () => {
+    const sourceDir = "/immutable-proof";
+    const reads = new Map();
+    const resultsBytes = Buffer.from('{"task_id":"ops","score":{"exact":true}}\n');
+    const files = new Map([
+      [join(sourceDir, "summary.json"), Buffer.from('{"proof_id":"proof"}\n')],
+      [join(sourceDir, "results.jsonl"), resultsBytes],
+      [join(sourceDir, "tasks.json"), Buffer.from('[{"id":"ops"}]\n')],
+    ]);
+    const source = readImmutableProofSource(sourceDir, (path) => {
+      reads.set(path, (reads.get(path) ?? 0) + 1);
+      if ((reads.get(path) ?? 0) > 1) throw new Error(`source file read twice: ${path}`);
+      return files.get(path);
+    });
+    assert.equal(reads.get(join(sourceDir, "results.jsonl")), 1);
+    assert.equal(source.resultsBytes, resultsBytes);
+    assert.deepEqual(source.rows, [{ task_id: "ops", score: { exact: true } }]);
+    assert.equal(
+      createHash("sha256").update(source.resultsBytes).digest("hex"),
+      createHash("sha256").update(resultsBytes).digest("hex"),
+    );
   });
 
   it("refreshes a stale immutable proof into an owner-only derived report package", () => {


### PR DESCRIPTION
## What changed

- derives current buyer reports from older grocery proof evidence without modifying the proof
- writes owner-only, content-addressed report packages with source, renderer, and output hashes
- rejects mismatched proof identity, suite hashes, task counts, and unsafe proof ids
- documents the refresh path for buyer demos and adds a versioned package manifest schema

## Why

The latest immutable grocery proof still contained a report produced by an older renderer. Rewriting that proof would violate the evidence contract; presenting it would give buyers a stale surface. This keeps evidence immutable while making the current report reproducible and auditable.

This path makes no model or provider call and does not add migration-cohort turns.

## Validation

- `npm run check` — 284/284 tests, 33 skills, build, typecheck, package smoke
- focused grocery proof suite — 12/12
- regenerated the real July 12 proof twice: first created a v3 package, second reused it
- verified source proof hashes were unchanged