### PR TITLE
Polish the desktop composer and cancellation UX

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -1272,6 +1272,11 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
                 setSelectedModel(id);
               }}
               onConnectAnthropic={connectAnthropic}
+              thinkingDisabled={streaming}
+              thinkingLoading={
+                selectedChoice.route === "local" && thinkingPending?.slotId === selectedChoice.slotId
+              }
+              onThinkingToggle={setThinking}
             />
             <ModelCardDrawer
               modelId={selectedChoice.route === "local" ? selectedChoice.modelId : selectedChoice.id}
@@ -1292,13 +1297,8 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
                 disabled={streaming}
               />
             </PromptInputBody>
-            <ThinkingToggle
-              selected={selectedChoice}
-              disabled={streaming}
-              loading={selectedChoice.route === "local" && thinkingPending?.slotId === selectedChoice.slotId}
-              onToggle={setThinking}
-            />
             <PromptInputSubmit
+              className="composer-submit"
               status={streaming ? "streaming" : err ? "error" : "ready"}
               onStop={stopStreaming}
               disabled={!streaming && (!input.trim() || (selectedChoice.route === "local" && !selectedChoice.active))}
@@ -1310,57 +1310,34 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
   );
 }
 
-function ThinkingToggle({
-  selected,
-  disabled,
-  loading,
-  onToggle,
-}: {
-  selected: ModelChoice;
-  disabled: boolean;
-  loading: boolean;
-  onToggle: (thinking: boolean) => void;
-}) {
-  const isLocal = selected.route === "local";
-  const isBusy = loading || (isLocal && selected.loading);
-  return (
-    <button
-      type="button"
-      className={"ai-thinking-toggle" + (isLocal && selected.thinking ? " active" : "") + (isBusy ? " loading" : "")}
-      disabled={!isLocal || disabled || isBusy}
-      title={isLocal ? "Reload this local model with thinking mode." : "Thinking is available for local models."}
-      onClick={() => isLocal && onToggle(!selected.thinking)}
-    >
-      <span className="thinking-loading-dot" />
-      {isBusy ? "Loading" : "Thinking"}
-    </button>
-  );
-}
-
 function ModelPicker({
   choices,
   selected,
   onSelect,
   onConnectAnthropic,
+  thinkingDisabled,
+  thinkingLoading,
+  onThinkingToggle,
 }: {
   choices: ModelChoice[];
   selected: ModelChoice;
   onSelect: (id: string) => void;
   onConnectAnthropic: () => void;
+  thinkingDisabled: boolean;
+  thinkingLoading: boolean;
+  onThinkingToggle: (thinking: boolean) => void;
 }) {
   const anthropicChoices = choices.filter((choice) => choice.route === "anthropic");
+  const thinkingBusy = selected.route === "local" && (selected.loading || thinkingLoading);
   return (
     <ModelSelector>
       <ModelSelectorTrigger asChild>
-        <button type="button" className="ai-model-trigger">
+        <button
+          type="button"
+          className="ai-model-trigger"
+          title={`${selected.label} · ${selected.route}`}
+        >
           <span>{selected.label}</span>
-          <span>
-            {selected.route === "local"
-              ? "local"
-              : selected.route === "anthropic"
-                ? "anthropic"
-                : "gateway"}
-          </span>
         </button>
       </ModelSelectorTrigger>
       <ModelSelectorContent>
@@ -1408,6 +1385,22 @@ function ModelPicker({
             )}
           </ModelSelectorGroup>
         </ModelSelectorList>
+        {selected.route === "local" && (
+          <div className="model-picker-controls">
+            <div>
+              <strong>Thinking</strong>
+              <span>Reload this local model with extended reasoning.</span>
+            </div>
+            <button
+              type="button"
+              className={selected.thinking ? "active" : ""}
+              disabled={thinkingDisabled || thinkingBusy}
+              onClick={() => onThinkingToggle(!selected.thinking)}
+            >
+              {thinkingBusy ? "Loading…" : selected.thinking ? "On" : "Off"}
+            </button>
+          </div>
+        )}
       </ModelSelectorContent>
     </ModelSelector>
   );

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2203,45 +2203,6 @@ select,
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.ai-model-trigger span:last-child {
-  color: var(--text-3);
-  text-transform: uppercase;
-}
-.ai-thinking-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  min-height: 30px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-control);
-  background: var(--surface-2);
-  color: var(--text-3);
-  padding: 5px 9px;
-  font-family: var(--mono);
-  font-size: 11px;
-  line-height: 1;
-}
-.ai-thinking-toggle.active {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
-  color: var(--text);
-}
-.ai-thinking-toggle:disabled {
-  opacity: 0.45;
-}
-.ai-thinking-toggle.loading {
-  opacity: 1;
-}
-.thinking-loading-dot {
-  display: none;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-}
-.ai-thinking-toggle.loading .thinking-loading-dot {
-  display: inline-block;
-  animation: pulse 1.1s ease-in-out infinite;
-}
 .chat-role {
   margin-bottom: 5px;
   font-family: var(--mono);
@@ -3063,7 +3024,7 @@ select,
 }
 
 .ai-chat-composer {
-  width: min(560px, 88%);
+  width: min(640px, 92%);
   margin-left: auto;
   margin-right: auto;
 }
@@ -3084,30 +3045,80 @@ select,
 .composer-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 2px 6px;
+  gap: 8px;
+  min-height: 48px;
+  padding: 5px 8px;
 }
 
 .composer-row [data-slot="input-group"],
 .composer-row [data-slot="prompt-input-body"] {
   width: auto;
-  min-width: 80px;
+  min-width: 160px;
   flex: 1 1 auto;
 }
 
 .composer-row textarea {
   width: 100%;
   min-width: 0;
-  min-height: 24px;
+  min-height: 32px;
   max-height: 120px;
-  padding: 9px 4px;
+  padding: 9px 6px;
+  font-size: 14px;
+  line-height: 1.35;
 }
 
 .composer-row .ai-model-trigger {
-  max-width: 132px;
+  max-width: 154px;
   border: 0;
   background: transparent;
   padding-inline: 4px;
+}
+
+.model-picker-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border-top: 1px solid var(--border);
+  padding: 12px 14px;
+}
+
+.model-picker-controls > div {
+  display: grid;
+  gap: 2px;
+}
+
+.model-picker-controls strong {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.model-picker-controls span {
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.model-picker-controls button {
+  min-width: 48px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  padding: 5px 10px;
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.model-picker-controls button.active {
+  border-color: color-mix(in srgb, var(--mb-cyan) 42%, var(--border));
+  background: color-mix(in srgb, var(--mb-cyan) 10%, transparent);
+  color: var(--mb-cyan);
+}
+
+.model-picker-controls button:disabled {
+  cursor: default;
+  opacity: 0.45;
 }
 
 .model-card-trigger {
@@ -3334,12 +3345,6 @@ select,
   }
 }
 
-.composer-row .ai-thinking-toggle {
-  border-color: transparent;
-  background: transparent;
-  padding-inline: 6px;
-}
-
 .composer-row > button:first-child {
   color: var(--text-2);
 }
@@ -3352,7 +3357,7 @@ select,
   caret-color: var(--mb-cyan);
 }
 
-.ai-chat-composer button[type="submit"] {
+.ai-chat-composer .composer-submit {
   width: 32px;
   height: 32px;
   flex: 0 0 32px;
@@ -3363,12 +3368,31 @@ select,
   transition: background 140ms ease, opacity 140ms ease;
 }
 
-.ai-chat-composer button[type="submit"]:hover:not(:disabled) {
+.ai-chat-composer .composer-submit:hover:not(:disabled) {
   background: color-mix(in srgb, var(--mb-cyan) 32%, transparent);
 }
 
-.ai-chat-composer button[type="submit"]:disabled {
+.ai-chat-composer .composer-submit:disabled {
   opacity: 0.35;
+}
+
+@media (max-width: 720px) {
+  .ai-chat-composer {
+    width: 96%;
+  }
+
+  .composer-row {
+    gap: 5px;
+    padding-inline: 6px;
+  }
+
+  .composer-row .ai-model-trigger {
+    max-width: 118px;
+  }
+
+  .model-card-trigger {
+    display: none;
+  }
 }
 
 /* Mint identifies the smaller worker; cyan remains the supervising route. */

--- a/apps/homescreen/app/lib/model-aliases.ts
+++ b/apps/homescreen/app/lib/model-aliases.ts
@@ -9,10 +9,16 @@ export type SnapshotAlias = {
 // `modelShortName` always prefers the `short_name` on the snapshot rows the
 // caller passes in. This map covers callers with no snapshot rows in hand
 // (e.g. the sidekick header) plus legacy alias ids, and must stay in sync
-// with the catalog's short_names.
+// with the catalog's short_names. Locally installed Understudy artifacts may
+// appear here before they are promoted into the public pullable catalog; that
+// keeps internal checkpoint ids out of the chat UI without advertising them.
 const FALLBACK_ALIASES: Record<string, string> = {
   "gemma-4-e2b-it-qat-mlx-vlm-understudy": "understudy-small",
   "gemma-4-e2b-it-qat-mlx-vlm-4bit-understudy": "understudy-small",
+  "gemma-4-e4b-it-qat-mlx-vlm-understudy": "understudy-balanced",
+  "gemma-4-e4b-it-qat-mlx-vlm-4bit-understudy": "understudy-balanced",
+  "gemma-4-12b-it-qat-mlx-vlm-understudy": "understudy-quality",
+  "gemma-4-12b-it-qat-mlx-vlm-4bit-understudy": "understudy-quality",
   "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy": "understudy-fast",
   "gemma-4-26b-a4b-it-qat-mlx-vlm-4bit-understudy": "understudy-fast",
 };

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -2993,6 +2993,34 @@ pub async fn chat_stream(
                             ),
                         });
                     }
+                    crate::conversation_sidecar::SidecarAttempt::Cancelled(reason) => {
+                        record_chat_run(
+                            &app,
+                            ChatRunInput {
+                                run_id: run_id.clone(),
+                                runtime_backend: "pi".to_string(),
+                                session_id: session_id.clone(),
+                                route: binding.route.clone(),
+                                model: binding.model_field.clone(),
+                                elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                                prompt_tokens: Some(prompt_tokens),
+                                completion_tokens: None,
+                                tool_calls: 0,
+                                sidekick_spawned: sidekick_plan.spawned,
+                                gateway_used: binding.route == "cloud",
+                                compacted,
+                                compaction_reason: compaction_reason.clone(),
+                                context_tokens_before: Some(context_tokens_before),
+                                local_mem_gb,
+                                gateway_available,
+                                gateway_avoided: gateway_available && binding.route != "cloud",
+                                status: "cancelled".to_string(),
+                                error: Some(reason),
+                            },
+                        );
+                        let _ = on_event.send(ChatEvent::Done);
+                        return Ok(());
+                    }
                     crate::conversation_sidecar::SidecarAttempt::FailedAfterOutput(reason) => {
                         let message = format!(
                             "Conversation runtime stopped after the turn began: {reason}. The compatibility engine was not retried, preventing a duplicate answer or tool execution."
@@ -3420,6 +3448,9 @@ async fn execute_prepared_benchmark(
         crate::conversation_sidecar::SidecarAttempt::FailedAfterOutput(reason) => Err(format!(
             "conversation runtime stopped after the benchmark began: {reason}; native retry was suppressed"
         )),
+        crate::conversation_sidecar::SidecarAttempt::Cancelled(reason) => Err(format!(
+            "conversation runtime benchmark cancelled: {reason}"
+        )),
         crate::conversation_sidecar::SidecarAttempt::NativeFallback(_)
         | crate::conversation_sidecar::SidecarAttempt::NotSelected => {
             benchmark_chat_native(app, mgr, prepared).await
@@ -3642,6 +3673,9 @@ pub async fn agent_chat(
         }
         crate::conversation_sidecar::SidecarAttempt::FailedAfterOutput(reason) => Err(format!(
             "conversation runtime stopped after the headless turn began: {reason}; native retry was suppressed"
+        )),
+        crate::conversation_sidecar::SidecarAttempt::Cancelled(reason) => Err(format!(
+            "conversation runtime headless turn cancelled: {reason}"
         )),
         crate::conversation_sidecar::SidecarAttempt::NativeFallback(_)
         | crate::conversation_sidecar::SidecarAttempt::NotSelected => {

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -161,7 +161,12 @@ pub(crate) enum SidecarAttempt {
     NotSelected,
     Completed(SidecarRunResult),
     NativeFallback(String),
+    Cancelled(String),
     FailedAfterOutput(String),
+}
+
+fn is_runtime_cancellation(error: &str) -> bool {
+    error.starts_with("conversation runtime cancelled:")
 }
 
 pub(crate) const CLOUD_SUPERVISOR_FALLBACK_NOTICE: &str =
@@ -787,6 +792,7 @@ pub(crate) async fn try_run_chat(
     }
     match execute_run(app, request, Some(on_event), None, None).await {
         Ok(result) => SidecarAttempt::Completed(result),
+        Err((error, _)) if is_runtime_cancellation(&error) => SidecarAttempt::Cancelled(error),
         Err((error, true)) => SidecarAttempt::FailedAfterOutput(error),
         Err((error, false)) => SidecarAttempt::NativeFallback(error),
     }
@@ -798,6 +804,7 @@ pub(crate) async fn try_run_chat_headless(app: &AppHandle, request: Value) -> Si
     }
     match execute_run(app, request, None, None, None).await {
         Ok(result) => SidecarAttempt::Completed(result),
+        Err((error, _)) if is_runtime_cancellation(&error) => SidecarAttempt::Cancelled(error),
         Err((error, true)) => SidecarAttempt::FailedAfterOutput(error),
         Err((error, false)) => SidecarAttempt::NativeFallback(error),
     }
@@ -1068,5 +1075,15 @@ mod tests {
         assert_eq!(target.run_id, "run-cancel-1");
         drop(guard);
         assert!(!locked(active_runs()).contains_key(session));
+    }
+
+    #[test]
+    fn runtime_cancellation_is_not_classified_as_an_error() {
+        assert!(is_runtime_cancellation(
+            "conversation runtime cancelled: cancelled_by_client"
+        ));
+        assert!(!is_runtime_cancellation(
+            "conversation runtime connection closed unexpectedly"
+        ));
     }
 }

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -66,6 +66,10 @@ const modelCardsPath = new URL(
   "../apps/homescreen/src-tauri/knowledge/model_cards.json",
   import.meta.url,
 );
+const modelAliasesPath = new URL(
+  "../apps/homescreen/app/lib/model-aliases.ts",
+  import.meta.url,
+);
 const rlmPanePath = new URL(
   "../apps/homescreen/app/components/RlmPane.tsx",
   import.meta.url,
@@ -90,18 +94,25 @@ const workloadDropRustPath = new URL(
 const captureImportPath = new URL("../src/capture-import.ts", import.meta.url);
 
 test("public desktop preserves the reviewed Train interaction language", async () => {
-  const [css, chat, sidebar] = await Promise.all([
+  const [css, chat, sidebar, aliases] = await Promise.all([
     readFile(cssPath, "utf8"),
     readFile(chatPath, "utf8"),
     readFile(sidebarPath, "utf8"),
+    readFile(modelAliasesPath, "utf8"),
   ]);
 
   assert.match(css, /understudy-agent@3f025022/);
   assert.match(css, /--mb-cyan:\s*#67e8f9/);
   assert.match(css, /--mb-mint:\s*#9edbd3/);
   assert.match(css, /\.composer-row\s*\{/);
+  assert.match(css, /\.ai-chat-composer \.composer-submit\s*\{/);
   assert.match(css, /\.persona-halo\.supervised/);
   assert.match(chat, /className="composer-row"/);
+  assert.match(chat, /className="composer-submit"/);
+  assert.doesNotMatch(chat, /<ThinkingToggle/);
+  assert.match(chat, /className="model-picker-controls"/);
+  assert.match(aliases, /"gemma-4-e4b-it-qat-mlx-vlm-understudy": "understudy-balanced"/);
+  assert.match(aliases, /"gemma-4-12b-it-qat-mlx-vlm-understudy": "understudy-quality"/);
   assert.match(
     chat,
     /Tried to hand off to a larger cloud model, but it is unavailable\. Continuing with the local model\./,


### PR DESCRIPTION
## What changed

- show stable Understudy names for locally installed 4B and 12B artifacts without adding them to the public download catalog
- simplify and widen the one-row composer, moving Thinking into the model picker
- bind send/stop styling to an explicit component class so streaming stays cyan
- classify intentional Pi cancellation separately from runtime failure, preserving the partial answer without a scary error

## Root cause

The stop button changes from `type="submit"` to `type="button"` while streaming, so a CSS selector tied to the submit type stopped matching and exposed the orange base style. The installed E4B artifact also lacked an offline display alias, and cancellation shared the generic failed-after-output path.

## Validation

- `npm run check` — 291 passed
- `npm --prefix apps/homescreen run build`
- `node --test tests/desktop-ui-lineage.test.mjs` — 14 passed
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` — 174 passed, 4 ignored
- `cargo clippy --manifest-path apps/homescreen/src-tauri/Cargo.toml --all-targets -- -D warnings`
- native streaming and cancellation replay at the exact 1292 x 932 CSS viewport from the report

Local `cargo fmt --check` still reports existing repository formatting drift in unrelated lines; this patch adds no new rustfmt diff.
