### PR TITLE
Resume Pi turns after output truncation

### DIFF
--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.5"
+version = "0.3.6"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.5";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.6";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -118,10 +118,13 @@ the latest 100 canonical runs with:
   conformance scenarios;
 - the readiness probe passing on release artifacts.
 
-The 2026-07-13 installed-app proof recorded the first 0.3.5 Pi-backed GUI turn.
-Two earlier 0.3.5 compatibility probes remain preserved, so 99 newer clean Pi
-turns are required before the rolling window can become eligible. Do not
-manufacture those rows; they are release-adoption evidence.
+The 2026-07-13 installed-app proof found that 0.3.5 could compact after a
+length-limited response without delivering a final answer, then record the run
+as successful. Those 0.3.5 rows remain preserved for diagnosis but are not
+release-adoption evidence for deletion. Runtime 0.3.6 resumes a bounded
+continuation only after the prior run and compaction settle, and fails closed
+if the provider remains truncated. Its exact-version cohort starts at zero.
+Do not manufacture those rows; they are release-adoption evidence.
 
 ## Removable ownership
 

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.5";
+export const RUNTIME_VERSION = "0.3.6";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -174,6 +174,13 @@ function zeroUsage() {
   };
 }
 
+const MAX_LENGTH_CONTINUATIONS = 2;
+const LENGTH_CONTINUATION_PROMPT = [
+  "Finish the original user request now.",
+  "Continue from exactly where the visible response stopped and do not repeat earlier prose.",
+  "Use the tool results already in context; call another tool only if it is required to answer.",
+].join(" ");
+
 /**
  * Pi uses `reserveTokens` both as the compaction trigger headroom and as the
  * summary generation budget. Its upstream default is tuned for coding-agent
@@ -377,6 +384,13 @@ function attachCanonicalAdapter(
 ) {
   let chain = Promise.resolve();
   let terminalEmitted = false;
+  let lastAssistantStopReason:
+    | "stop"
+    | "length"
+    | "toolUse"
+    | "error"
+    | "aborted"
+    | undefined;
   let emittedTextDelta = false;
   let compactionSourceMessages = 0;
   const rawToolArguments = new Map<string, string>();
@@ -438,6 +452,7 @@ function attachCanonicalAdapter(
         result: event.result,
       });
     } else if (event.type === "message_end" && event.message.role === "assistant") {
+      lastAssistantStopReason = event.message.stopReason;
       enqueue(
         "usage",
         usageData(
@@ -495,6 +510,17 @@ function attachCanonicalAdapter(
     enqueue,
     flush: () => chain,
     terminalEmitted: () => terminalEmitted,
+    lastAssistantStopReason: () => lastAssistantStopReason,
+    enqueueTerminalError: (code: string, message: string, recoverable: boolean) => {
+      if (terminalEmitted) return;
+      terminalEmitted = true;
+      enqueue("error", {
+        stage: "model_stream",
+        code,
+        message,
+        recoverable,
+      });
+    },
   };
 }
 
@@ -1295,6 +1321,8 @@ export async function runPiConversation(
     messages: request.messages,
     persistent: true,
   });
+  let lengthContinuationAttempts = 0;
+  let lengthContinuationFailure: unknown;
   const adapter = attachCanonicalAdapter(session, request, writer, {
     abortReason: () => abortSignal?.reason,
   });
@@ -1326,10 +1354,53 @@ export async function runPiConversation(
         "Keep the checkpoint concise. Preserve exact user constraints, named facts, tool results, unresolved work, and decisions needed for the next response. Copy every named label or identifier and the sentence it names verbatim; do not shorten or paraphrase named facts. Keep each label adjacent to its fact so later references remain resolvable.",
       );
     }
-    await session.prompt(latest.content, {
-      images: imageContent(latest),
-      expandPromptTemplates: false,
-    });
+    try {
+      await session.prompt(latest.content, {
+        images: imageContent(latest),
+        expandPromptTemplates: false,
+      });
+    } catch (error) {
+      lengthContinuationFailure = error;
+    }
+    while (
+      !abortSignal?.aborted &&
+      adapter.lastAssistantStopReason() === "length" &&
+      lengthContinuationAttempts < MAX_LENGTH_CONTINUATIONS
+    ) {
+      lengthContinuationAttempts += 1;
+      try {
+        // Start a fresh Pi prompt only after the previous run has settled. This
+        // lets Pi compact first; queueing a follow-up from message_end would be
+        // consumed before its post-run compaction check and could overflow the
+        // same context a second time.
+        await session.prompt(LENGTH_CONTINUATION_PROMPT, {
+          expandPromptTemplates: false,
+        });
+        lengthContinuationFailure = undefined;
+      } catch (error) {
+        lengthContinuationFailure = error;
+      }
+    }
+    if (lengthContinuationFailure && !adapter.terminalEmitted()) {
+      if (adapter.lastAssistantStopReason() === "length") {
+        adapter.enqueueTerminalError(
+          "pi_length_continuation_failed",
+          safeErrorMessage(lengthContinuationFailure),
+          true,
+        );
+      } else {
+        throw lengthContinuationFailure;
+      }
+    } else if (
+      adapter.lastAssistantStopReason() === "length" &&
+      !adapter.terminalEmitted()
+    ) {
+      adapter.enqueueTerminalError(
+        "pi_length_continuation_exhausted",
+        `Provider stopped at its output limit after ${lengthContinuationAttempts} continuation attempts.`,
+        true,
+      );
+    }
   } catch (error) {
     if (!adapter.terminalEmitted()) {
       await writer.emit(

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -625,6 +625,174 @@ test("Pi runtime recovers from an unexpected provider context overflow", async (
   );
 });
 
+test("Pi runtime resumes a length-limited turn after compaction", async () => {
+  const longInput = JSON.parse(
+    readFileSync(
+      new URL(
+        "../schemas/conversation-runtime-conformance/inputs/long-chat-compaction.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  const requests = [];
+  let primaryCalls = 0;
+  let compactionCalls = 0;
+  const server = createServer(async (request, response) => {
+    const body = await requestJson(request);
+    requests.push(body);
+    const isCompaction = JSON.stringify(body.messages).includes(
+      "You are a context summarization assistant",
+    );
+    const call = isCompaction ? ++compactionCalls : ++primaryCalls;
+    sendFixtureSse(response, [
+      {
+        id: `chatcmpl-${isCompaction ? "compaction" : "length-continuation"}-${call}`,
+        object: "chat.completion.chunk",
+        created: 1,
+        model: body.model,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: "assistant",
+              content: isCompaction
+                ? call === 1
+                  ? "The original request and gathered evidence remain available after compaction."
+                  : "Architecture note one assigns presentation and consent to the desktop, ordered conversation events to the runtime, and immutable attribution to the evidence ledger."
+                : call === 1
+                  ? "Let me inspect the existing evidence."
+                  : " The three owners are the desktop, the runtime, and the evidence ledger.",
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: `chatcmpl-${isCompaction ? "compaction" : "length-continuation"}-${call}`,
+        object: "chat.completion.chunk",
+        created: 1,
+        model: body.model,
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: !isCompaction && call === 1 ? "length" : "stop",
+          },
+        ],
+        usage:
+          !isCompaction && call === 1
+            ? { prompt_tokens: 40_000, completion_tokens: 16, total_tokens: 40_016 }
+            : { prompt_tokens: 300, completion_tokens: 15, total_tokens: 315 },
+      },
+    ]);
+  });
+  await new Promise((accept) => server.listen(0, "127.0.0.1", accept));
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  const events = [];
+  try {
+    await runPiConversation(
+      {
+        run_id: "run-length-continuation",
+        session_id: "session-length-continuation",
+        base_url: `http://127.0.0.1:${address.port}/v1`,
+        model: "length-continuation-fixture",
+        role: "primary",
+        messages: longInput.messages,
+        max_output_tokens: 128,
+        context_window_tokens: 2_048,
+        provider_context_window_tokens: 32_768,
+        runtime_backend: "pi",
+      },
+      (event) => events.push(event),
+    );
+  } finally {
+    await new Promise((accept) => server.close(accept));
+  }
+
+  validateRuntimeTrace(events);
+  assert.equal(primaryCalls, 2);
+  assert.ok(compactionCalls >= 1);
+  assert.match(
+    JSON.stringify(
+      requests.findLast((request) =>
+        JSON.stringify(request.messages).includes("Finish the original user request now"),
+      )?.messages,
+    ),
+    /Finish the original user request now/,
+  );
+  assert.ok(events.some((event) => event.event === "compaction_boundary"));
+  assert.equal(events.some((event) => event.event === "error"), false);
+  assert.match(
+    events
+      .filter((event) => event.event === "delta")
+      .map((event) => event.data.text)
+      .join(""),
+    /three owners are the desktop, the runtime, and the evidence ledger/,
+  );
+});
+
+test("Pi runtime fails closed when bounded length continuations are exhausted", async () => {
+  let requests = 0;
+  const server = createServer(async (request, response) => {
+    const body = await requestJson(request);
+    requests += 1;
+    sendFixtureSse(response, [
+      {
+        id: `chatcmpl-length-exhausted-${requests}`,
+        object: "chat.completion.chunk",
+        created: 1,
+        model: body.model,
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant", content: "Still working." },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: `chatcmpl-length-exhausted-${requests}`,
+        object: "chat.completion.chunk",
+        created: 1,
+        model: body.model,
+        choices: [{ index: 0, delta: {}, finish_reason: "length" }],
+        usage: { prompt_tokens: 32, completion_tokens: 2, total_tokens: 34 },
+      },
+    ]);
+  });
+  await new Promise((accept) => server.listen(0, "127.0.0.1", accept));
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  const events = [];
+  try {
+    await runPiConversation(
+      {
+        run_id: "run-length-exhausted",
+        session_id: "session-length-exhausted",
+        base_url: `http://127.0.0.1:${address.port}/v1`,
+        model: "length-exhausted-fixture",
+        role: "primary",
+        messages: [{ role: "user", content: "Give me the complete answer." }],
+        max_output_tokens: 8,
+        context_window_tokens: 2_048,
+        provider_context_window_tokens: 32_768,
+        runtime_backend: "pi",
+      },
+      (event) => events.push(event),
+    );
+  } finally {
+    await new Promise((accept) => server.close(accept));
+  }
+
+  validateRuntimeTrace(events);
+  assert.equal(requests, 3);
+  const terminalError = events.find((event) => event.event === "error");
+  assert.equal(terminalError?.data.code, "pi_length_continuation_exhausted");
+  assert.equal(terminalError?.data.recoverable, true);
+});
+
 test("Pi runtime deterministically interrupts a student and continues with the teacher", async () => {
   const requests = [];
   const server = createServer(async (request, response) => {
@@ -2350,7 +2518,7 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       model: "conformance-cli",
     });
     assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
-    assert.equal(cliReport.metadata.runtime_version, "0.3.5");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.6");
     assert.equal(
       cliReport.metadata.event_schema,
       "understudy-conversation-runtime-event-v1",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -77,7 +77,7 @@ function writeReleaseEvidence() {
     adapter_id: "pi",
     generated_at: "2026-07-12T20:00:00.000Z",
     metadata: {
-      runtime_version: "0.3.5",
+      runtime_version: "0.3.6",
       event_schema: "understudy-conversation-runtime-event-v1",
       network_mode: "offline",
       provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
@@ -121,7 +121,7 @@ function writeReleaseEvidence() {
     },
     app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
     runtime: {
-      runtime_version: "0.3.5",
+      runtime_version: "0.3.6",
       event_schema: "understudy-conversation-runtime-event-v1",
       ready_ms: 700,
       rss_mb: 120,
@@ -180,7 +180,7 @@ before(async () => {
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
         app_version: "0.3.2",
-        runtime_version: "0.3.5",
+        runtime_version: "0.3.6",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,


### PR DESCRIPTION
## What changed
- resume a Pi response after a provider output-limit stop, only after the prior run and any compaction have settled
- bound automatic continuation to two attempts
- emit a recoverable terminal error when continuation fails or remains truncated, so Desktop cannot record an incomplete answer as successful
- bump the desktop and conversation runtime to 0.3.6 so pre-fix 0.3.5 rows cannot satisfy the exact-release deletion cohort

## Why
A genuine 0.3.5 desktop run compacted after seven tool calls, ended with stopReason=length, showed no substantive final answer, and was still classified as ok.

## Verification
- npm run check: 285 tests passed; TypeScript build/typecheck, 33 skills, and package smoke passed
- cargo clippy --all-targets -- -D warnings
- cargo test: 172 passed, 4 ignored
- bun install --frozen-lockfile and bun run build

The 0.3.6 cohort intentionally starts from zero. No existing rows were modified and no Rust conversation functionality was added.