### PR TITLE
Release CLI 0.6.5 for Desktop runtime 0.3.8

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.4"
+    "version": "0.6.5"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.4"
+    "version": "0.6.5"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Notable, user-facing changes to the Understudy skills + CLI. Versions track the
 plugin: `package.json`, `.claude-plugin/plugin.json`,
 `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`,
 `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`,
-`.opencode/adapter.json`, and `.hermes/adapter.json` are bumped together on any
-release that changes the skill catalog, CLI surface, or agent-platform adapter
-surface, because an installed plugin has no other
+`.opencode/adapter.json`, `.hermes/adapter.json`, and `.devin/adapter.json` are
+bumped together on any release that changes the skill catalog, CLI surface, or
+agent-platform adapter surface, because an installed plugin has no other
 staleness signal. After upgrading, reload or enable the plugin in your coding
 agent.
 
@@ -43,6 +43,11 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
   feedback can measure missed errors as well as bad nudges and takeovers.
 
 ### Fixed
+
+- **Desktop repair now installs the ConversationRuntime version the app
+  requires.** CLI and adapter manifests advance to 0.6.5 with runtime 0.3.8,
+  and Desktop 0.3.8 requires that CLI release. The health check can no longer
+  accept a stale 0.6.4 checkout and repeatedly repair back to runtime 0.3.7.
 
 - **Dropped Workload Card review no longer asks a local model to open an
   inaccessible filesystem path.** Desktop now passes only the bounded,

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.4";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.5";
 const UNDERSTUDY_INSTALLER_URL: &str =
     "https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

Desktop 0.3.8 requires ConversationRuntime 0.3.8, but the public CLI and every adapter still reported 0.6.4. Because the installer pulls GitHub main and Desktop compares the CLI package version, an older 0.6.4 checkout could appear current while `understudy runtime repair` kept reinstalling runtime 0.3.7.

## What changed

- bump the CLI package and all adapter/plugin staleness signals to 0.6.5
- make Desktop 0.3.8 require CLI 0.6.5
- document the release coupling in the changelog
- leave the independent managed MLX/VLM runtime version unchanged

## Validation

- `npm run check`: 291/291 tests, 33 public skills, package smoke passed
- Rust: 174 passed, 4 real-artifact tests ignored
- clippy with warnings denied passed
- `git diff --check` passed

After merge, rebuild the signed Desktop artifact from exact `origin/main`; the existing 0.3.8 DMG predates this required CLI-version fix.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->