### PR TITLE
Fix desktop composer alignment and cyan selection

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Channel, invoke } from "@tauri-apps/api/core";
+import { Channel, invoke, isTauri } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import {
   Conversation,
@@ -493,6 +493,7 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
   }, []);
 
   useEffect(() => {
+    if (!isTauri()) return;
     let disposed = false;
     let unlisten: (() => void) | null = null;
     void getCurrentWebview()

--- a/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
+++ b/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { WrenchIcon, XIcon } from "lucide-react";
@@ -36,9 +36,11 @@ export function RuntimeRepairPrompt() {
   useEffect(() => {
     void refreshHealth();
     const timer = window.setInterval(() => void refreshHealth(), HEALTH_REFRESH_MS);
-    const unlisten = listen<RuntimeRepairRequest>("runtime-repair-needed", (event) => {
-      setPrompt(promptForRuntimeRequest(event.payload));
-    });
+    const unlisten = isTauri()
+      ? listen<RuntimeRepairRequest>("runtime-repair-needed", (event) => {
+          setPrompt(promptForRuntimeRequest(event.payload));
+        })
+      : Promise.resolve(() => {});
     const onError = (event: ErrorEvent) => {
       const error = event.error ?? event.message;
       if (isMissingMlxVlmError(error)) setPrompt(promptForRuntimeRequest(MLX_REPAIR_REQUEST));

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -131,8 +131,8 @@
     overflow: hidden;
   }
   ::selection {
-    background: var(--c-stamp);
-    color: var(--c-paper);
+    background: color-mix(in srgb, var(--mb-cyan) 68%, transparent);
+    color: #071114;
   }
 }
 
@@ -3045,16 +3045,18 @@ select,
 .composer-row {
   display: flex;
   align-items: center;
+  width: 100%;
   gap: 8px;
   min-height: 48px;
   padding: 5px 8px;
 }
 
 .composer-row [data-slot="input-group"],
-.composer-row [data-slot="prompt-input-body"] {
+.composer-row .composer-row-body {
+  display: flex;
   width: auto;
-  min-width: 160px;
-  flex: 1 1 auto;
+  min-width: 0;
+  flex: 1 1 0;
 }
 
 .composer-row textarea {
@@ -3361,6 +3363,7 @@ select,
   width: 32px;
   height: 32px;
   flex: 0 0 32px;
+  margin-left: auto;
   border: 0;
   border-radius: 999px;
   background: color-mix(in srgb, var(--mb-cyan) 20%, transparent);

--- a/apps/homescreen/app/lib/useStatus.ts
+++ b/apps/homescreen/app/lib/useStatus.ts
@@ -1,5 +1,5 @@
 "use client";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 
@@ -62,6 +62,7 @@ export function useStatus(): StatusController {
   }, []);
 
   useEffect(() => {
+    if (!isTauri()) return;
     refresh();
     const unsubStatus = listen<StatusSnapshot>("status-changed", (e) => setSnap(e.payload));
     const unsubRes = listen("residency-changed", () => refresh());

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { HistoryIcon, PanelLeftIcon, PinIcon, PinOffIcon, SquarePenIcon } from "lucide-react";
@@ -33,6 +34,7 @@ export default function Page() {
 
   // Inbound: a coding agent (via the local server) can drive the GUI to a pane.
   useEffect(() => {
+    if (!isTauri()) return;
     const valid: PaneId[] = [
       "status",
       "chat",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -87,6 +87,10 @@ const modelSelectionPath = new URL(
   "../apps/homescreen/app/lib/model-selection.mjs",
   import.meta.url,
 );
+const statusHookPath = new URL(
+  "../apps/homescreen/app/lib/useStatus.ts",
+  import.meta.url,
+);
 const workloadDropRustPath = new URL(
   "../apps/homescreen/src-tauri/src/workload_drop.rs",
   import.meta.url,
@@ -94,21 +98,41 @@ const workloadDropRustPath = new URL(
 const captureImportPath = new URL("../src/capture-import.ts", import.meta.url);
 
 test("public desktop preserves the reviewed Train interaction language", async () => {
-  const [css, chat, sidebar, aliases] = await Promise.all([
+  const [css, chat, sidebar, aliases, statusHook, page, runtimeRepairPrompt] = await Promise.all([
     readFile(cssPath, "utf8"),
     readFile(chatPath, "utf8"),
     readFile(sidebarPath, "utf8"),
     readFile(modelAliasesPath, "utf8"),
+    readFile(statusHookPath, "utf8"),
+    readFile(pagePath, "utf8"),
+    readFile(runtimeRepairPromptPath, "utf8"),
   ]);
 
   assert.match(css, /understudy-agent@3f025022/);
   assert.match(css, /--mb-cyan:\s*#67e8f9/);
   assert.match(css, /--mb-mint:\s*#9edbd3/);
-  assert.match(css, /\.composer-row\s*\{/);
+  assert.match(
+    css,
+    /::selection\s*\{[\s\S]*?background:\s*color-mix\(in srgb, var\(--mb-cyan\) 68%, transparent\);/,
+  );
+  assert.match(css, /\.composer-row\s*\{[\s\S]*?width:\s*100%;/);
+  assert.match(
+    css,
+    /\.composer-row \.composer-row-body\s*\{[\s\S]*?display:\s*flex;[\s\S]*?flex:\s*1 1 0;/,
+  );
   assert.match(css, /\.ai-chat-composer \.composer-submit\s*\{/);
+  assert.match(
+    css,
+    /\.ai-chat-composer \.composer-submit\s*\{[\s\S]*?margin-left:\s*auto;/,
+  );
   assert.match(css, /\.persona-halo\.supervised/);
   assert.match(chat, /className="composer-row"/);
+  assert.match(chat, /<PromptInputBody className="composer-row-body">/);
   assert.match(chat, /className="composer-submit"/);
+  assert.match(chat, /if \(!isTauri\(\)\) return;/);
+  assert.match(statusHook, /if \(!isTauri\(\)\) return;/);
+  assert.match(page, /if \(!isTauri\(\)\) return;/);
+  assert.match(runtimeRepairPrompt, /const unlisten = isTauri\(\)/);
   assert.doesNotMatch(chat, /<ThinkingToggle/);
   assert.match(chat, /className="model-picker-controls"/);
   assert.match(aliases, /"gemma-4-e4b-it-qat-mlx-vlm-understudy": "understudy-balanced"/);


### PR DESCRIPTION
## What changed
- make the composer row and prompt body consume the available width so Send stays pinned to the right
- replace the stale terracotta text-selection color with Understudy cyan
- guard native Tauri listeners outside the desktop runtime so the exported UI can be verified through the browser API
- add regression coverage for the layout, selection token, and runtime guards

## Verification
- `npm run check` (291 tests)
- `bun run build`
- production-export visual QA at 1024×715 and 640px wide
- zero browser console errors on a clean load
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->