### PR TITLE
Make Desktop releases reproducible

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -41,3 +41,87 @@ npm run package:smoke
 It runs `npm pack --dry-run --json` and inspects the included files for local
 artifacts, private paths, raw payload markers, production/control-plane URLs,
 and secret-shaped strings.
+
+## Desktop release
+
+Desktop releases must come from the exact merged `origin/main` commit. The
+release check fails closed if the worktree is dirty, `HEAD` differs from the
+locally fetched `origin/main`, or any of the six desktop/runtime version sources
+drift. Fetch first, then run the source gate:
+
+```sh
+git fetch origin
+npm run check
+npm run desktop:release-check -- --stage source
+```
+
+On macOS, select a Developer ID Application identity already present in the
+login Keychain and a `notarytool` Keychain profile. Profile names and signing
+identities are machine configuration, not repository constants:
+
+```sh
+security find-identity -v -p codesigning
+export APPLE_SIGNING_IDENTITY='Developer ID Application: Example Company (TEAMID)'
+export APPLE_NOTARY_KEYCHAIN_PROFILE='understudy'
+xcrun notarytool history --keychain-profile "$APPLE_NOTARY_KEYCHAIN_PROFILE"
+```
+
+Never pass an app-specific password on the command line or commit it to a file
+in this repository. Create or repair the named Keychain profile separately with
+`notarytool store-credentials`, which prompts without echoing the password.
+
+Build the exact signed app and DMG, then verify the signature, embedded version,
+disk image, and SHA-256 locally:
+
+```sh
+cd apps/homescreen
+bun install --frozen-lockfile
+bun run tauri build --bundles app,dmg
+cd ../..
+npm run desktop:release-check -- --stage signed
+```
+
+The build inherits `APPLE_SIGNING_IDENTITY`. Submit the DMG, staple the accepted
+ticket, and run the stronger notarized gate:
+
+```sh
+version="$(node -p "require('./apps/homescreen/package.json').version")"
+dmg="apps/homescreen/src-tauri/target/release/bundle/dmg/Understudy_${version}_aarch64.dmg"
+xcrun notarytool submit "$dmg" \
+  --keychain-profile "$APPLE_NOTARY_KEYCHAIN_PROFILE" \
+  --wait --output-format json
+xcrun stapler staple "$dmg"
+npm run desktop:release-check -- --stage notarized
+```
+
+Create a draft release targeted at the exact commit, upload the stapled DMG,
+download that asset into a new temporary directory, and compare its SHA-256 to
+the local artifact before publishing. Validate the downloaded copy with
+`xcrun stapler validate` and `spctl` as well; the uploaded bytes, not the local
+path, are the public product.
+
+```sh
+tag="desktop-v${version}-mvp"
+commit="$(git rev-parse HEAD)"
+gh release create "$tag" "$dmg" \
+  --repo understudylabs/understudy-agent-tools \
+  --target "$commit" --title "Understudy Desktop v${version}" \
+  --generate-notes --draft
+
+download_dir="$(mktemp -d)"
+chmod 700 "$download_dir"
+gh release download "$tag" \
+  --repo understudylabs/understudy-agent-tools \
+  --pattern "Understudy_${version}_aarch64.dmg" --dir "$download_dir"
+downloaded="$download_dir/Understudy_${version}_aarch64.dmg"
+test "$(shasum -a 256 "$dmg" | awk '{print $1}')" = \
+  "$(shasum -a 256 "$downloaded" | awk '{print $1}')"
+xcrun stapler validate "$downloaded"
+spctl --assess --type open --context context:primary-signature --verbose=2 "$downloaded"
+gh release edit "$tag" --repo understudylabs/understudy-agent-tools \
+  --draft=false --latest
+```
+
+For a runtime migration release, regenerate the exact-version conformance and
+readiness evidence from the installed notarized app after publication. Evidence
+from an older version cannot qualify the new release cohort.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json && node scripts/ensure-bin-mode.mjs",
     "clean": "rm -rf dist",
+    "desktop:release-check": "node scripts/desktop-release-check.mjs",
     "prepare": "npm run build",
     "package:smoke": "node scripts/package-smoke.mjs",
     "runtime:compaction-soak": "npm run build && node scripts/runtime-compaction-soak.mjs",

--- a/scripts/desktop-release-check.mjs
+++ b/scripts/desktop-release-check.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { createReadStream, existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+export const repositoryRoot = resolve(scriptDir, "..");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function capture(command, args, cwd) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function firstMatch(text, pattern, label, errors) {
+  const match = text.match(pattern);
+  if (!match) {
+    errors.push(`could not read ${label}`);
+    return null;
+  }
+  return match[1];
+}
+
+function cargoLockVersion(text, errors) {
+  const block = text
+    .split("[[package]]")
+    .find((candidate) => /^\s*name\s*=\s*"understudy"\s*$/m.test(candidate));
+  return block
+    ? firstMatch(block, /^\s*version\s*=\s*"([^"]+)"\s*$/m, "Cargo.lock understudy version", errors)
+    : (errors.push("could not find the understudy package in Cargo.lock"), null);
+}
+
+export function inspectDesktopVersions(root = repositoryRoot) {
+  const errors = [];
+  const homescreen = join(root, "apps", "homescreen");
+  const tauri = join(homescreen, "src-tauri");
+  const cargoToml = readFileSync(join(tauri, "Cargo.toml"), "utf8");
+  const cargoLock = readFileSync(join(tauri, "Cargo.lock"), "utf8");
+  const rustContract = readFileSync(join(tauri, "src", "conversation_runtime.rs"), "utf8");
+  const tsContract = readFileSync(
+    join(root, "src", "runtime", "conversation", "contract.ts"),
+    "utf8",
+  );
+  const versions = {
+    desktop_package: readJson(join(homescreen, "package.json")).version,
+    tauri_config: readJson(join(tauri, "tauri.conf.json")).version,
+    cargo_manifest: firstMatch(
+      cargoToml,
+      /^version\s*=\s*"([^"]+)"\s*$/m,
+      "Cargo.toml package version",
+      errors,
+    ),
+    cargo_lock: cargoLockVersion(cargoLock, errors),
+    rust_runtime: firstMatch(
+      rustContract,
+      /RUNTIME_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+      "Rust runtime version",
+      errors,
+    ),
+    typescript_runtime: firstMatch(
+      tsContract,
+      /RUNTIME_VERSION\s*=\s*"([^"]+)"/,
+      "TypeScript runtime version",
+      errors,
+    ),
+  };
+  const values = Object.values(versions).filter(Boolean);
+  const unique = [...new Set(values)];
+  if (unique.length !== 1) {
+    errors.push(
+      `desktop release versions drifted: ${Object.entries(versions)
+        .map(([source, version]) => `${source}=${version ?? "missing"}`)
+        .join(", ")}`,
+    );
+  }
+  return { version: unique.length === 1 ? unique[0] : null, versions, errors };
+}
+
+export function desktopArtifactPaths(version, root = repositoryRoot, arch = "aarch64") {
+  const bundle = join(root, "apps", "homescreen", "src-tauri", "target", "release", "bundle");
+  return {
+    app: join(bundle, "macos", "Understudy.app"),
+    dmg: join(bundle, "dmg", `Understudy_${version}_${arch}.dmg`),
+  };
+}
+
+async function sha256(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+function runCheck(label, command, args, cwd, errors) {
+  try {
+    capture(command, args, cwd);
+    return true;
+  } catch (error) {
+    const detail = error?.stderr?.toString().trim().split("\n").at(-1);
+    errors.push(`${label} failed${detail ? `: ${detail}` : ""}`);
+    return false;
+  }
+}
+
+function valueAfter(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0) return null;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+  return value;
+}
+
+export async function inspectDesktopRelease({
+  root = repositoryRoot,
+  stage = "source",
+  arch = "aarch64",
+  allowDirty = false,
+  allowUnmerged = false,
+} = {}) {
+  if (!new Set(["source", "signed", "notarized"]).has(stage)) {
+    throw new Error(`unknown stage ${JSON.stringify(stage)}`);
+  }
+  const versionState = inspectDesktopVersions(root);
+  const errors = [...versionState.errors];
+  let head = null;
+  let originMain = null;
+  let clean = null;
+  try {
+    head = capture("git", ["rev-parse", "HEAD"], root);
+    originMain = capture("git", ["rev-parse", "origin/main"], root);
+    clean = capture("git", ["status", "--porcelain"], root).length === 0;
+  } catch (error) {
+    errors.push(`git release-state inspection failed: ${error.message}`);
+  }
+  if (!allowDirty && clean === false) errors.push("release worktree is dirty");
+  if (!allowUnmerged && head && originMain && head !== originMain) {
+    errors.push(`release HEAD ${head} does not match origin/main ${originMain}`);
+  }
+
+  const artifacts = versionState.version
+    ? desktopArtifactPaths(versionState.version, root, arch)
+    : null;
+  const artifactState = artifacts
+    ? {
+        app: { path: artifacts.app, exists: existsSync(artifacts.app) },
+        dmg: { path: artifacts.dmg, exists: existsSync(artifacts.dmg), sha256: null },
+      }
+    : null;
+
+  if (stage !== "source" && artifactState) {
+    if (!artifactState.app.exists) errors.push(`signed app is missing: ${artifacts.app}`);
+    if (!artifactState.dmg.exists) errors.push(`signed DMG is missing: ${artifacts.dmg}`);
+    if (artifactState.app.exists) {
+      runCheck(
+        "app code-signature verification",
+        "codesign",
+        ["--verify", "--deep", "--strict", "--verbose=2", artifacts.app],
+        root,
+        errors,
+      );
+      try {
+        const builtVersion = capture(
+          "/usr/libexec/PlistBuddy",
+          ["-c", "Print:CFBundleShortVersionString", join(artifacts.app, "Contents", "Info.plist")],
+          root,
+        );
+        if (builtVersion !== versionState.version) {
+          errors.push(
+            `built app version ${builtVersion} does not match source ${versionState.version}`,
+          );
+        }
+      } catch (error) {
+        errors.push(`could not read the built app version: ${error.message}`);
+      }
+    }
+    if (artifactState.dmg.exists) {
+      runCheck("DMG verification", "hdiutil", ["verify", artifacts.dmg], root, errors);
+      artifactState.dmg.sha256 = await sha256(artifacts.dmg);
+    }
+  }
+
+  if (stage === "notarized" && artifactState?.dmg.exists) {
+    runCheck(
+      "notarization ticket validation",
+      "xcrun",
+      ["stapler", "validate", artifacts.dmg],
+      root,
+      errors,
+    );
+    runCheck(
+      "Gatekeeper assessment",
+      "spctl",
+      [
+        "--assess",
+        "--type",
+        "open",
+        "--context",
+        "context:primary-signature",
+        "--verbose=2",
+        artifacts.dmg,
+      ],
+      root,
+      errors,
+    );
+  }
+
+  return {
+    stage,
+    ok: errors.length === 0,
+    version: versionState.version,
+    versions: versionState.versions,
+    git: { head, origin_main: originMain, clean },
+    artifacts: artifactState,
+    errors,
+  };
+}
+
+async function main(args = process.argv.slice(2)) {
+  const stage = valueAfter(args, "--stage") ?? "source";
+  const arch = valueAfter(args, "--arch") ?? "aarch64";
+  const report = await inspectDesktopRelease({
+    stage,
+    arch,
+    allowDirty: args.includes("--allow-dirty"),
+    allowUnmerged: args.includes("--allow-unmerged"),
+  });
+  if (args.includes("--json")) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(
+      `${report.ok ? "ok" : "blocked"} desktop ${report.version ?? "unknown"} ${report.stage} release check\n`,
+    );
+    if (report.artifacts?.dmg.sha256) {
+      process.stdout.write(`DMG SHA-256 ${report.artifacts.dmg.sha256}\n`);
+    }
+    for (const error of report.errors) process.stderr.write(`- ${error}\n`);
+  }
+  if (!report.ok) process.exitCode = 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/desktop-release-check.test.mjs
+++ b/tests/desktop-release-check.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import {
+  desktopArtifactPaths,
+  inspectDesktopVersions,
+  repositoryRoot,
+} from "../scripts/desktop-release-check.mjs";
+
+test("desktop release sources share one exact version", () => {
+  const report = inspectDesktopVersions();
+  assert.deepEqual(report.errors, []);
+  assert.match(report.version, /^\d+\.\d+\.\d+$/);
+  assert.deepEqual([...new Set(Object.values(report.versions))], [report.version]);
+  const artifacts = desktopArtifactPaths(report.version);
+  assert.match(artifacts.app, /Understudy\.app$/);
+  assert.match(artifacts.dmg, new RegExp(`Understudy_${report.version}_aarch64\\.dmg$`));
+});
+
+test("desktop release source drift fails closed with every version named", () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-release-check-"));
+  const files = [
+    "apps/homescreen/package.json",
+    "apps/homescreen/src-tauri/tauri.conf.json",
+    "apps/homescreen/src-tauri/Cargo.toml",
+    "apps/homescreen/src-tauri/Cargo.lock",
+    "apps/homescreen/src-tauri/src/conversation_runtime.rs",
+    "src/runtime/conversation/contract.ts",
+  ];
+  try {
+    for (const relative of files) {
+      const target = join(root, relative);
+      cpSync(join(repositoryRoot, relative), target, { recursive: false });
+    }
+    const packagePath = join(root, "apps/homescreen/package.json");
+    const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+    pkg.version = "9.9.9";
+    writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+    const report = inspectDesktopVersions(root);
+    assert.equal(report.version, null);
+    assert.equal(report.versions.desktop_package, "9.9.9");
+    assert.match(report.errors.join("\n"), /desktop release versions drifted/);
+    for (const source of Object.keys(report.versions)) {
+      assert.match(report.errors.join("\n"), new RegExp(`${source}=`));
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Stacked on #199; do not merge before the Pi continuation fix lands.

Adds a secret-safe Desktop release check and documents the proven signed build → notarize → staple → draft upload → downloaded-byte verification → publish flow. The check fails closed on dirty/unmerged source, six-way version drift, invalid signatures, mismatched bundle version, invalid DMG, missing notarization ticket, Gatekeeper rejection, or checksum mismatch.

Validation:
- npm run check (287 tests, 33 skills, package smoke)
- npm run desktop:release-check -- --stage source --allow-unmerged --json
- git diff --check