### PR TITLE
Show consistent progress for desktop operations

### DIFF
--- a/apps/homescreen/app/components/ModelDownloadNotice.tsx
+++ b/apps/homescreen/app/components/ModelDownloadNotice.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { OperationNotice, type OperationNoticeState } from "./OperationNotice";
+
+const POLL_MS = 1_000;
+const TERMINAL_VISIBLE_MS = 3_500;
+
+type DownloadStatus = "running" | "done" | "error" | "cancelled";
+
+type DownloadProgress = {
+  id: string;
+  model_id: string;
+  status: DownloadStatus;
+  started_at: string;
+  planned_files: number;
+  files: Record<string, { downloaded: number; total?: number | null }>;
+  downloaded_bytes: number;
+  resumed_bytes: number;
+  total_bytes?: number | null;
+  error?: string | null;
+  resumable: boolean;
+};
+
+type SnapshotModel = {
+  id: string;
+  short_name?: string | null;
+  name: string;
+};
+
+type BootstrapStatus = {
+  snapshots: SnapshotModel[];
+};
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024 * 1024) return `${Math.max(0, bytes / 1024).toFixed(0)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+function fallbackModelName(modelId: string) {
+  return modelId.split("/").at(-1) || modelId;
+}
+
+export function ModelDownloadNotice() {
+  const [rows, setRows] = useState<DownloadProgress[]>([]);
+  const [models, setModels] = useState<SnapshotModel[]>([]);
+  const [visibleId, setVisibleId] = useState<string | null>(null);
+  const [actionBusy, setActionBusy] = useState(false);
+  const [actionError, setActionError] = useState<{ id: string; message: string } | null>(null);
+  const initialized = useRef(false);
+  const previousStatuses = useRef(new Map<string, DownloadStatus>());
+  const dismissed = useRef(new Set<string>());
+  const hideTimer = useRef<number | null>(null);
+
+  const clearHideTimer = useCallback(() => {
+    if (hideTimer.current !== null) {
+      window.clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+  }, []);
+
+  const ingest = useCallback(
+    (next: DownloadProgress[]) => {
+      setRows(next);
+      const active = next.find((row) => row.status === "running");
+
+      if (!initialized.current) {
+        initialized.current = true;
+        previousStatuses.current = new Map(next.map((row) => [row.id, row.status]));
+        if (active && !dismissed.current.has(active.id)) setVisibleId(active.id);
+        return;
+      }
+
+      const transitioned = next.find((row) => {
+        const previous = previousStatuses.current.get(row.id);
+        return previous === "running" && row.status !== "running";
+      });
+      previousStatuses.current = new Map(next.map((row) => [row.id, row.status]));
+
+      if (active && !dismissed.current.has(active.id)) {
+        clearHideTimer();
+        setVisibleId(active.id);
+        return;
+      }
+      if (!transitioned) return;
+
+      dismissed.current.delete(transitioned.id);
+      clearHideTimer();
+      setVisibleId(transitioned.id);
+      if (transitioned.status !== "error") {
+        hideTimer.current = window.setTimeout(() => {
+          setVisibleId((current) => (current === transitioned.id ? null : current));
+          hideTimer.current = null;
+        }, TERMINAL_VISIBLE_MS);
+      }
+    },
+    [clearHideTimer],
+  );
+
+  const refresh = useCallback(() => {
+    if (!isTauri()) return Promise.resolve();
+    return invoke<DownloadProgress[]>("list_snapshot_downloads").then(ingest).catch(() => {});
+  }, [ingest]);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    void invoke<BootstrapStatus>("bootstrap_status")
+      .then((status) => setModels(status.snapshots))
+      .catch(() => {});
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), POLL_MS);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  useEffect(
+    () => () => {
+      clearHideTimer();
+    },
+    [clearHideTimer],
+  );
+
+  const row = rows.find((candidate) => candidate.id === visibleId) ?? null;
+  const activeCount = rows.filter((candidate) => candidate.status === "running").length;
+  const modelLabel = useMemo(() => {
+    if (!row) return "";
+    const model = models.find((candidate) => candidate.id === row.model_id);
+    return model?.short_name || model?.name || fallbackModelName(row.model_id);
+  }, [models, row]);
+
+  if (!row) return null;
+
+  const total = row.total_bytes ?? null;
+  const percent = total ? Math.min(100, (row.downloaded_bytes / total) * 100) : null;
+  const transferred = `${formatBytes(row.downloaded_bytes)}${total ? ` / ${formatBytes(total)}` : ""}`;
+  const resumed = row.resumed_bytes > 0 ? ` · resumed ${formatBytes(row.resumed_bytes)}` : "";
+  const more = activeCount > 1 ? ` · +${activeCount - 1} more` : "";
+
+  let state: OperationNoticeState = "idle";
+  let title = "Download paused";
+  let message = `${modelLabel} · partial files kept`;
+  let meta = `${transferred}${more}`;
+  let actionLabel: string | null = row.resumable ? "Resume" : null;
+
+  if (row.status === "running") {
+    state = "running";
+    title = "Downloading model";
+    message = modelLabel;
+    meta = `${transferred}${percent === null ? "" : ` · ${percent.toFixed(0)}%`}${resumed}${more}`;
+    actionLabel = "Pause";
+  } else if (row.status === "done") {
+    state = "success";
+    title = "Model ready";
+    message = modelLabel;
+    meta = `Downloaded ${row.planned_files || Object.keys(row.files).length} files`;
+    actionLabel = null;
+  } else if (row.status === "error") {
+    state = "error";
+    title = "Model download needs attention";
+    message = row.error || `${modelLabel} could not be downloaded`;
+  }
+  if (actionError?.id === row.id) {
+    state = "error";
+    title = "Model download needs attention";
+    message = actionError.message;
+  }
+
+  const act = async () => {
+    if (actionBusy) return;
+    setActionError(null);
+    setActionBusy(true);
+    try {
+      if (row.status === "running") {
+        await invoke("cancel_snapshot_download", { downloadId: row.id });
+      } else {
+        await invoke("start_snapshot_download", { modelId: row.model_id });
+      }
+      await refresh();
+    } catch (error) {
+      setActionError({ id: row.id, message: String(error) });
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  return (
+    <OperationNotice
+      className="model-download-notice"
+      state={state}
+      icon="download"
+      title={title}
+      message={message}
+      meta={meta}
+      progress={
+        row.status === "running"
+          ? {
+              value: total ? row.downloaded_bytes : null,
+              max: total ?? 1,
+              label: percent === null ? transferred : `${percent.toFixed(0)}% downloaded`,
+            }
+          : null
+      }
+      actionLabel={actionBusy ? "Working…" : actionLabel}
+      actionDisabled={actionBusy}
+      onAction={actionLabel ? () => void act() : undefined}
+      dismissLabel="Dismiss model download status"
+      onDismiss={() => {
+        dismissed.current.add(row.id);
+        clearHideTimer();
+        setVisibleId(null);
+      }}
+    />
+  );
+}

--- a/apps/homescreen/app/components/OperationNotice.tsx
+++ b/apps/homescreen/app/components/OperationNotice.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  CircleCheckIcon,
+  DownloadIcon,
+  LoaderCircleIcon,
+  TriangleAlertIcon,
+  WrenchIcon,
+  XIcon,
+} from "lucide-react";
+
+export type OperationNoticeState = "idle" | "running" | "success" | "error";
+export type OperationNoticeIcon = "repair" | "download";
+
+type OperationNoticeProgress = {
+  value: number | null;
+  max: number;
+  label: string;
+};
+
+type OperationNoticeProps = {
+  state: OperationNoticeState;
+  icon: OperationNoticeIcon;
+  title: string;
+  message: string;
+  meta?: string | null;
+  progress?: OperationNoticeProgress | null;
+  actionLabel?: string | null;
+  actionDisabled?: boolean;
+  onAction?: () => void;
+  dismissLabel: string;
+  dismissDisabled?: boolean;
+  onDismiss: () => void;
+  className?: string;
+};
+
+export function OperationNotice({
+  state,
+  icon,
+  title,
+  message,
+  meta,
+  progress,
+  actionLabel,
+  actionDisabled = false,
+  onAction,
+  dismissLabel,
+  dismissDisabled = false,
+  onDismiss,
+  className,
+}: OperationNoticeProps) {
+  const iconClass = `operation-notice-icon${state === "running" ? " is-spinning" : ""}`;
+  const statusIcon =
+    state === "running" ? (
+      <LoaderCircleIcon className={iconClass} size={17} aria-hidden="true" />
+    ) : state === "success" ? (
+      <CircleCheckIcon className={iconClass} size={17} aria-hidden="true" />
+    ) : state === "error" ? (
+      <TriangleAlertIcon className={iconClass} size={17} aria-hidden="true" />
+    ) : icon === "download" ? (
+      <DownloadIcon className={iconClass} size={17} aria-hidden="true" />
+    ) : (
+      <WrenchIcon className={iconClass} size={17} aria-hidden="true" />
+    );
+
+  return (
+    <aside
+      className={`operation-notice is-${state}${className ? ` ${className}` : ""}`}
+      aria-live="polite"
+      aria-label={title}
+      aria-busy={state === "running"}
+    >
+      {statusIcon}
+      <div className="operation-notice-copy">
+        <strong>{title}</strong>
+        <span title={message}>{message}</span>
+        {progress ? (
+          <div className="operation-notice-progress">
+            <progress
+              max={Math.max(1, progress.max)}
+              {...(progress.value === null ? {} : { value: Math.max(0, progress.value) })}
+              aria-label={progress.label}
+            />
+            <code>{meta || progress.label}</code>
+          </div>
+        ) : meta ? (
+          <code>{meta}</code>
+        ) : null}
+      </div>
+      <div className="operation-notice-actions">
+        {actionLabel && onAction ? (
+          <button
+            type="button"
+            className="operation-notice-action"
+            disabled={actionDisabled}
+            onClick={onAction}
+          >
+            {actionLabel}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="operation-notice-dismiss"
+          aria-label={dismissLabel}
+          title={dismissLabel}
+          disabled={dismissDisabled}
+          onClick={onDismiss}
+        >
+          <XIcon size={14} aria-hidden="true" />
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
+++ b/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { WrenchIcon, XIcon } from "lucide-react";
+import { OperationNotice } from "./OperationNotice";
 import {
   CONVERSATION_RUNTIME_REPAIR_REQUEST,
   MLX_REPAIR_REQUEST,
@@ -18,28 +18,95 @@ import {
 } from "../lib/runtime-repair";
 
 const HEALTH_REFRESH_MS = 15 * 60 * 1_000;
+const SUCCESS_VISIBLE_MS = 2_400;
+
+type NativeRepairProgress = {
+  operation: string;
+  phase: string;
+  message: string;
+  step: number;
+  total: number;
+};
+
+type RepairProgress = {
+  status: "idle" | "running" | "success" | "error";
+  message: string;
+  detail: string;
+  step: number;
+  total: number;
+  startedAt: number | null;
+};
+
+const IDLE_PROGRESS: RepairProgress = {
+  status: "idle",
+  message: "",
+  detail: "",
+  step: 0,
+  total: 0,
+  startedAt: null,
+};
 
 export function RuntimeRepairPrompt() {
   const [prompt, setPrompt] = useState<RepairPrompt | null>(null);
-  const [busy, setBusy] = useState(false);
+  const [progress, setProgress] = useState<RepairProgress>(IDLE_PROGRESS);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const successTimer = useRef<number | null>(null);
+  const busy = progress.status === "running";
 
-  const refreshHealth = useCallback(async () => {
+  const refreshHealth = useCallback(async (): Promise<DesktopHealth | null> => {
     try {
       const health = await invoke<DesktopHealth>("desktop_health");
       setPrompt(promptForHealth(health));
+      return health;
     } catch {
       // Health is best-effort. Offline startup and the native runtime fallback
       // must remain available even if the aggregate check itself fails.
+      return null;
     }
   }, []);
+
+  useEffect(() => {
+    if (!busy || progress.startedAt === null) {
+      setElapsedSeconds(0);
+      return;
+    }
+    const updateElapsed = () => {
+      setElapsedSeconds(Math.max(0, Math.floor((Date.now() - progress.startedAt!) / 1_000)));
+    };
+    updateElapsed();
+    const timer = window.setInterval(updateElapsed, 1_000);
+    return () => window.clearInterval(timer);
+  }, [busy, progress.startedAt]);
+
+  useEffect(
+    () => () => {
+      if (successTimer.current !== null) window.clearTimeout(successTimer.current);
+    },
+    [],
+  );
 
   useEffect(() => {
     void refreshHealth();
     const timer = window.setInterval(() => void refreshHealth(), HEALTH_REFRESH_MS);
     const unlisten = isTauri()
-      ? listen<RuntimeRepairRequest>("runtime-repair-needed", (event) => {
-          setPrompt(promptForRuntimeRequest(event.payload));
-        })
+      ? Promise.all([
+          listen<RuntimeRepairRequest>("runtime-repair-needed", (event) => {
+            setPrompt(promptForRuntimeRequest(event.payload));
+          }),
+          listen<NativeRepairProgress>("runtime-repair-progress", (event) => {
+            setProgress((current) =>
+              current.status === "running"
+                ? {
+                    ...current,
+                    message: event.payload.message,
+                    detail: `Step ${event.payload.step} of ${event.payload.total}`,
+                    step: event.payload.step,
+                    total: event.payload.total,
+                  }
+                : current,
+            );
+          }),
+        ]).then((removers) => () => removers.forEach((remove) => remove()))
       : Promise.resolve(() => {});
     const onError = (event: ErrorEvent) => {
       const error = event.error ?? event.message;
@@ -71,50 +138,148 @@ export function RuntimeRepairPrompt() {
       await openUrl(prompt.command);
       return;
     }
-    const command =
-      prompt.runtime === "cli"
-        ? "install_understudy_agent_tools"
-        : prompt.runtime === "conversation-runtime"
-          ? "conversation_runtime_repair"
-          : "install_mlx_runtime";
-    setBusy(true);
+    const activePrompt = prompt;
+    const total = activePrompt.runtime === "cli" ? 4 : 2;
+    const initialMessage =
+      activePrompt.runtime === "cli"
+        ? "Downloading the latest Understudy CLI…"
+        : activePrompt.runtime === "conversation-runtime"
+          ? "Updating the managed conversation runtime…"
+          : "Repairing the local model runtime…";
+    setProgress({
+      status: "running",
+      message: initialMessage,
+      detail: `Step 1 of ${total}`,
+      step: 1,
+      total,
+      startedAt: Date.now(),
+    });
     try {
-      await invoke(command);
-      await refreshHealth();
+      if (activePrompt.runtime === "cli") {
+        await invoke("install_understudy_agent_tools");
+        const health = await invoke<DesktopHealth>("desktop_health");
+        if (!health.cli.available || health.cli.update_available === true) {
+          throw new Error(health.cli.detail || "The updated CLI could not be verified.");
+        }
+        if (!health.conversation_runtime.available) {
+          setProgress((current) => ({
+            ...current,
+            message: "Updating the version-coupled conversation runtime…",
+            detail: "Step 3 of 4",
+            step: 3,
+            total: 4,
+          }));
+          await invoke("conversation_runtime_repair");
+        }
+      } else {
+        const command =
+          activePrompt.runtime === "conversation-runtime"
+            ? "conversation_runtime_repair"
+            : "install_mlx_runtime";
+        await invoke(command);
+      }
+
+      setProgress((current) => ({
+        ...current,
+        message: "Verifying the CLI and local runtimes…",
+        detail: `Step ${total} of ${total}`,
+        step: total,
+        total,
+      }));
+      const finalHealth = await invoke<DesktopHealth>("desktop_health");
+      if (!finalHealth.cli.available) throw new Error(finalHealth.cli.detail);
+      if (
+        activePrompt.runtime === "conversation-runtime" &&
+        !finalHealth.conversation_runtime.available
+      ) {
+        throw new Error(finalHealth.conversation_runtime.detail);
+      }
+      if (activePrompt.runtime === "mlx-vlm" && !finalHealth.mlx_vlm.available) {
+        throw new Error(finalHealth.mlx_vlm.detail);
+      }
+      if (activePrompt.runtime === "cli" && !finalHealth.conversation_runtime.available) {
+        throw new Error(finalHealth.conversation_runtime.detail);
+      }
+
+      const cliVersion = finalHealth.cli.installed_version ?? "current";
+      const runtimeVersion = finalHealth.conversation_runtime.installed_version ?? "ready";
+      const nextPrompt = promptForHealth(finalHealth);
+      setProgress({
+        status: "success",
+        message: "Understudy is ready",
+        detail: `CLI ${cliVersion} · runtime ${runtimeVersion}`,
+        step: total,
+        total,
+        startedAt: null,
+      });
+      if (successTimer.current !== null) window.clearTimeout(successTimer.current);
+      successTimer.current = window.setTimeout(() => {
+        setPrompt(nextPrompt);
+        setProgress(IDLE_PROGRESS);
+        successTimer.current = null;
+      }, SUCCESS_VISIBLE_MS);
     } catch (error) {
-      setPrompt((current) =>
-        current
-          ? {
-              ...current,
-              reason: `${String(error)} Run ${current.command} in Terminal.`,
-            }
-          : current,
-      );
-    } finally {
-      setBusy(false);
+      setProgress((current) => ({
+        ...current,
+        status: "error",
+        message: "Repair stopped",
+        detail: String(error),
+        startedAt: null,
+      }));
+      setPrompt({
+        ...activePrompt,
+        reason: `${String(error)} Run ${activePrompt.command} in Terminal.`,
+      });
     }
   };
 
   if (!prompt) return null;
+  const title =
+    progress.status === "running"
+      ? "Updating Understudy"
+      : progress.status === "success"
+        ? progress.message
+        : progress.status === "error"
+          ? progress.message
+          : prompt.title;
+  const reason =
+    progress.status === "running"
+      ? progress.message
+      : progress.status === "success" || progress.status === "error"
+        ? progress.detail
+        : prompt.reason;
   return (
-    <aside className="runtime-repair-prompt" aria-live="polite" aria-label={prompt.title}>
-      <WrenchIcon className="runtime-repair-icon" size={17} aria-hidden="true" />
-      <div className="runtime-repair-copy">
-        <strong>{prompt.title}</strong>
-        <span>{prompt.reason}</span>
-        <code>{prompt.command}</code>
-      </div>
-      <button type="button" className="runtime-repair-action" disabled={busy} onClick={repair}>
-        {busy ? "Repairing…" : prompt.actionLabel}
-      </button>
-      <button
-        type="button"
-        className="runtime-repair-dismiss"
-        aria-label="Dismiss repair prompt"
-        onClick={() => setPrompt(null)}
-      >
-        <XIcon size={14} aria-hidden="true" />
-      </button>
-    </aside>
+    <OperationNotice
+      className="runtime-repair-prompt"
+      state={progress.status}
+      icon="repair"
+      title={title}
+      message={reason}
+      meta={
+        progress.status === "running"
+          ? `${progress.detail} · ${elapsedSeconds}s`
+          : progress.status === "success"
+            ? "Verified"
+            : prompt.command
+      }
+      progress={
+        progress.status === "running"
+          ? {
+              value: progress.step,
+              max: progress.total,
+              label: progress.detail,
+            }
+          : null
+      }
+      actionLabel={busy ? "Working…" : progress.status === "success" ? "Ready" : prompt.actionLabel}
+      actionDisabled={busy}
+      onAction={() => void repair()}
+      dismissLabel={busy ? "Repair in progress" : "Dismiss repair prompt"}
+      dismissDisabled={busy}
+      onDismiss={() => {
+        setPrompt(null);
+        setProgress(IDLE_PROGRESS);
+      }}
+    />
   );
 }

--- a/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
+++ b/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
@@ -133,7 +133,7 @@ export function RuntimeRepairPrompt() {
   }, [refreshHealth]);
 
   const repair = async () => {
-    if (!prompt || busy) return;
+    if (!prompt || busy || progress.status === "success") return;
     if (prompt.runtime === "desktop") {
       await openUrl(prompt.command);
       return;
@@ -272,7 +272,7 @@ export function RuntimeRepairPrompt() {
           : null
       }
       actionLabel={busy ? "Working…" : progress.status === "success" ? "Ready" : prompt.actionLabel}
-      actionDisabled={busy}
+      actionDisabled={busy || progress.status === "success"}
       onAction={() => void repair()}
       dismissLabel={busy ? "Repair in progress" : "Dismiss repair prompt"}
       dismissDisabled={busy}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2603,38 +2603,63 @@ select,
     justify-content: flex-end;
   }
 }
-.runtime-repair-prompt {
+.operation-notice-stack {
   position: fixed;
   z-index: 80;
   top: 42px;
   right: 16px;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  gap: 8px;
+  width: min(520px, calc(100vw - 32px));
+}
+.operation-notice {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
-  width: min(520px, calc(100vw - 32px));
+  width: 100%;
   padding: 10px 10px 10px 12px;
-  border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--border));
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 42%, var(--border));
   border-radius: var(--r-control);
   background: color-mix(in srgb, var(--surface) 94%, transparent);
   box-shadow: 0 12px 32px rgb(0 0 0 / 24%);
   backdrop-filter: blur(16px);
 }
-.runtime-repair-icon {
-  color: var(--accent);
+.operation-notice-icon {
+  color: var(--mb-cyan);
 }
-.runtime-repair-copy {
+.operation-notice-icon.is-spinning {
+  animation: spin 900ms linear infinite;
+}
+.operation-notice.is-running {
+  background: color-mix(in srgb, var(--mb-cyan) 5%, var(--surface));
+}
+.operation-notice.is-success {
+  border-color: color-mix(in srgb, var(--running) 50%, var(--border));
+}
+.operation-notice.is-success .operation-notice-icon,
+.operation-notice.is-success .operation-notice-copy code {
+  color: var(--running);
+}
+.operation-notice.is-error {
+  border-color: color-mix(in srgb, var(--error) 55%, var(--border));
+}
+.operation-notice.is-error .operation-notice-icon,
+.operation-notice.is-error .operation-notice-copy code {
+  color: var(--error);
+}
+.operation-notice-copy {
   display: grid;
   gap: 2px;
   min-width: 0;
 }
-.runtime-repair-copy strong {
+.operation-notice-copy strong {
   color: var(--text);
   font-size: 11px;
   font-weight: 600;
 }
-.runtime-repair-copy span,
-.runtime-repair-copy code {
+.operation-notice-copy span,
+.operation-notice-copy code {
   overflow: hidden;
   color: var(--text-2);
   font-size: 10px;
@@ -2642,38 +2667,74 @@ select,
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.runtime-repair-copy code {
-  color: var(--accent);
+.operation-notice-copy code {
+  color: var(--mb-cyan);
 }
-.runtime-repair-action,
-.runtime-repair-dismiss {
+.operation-notice-progress {
+  display: grid;
+  grid-template-columns: minmax(84px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+.operation-notice-progress progress {
+  width: 100%;
+  height: 3px;
+  overflow: hidden;
+  border: 0;
+  border-radius: var(--r-pill);
+  appearance: none;
+}
+.operation-notice-progress progress::-webkit-progress-bar {
+  background: color-mix(in srgb, var(--mb-cyan) 14%, var(--border));
+}
+.operation-notice-progress progress::-webkit-progress-value {
+  border-radius: var(--r-pill);
+  background: var(--mb-cyan);
+}
+.operation-notice-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.operation-notice-action,
+.operation-notice-dismiss {
   border: 1px solid var(--border);
   border-radius: var(--r-control);
   background: var(--elevated);
   color: var(--text);
 }
-.runtime-repair-action {
+.operation-notice-action {
   min-height: 30px;
   padding: 0 10px;
   font: inherit;
   font-size: 10px;
   white-space: nowrap;
 }
-.runtime-repair-action:hover:not(:disabled) {
-  border-color: var(--accent);
+.operation-notice-action:hover:not(:disabled) {
+  border-color: var(--mb-cyan);
 }
-.runtime-repair-action:disabled {
+.operation-notice-action:disabled {
   opacity: 0.6;
 }
-.runtime-repair-dismiss {
+.operation-notice-dismiss {
   display: grid;
   width: 28px;
   height: 28px;
   padding: 0;
   place-items: center;
 }
-.runtime-repair-dismiss:hover {
-  color: var(--accent);
+.operation-notice-dismiss:hover {
+  color: var(--mb-cyan);
+}
+.operation-notice-dismiss:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+@media (prefers-reduced-motion: reduce) {
+  .operation-notice-icon.is-spinning {
+    animation: none;
+  }
 }
 .chat-image-list {
   display: flex;

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -16,6 +16,7 @@ import { DownloadQrButton } from "./components/DownloadQrButton";
 import { isTrainingPane, TrainingPane } from "./components/TrainingPane";
 import { RlmPane } from "./components/RlmPane";
 import { RuntimeRepairPrompt } from "./components/RuntimeRepairPrompt";
+import { ModelDownloadNotice } from "./components/ModelDownloadNotice";
 import { useStatus } from "./lib/useStatus";
 
 export default function Page() {
@@ -156,7 +157,10 @@ export default function Page() {
         )}
       </button>
       <DownloadQrButton />
-      <RuntimeRepairPrompt />
+      <div className="operation-notice-stack">
+        <RuntimeRepairPrompt />
+        <ModelDownloadNotice />
+      </div>
       <Sidebar
         active={pane}
         onSelect={(next) => {

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -64,6 +64,34 @@ pub struct DesktopHealth {
 }
 
 #[derive(Serialize, Clone)]
+struct RuntimeRepairProgress {
+    operation: &'static str,
+    phase: &'static str,
+    message: &'static str,
+    step: u8,
+    total: u8,
+}
+
+fn emit_runtime_repair_progress(
+    app: &AppHandle,
+    phase: &'static str,
+    message: &'static str,
+    step: u8,
+    total: u8,
+) {
+    let _ = app.emit(
+        "runtime-repair-progress",
+        RuntimeRepairProgress {
+            operation: "cli-update",
+            phase,
+            message,
+            step,
+            total,
+        },
+    );
+}
+
+#[derive(Serialize, Clone)]
 #[serde(tag = "type")]
 pub enum DownloadEvent {
     Plan {
@@ -165,7 +193,14 @@ pub fn install_mlx_runtime() -> Result<String, String> {
     command_output(out)
 }
 
-pub fn install_understudy_agent_tools() -> Result<String, String> {
+pub fn install_understudy_agent_tools(app: &AppHandle) -> Result<String, String> {
+    emit_runtime_repair_progress(
+        app,
+        "download",
+        "Downloading the latest Understudy installer…",
+        1,
+        4,
+    );
     let script = std::env::temp_dir().join(format!(
         "understudy-agent-tools-install-{}.sh",
         std::process::id()
@@ -191,6 +226,14 @@ pub fn install_understudy_agent_tools() -> Result<String, String> {
         return Err(error);
     }
 
+    emit_runtime_repair_progress(
+        app,
+        "install",
+        "Installing the CLI and its dependencies…",
+        2,
+        4,
+    );
+
     let installed = Command::new("sh")
         .arg(&script)
         .args(["--noninteractive", "--agents", "none", "--keep-login"])
@@ -201,7 +244,17 @@ pub fn install_understudy_agent_tools() -> Result<String, String> {
         .output()
         .map_err(|e| format!("Understudy installer failed to start: {e}"));
     let _ = std::fs::remove_file(&script);
-    installed.and_then(command_output)
+    let result = installed.and_then(command_output);
+    if result.is_ok() {
+        emit_runtime_repair_progress(
+            app,
+            "cli-ready",
+            "CLI installed. Checking the managed runtimes…",
+            3,
+            4,
+        );
+    }
+    result
 }
 
 /// Aggregate bounded public update checks and local runtime diagnostics for

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -1187,10 +1187,12 @@ pub async fn install_mlx_runtime() -> Result<String, String> {
 }
 
 #[tauri::command]
-pub async fn install_understudy_agent_tools() -> Result<String, String> {
-    tauri::async_runtime::spawn_blocking(crate::bootstrap::install_understudy_agent_tools)
-        .await
-        .map_err(|e| format!("install_understudy_agent_tools task failed: {e}"))?
+pub async fn install_understudy_agent_tools(app: AppHandle) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::bootstrap::install_understudy_agent_tools(&app)
+    })
+    .await
+    .map_err(|e| format!("install_understudy_agent_tools task failed: {e}"))?
 }
 
 /// Start the same background download registry exposed to agents. The UI

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -234,6 +234,8 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.match(prompt, /Updating the version-coupled conversation runtime/);
   assert.match(prompt, /Verifying the CLI and local runtimes/);
   assert.match(prompt, /elapsedSeconds/);
+  assert.match(prompt, /busy \|\| progress\.status === "success"/);
+  assert.match(prompt, /actionDisabled=\{busy \|\| progress\.status === "success"\}/);
   assert.match(downloadNotice, /"list_snapshot_downloads"/);
   assert.match(downloadNotice, /"cancel_snapshot_download"/);
   assert.match(downloadNotice, /"start_snapshot_download"/);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -10,6 +10,14 @@ const runtimeRepairPromptPath = new URL(
   "../apps/homescreen/app/components/RuntimeRepairPrompt.tsx",
   import.meta.url,
 );
+const operationNoticePath = new URL(
+  "../apps/homescreen/app/components/OperationNotice.tsx",
+  import.meta.url,
+);
+const modelDownloadNoticePath = new URL(
+  "../apps/homescreen/app/components/ModelDownloadNotice.tsx",
+  import.meta.url,
+);
 const runtimeRepairLibPath = new URL(
   "../apps/homescreen/app/lib/runtime-repair.ts",
   import.meta.url,
@@ -202,19 +210,33 @@ test("desktop restores the reviewed persisted always-on-top pin", async () => {
   assert.match(permissions, /core:window:allow-set-always-on-top/);
 });
 
-test("desktop has one managed runtime repair surface", async () => {
-  const [page, prompt, repair] = await Promise.all([
+test("desktop has one shared managed-operation notice surface", async () => {
+  const [page, prompt, operationNotice, downloadNotice, repair] = await Promise.all([
     readFile(pagePath, "utf8"),
     readFile(runtimeRepairPromptPath, "utf8"),
+    readFile(operationNoticePath, "utf8"),
+    readFile(modelDownloadNoticePath, "utf8"),
     readFile(runtimeRepairLibPath, "utf8"),
   ]);
 
   assert.match(page, /<RuntimeRepairPrompt\s*\/>/);
+  assert.match(page, /<ModelDownloadNotice\s*\/>/);
+  assert.match(page, /className="operation-notice-stack"/);
+  assert.match(prompt, /<OperationNotice/);
+  assert.match(downloadNotice, /<OperationNotice/);
+  assert.match(operationNotice, /aria-busy=\{state === "running"\}/);
   assert.match(prompt, /invoke<DesktopHealth>\("desktop_health"\)/);
   assert.match(prompt, /listen<RuntimeRepairRequest>\("runtime-repair-needed"/);
   assert.match(prompt, /"install_understudy_agent_tools"/);
   assert.match(prompt, /"install_mlx_runtime"/);
   assert.match(prompt, /"conversation_runtime_repair"/);
+  assert.match(prompt, /listen<NativeRepairProgress>\("runtime-repair-progress"/);
+  assert.match(prompt, /Updating the version-coupled conversation runtime/);
+  assert.match(prompt, /Verifying the CLI and local runtimes/);
+  assert.match(prompt, /elapsedSeconds/);
+  assert.match(downloadNotice, /"list_snapshot_downloads"/);
+  assert.match(downloadNotice, /"cancel_snapshot_download"/);
+  assert.match(downloadNotice, /"start_snapshot_download"/);
   assert.match(repair, /understudy models runtime repair/);
   assert.match(repair, /understudy runtime repair/);
   assert.match(repair, /install\.sh \| bash -s -- --yes/);
@@ -307,7 +329,10 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
 });
 
 test("desktop model downloads are app-owned, pausable, and resumable", async () => {
-  const statusPane = await readFile(statusPanePath, "utf8");
+  const [statusPane, downloadNotice] = await Promise.all([
+    readFile(statusPanePath, "utf8"),
+    readFile(modelDownloadNoticePath, "utf8"),
+  ]);
 
   assert.match(statusPane, /"start_snapshot_download"/);
   assert.match(statusPane, /"list_snapshot_downloads"/);
@@ -315,6 +340,9 @@ test("desktop model downloads are app-owned, pausable, and resumable", async () 
   assert.match(statusPane, /"cancel_snapshot_download"/);
   assert.match(statusPane, /Resume keeps partial files/);
   assert.match(statusPane, /busyActionLabel="Pause"/);
+  assert.match(downloadNotice, /title = "Downloading model"/);
+  assert.match(downloadNotice, /actionLabel = "Pause"/);
+  assert.match(downloadNotice, /row\.resumable \? "Resume" : null/);
   assert.doesNotMatch(statusPane, /new Channel<DownloadEvent>/);
   assert.doesNotMatch(statusPane, /invoke\([^\n]*"download_snapshot_model"/);
 });


### PR DESCRIPTION
## What changed

- adds one shared compact operation notice for runtime repair and model downloads
- shows CLI repair phases, elapsed time, verification, and automatic version-coupled runtime repair
- keeps model downloads visible across panes with bytes, percent, resumed data, pause, resume, completion, and errors
- preserves the durable Status-pane download cards as the long-lived control surface

## Why

CLI updates and large model downloads could take long enough to look frozen, and their status treatments were inconsistent. This makes every desktop-owned background operation use the same quiet cyan pattern.

## Validation

- `npm run check`
- 291 Node tests
- Next static production build
- 174 Rust tests (4 ignored)
- `cargo clippy --all-targets -- -D warnings`
- visual QA at the source screenshot viewport with repair and download notices stacked; no browser warnings/errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->