### PR TITLE
Make CLI 0.6.9 the honest current command surface

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.8"
+    "version": "0.6.9"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.8"
+    "version": "0.6.9"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Fixed
 
+- **CLI installs expose one honest staleness signal for the current command
+  surface.** CLI and adapter manifests advance to 0.6.9 after the
+  proof-scoped correction handoff, GEPA spend fuse, and portable fail-closed
+  grocery proof landed. Desktop's required CLI floor advances with them, so an
+  older 0.6.8 checkout can no longer look current while missing those commands.
+
 - **macOS memory headroom stays conservative without collapsing to zero under
   compression.** Desktop 0.3.12 updates the pinned system-memory reader to the
   current Apple XNU available-memory calculation. Model warming still keeps

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.8";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.9";
 const UNDERSTUDY_INSTALLER_URL: &str =
     "https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

The current source tree gained proof-scoped correction handoff, the GEPA spend fuse, and the portable fail-closed grocery proof after CLI 0.6.8 shipped. Because the package and adapter manifests still said 0.6.8, an older global checkout could appear current while missing `desktop supervision prepare-proof` and related commands.

## What

- advance the CLI package and every adapter/plugin release signal to 0.6.9
- advance Desktop's minimum supported CLI floor to 0.6.9
- document the staleness fix in the changelog
- leave Desktop/runtime at 0.3.12; this is a CLI surface-integrity patch

## Validation

- `npm run check` — 309 tests, build, typecheck, package smoke, 33 public skills
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` — 157 passed, 4 ignored
- `node --test tests/desktop-release-check.test.mjs` — 3 passed
- `node scripts/desktop-release-check.mjs --stage source --allow-dirty --json` — source versions and 0.6.9 compatibility contract clean
- `git diff --check`

No provider calls, uploads, or production mutations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->