### PR TITLE
Start fresh chats without losing history

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -393,6 +393,13 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
     setPacedRevealed(null);
   };
 
+  const resetDroppedWorkload = () => {
+    dropRequestGeneration.current += 1;
+    dropInFlight.current = false;
+    setDroppedWorkload(null);
+    setDropRunning(false);
+  };
+
   const startStreamPacer = (messageIndex: number) => {
     resetStreamPacer();
     if (!pacingEnabled()) return null;
@@ -843,10 +850,7 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
     setSessionHydrated(true);
     setHistoryOpen(false);
     setAssistantSpeaking(false);
-    dropRequestGeneration.current += 1;
-    dropInFlight.current = false;
-    setDroppedWorkload(null);
-    setDropRunning(false);
+    resetDroppedWorkload();
     setPersonaReady(false);
     setIntroThinking(true);
     setPersonaCycle((value) => value + 1);
@@ -910,7 +914,7 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
       setMessages(restored);
       setInput("");
       setAssistantSpeaking(false);
-      setDroppedWorkload(null);
+      resetDroppedWorkload();
       setHistoryOpen(false);
       setPersonaCycle((value) => value + 1);
     } catch (error) {

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -129,6 +129,12 @@ type PersistedChatSession = {
   messages: Msg[];
   updated_at: string;
 };
+type ChatSessionSummary = {
+  session_id: string;
+  title: string;
+  message_count: number;
+  updated_at: string;
+};
 type LocalModelChoice = {
   id: string;
   modelId: string;
@@ -170,6 +176,21 @@ const CLOUD_MODEL: ModelChoice = {
   slotId: null,
   active: true,
 };
+
+// This survives ChatPane remounts while the app is open (for example, after
+// visiting Models) but resets with the webview on a new app launch.
+let activeChatSessionId: string | null = null;
+
+function chatHistoryTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Saved chat";
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
 
 function compactBytes(bytes: number): string {
   if (bytes < 1_024) return `${bytes} B`;
@@ -326,10 +347,16 @@ function ChatToolTrace({ tool }: { tool: ToolTrace }) {
   );
 }
 
-export function ChatPane({ resetToken }: { resetToken: number }) {
+export function ChatPane({ resetToken, historyToken }: { resetToken: number; historyToken: number }) {
+  const [initialSession] = useState(() => {
+    const restore = activeChatSessionId !== null;
+    const sessionId = activeChatSessionId ?? crypto.randomUUID();
+    activeChatSessionId = sessionId;
+    return { sessionId, restore };
+  });
   const [messages, setMessages] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
-  const [sessionId, setSessionId] = useState(() => crypto.randomUUID());
+  const [sessionId, setSessionId] = useState(initialSession.sessionId);
   const [streaming, setStreaming] = useState(false);
   const [assistantSpeaking, setAssistantSpeaking] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -341,13 +368,17 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const [personaCycle, setPersonaCycle] = useState(0);
   const [introThinking, setIntroThinking] = useState(true);
   const [sidekickEvents, setSidekickEvents] = useState<SidekickEvent[]>([]);
-  const [sessionHydrated, setSessionHydrated] = useState(false);
+  const [sessionHydrated, setSessionHydrated] = useState(!initialSession.restore);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historySessions, setHistorySessions] = useState<ChatSessionSummary[]>([]);
   const [dropHovering, setDropHovering] = useState(false);
   const [dropRunning, setDropRunning] = useState(false);
   const [droppedWorkload, setDroppedWorkload] = useState<DroppedWorkload | null>(null);
   const [pacingMessageIndex, setPacingMessageIndex] = useState<number | null>(null);
   const [pacedRevealed, setPacedRevealed] = useState<number | null>(null);
   const observedResetToken = useRef(false);
+  const observedHistoryToken = useRef(false);
   const dropInFlight = useRef(false);
   const dropRequestGeneration = useRef(0);
   const selectedModelUserOwned = useRef(false);
@@ -517,38 +548,50 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     };
   }, []);
 
+  const hydrateSavedMessages = async (
+    saved: PersistedChatSession,
+    isCancelled: () => boolean = () => false,
+  ): Promise<Msg[] | null> => {
+    const attachmentRefs = recentUniqueAttachmentRefs(saved.messages);
+    const hydrated =
+      attachmentRefs.length > 0
+        ? await invoke<Array<ChatAttachment & { dataUrl: string }>>(
+            "chat_attachments_hydrate",
+            {
+              sessionId: saved.session_id,
+              attachments: attachmentRefs,
+            },
+          ).catch((error) => {
+            if (!isCancelled()) {
+              setNotice(`Some saved image previews could not be restored: ${String(error)}`);
+            }
+            return [];
+          })
+        : [];
+    if (isCancelled()) return null;
+    if (hydrated.length < attachmentRefs.length) {
+      setNotice("Some saved image previews are unavailable; their history references were preserved.");
+    }
+    return withHydratedAttachments(saved.messages, hydrated);
+  };
+
   useEffect(() => {
+    // A cold launch intentionally begins with a new blank session. If the user
+    // merely navigated away from Chat and back, restore the active session by
+    // its exact ID instead of whichever historical chat happens to be newest.
+    if (!initialSession.restore) return;
     let cancelled = false;
-    invoke<PersistedChatSession | null>("chat_session_latest")
+    invoke<PersistedChatSession | null>("chat_session_get", {
+      sessionId: initialSession.sessionId,
+    })
       .then(async (saved) => {
         if (cancelled || !saved) return;
-        const attachmentRefs = recentUniqueAttachmentRefs(saved.messages);
-        const hydrated =
-          attachmentRefs.length > 0
-            ? await invoke<Array<ChatAttachment & { dataUrl: string }>>(
-                "chat_attachments_hydrate",
-                {
-                  sessionId: saved.session_id,
-                  attachments: attachmentRefs,
-                },
-              ).catch((error) => {
-                if (!cancelled) {
-                  setNotice(`Some saved image previews could not be restored: ${String(error)}`);
-                }
-                return [];
-              })
-            : [];
-        if (cancelled) return;
-        if (hydrated.length < attachmentRefs.length) {
-          setNotice("Some saved image previews are unavailable; their history references were preserved.");
-        }
-        setSessionId(saved.session_id);
-        setMessages(withHydratedAttachments(saved.messages, hydrated));
+        const restored = await hydrateSavedMessages(saved, () => cancelled);
+        if (!restored || cancelled) return;
+        setMessages(restored);
       })
       .catch((error) => {
-        // A corrupt or legacy session must never block a fresh local chat, but
-        // the user should know why the previous conversation is not visible.
-        if (!cancelled) setNotice(`Saved chat could not be restored: ${String(error)}`);
+        if (!cancelled) setNotice(`Current chat could not be restored: ${String(error)}`);
       })
       .finally(() => {
         if (!cancelled) setSessionHydrated(true);
@@ -559,7 +602,7 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   }, []);
 
   useEffect(() => {
-    if (!sessionHydrated || streaming) return;
+    if (!sessionHydrated || streaming || messages.length === 0) return;
     const timer = window.setTimeout(() => {
       invoke("chat_session_save", {
         sessionId,
@@ -781,14 +824,24 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
   const restartChat = () => {
     if (streaming) return;
     resetStreamPacer();
-    void invoke("chat_attachments_delete_session", { sessionId }).catch(() => {
-      // Starting a fresh chat still succeeds; orphan cleanup is local and best-effort.
-    });
+    if (messages.length > 0) {
+      void invoke("chat_session_save", {
+        sessionId,
+        messages: persistableChatMessages(messages),
+      }).catch(() => {
+        // The debounced save normally ran already. Starting a new chat should
+        // remain available if this final best-effort flush fails.
+      });
+    }
+    const nextSessionId = crypto.randomUUID();
+    activeChatSessionId = nextSessionId;
     setMessages([]);
     setInput("");
     setErr(null);
     setNotice(null);
-    setSessionId(crypto.randomUUID());
+    setSessionId(nextSessionId);
+    setSessionHydrated(true);
+    setHistoryOpen(false);
     setAssistantSpeaking(false);
     dropRequestGeneration.current += 1;
     dropInFlight.current = false;
@@ -806,6 +859,66 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
     }
     restartChat();
   }, [resetToken]);
+
+  const showHistory = () => {
+    if (streaming) {
+      setNotice("Finish or stop the current turn before opening another chat.");
+      return;
+    }
+    setHistoryOpen(true);
+    setHistoryLoading(true);
+    invoke<ChatSessionSummary[]>("chat_sessions_list", { limit: 30 })
+      .then(setHistorySessions)
+      .catch((error) => setNotice(`Chat history could not be loaded: ${String(error)}`))
+      .finally(() => setHistoryLoading(false));
+  };
+
+  useEffect(() => {
+    if (!observedHistoryToken.current) {
+      observedHistoryToken.current = true;
+      return;
+    }
+    showHistory();
+  }, [historyToken]);
+
+  const restoreHistorySession = async (historySessionId: string) => {
+    if (streaming) return;
+    setHistoryLoading(true);
+    setErr(null);
+    setNotice(null);
+    try {
+      if (messages.length > 0) {
+        await invoke("chat_session_save", {
+          sessionId,
+          messages: persistableChatMessages(messages),
+        }).catch(() => {
+          setNotice("The current chat could not be saved before switching.");
+        });
+      }
+      const saved = await invoke<PersistedChatSession | null>("chat_session_get", {
+        sessionId: historySessionId,
+      });
+      if (!saved) {
+        setNotice("That saved chat is no longer available.");
+        return;
+      }
+      const restored = await hydrateSavedMessages(saved);
+      if (!restored) return;
+      resetStreamPacer();
+      activeChatSessionId = saved.session_id;
+      setSessionId(saved.session_id);
+      setMessages(restored);
+      setInput("");
+      setAssistantSpeaking(false);
+      setDroppedWorkload(null);
+      setHistoryOpen(false);
+      setPersonaCycle((value) => value + 1);
+    } catch (error) {
+      setNotice(`Saved chat could not be opened: ${String(error)}`);
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
 
   const setThinking = async (thinking: boolean) => {
     if (selectedChoice.route !== "local") return;
@@ -894,6 +1007,52 @@ export function ChatPane({ resetToken }: { resetToken: number }) {
         <div className="workload-drop-overlay" role="status">
           <div className="workload-drop-overlay-title">Drop one file or folder</div>
           <div>Metadata only · stays on this Mac</div>
+        </div>
+      )}
+      {historyOpen && (
+        <div
+          className="chat-history-overlay"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) setHistoryOpen(false);
+          }}
+        >
+          <section className="chat-history-panel" role="dialog" aria-modal="true" aria-labelledby="chat-history-title">
+            <header className="chat-history-header">
+              <div>
+                <h2 id="chat-history-title">Chat history</h2>
+                <p>Open an earlier conversation on this Mac.</p>
+              </div>
+              <button type="button" aria-label="Close chat history" onClick={() => setHistoryOpen(false)}>
+                ×
+              </button>
+            </header>
+            <div className="chat-history-list">
+              {historyLoading && historySessions.length === 0 ? (
+                <div className="chat-history-empty">Loading…</div>
+              ) : historySessions.length === 0 ? (
+                <div className="chat-history-empty">No earlier chats yet.</div>
+              ) : (
+                historySessions.map((saved) => (
+                  <button
+                    type="button"
+                    className={"chat-history-row" + (saved.session_id === sessionId ? " current" : "")}
+                    key={saved.session_id}
+                    onClick={() => void restoreHistorySession(saved.session_id)}
+                    disabled={historyLoading}
+                  >
+                    <span className="chat-history-row-title">
+                      {saved.title.trim().replace(/\s+/g, " ") || "Untitled chat"}
+                    </span>
+                    <span className="chat-history-row-meta">
+                      {chatHistoryTime(saved.updated_at)} · {saved.message_count} message{saved.message_count === 1 ? "" : "s"}
+                      {saved.session_id === sessionId ? " · current" : ""}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </section>
         </div>
       )}
       <div className={"persona-stage" + (personaReady ? " persona-ready" : "")} aria-hidden="true">

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -233,6 +233,24 @@ select,
   background: var(--surface-2);
   color: var(--text);
 }
+.titlebar-chat-history {
+  position: fixed;
+  z-index: 30;
+  top: 9px;
+  left: calc(var(--traffic-left) + 76px);
+  display: inline-grid;
+  place-content: center;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: var(--r-control);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  color: var(--text-2);
+}
+.titlebar-chat-history:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
 .titlebar-pin {
   position: fixed;
   z-index: 30;
@@ -246,6 +264,9 @@ select,
   border-radius: var(--r-control);
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   color: var(--text-2);
+}
+.titlebar-pin.with-chat-controls {
+  left: calc(var(--traffic-left) + 114px);
 }
 .titlebar-pin:hover {
   background: var(--surface-2);
@@ -1918,6 +1939,105 @@ select,
   display: flex;
   flex-direction: column;
   min-height: 0;
+}
+.chat-history-overlay {
+  position: fixed;
+  z-index: 75;
+  inset: 0;
+  display: grid;
+  place-items: start center;
+  padding: calc(var(--titlebar-h) + 24px) 18px 18px;
+  background: color-mix(in srgb, var(--c-window) 74%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+.chat-history-panel {
+  width: min(480px, 100%);
+  max-height: min(620px, calc(100vh - var(--titlebar-h) - 48px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+}
+.chat-history-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+  border-bottom: 1px solid var(--border);
+}
+.chat-history-header h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 600;
+}
+.chat-history-header p {
+  margin: 4px 0 0;
+  color: var(--text-3);
+  font-size: 12px;
+}
+.chat-history-header button {
+  display: grid;
+  place-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: var(--r-control);
+  background: transparent;
+  color: var(--text-3);
+  font-size: 20px;
+  line-height: 1;
+}
+.chat-history-header button:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+.chat-history-list {
+  min-height: 90px;
+  overflow: auto;
+  padding: 8px;
+}
+.chat-history-row {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text);
+  padding: 11px 12px;
+  text-align: left;
+}
+.chat-history-row:hover,
+.chat-history-row.current {
+  background: var(--surface-2);
+}
+.chat-history-row:disabled {
+  opacity: 0.65;
+}
+.chat-history-row-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 500;
+}
+.chat-history-row-meta {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+.chat-history-empty {
+  display: grid;
+  place-content: center;
+  min-height: 110px;
+  color: var(--text-3);
+  font-size: 12px;
 }
 .ai-chat {
   padding: var(--titlebar-h) 24px 24px;

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { PanelLeftIcon, PinIcon, PinOffIcon, SquarePenIcon } from "lucide-react";
+import { HistoryIcon, PanelLeftIcon, PinIcon, PinOffIcon, SquarePenIcon } from "lucide-react";
 import { Sidebar, type PaneId } from "./components/Sidebar";
 import { StatusPane } from "./components/StatusPane";
 import { ModelsPane } from "./components/ModelsPane";
@@ -21,6 +21,7 @@ export default function Page() {
   const [pane, setPane] = useState<PaneId>("chat");
   const [railOpen, setRailOpen] = useState(false);
   const [chatResetToken, setChatResetToken] = useState(0);
+  const [chatHistoryToken, setChatHistoryToken] = useState(0);
   const [pinned, setPinned] = useState(false);
   const status = useStatus();
   const connected = status.snap?.connected ?? false;
@@ -117,19 +118,30 @@ export default function Page() {
         <PanelLeftIcon aria-hidden="true" size={16} strokeWidth={2} />
       </button>
       {pane === "chat" && (
-        <button
-          type="button"
-          className="titlebar-new-chat"
-          aria-label="New chat"
-          title="New chat (Cmd+N)"
-          onClick={newChat}
-        >
-          <SquarePenIcon aria-hidden="true" size={15} strokeWidth={2} />
-        </button>
+        <>
+          <button
+            type="button"
+            className="titlebar-new-chat"
+            aria-label="New chat"
+            title="New chat (Cmd+N)"
+            onClick={newChat}
+          >
+            <SquarePenIcon aria-hidden="true" size={15} strokeWidth={2} />
+          </button>
+          <button
+            type="button"
+            className="titlebar-chat-history"
+            aria-label="Chat history"
+            title="Chat history"
+            onClick={() => setChatHistoryToken((token) => token + 1)}
+          >
+            <HistoryIcon aria-hidden="true" size={15} strokeWidth={2} />
+          </button>
+        </>
       )}
       <button
         type="button"
-        className={"titlebar-pin" + (pinned ? " pinned" : "")}
+        className={"titlebar-pin" + (pane === "chat" ? " with-chat-controls" : "") + (pinned ? " pinned" : "")}
         aria-label={pinned ? "Unpin window (always on top)" : "Pin window always on top"}
         aria-pressed={pinned}
         title={pinned ? "Unpin window" : "Keep window on top"}
@@ -153,7 +165,7 @@ export default function Page() {
       />
       <main className="content">
         {pane === "status" && <StatusPane status={status} />}
-        {pane === "chat" && <ChatPane resetToken={chatResetToken} />}
+        {pane === "chat" && <ChatPane resetToken={chatResetToken} historyToken={chatHistoryToken} />}
         {pane === "models" && <ModelsPane />}
         {pane === "capture" && <CapturePane />}
         {pane === "rlm" && <RlmPane />}

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -2346,6 +2346,18 @@ pub struct DesktopChatSession {
     updated_at: String,
 }
 
+fn desktop_chat_session_from_row(
+    row: crate::db::ChatSessionRow,
+) -> Result<DesktopChatSession, String> {
+    let messages = serde_json::from_str(&row.messages)
+        .map_err(|error| format!("saved chat transcript is invalid: {error}"))?;
+    Ok(DesktopChatSession {
+        session_id: row.session_id,
+        messages,
+        updated_at: row.updated_at,
+    })
+}
+
 #[tauri::command]
 pub fn chat_session_latest(app: AppHandle) -> Result<Option<DesktopChatSession>, String> {
     let db = app.state::<crate::db::Db>();
@@ -2377,6 +2389,34 @@ pub fn chat_session_latest(app: AppHandle) -> Result<Option<DesktopChatSession>,
         messages,
         updated_at,
     }))
+}
+
+#[tauri::command]
+pub fn chat_sessions_list(
+    app: AppHandle,
+    limit: Option<u32>,
+) -> Result<Vec<crate::db::ChatSessionSummaryRow>, String> {
+    // Preserve the v1-to-v2 migration now that cold launches no longer reopen
+    // the newest chat automatically.
+    let _ = chat_session_latest(app.clone())?;
+    app.state::<crate::db::Db>()
+        .list_chat_sessions(DESKTOP_CHAT_SESSION_SCHEMA, limit.unwrap_or(30))
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn chat_session_get(
+    app: AppHandle,
+    session_id: String,
+) -> Result<Option<DesktopChatSession>, String> {
+    if session_id.trim().is_empty() || session_id.len() > 200 {
+        return Err("invalid chat session id".to_string());
+    }
+    app.state::<crate::db::Db>()
+        .chat_session(&session_id, DESKTOP_CHAT_SESSION_SCHEMA)
+        .map_err(|error| error.to_string())?
+        .map(desktop_chat_session_from_row)
+        .transpose()
 }
 
 #[tauri::command]

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -181,6 +181,14 @@ pub struct ChatSessionRow {
 }
 
 #[derive(Serialize, Clone)]
+pub struct ChatSessionSummaryRow {
+    pub session_id: String,
+    pub title: String,
+    pub message_count: u64,
+    pub updated_at: String,
+}
+
+#[derive(Serialize, Clone)]
 pub struct SidekickRunRow {
     pub id: u64,
     pub session_id: String,
@@ -1129,6 +1137,51 @@ impl Db {
         }))
     }
 
+    pub fn chat_session(&self, session_id: &str, schema: &str) -> Result<Option<ChatSessionRow>> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT session_id, schema, messages, updated_at
+             FROM chat_sessions WHERE session_id=?1 AND schema=?2 LIMIT 1",
+        )?;
+        let mut rows = stmt.query(rusqlite::params![session_id, schema])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        Ok(Some(ChatSessionRow {
+            session_id: row.get(0)?,
+            schema: row.get(1)?,
+            messages: row.get(2)?,
+            updated_at: row.get(3)?,
+        }))
+    }
+
+    pub fn list_chat_sessions(
+        &self,
+        schema: &str,
+        limit: u32,
+    ) -> Result<Vec<ChatSessionSummaryRow>> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT session_id,
+                    substr(CAST(COALESCE(json_extract(messages, '$[0].content'), '') AS TEXT), 1, 160),
+                    COALESCE(json_array_length(messages), 0),
+                    updated_at
+             FROM chat_sessions
+             WHERE schema=?1 AND COALESCE(json_array_length(messages), 0) > 0
+             ORDER BY updated_at DESC, rowid DESC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![schema, limit.clamp(1, 100)], |row| {
+            Ok(ChatSessionSummaryRow {
+                session_id: row.get(0)?,
+                title: row.get(1)?,
+                message_count: row.get(2)?,
+                updated_at: row.get(3)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
     // Mirrors the sidekick_runs column list; not restructured to avoid churn.
     #[allow(clippy::too_many_arguments)]
     pub fn record_sidekick_run(
@@ -1708,6 +1761,43 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM chat_sessions", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 3);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn chat_session_history_lists_non_empty_chats_and_loads_exact_session() {
+        let (dir, db) = temp_db("chat-session-history");
+        db.save_active_chat_session("empty", "desktop-chat-v2", "[]")
+            .unwrap();
+        db.save_active_chat_session(
+            "first",
+            "desktop-chat-v2",
+            r#"[{"role":"user","content":"Plan the launch"},{"role":"assistant","content":"Okay"}]"#,
+        )
+        .unwrap();
+        db.save_active_chat_session(
+            "second",
+            "desktop-chat-v2",
+            r#"[{"role":"user","content":"Review the benchmark"}]"#,
+        )
+        .unwrap();
+
+        let summaries = db.list_chat_sessions("desktop-chat-v2", 20).unwrap();
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].session_id, "second");
+        assert_eq!(summaries[0].title, "Review the benchmark");
+        assert_eq!(summaries[0].message_count, 1);
+        assert_eq!(summaries[1].title, "Plan the launch");
+
+        let exact = db
+            .chat_session("first", "desktop-chat-v2")
+            .unwrap()
+            .unwrap();
+        assert!(exact.messages.contains("Plan the launch"));
+        assert!(db
+            .chat_session("missing", "desktop-chat-v2")
+            .unwrap()
+            .is_none());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -191,6 +191,8 @@ pub fn run() {
             commands::chat_runs,
             commands::chat_route_metrics,
             commands::chat_session_latest,
+            commands::chat_sessions_list,
+            commands::chat_session_get,
             commands::chat_session_save,
             chat_attachments::chat_attachments_store,
             chat_attachments::chat_attachments_hydrate,

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -222,6 +222,11 @@ test("desktop starts fresh on launch and can reopen an exact Pi session", async 
   assert.match(chat, /"chat_sessions_list"/);
   assert.match(chat, /"chat_session_get"/);
   assert.match(chat, /activeChatSessionId = saved\.session_id/);
+  assert.match(
+    chat,
+    /const resetDroppedWorkload = \(\) => \{[\s\S]*dropRequestGeneration\.current \+= 1;[\s\S]*dropInFlight\.current = false;[\s\S]*setDropRunning\(false\);/,
+  );
+  assert.equal(chat.match(/resetDroppedWorkload\(\);/g)?.length, 2);
   assert.match(page, /aria-label="Chat history"/);
   assert.match(commands, /pub fn chat_sessions_list/);
   assert.match(commands, /pub fn chat_session_get/);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -186,7 +186,7 @@ test("desktop has one managed runtime repair surface", async () => {
   assert.doesNotMatch(repair, /understudy update/);
 });
 
-test("desktop persists image references instead of transcript-embedded bytes", async () => {
+test("desktop persists image references and retains them with chat history", async () => {
   const [chat, attachmentLib, attachmentRust] = await Promise.all([
     readFile(chatPath, "utf8"),
     readFile(attachmentLibPath, "utf8"),
@@ -195,7 +195,7 @@ test("desktop persists image references instead of transcript-embedded bytes", a
 
   assert.match(chat, /"chat_attachments_store"/);
   assert.match(chat, /"chat_attachments_hydrate"/);
-  assert.match(chat, /"chat_attachments_delete_session"/);
+  assert.doesNotMatch(chat, /"chat_attachments_delete_session"/);
   assert.match(chat, /persistableChatMessages\(messages\)/);
   assert.match(attachmentLib, /previewUrl: _previewUrl/);
   assert.match(
@@ -207,6 +207,24 @@ test("desktop persists image references instead of transcript-embedded bytes", a
   assert.match(attachmentRust, /from_mode\(0o700\)/);
   assert.match(attachmentRust, /options\.mode\(0o600\)/);
   assert.match(attachmentRust, /migrate_legacy_messages/);
+});
+
+test("desktop starts fresh on launch and can reopen an exact Pi session", async () => {
+  const [chat, page, commands] = await Promise.all([
+    readFile(chatPath, "utf8"),
+    readFile(pagePath, "utf8"),
+    readFile(new URL("../apps/homescreen/src-tauri/src/commands.rs", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(chat, /let activeChatSessionId: string \| null = null/);
+  assert.match(chat, /const restore = activeChatSessionId !== null/);
+  assert.doesNotMatch(chat, /invoke<PersistedChatSession \| null>\("chat_session_latest"\)/);
+  assert.match(chat, /"chat_sessions_list"/);
+  assert.match(chat, /"chat_session_get"/);
+  assert.match(chat, /activeChatSessionId = saved\.session_id/);
+  assert.match(page, /aria-label="Chat history"/);
+  assert.match(commands, /pub fn chat_sessions_list/);
+  assert.match(commands, /pub fn chat_session_get/);
 });
 
 test("desktop compiles one dropped path through the bounded public CLI", async () => {


### PR DESCRIPTION
## What changed

- Start every cold Desktop launch in a new blank chat instead of automatically reopening the newest transcript.
- Add a quiet titlebar History control that lists non-empty local chats and reopens an exact saved session.
- Reuse the selected session ID so Pi resumes the matching persistent runtime context.
- Keep the active chat across in-app pane navigation during the same launch.
- Preserve image attachments when starting a new chat instead of deleting history-owned files.

## Why

A new launch should feel clean, but users still need a dependable way to go backward. Desktop SQLite is the durable history index and transcript/attachment projection; Pi resumes model context when Desktop supplies the same session ID.

All history remains local on the Mac.

## Validation

- `npm test` — 290 passed
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` — 173 passed, 4 real-artifact tests ignored
- `cargo clippy --manifest-path apps/homescreen/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `npm run build` in `apps/homescreen` — production Next build passed
