### PR TITLE
Release Desktop/runtime 0.3.13 with CLI 0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Fixed
 
+- **Desktop repair and the canonical runtime ship with the current CLI
+  contract.** Desktop/runtime 0.3.13 requires CLI 0.6.9, so a newly installed
+  app cannot repair itself back to the older 0.6.8 command surface that lacks
+  proof-scoped correction handoff, the GEPA spend fuse, and the portable
+  fail-closed grocery proof.
+
 - **CLI installs expose one honest staleness signal for the current command
   surface.** CLI and adapter manifests advance to 0.6.9 after the
   proof-scoped correction handoff, GEPA spend fuse, and portable fail-closed

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.12",
+  "version": "0.3.13",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.12"
+version = "0.3.13"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.12";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.13";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.12";
+export const RUNTIME_VERSION = "0.3.13";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -2517,7 +2517,7 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       model: "conformance-cli",
     });
     assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
-    assert.equal(cliReport.metadata.runtime_version, "0.3.12");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.13");
     assert.equal(
       cliReport.metadata.event_schema,
       "understudy-conversation-runtime-event-v1",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -98,7 +98,7 @@ function writeReleaseEvidence() {
     adapter_id: "pi",
     generated_at: "2026-07-12T20:00:00.000Z",
     metadata: {
-      runtime_version: "0.3.12",
+      runtime_version: "0.3.13",
       event_schema: "understudy-conversation-runtime-event-v1",
       network_mode: "offline",
       provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
@@ -142,7 +142,7 @@ function writeReleaseEvidence() {
     },
     app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
     runtime: {
-      runtime_version: "0.3.12",
+      runtime_version: "0.3.13",
       event_schema: "understudy-conversation-runtime-event-v1",
       ready_ms: 700,
       rss_mb: 120,
@@ -244,7 +244,7 @@ before(async () => {
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
         app_version: "0.3.2",
-        runtime_version: "0.3.12",
+        runtime_version: "0.3.13",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,
@@ -271,7 +271,7 @@ before(async () => {
         run_id: `cohort-run-${index}`,
         runtime_backend: "pi",
         app_version: "0.3.2",
-        runtime_version: "0.3.12",
+        runtime_version: "0.3.13",
         session_id: `cohort-session-${index}`,
         status: "ok",
         prompt_tokens: cohortFailure === "token-mismatch" && index === 0 ? 11 : 10,


### PR DESCRIPTION
## Why

CLI 0.6.9 is now the honest current sidecar surface, but the public Desktop 0.3.12 binary still embeds the older 0.6.8 compatibility floor. Desktop/runtime 0.3.13 makes the app and canonical sidecar one exact release unit again.

## What

- advance all six Desktop/runtime version sources to 0.3.13
- keep the already-merged CLI/package/plugin surface at 0.6.9
- update exact-version conformance and API fixtures
- document that repair may no longer restore the incomplete 0.6.8 command surface

## Validation

- `npm run check` — 309 tests, build, typecheck, 33 public skills, package smoke
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` — 157 passed, 4 real-evidence opt-ins ignored
- `node scripts/desktop-release-check.mjs --stage source --allow-dirty --json` — six sources at 0.3.13; CLI/floor at 0.6.9; baseline 0.3.12/0.6.8
- targeted runtime/API/release suite — 49 tests passed
- `git diff --check`

No provider calls or uploads. Signed/notarized artifacts will be built only from the exact merged `origin/main` commit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->