### PR TITLE
Enforce GEPA provider spend reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,14 @@ handoff with a deterministic 75/25 train/dev split. Its inputs preserve the
 small-model partial, supervisor reason, and failed teacher attempt; its target
 is the frozen expected JSON. The handoff is preparation only: it performs no
 provider call and never admits promotion or smoke rows.
+Executing the provider-backed DSPy adapter additionally requires an approved
+dollar cap and explicit input/output token prices. Before every request, the
+runtime reserves a conservative upper bound from the serialized input bytes and
+the configured output-token ceiling; it disables client-side retries and stops
+before a request whose reservation could exceed the cap. Candidate, proof, and terminal
+run-state artifacts record the cumulative reservation, metered token
+attribution, and user-supplied price basis. This is a fail-closed cap under that
+declared basis, not a claim about the provider's final invoice.
 The strict tool proof is also local-only: Pi runs each selected model serially,
 the CLI restores the previous residency set in a `finally` path, and promotion
 requires the frozen 30-task suite repeated three times with complete owner-only

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -55,7 +55,7 @@ understudy route-decision plan --workload-card .understudy/workload-discovery/wo
 understudy skills --search gepa
 understudy optimize-workload check --repo .
 understudy optimize-workload dry-run --repo .
-understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model gpt-4o-mini --execute
+understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model gpt-4o-mini --budget-usd <approved-usd> --input-usd-per-million <input-price> --output-usd-per-million <output-price> --execute
 understudy optimize-workload adapter run --repo . --adapter eval-input-gepa --manifest eval-input-manifest.json --execute
 understudy value report --workload-card .understudy/workload-discovery/workload-card.json --route-decision .understudy/route-decision/route-decision-packet.json --requests-per-month 10000
 ```
@@ -152,7 +152,14 @@ exposed through
 authenticated Understudy gateway key, passes it into the local `uv` runtime as
 environment, configures DSPy against the gateway, runs train/dev rows only,
 excludes holdout, and writes `.understudy/optimize-workload/candidate.json`
-plus `proof-packet.json`.
+plus `proof-packet.json`. Live execution requires `--budget-usd`,
+`--input-usd-per-million`, and `--output-usd-per-million` before auth is
+resolved. The runtime disables client-side retries, shares one cumulative spend
+ledger across DSPy LM copies, and reserves a conservative per-call upper bound
+before provider execution. Missing usage, usage beyond the reservation, or a
+next call that could cross the cap produces an owner-only terminal run state
+instead of continuing. Recorded cost is attribution under the supplied token
+prices, not the provider's final bill.
 
 The generic adapter registry is exposed through
 `optimize-workload adapter run`. The first registry-backed non-DSPy adapter

--- a/docs/optimize-workload-contract.md
+++ b/docs/optimize-workload-contract.md
@@ -124,7 +124,7 @@ Future TypeScript commands should follow this behavior:
 
 ```bash
 understudy optimize-workload dry-run --repo .
-understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model gpt-4o-mini --execute
+understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model gpt-4o-mini --budget-usd <approved-usd> --input-usd-per-million <input-price> --output-usd-per-million <output-price> --execute
 understudy optimize-workload adapter run --repo . --adapter eval-input-gepa --manifest eval-input-manifest.json --execute
 ```
 
@@ -141,10 +141,14 @@ Required behavior:
 - Rubric scoring and DSPy scaffold/parity: keep as skill/reference guidance
   guidance unless a concrete adapter needs executable support.
 - DSPy GEPA adapter: expose through `adapter run`, require `--execute`, require
-  an explicit model/deployment, resolve the Understudy API key without printing
-  it, pass auth only through the child environment, run train/dev rows only,
-  exclude holdout rows, and write a candidate/proof packet with
-  `provider_calls: true`.
+  an explicit model/deployment, positive dollar cap, and non-zero user-supplied
+  token-price basis before resolving auth. Pass auth only through the child
+  environment, disable client-side retries, and reserve a conservative
+  price-basis upper bound before every request. Stop before a reservation could cross the
+  cap; fail closed when usage is missing or exceeds the reservation. Run
+  train/dev rows only, exclude holdout rows, and write owner-only candidate,
+  proof, and terminal run-state artifacts with reservation and attribution
+  evidence. The attribution is not a provider-invoice claim.
 - Eval-input GEPA adapter: require `--execute`, read a local manifest with
   `rows`, `inputs`, or `inputs_path`, support exact-match label and tool-call
   objectives, invoke upstream `gepa.optimize` through `uv`, run train/dev rows

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -109,8 +109,12 @@ validator kinds in [`reference.md`](reference.md):
    `optimize-workload adapter run --adapter <name> ... --execute`.
    `eval-input-gepa` runs upstream GEPA locally without provider calls unless a
    model-backed path is explicitly selected. `adapter run --adapter dspy-gepa
-   --execute` resolves the Understudy API key, passes it to the child process
-   through environment only, and runs train/dev rows through the gateway. GEPA's
+   --execute` additionally requires an approved dollar cap and explicit input
+   and output token prices before it resolves the Understudy API key. It passes
+   auth to the child process through environment only, disables client-side
+   retries, and reserves each request against one cumulative price-basis ledger before
+   running train/dev rows through the gateway. Treat the resulting attribution
+   as a conservative cap under the supplied prices, not a provider invoice. GEPA's
    edge is natural-language feedback: the metric must return a diagnosis of
    *why* each failing row failed and what to change, not a bare score — bland
    feedback wastes the optimizer. For an agentic workload this means the
@@ -123,7 +127,8 @@ validator kinds in [`reference.md`](reference.md):
    [`../../docs/optimize-workload-contract.md`](../../docs/optimize-workload-contract.md)
    for adapter, metric feedback, and claim packet details.
 6. When GEPA is available and explicitly approved, run train/dev-only and
-   record the command, model/deployment, metric-call budget, seed, selected
+   record the command, model/deployment, metric-call budget, dollar cap, token
+   price basis, reserved upper bound, attributed usage, seed, selected
    candidate, rejected variants when available, and whether provider calls were
    made through Understudy.
 7. Freeze the candidate before any holdout validation.

--- a/skills/optimize-workload/reference.md
+++ b/skills/optimize-workload/reference.md
@@ -175,7 +175,8 @@ Three ways to optimize, picked by commitment and workload shape:
 3. **Program lane (opt-in).** The agent can scaffold a reusable DSPy program
    from local samples using the program-scaffold pattern, verify parity, then
    run the approval-gated `adapter run --adapter dspy-gepa --execute` path
-   against the Understudy gateway. Full GEPA optimization over that program is
+   against the Understudy gateway with an explicit dollar cap and input/output
+   token-price basis. Full GEPA optimization over that program is
    gated by parity: the scaffolded program must reproduce the incumbent
    baseline before optimization, or you optimize a reconstruction that diverges
    from production.

--- a/src/commands/optimize-workload.ts
+++ b/src/commands/optimize-workload.ts
@@ -63,6 +63,9 @@ export function registerOptimizeWorkloadCommand(program: Command): void {
     .option("--train-split <value>", "Train split value", "train")
     .option("--dev-split <value>", "Dev split value", "dev")
     .option("--max-tokens <number>", "Per-call max token cap", "256")
+    .option("--budget-usd <amount>", "Required spend cap under the supplied DSPy token-price basis")
+    .option("--input-usd-per-million <amount>", "Required input-token price basis for DSPy GEPA")
+    .option("--output-usd-per-million <amount>", "Required output-token price basis for DSPy GEPA")
     .option("--score-objective <name>", "exact_match, tool_call, or mixed", "exact_match")
     .option("--reflection-minibatch-size <number>", "GEPA reflection minibatch size", "1")
     .option("--execute", "After explicit approval, create a uv env and run the adapter")
@@ -81,6 +84,9 @@ export function registerOptimizeWorkloadCommand(program: Command): void {
         trainSplit?: string;
         devSplit?: string;
         maxTokens?: string;
+        budgetUsd?: string;
+        inputUsdPerMillion?: string;
+        outputUsdPerMillion?: string;
         scoreObjective?: string;
         reflectionMinibatchSize?: string;
         execute?: boolean;

--- a/src/desktop/proof-corrections.ts
+++ b/src/desktop/proof-corrections.ts
@@ -561,7 +561,7 @@ export function prepareProofCorrectionGepaHandoff(
     input_keys: ["workflow", "prompt", "student_partial", "supervisor_reason", "teacher_attempt"],
     output_keys: ["answer_json"],
     recommended_adapter: "dspy-gepa",
-    command_template: "understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples <samples-path> --input-keys workflow,prompt,student_partial,supervisor_reason,teacher_attempt --output-keys answer_json --model <gateway-model> --max-metric-calls 24",
+    command_template: "understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples <samples-path> --input-keys workflow,prompt,student_partial,supervisor_reason,teacher_attempt --output-keys answer_json --model <gateway-model> --max-metric-calls 24 --budget-usd <approved-usd> --input-usd-per-million <input-price> --output-usd-per-million <output-price> --execute",
     files: { samples_sha256: samplesSha256 },
     provider_calls_performed: false,
     upload_performed: false,

--- a/src/optimize-workload.ts
+++ b/src/optimize-workload.ts
@@ -80,6 +80,9 @@ type AdapterRunOptions = {
   trainSplit?: string;
   devSplit?: string;
   maxTokens?: string;
+  budgetUsd?: string;
+  inputUsdPerMillion?: string;
+  outputUsdPerMillion?: string;
   scoreObjective?: string;
   reflectionMinibatchSize?: string;
 };
@@ -118,6 +121,18 @@ const adapterRegistry: Record<string, UvAdapterSpec> = {
       if (!options.model) {
         throw new Error("--model is required for dspy-gepa");
       }
+      const budgetUsd = requiredPositiveNumber(options.budgetUsd, "--budget-usd");
+      const inputUsdPerMillion = requiredNonNegativeNumber(
+        options.inputUsdPerMillion,
+        "--input-usd-per-million",
+      );
+      const outputUsdPerMillion = requiredNonNegativeNumber(
+        options.outputUsdPerMillion,
+        "--output-usd-per-million",
+      );
+      if (inputUsdPerMillion === 0 && outputUsdPerMillion === 0) {
+        throw new Error("dspy-gepa requires a non-zero input or output price basis");
+      }
       return [
         "dspy-gepa",
         "--repo",
@@ -142,6 +157,12 @@ const adapterRegistry: Record<string, UvAdapterSpec> = {
         options.devSplit ?? "dev",
         "--max-tokens",
         options.maxTokens ?? "256",
+        "--budget-usd",
+        String(budgetUsd),
+        "--input-usd-per-million",
+        String(inputUsdPerMillion),
+        "--output-usd-per-million",
+        String(outputUsdPerMillion),
       ];
     },
   },
@@ -242,6 +263,24 @@ function parseBudgetUsd(budgetUsd: string | undefined): number | null {
   const parsed = Number(budgetUsd);
   if (!Number.isFinite(parsed) || parsed < 0) {
     throw new Error(`Invalid --budget-usd value "${budgetUsd}". Use a non-negative number.`);
+  }
+  return parsed;
+}
+
+function requiredPositiveNumber(value: string | undefined, flag: string): number {
+  if (value === undefined) throw new Error(`${flag} is required for provider-backed dspy-gepa`);
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive number`);
+  }
+  return parsed;
+}
+
+function requiredNonNegativeNumber(value: string | undefined, flag: string): number {
+  if (value === undefined) throw new Error(`${flag} is required for provider-backed dspy-gepa`);
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative number`);
   }
   return parsed;
 }
@@ -399,6 +438,7 @@ export function runOptimizerAdapter(options: AdapterRunOptions): Record<string, 
       reason: "pass --execute after explicit approval to run this adapter",
     };
   }
+  const args = adapter.buildArgs(repo, options);
   const env: Record<string, string> = {};
   if (adapter.requiresAuth(options)) {
     const auth = resolveOptimizerAuth(repo);
@@ -406,7 +446,7 @@ export function runOptimizerAdapter(options: AdapterRunOptions): Record<string, 
     env.UNDERSTUDY_GATEWAY_URL = auth.gatewayUrl;
     env.UNDERSTUDY_AUTH_SOURCE = auth.source;
   }
-  const out = runUvPython(repo, runtimePath, adapter.buildArgs(repo, options), adapter.packages, env);
+  const out = runUvPython(repo, runtimePath, args, adapter.packages, env);
   freezeCandidateIntoActiveExperiment(repo, out);
   return out;
 }

--- a/src/optimize-workload/runtime-source.ts
+++ b/src/optimize-workload/runtime-source.ts
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +36,198 @@ def normalize_dspy_model(value: str) -> str:
     if "/" in value:
         return value
     return f"openai/{value}"
+
+
+class SpendBudgetExceeded(RuntimeError):
+    pass
+
+
+class SpendEvidenceError(RuntimeError):
+    pass
+
+
+def positive_float(value: Any, label: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or not parsed > 0:
+        raise ValueError(f"{label} must be positive")
+    return parsed
+
+
+def non_negative_float(value: Any, label: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValueError(f"{label} must be non-negative")
+    return parsed
+
+
+def input_token_ceiling_from_bytes(message_bytes: int, message_count: int) -> int:
+    if message_bytes < 0 or message_count < 0:
+        raise ValueError("message bytes and count must be non-negative")
+    # Byte-level tokenizers cannot emit more tokens than UTF-8 bytes for the
+    # serialized content. The fixed and per-message allowances cover chat
+    # framing, provider wrappers, and DSPy signature material not visible in
+    # the message text. This is intentionally conservative.
+    return message_bytes + 4096 + (64 * message_count)
+
+
+def serialized_message_shape(prompt: str | None, messages: list[dict[str, Any]] | None) -> tuple[int, int]:
+    normalized = messages or [{"role": "user", "content": prompt or ""}]
+    serialized = json.dumps(normalized, ensure_ascii=False, separators=(",", ":"), default=str)
+    return len(serialized.encode("utf-8")), len(normalized)
+
+
+def token_price(input_tokens: int, output_tokens: int, input_usd_per_million: float, output_usd_per_million: float) -> float:
+    return (
+        (input_tokens * input_usd_per_million)
+        + (output_tokens * output_usd_per_million)
+    ) / 1_000_000
+
+
+def usage_token_count(usage: Any, *names: str) -> int | None:
+    for name in names:
+        if isinstance(usage, dict):
+            value = usage.get(name)
+        else:
+            value = getattr(usage, name, None)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)) and value >= 0 and int(value) == value:
+            return int(value)
+    return None
+
+
+def write_owner_only_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    os.replace(temporary, path)
+    path.chmod(0o600)
+
+
+class SpendLedger:
+    def __init__(
+        self,
+        budget_usd: float,
+        input_usd_per_million: float,
+        output_usd_per_million: float,
+    ) -> None:
+        self.budget_usd = positive_float(budget_usd, "budget_usd")
+        self.input_usd_per_million = non_negative_float(
+            input_usd_per_million,
+            "input_usd_per_million",
+        )
+        self.output_usd_per_million = non_negative_float(
+            output_usd_per_million,
+            "output_usd_per_million",
+        )
+        if self.input_usd_per_million == 0 and self.output_usd_per_million == 0:
+            raise ValueError("at least one token price must be non-zero")
+        self.reserved_upper_bound_usd = 0.0
+        self.attributed_cost_usd = 0.0
+        self.calls_attempted = 0
+        self.calls_completed = 0
+        self.usage_complete = True
+        self.entries: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> SpendLedger:
+        # DSPy copies LMs for rollout variants. Every copy must share the same
+        # process-wide ledger or a copied optimizer could bypass the cap.
+        return self
+
+    def projected_reservation(self, input_token_ceiling: int, output_token_ceiling: int) -> float:
+        return token_price(
+            input_token_ceiling,
+            output_token_ceiling,
+            self.input_usd_per_million,
+            self.output_usd_per_million,
+        )
+
+    def reserve(self, input_token_ceiling: int, output_token_ceiling: int) -> int:
+        projected = self.projected_reservation(input_token_ceiling, output_token_ceiling)
+        with self._lock:
+            next_total = self.reserved_upper_bound_usd + projected
+            if next_total > self.budget_usd + 1e-12:
+                raise SpendBudgetExceeded("next-call-reservation-exceeds-budget")
+            self.calls_attempted += 1
+            call_id = self.calls_attempted
+            self.reserved_upper_bound_usd = next_total
+            self.entries.append({
+                "call_id": call_id,
+                "status": "reserved",
+                "input_token_ceiling": input_token_ceiling,
+                "output_token_ceiling": output_token_ceiling,
+                "reserved_upper_bound_usd": projected,
+            })
+            return call_id
+
+    def mark_error(self, call_id: int) -> None:
+        with self._lock:
+            self.entries[call_id - 1]["status"] = "provider-error-billing-ambiguous"
+            self.usage_complete = False
+
+    def complete(self, call_id: int, response: Any) -> None:
+        usage = getattr(response, "usage", None)
+        input_tokens = usage_token_count(usage, "prompt_tokens", "input_tokens")
+        output_tokens = usage_token_count(usage, "completion_tokens", "output_tokens")
+        with self._lock:
+            entry = self.entries[call_id - 1]
+            if input_tokens is None or output_tokens is None:
+                entry["status"] = "usage-missing"
+                self.usage_complete = False
+                raise SpendEvidenceError("provider-usage-missing")
+            if (
+                input_tokens > int(entry["input_token_ceiling"])
+                or output_tokens > int(entry["output_token_ceiling"])
+            ):
+                entry["status"] = "usage-exceeds-reservation"
+                self.usage_complete = False
+                raise SpendEvidenceError("provider-usage-exceeds-reservation")
+            attributed = token_price(
+                input_tokens,
+                output_tokens,
+                self.input_usd_per_million,
+                self.output_usd_per_million,
+            )
+            entry.update({
+                "status": "complete",
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "attributed_cost_usd": attributed,
+            })
+            self.calls_completed += 1
+            self.attributed_cost_usd += attributed
+
+    def evidence(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "approved_budget_usd": self.budget_usd,
+                "reserved_upper_bound_usd": self.reserved_upper_bound_usd,
+                "attributed_cost_usd": self.attributed_cost_usd,
+                "calls_attempted": self.calls_attempted,
+                "calls_completed": self.calls_completed,
+                "usage_complete": self.usage_complete,
+                "client_num_retries": 0,
+                "provider_invoice_verified": False,
+                "price_basis": {
+                    "source": "user-supplied",
+                    "input_usd_per_million": self.input_usd_per_million,
+                    "output_usd_per_million": self.output_usd_per_million,
+                    "scope": "token-price-attribution-not-provider-invoice",
+                },
+                "reservations_are_cumulative": True,
+                "entries": [dict(entry) for entry in self.entries],
+            }
 
 
 def split_train_dev(rows: list[dict[str, Any]], split_key: str, train_split: str, dev_split: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
@@ -69,8 +263,115 @@ def exact_match_feedback(output_keys: list[str], gold: Any, pred: Any) -> Any:
     return ScoreWithFeedback(score=score, feedback=feedback)
 
 
-def dspy_gepa(args: argparse.Namespace) -> None:
+def dspy_run_state_path(args: argparse.Namespace) -> Path:
+    return Path(args.repo) / ".understudy" / "optimize-workload" / "dspy-gepa" / "run-state.json"
+
+
+def write_dspy_run_state(
+    args: argparse.Namespace,
+    ledger: SpendLedger,
+    status: str,
+    reason: str | None,
+) -> None:
+    evidence = ledger.evidence()
+    write_owner_only_json(dspy_run_state_path(args), {
+        "schema_version": "understudy.dspy_gepa_run_state.v1",
+        "status": status,
+        "reason": reason,
+        "adapter": "dspy-gepa",
+        "model": args.model,
+        "provider_calls": evidence["calls_attempted"] > 0,
+        "optimizer_execution": True,
+        "spend_evidence": evidence,
+    })
+
+
+def emit_dspy_failure(
+    args: argparse.Namespace,
+    ledger: SpendLedger,
+    status: str,
+    reason: str,
+    exit_code: int,
+) -> None:
+    write_dspy_run_state(args, ledger, status, reason)
+    evidence = ledger.evidence()
+    emit({
+        "schema_version": "understudy.dspy_gepa_adapter.v1",
+        "status": status,
+        "reason": reason,
+        "adapter": "dspy-gepa",
+        "model": args.model,
+        "provider_calls": evidence["calls_attempted"] > 0,
+        "optimizer_execution": True,
+        "spend_evidence": evidence,
+        "run_state_path": ".understudy/optimize-workload/dspy-gepa/run-state.json",
+    })
+    raise SystemExit(exit_code)
+
+
+def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
     import dspy
+
+    class BudgetedLM(dspy.LM):
+        def __init__(self, *lm_args: Any, spend_ledger: SpendLedger, **lm_kwargs: Any) -> None:
+            self._spend_ledger = spend_ledger
+            super().__init__(*lm_args, **lm_kwargs)
+
+        def _output_token_ceiling(self, call_kwargs: dict[str, Any]) -> int:
+            value = (
+                call_kwargs.get("max_tokens")
+                or call_kwargs.get("max_completion_tokens")
+                or self.kwargs.get("max_tokens")
+                or self.kwargs.get("max_completion_tokens")
+            )
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError("LM call is missing a numeric output-token ceiling")
+            parsed = int(value)
+            if parsed <= 0 or parsed != value:
+                raise ValueError("LM output-token ceiling must be a positive integer")
+            return parsed
+
+        def _reserve_call(
+            self,
+            prompt: str | None,
+            messages: list[dict[str, Any]] | None,
+            call_kwargs: dict[str, Any],
+        ) -> int:
+            message_bytes, message_count = serialized_message_shape(prompt, messages)
+            return self._spend_ledger.reserve(
+                input_token_ceiling_from_bytes(message_bytes, message_count),
+                self._output_token_ceiling(call_kwargs),
+            )
+
+        def forward(
+            self,
+            prompt: str | None = None,
+            messages: list[dict[str, Any]] | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            call_id = self._reserve_call(prompt, messages, kwargs)
+            try:
+                response = super().forward(prompt=prompt, messages=messages, **kwargs)
+            except BaseException:
+                self._spend_ledger.mark_error(call_id)
+                raise
+            self._spend_ledger.complete(call_id, response)
+            return response
+
+        async def aforward(
+            self,
+            prompt: str | None = None,
+            messages: list[dict[str, Any]] | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            call_id = self._reserve_call(prompt, messages, kwargs)
+            try:
+                response = await super().aforward(prompt=prompt, messages=messages, **kwargs)
+            except BaseException:
+                self._spend_ledger.mark_error(call_id)
+                raise
+            self._spend_ledger.complete(call_id, response)
+            return response
 
     api_key = os.environ.get("UNDERSTUDY_API_KEY")
     gateway_url = os.environ.get("UNDERSTUDY_GATEWAY_URL")
@@ -88,12 +389,14 @@ def dspy_gepa(args: argparse.Namespace) -> None:
         if missing:
             raise ValueError(f"sample row is missing keys: {', '.join(missing)}")
 
-    lm = dspy.LM(
+    lm = BudgetedLM(
         normalize_dspy_model(args.model),
+        spend_ledger=ledger,
         api_key=api_key,
         api_base=normalize_gateway_url(gateway_url),
         max_tokens=int(args.max_tokens),
         cache=False,
+        num_retries=0,
     )
     dspy.configure(lm=lm)
     signature = dspy.Signature(f"{', '.join(input_keys)} -> {', '.join(output_keys)}")
@@ -121,6 +424,7 @@ def dspy_gepa(args: argparse.Namespace) -> None:
     )
     optimized = teleprompter.compile(student, trainset=trainset, valset=devset)
 
+    spend_evidence = ledger.evidence()
     candidate = {
         "schema_version": "understudy.dspy_gepa_candidate.v1",
         "adapter": "dspy-gepa",
@@ -135,33 +439,36 @@ def dspy_gepa(args: argparse.Namespace) -> None:
         "baseline_first_score": float(baseline_feedback.score),
         "baseline_first_feedback": baseline_feedback.feedback,
         "optimized_program_class": optimized.__class__.__name__,
+        "spend_evidence": spend_evidence,
     }
     optimize_dir = Path(args.repo) / ".understudy" / "optimize-workload"
     optimize_dir.mkdir(parents=True, exist_ok=True)
     candidate_path = optimize_dir / "candidate.json"
     proof_path = optimize_dir / "proof-packet.json"
-    candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_owner_only_json(candidate_path, candidate)
     proof = {
         "schema_version": "understudy.optimize-workload.proof.v1",
         "mode": "dspy-gepa",
         "status": "candidate-created",
         "backend": "uv-gepa",
         "adapter": "dspy-gepa",
-        "provider_calls": True,
+        "provider_calls": spend_evidence["calls_attempted"] > 0,
         "live_optimizer_execution": True,
         "package_installs": True,
         "holdout_accessed_during_optimization": False,
         "train_count": len(trainset),
         "dev_count": len(devset),
         "candidate": ".understudy/optimize-workload/candidate.json",
+        "spend_evidence": spend_evidence,
     }
-    proof_path.write_text(json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_owner_only_json(proof_path, proof)
+    write_dspy_run_state(args, ledger, "candidate-created", None)
     emit({
         "schema_version": "understudy.dspy_gepa_adapter.v1",
         "status": "candidate-created",
         "adapter": "dspy-gepa",
         "model": args.model,
-        "provider_calls": True,
+        "provider_calls": spend_evidence["calls_attempted"] > 0,
         "optimizer_execution": True,
         "auth_source": os.environ.get("UNDERSTUDY_AUTH_SOURCE", "unknown"),
         "gateway_url_configured": True,
@@ -172,7 +479,37 @@ def dspy_gepa(args: argparse.Namespace) -> None:
         "max_metric_calls": int(args.max_metric_calls),
         "candidate_path": ".understudy/optimize-workload/candidate.json",
         "proof_packet_path": ".understudy/optimize-workload/proof-packet.json",
+        "run_state_path": ".understudy/optimize-workload/dspy-gepa/run-state.json",
+        "spend_evidence": spend_evidence,
     })
+
+
+def dspy_gepa(args: argparse.Namespace) -> None:
+    ledger = SpendLedger(
+        args.budget_usd,
+        args.input_usd_per_million,
+        args.output_usd_per_million,
+    )
+    try:
+        _dspy_gepa_execute(args, ledger)
+    except SpendBudgetExceeded:
+        emit_dspy_failure(
+            args,
+            ledger,
+            "budget-blocked",
+            "next-call-reservation-exceeds-budget",
+            4,
+        )
+    except SpendEvidenceError as error:
+        emit_dspy_failure(args, ledger, "spend-evidence-error", str(error), 5)
+    except KeyboardInterrupt:
+        emit_dspy_failure(args, ledger, "cancelled", "optimizer-cancelled", 130)
+    except ImportError:
+        emit_dspy_failure(args, ledger, "error", "runtime-dependency-error", 3)
+    except ValueError:
+        emit_dspy_failure(args, ledger, "error", "invalid-runtime-input", 3)
+    except Exception:
+        emit_dspy_failure(args, ledger, "error", "optimizer-execution-failed", 3)
 
 
 def load_json_or_jsonl(path: Path) -> Any:
@@ -457,6 +794,46 @@ def eval_input_gepa(args: argparse.Namespace) -> None:
     })
 
 
+def budget_preflight(args: argparse.Namespace) -> None:
+    ledger = SpendLedger(
+        args.budget_usd,
+        args.input_usd_per_million,
+        args.output_usd_per_million,
+    )
+    message_bytes = int(args.message_bytes)
+    message_count = int(args.message_count)
+    output_token_ceiling = int(args.max_tokens)
+    call_count = int(args.call_count)
+    if output_token_ceiling <= 0 or call_count <= 0:
+        raise ValueError("max_tokens and call_count must be positive")
+    input_token_ceiling = input_token_ceiling_from_bytes(message_bytes, message_count)
+    projected = ledger.projected_reservation(input_token_ceiling, output_token_ceiling)
+    allowed = True
+    try:
+        for _ in range(call_count):
+            ledger.reserve(input_token_ceiling, output_token_ceiling)
+    except SpendBudgetExceeded:
+        allowed = False
+    evidence = ledger.evidence()
+    emit({
+        "schema_version": "understudy.dspy_gepa_budget_preflight.v1",
+        "status": "allowed" if allowed else "budget-blocked",
+        "allowed": allowed,
+        "provider_calls": False,
+        "approved_budget_usd": ledger.budget_usd,
+        "input_token_ceiling": input_token_ceiling,
+        "output_token_ceiling": output_token_ceiling,
+        "projected_per_call_reservation_usd": projected,
+        "projected_requested_reservations_usd": projected * call_count,
+        "requested_call_count": call_count,
+        "simulated_reservation_count": evidence["calls_attempted"],
+        "reserved_upper_bound_usd": evidence["reserved_upper_bound_usd"],
+        "price_basis": evidence["price_basis"],
+    })
+    if not allowed:
+        raise SystemExit(4)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
@@ -473,6 +850,9 @@ def main() -> None:
     dspy_gepa_parser.add_argument("--train-split", default="train")
     dspy_gepa_parser.add_argument("--dev-split", default="dev")
     dspy_gepa_parser.add_argument("--max-tokens", default="256")
+    dspy_gepa_parser.add_argument("--budget-usd", required=True)
+    dspy_gepa_parser.add_argument("--input-usd-per-million", required=True)
+    dspy_gepa_parser.add_argument("--output-usd-per-million", required=True)
     dspy_gepa_parser.set_defaults(func=dspy_gepa)
 
     eval_input_gepa_parser = sub.add_parser("eval-input-gepa")
@@ -486,6 +866,16 @@ def main() -> None:
     eval_input_gepa_parser.add_argument("--reflection-minibatch-size", default="1")
     eval_input_gepa_parser.add_argument("--model", default=None)
     eval_input_gepa_parser.set_defaults(func=eval_input_gepa)
+
+    budget_preflight_parser = sub.add_parser("budget-preflight")
+    budget_preflight_parser.add_argument("--message-bytes", required=True)
+    budget_preflight_parser.add_argument("--message-count", required=True)
+    budget_preflight_parser.add_argument("--max-tokens", required=True)
+    budget_preflight_parser.add_argument("--call-count", default="1")
+    budget_preflight_parser.add_argument("--budget-usd", required=True)
+    budget_preflight_parser.add_argument("--input-usd-per-million", required=True)
+    budget_preflight_parser.add_argument("--output-usd-per-million", required=True)
+    budget_preflight_parser.set_defaults(func=budget_preflight)
 
     args = parser.parse_args()
     args.func(args)

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -9,6 +9,7 @@ import { describe, it } from "node:test";
 
 const cli = ["node", resolve("dist/bin.js")];
 const uvAvailable = spawnSync("uv", ["--version"], { encoding: "utf8" }).status === 0;
+const pythonAvailable = spawnSync("python3", ["--version"], { encoding: "utf8" }).status === 0;
 
 // Ambient Understudy credentials (a developer's shell, a CI secret) must not
 // leak into spawned CLIs — fixtures provide their own.
@@ -932,6 +933,380 @@ describe("understudy CLI", () => {
       assert.equal(payload.status, "blocked");
       assert.equal(payload.provider_calls, false);
       assert.equal(payload.optimizer_execution, false);
+    }));
+
+  it("requires a hard budget and price basis before resolving live DSPy auth", () =>
+    withOptimizerFixtureRepo(({ repo, samplesPath }) => {
+      const result = run([
+        "optimize-workload",
+        "adapter",
+        "run",
+        "--repo",
+        repo,
+        "--adapter",
+        "dspy-gepa",
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "synthetic-deployment",
+        "--execute",
+      ]);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /--budget-usd is required/);
+      assert.doesNotMatch(result.stderr, /login|gateway|api key|uv run/i);
+    }));
+
+  it("rejects a zero DSPy price basis before auth or provider execution", () =>
+    withOptimizerFixtureRepo(({ repo, samplesPath }) => {
+      const result = run([
+        "optimize-workload",
+        "adapter",
+        "run",
+        "--repo",
+        repo,
+        "--adapter",
+        "dspy-gepa",
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "synthetic-deployment",
+        "--budget-usd",
+        "1",
+        "--input-usd-per-million",
+        "0",
+        "--output-usd-per-million",
+        "0",
+        "--execute",
+      ]);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /non-zero input or output price basis/);
+      assert.doesNotMatch(result.stderr, /login|gateway|api key|uv run/i);
+    }));
+
+  it("preflights cumulative DSPy reservations without importing DSPy or calling a provider", { skip: !pythonAvailable }, () =>
+    withOptimizerFixtureRepo(({ repo, samplesPath }) => {
+      const scaffold = run([
+        "optimize-workload",
+        "adapter",
+        "run",
+        "--repo",
+        repo,
+        "--adapter",
+        "dspy-gepa",
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "synthetic-deployment",
+      ]);
+      assert.equal(scaffold.status, 1);
+      const runtime = join(repo, ".understudy", "optimize-workload", "uv-runtime", "optimizer_runtime.py");
+      const common = [
+        runtime,
+        "budget-preflight",
+        "--message-bytes",
+        "1000",
+        "--message-count",
+        "1",
+        "--max-tokens",
+        "256",
+        "--input-usd-per-million",
+        "1",
+        "--output-usd-per-million",
+        "2",
+      ];
+      const allowed = spawnSync("python3", [...common, "--call-count", "1", "--budget-usd", "0.01"], {
+        encoding: "utf8",
+      });
+      assert.equal(allowed.status, 0, allowed.stderr);
+      const allowedPayload = JSON.parse(allowed.stdout);
+      assert.equal(allowedPayload.allowed, true);
+      assert.equal(allowedPayload.provider_calls, false);
+      assert.equal(allowedPayload.input_token_ceiling, 5160);
+      assert.equal(allowedPayload.simulated_reservation_count, 1);
+      assert.equal(allowedPayload.price_basis.scope, "token-price-attribution-not-provider-invoice");
+
+      const blocked = spawnSync("python3", [...common, "--call-count", "2", "--budget-usd", "0.01"], {
+        encoding: "utf8",
+      });
+      assert.equal(blocked.status, 4, blocked.stderr);
+      const blockedPayload = JSON.parse(blocked.stdout);
+      assert.equal(blockedPayload.allowed, false);
+      assert.equal(blockedPayload.status, "budget-blocked");
+      assert.equal(blockedPayload.provider_calls, false);
+      assert.equal(blockedPayload.requested_call_count, 2);
+      assert.equal(blockedPayload.simulated_reservation_count, 1);
+      assert.ok(blockedPayload.reserved_upper_bound_usd <= blockedPayload.approved_budget_usd);
+    }));
+
+  it("blocks before the first DSPy provider call and persists terminal spend evidence", { skip: !pythonAvailable }, () =>
+    withOptimizerFixtureRepo(({ repo, samplesPath }) => {
+      const scaffold = run([
+        "optimize-workload",
+        "adapter",
+        "run",
+        "--repo",
+        repo,
+        "--adapter",
+        "dspy-gepa",
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "synthetic-deployment",
+      ]);
+      assert.equal(scaffold.status, 1);
+      const runtime = join(repo, ".understudy", "optimize-workload", "uv-runtime", "optimizer_runtime.py");
+      const stubDir = join(repo, "python-stubs");
+      const sentinel = join(repo, "provider-was-called");
+      mkdirSync(stubDir, { recursive: true });
+      writeFileSync(join(stubDir, "dspy.py"), `
+import os
+
+configured_lm = None
+
+def configure(lm):
+    global configured_lm
+    configured_lm = lm
+
+class LM:
+    def __init__(self, model, max_tokens=None, **kwargs):
+        self.model = model
+        self.kwargs = {"max_tokens": max_tokens}
+    def __call__(self, prompt=None, messages=None, **kwargs):
+        return self.forward(prompt=prompt, messages=messages, **kwargs)
+    def forward(self, prompt=None, messages=None, **kwargs):
+        with open(os.environ["PROVIDER_SENTINEL"], "w", encoding="utf-8") as handle:
+            handle.write("called")
+        raise AssertionError("provider boundary reached")
+
+class Signature:
+    def __init__(self, value):
+        self.value = value
+
+class Example:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+    def with_inputs(self, *keys):
+        return self
+
+class Predict:
+    def __init__(self, signature):
+        self.signature = signature
+    def __call__(self, **kwargs):
+        return configured_lm(prompt=str(kwargs))
+
+class ChainOfThought(Predict):
+    pass
+`, "utf8");
+      const result = spawnSync("python3", [
+        runtime,
+        "dspy-gepa",
+        "--repo",
+        repo,
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "synthetic-deployment",
+        "--max-tokens",
+        "256",
+        "--budget-usd",
+        "0.000001",
+        "--input-usd-per-million",
+        "1",
+        "--output-usd-per-million",
+        "2",
+      ], {
+        encoding: "utf8",
+        env: {
+          ...baseEnv,
+          PYTHONPATH: stubDir,
+          PROVIDER_SENTINEL: sentinel,
+          UNDERSTUDY_API_KEY: "fixture-key",
+          UNDERSTUDY_GATEWAY_URL: "http://127.0.0.1:9",
+        },
+      });
+      assert.equal(result.status, 4, result.stderr);
+      assert.equal(existsSync(sentinel), false);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.status, "budget-blocked");
+      assert.equal(payload.reason, "next-call-reservation-exceeds-budget");
+      assert.equal(payload.provider_calls, false);
+      assert.equal(payload.spend_evidence.calls_attempted, 0);
+      assert.equal(payload.spend_evidence.reserved_upper_bound_usd, 0);
+
+      const runStatePath = join(repo, ".understudy", "optimize-workload", "dspy-gepa", "run-state.json");
+      const runState = JSON.parse(readFileSync(runStatePath, "utf8"));
+      assert.equal(runState.status, "budget-blocked");
+      assert.equal(runState.provider_calls, false);
+      assert.equal(statSync(runStatePath).mode & 0o777, 0o600);
+    }));
+
+  it("shares one metered ledger across DSPy LM copies and disables retries", { skip: !pythonAvailable }, () =>
+    withOptimizerFixtureRepo(({ repo, samplesPath }) => {
+      const scaffold = run([
+        "optimize-workload",
+        "adapter",
+        "run",
+        "--repo",
+        repo,
+        "--adapter",
+        "dspy-gepa",
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "synthetic-deployment",
+      ]);
+      assert.equal(scaffold.status, 1);
+      const runtime = join(repo, ".understudy", "optimize-workload", "uv-runtime", "optimizer_runtime.py");
+      const stubRoot = join(repo, "metered-python-stubs");
+      const dspyRoot = join(stubRoot, "dspy");
+      const gepaRoot = join(dspyRoot, "teleprompt", "gepa");
+      const sentinel = join(repo, "provider-call-count");
+      mkdirSync(gepaRoot, { recursive: true });
+      writeFileSync(join(dspyRoot, "__init__.py"), `
+import copy
+import os
+from types import SimpleNamespace
+
+configured_lm = None
+
+def configure(lm):
+    global configured_lm
+    configured_lm = lm
+
+class LM:
+    def __init__(self, model, max_tokens=None, num_retries=3, **kwargs):
+        self.model = model
+        self.kwargs = {"max_tokens": max_tokens}
+        self.num_retries = num_retries
+    def __call__(self, prompt=None, messages=None, **kwargs):
+        return self.forward(prompt=prompt, messages=messages, **kwargs)
+    def forward(self, prompt=None, messages=None, **kwargs):
+        if self.num_retries != 0:
+            raise AssertionError("retries were not disabled")
+        with open(os.environ["PROVIDER_SENTINEL"], "a", encoding="utf-8") as handle:
+            handle.write("called\\n")
+        return SimpleNamespace(usage={"prompt_tokens": 10, "completion_tokens": 5})
+
+class Signature:
+    def __init__(self, value):
+        self.value = value
+
+class Example:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+    def with_inputs(self, *keys):
+        return self
+
+class Predict:
+    def __init__(self, signature):
+        self.signature = signature
+    def __call__(self, **kwargs):
+        configured_lm.forward(prompt=str(kwargs))
+        return SimpleNamespace(answer="a1")
+
+class ChainOfThought(Predict):
+    pass
+
+class GEPA:
+    def __init__(self, reflection_lm=None, **kwargs):
+        self.reflection_lm = reflection_lm
+    def compile(self, student, trainset=None, valset=None):
+        copied = copy.deepcopy(self.reflection_lm)
+        copied.forward(prompt="reflection")
+        return student
+`, "utf8");
+      writeFileSync(join(dspyRoot, "teleprompt", "__init__.py"), "", "utf8");
+      writeFileSync(join(gepaRoot, "__init__.py"), "", "utf8");
+      writeFileSync(join(gepaRoot, "gepa_utils.py"), `
+class ScoreWithFeedback:
+    def __init__(self, score, feedback):
+        self.score = score
+        self.feedback = feedback
+`, "utf8");
+      const result = spawnSync("python3", [
+        runtime,
+        "dspy-gepa",
+        "--repo",
+        repo,
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "synthetic-deployment",
+        "--max-metric-calls",
+        "2",
+        "--max-tokens",
+        "256",
+        "--budget-usd",
+        "0.02",
+        "--input-usd-per-million",
+        "1",
+        "--output-usd-per-million",
+        "2",
+      ], {
+        encoding: "utf8",
+        env: {
+          ...baseEnv,
+          PYTHONPATH: stubRoot,
+          PROVIDER_SENTINEL: sentinel,
+          UNDERSTUDY_API_KEY: "fixture-key",
+          UNDERSTUDY_GATEWAY_URL: "http://127.0.0.1:9",
+          UNDERSTUDY_AUTH_SOURCE: "fixture",
+        },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(readFileSync(sentinel, "utf8").trim().split("\n").length, 2);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.status, "candidate-created");
+      assert.equal(payload.provider_calls, true);
+      assert.equal(payload.spend_evidence.calls_attempted, 2);
+      assert.equal(payload.spend_evidence.calls_completed, 2);
+      assert.equal(payload.spend_evidence.usage_complete, true);
+      assert.equal(payload.spend_evidence.client_num_retries, 0);
+      assert.equal(payload.spend_evidence.provider_invoice_verified, false);
+      assert.equal(payload.spend_evidence.attributed_cost_usd, 0.00004);
+      assert.equal(payload.spend_evidence.entries.length, 2);
+      assert.ok(
+        payload.spend_evidence.attributed_cost_usd
+          < payload.spend_evidence.reserved_upper_bound_usd,
+      );
+
+      const candidatePath = join(repo, ".understudy", "optimize-workload", "candidate.json");
+      const proofPath = join(repo, ".understudy", "optimize-workload", "proof-packet.json");
+      const runStatePath = join(repo, ".understudy", "optimize-workload", "dspy-gepa", "run-state.json");
+      for (const artifactPath of [candidatePath, proofPath, runStatePath]) {
+        assert.equal(statSync(artifactPath).mode & 0o777, 0o600);
+      }
+      const proof = JSON.parse(readFileSync(proofPath, "utf8"));
+      assert.equal(proof.holdout_accessed_during_optimization, false);
+      assert.equal(proof.spend_evidence.calls_completed, 2);
     }));
 
   it("blocks a registry optimizer adapter unless execution is explicit", () =>

--- a/tests/proof-corrections.test.mjs
+++ b/tests/proof-corrections.test.mjs
@@ -196,6 +196,10 @@ describe("proof-scoped correction evidence", () => {
       assert.equal(gepa.handoff.provider_calls_performed, false);
       assert.equal(gepa.handoff.upload_performed, false);
       assert.deepEqual(gepa.handoff.output_keys, ["answer_json"]);
+      assert.match(gepa.handoff.command_template, /--budget-usd <approved-usd>/);
+      assert.match(gepa.handoff.command_template, /--input-usd-per-million <input-price>/);
+      assert.match(gepa.handoff.command_template, /--output-usd-per-million <output-price>/);
+      assert.match(gepa.handoff.command_template, /--execute$/);
       assert.equal(new Set(gepa.samples.map((row) => row.input_id)).size, 4);
       assert.equal(gepa.samples.filter((row) => row.split === "dev").length, 1);
       assert.ok(gepa.samples.every(


### PR DESCRIPTION
## What changed

- require an approved USD cap and explicit input/output token prices before DSPy GEPA resolves auth or reaches a provider
- reserve a conservative cumulative upper bound before every request, share the ledger across DSPy LM copies, and disable client-side retries
- fail closed when usage attribution is missing or exceeds the reservation
- persist owner-only candidate, proof, and terminal run-state spend evidence
- include the required spend flags in correction-pair GEPA handoffs and document the provider-invoice boundary

## Why

Execution approval and metric-call limits constrained intent and call count, but not dollars. DSPy's default retry behavior and absent usage evidence could therefore exceed an operator's expected spend without a durable audit trail.

This patch makes the client request budget fail closed under the operator-supplied token-price basis. It deliberately does **not** claim to verify provider invoices or server-side retry billing.

## Verification

- `git diff --check`
- `npm run check`
  - 305 tests passed
  - typecheck/build passed
  - 33 public skills validated
  - npm package smoke passed
- exact frozen correction handoff: 8 rows, deterministic 6 train / 2 dev split
- real installed DSPy runtime with an unreachable loopback gateway and a deliberately tiny cap:
  - exit 4, `budget-blocked`
  - `next-call-reservation-exceeds-budget`
  - zero calls attempted/completed
  - no candidate emitted
  - terminal run-state mode `0600`
  - client retries `0`
  - provider invoice verification explicitly `false`


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->