### PR TITLE
Make Pi compaction soak resolve Desktop slots

### DIFF
--- a/scripts/runtime-compaction-soak.mjs
+++ b/scripts/runtime-compaction-soak.mjs
@@ -1,31 +1,84 @@
 #!/usr/bin/env node
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { validateRuntimeTrace } from "../dist/runtime/conversation/contract.js";
 import { runPiConversation } from "../dist/runtime/conversation/pi-runtime.js";
+import {
+  requireDesktopApi,
+  resolveDesktopSlotProviderTarget,
+} from "../dist/internal/desktop-api.js";
 
 function option(name, fallback) {
   const index = process.argv.indexOf(`--${name}`);
   return index >= 0 ? process.argv[index + 1] : fallback;
 }
 
-const baseUrl = option("base-url");
-const model = option("model");
+let baseUrl = option("base-url");
+let model = option("model");
+let artifactId = null;
+const slotRaw = option("slot");
 const output = option("output");
 const cycles = Number(option("cycles", "28"));
 const logicalContext = Number(option("context-window", "8192"));
-const providerContext = Number(option("provider-context-window", "262144"));
+const providerContextRaw = option("provider-context-window");
+
+if (process.argv.includes("--help")) {
+  process.stdout.write(
+    "usage: runtime-compaction-soak --slot <warm-desktop-slot> [--cycles <2-100>] [--output <private-json>]\n" +
+      "   or: runtime-compaction-soak --base-url <local-openai-url> --model <exact-served-model> --provider-context-window <tokens>\n",
+  );
+  process.exit(0);
+}
+
+function configuredContextWindow(modelPath) {
+  try {
+    const config = JSON.parse(readFileSync(join(modelPath, "config.json"), "utf8"));
+    const candidates = [
+      config?.text_config?.max_position_embeddings,
+      config?.max_position_embeddings,
+      config?.text_config?.n_positions,
+      config?.n_positions,
+    ];
+    return candidates.find((value) => Number.isInteger(value) && value >= 1_024) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+if (slotRaw) {
+  if (baseUrl || model) {
+    throw new Error("--slot cannot be combined with --base-url or --model");
+  }
+  const slot = Number(slotRaw);
+  if (!Number.isInteger(slot) || slot <= 0) {
+    throw new Error("--slot must be a positive integer");
+  }
+  const target = await resolveDesktopSlotProviderTarget(await requireDesktopApi(), slot);
+  baseUrl = target.baseUrl;
+  model = target.model;
+  artifactId = target.artifactId;
+}
 
 if (!baseUrl || !model) {
   throw new Error(
-    "usage: runtime-compaction-soak --base-url <local-openai-url> --model <served-id> [--output <json>]",
+    "provide --slot <warm-desktop-slot> or both --base-url and --model",
   );
 }
+const configuredProviderContext = configuredContextWindow(model);
+const providerContext = Number(
+  providerContextRaw ?? configuredProviderContext ?? "262144",
+);
 if (!Number.isInteger(cycles) || cycles < 2 || cycles > 100) {
   throw new Error("--cycles must be an integer from 2 to 100");
+}
+if (!Number.isInteger(logicalContext) || logicalContext < 1_024) {
+  throw new Error("--context-window must be an integer of at least 1024");
+}
+if (!Number.isInteger(providerContext) || providerContext < logicalContext) {
+  throw new Error("provider context window must be an integer at least as large as the logical context window");
 }
 
 const notes = [
@@ -94,6 +147,7 @@ const answer = events
   .map((event) => String(event.data.text))
   .join("");
 const boundary = events.find((event) => event.event === "compaction_boundary")?.data;
+const terminalError = events.findLast((event) => event.event === "error")?.data;
 const requiredAnswer = [
   "desktop",
   "presentation and consent",
@@ -114,6 +168,7 @@ const result = {
   session_id: events[0]?.session_id,
   runtime_id: events[0]?.runtime_id,
   model,
+  artifact_id: artifactId,
   logical_context_window_tokens: logicalContext,
   provider_context_window_tokens: providerContext,
   source_message_count: boundary?.source_message_count ?? null,
@@ -123,6 +178,14 @@ const result = {
   summary_sha256: boundary?.summary_sha256 ?? null,
   answer,
   terminal_event: events.at(-1)?.event,
+  terminal_error: terminalError
+    ? {
+        stage: String(terminalError.stage ?? "unknown"),
+        code: String(terminalError.code ?? "unknown"),
+        message: String(terminalError.message ?? "unknown error").slice(0, 1_000),
+        recoverable: terminalError.recoverable === true,
+      }
+    : null,
 };
 const rendered = `${JSON.stringify(result, null, 2)}\n`;
 if (output) writeFileSync(output, rendered, { mode: 0o600 });

--- a/tests/runtime-compaction-soak.test.mjs
+++ b/tests/runtime-compaction-soak.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptUrl = new URL("../scripts/runtime-compaction-soak.mjs", import.meta.url);
+const script = fileURLToPath(scriptUrl);
+
+function run(args) {
+  return spawnSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+  });
+}
+
+test("compaction soak prefers an attested Desktop slot and reports terminal errors", async () => {
+  const help = run(["--help"]);
+  assert.equal(help.status, 0, help.stderr);
+  assert.match(help.stdout, /--slot <warm-desktop-slot>/);
+  assert.match(help.stdout, /--model <exact-served-model>/);
+
+  const mixed = run([
+    "--slot", "7",
+    "--base-url", "http://127.0.0.1:8096/v1",
+    "--model", "friendly-alias",
+  ]);
+  assert.notEqual(mixed.status, 0);
+  assert.match(mixed.stderr, /--slot cannot be combined/);
+
+  const source = await readFile(scriptUrl, "utf8");
+  assert.match(source, /resolveDesktopSlotProviderTarget/);
+  assert.match(source, /configuredContextWindow/);
+  assert.match(source, /terminal_error: terminalError/);
+});


### PR DESCRIPTION
## What changed

- add a preferred `--slot <warm-desktop-slot>` target to the Pi compaction soak
- resolve the attested loopback URL, exact local model path, artifact ID, and configured provider context window from Desktop state
- reject ambiguous mixed target flags and emit bounded canonical terminal-error diagnostics
- add regression coverage for the public invocation contract

## Why

The manual soak accepted a friendly artifact alias as `--model`. MLX/VLM treated that alias as a Hugging Face repository ID and returned HTTP 500, which looked like a Pi summarization failure. Resolving the running Desktop slot removes that identity footgun and measures the real served artifact.

Generated soak traffic remains in a temporary runtime home and is explicitly not release-adoption evidence; it cannot advance the genuine 100-turn Rust deletion gate.

## Validation

- `npm test` — 290 passed
- live local 0.3.6 Pi soak against Desktop slot 7 — passed
- 448 source messages compacted to 10
- estimated tokens reduced from 14,337 to 635
- retained the three named ownership facts
- terminal event `usage`; no terminal error

The owner-only live evidence remains outside the repository under `.understudy/capture-evidence/`.