### PR TITLE
Release CLI 0.6.6 and Desktop 0.3.10

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.5"
+    "version": "0.6.6"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.5"
+    "version": "0.6.6"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Fixed
 
+- **Desktop and its canonical sidecar now release as one compatibility unit.**
+  CLI and adapter manifests advance to 0.6.6 with runtime/Desktop 0.3.10, and
+  Desktop requires that CLI release. The release gate now rejects a runtime
+  version bump unless the distributed CLI also advances and the Desktop CLI
+  floor matches it, preventing a signed app from repairing back to an older
+  sidecar.
+
 - **Desktop repair now installs the ConversationRuntime version the app
   requires.** CLI and adapter manifests advance to 0.6.5 with runtime 0.3.8,
   and Desktop 0.3.8 requires that CLI release. The health check can no longer

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.9",
+  "version": "0.3.10",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.9"
+version = "0.3.10"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.5";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.6";
 const UNDERSTUDY_INSTALLER_URL: &str =
     "https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh";
 

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.9";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.10";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,6 +18,10 @@ git ls-files
   any release that changes the skill catalog or CLI surface — installed
   adapters have no other staleness signal; `understudy doctor --json` fails if
   they drift;
+- the CLI package and every adapter manifest advance on every ConversationRuntime
+  release, even when no command surface changed: the CLI distributes the canonical
+  sidecar, and Desktop must raise `MIN_UNDERSTUDY_CLI_VERSION` to that exact package
+  version;
 - adapter install and onboarding parity checked across Claude Code, Cursor,
   Codex, OpenCode, and Hermes Agent: `install.sh --agents ...`, `understudy
   platforms`, and `skills/install-agent-adapter/reference.md` describe the same
@@ -46,8 +50,9 @@ and secret-shaped strings.
 
 Desktop releases must come from the exact merged `origin/main` commit. The
 release check fails closed if the worktree is dirty, `HEAD` differs from the
-locally fetched `origin/main`, or any of the six desktop/runtime version sources
-drift. Fetch first, then run the source gate:
+locally fetched `origin/main`, any of the six desktop/runtime version sources
+drift, the Desktop CLI floor differs from the distributed package, or a runtime
+version advances without a newer CLI package. Fetch first, then run the source gate:
 
 ```sh
 git fetch origin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/scripts/desktop-release-check.mjs
+++ b/scripts/desktop-release-check.mjs
@@ -21,6 +21,36 @@ function capture(command, args, cwd) {
   }).trim();
 }
 
+function versionTuple(value) {
+  const match = String(value).match(/^(\d+)\.(\d+)\.(\d+)$/);
+  return match ? match.slice(1).map(Number) : null;
+}
+
+function compareVersions(left, right) {
+  const a = versionTuple(left);
+  const b = versionTuple(right);
+  if (!a || !b) return null;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return a[index] > b[index] ? 1 : -1;
+  }
+  return 0;
+}
+
+export function runtimeCliAdvancementError({
+  runtime_version: runtimeVersion,
+  cli_version: cliVersion,
+  baseline_runtime_version: baselineRuntimeVersion,
+  baseline_cli_version: baselineCliVersion,
+}) {
+  if (runtimeVersion === baselineRuntimeVersion) return null;
+  const comparison = compareVersions(cliVersion, baselineCliVersion);
+  if (comparison === 1) return null;
+  return (
+    `conversation runtime advanced from ${baselineRuntimeVersion} to ${runtimeVersion}, ` +
+    `but CLI ${cliVersion} did not advance beyond ${baselineCliVersion}`
+  );
+}
+
 function firstMatch(text, pattern, label, errors) {
   const match = text.match(pattern);
   if (!match) {
@@ -50,6 +80,19 @@ export function inspectDesktopVersions(root = repositoryRoot) {
     join(root, "src", "runtime", "conversation", "contract.ts"),
     "utf8",
   );
+  const cliPackage = readJson(join(root, "package.json")).version;
+  const bootstrap = readFileSync(join(tauri, "src", "bootstrap.rs"), "utf8");
+  const minimumCli = firstMatch(
+    bootstrap,
+    /MIN_UNDERSTUDY_CLI_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+    "minimum Desktop CLI version",
+    errors,
+  );
+  if (cliPackage !== minimumCli) {
+    errors.push(
+      `Desktop minimum CLI must match the distributed package: package=${cliPackage}, minimum=${minimumCli ?? "missing"}`,
+    );
+  }
   const versions = {
     desktop_package: readJson(join(homescreen, "package.json")).version,
     tauri_config: readJson(join(tauri, "tauri.conf.json")).version,
@@ -82,7 +125,41 @@ export function inspectDesktopVersions(root = repositoryRoot) {
         .join(", ")}`,
     );
   }
-  return { version: unique.length === 1 ? unique[0] : null, versions, errors };
+  return {
+    version: unique.length === 1 ? unique[0] : null,
+    versions,
+    compatibility: { cli_package: cliPackage, minimum_cli: minimumCli },
+    errors,
+  };
+}
+
+function priorDesktopReleaseBaseline(root, head) {
+  const tags = capture(
+    "git",
+    ["tag", "--merged", head, "--list", "desktop-v*-mvp", "--sort=-version:refname"],
+    root,
+  ).split("\n").filter(Boolean);
+  for (const tag of tags) {
+    const commit = capture("git", ["rev-list", "-n", "1", tag], root);
+    if (commit === head) continue;
+    const runtimeSource = capture(
+      "git",
+      ["show", `${tag}:src/runtime/conversation/contract.ts`],
+      root,
+    );
+    const runtimeMatch = runtimeSource.match(/RUNTIME_VERSION\s*=\s*"([^"]+)"/);
+    const cliPackage = JSON.parse(capture("git", ["show", `${tag}:package.json`], root));
+    if (!runtimeMatch || typeof cliPackage.version !== "string") {
+      throw new Error(`could not read runtime/CLI versions from ${tag}`);
+    }
+    return {
+      tag,
+      commit,
+      runtime_version: runtimeMatch[1],
+      cli_version: cliPackage.version,
+    };
+  }
+  return null;
 }
 
 export function desktopArtifactPaths(version, root = repositoryRoot, arch = "aarch64") {
@@ -133,6 +210,7 @@ export async function inspectDesktopRelease({
   let head = null;
   let originMain = null;
   let clean = null;
+  let baseline = null;
   try {
     head = capture("git", ["rev-parse", "HEAD"], root);
     originMain = capture("git", ["rev-parse", "origin/main"], root);
@@ -143,6 +221,22 @@ export async function inspectDesktopRelease({
   if (!allowDirty && clean === false) errors.push("release worktree is dirty");
   if (!allowUnmerged && head && originMain && head !== originMain) {
     errors.push(`release HEAD ${head} does not match origin/main ${originMain}`);
+  }
+  if (head && versionState.version) {
+    try {
+      baseline = priorDesktopReleaseBaseline(root, head);
+      if (baseline) {
+        const error = runtimeCliAdvancementError({
+          runtime_version: versionState.version,
+          cli_version: versionState.compatibility.cli_package,
+          baseline_runtime_version: baseline.runtime_version,
+          baseline_cli_version: baseline.cli_version,
+        });
+        if (error) errors.push(error);
+      }
+    } catch (error) {
+      errors.push(`release baseline inspection failed: ${error.message}`);
+    }
   }
 
   const artifacts = versionState.version
@@ -217,6 +311,7 @@ export async function inspectDesktopRelease({
     ok: errors.length === 0,
     version: versionState.version,
     versions: versionState.versions,
+    compatibility: { ...versionState.compatibility, baseline },
     git: { head, origin_main: originMain, clean },
     artifacts: artifactState,
     errors,

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.9";
+export const RUNTIME_VERSION = "0.3.10";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -2517,7 +2517,7 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       model: "conformance-cli",
     });
     assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
-    assert.equal(cliReport.metadata.runtime_version, "0.3.9");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.10");
     assert.equal(
       cliReport.metadata.event_schema,
       "understudy-conversation-runtime-event-v1",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -92,7 +92,7 @@ function writeReleaseEvidence() {
     adapter_id: "pi",
     generated_at: "2026-07-12T20:00:00.000Z",
     metadata: {
-      runtime_version: "0.3.9",
+      runtime_version: "0.3.10",
       event_schema: "understudy-conversation-runtime-event-v1",
       network_mode: "offline",
       provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
@@ -136,7 +136,7 @@ function writeReleaseEvidence() {
     },
     app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
     runtime: {
-      runtime_version: "0.3.9",
+      runtime_version: "0.3.10",
       event_schema: "understudy-conversation-runtime-event-v1",
       ready_ms: 700,
       rss_mb: 120,
@@ -195,7 +195,7 @@ before(async () => {
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
         app_version: "0.3.2",
-        runtime_version: "0.3.9",
+        runtime_version: "0.3.10",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,
@@ -222,7 +222,7 @@ before(async () => {
         run_id: `cohort-run-${index}`,
         runtime_backend: "pi",
         app_version: "0.3.2",
-        runtime_version: "0.3.9",
+        runtime_version: "0.3.10",
         session_id: `cohort-session-${index}`,
         status: "ok",
         prompt_tokens: cohortFailure === "token-mismatch" && index === 0 ? 11 : 10,

--- a/tests/desktop-release-check.test.mjs
+++ b/tests/desktop-release-check.test.mjs
@@ -7,6 +7,7 @@ import {
   desktopArtifactPaths,
   inspectDesktopVersions,
   repositoryRoot,
+  runtimeCliAdvancementError,
 } from "../scripts/desktop-release-check.mjs";
 
 test("desktop release sources share one exact version", () => {
@@ -14,6 +15,7 @@ test("desktop release sources share one exact version", () => {
   assert.deepEqual(report.errors, []);
   assert.match(report.version, /^\d+\.\d+\.\d+$/);
   assert.deepEqual([...new Set(Object.values(report.versions))], [report.version]);
+  assert.equal(report.compatibility.cli_package, report.compatibility.minimum_cli);
   const artifacts = desktopArtifactPaths(report.version);
   assert.match(artifacts.app, /Understudy\.app$/);
   assert.match(artifacts.dmg, new RegExp(`Understudy_${report.version}_aarch64\\.dmg$`));
@@ -27,6 +29,8 @@ test("desktop release source drift fails closed with every version named", () =>
     "apps/homescreen/src-tauri/Cargo.toml",
     "apps/homescreen/src-tauri/Cargo.lock",
     "apps/homescreen/src-tauri/src/conversation_runtime.rs",
+    "apps/homescreen/src-tauri/src/bootstrap.rs",
+    "package.json",
     "src/runtime/conversation/contract.ts",
   ];
   try {
@@ -48,4 +52,34 @@ test("desktop release source drift fails closed with every version named", () =>
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("runtime releases require a newer distributed CLI sidecar", () => {
+  assert.equal(
+    runtimeCliAdvancementError({
+      runtime_version: "0.3.10",
+      cli_version: "0.6.6",
+      baseline_runtime_version: "0.3.9",
+      baseline_cli_version: "0.6.5",
+    }),
+    null,
+  );
+  assert.match(
+    runtimeCliAdvancementError({
+      runtime_version: "0.3.10",
+      cli_version: "0.6.5",
+      baseline_runtime_version: "0.3.9",
+      baseline_cli_version: "0.6.5",
+    }),
+    /CLI 0\.6\.5 did not advance/,
+  );
+  assert.equal(
+    runtimeCliAdvancementError({
+      runtime_version: "0.3.9",
+      cli_version: "0.6.5",
+      baseline_runtime_version: "0.3.9",
+      baseline_cli_version: "0.6.5",
+    }),
+    null,
+  );
 });


### PR DESCRIPTION
## Why

The 0.3.9 artifact exposed a real compatibility hole before public rollout: Desktop/runtime 0.3.9 required runtime 0.3.9 while the installable CLI still owned runtime 0.3.8. The draft was retracted and 0.3.8 remains Latest.

This patch releases the pair atomically:

- CLI/package/adapters 0.6.6
- Desktop/runtime 0.3.10
- Desktop minimum CLI 0.6.6
- a fail-closed release check that rejects future runtime bumps without a newer CLI

It also carries the already-merged canonical-only Pi runtime after removal of the legacy Rust conversation engine in #203.

## Verification

- root `npm run check`: 289 tests, 33 public skills, package smoke
- homescreen production build
- Rust: 157 passed, 4 ignored
- strict Clippy (`-D warnings`)
- release-check unit tests, including stale-CLI rejection
- source release gate: CLI 0.6.6 / Desktop+runtime 0.3.10

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->