### PR TITLE
Fix Codex marketplace registration from npm symlink

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -959,6 +959,16 @@ install_codex_plugin() {
     return 0
   fi
 
+  # npm installs this package through a symlink into the durable source
+  # checkout. Codex currently misclassifies that symlink as a Git marketplace
+  # and injects a ref, which it then rejects for the local source. Hand Codex
+  # the physical directory so local marketplace registration stays local.
+  if ! repo="$(cd "$repo" && pwd -P)"; then
+    warn "Could not resolve the Codex marketplace source directory."
+    record_adapter_failure "codex" "marketplace source could not be resolved"
+    return 0
+  fi
+
   say "Registering the Understudy Codex marketplace from $repo."
   if codex plugin marketplace add "$repo" >>"$LOG_FILE" 2>&1; then
     ok "Understudy Codex marketplace registered."

--- a/install.sh
+++ b/install.sh
@@ -964,8 +964,8 @@ install_codex_plugin() {
   # and injects a ref, which it then rejects for the local source. Hand Codex
   # the physical directory so local marketplace registration stays local.
   if ! repo="$(cd "$repo" && pwd -P)"; then
-    warn "Could not resolve the Codex marketplace source directory."
-    record_adapter_failure "codex" "marketplace source could not be resolved"
+    say "Could not resolve the Codex marketplace source directory."
+    adapter_prereq_missing "codex" "the marketplace source could not be resolved"
     return 0
   fi
 

--- a/tests/installer.test.mjs
+++ b/tests/installer.test.mjs
@@ -417,6 +417,61 @@ describe("install.sh", () => {
     assert.match(readFileSync(calls, "utf8"), /plugin marketplace add /);
   });
 
+  it("resolves the npm package symlink before registering the Codex marketplace", () => {
+    const script = readFileSync("install.sh", "utf8");
+    const home = join(root, "home");
+    const bin = join(root, "bin");
+    const npmRoot = join(root, "npm-root");
+    const packageLink = join(npmRoot, "@understudylabs", "understudy-agent-tools");
+    const calls = join(root, "codex-realpath-calls.txt");
+    mkdirSync(dirname(packageLink), { recursive: true });
+    mkdirSync(bin, { recursive: true });
+    symlinkSync(process.cwd(), packageLink, "dir");
+    writeFileSync(
+      join(bin, "npm"),
+      `#!/usr/bin/env bash\nif [[ "$*" == "root -g" ]]; then printf '%s\\n' "${npmRoot}"; exit 0; fi\nexit 1\n`,
+    );
+    writeFileSync(
+      join(bin, "codex"),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${calls}"\nexit 0\n`,
+    );
+    chmodSync(join(bin, "npm"), 0o755);
+    chmodSync(join(bin, "codex"), 0o755);
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-s",
+        "--",
+        "--non-interactive",
+        "--only-step",
+        "2",
+        "--agents",
+        "codex",
+        "--no-launch-agent",
+        "--lab",
+        join(root, "lab"),
+      ],
+      {
+        cwd: process.cwd(),
+        input: script,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CI: "1",
+          HOME: home,
+          PATH: `${bin}:${process.env.PATH}`,
+          UNDERSTUDY_INSTALL_LOG_DIR: join(root, "logs"),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const callsText = readFileSync(calls, "utf8");
+    assert.ok(callsText.includes(`plugin marketplace add ${process.cwd()}`));
+    assert.equal(callsText.includes(packageLink), false);
+  });
+
   it("links the OpenCode skills when explicitly requested", () => {
     const script = readFileSync("install.sh", "utf8");
     const home = join(root, "home");


### PR DESCRIPTION
## What changed
- resolve the npm-installed package symlink to its physical checkout before registering the local Codex marketplace
- add a regression test proving Codex receives the physical path

## Why
Codex misclassifies the npm symlink as a Git marketplace and fails with `--ref is only supported for git marketplace sources`. The physical local path registers successfully.

## Impact
Fresh installs no longer report a false Codex adapter failure. Marketplace registration remains local and points at the stable installed source checkout.

## Validation
- `node --test tests/installer.test.mjs` (26 passing)
- `npm run check` (290 tests, typecheck/build, 33 skill validations, package smoke)
- `git diff --check`
- live registration verified against the installed npm symlink and stable resolved source
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->