### PR TITLE
Fail closed on invalid persisted Pi cohorts

### DIFF
--- a/src/commands/desktop.ts
+++ b/src/commands/desktop.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_DESKTOP_READINESS_EVIDENCE,
   evaluateDesktopRuntimeReleaseEvidence,
 } from "../runtime/conversation/release-gate.js";
+import { validateRuntimeTrace } from "../runtime/conversation/contract.js";
 import {
   TIEBREAKER_MODEL,
   analyzeTiebreaker,
@@ -64,6 +65,28 @@ interface DesktopMigrationStatus {
   remaining_consecutive_pi_rows?: number;
   pi_runtime_share?: number | null;
   compatibility_engine_delete_ready?: boolean;
+}
+
+interface DesktopChatRun {
+  run_id?: string | null;
+  runtime_backend?: string;
+  app_version?: string;
+  runtime_version?: string;
+  session_id?: string;
+  status?: string;
+  prompt_tokens?: number | null;
+  completion_tokens?: number | null;
+  tool_calls?: number;
+}
+
+interface ReleaseCohortTraceAudit {
+  evaluated: boolean;
+  ready: boolean;
+  expected_rows: number;
+  inspected_rows: number;
+  valid_trace_rows: number;
+  invalid_trace_rows: number;
+  reasons: string[];
 }
 
 interface SupervisionExportPacket {
@@ -259,6 +282,175 @@ async function* ndjson(response: Response): AsyncGenerator<RuntimeEvent> {
   }
   buffer += decoder.decode();
   if (buffer.trim()) yield JSON.parse(buffer.trim()) as RuntimeEvent;
+}
+
+async function mapLimited<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  task: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, concurrency), values.length) },
+    async () => {
+      while (next < values.length) {
+        const index = next;
+        next += 1;
+        results[index] = await task(values[index], index);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function skippedCohortTraceAudit(expectedRows: number, reason: string): ReleaseCohortTraceAudit {
+  return {
+    evaluated: false,
+    ready: false,
+    expected_rows: expectedRows,
+    inspected_rows: 0,
+    valid_trace_rows: 0,
+    invalid_trace_rows: 0,
+    reasons: [reason],
+  };
+}
+
+async function auditReleaseCohortTraces(
+  capability: Awaited<ReturnType<typeof requireDesktopApi>>,
+  migration: DesktopMigrationStatus,
+  expectedRows: number,
+  observedRowLimit: number,
+): Promise<ReleaseCohortTraceAudit> {
+  const query = `?limit=${observedRowLimit}`;
+  let value: unknown;
+  try {
+    value = await desktopControlJson(
+      capability,
+      `/v1/chat/runs${query}`,
+      `/api/chat/runs${query}`,
+    );
+  } catch (error) {
+    return skippedCohortTraceAudit(
+      expectedRows,
+      `release chat rows are unavailable: ${String(error)}`,
+    );
+  }
+  if (!Array.isArray(value)) {
+    return skippedCohortTraceAudit(expectedRows, "release chat rows must be an array");
+  }
+
+  const rows = value
+    .filter((candidate): candidate is DesktopChatRun => {
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
+      const row = candidate as DesktopChatRun;
+      return row.app_version === migration.app_version
+        && row.runtime_version === migration.runtime_version
+        && typeof row.run_id === "string"
+        && row.run_id.trim() !== "";
+    })
+    .slice(0, expectedRows);
+  const reasons: string[] = [];
+  if (rows.length !== expectedRows) {
+    reasons.push(`expected ${expectedRows} exact-release chat rows, found ${rows.length}`);
+  }
+  const runIds = rows.map((row) => row.run_id as string);
+  if (new Set(runIds).size !== runIds.length) {
+    reasons.push("release cohort contains duplicate run_id values");
+  }
+
+  const results = await mapLimited(rows, 8, async (row) => {
+    const runId = row.run_id as string;
+    if (row.runtime_backend !== "pi") {
+      return `${runId}: runtime backend is ${String(row.runtime_backend ?? "missing")}`;
+    }
+    if (row.status !== "ok") {
+      return `${runId}: chat row status is ${String(row.status ?? "missing")}`;
+    }
+    for (const [field, candidate] of [
+      ["prompt_tokens", row.prompt_tokens],
+      ["completion_tokens", row.completion_tokens],
+      ["tool_calls", row.tool_calls],
+    ] as const) {
+      if (typeof candidate !== "number" || !Number.isInteger(candidate) || candidate < 0) {
+        return `${runId}: ${field} attribution is missing or invalid`;
+      }
+    }
+
+    try {
+      const response = await desktopApiFetch(
+        capability,
+        `/v1/runs/${encodeURIComponent(runId)}/events`,
+        { signal: AbortSignal.timeout(5_000) },
+      );
+      if (!response.ok) throw await responseError(response);
+      const events: RuntimeEvent[] = [];
+      for await (const event of ndjson(response)) events.push(event);
+      validateRuntimeTrace(events);
+      const first = events[0];
+      if (first?.run_id !== runId || first.session_id !== row.session_id) {
+        return `${runId}: persisted trace identity does not match the chat row`;
+      }
+      if (events.some((event) => event.event === "error" || event.event === "cancellation")) {
+        return `${runId}: successful chat row contains a terminal runtime failure`;
+      }
+      const usageEvents = events.filter((event) => event.event === "usage");
+      const usageRoles = new Set(usageEvents.map((event) => String(event.data?.role)));
+      if (!["primary", "student", "teacher"].some((role) => usageRoles.has(role))) {
+        return `${runId}: persisted trace has no primary, student, or teacher usage`;
+      }
+      if (
+        usageEvents.some(
+          (event) => !["primary", "student", "teacher", "supervisor"].includes(
+            String(event.data?.role),
+          ),
+        )
+      ) {
+        return `${runId}: persisted trace contains unattributed usage`;
+      }
+      if (usageEvents.some((event) => event.data?.complete !== true)) {
+        return `${runId}: persisted trace contains incomplete usage attribution`;
+      }
+      const inputTokens = usageEvents.reduce(
+        (total, event) => total + Number(event.data?.input_tokens ?? 0),
+        0,
+      );
+      const outputTokens = usageEvents.reduce(
+        (total, event) => total + Number(event.data?.output_tokens ?? 0),
+        0,
+      );
+      if (inputTokens !== row.prompt_tokens || outputTokens !== row.completion_tokens) {
+        return `${runId}: chat-row token totals do not match persisted usage`;
+      }
+      const toolCalls = events.filter((event) => event.event === "tool_call").length;
+      if (row.tool_calls !== toolCalls) {
+        return `${runId}: chat-row tool count does not match persisted trace`;
+      }
+      const terminal = events.at(-1);
+      if (terminal?.event !== "usage" || terminal.data?.complete !== true) {
+        return `${runId}: persisted trace does not end in complete usage`;
+      }
+      return null;
+    } catch (error) {
+      return `${runId}: ${String(error)}`;
+    }
+  });
+  reasons.push(...results.filter((reason): reason is string => reason !== null));
+  const boundedReasons = reasons.slice(0, 10);
+  if (reasons.length > boundedReasons.length) {
+    boundedReasons.push(`${reasons.length - boundedReasons.length} additional cohort failures omitted`);
+  }
+  const invalidTraceRows = results.filter((reason) => reason !== null).length;
+  return {
+    evaluated: true,
+    ready: reasons.length === 0 && rows.length === expectedRows,
+    expected_rows: expectedRows,
+    inspected_rows: rows.length,
+    valid_trace_rows: rows.length - invalidTraceRows,
+    invalid_trace_rows: invalidTraceRows,
+    reasons: boundedReasons,
+  };
 }
 
 async function printRuntimeEvents(response: Response, json: boolean): Promise<number> {
@@ -481,7 +673,7 @@ export function registerDesktopCommand(program: Command): void {
       const piRows = Number(value.pi_runtime_rows ?? 0);
       const fallbacks = Number(value.compatibility_fallback_rows ?? 0);
       const consecutivePiRows = Number(value.consecutive_pi_rows ?? piRows);
-      const cohortReady =
+      const cohortVolumeReady =
         value.compatibility_engine_delete_ready === true &&
         canonical >= required &&
         piRows === canonical &&
@@ -500,6 +692,20 @@ export function registerDesktopCommand(program: Command): void {
         conformance_path: opts.conformanceEvidence,
         readiness_path: opts.readinessEvidence,
       });
+      const cohortTraceAudit = cohortVolumeReady && releaseEvidence.ready
+        ? await auditReleaseCohortTraces(
+            capability,
+            value,
+            required,
+            Number(value.observed_row_limit ?? opts.limit),
+          )
+        : skippedCohortTraceAudit(
+            required,
+            cohortVolumeReady
+              ? "static release evidence is not ready"
+              : "release cohort volume is incomplete",
+          );
+      const cohortReady = cohortVolumeReady && cohortTraceAudit.ready;
       const ready = cohortReady && releaseEvidence.ready;
       const output = {
         ...value,
@@ -508,6 +714,8 @@ export function registerDesktopCommand(program: Command): void {
         consecutive_pi_rows: consecutivePiRows,
         remaining_consecutive_pi_rows: remainingConsecutive,
         observed_row_limit: value.observed_row_limit ?? opts.limit,
+        release_cohort_volume_ready: cohortVolumeReady,
+        release_cohort_trace_audit: cohortTraceAudit,
         release_cohort_ready: cohortReady,
         release_evidence: releaseEvidence,
         compatibility_engine_delete_ready: ready,
@@ -524,8 +732,12 @@ export function registerDesktopCommand(program: Command): void {
           `canonical runs: ${canonical}/${required} (${remaining} remaining)`,
           `Pi runs: ${piRows} (${share}); compatibility fallbacks: ${fallbacks}`,
           `clean Pi streak: ${consecutivePiRows}/${required} (${remainingConsecutive} remaining)`,
+          `persisted trace audit: ${cohortTraceAudit.valid_trace_rows}/${required} valid${
+            cohortTraceAudit.evaluated ? "" : " (not yet evaluated)"
+          }`,
           `conformance evidence: ${releaseEvidence.conformance.ready ? "ready" : "missing or stale"}`,
           `startup/memory evidence: ${releaseEvidence.readiness.ready ? "ready" : "missing or stale"}`,
+          ...cohortTraceAudit.reasons.map((reason) => `blocked: ${reason}`),
           ...releaseEvidence.reasons.map((reason) => `blocked: ${reason}`),
         ].join("\n"),
       );

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -31,6 +31,7 @@ let server;
 let port;
 let lastTurn;
 let lastFeedback;
+let cohortFailure = null;
 const mcpCalls = [];
 const controlCalls = [];
 
@@ -59,6 +60,20 @@ function envelope(sequence, event, data) {
     run_id: "run-desktop",
     session_id: "session-desktop",
     runtime_id: "understudy-pi-runtime-v1",
+    sequence,
+    emitted_at: "2026-07-12T00:00:00Z",
+    event,
+    data,
+  };
+}
+
+function cohortEnvelope(runId, sessionId, sequence, event, data) {
+  return {
+    schema_version: "understudy-conversation-runtime-event-v1",
+    event_id: `${runId}:${sequence}`,
+    run_id: runId,
+    session_id: sessionId,
+    runtime_id: "pi-agent-session",
     sequence,
     emitted_at: "2026-07-12T00:00:00Z",
     event,
@@ -193,6 +208,57 @@ before(async () => {
         compatibility_engine_delete_ready: ready,
         groups: [],
       }));
+      return;
+    }
+    if (request.method === "GET" && request.url === "/v1/chat/runs?limit=100") {
+      response.writeHead(404);
+      response.end("old desktop without versioned chat-run routes");
+      return;
+    }
+    if (request.method === "GET" && request.url === "/api/chat/runs?limit=100") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify(Array.from({ length: 100 }, (_, index) => ({
+        id: 100 - index,
+        run_id: `cohort-run-${index}`,
+        runtime_backend: "pi",
+        app_version: "0.3.2",
+        runtime_version: "0.3.6",
+        session_id: `cohort-session-${index}`,
+        status: "ok",
+        prompt_tokens: cohortFailure === "token-mismatch" && index === 0 ? 11 : 10,
+        completion_tokens: 3,
+        tool_calls: 0,
+      }))));
+      return;
+    }
+    const cohortRunMatch = request.url?.match(/^\/v1\/runs\/(cohort-run-(\d+))\/events$/);
+    if (request.method === "GET" && cohortRunMatch) {
+      const [, runId, index] = cohortRunMatch;
+      const sessionId = `cohort-session-${index}`;
+      const events = [
+        cohortEnvelope(runId, sessionId, 0, "message", { role: "user", text: "inspect" }),
+        cohortEnvelope(runId, sessionId, 1, "delta", { role: "primary", text: "ok" }),
+      ];
+      if (cohortFailure === "orphan-tool" && index === "0") {
+        events.push(cohortEnvelope(runId, sessionId, 2, "tool_call", {
+          call_id: "orphan-call",
+          name: "inspect",
+          raw_arguments: "{}",
+        }));
+      }
+      events.push(cohortEnvelope(runId, sessionId, events.length, "usage", {
+        role: "primary",
+        model: "understudy-small",
+        input_tokens: 10,
+        output_tokens: 3,
+        reasoning_tokens: 0,
+        cached_input_tokens: 0,
+        total_tokens: 13,
+        source: "provider",
+        complete: true,
+      }));
+      response.writeHead(200, { "content-type": "application/x-ndjson" });
+      response.end(`${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
       return;
     }
     const controlValues = {
@@ -509,6 +575,11 @@ describe("desktop API CLI", () => {
     assert.equal(value.remaining_canonical_runtime_rows, 0);
     assert.equal(value.consecutive_pi_rows, 100);
     assert.equal(value.remaining_consecutive_pi_rows, 0);
+    assert.equal(value.release_cohort_volume_ready, true);
+    assert.equal(value.release_cohort_trace_audit.evaluated, true);
+    assert.equal(value.release_cohort_trace_audit.ready, true);
+    assert.equal(value.release_cohort_trace_audit.inspected_rows, 100);
+    assert.equal(value.release_cohort_trace_audit.valid_trace_rows, 100);
     assert.equal(value.release_cohort_ready, true);
     assert.equal(value.release_evidence.ready, true);
     assert.equal(value.compatibility_engine_delete_ready, true);
@@ -525,6 +596,9 @@ describe("desktop API CLI", () => {
     assert.equal(pending.remaining_canonical_runtime_rows, 1);
     assert.equal(pending.consecutive_pi_rows, 98);
     assert.equal(pending.remaining_consecutive_pi_rows, 2);
+    assert.equal(pending.release_cohort_volume_ready, false);
+    assert.equal(pending.release_cohort_trace_audit.evaluated, false);
+    assert.equal(pending.release_cohort_ready, false);
     assert.equal(pending.release_evidence.ready, true);
     assert.equal(pending.compatibility_engine_delete_ready, false);
 
@@ -536,7 +610,9 @@ describe("desktop API CLI", () => {
     ]);
     assert.equal(missingEvidence.status, 2, missingEvidence.stderr);
     const missing = JSON.parse(missingEvidence.stdout);
-    assert.equal(missing.release_cohort_ready, true);
+    assert.equal(missing.release_cohort_volume_ready, true);
+    assert.equal(missing.release_cohort_trace_audit.evaluated, false);
+    assert.equal(missing.release_cohort_ready, false);
     assert.equal(missing.release_evidence.ready, false);
     assert.equal(missing.compatibility_engine_delete_ready, false);
     assert.match(missing.release_evidence.reasons.join("\n"), /conformance evidence is missing/);
@@ -554,9 +630,55 @@ describe("desktop API CLI", () => {
     ]);
     assert.equal(staleEvidence.status, 2, staleEvidence.stderr);
     const stale = JSON.parse(staleEvidence.stdout);
-    assert.equal(stale.release_cohort_ready, true);
+    assert.equal(stale.release_cohort_volume_ready, true);
+    assert.equal(stale.release_cohort_trace_audit.evaluated, false);
+    assert.equal(stale.release_cohort_ready, false);
     assert.equal(stale.compatibility_engine_delete_ready, false);
     assert.match(stale.release_evidence.reasons.join("\n"), /fixture hash is stale/);
+
+    cohortFailure = "orphan-tool";
+    try {
+      const invalidTrace = await runCli([
+        "desktop", "migration-status", "--limit", "100", "--require-ready",
+        "--conformance-evidence", conformanceEvidencePath,
+        "--readiness-evidence", readinessEvidencePath,
+        "--json",
+      ]);
+      assert.equal(invalidTrace.status, 2, invalidTrace.stderr);
+      const invalid = JSON.parse(invalidTrace.stdout);
+      assert.equal(invalid.release_cohort_volume_ready, true);
+      assert.equal(invalid.release_cohort_trace_audit.evaluated, true);
+      assert.equal(invalid.release_cohort_trace_audit.ready, false);
+      assert.equal(invalid.release_cohort_trace_audit.invalid_trace_rows, 1);
+      assert.equal(invalid.release_cohort_ready, false);
+      assert.equal(invalid.compatibility_engine_delete_ready, false);
+      assert.match(
+        invalid.release_cohort_trace_audit.reasons.join("\n"),
+        /orphaned tool calls without results/,
+      );
+    } finally {
+      cohortFailure = null;
+    }
+
+    cohortFailure = "token-mismatch";
+    try {
+      const invalidAttribution = await runCli([
+        "desktop", "migration-status", "--limit", "100", "--require-ready",
+        "--conformance-evidence", conformanceEvidencePath,
+        "--readiness-evidence", readinessEvidencePath,
+        "--json",
+      ]);
+      assert.equal(invalidAttribution.status, 2, invalidAttribution.stderr);
+      const invalid = JSON.parse(invalidAttribution.stdout);
+      assert.equal(invalid.release_cohort_trace_audit.ready, false);
+      assert.equal(invalid.release_cohort_trace_audit.invalid_trace_rows, 1);
+      assert.match(
+        invalid.release_cohort_trace_audit.reasons.join("\n"),
+        /chat-row token totals do not match persisted usage/,
+      );
+    } finally {
+      cohortFailure = null;
+    }
   });
 
   it("operates model downloads and residency through versioned REST with one-release fallback", async () => {


### PR DESCRIPTION
## What changed

- Keep the existing 100-turn Pi volume gate as a cheap first check.
- Once volume and frozen release evidence are ready, fetch the exact 100 Desktop chat rows and replay each persisted canonical trace.
- Fail closed on release/session identity drift, non-Pi or unsuccessful rows, malformed events, orphaned tools, incomplete or unattributed usage, SQLite-to-trace token/tool count drift, runtime failures, or a non-usage terminal event.
- Bound the trace audit to eight concurrent loopback reads and ten displayed failure reasons.

## Why

The prior deletion gate trusted the route-accounting row count. It could report 100 Pi turns even if the underlying persisted evidence had broken tool pairing, missing usage, token drift, or runtime errors. That is too weak to authorize deleting the Rust compatibility runtime.

This stays entirely in the Node CLI; it adds no Rust harness code. API-generated diagnostic turns do not enter `chat_runs`, so the gate still measures genuine Desktop chat turns. Synthetic fixtures exist only inside the test server and never touch the real cohort.

## Validation

- `npm run check`
  - build and typecheck
  - 289 tests
  - 33 public skills
  - npm package smoke
- Added explicit 100-row success, orphaned-tool failure, and token-attribution mismatch fixtures.
- Read-only live check against Desktop 0.3.6 reports the honest 0/100 state and skips trace replay until the volume gate is ready.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->