### PR TITLE
Reconnect healthy Desktop runtimes automatically

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.6"
+    "version": "0.6.7"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.6"
+    "version": "0.6.7"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Fixed
 
+- **Healthy runtimes reconnect instead of asking for repair.** Desktop 0.3.11
+  quietly rebinds the CLI-owned conversation runtime to the current
+  authenticated Desktop tool session at launch. A healthy process with a
+  stale tool credential is described as reconnecting, the UI clears the
+  transient state after readiness, and genuine repair failures remain
+  actionable. CLI and adapter manifests advance to 0.6.7 with runtime/Desktop
+  0.3.11.
+
 - **Desktop and its canonical sidecar now release as one compatibility unit.**
   CLI and adapter manifests advance to 0.6.6 with runtime/Desktop 0.3.10, and
   Desktop requires that CLI release. The release gate now rejects a runtime

--- a/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
+++ b/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
@@ -87,6 +87,10 @@ export function RuntimeRepairPrompt() {
 
   useEffect(() => {
     void refreshHealth();
+    // Startup reconnect is intentionally backgrounded. Reconcile once after
+    // the native side has had time to bind the CLI runtime to this Desktop
+    // session, even if the ready event raced the webview listener.
+    const settleTimer = window.setTimeout(() => void refreshHealth(), 2_500);
     const timer = window.setInterval(() => void refreshHealth(), HEALTH_REFRESH_MS);
     const unlisten = isTauri()
       ? Promise.all([
@@ -103,8 +107,11 @@ export function RuntimeRepairPrompt() {
                     step: event.payload.step,
                     total: event.payload.total,
                   }
-                : current,
+              : current,
             );
+          }),
+          listen("conversation-runtime-ready", () => {
+            void refreshHealth();
           }),
         ]).then((removers) => () => removers.forEach((remove) => remove()))
       : Promise.resolve(() => {});
@@ -125,6 +132,7 @@ export function RuntimeRepairPrompt() {
     window.addEventListener("error", onError);
     window.addEventListener("unhandledrejection", onRejection);
     return () => {
+      window.clearTimeout(settleTimer);
       window.clearInterval(timer);
       void unlisten.then((remove) => remove());
       window.removeEventListener("error", onError);

--- a/apps/homescreen/app/lib/runtime-repair.ts
+++ b/apps/homescreen/app/lib/runtime-repair.ts
@@ -101,10 +101,20 @@ export function promptForHealth(health: DesktopHealth): RepairPrompt | null {
     });
   }
   if (!health.conversation_runtime.available) {
-    return promptForRuntimeRequest({
+    const reconnecting = health.conversation_runtime.detail.includes(
+      "reconnecting automatically",
+    );
+    const prompt = promptForRuntimeRequest({
       ...CONVERSATION_RUNTIME_REPAIR_REQUEST,
       reason: health.conversation_runtime.detail || CONVERSATION_RUNTIME_REPAIR_REQUEST.reason,
     });
+    return reconnecting
+      ? {
+          ...prompt,
+          title: "Runtime reconnecting",
+          actionLabel: "Reconnect now",
+        }
+      : prompt;
   }
   if (health.desktop.update_available === true) {
     return {

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.10",
+  "version": "0.3.11",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.10"
+version = "0.3.11"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.6";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.7";
 const UNDERSTUDY_INSTALLER_URL: &str =
     "https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh";
 

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.10";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.11";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -426,7 +426,13 @@ pub(crate) fn health(app: &AppHandle) -> VersionHealth {
         Ok(status) => {
             let schema_matches = status.event_schema == EVENT_SCHEMA;
             let version_matches = status.runtime_version == RUNTIME_VERSION;
-            let ready = compatible(&status, app);
+            let process_ready = status.installed
+                && status.running
+                && status.healthy
+                && schema_matches
+                && version_matches;
+            let desktop_connected = tool_token_matches(&status, app);
+            let ready = process_ready && desktop_connected;
             let detail = if ready {
                 status.detail
             } else if !schema_matches {
@@ -439,6 +445,9 @@ pub(crate) fn health(app: &AppHandle) -> VersionHealth {
                     "runtime {} does not match required {}; update or repair the CLI before chatting",
                     status.runtime_version, RUNTIME_VERSION
                 )
+            } else if process_ready && !desktop_connected {
+                "runtime is healthy but is not connected to this Desktop session; reconnecting automatically"
+                    .to_string()
             } else {
                 format!("{}; run Understudy repair before chatting", status.detail)
             };

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -32,7 +32,7 @@ mod workload_drop;
 
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 fn show_window(app: &tauri::AppHandle) {
     if let Some(w) = app.get_webview_window("main") {
@@ -78,6 +78,22 @@ pub fn run() {
 
             // Local API server (HTTP + MCP + A2A) for coding agents.
             server::start(app.handle().clone());
+
+            // The CLI-owned runtime may survive an app restart, while the
+            // Desktop tool credential is bound to the current local API.
+            // Reconcile that binding quietly at launch so a healthy runtime
+            // never becomes a user-facing repair chore.
+            let runtime_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                match conversation_sidecar::ensure_agent_ready(runtime_handle.clone()).await {
+                    Ok(()) => {
+                        let _ = runtime_handle.emit("conversation-runtime-ready", ());
+                    }
+                    Err(error) => {
+                        eprintln!("understudy runtime: automatic reconnect failed: {error}");
+                    }
+                }
+            });
 
             // Menu-bar tray.
             let show = MenuItem::with_id(app, "show", "Show Understudy", true, None::<&str>)?;

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.10";
+export const RUNTIME_VERSION = "0.3.11";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -2517,7 +2517,7 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       model: "conformance-cli",
     });
     assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
-    assert.equal(cliReport.metadata.runtime_version, "0.3.10");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.11");
     assert.equal(
       cliReport.metadata.event_schema,
       "understudy-conversation-runtime-event-v1",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -92,7 +92,7 @@ function writeReleaseEvidence() {
     adapter_id: "pi",
     generated_at: "2026-07-12T20:00:00.000Z",
     metadata: {
-      runtime_version: "0.3.10",
+      runtime_version: "0.3.11",
       event_schema: "understudy-conversation-runtime-event-v1",
       network_mode: "offline",
       provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
@@ -136,7 +136,7 @@ function writeReleaseEvidence() {
     },
     app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
     runtime: {
-      runtime_version: "0.3.10",
+      runtime_version: "0.3.11",
       event_schema: "understudy-conversation-runtime-event-v1",
       ready_ms: 700,
       rss_mb: 120,
@@ -195,7 +195,7 @@ before(async () => {
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
         app_version: "0.3.2",
-        runtime_version: "0.3.10",
+        runtime_version: "0.3.11",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,
@@ -222,7 +222,7 @@ before(async () => {
         run_id: `cohort-run-${index}`,
         runtime_backend: "pi",
         app_version: "0.3.2",
-        runtime_version: "0.3.10",
+        runtime_version: "0.3.11",
         session_id: `cohort-session-${index}`,
         status: "ok",
         prompt_tokens: cohortFailure === "token-mismatch" && index === 0 ? 11 : 10,

--- a/tests/desktop-release-check.test.mjs
+++ b/tests/desktop-release-check.test.mjs
@@ -57,28 +57,28 @@ test("desktop release source drift fails closed with every version named", () =>
 test("runtime releases require a newer distributed CLI sidecar", () => {
   assert.equal(
     runtimeCliAdvancementError({
-      runtime_version: "0.3.10",
-      cli_version: "0.6.6",
-      baseline_runtime_version: "0.3.9",
-      baseline_cli_version: "0.6.5",
+      runtime_version: "0.3.11",
+      cli_version: "0.6.7",
+      baseline_runtime_version: "0.3.10",
+      baseline_cli_version: "0.6.6",
     }),
     null,
   );
   assert.match(
     runtimeCliAdvancementError({
-      runtime_version: "0.3.10",
-      cli_version: "0.6.5",
-      baseline_runtime_version: "0.3.9",
-      baseline_cli_version: "0.6.5",
+      runtime_version: "0.3.11",
+      cli_version: "0.6.6",
+      baseline_runtime_version: "0.3.10",
+      baseline_cli_version: "0.6.6",
     }),
-    /CLI 0\.6\.5 did not advance/,
+    /CLI 0\.6\.6 did not advance/,
   );
   assert.equal(
     runtimeCliAdvancementError({
-      runtime_version: "0.3.9",
-      cli_version: "0.6.5",
-      baseline_runtime_version: "0.3.9",
-      baseline_cli_version: "0.6.5",
+      runtime_version: "0.3.10",
+      cli_version: "0.6.6",
+      baseline_runtime_version: "0.3.10",
+      baseline_cli_version: "0.6.6",
     }),
     null,
   );

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -231,6 +231,8 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.match(prompt, /"install_mlx_runtime"/);
   assert.match(prompt, /"conversation_runtime_repair"/);
   assert.match(prompt, /listen<NativeRepairProgress>\("runtime-repair-progress"/);
+  assert.match(prompt, /listen\("conversation-runtime-ready"/);
+  assert.match(prompt, /setTimeout\(\(\) => void refreshHealth\(\), 2_500\)/);
   assert.match(prompt, /Updating the version-coupled conversation runtime/);
   assert.match(prompt, /Verifying the CLI and local runtimes/);
   assert.match(prompt, /elapsedSeconds/);
@@ -241,6 +243,8 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.match(downloadNotice, /"start_snapshot_download"/);
   assert.match(repair, /understudy models runtime repair/);
   assert.match(repair, /understudy runtime repair/);
+  assert.match(repair, /Runtime reconnecting/);
+  assert.match(repair, /Reconnect now/);
   assert.match(repair, /install\.sh \| bash -s -- --yes/);
   assert.doesNotMatch(repair, /understudy update/);
 });


### PR DESCRIPTION
## What changed

- reconnect the CLI-owned conversation runtime to the current Desktop tool session during launch
- distinguish a healthy-but-disconnected runtime from a runtime that actually needs repair
- clear the transient reconnect state through a native ready event plus one bounded startup reconciliation
- release the paired CLI/adapter as 0.6.7 and Desktop/runtime as 0.3.11

## Root cause and impact

Updating or repairing the CLI before launching Desktop could leave a healthy runtime holding a stale local Desktop tool credential. Health correctly blocked tool-enabled chat, but the UI mislabeled that credential mismatch as a broken runtime and asked the user to repair it again. Desktop now repairs the binding automatically; genuine install, process, schema, and version failures remain actionable.

## Validation

- `npm run check` — 289/289 Node tests, 33 public skills, package smoke
- `cd apps/homescreen && bun run build`
- `cargo test` — 157 passed, 4 ignored
- strict `cargo clippy --all-targets --all-features -- -D warnings`
- `npm run desktop:release-check -- --stage source --allow-unmerged --json`
- live mismatch proof: manually repaired the runtime before Desktop launch, confirmed the stale token, launched the patched app, and verified automatic reconnection with a healthy runtime and no manual repair
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->