### PR TITLE
Add proof-scoped correction and GEPA handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ understudy desktop supervisor-feedback --session my-task --run-id my-task-1 \
 understudy desktop supervisor-feedback --session my-task --run-id my-task-1 \
   --marker my-task-1:verdict:0 --stage stop --correct-action interrupt
 understudy desktop supervision export --reviewed-only --json
+understudy desktop supervision prepare-proof --proof ~/.understudy/proofs/<proof-id> --json
 understudy desktop tool-proof run --suite core \
   --candidate local-main:7 --candidate local-fast:6 --repetitions 1
 understudy desktop tool-proof list --json
@@ -507,6 +508,17 @@ missing or estimated usage is counted as excluded rather than treated as zero.
 The export also reports incomplete interventions and any journal or intervention
 rows omitted by its bounded recent-evidence window, so aggregates are never
 presented as all-time metrics when the safety cap was reached.
+`supervision prepare-proof` joins only exact proof/run/session/marker identities
+to those canonical pairs. It records deterministic structured-output scores
+separately from human judgment, keeps promotion and smoke proofs
+evaluation-only, and emits training-eligible rows only for a separately
+declared train or development split. The content-addressed JSONL and manifest
+remain owner-only and local; the command performs no upload. When at least two
+eligible rows exist, the same command also prepares an owner-only DSPy/GEPA
+handoff with a deterministic 75/25 train/dev split. Its inputs preserve the
+small-model partial, supervisor reason, and failed teacher attempt; its target
+is the frozen expected JSON. The handoff is preparation only: it performs no
+provider call and never admits promotion or smoke rows.
 The strict tool proof is also local-only: Pi runs each selected model serially,
 the CLI restores the previous residency set in a `finally` path, and promotion
 requires the frozen 30-task suite repeated three times with complete owner-only

--- a/experiments/desktop-grocery-proof/DEMO.md
+++ b/experiments/desktop-grocery-proof/DEMO.md
@@ -192,3 +192,14 @@ required to learn whether the opportunity is real.
   owner-only evidence, cached offline models, and explicit remote-route consent.
 - Product or finance: emphasize measured route coverage and avoided migration
   risk; do not extrapolate savings until the buyer's frozen slice is scored.
+
+For the applied-AI handoff, run:
+
+```sh
+understudy desktop supervision prepare-proof --proof <proof-directory> --json
+```
+
+Call out the provenance line explicitly: deterministic evaluator judgments are
+not human labels, the frozen promotion proof remains evaluation-only, and GEPA
+handoff preparation makes no provider call. Only a separately frozen
+development/train proof can produce optimizer samples.

--- a/experiments/desktop-grocery-proof/README.md
+++ b/experiments/desktop-grocery-proof/README.md
@@ -30,6 +30,21 @@ node experiments/desktop-grocery-proof/run.mjs \
   --teacher-slot 5
 ```
 
+Prompt or policy optimization uses a separate 18-task development slice,
+never the promotion proof:
+
+```sh
+node experiments/desktop-grocery-proof/run.mjs \
+  --suite development \
+  --student-slot 9 \
+  --teacher-slot 5
+```
+
+The development suite is tagged `data_split: development` and can produce
+training-eligible proof corrections. The promotion suite is tagged
+`data_split: holdout`; the proof-scoped exporter refuses to treat it as
+training data.
+
 The buyer report summarizes a promotion run at the three workflow-cluster
 level and keeps all 30 task decisions in a collapsed audit. It remains
 synthetic qualification evidence, not a production replacement claim.
@@ -74,6 +89,23 @@ Evidence is written owner-only beneath
 `~/.understudy/proofs/grocery-marketplace/<proof-id>/`: frozen tasks, one
 canonical event JSONL per run, scored results JSONL, and a summary. Every row
 retains the exact `run_id` and frozen suite SHA-256.
+
+After a run, prepare proof-scoped correction evidence through the authenticated
+Desktop API:
+
+```sh
+understudy desktop supervision prepare-proof --proof <proof-directory> --json
+```
+
+The command fails closed unless every proof intervention matches exactly one
+canonical correction pair by run, capture, session, and marker identity.
+Promotion proofs are always marked `holdout` and cannot become GEPA training
+rows. Deterministic exact-output scoring remains explicitly non-human; actual
+human feedback is preserved separately when present. A development proof with
+at least two eligible interventions also produces a local GEPA handoff. It uses
+the small-model partial, supervisor reason, and teacher attempt as inputs and
+the frozen expected JSON as the target, with a hash-stable 75/25 train/dev
+split. This prepares optimizer evidence only; it does not call a provider.
 
 Each run also writes a self-contained `report.html` plus its structured
 `report.json` model. The report leads with a bounded route recommendation,

--- a/experiments/desktop-grocery-proof/run.mjs
+++ b/experiments/desktop-grocery-proof/run.mjs
@@ -14,6 +14,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 const suiteFiles = {
   smoke: "tasks.json",
+  development: "tasks.development.json",
   promotion: "tasks.promotion.json",
 };
 
@@ -601,6 +602,11 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
     api_version: capabilities.api_version,
     event_schema: capabilities.event_schema,
     suite_id: suite,
+    data_split: suite === "promotion"
+      ? "holdout"
+      : suite === "development"
+        ? "development"
+        : "smoke",
     task_count: tasks.length,
     run_count: rows.length,
     slots: { student: options.studentSlot, teacher: options.teacherSlot },

--- a/experiments/desktop-grocery-proof/tasks.development.json
+++ b/experiments/desktop-grocery-proof/tasks.development.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "dev-code-lost-update-stock",
+    "workflow": "codebase-analysis",
+    "workflow_title": "Codebase analysis",
+    "title": "Concurrent shelf stock decrement",
+    "prompt": "Review this synthetic grocery inventory code. Return only one minified JSON object with exactly the keys bug, affected_entity, and fix. Allowed bug values: lost_update, stale_write, missing_idempotency, double_charge, or none. Allowed fix values: atomic_conditional_decrement, compare_and_swap, idempotency_key, unique_constraint, mutex, or none. Two workers both read available=1 for SKU BANANA-9 and each writes available=0 without a conditional update.",
+    "expected": { "bug": "lost_update", "affected_entity": "BANANA-9", "fix": "atomic_conditional_decrement" }
+  },
+  {
+    "id": "dev-code-stale-catalog-version",
+    "workflow": "codebase-analysis",
+    "workflow_title": "Codebase analysis",
+    "title": "Stale catalog description write",
+    "prompt": "Review this synthetic grocery catalog update. Return only one minified JSON object with exactly the keys bug, affected_entity, and fix. Allowed bug values: lost_update, stale_write, missing_idempotency, double_charge, or none. Allowed fix values: atomic_conditional_decrement, compare_and_swap, idempotency_key, unique_constraint, mutex, or none. Worker A advances SKU MILK-2 from version 12 to 13. Worker B later writes its version-12 copy without checking the stored version.",
+    "expected": { "bug": "stale_write", "affected_entity": "MILK-2", "fix": "compare_and_swap" }
+  },
+  {
+    "id": "dev-code-retried-refund-event",
+    "workflow": "codebase-analysis",
+    "workflow_title": "Codebase analysis",
+    "title": "Retried refund event",
+    "prompt": "Review this synthetic grocery refund handler. Return only one minified JSON object with exactly the keys bug, affected_entity, and fix. Allowed bug values: lost_update, stale_write, missing_idempotency, double_charge, or none. Allowed fix values: atomic_conditional_decrement, compare_and_swap, idempotency_key, unique_constraint, mutex, or none. The handler credits every received refund event. Event evt-dev-71 is delivered twice after an acknowledgement timeout, and no event id is stored.",
+    "expected": { "bug": "missing_idempotency", "affected_entity": "evt-dev-71", "fix": "idempotency_key" }
+  },
+  {
+    "id": "dev-code-concurrent-cart-create",
+    "workflow": "codebase-analysis",
+    "workflow_title": "Codebase analysis",
+    "title": "Concurrent cart creation",
+    "prompt": "Review this synthetic grocery cart creation path. Return only one minified JSON object with exactly the keys bug, affected_entity, and fix. Allowed bug values: lost_update, stale_write, missing_idempotency, double_charge, or none. Allowed fix values: atomic_conditional_decrement, compare_and_swap, idempotency_key, unique_constraint, mutex, or none. Two workers both see that cart-dev-42 is absent and insert it; the table has no unique constraint.",
+    "expected": { "bug": "missing_idempotency", "affected_entity": "cart-dev-42", "fix": "unique_constraint" }
+  },
+  {
+    "id": "dev-code-retried-charge",
+    "workflow": "codebase-analysis",
+    "workflow_title": "Codebase analysis",
+    "title": "Retried payment capture",
+    "prompt": "Review this synthetic grocery payment flow. Return only one minified JSON object with exactly the keys bug, affected_entity, and fix. Allowed bug values: lost_update, stale_write, missing_idempotency, double_charge, or none. Allowed fix values: atomic_conditional_decrement, compare_and_swap, idempotency_key, unique_constraint, mutex, or none. The client times out and retries capture payment-dev-5. Both attempts call the payment provider without an idempotency key and both succeed.",
+    "expected": { "bug": "double_charge", "affected_entity": "payment-dev-5", "fix": "idempotency_key" }
+  },
+  {
+    "id": "dev-code-locked-reconciliation",
+    "workflow": "codebase-analysis",
+    "workflow_title": "Codebase analysis",
+    "title": "Locked reconciliation update",
+    "prompt": "Review this synthetic grocery reconciliation path. Return only one minified JSON object with exactly the keys bug, affected_entity, and fix. Allowed bug values: lost_update, stale_write, missing_idempotency, double_charge, or none. Allowed fix values: atomic_conditional_decrement, compare_and_swap, idempotency_key, unique_constraint, mutex, or none. Updates for ledger-dev-8 execute inside one mutex, the event id is unique, and each write checks the current version.",
+    "expected": { "bug": "none", "affected_entity": "ledger-dev-8", "fix": "none" }
+  },
+  {
+    "id": "dev-cart-dairy-free-creamer",
+    "workflow": "cart-assistant",
+    "workflow_title": "Cart assistant",
+    "title": "Dairy-free creamer replacement",
+    "prompt": "Choose a substitute for a synthetic grocery cart. Return only one minified JSON object with exactly the keys substitute_sku, quantity, and reason_code. Allowed reason_code values: exact_constraint_match or no_safe_substitute. Need two 16 oz dairy-free creamers, severe tree-nut allergy, price at most $5.50, stock at least 2. Candidates: OAT-CREAM-16={dairy_free:true,allergens:[],size_oz:16,stock:3,price:4.99}; ALMOND-CREAM-16={dairy_free:true,allergens:[almond],size_oz:16,stock:8,price:4.49}; DAIRY-CREAM-16={dairy_free:false,allergens:[],size_oz:16,stock:6,price:3.99}.",
+    "expected": { "substitute_sku": "OAT-CREAM-16", "quantity": 2, "reason_code": "exact_constraint_match" }
+  },
+  {
+    "id": "dev-cart-no-safe-crackers",
+    "workflow": "cart-assistant",
+    "workflow_title": "Cart assistant",
+    "title": "No safe cracker replacement",
+    "prompt": "Choose a substitute for a synthetic grocery cart. Return only one minified JSON object with exactly the keys substitute_sku, quantity, and reason_code. Allowed reason_code values: exact_constraint_match or no_safe_substitute. Need one gluten-free 8 oz cracker box with no sesame and price at most $5.00. Candidates: GF-SES-8={gluten_free:true,allergens:[sesame],size_oz:8,stock:4,price:4.49}; WHEAT-8={gluten_free:false,allergens:[],size_oz:8,stock:7,price:3.49}; GF-12={gluten_free:true,allergens:[],size_oz:12,stock:2,price:5.49}.",
+    "expected": { "substitute_sku": "none", "quantity": 0, "reason_code": "no_safe_substitute" }
+  },
+  {
+    "id": "dev-cart-size-equivalent-rice",
+    "workflow": "cart-assistant",
+    "workflow_title": "Cart assistant",
+    "title": "Equivalent rice quantity",
+    "prompt": "Choose a substitute for a synthetic grocery cart. Return only one minified JSON object with exactly the keys substitute_sku, quantity, and reason_code. Allowed reason_code values: exact_constraint_match or no_safe_substitute. Need 32 oz total brown rice, organic, total price at most $8.00, and sufficient stock. Candidates: RICE-32={organic:true,size_oz:32,stock:0,price:6.99}; RICE-16={organic:true,size_oz:16,stock:2,price:3.75}; WHITE-32={organic:true,size_oz:32,stock:5,price:5.99,brown:false}.",
+    "expected": { "substitute_sku": "RICE-16", "quantity": 2, "reason_code": "exact_constraint_match" }
+  },
+  {
+    "id": "dev-cart-low-sugar-bars",
+    "workflow": "cart-assistant",
+    "workflow_title": "Cart assistant",
+    "title": "Low-sugar snack bars",
+    "prompt": "Choose a substitute for a synthetic grocery cart. Return only one minified JSON object with exactly the keys substitute_sku, quantity, and reason_code. Allowed reason_code values: exact_constraint_match or no_safe_substitute. Need three boxes of six nut-free bars, added sugar at most 2g per bar, price at most $6.00 per box, stock at least 3. Candidates: BAR-LOW={count:6,nut_free:true,added_sugar_g:2,stock:3,price:5.49}; BAR-NUT={count:6,nut_free:false,added_sugar_g:1,stock:8,price:4.99}; BAR-SWEET={count:6,nut_free:true,added_sugar_g:8,stock:6,price:4.49}.",
+    "expected": { "substitute_sku": "BAR-LOW", "quantity": 3, "reason_code": "exact_constraint_match" }
+  },
+  {
+    "id": "dev-cart-stock-shortage-soup",
+    "workflow": "cart-assistant",
+    "workflow_title": "Cart assistant",
+    "title": "Organic soup stock shortage",
+    "prompt": "Choose a substitute for a synthetic grocery cart. Return only one minified JSON object with exactly the keys substitute_sku, quantity, and reason_code. Allowed reason_code values: exact_constraint_match or no_safe_substitute. Need four identical 14 oz organic tomato soups, vegan, stock at least 4. Candidates: SOUP-ORG={organic:true,vegan:true,size_oz:14,stock:3}; SOUP-DAIRY={organic:true,vegan:false,size_oz:14,stock:8}; SOUP-28={organic:true,vegan:true,size_oz:28,stock:2}.",
+    "expected": { "substitute_sku": "none", "quantity": 0, "reason_code": "no_safe_substitute" }
+  },
+  {
+    "id": "dev-cart-kosher-cheese",
+    "workflow": "cart-assistant",
+    "workflow_title": "Cart assistant",
+    "title": "Kosher cheese replacement",
+    "prompt": "Choose a substitute for a synthetic grocery cart. Return only one minified JSON object with exactly the keys substitute_sku, quantity, and reason_code. Allowed reason_code values: exact_constraint_match or no_safe_substitute. Need one 8 oz kosher-certified cheddar, price at most $7.00, stock at least 1. Candidates: CHEDDAR-K={kosher:true,variety:cheddar,size_oz:8,stock:2,price:6.49}; SWISS-K={kosher:true,variety:swiss,size_oz:8,stock:4,price:5.99}; CHEDDAR-NK={kosher:false,variety:cheddar,size_oz:8,stock:8,price:4.99}.",
+    "expected": { "substitute_sku": "CHEDDAR-K", "quantity": 1, "reason_code": "exact_constraint_match" }
+  },
+  {
+    "id": "dev-ops-mixed-signals",
+    "workflow": "ops-classification",
+    "workflow_title": "Operations classification",
+    "title": "Mixed development signals",
+    "prompt": "Classify three synthetic grocery order exceptions. Return only one minified JSON object whose keys are dev-order-301, dev-order-302, and dev-order-303. Allowed values: cold_chain, fraud_review, courier_delay, or no_action. Rules in priority order: temperature above 41F for more than 30 minutes => cold_chain; otherwise at least 5 payment retries plus billing mismatch => fraud_review; otherwise courier more than 20 minutes late while food remains safe => courier_delay; otherwise no_action. Events: dev-order-301 temperature=45F duration=36m; dev-order-302 payment_retries=5 billing_mismatch=true; dev-order-303 courier_late=24m food_safe=true.",
+    "expected": { "dev-order-301": "cold_chain", "dev-order-302": "fraud_review", "dev-order-303": "courier_delay" }
+  },
+  {
+    "id": "dev-ops-threshold-boundaries",
+    "workflow": "ops-classification",
+    "workflow_title": "Operations classification",
+    "title": "Development threshold boundaries",
+    "prompt": "Classify three synthetic grocery order exceptions. Return only one minified JSON object whose keys are dev-order-304, dev-order-305, and dev-order-306. Allowed values: cold_chain, fraud_review, courier_delay, or no_action. Rules in priority order: temperature above 41F for more than 30 minutes => cold_chain; otherwise at least 5 payment retries plus billing mismatch => fraud_review; otherwise courier more than 20 minutes late while food remains safe => courier_delay; otherwise no_action. Events: dev-order-304 temperature=42F duration=30m; dev-order-305 payment_retries=5 billing_mismatch=false; dev-order-306 courier_late=20m food_safe=true.",
+    "expected": { "dev-order-304": "no_action", "dev-order-305": "no_action", "dev-order-306": "no_action" }
+  },
+  {
+    "id": "dev-ops-cold-priority",
+    "workflow": "ops-classification",
+    "workflow_title": "Operations classification",
+    "title": "Cold-chain priority development",
+    "prompt": "Classify three synthetic grocery order exceptions. Return only one minified JSON object whose keys are dev-order-307, dev-order-308, and dev-order-309. Allowed values: cold_chain, fraud_review, courier_delay, or no_action. Rules in priority order: temperature above 41F for more than 30 minutes => cold_chain; otherwise at least 5 payment retries plus billing mismatch => fraud_review; otherwise courier more than 20 minutes late while food remains safe => courier_delay; otherwise no_action. Events: dev-order-307 temperature=47F duration=40m payment_retries=8 billing_mismatch=true; dev-order-308 temperature=42F duration=35m courier_late=55m food_safe=false; dev-order-309 temperature=39F duration=50m payment_retries=6 billing_mismatch=true.",
+    "expected": { "dev-order-307": "cold_chain", "dev-order-308": "cold_chain", "dev-order-309": "fraud_review" }
+  },
+  {
+    "id": "dev-ops-fraud-requires-both",
+    "workflow": "ops-classification",
+    "workflow_title": "Operations classification",
+    "title": "Fraud conjunction development",
+    "prompt": "Classify three synthetic grocery order exceptions. Return only one minified JSON object whose keys are dev-order-310, dev-order-311, and dev-order-312. Allowed values: cold_chain, fraud_review, courier_delay, or no_action. Rules in priority order: temperature above 41F for more than 30 minutes => cold_chain; otherwise at least 5 payment retries plus billing mismatch => fraud_review; otherwise courier more than 20 minutes late while food remains safe => courier_delay; otherwise no_action. Events: dev-order-310 payment_retries=7 billing_mismatch=true; dev-order-311 payment_retries=9 billing_mismatch=false; dev-order-312 payment_retries=3 billing_mismatch=true.",
+    "expected": { "dev-order-310": "fraud_review", "dev-order-311": "no_action", "dev-order-312": "no_action" }
+  },
+  {
+    "id": "dev-ops-delay-safety",
+    "workflow": "ops-classification",
+    "workflow_title": "Operations classification",
+    "title": "Courier safety development",
+    "prompt": "Classify three synthetic grocery order exceptions. Return only one minified JSON object whose keys are dev-order-313, dev-order-314, and dev-order-315. Allowed values: cold_chain, fraud_review, courier_delay, or no_action. Rules in priority order: temperature above 41F for more than 30 minutes => cold_chain; otherwise at least 5 payment retries plus billing mismatch => fraud_review; otherwise courier more than 20 minutes late while food remains safe => courier_delay; otherwise no_action. Events: dev-order-313 courier_late=22m food_safe=true; dev-order-314 courier_late=48m food_safe=false; dev-order-315 courier_late=18m food_safe=true.",
+    "expected": { "dev-order-313": "courier_delay", "dev-order-314": "no_action", "dev-order-315": "no_action" }
+  },
+  {
+    "id": "dev-ops-priority-combination",
+    "workflow": "ops-classification",
+    "workflow_title": "Operations classification",
+    "title": "Combined signal development",
+    "prompt": "Classify three synthetic grocery order exceptions. Return only one minified JSON object whose keys are dev-order-316, dev-order-317, and dev-order-318. Allowed values: cold_chain, fraud_review, courier_delay, or no_action. Rules in priority order: temperature above 41F for more than 30 minutes => cold_chain; otherwise at least 5 payment retries plus billing mismatch => fraud_review; otherwise courier more than 20 minutes late while food remains safe => courier_delay; otherwise no_action. Events: dev-order-316 temperature=44F duration=45m payment_retries=7 billing_mismatch=true; dev-order-317 temperature=40F duration=45m payment_retries=7 billing_mismatch=true courier_late=35m food_safe=true; dev-order-318 payment_retries=2 billing_mismatch=false courier_late=35m food_safe=true.",
+    "expected": { "dev-order-316": "cold_chain", "dev-order-317": "fraud_review", "dev-order-318": "courier_delay" }
+  }
+]

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,6 +3,27 @@
 Versioned JSON Schemas for artifacts that cross surface boundaries (desktop
 app, skills, CLI, ladder). One spine, adopted everywhere.
 
+## Proof-scoped correction evidence
+
+[`understudy.proof_correction_evidence.v1.schema.json`](understudy.proof_correction_evidence.v1.schema.json)
+wraps one canonical `understudy.correction_pair.v1` row with immutable proof
+identity, deterministic evaluator output, human-label provenance, and an
+explicit training-eligibility decision. A deterministic exact-output score is
+never represented as a human label.
+
+[`understudy.proof_correction_export.v1.schema.json`](understudy.proof_correction_export.v1.schema.json)
+is the content-addressed manifest for those rows. Promotion and smoke proofs
+remain evaluation-only; only separately declared train or development splits
+can become GEPA inputs, and incomplete token attribution fails eligibility.
+
+[`understudy.proof_correction_gepa_samples.v1.schema.json`](understudy.proof_correction_gepa_samples.v1.schema.json)
+and
+[`understudy.proof_correction_gepa_handoff.v1.schema.json`](understudy.proof_correction_gepa_handoff.v1.schema.json)
+define the local DSPy/GEPA projection. The projection binds every sample back
+to its proof and correction evidence hashes, freezes a deterministic train/dev
+split, excludes holdout rows, and records that preparation made no provider
+call or upload.
+
 ## `understudy.desktop_grocery_report_package.v1`
 
 [`understudy.desktop_grocery_report_package.v1.schema.json`](understudy.desktop_grocery_report_package.v1.schema.json)

--- a/schemas/understudy.proof_correction_evidence.v1.schema.json
+++ b/schemas/understudy.proof_correction_evidence.v1.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.understudylabs.com/understudy.proof_correction_evidence.v1.schema.json",
+  "title": "Understudy proof-scoped correction evidence v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "proof",
+    "correction_pair",
+    "evaluator_judgment",
+    "judgment_provenance",
+    "training"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "understudy.proof_correction_evidence.v1" },
+    "proof": {
+      "type": "object",
+      "required": [
+        "proof_id",
+        "suite_id",
+        "suite_sha256",
+        "summary_sha256",
+        "results_sha256",
+        "tasks_sha256",
+        "data_split",
+        "task_id",
+        "workflow",
+        "run_id",
+        "capture_run_id",
+        "session_id",
+        "marker_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "proof_id": { "type": "string", "minLength": 1 },
+        "suite_id": { "type": "string", "minLength": 1 },
+        "suite_sha256": { "$ref": "#/$defs/sha256" },
+        "summary_sha256": { "$ref": "#/$defs/sha256" },
+        "results_sha256": { "$ref": "#/$defs/sha256" },
+        "tasks_sha256": { "$ref": "#/$defs/sha256" },
+        "data_split": { "enum": ["train", "development", "holdout", "smoke"] },
+        "task_id": { "type": "string", "minLength": 1 },
+        "workflow": { "type": "string", "minLength": 1 },
+        "run_id": { "type": "string", "minLength": 1 },
+        "capture_run_id": { "type": "string", "minLength": 1 },
+        "session_id": { "type": "string", "minLength": 1 },
+        "marker_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "correction_pair": {
+      "$ref": "understudy.correction_pair.v1.schema.json"
+    },
+    "evaluator_judgment": {
+      "type": "object",
+      "required": [
+        "source",
+        "human",
+        "evaluator_version",
+        "student_exact",
+        "final_exact",
+        "student_field_accuracy",
+        "final_field_accuracy",
+        "intervention_was_warranted",
+        "correction_succeeded",
+        "outcome"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": { "const": "deterministic_structured_output_evaluator" },
+        "human": { "const": false },
+        "evaluator_version": { "const": "understudy.exact_object_score.v1" },
+        "student_exact": { "type": "boolean" },
+        "final_exact": { "type": "boolean" },
+        "student_field_accuracy": { "type": "number", "minimum": 0, "maximum": 1 },
+        "final_field_accuracy": { "type": "number", "minimum": 0, "maximum": 1 },
+        "intervention_was_warranted": { "type": "boolean" },
+        "correction_succeeded": { "type": "boolean" },
+        "outcome": {
+          "enum": [
+            "correct_intervention",
+            "unsuccessful_intervention",
+            "false_positive_intervention"
+          ]
+        }
+      }
+    },
+    "judgment_provenance": {
+      "type": "object",
+      "required": [
+        "primary_source",
+        "human_reviewed",
+        "human_judgment",
+        "deterministic_evaluator_is_human_label"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "primary_source": { "enum": ["human", "deterministic_evaluator"] },
+        "human_reviewed": { "type": "boolean" },
+        "human_judgment": { "type": ["object", "null"] },
+        "deterministic_evaluator_is_human_label": { "const": false }
+      }
+    },
+    "training": {
+      "type": "object",
+      "required": ["eligible", "recommended_method", "targets", "exclusion_reasons"],
+      "additionalProperties": false,
+      "properties": {
+        "eligible": { "type": "boolean" },
+        "recommended_method": { "const": "gepa_prompt_policy_first" },
+        "targets": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "supervisor_policy",
+              "teacher_continuation_positive",
+              "teacher_continuation_repair"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "exclusion_reasons": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/schemas/understudy.proof_correction_export.v1.schema.json
+++ b/schemas/understudy.proof_correction_export.v1.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.understudylabs.com/understudy.proof_correction_export.v1.schema.json",
+  "title": "Understudy proof correction export manifest v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "source",
+    "source_pair_count",
+    "expected_intervention_count",
+    "exported_row_count",
+    "training_eligible_count",
+    "human_reviewed_count",
+    "deterministic_only_count",
+    "outcomes",
+    "files",
+    "optimizer_boundary",
+    "upload_performed"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "understudy.proof_correction_export.v1" },
+    "source": {
+      "type": "object",
+      "required": [
+        "proof_id",
+        "suite_id",
+        "suite_sha256",
+        "summary_sha256",
+        "results_sha256",
+        "tasks_sha256",
+        "data_split"
+      ]
+    },
+    "source_pair_count": { "type": "integer", "minimum": 0 },
+    "expected_intervention_count": { "type": "integer", "minimum": 0 },
+    "exported_row_count": { "type": "integer", "minimum": 0 },
+    "training_eligible_count": { "type": "integer", "minimum": 0 },
+    "human_reviewed_count": { "type": "integer", "minimum": 0 },
+    "deterministic_only_count": { "type": "integer", "minimum": 0 },
+    "outcomes": {
+      "type": "object",
+      "required": [
+        "correct_intervention",
+        "unsuccessful_intervention",
+        "false_positive_intervention"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "correct_intervention": { "type": "integer", "minimum": 0 },
+        "unsuccessful_intervention": { "type": "integer", "minimum": 0 },
+        "false_positive_intervention": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "files": {
+      "type": "object",
+      "required": ["evidence_jsonl_sha256"],
+      "additionalProperties": false,
+      "properties": {
+        "evidence_jsonl_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "optimizer_boundary": {
+      "type": "object",
+      "required": [
+        "holdout_rows_are_training_eligible",
+        "recommended_method",
+        "next_action"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "holdout_rows_are_training_eligible": { "const": false },
+        "recommended_method": { "const": "gepa_prompt_policy_first" },
+        "next_action": { "type": "string", "minLength": 1 }
+      }
+    },
+    "upload_performed": { "const": false }
+  }
+}

--- a/schemas/understudy.proof_correction_gepa_handoff.v1.schema.json
+++ b/schemas/understudy.proof_correction_gepa_handoff.v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.understudylabs.com/understudy.proof_correction_gepa_handoff.v1.schema.json",
+  "title": "Understudy proof correction GEPA handoff v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "source",
+    "evidence_sha256",
+    "status",
+    "reason",
+    "row_count",
+    "train_count",
+    "dev_count",
+    "excluded_count",
+    "split_strategy",
+    "input_keys",
+    "output_keys",
+    "recommended_adapter",
+    "command_template",
+    "files",
+    "provider_calls_performed",
+    "upload_performed"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "understudy.proof_correction_gepa_handoff.v1" },
+    "source": { "type": "object" },
+    "evidence_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "status": { "enum": ["ready", "blocked"] },
+    "reason": { "type": ["string", "null"] },
+    "row_count": { "type": "integer", "minimum": 0 },
+    "train_count": { "type": "integer", "minimum": 0 },
+    "dev_count": { "type": "integer", "minimum": 0 },
+    "excluded_count": { "type": "integer", "minimum": 0 },
+    "split_strategy": { "const": "sha256_stratified_75_25_v1" },
+    "input_keys": {
+      "const": ["workflow", "prompt", "student_partial", "supervisor_reason", "teacher_attempt"]
+    },
+    "output_keys": { "const": ["answer_json"] },
+    "recommended_adapter": { "const": "dspy-gepa" },
+    "command_template": { "type": "string", "minLength": 1 },
+    "files": {
+      "type": "object",
+      "required": ["samples_sha256"],
+      "additionalProperties": false,
+      "properties": {
+        "samples_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    },
+    "provider_calls_performed": { "const": false },
+    "upload_performed": { "const": false }
+  }
+}

--- a/schemas/understudy.proof_correction_gepa_samples.v1.schema.json
+++ b/schemas/understudy.proof_correction_gepa_samples.v1.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.understudylabs.com/understudy.proof_correction_gepa_samples.v1.schema.json",
+  "title": "Understudy proof correction GEPA samples v1",
+  "type": "object",
+  "required": ["schema_version", "rows"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "understudy.proof_correction_gepa_samples.v1" },
+    "rows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "schema_version",
+          "input_id",
+          "split",
+          "workflow",
+          "prompt",
+          "student_partial",
+          "supervisor_reason",
+          "teacher_attempt",
+          "answer_json",
+          "provenance"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "schema_version": { "const": "understudy.proof_correction_gepa_sample.v1" },
+          "input_id": { "type": "string", "minLength": 1 },
+          "split": { "enum": ["train", "dev"] },
+          "workflow": { "type": "string", "minLength": 1 },
+          "prompt": { "type": "string", "minLength": 1 },
+          "student_partial": { "type": "string", "minLength": 1 },
+          "supervisor_reason": { "type": "string", "minLength": 1 },
+          "teacher_attempt": { "type": "string", "minLength": 1 },
+          "answer_json": { "type": "string", "minLength": 2 },
+          "provenance": {
+            "type": "object",
+            "required": [
+              "proof_id",
+              "suite_sha256",
+              "evidence_sha256",
+              "run_id",
+              "capture_run_id",
+              "session_id",
+              "marker_id",
+              "deterministic_evaluator_is_human_label"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "proof_id": { "type": "string", "minLength": 1 },
+              "suite_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+              "evidence_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+              "run_id": { "type": "string", "minLength": 1 },
+              "capture_run_id": { "type": "string", "minLength": 1 },
+              "session_id": { "type": "string", "minLength": 1 },
+              "marker_id": { "type": "string", "minLength": 1 },
+              "deterministic_evaluator_is_human_label": { "const": false }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/commands/desktop.ts
+++ b/src/commands/desktop.ts
@@ -43,6 +43,10 @@ import {
   runDesktopToolProof,
   type ToolProofCandidate,
 } from "../desktop/tool-proof.js";
+import {
+  prepareProofCorrectionEvidence,
+  prepareProofCorrectionGepaHandoff,
+} from "../desktop/proof-corrections.js";
 
 interface RuntimeEvent {
   run_id?: string;
@@ -1084,6 +1088,132 @@ export function registerDesktopCommand(program: Command): void {
           `pairs: ${outputPath} (${pairWrite})`,
           `metrics: ${metricsPath} (${metricsWrite})`,
           `evidence omitted: ${evidenceWindow.incomplete_interventions + evidenceWindow.truncated_interventions + evidenceWindow.invalid_journals + evidenceWindow.missing_journals + evidenceWindow.truncated_journals}`,
+          "upload performed: false",
+        ].join("\n"),
+      );
+    });
+
+  supervision
+    .command("prepare-proof")
+    .description(
+      "Join one immutable proof to canonical correction pairs with explicit judgment provenance.",
+    )
+    .requiredOption("--proof <path>", "Immutable proof directory containing summary, results, and tasks")
+    .option("--output <path>", "Proof-scoped correction evidence JSONL path")
+    .option("--manifest-output <path>", "Proof-scoped correction manifest JSON path")
+    .option("--gepa-samples-output <path>", "Owner-only GEPA correction samples JSON path")
+    .option("--gepa-handoff-output <path>", "Owner-only GEPA handoff manifest JSON path")
+    .option("--json", "Output artifact metadata as JSON")
+    .action(async function (this: Command, opts: {
+      proof: string;
+      output?: string;
+      manifestOutput?: string;
+      gepaSamplesOutput?: string;
+      gepaHandoffOutput?: string;
+      json?: boolean;
+    }) {
+      const capability = await requireDesktopApi();
+      const response = await desktopApiFetch(capability, "/v1/supervision/corrections");
+      if (!response.ok) throw await responseError(response);
+      const packet = await response.json() as SupervisionExportPacket;
+      if (packet.schema_version !== "understudy.supervision.export_packet.v1") {
+        throw new Error(`unsupported supervision export schema: ${String(packet.schema_version)}`);
+      }
+      if (!Array.isArray(packet.correction_pairs)) {
+        throw new Error("desktop returned an incomplete supervision export packet");
+      }
+      for (const [index, row] of packet.correction_pairs.entries()) {
+        validateCorrectionPair(row, index);
+      }
+      const prepared = prepareProofCorrectionEvidence(opts.proof, packet.correction_pairs);
+      const gepa = prepareProofCorrectionGepaHandoff(prepared);
+      const safeProofId = prepared.manifest.source.proof_id.replaceAll(/[^a-zA-Z0-9._-]/g, "-");
+      const outputRoot = join(
+        homedir(),
+        ".understudy",
+        "exports",
+        "supervision",
+        "proofs",
+        safeProofId,
+      );
+      const outputPath = opts.output
+        ? resolve(opts.output)
+        : join(outputRoot, `${prepared.evidence_sha256}.proof-corrections.jsonl`);
+      const manifestSha256 = sha256(prepared.manifest_json);
+      const manifestPath = opts.manifestOutput
+        ? resolve(opts.manifestOutput)
+        : join(outputRoot, `${manifestSha256}.manifest.json`);
+      const gepaSamplesPath = opts.gepaSamplesOutput
+        ? resolve(opts.gepaSamplesOutput)
+        : join(outputRoot, `${gepa.samples_sha256}.gepa-samples.json`);
+      const gepaHandoffSha256 = sha256(gepa.handoff_json);
+      const gepaHandoffPath = opts.gepaHandoffOutput
+        ? resolve(opts.gepaHandoffOutput)
+        : join(outputRoot, `${gepaHandoffSha256}.gepa-handoff.json`);
+      const evidenceWrite = writeImmutableArtifact(outputPath, prepared.evidence_jsonl);
+      const manifestWrite = writeImmutableArtifact(manifestPath, prepared.manifest_json);
+      const gepaSamplesWrite = writeImmutableArtifact(gepaSamplesPath, gepa.samples_json);
+      const gepaHandoffWrite = writeImmutableArtifact(gepaHandoffPath, gepa.handoff_json);
+      const result = {
+        schema_version: "understudy.proof_correction_export_result.v1",
+        proof_id: prepared.manifest.source.proof_id,
+        suite_id: prepared.manifest.source.suite_id,
+        data_split: prepared.manifest.source.data_split,
+        correction_evidence: {
+          path: outputPath,
+          sha256: prepared.evidence_sha256,
+          row_count: prepared.rows.length,
+          write: evidenceWrite,
+        },
+        manifest: {
+          path: manifestPath,
+          sha256: manifestSha256,
+          write: manifestWrite,
+        },
+        judgments: {
+          human_reviewed: prepared.manifest.human_reviewed_count,
+          deterministic_only: prepared.manifest.deterministic_only_count,
+          deterministic_evaluator_is_human_label: false,
+        },
+        training: {
+          eligible_rows: prepared.manifest.training_eligible_count,
+          holdout_rows_are_training_eligible: false,
+          recommended_method: prepared.manifest.optimizer_boundary.recommended_method,
+          next_action: prepared.manifest.optimizer_boundary.next_action,
+        },
+        gepa_handoff: {
+          status: gepa.handoff.status,
+          reason: gepa.handoff.reason,
+          samples: {
+            path: gepaSamplesPath,
+            sha256: gepa.samples_sha256,
+            row_count: gepa.handoff.row_count,
+            train_count: gepa.handoff.train_count,
+            dev_count: gepa.handoff.dev_count,
+            write: gepaSamplesWrite,
+          },
+          manifest: {
+            path: gepaHandoffPath,
+            sha256: gepaHandoffSha256,
+            write: gepaHandoffWrite,
+          },
+          provider_calls_performed: false,
+        },
+        outcomes: prepared.manifest.outcomes,
+        upload_performed: false,
+      };
+      printStructured(
+        result,
+        jsonRequested(this, opts.json),
+        [
+          `proof: ${result.proof_id} (${result.data_split})`,
+          `correction evidence: ${prepared.rows.length}`,
+          `human reviewed: ${prepared.manifest.human_reviewed_count}`,
+          `training eligible: ${prepared.manifest.training_eligible_count}`,
+          `evidence: ${outputPath} (${evidenceWrite})`,
+          `manifest: ${manifestPath} (${manifestWrite})`,
+          `GEPA handoff: ${gepa.handoff.status} (${gepa.handoff.train_count} train / ${gepa.handoff.dev_count} dev)`,
+          `next: ${prepared.manifest.optimizer_boundary.next_action}`,
           "upload performed: false",
         ].join("\n"),
       );

--- a/src/desktop/proof-corrections.ts
+++ b/src/desktop/proof-corrections.ts
@@ -1,0 +1,576 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export const PROOF_CORRECTION_EVIDENCE_SCHEMA =
+  "understudy.proof_correction_evidence.v1" as const;
+export const PROOF_CORRECTION_EXPORT_SCHEMA =
+  "understudy.proof_correction_export.v1" as const;
+export const PROOF_CORRECTION_GEPA_SAMPLE_SCHEMA =
+  "understudy.proof_correction_gepa_sample.v1" as const;
+export const PROOF_CORRECTION_GEPA_HANDOFF_SCHEMA =
+  "understudy.proof_correction_gepa_handoff.v1" as const;
+
+type JsonObject = Record<string, unknown>;
+type DataSplit = "train" | "development" | "holdout" | "smoke";
+type CorrectionOutcome =
+  | "correct_intervention"
+  | "unsuccessful_intervention"
+  | "false_positive_intervention";
+
+type ProofSource = {
+  proof_id: string;
+  suite_id: string;
+  suite_sha256: string;
+  summary_sha256: string;
+  results_sha256: string;
+  tasks_sha256: string;
+  data_split: DataSplit;
+};
+
+export type ProofCorrectionEvidence = {
+  schema_version: typeof PROOF_CORRECTION_EVIDENCE_SCHEMA;
+  proof: ProofSource & {
+    task_id: string;
+    workflow: string;
+    run_id: string;
+    capture_run_id: string;
+    session_id: string;
+    marker_id: string;
+  };
+  correction_pair: JsonObject;
+  evaluator_judgment: {
+    source: "deterministic_structured_output_evaluator";
+    human: false;
+    evaluator_version: "understudy.exact_object_score.v1";
+    student_exact: boolean;
+    final_exact: boolean;
+    student_field_accuracy: number;
+    final_field_accuracy: number;
+    intervention_was_warranted: boolean;
+    correction_succeeded: boolean;
+    outcome: CorrectionOutcome;
+  };
+  judgment_provenance: {
+    primary_source: "human" | "deterministic_evaluator";
+    human_reviewed: boolean;
+    human_judgment: unknown;
+    deterministic_evaluator_is_human_label: false;
+  };
+  training: {
+    eligible: boolean;
+    recommended_method: "gepa_prompt_policy_first";
+    targets: string[];
+    exclusion_reasons: string[];
+  };
+};
+
+export type ProofCorrectionManifest = {
+  schema_version: typeof PROOF_CORRECTION_EXPORT_SCHEMA;
+  source: ProofSource;
+  source_pair_count: number;
+  expected_intervention_count: number;
+  exported_row_count: number;
+  training_eligible_count: number;
+  human_reviewed_count: number;
+  deterministic_only_count: number;
+  outcomes: Record<CorrectionOutcome, number>;
+  files: {
+    evidence_jsonl_sha256: string;
+  };
+  optimizer_boundary: {
+    holdout_rows_are_training_eligible: false;
+    recommended_method: "gepa_prompt_policy_first";
+    next_action: string;
+  };
+  upload_performed: false;
+};
+
+export type PreparedProofCorrections = {
+  proof_root: string;
+  rows: ProofCorrectionEvidence[];
+  evidence_jsonl: string;
+  evidence_sha256: string;
+  manifest: ProofCorrectionManifest;
+  manifest_json: string;
+};
+
+export type ProofCorrectionGepaSample = {
+  schema_version: typeof PROOF_CORRECTION_GEPA_SAMPLE_SCHEMA;
+  input_id: string;
+  split: "train" | "dev";
+  workflow: string;
+  prompt: string;
+  student_partial: string;
+  supervisor_reason: string;
+  teacher_attempt: string;
+  answer_json: string;
+  provenance: {
+    proof_id: string;
+    suite_sha256: string;
+    evidence_sha256: string;
+    run_id: string;
+    capture_run_id: string;
+    session_id: string;
+    marker_id: string;
+    deterministic_evaluator_is_human_label: false;
+  };
+};
+
+export type ProofCorrectionGepaHandoff = {
+  schema_version: typeof PROOF_CORRECTION_GEPA_HANDOFF_SCHEMA;
+  source: ProofSource;
+  evidence_sha256: string;
+  status: "ready" | "blocked";
+  reason: string | null;
+  row_count: number;
+  train_count: number;
+  dev_count: number;
+  excluded_count: number;
+  split_strategy: "sha256_stratified_75_25_v1";
+  input_keys: ["workflow", "prompt", "student_partial", "supervisor_reason", "teacher_attempt"];
+  output_keys: ["answer_json"];
+  recommended_adapter: "dspy-gepa";
+  command_template: string;
+  files: {
+    samples_sha256: string;
+  };
+  provider_calls_performed: false;
+  upload_performed: false;
+};
+
+export type PreparedProofCorrectionGepaHandoff = {
+  samples: ProofCorrectionGepaSample[];
+  samples_json: string;
+  samples_sha256: string;
+  handoff: ProofCorrectionGepaHandoff;
+  handoff_json: string;
+};
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as JsonObject)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function object(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function finiteNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  return value;
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function parseJsonl(bytes: Buffer, label: string): JsonObject[] {
+  return bytes
+    .toString("utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => object(JSON.parse(line), `${label} row ${index}`));
+}
+
+function dataSplit(summary: JsonObject): DataSplit {
+  const explicit = summary.data_split;
+  if (
+    explicit === "train"
+    || explicit === "development"
+    || explicit === "holdout"
+    || explicit === "smoke"
+  ) {
+    return explicit;
+  }
+  const suite = summary.suite_id;
+  if (suite === "promotion") return "holdout";
+  if (suite === "development") return "development";
+  if (suite === "smoke") return "smoke";
+  throw new Error("proof summary must declare data_split for an unknown suite");
+}
+
+function interventionMarkers(row: JsonObject): string[] {
+  if (!Array.isArray(row.verdicts)) throw new Error(`proof run ${String(row.run_id)} has no verdicts`);
+  return row.verdicts.flatMap((value, index) => {
+    const verdict = object(value, `proof run ${String(row.run_id)} verdict ${index}`);
+    if (verdict.verdict !== "interrupt" && verdict.verdict !== "nudge") return [];
+    return [string(verdict.marker_id, `proof run ${String(row.run_id)} intervention marker` )];
+  });
+}
+
+function pairKey(runId: string, markerId: string): string {
+  return `${runId}\u0000${markerId}`;
+}
+
+function validateCorrectionPair(pair: JsonObject, index: number): void {
+  if (pair.schema_version !== "understudy.correction_pair.v1") {
+    throw new Error(`correction pair ${index} has an unsupported schema_version`);
+  }
+  for (const field of ["run_id", "session_id", "marker_id"]) {
+    string(pair[field], `correction pair ${index} ${field}`);
+  }
+  object(pair.run_usage, `correction pair ${index} run_usage`);
+}
+
+function correctionOutcome(studentExact: boolean, finalExact: boolean): CorrectionOutcome {
+  if (studentExact) return "false_positive_intervention";
+  return finalExact ? "correct_intervention" : "unsuccessful_intervention";
+}
+
+function trainingTargets(outcome: CorrectionOutcome): string[] {
+  switch (outcome) {
+    case "correct_intervention":
+      return ["supervisor_policy", "teacher_continuation_positive"];
+    case "unsuccessful_intervention":
+      return ["teacher_continuation_repair"];
+    case "false_positive_intervention":
+      return ["supervisor_policy"];
+  }
+}
+
+export function prepareProofCorrectionEvidence(
+  proofPath: string,
+  sourcePairs: JsonObject[],
+): PreparedProofCorrections {
+  const proofRoot = resolve(proofPath);
+  const summaryBytes = readFileSync(join(proofRoot, "summary.json"));
+  const resultsBytes = readFileSync(join(proofRoot, "results.jsonl"));
+  const tasksBytes = readFileSync(join(proofRoot, "tasks.json"));
+  const summary = object(JSON.parse(summaryBytes.toString("utf8")), "proof summary");
+  const resultRows = parseJsonl(resultsBytes, "proof results");
+  const tasksValue: unknown = JSON.parse(tasksBytes.toString("utf8"));
+  if (!Array.isArray(tasksValue) || tasksValue.length === 0) {
+    throw new Error("proof tasks must be a non-empty array");
+  }
+  const tasks = tasksValue.map((value, index) => object(value, `proof task ${index}`));
+
+  if (summary.format !== "understudy.desktop_grocery_proof.v3") {
+    throw new Error(`unsupported proof format: ${String(summary.format)}`);
+  }
+  const proofId = string(summary.proof_id, "proof summary proof_id");
+  const suiteId = string(summary.suite_id, "proof summary suite_id");
+  const suiteSha256 = string(summary.suite_sha256, "proof summary suite_sha256");
+  if (sha256(tasksBytes) !== suiteSha256) throw new Error("proof task suite hash mismatch");
+  if (summary.task_count !== tasks.length) throw new Error("proof task count mismatch");
+  if (summary.run_count !== resultRows.length) throw new Error("proof run count mismatch");
+  const split = dataSplit(summary);
+
+  const taskById = new Map(tasks.map((task, index) => {
+    const taskId = string(task.id, `proof task ${index} id`);
+    return [taskId, task] as const;
+  }));
+  if (taskById.size !== tasks.length) throw new Error("proof task ids must be unique");
+
+  const runIds = new Set<string>();
+  const sessionIds = new Set<string>();
+  const supervised = new Map<string, JsonObject>();
+  for (const [index, row] of resultRows.entries()) {
+    if (row.proof_id !== proofId || row.suite_sha256 !== suiteSha256) {
+      throw new Error(`proof result ${index} identity mismatch`);
+    }
+    const runId = string(row.run_id, `proof result ${index} run_id`);
+    const captureRunId = string(row.capture_run_id, `proof result ${index} capture_run_id`);
+    const sessionId = string(row.session_id, `proof result ${index} session_id`);
+    if (captureRunId !== runId) throw new Error(`proof result ${index} capture_run_id mismatch`);
+    if (runIds.has(runId)) throw new Error(`proof reuses run_id ${runId}`);
+    if (sessionIds.has(sessionId)) throw new Error(`proof reuses session_id ${sessionId}`);
+    runIds.add(runId);
+    sessionIds.add(sessionId);
+    const taskId = string(row.task_id, `proof result ${index} task_id`);
+    if (!taskById.has(taskId)) throw new Error(`proof result ${index} references unknown task ${taskId}`);
+    if (row.terminal_status !== "completed") {
+      throw new Error(`proof result ${index} did not complete terminally`);
+    }
+    if (row.mode === "supervised") supervised.set(runId, row);
+  }
+
+  const expected = [...supervised.entries()].flatMap(([runId, row]) =>
+    interventionMarkers(row).map((markerId) => ({ runId, markerId, row })),
+  );
+  const expectedKeys = new Set(expected.map(({ runId, markerId }) => pairKey(runId, markerId)));
+  if (expectedKeys.size !== expected.length) throw new Error("proof intervention markers must be unique");
+
+  const pairByKey = new Map<string, JsonObject>();
+  for (const [index, pair] of sourcePairs.entries()) {
+    validateCorrectionPair(pair, index);
+    const runId = pair.run_id as string;
+    if (!supervised.has(runId)) continue;
+    const key = pairKey(runId, pair.marker_id as string);
+    if (!expectedKeys.has(key)) {
+      throw new Error(`proof correction pair ${runId}/${String(pair.marker_id)} has no matching intervention`);
+    }
+    if (pairByKey.has(key)) throw new Error(`duplicate correction pair ${runId}/${String(pair.marker_id)}`);
+    pairByKey.set(key, pair);
+  }
+  const missing = expected.filter(({ runId, markerId }) => !pairByKey.has(pairKey(runId, markerId)));
+  if (missing.length > 0) {
+    throw new Error(
+      `proof correction export is incomplete; missing ${missing.length} intervention pair(s): `
+      + missing.map(({ runId, markerId }) => `${runId}/${markerId}`).join(", "),
+    );
+  }
+
+  const source: ProofSource = {
+    proof_id: proofId,
+    suite_id: suiteId,
+    suite_sha256: suiteSha256,
+    summary_sha256: sha256(summaryBytes),
+    results_sha256: sha256(resultsBytes),
+    tasks_sha256: sha256(tasksBytes),
+    data_split: split,
+  };
+  const rows = expected.map(({ runId, markerId, row }) => {
+    const pair = pairByKey.get(pairKey(runId, markerId))!;
+    const sessionId = string(row.session_id, `proof run ${runId} session_id`);
+    if (pair.session_id !== sessionId) throw new Error(`correction pair ${runId}/${markerId} session mismatch`);
+    const taskId = string(row.task_id, `proof run ${runId} task_id`);
+    const task = taskById.get(taskId)!;
+    const studentScore = object(row.student_score, `proof run ${runId} student_score`);
+    const finalScore = object(row.score, `proof run ${runId} score`);
+    const studentExact = boolean(studentScore.exact, `proof run ${runId} student exact score`);
+    const finalExact = boolean(finalScore.exact, `proof run ${runId} final exact score`);
+    const outcome = correctionOutcome(studentExact, finalExact);
+    const runUsage = object(pair.run_usage, `correction pair ${runId}/${markerId} run_usage`);
+    const exclusionReasons = [] as string[];
+    if (split !== "train" && split !== "development") exclusionReasons.push(`${split}_suite`);
+    if (runUsage.attribution_complete !== true) exclusionReasons.push("incomplete_role_usage");
+    const humanReviewed = pair.human_judgment != null;
+    return {
+      schema_version: PROOF_CORRECTION_EVIDENCE_SCHEMA,
+      proof: {
+        ...source,
+        task_id: taskId,
+        workflow: typeof task.workflow === "string" ? task.workflow : taskId,
+        run_id: runId,
+        capture_run_id: string(row.capture_run_id, `proof run ${runId} capture_run_id`),
+        session_id: sessionId,
+        marker_id: markerId,
+      },
+      correction_pair: pair,
+      evaluator_judgment: {
+        source: "deterministic_structured_output_evaluator",
+        human: false,
+        evaluator_version: "understudy.exact_object_score.v1",
+        student_exact: studentExact,
+        final_exact: finalExact,
+        student_field_accuracy: finiteNumber(
+          studentScore.field_accuracy,
+          `proof run ${runId} student field accuracy`,
+        ),
+        final_field_accuracy: finiteNumber(
+          finalScore.field_accuracy,
+          `proof run ${runId} final field accuracy`,
+        ),
+        intervention_was_warranted: !studentExact,
+        correction_succeeded: !studentExact && finalExact,
+        outcome,
+      },
+      judgment_provenance: {
+        primary_source: humanReviewed ? "human" : "deterministic_evaluator",
+        human_reviewed: humanReviewed,
+        human_judgment: pair.human_judgment ?? null,
+        deterministic_evaluator_is_human_label: false,
+      },
+      training: {
+        eligible: exclusionReasons.length === 0,
+        recommended_method: "gepa_prompt_policy_first",
+        targets: trainingTargets(outcome),
+        exclusion_reasons: exclusionReasons,
+      },
+    } satisfies ProofCorrectionEvidence;
+  });
+  const evidenceJsonl = rows.length > 0
+    ? `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`
+    : "";
+  const evidenceSha256 = sha256(evidenceJsonl);
+  const outcomes: Record<CorrectionOutcome, number> = {
+    correct_intervention: 0,
+    unsuccessful_intervention: 0,
+    false_positive_intervention: 0,
+  };
+  for (const row of rows) outcomes[row.evaluator_judgment.outcome] += 1;
+  const trainingEligibleCount = rows.filter((row) => row.training.eligible).length;
+  const humanReviewedCount = rows.filter((row) => row.judgment_provenance.human_reviewed).length;
+  const manifest: ProofCorrectionManifest = {
+    schema_version: PROOF_CORRECTION_EXPORT_SCHEMA,
+    source,
+    source_pair_count: sourcePairs.length,
+    expected_intervention_count: expected.length,
+    exported_row_count: rows.length,
+    training_eligible_count: trainingEligibleCount,
+    human_reviewed_count: humanReviewedCount,
+    deterministic_only_count: rows.length - humanReviewedCount,
+    outcomes,
+    files: { evidence_jsonl_sha256: evidenceSha256 },
+    optimizer_boundary: {
+      holdout_rows_are_training_eligible: false,
+      recommended_method: "gepa_prompt_policy_first",
+      next_action: trainingEligibleCount > 0
+        ? "Use only eligible development or train rows; preserve holdout rows for promotion evaluation."
+        : "Collect a separate development split before optimization; this proof remains evaluation-only.",
+    },
+    upload_performed: false,
+  };
+  return {
+    proof_root: proofRoot,
+    rows,
+    evidence_jsonl: evidenceJsonl,
+    evidence_sha256: evidenceSha256,
+    manifest,
+    manifest_json: `${JSON.stringify(manifest, null, 2)}\n`,
+  };
+}
+
+export function prepareProofCorrectionGepaHandoff(
+  prepared: PreparedProofCorrections,
+): PreparedProofCorrectionGepaHandoff {
+  const tasksBytes = readFileSync(join(prepared.proof_root, "tasks.json"));
+  if (sha256(tasksBytes) !== prepared.manifest.source.tasks_sha256) {
+    throw new Error("proof tasks changed after correction evidence preparation");
+  }
+  const tasksValue: unknown = JSON.parse(tasksBytes.toString("utf8"));
+  if (!Array.isArray(tasksValue)) throw new Error("proof tasks must be an array");
+  const taskById = new Map(tasksValue.map((value, index) => {
+    const task = object(value, `proof task ${index}`);
+    return [string(task.id, `proof task ${index} id`), task] as const;
+  }));
+  const evidenceSha256 = prepared.evidence_sha256;
+  const eligible = prepared.rows.filter(
+    (row) => row.training.eligible
+      && row.training.targets.some((target) => target.startsWith("teacher_continuation_")),
+  );
+  const candidates = eligible.map((row) => {
+    const task = taskById.get(row.proof.task_id);
+    if (!task) throw new Error(`GEPA row references unknown task ${row.proof.task_id}`);
+    const expected = object(task.expected, `proof task ${row.proof.task_id} expected`);
+    const pair = row.correction_pair;
+    const student = object(pair.student, `correction pair ${row.proof.marker_id} student`);
+    const supervisor = object(pair.supervisor, `correction pair ${row.proof.marker_id} supervisor`);
+    const continuation = object(pair.continuation, `correction pair ${row.proof.marker_id} continuation`);
+    const inputId = `${row.proof.run_id}:${row.proof.marker_id}`;
+    return {
+      inputId,
+      rank: sha256(`${prepared.manifest.source.proof_id}\u0000${inputId}`),
+      row,
+      workflow: row.proof.workflow,
+      prompt: string(pair.user_request, `correction pair ${row.proof.marker_id} user_request`),
+      studentPartial: string(
+        student.partial_output,
+        `correction pair ${row.proof.marker_id} student partial_output`,
+      ),
+      supervisorReason: string(
+        supervisor.reason,
+        `correction pair ${row.proof.marker_id} supervisor reason`,
+      ),
+      teacherAttempt: string(
+        continuation.output,
+        `correction pair ${row.proof.marker_id} continuation output`,
+      ),
+      answerJson: canonicalJson(expected),
+    };
+  }).sort((left, right) => left.rank.localeCompare(right.rank));
+
+  const ready = candidates.length >= 2;
+  const devCount = ready ? Math.max(1, Math.floor(candidates.length * 0.25)) : 0;
+  const grouped = new Map<string, typeof candidates>();
+  for (const candidate of candidates) {
+    const group = grouped.get(candidate.workflow) ?? [];
+    group.push(candidate);
+    grouped.set(candidate.workflow, group);
+  }
+  const devIds = new Set<string>();
+  const rankedGroups = [...grouped.entries()]
+    .filter(([, group]) => group.length >= 2)
+    .sort(([left], [right]) => sha256(left).localeCompare(sha256(right)));
+  for (const [, group] of rankedGroups) {
+    if (devIds.size >= devCount) break;
+    devIds.add(group[0].inputId);
+  }
+  for (const candidate of candidates) {
+    if (devIds.size >= devCount) break;
+    if (devIds.has(candidate.inputId)) continue;
+    const group = grouped.get(candidate.workflow)!;
+    const selectedInGroup = group.filter((row) => devIds.has(row.inputId)).length;
+    if (group.length - selectedInGroup <= 1) continue;
+    devIds.add(candidate.inputId);
+  }
+  const samples = ready ? candidates.map((candidate) => ({
+    schema_version: PROOF_CORRECTION_GEPA_SAMPLE_SCHEMA,
+    input_id: candidate.inputId,
+    split: devIds.has(candidate.inputId) ? "dev" : "train",
+    workflow: candidate.workflow,
+    prompt: candidate.prompt,
+    student_partial: candidate.studentPartial,
+    supervisor_reason: candidate.supervisorReason,
+    teacher_attempt: candidate.teacherAttempt,
+    answer_json: candidate.answerJson,
+    provenance: {
+      proof_id: candidate.row.proof.proof_id,
+      suite_sha256: candidate.row.proof.suite_sha256,
+      evidence_sha256: evidenceSha256,
+      run_id: candidate.row.proof.run_id,
+      capture_run_id: candidate.row.proof.capture_run_id,
+      session_id: candidate.row.proof.session_id,
+      marker_id: candidate.row.proof.marker_id,
+      deterministic_evaluator_is_human_label: false,
+    },
+  } satisfies ProofCorrectionGepaSample)) : [];
+  const samplesJson = `${JSON.stringify({
+    schema_version: "understudy.proof_correction_gepa_samples.v1",
+    rows: samples,
+  }, null, 2)}\n`;
+  const samplesSha256 = sha256(samplesJson);
+  const trainCount = samples.filter((sample) => sample.split === "train").length;
+  const handoff: ProofCorrectionGepaHandoff = {
+    schema_version: PROOF_CORRECTION_GEPA_HANDOFF_SCHEMA,
+    source: prepared.manifest.source,
+    evidence_sha256: evidenceSha256,
+    status: ready ? "ready" : "blocked",
+    reason: ready
+      ? null
+      : `GEPA requires at least two eligible development or train rows; found ${candidates.length}`,
+    row_count: samples.length,
+    train_count: trainCount,
+    dev_count: samples.length - trainCount,
+    excluded_count: prepared.rows.length - eligible.length,
+    split_strategy: "sha256_stratified_75_25_v1",
+    input_keys: ["workflow", "prompt", "student_partial", "supervisor_reason", "teacher_attempt"],
+    output_keys: ["answer_json"],
+    recommended_adapter: "dspy-gepa",
+    command_template: "understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples <samples-path> --input-keys workflow,prompt,student_partial,supervisor_reason,teacher_attempt --output-keys answer_json --model <gateway-model> --max-metric-calls 24",
+    files: { samples_sha256: samplesSha256 },
+    provider_calls_performed: false,
+    upload_performed: false,
+  };
+  return {
+    samples,
+    samples_json: samplesJson,
+    samples_sha256: samplesSha256,
+    handoff,
+    handoff_json: `${JSON.stringify(handoff, null, 2)}\n`,
+  };
+}

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   mkdirSync,
@@ -26,6 +27,11 @@ const conformanceEvidencePath = join(root, "desktop-runtime-conformance.json");
 const readinessEvidencePath = join(root, "desktop-runtime-readiness.json");
 const correctionOutputPath = join(root, "exports", "correction-pairs.jsonl");
 const correctionMetricsPath = join(root, "exports", "supervision-metrics.json");
+const proofCorrectionRoot = join(root, "proof-correction-fixture");
+const proofCorrectionOutputPath = join(root, "exports", "proof-corrections.jsonl");
+const proofCorrectionManifestPath = join(root, "exports", "proof-corrections.manifest.json");
+const proofCorrectionGepaSamplesPath = join(root, "exports", "proof-corrections.gepa-samples.json");
+const proofCorrectionGepaHandoffPath = join(root, "exports", "proof-corrections.gepa-handoff.json");
 const token = "desktop-api-test-token-".padEnd(64, "a");
 let server;
 let port;
@@ -148,8 +154,51 @@ function writeReleaseEvidence() {
   chmodSync(readinessEvidencePath, 0o600);
 }
 
+function writeProofCorrectionFixture() {
+  mkdirSync(proofCorrectionRoot, { recursive: true, mode: 0o700 });
+  const tasks = [{
+    id: "desktop-proof-task",
+    workflow: "ops-classification",
+    title: "Desktop proof task",
+    prompt: "synthetic",
+    expected: { answer: "correct" },
+  }];
+  const tasksBytes = Buffer.from(`${JSON.stringify(tasks)}\n`);
+  const suiteSha256 = createHash("sha256").update(tasksBytes).digest("hex");
+  const summary = {
+    format: "understudy.desktop_grocery_proof.v3",
+    proof_id: "desktop-proof-fixture",
+    suite_id: "promotion",
+    suite_sha256: suiteSha256,
+    task_count: 1,
+    run_count: 1,
+  };
+  const result = {
+    proof_id: summary.proof_id,
+    suite_sha256: suiteSha256,
+    run_id: "run-desktop",
+    capture_run_id: "run-desktop",
+    session_id: "session-desktop",
+    task_id: "desktop-proof-task",
+    mode: "supervised",
+    score: { exact: true, matched_fields: 1, total_fields: 1, field_accuracy: 1 },
+    student_score: { exact: false, matched_fields: 0, total_fields: 1, field_accuracy: 0 },
+    supervisor_intervened: true,
+    verdicts: [{ verdict: "interrupt", marker_id: "run-desktop:intervention:0" }],
+    terminal_status: "completed",
+  };
+  writeFileSync(join(proofCorrectionRoot, "summary.json"), `${JSON.stringify(summary)}\n`, {
+    mode: 0o600,
+  });
+  writeFileSync(join(proofCorrectionRoot, "results.jsonl"), `${JSON.stringify(result)}\n`, {
+    mode: 0o600,
+  });
+  writeFileSync(join(proofCorrectionRoot, "tasks.json"), tasksBytes, { mode: 0o600 });
+}
+
 before(async () => {
   writeReleaseEvidence();
+  writeProofCorrectionFixture();
   server = createServer(async (request, response) => {
     if (request.url === "/health") {
       response.writeHead(200);
@@ -540,6 +589,22 @@ describe("desktop API CLI", () => {
       resolve("schemas/understudy.supervision_metrics.v1.schema.json"),
       "utf8",
     ));
+    const proofCorrectionSchema = JSON.parse(readFileSync(
+      resolve("schemas/understudy.proof_correction_evidence.v1.schema.json"),
+      "utf8",
+    ));
+    const proofCorrectionExportSchema = JSON.parse(readFileSync(
+      resolve("schemas/understudy.proof_correction_export.v1.schema.json"),
+      "utf8",
+    ));
+    const proofCorrectionGepaSamplesSchema = JSON.parse(readFileSync(
+      resolve("schemas/understudy.proof_correction_gepa_samples.v1.schema.json"),
+      "utf8",
+    ));
+    const proofCorrectionGepaHandoffSchema = JSON.parse(readFileSync(
+      resolve("schemas/understudy.proof_correction_gepa_handoff.v1.schema.json"),
+      "utf8",
+    ));
     assert.equal(pairSchema.properties.schema_version.const, "understudy.correction_pair.v1");
     assert.ok(pairSchema.required.includes("run_id"));
     assert.ok(pairSchema.required.includes("human_judgment"));
@@ -550,6 +615,33 @@ describe("desktop API CLI", () => {
     );
     assert.ok(metricsSchema.required.includes("intervention_precision"));
     assert.ok(metricsSchema.required.includes("false_positive_nudge_rate"));
+    assert.equal(
+      proofCorrectionSchema.properties.evaluator_judgment.properties.human.const,
+      false,
+    );
+    assert.equal(
+      proofCorrectionSchema.properties.judgment_provenance.properties
+        .deterministic_evaluator_is_human_label.const,
+      false,
+    );
+    assert.equal(
+      proofCorrectionExportSchema.properties.optimizer_boundary.properties
+        .holdout_rows_are_training_eligible.const,
+      false,
+    );
+    assert.equal(
+      proofCorrectionGepaSamplesSchema.properties.rows.items.properties
+        .provenance.properties.deterministic_evaluator_is_human_label.const,
+      false,
+    );
+    assert.equal(
+      proofCorrectionGepaHandoffSchema.properties.provider_calls_performed.const,
+      false,
+    );
+    assert.equal(
+      proofCorrectionGepaHandoffSchema.properties.recommended_adapter.const,
+      "dspy-gepa",
+    );
     assert.equal(contract.security[0].desktopBearer.length, 0);
   });
 
@@ -867,6 +959,60 @@ describe("desktop API CLI", () => {
     ]);
     assert.notEqual(refused.status, 0);
     assert.match(refused.stderr, /refusing to replace immutable artifact/);
+  });
+
+  it("prepares proof-scoped deterministic correction evidence without claiming human labels", async () => {
+    const result = await runCli([
+      "desktop", "supervision", "prepare-proof",
+      "--proof", proofCorrectionRoot,
+      "--output", proofCorrectionOutputPath,
+      "--manifest-output", proofCorrectionManifestPath,
+      "--gepa-samples-output", proofCorrectionGepaSamplesPath,
+      "--gepa-handoff-output", proofCorrectionGepaHandoffPath,
+      "--json",
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    const value = JSON.parse(result.stdout);
+    assert.equal(value.upload_performed, false);
+    assert.equal(value.data_split, "holdout");
+    assert.equal(value.correction_evidence.row_count, 1);
+    assert.equal(value.judgments.human_reviewed, 0);
+    assert.equal(value.judgments.deterministic_only, 1);
+    assert.equal(value.judgments.deterministic_evaluator_is_human_label, false);
+    assert.equal(value.training.eligible_rows, 0);
+    assert.equal(value.training.holdout_rows_are_training_eligible, false);
+    assert.equal(value.gepa_handoff.status, "blocked");
+    assert.equal(value.gepa_handoff.samples.row_count, 0);
+    assert.equal(value.gepa_handoff.provider_calls_performed, false);
+    assert.deepEqual(value.outcomes, {
+      correct_intervention: 1,
+      unsuccessful_intervention: 0,
+      false_positive_intervention: 0,
+    });
+    const rows = readFileSync(proofCorrectionOutputPath, "utf8")
+      .trim()
+      .split("\n")
+      .map(JSON.parse);
+    assert.equal(rows[0].schema_version, "understudy.proof_correction_evidence.v1");
+    assert.equal(rows[0].proof.run_id, rows[0].proof.capture_run_id);
+    assert.equal(rows[0].judgment_provenance.human_reviewed, false);
+    assert.equal(rows[0].training.eligible, false);
+    const manifest = JSON.parse(readFileSync(proofCorrectionManifestPath, "utf8"));
+    assert.equal(manifest.schema_version, "understudy.proof_correction_export.v1");
+    assert.equal(manifest.files.evidence_jsonl_sha256, value.correction_evidence.sha256);
+    const gepaSamples = JSON.parse(readFileSync(proofCorrectionGepaSamplesPath, "utf8"));
+    const gepaHandoff = JSON.parse(readFileSync(proofCorrectionGepaHandoffPath, "utf8"));
+    assert.equal(gepaSamples.schema_version, "understudy.proof_correction_gepa_samples.v1");
+    assert.deepEqual(gepaSamples.rows, []);
+    assert.equal(gepaHandoff.schema_version, "understudy.proof_correction_gepa_handoff.v1");
+    assert.equal(gepaHandoff.status, "blocked");
+    assert.equal(gepaHandoff.files.samples_sha256, value.gepa_handoff.samples.sha256);
+    if (process.platform !== "win32") {
+      assert.equal(statSync(proofCorrectionOutputPath).mode & 0o077, 0);
+      assert.equal(statSync(proofCorrectionManifestPath).mode & 0o077, 0);
+      assert.equal(statSync(proofCorrectionGepaSamplesPath).mode & 0o077, 0);
+      assert.equal(statSync(proofCorrectionGepaHandoffPath).mode & 0o077, 0);
+    }
   });
 
   it("records an explicit supervisor judgment", async () => {

--- a/tests/desktop-grocery-proof.test.mjs
+++ b/tests/desktop-grocery-proof.test.mjs
@@ -35,6 +35,7 @@ import {
 describe("desktop grocery proof", () => {
   it("keeps the 30-task grocery promotion suite frozen and balanced", () => {
     assert.equal(resolveGrocerySuiteFile("smoke"), "tasks.json");
+    assert.equal(resolveGrocerySuiteFile("development"), "tasks.development.json");
     assert.equal(resolveGrocerySuiteFile("promotion"), "tasks.promotion.json");
     assert.throws(() => resolveGrocerySuiteFile("unknown"), /unknown grocery proof suite/);
     const bytes = readFileSync(join(
@@ -65,6 +66,39 @@ describe("desktop grocery proof", () => {
     assert.ok(identities.every(({ runId, captureRunId }) => runId === captureRunId));
     assert.ok(identities.every(({ sessionId }) => sessionId.endsWith("-session")));
     assert.ok(identities.every(({ runId, sessionId }) => runId.length <= 200 && sessionId.length <= 200));
+  });
+
+  it("keeps a separate balanced development suite out of the frozen promotion slice", () => {
+    const developmentBytes = readFileSync(join(
+      process.cwd(),
+      "experiments",
+      "desktop-grocery-proof",
+      "tasks.development.json",
+    ));
+    assert.equal(
+      createHash("sha256").update(developmentBytes).digest("hex"),
+      "e124fd535000d3c3eb259eb0ae17b43a7e1bcd98a66e735a3cfa6aebadd36ca5",
+    );
+    const development = JSON.parse(developmentBytes);
+    const promotion = JSON.parse(readFileSync(join(
+      process.cwd(),
+      "experiments",
+      "desktop-grocery-proof",
+      "tasks.promotion.json",
+    )));
+    assert.equal(development.length, 18);
+    assert.equal(new Set(development.map((task) => task.id)).size, 18);
+    assert.deepEqual(
+      Object.fromEntries(Object.entries(Object.groupBy(development, (task) => task.workflow))
+        .map(([workflow, rows]) => [workflow, rows.length])),
+      { "codebase-analysis": 6, "cart-assistant": 6, "ops-classification": 6 },
+    );
+    assert.ok(development.every((task) => Object.keys(task.expected).length === 3));
+    assert.ok(development.every((task) => /one minified JSON object/i.test(task.prompt)));
+    assert.deepEqual(
+      development.map((task) => task.id).filter((id) => promotion.some((task) => task.id === id)),
+      [],
+    );
   });
 
   it("extracts bounded JSON and scores exact fields without an LLM judge", () => {

--- a/tests/proof-corrections.test.mjs
+++ b/tests/proof-corrections.test.mjs
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  prepareProofCorrectionEvidence,
+  prepareProofCorrectionGepaHandoff,
+} from "../dist/desktop/proof-corrections.js";
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function correctionPair({ humanJudgment = null, index = 0 } = {}) {
+  const runId = index === 0 ? "proof-run" : `proof-run-${index}`;
+  return {
+    schema_version: "understudy.correction_pair.v1",
+    event_schema: "understudy-conversation-runtime-event-v1",
+    runtime_id: "pi-agent-session",
+    session_id: `${runId}-session`,
+    run_id: runId,
+    marker_id: `${runId}:intervention:0`,
+    verdict_event_id: `${runId}:12`,
+    verdict_sequence: 12,
+    captured_at: "2026-07-14T00:00:00Z",
+    user_request: "synthetic structured-output request",
+    student: {
+      model: "understudy-small",
+      status: "interrupted",
+      partial_output: '{"answer":"wrong"}',
+      intervention_at_chars: 18,
+    },
+    supervisor: {
+      action: "interrupt",
+      source: "model",
+      reason: "The structured answer is incorrect.",
+      raw: "INTERRUPT",
+      probabilities: { interrupt: 0.9, continue: 0.1 },
+      probability_kind: "first_token_probability_from_logprob",
+    },
+    continuation: {
+      model: "understudy-main",
+      authorship: "teacher_continuation",
+      output: '{"answer":"correct"}',
+    },
+    tool_results: [],
+    run_usage: {
+      scope: "entire_canonical_run",
+      student: {},
+      supervisor: {},
+      teacher: {},
+      attribution_complete: true,
+      incomplete_roles: [],
+    },
+    human_judgment: humanJudgment,
+  };
+}
+
+function writeProof(root, {
+  dataSplit,
+  captureRunId = "proof-run",
+  finalExact = true,
+  rowCount = 1,
+} = {}) {
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  const tasks = Array.from({ length: rowCount }, (_, index) => ({
+    id: index === 0 ? "task-one" : `task-${index}`,
+    workflow: "ops-classification",
+    title: "Synthetic classification",
+    prompt: `synthetic ${index}`,
+    expected: { answer: `correct-${index}` },
+  }));
+  const tasksBytes = Buffer.from(`${JSON.stringify(tasks)}\n`);
+  const suiteHash = sha256(tasksBytes);
+  const rows = tasks.map((task, index) => {
+    const runId = index === 0 ? "proof-run" : `proof-run-${index}`;
+    return {
+    proof_id: "proof-fixture",
+    suite_sha256: suiteHash,
+    run_id: runId,
+    capture_run_id: index === 0 ? captureRunId : runId,
+    session_id: `${runId}-session`,
+    task_id: task.id,
+    mode: "supervised",
+    score: {
+      exact: finalExact,
+      matched_fields: finalExact ? 1 : 0,
+      total_fields: 1,
+      field_accuracy: finalExact ? 1 : 0,
+    },
+    student_score: {
+      exact: false,
+      matched_fields: 0,
+      total_fields: 1,
+      field_accuracy: 0,
+    },
+    supervisor_intervened: true,
+    verdicts: [{
+      verdict: "interrupt",
+      marker_id: `${runId}:intervention:0`,
+    }],
+    terminal_status: "completed",
+  }});
+  const summary = {
+    format: "understudy.desktop_grocery_proof.v3",
+    proof_id: "proof-fixture",
+    suite_id: dataSplit === "development" ? "development" : "promotion",
+    ...(dataSplit ? { data_split: dataSplit } : {}),
+    suite_sha256: suiteHash,
+    task_count: tasks.length,
+    run_count: rows.length,
+  };
+  writeFileSync(join(root, "summary.json"), `${JSON.stringify(summary)}\n`, { mode: 0o600 });
+  writeFileSync(
+    join(root, "results.jsonl"),
+    `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
+    { mode: 0o600 },
+  );
+  writeFileSync(join(root, "tasks.json"), tasksBytes, { mode: 0o600 });
+}
+
+describe("proof-scoped correction evidence", () => {
+  it("keeps a promotion proof as deterministic evaluation evidence, never a human label", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-proof-corrections-"));
+    try {
+      writeProof(root);
+      const prepared = prepareProofCorrectionEvidence(root, [correctionPair()]);
+      assert.equal(prepared.rows.length, 1);
+      assert.equal(prepared.manifest.source.data_split, "holdout");
+      assert.equal(prepared.manifest.training_eligible_count, 0);
+      assert.equal(prepared.manifest.deterministic_only_count, 1);
+      assert.deepEqual(prepared.manifest.outcomes, {
+        correct_intervention: 1,
+        unsuccessful_intervention: 0,
+        false_positive_intervention: 0,
+      });
+      const row = prepared.rows[0];
+      assert.equal(row.proof.run_id, row.proof.capture_run_id);
+      assert.equal(row.evaluator_judgment.source, "deterministic_structured_output_evaluator");
+      assert.equal(row.evaluator_judgment.human, false);
+      assert.equal(row.judgment_provenance.human_reviewed, false);
+      assert.equal(row.judgment_provenance.deterministic_evaluator_is_human_label, false);
+      assert.equal(row.training.eligible, false);
+      assert.deepEqual(row.training.exclusion_reasons, ["holdout_suite"]);
+      assert.match(prepared.manifest.optimizer_boundary.next_action, /separate development split/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a separately declared development split while preserving human provenance", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-proof-corrections-dev-"));
+    try {
+      writeProof(root, { dataSplit: "development", finalExact: false });
+      const humanJudgment = {
+        helpful: true,
+        correct_action: "interrupt",
+        justification: "The intervention was warranted, but the continuation was still wrong.",
+        created_at: "2026-07-14T00:01:00Z",
+      };
+      const prepared = prepareProofCorrectionEvidence(
+        root,
+        [correctionPair({ humanJudgment })],
+      );
+      const row = prepared.rows[0];
+      assert.equal(prepared.manifest.training_eligible_count, 1);
+      assert.equal(prepared.manifest.human_reviewed_count, 1);
+      assert.equal(row.judgment_provenance.primary_source, "human");
+      assert.equal(row.judgment_provenance.human_judgment, humanJudgment);
+      assert.equal(row.evaluator_judgment.outcome, "unsuccessful_intervention");
+      assert.deepEqual(row.training.targets, ["teacher_continuation_repair"]);
+      assert.equal(row.training.eligible, true);
+      assert.deepEqual(row.training.exclusion_reasons, []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepares a deterministic train/dev GEPA handoff only from eligible rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-proof-corrections-gepa-"));
+    try {
+      writeProof(root, { dataSplit: "development", finalExact: false, rowCount: 4 });
+      const prepared = prepareProofCorrectionEvidence(
+        root,
+        Array.from({ length: 4 }, (_, index) => correctionPair({ index })),
+      );
+      const gepa = prepareProofCorrectionGepaHandoff(prepared);
+      assert.equal(gepa.handoff.status, "ready");
+      assert.equal(gepa.handoff.row_count, 4);
+      assert.equal(gepa.handoff.train_count, 3);
+      assert.equal(gepa.handoff.dev_count, 1);
+      assert.equal(gepa.handoff.excluded_count, 0);
+      assert.equal(gepa.handoff.provider_calls_performed, false);
+      assert.equal(gepa.handoff.upload_performed, false);
+      assert.deepEqual(gepa.handoff.output_keys, ["answer_json"]);
+      assert.equal(new Set(gepa.samples.map((row) => row.input_id)).size, 4);
+      assert.equal(gepa.samples.filter((row) => row.split === "dev").length, 1);
+      assert.ok(gepa.samples.every(
+        (row) => row.provenance.deterministic_evaluator_is_human_label === false,
+      ));
+      assert.ok(gepa.samples.every((row) => JSON.parse(row.answer_json).answer));
+
+      const repeated = prepareProofCorrectionGepaHandoff(prepared);
+      assert.equal(repeated.samples_sha256, gepa.samples_sha256);
+      assert.deepEqual(repeated.samples, gepa.samples);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on missing pairs or capture identity drift", () => {
+    const missingRoot = mkdtempSync(join(tmpdir(), "understudy-proof-corrections-missing-"));
+    const driftRoot = mkdtempSync(join(tmpdir(), "understudy-proof-corrections-drift-"));
+    try {
+      writeProof(missingRoot);
+      assert.throws(
+        () => prepareProofCorrectionEvidence(missingRoot, []),
+        /missing 1 intervention pair/,
+      );
+      writeProof(driftRoot, { captureRunId: "different-capture" });
+      assert.throws(
+        () => prepareProofCorrectionEvidence(driftRoot, [correctionPair()]),
+        /capture_run_id mismatch/,
+      );
+    } finally {
+      rmSync(missingRoot, { recursive: true, force: true });
+      rmSync(driftRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What changed

- add a frozen 18-task development suite that is disjoint from the promotion holdout
- join immutable proof runs to canonical correction pairs by run, capture, session, and marker identity
- keep deterministic evaluator judgments separate from human labels and fail closed on incomplete attribution
- automatically prepare owner-only DSPy/GEPA samples from eligible teacher-continuation rows with a deterministic workflow-stratified 75/25 train/dev split
- keep promotion and smoke evidence evaluation-only; no upload or provider call occurs during preparation

## Why

The previous correction export was not proof-scoped and did not provide a safe optimizer boundary. That made it too easy to treat deterministic benchmark judgments as human labels or accidentally train on the frozen promotion slice.

## Live evidence

The development suite completed 54/54 local runs with matching capture identities and event files:

- small-only: 5/18 exact
- teacher-only: 11/18 exact
- supervised: 5/18 exact
- intervention precision: 100%; recall: 61.54%; correction success: 0%
- supervisor token overhead: 46.62%

The proof-scoped export joined all 8 interventions and prepared 6 train / 2 dev GEPA samples. All 8 judgments are explicitly deterministic-only; the optimizer dry run remained blocked without explicit execution approval.

## Validation

- npm run check
- 300 tests passed
- TypeScript build and typecheck passed
- 33 public skills validated
- npm package smoke passed
- live immutable proof and owner-only export validation passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->