### PR TITLE
Make grocery buyer proofs portable and fail closed

### DIFF
--- a/experiments/desktop-grocery-proof/DEMO.md
+++ b/experiments/desktop-grocery-proof/DEMO.md
@@ -8,15 +8,15 @@ and its evidence, not to claim production readiness from three examples.
 
 ## Before the call
 
-Run Understudy Desktop 0.3.2+ with an Understudy E2B slot and 26B slot warm.
-Confirm that agents can discover the app, then create a fresh proof:
+Run the current Understudy Desktop with at least two local model slots warm.
+Confirm that agents can discover the app, then create a fresh proof. The runner
+selects the smallest warm model as the student and the largest warm model as
+the main/teacher, so the demo has no machine-specific slot ids:
 
 ```sh
 understudy desktop capabilities
 understudy desktop status --json
-node experiments/desktop-grocery-proof/run.mjs \
-  --student-slot 9 \
-  --teacher-slot 5
+node experiments/desktop-grocery-proof/run.mjs
 ```
 
 Keep the resulting proof directory open. Do not use customer prompts, traces,
@@ -27,9 +27,7 @@ extrapolating from the three-task demo:
 
 ```sh
 node experiments/desktop-grocery-proof/run.mjs \
-  --suite promotion \
-  --student-slot 9 \
-  --teacher-slot 5
+  --suite promotion
 ```
 
 If reusing an existing proof, derive a report with the current renderer instead
@@ -74,11 +72,12 @@ support, cancellation, replay, and supervisor feedback.
 
 ## 3-8 minutes: show one runtime, multiple routes
 
-Explain the three default frozen routes:
+Explain the three default frozen routes using the model ids recorded in the
+new proof summary:
 
-1. E2B alone;
-2. 26B alone;
-3. E2B working first while 26B supervises.
+1. the smallest warm local model alone;
+2. the largest warm local model alone;
+3. the smaller model working first while the larger model supervises.
 
 If configured, add the fourth route: the hosted incumbent, executed by Pi with
 the same run identity, canonical events, and deterministic scorer.
@@ -112,15 +111,10 @@ jq '.by_mode | with_entries(.value |= {
 })' "$PROOF/summary.json"
 ```
 
-For the measured synthetic slice, the expected story is:
-
-- E2B handles cart substitution and operations classification.
-- 26B handles all three tasks.
-- E2B is faster, but misses the required atomic inventory fix.
-- Supervision retains the E2B answer and the 26B judge misses that known error.
-
-Do not hide the miss. It is the strongest product moment: Understudy tells the
-team that supervision is not yet safe for code analysis instead of turning an
+Do not memorize or pre-script a winning route. State the result in the fresh
+report, including any incumbent miss, supervisor miss, false positive, or
+unsuccessful correction. That is the strongest product moment: Understudy tells
+the team where a smaller or supervised route is unsafe instead of turning an
 architecture idea into an unsupported savings claim.
 
 ## 15-22 minutes: inspect the failed judgment

--- a/experiments/desktop-grocery-proof/README.md
+++ b/experiments/desktop-grocery-proof/README.md
@@ -11,13 +11,20 @@ The tasks cover codebase analysis, cart substitution, and operations
 classification. Scoring is deterministic field equality; no remote judge,
 provider call, upload, or customer data is involved.
 
-With Understudy Desktop 0.3.2+ running and both slots warm:
+With Understudy Desktop running and at least two local model slots warm:
 
 ```sh
-node experiments/desktop-grocery-proof/run.mjs \
-  --student-slot 9 \
-  --teacher-slot 5
+understudy desktop status --json
+node experiments/desktop-grocery-proof/run.mjs
 ```
+
+The runner discovers the current residency set through the versioned Desktop
+API. It assigns the smallest warm model to the student route and the largest
+warm model to the main/teacher route, then records both model ids and the
+selection source in the immutable summary. Machine-specific slot ids are never
+required for the normal demo. Use `--student-slot <id> --teacher-slot <id>`
+together only when deliberately comparing a different warm pair; a missing or
+stopped requested slot fails before any task runs.
 
 The separate promotion suite freezes 30 harder tasks—10 per workflow—behind
 the same routes, scorer, run identity, and evidence contract. Use it after the
@@ -25,9 +32,7 @@ smoke passes:
 
 ```sh
 node experiments/desktop-grocery-proof/run.mjs \
-  --suite promotion \
-  --student-slot 9 \
-  --teacher-slot 5
+  --suite promotion
 ```
 
 Prompt or policy optimization uses a separate 18-task development slice,
@@ -35,9 +40,7 @@ never the promotion proof:
 
 ```sh
 node experiments/desktop-grocery-proof/run.mjs \
-  --suite development \
-  --student-slot 9 \
-  --teacher-slot 5
+  --suite development
 ```
 
 The development suite is tagged `data_split: development` and can produce
@@ -58,6 +61,10 @@ run cancellation or aborts the Pi incumbent run, preserves the canonical
 terminal event, and counts as a failed task rather than hanging or disappearing.
 Use `--turn-timeout-ms <milliseconds>` only when a deliberately slower baseline
 needs a different frozen ceiling.
+The runner also fails the whole proof immediately on a canonical error,
+cancellation, or a turn with no complete provider usage. It preserves that
+turn's owner-only event JSONL for diagnosis but does not publish `summary.json`
+or a buyer report from incomplete evidence.
 
 To compare a hosted incumbent on the identical slice, opt in explicitly. This
 fourth route uses Pi and the same canonical event contract; it does not add a
@@ -68,8 +75,6 @@ and `--confirm-spend` before any synthetic prompt leaves the machine:
 ```sh
 export INCUMBENT_API_KEY='<set in the terminal, never in chat>'
 node experiments/desktop-grocery-proof/run.mjs \
-  --student-slot 9 \
-  --teacher-slot 5 \
   --incumbent-base-url https://provider.example/v1 \
   --incumbent-model incumbent-model-id \
   --incumbent-provider-kind openai-compatible \

--- a/experiments/desktop-grocery-proof/run.mjs
+++ b/experiments/desktop-grocery-proof/run.mjs
@@ -116,6 +116,18 @@ export function summarizeEvents(events, elapsedMs) {
   };
 }
 
+export function requireSuccessfulProofTurn(modeId, taskId, evidence) {
+  if (evidence.terminal_status !== "completed") {
+    throw new Error(
+      `${modeId}/${taskId} ended in ${evidence.terminal_status}: ${String(evidence.terminal_reason ?? "unknown runtime failure")}`,
+    );
+  }
+  const usage = Object.values(evidence.usage ?? {});
+  if (!usage.some((row) => row?.complete === true && row?.source === "provider")) {
+    throw new Error(`${modeId}/${taskId} did not report any complete provider usage`);
+  }
+}
+
 function isRemoteUrl(value) {
   const { hostname } = new URL(value);
   return !["127.0.0.1", "localhost", "::1", "[::1]"].includes(hostname);
@@ -233,8 +245,8 @@ export function validateIncumbentOptions(options) {
 
 function parseArgs(argv) {
   const options = {
-    studentSlot: 9,
-    teacherSlot: 5,
+    studentSlot: null,
+    teacherSlot: null,
     suite: "smoke",
     maxTokens: 384,
     turnTimeoutMs: 120_000,
@@ -278,14 +290,25 @@ function parseArgs(argv) {
     index += 1;
   }
   for (const [name, value] of Object.entries({
-    studentSlot: options.studentSlot,
-    teacherSlot: options.teacherSlot,
     maxTokens: options.maxTokens,
     turnTimeoutMs: options.turnTimeoutMs,
   })) {
     if (!Number.isInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer`);
   }
-  if (options.studentSlot === options.teacherSlot) {
+  const studentSpecified = options.studentSlot !== null;
+  const teacherSpecified = options.teacherSlot !== null;
+  if (studentSpecified !== teacherSpecified) {
+    throw new Error("pass both --student-slot and --teacher-slot, or omit both for automatic discovery");
+  }
+  for (const [name, value] of Object.entries({
+    studentSlot: options.studentSlot,
+    teacherSlot: options.teacherSlot,
+  })) {
+    if (value !== null && (!Number.isInteger(value) || value <= 0)) {
+      throw new Error(`${name} must be a positive integer`);
+    }
+  }
+  if (studentSpecified && options.studentSlot === options.teacherSlot) {
     throw new Error("student and teacher slots must be distinct");
   }
   resolveGrocerySuiteFile(options.suite);
@@ -319,6 +342,64 @@ async function apiFetch(capability, path, init = {}) {
   headers.set("authorization", `Bearer ${capability.token}`);
   if (init.body !== undefined) headers.set("content-type", "application/json");
   return fetch(new URL(path, capability.baseUrl), { ...init, headers });
+}
+
+export function resolveProofSlots(residency, requested = {}) {
+  const slots = Array.isArray(residency?.slots) ? residency.slots : [];
+  const running = slots.filter((slot) => (
+    Number.isInteger(Number(slot?.id))
+    && Number(slot.id) > 0
+    && slot?.state === "running"
+    && typeof slot?.model_id === "string"
+    && slot.model_id.length > 0
+  ));
+  const studentSpecified = requested.studentSlot != null;
+  const teacherSpecified = requested.teacherSlot != null;
+  if (studentSpecified !== teacherSpecified) {
+    throw new Error("pass both student and teacher slots, or omit both for automatic discovery");
+  }
+
+  if (studentSpecified) {
+    const student = running.find((slot) => Number(slot.id) === requested.studentSlot);
+    const teacher = running.find((slot) => Number(slot.id) === requested.teacherSlot);
+    if (!student || !teacher) {
+      throw new Error(
+        `requested grocery proof slots must both be running; available running slots: ${running.map((slot) => slot.id).join(", ") || "none"}`,
+      );
+    }
+    if (student.id === teacher.id) throw new Error("student and teacher slots must be distinct");
+    return {
+      source: "explicit",
+      studentSlot: Number(student.id),
+      teacherSlot: Number(teacher.id),
+      studentModel: student.model_id,
+      teacherModel: teacher.model_id,
+    };
+  }
+
+  if (running.length < 2) {
+    throw new Error(
+      `grocery proof requires two warm local models; found ${running.length}. Warm a small and a larger model, or pass explicit slots.`,
+    );
+  }
+  const ranked = [...running].sort((left, right) => {
+    const leftMemory = typeof left.mem_gb === "number" && Number.isFinite(left.mem_gb)
+      ? left.mem_gb
+      : Number.POSITIVE_INFINITY;
+    const rightMemory = typeof right.mem_gb === "number" && Number.isFinite(right.mem_gb)
+      ? right.mem_gb
+      : Number.POSITIVE_INFINITY;
+    return leftMemory - rightMemory || Number(left.id) - Number(right.id);
+  });
+  const student = ranked[0];
+  const teacher = ranked.at(-1);
+  return {
+    source: "auto",
+    studentSlot: Number(student.id),
+    teacherSlot: Number(teacher.id),
+    studentModel: student.model_id,
+    teacherModel: teacher.model_id,
+  };
 }
 
 async function readNdjson(response) {
@@ -385,14 +466,22 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
   ) {
     throw new Error("Understudy Desktop 2.1.0 local supervision API is required");
   }
+  const residencyResponse = await apiFetch(capability, "/v1/residency");
+  if (!residencyResponse.ok) throw new Error(`residency returned ${residencyResponse.status}`);
+  const slotSelection = resolveProofSlots(await residencyResponse.json(), options);
+  process.stdout.write(
+    `slots      student=${slotSelection.studentSlot} (${slotSelection.studentModel}) `
+    + `teacher=${slotSelection.teacherSlot} (${slotSelection.teacherModel}) `
+    + `source=${slotSelection.source}\n`,
+  );
 
   const modes = [
-    { id: "small", slotId: options.studentSlot },
-    { id: "main", slotId: options.teacherSlot },
+    { id: "small", slotId: slotSelection.studentSlot },
+    { id: "main", slotId: slotSelection.teacherSlot },
     {
       id: "supervised",
-      slotId: options.studentSlot,
-      supervisorSlotId: options.teacherSlot,
+      slotId: slotSelection.studentSlot,
+      supervisorSlotId: slotSelection.teacherSlot,
     },
   ];
   if (incumbentEnabled) modes.push({ id: "hosted" });
@@ -445,6 +534,11 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
           clearTimeout(timeout);
         }
       }
+      writeProofFile(
+        join(outputDir, `${mode.id}-${task.id}.events.jsonl`),
+        `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
+      );
+      validateRuntimeTrace(events);
       const evidence = summarizeEvents(events, Math.round(performance.now() - before));
       const parsed = extractJsonObject(evidence.output);
       const score = scoreObject(parsed, task.expected);
@@ -493,8 +587,8 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
         task_id: task.id,
         task_title: task.title,
         mode: mode.id,
-        student_slot_id: mode.id === "hosted" ? null : options.studentSlot,
-        teacher_slot_id: mode.id === "hosted" ? null : options.teacherSlot,
+        student_slot_id: mode.id === "hosted" ? null : slotSelection.studentSlot,
+        teacher_slot_id: mode.id === "hosted" ? null : slotSelection.teacherSlot,
         model: mode.id === "hosted" ? options.incumbentModel : null,
         parsed_output: parsed,
         score,
@@ -519,11 +613,8 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
           : null,
         ...evidence,
       };
+      requireSuccessfulProofTurn(mode.id, task.id, evidence);
       rows.push(row);
-      writeProofFile(
-        join(outputDir, `${mode.id}-${task.id}.events.jsonl`),
-        `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
-      );
       process.stdout.write(
         `${mode.id.padEnd(10)} ${task.id.padEnd(20)} accuracy=${score.field_accuracy.toFixed(2)} `
         + `latency=${evidence.elapsed_ms}ms verdicts=${evidence.verdicts.length} `
@@ -609,7 +700,13 @@ export async function runProof(options = parseArgs(process.argv.slice(2))) {
         : "smoke",
     task_count: tasks.length,
     run_count: rows.length,
-    slots: { student: options.studentSlot, teacher: options.teacherSlot },
+    slots: {
+      student: slotSelection.studentSlot,
+      teacher: slotSelection.teacherSlot,
+      source: slotSelection.source,
+      student_model: slotSelection.studentModel,
+      teacher_model: slotSelection.teacherModel,
+    },
     incumbent: incumbentEnabled ? {
       model: options.incumbentModel,
       provider_kind: options.incumbentProviderKind,

--- a/tests/desktop-grocery-proof.test.mjs
+++ b/tests/desktop-grocery-proof.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   statSync,
@@ -18,7 +20,10 @@ import {
   extractJsonObject,
   groceryProofIdentity,
   incumbentBudgetPreflight,
+  requireSuccessfulProofTurn,
+  resolveProofSlots,
   resolveGrocerySuiteFile,
+  runProof,
   runHostedIncumbent,
   scoreObject,
   summarizeEvents,
@@ -33,6 +38,49 @@ import {
 } from "../experiments/desktop-grocery-proof/report.mjs";
 
 describe("desktop grocery proof", () => {
+  it("discovers the smallest and largest warm models without machine-specific slot ids", () => {
+    const residency = {
+      slots: [
+        { id: 5, model_id: "large-stopped", state: "stopped", mem_gb: 24 },
+        { id: 7, model_id: "small-running", state: "running", mem_gb: 5.25 },
+        { id: 6, model_id: "teacher-running", state: "running", mem_gb: 7 },
+        { id: 9, model_id: "largest-running", state: "running", mem_gb: 18.8 },
+      ],
+    };
+    assert.deepEqual(resolveProofSlots(residency), {
+      source: "auto",
+      studentSlot: 7,
+      teacherSlot: 9,
+      studentModel: "small-running",
+      teacherModel: "largest-running",
+    });
+    assert.deepEqual(resolveProofSlots(residency, { studentSlot: 7, teacherSlot: 6 }), {
+      source: "explicit",
+      studentSlot: 7,
+      teacherSlot: 6,
+      studentModel: "small-running",
+      teacherModel: "teacher-running",
+    });
+  });
+
+  it("fails clearly when automatic or explicit grocery proof slots are not runnable", () => {
+    const oneWarm = {
+      slots: [
+        { id: 7, model_id: "small-running", state: "running", mem_gb: 5.25 },
+        { id: 6, model_id: "teacher-stopped", state: "stopped", mem_gb: 7 },
+      ],
+    };
+    assert.throws(() => resolveProofSlots(oneWarm), /requires two warm local models; found 1/);
+    assert.throws(
+      () => resolveProofSlots(oneWarm, { studentSlot: 7 }),
+      /pass both student and teacher slots/,
+    );
+    assert.throws(
+      () => resolveProofSlots(oneWarm, { studentSlot: 7, teacherSlot: 6 }),
+      /must both be running; available running slots: 7/,
+    );
+  });
+
   it("keeps the 30-task grocery promotion suite frozen and balanced", () => {
     assert.equal(resolveGrocerySuiteFile("smoke"), "tasks.json");
     assert.equal(resolveGrocerySuiteFile("development"), "tasks.development.json");
@@ -135,6 +183,131 @@ describe("desktop grocery proof", () => {
     assert.equal(summary.teacher_continuations, 1);
     assert.equal(summary.small_model_output_share, 0.5);
     assert.equal(summary.supervisor_token_overhead, 9 / 26);
+  });
+
+  it("refuses to publish a buyer proof from terminal errors or missing usage", () => {
+    assert.throws(
+      () => requireSuccessfulProofTurn("small", "cart", {
+        terminal_status: "error",
+        terminal_reason: "runtime dependency missing",
+        usage: {},
+      }),
+      /small\/cart ended in error: runtime dependency missing/,
+    );
+    assert.throws(
+      () => requireSuccessfulProofTurn("main", "ops", {
+        terminal_status: "completed",
+        terminal_reason: null,
+        usage: {},
+      }),
+      /did not report any complete provider usage/,
+    );
+    assert.doesNotThrow(() => requireSuccessfulProofTurn("supervised", "code", {
+      terminal_status: "completed",
+      terminal_reason: null,
+      usage: {
+        student: { complete: false, source: "unavailable" },
+        teacher: { complete: true, source: "provider" },
+      },
+    }));
+  });
+
+  it("preserves a failed turn but does not publish an incomplete buyer report", async () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-grocery-failed-proof-"));
+    const outputRoot = join(root, "proofs");
+    const capabilityPath = join(root, "desktop-api.json");
+    const previousCapability = process.env.UNDERSTUDY_DESKTOP_API_FILE;
+    const server = createServer(async (request, response) => {
+      if (request.url === "/v1/capabilities") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          schema_version: "understudy.desktop_api.v2",
+          api_version: "2.2.0",
+          event_schema: "understudy-conversation-runtime-event-v1",
+          features: { local_supervision: true },
+        }));
+        return;
+      }
+      if (request.url === "/v1/residency") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          slots: [
+            { id: 7, model_id: "small-fixture", state: "running", mem_gb: 5 },
+            { id: 6, model_id: "teacher-fixture", state: "running", mem_gb: 7 },
+          ],
+        }));
+        return;
+      }
+      if (request.url?.startsWith("/v1/conversations/") && request.method === "POST") {
+        let body = "";
+        for await (const chunk of request) body += chunk;
+        const input = JSON.parse(body);
+        const sessionId = decodeURIComponent(request.url.split("/")[3]);
+        response.writeHead(200, { "content-type": "application/x-ndjson" });
+        response.end(`${JSON.stringify({
+          schema_version: "understudy-conversation-runtime-event-v1",
+          event_id: `${input.runId}:0`,
+          run_id: input.runId,
+          session_id: sessionId,
+          runtime_id: "grocery-proof-fixture",
+          sequence: 0,
+          emitted_at: "2026-07-14T00:00:00Z",
+          event: "error",
+          data: {
+            stage: "dispatch",
+            code: "fixture_dispatch_failed",
+            message: "fixture dispatch failed",
+            recoverable: false,
+          },
+        })}\n`);
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+    await new Promise((accept) => server.listen(0, "127.0.0.1", accept));
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    writeFileSync(capabilityPath, `${JSON.stringify({
+      base_url: `http://127.0.0.1:${address.port}`,
+      token: "a".repeat(64),
+    })}\n`, { mode: 0o600 });
+    process.env.UNDERSTUDY_DESKTOP_API_FILE = capabilityPath;
+    try {
+      await assert.rejects(
+        () => runProof({
+          studentSlot: null,
+          teacherSlot: null,
+          suite: "smoke",
+          maxTokens: 64,
+          turnTimeoutMs: 5_000,
+          outputRoot,
+          reportFrom: null,
+          reportOutputRoot: null,
+          incumbentBaseUrl: null,
+          incumbentModel: null,
+          incumbentProviderKind: "openai-compatible",
+          incumbentApiKeyEnv: null,
+          incumbentInputUsdPerMillion: null,
+          incumbentOutputUsdPerMillion: null,
+          budgetUsd: null,
+          confirmSpend: false,
+        }),
+        /small\/codebase-analysis ended in error: fixture dispatch failed/,
+      );
+      const proofDirs = readdirSync(outputRoot);
+      assert.equal(proofDirs.length, 1);
+      const proofDir = join(outputRoot, proofDirs[0]);
+      assert.equal(existsSync(join(proofDir, "small-codebase-analysis.events.jsonl")), true);
+      assert.equal(existsSync(join(proofDir, "summary.json")), false);
+      assert.equal(existsSync(join(proofDir, "report.json")), false);
+      assert.equal(existsSync(join(proofDir, "report.html")), false);
+    } finally {
+      await new Promise((accept) => server.close(accept));
+      if (previousCapability === undefined) delete process.env.UNDERSTUDY_DESKTOP_API_FILE;
+      else process.env.UNDERSTUDY_DESKTOP_API_FILE = previousCapability;
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("replaces a rejected completed answer while retaining role evidence", () => {


### PR DESCRIPTION
## What changed

- discover the current warm student and teacher models from the versioned Desktop residency API instead of hardcoding machine-specific slot IDs
- choose the smallest warm model as the student and the largest warm model as the main/teacher, while preserving validated explicit overrides
- record the selected model IDs and selection source in immutable proof summaries
- validate every local Desktop event stream against the canonical ConversationRuntime contract before scoring
- fail closed on terminal errors, cancellations, or missing complete provider usage
- preserve the failed turn's owner-only event JSONL for diagnosis without publishing a summary or buyer report
- update the 30-minute demo and experiment docs to use fresh measured results rather than a stale E2B/26B story

## Why

The buyer proof still assumed one developer machine's slots. More seriously, a broken runtime could return canonical error events for every task while the runner exited successfully and generated a persuasive-looking report. That undermines the exact evidence-integrity story this migration is supposed to establish.

## Impact

A fresh Desktop install with any two warm local models can run the same grocery-platform proof without hand-editing slot IDs. Broken or incomplete runtime evidence cannot become a buyer-facing recommendation.

## Validation

- `npm run check`
  - 309 tests passed
  - typecheck and build passed
  - 33 public skills validated
  - npm package smoke passed
- `node --test tests/desktop-grocery-proof.test.mjs`
  - 22 tests passed
- real local no-slot smoke against Desktop 0.3.12
  - automatically selected slot 7 / 4B as student and slot 6 / 12B as teacher
  - 9 identical-slice turns completed
  - 0 terminal errors
  - all 9 immutable event files passed the canonical runtime validator
- no provider calls, uploads, or customer data

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->