### PR TITLE
Give runtime 0.3.13 a unique CLI 0.6.10 identity

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.9"
+    "version": "0.6.10"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.9"
+    "version": "0.6.10"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,14 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Fixed
 
-- **Desktop repair and the canonical runtime ship with the current CLI
-  contract.** Desktop/runtime 0.3.13 requires CLI 0.6.9, so a newly installed
-  app cannot repair itself back to the older 0.6.8 command surface that lacks
-  proof-scoped correction handoff, the GEPA spend fuse, and the portable
-  fail-closed grocery proof.
+- **Every canonical-runtime build has an unambiguous CLI distribution
+  identity.** Desktop/runtime 0.3.13 requires CLI 0.6.10. Reusing 0.6.9 after
+  its runtime advanced from 0.3.12 to 0.3.13 would have let an installed older
+  sidecar look current, so the release gate now audits the entire first-parent
+  runtime transition rather than only the last public Desktop tag. A newly
+  installed app cannot repair itself back to the older 0.6.8 command surface
+  that lacks proof-scoped correction handoff, the GEPA spend fuse, and the
+  portable fail-closed grocery proof.
 
 - **CLI installs expose one honest staleness signal for the current command
   surface.** CLI and adapter manifests advance to 0.6.9 after the

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.9";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.10";
 const UNDERSTUDY_INSTALLER_URL: &str =
     "https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/scripts/desktop-release-check.mjs
+++ b/scripts/desktop-release-check.mjs
@@ -162,6 +162,36 @@ function priorDesktopReleaseBaseline(root, head) {
   return null;
 }
 
+export function priorRuntimeTransitionBaseline(root, head, runtimeVersion) {
+  const commits = capture(
+    "git",
+    ["rev-list", "--first-parent", head],
+    root,
+  ).split("\n").filter(Boolean);
+  for (const commit of commits) {
+    const runtimeSource = capture(
+      "git",
+      ["show", `${commit}:src/runtime/conversation/contract.ts`],
+      root,
+    );
+    const runtimeMatch = runtimeSource.match(/RUNTIME_VERSION\s*=\s*"([^"]+)"/);
+    if (!runtimeMatch) {
+      throw new Error(`could not read runtime version from ${commit}`);
+    }
+    if (runtimeMatch[1] === runtimeVersion) continue;
+    const cliPackage = JSON.parse(capture("git", ["show", `${commit}:package.json`], root));
+    if (typeof cliPackage.version !== "string") {
+      throw new Error(`could not read CLI version from ${commit}`);
+    }
+    return {
+      commit,
+      runtime_version: runtimeMatch[1],
+      cli_version: cliPackage.version,
+    };
+  }
+  return null;
+}
+
 export function desktopArtifactPaths(version, root = repositoryRoot, arch = "aarch64") {
   const bundle = join(root, "apps", "homescreen", "src-tauri", "target", "release", "bundle");
   return {
@@ -211,6 +241,7 @@ export async function inspectDesktopRelease({
   let originMain = null;
   let clean = null;
   let baseline = null;
+  let runtimeTransition = null;
   try {
     head = capture("git", ["rev-parse", "HEAD"], root);
     originMain = capture("git", ["rev-parse", "origin/main"], root);
@@ -236,6 +267,29 @@ export async function inspectDesktopRelease({
       }
     } catch (error) {
       errors.push(`release baseline inspection failed: ${error.message}`);
+    }
+    try {
+      runtimeTransition = priorRuntimeTransitionBaseline(
+        root,
+        head,
+        versionState.version,
+      );
+      if (runtimeTransition) {
+        const error = runtimeCliAdvancementError({
+          runtime_version: versionState.version,
+          cli_version: versionState.compatibility.cli_package,
+          baseline_runtime_version: runtimeTransition.runtime_version,
+          baseline_cli_version: runtimeTransition.cli_version,
+        });
+        if (error) errors.push(`runtime transition: ${error}`);
+      } else if (baseline && baseline.runtime_version !== versionState.version) {
+        errors.push(
+          `could not locate the ${baseline.runtime_version} -> ${versionState.version} ` +
+          "runtime transition in first-parent history",
+        );
+      }
+    } catch (error) {
+      errors.push(`runtime transition inspection failed: ${error.message}`);
     }
   }
 
@@ -311,7 +365,11 @@ export async function inspectDesktopRelease({
     ok: errors.length === 0,
     version: versionState.version,
     versions: versionState.versions,
-    compatibility: { ...versionState.compatibility, baseline },
+    compatibility: {
+      ...versionState.compatibility,
+      baseline,
+      runtime_transition: runtimeTransition,
+    },
     git: { head, origin_main: originMain, clean },
     artifacts: artifactState,
     errors,

--- a/tests/desktop-release-check.test.mjs
+++ b/tests/desktop-release-check.test.mjs
@@ -1,14 +1,30 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import {
   desktopArtifactPaths,
+  inspectDesktopRelease,
   inspectDesktopVersions,
   repositoryRoot,
   runtimeCliAdvancementError,
 } from "../scripts/desktop-release-check.mjs";
+
+function git(root, args) {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function replaceOnce(path, from, to) {
+  const source = readFileSync(path, "utf8");
+  assert.ok(source.includes(from), `${path} must contain ${from}`);
+  writeFileSync(path, source.replace(from, to));
+}
 
 test("desktop release sources share one exact version", () => {
   const report = inspectDesktopVersions();
@@ -82,4 +98,121 @@ test("runtime releases require a newer distributed CLI sidecar", () => {
     }),
     null,
   );
+});
+
+test("release history rejects one CLI version for two runtime builds", async () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-runtime-transition-"));
+  const files = [
+    "apps/homescreen/package.json",
+    "apps/homescreen/src-tauri/tauri.conf.json",
+    "apps/homescreen/src-tauri/Cargo.toml",
+    "apps/homescreen/src-tauri/Cargo.lock",
+    "apps/homescreen/src-tauri/src/conversation_runtime.rs",
+    "apps/homescreen/src-tauri/src/bootstrap.rs",
+    "package.json",
+    "src/runtime/conversation/contract.ts",
+  ];
+  const paths = Object.fromEntries(files.map((relative) => [relative, join(root, relative)]));
+  try {
+    for (const relative of files) {
+      cpSync(join(repositoryRoot, relative), paths[relative], { recursive: false });
+    }
+    git(root, ["init", "--quiet"]);
+    git(root, ["config", "user.name", "Understudy Release Test"]);
+    git(root, ["config", "user.email", "release-test@invalid.example"]);
+
+    replaceOnce(paths["package.json"], '"version": "0.6.10"', '"version": "0.6.9"');
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.10"',
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.9"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/package.json"],
+      '"version": "0.3.13"',
+      '"version": "0.3.12"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/tauri.conf.json"],
+      '"version": "0.3.13"',
+      '"version": "0.3.12"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/Cargo.toml"],
+      'version = "0.3.13"',
+      'version = "0.3.12"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/Cargo.lock"],
+      'name = "understudy"\nversion = "0.3.13"',
+      'name = "understudy"\nversion = "0.3.12"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
+      'RUNTIME_VERSION: &str = "0.3.13"',
+      'RUNTIME_VERSION: &str = "0.3.12"',
+    );
+    replaceOnce(
+      paths["src/runtime/conversation/contract.ts"],
+      'RUNTIME_VERSION = "0.3.13"',
+      'RUNTIME_VERSION = "0.3.12"',
+    );
+    git(root, ["add", "."]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.12 and CLI 0.6.9"]);
+    const transitionCommit = git(root, ["rev-parse", "HEAD"]);
+
+    replaceOnce(
+      paths["apps/homescreen/package.json"],
+      '"version": "0.3.12"',
+      '"version": "0.3.13"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/tauri.conf.json"],
+      '"version": "0.3.12"',
+      '"version": "0.3.13"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/Cargo.toml"],
+      'version = "0.3.12"',
+      'version = "0.3.13"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/Cargo.lock"],
+      'name = "understudy"\nversion = "0.3.12"',
+      'name = "understudy"\nversion = "0.3.13"',
+    );
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
+      'RUNTIME_VERSION: &str = "0.3.12"',
+      'RUNTIME_VERSION: &str = "0.3.13"',
+    );
+    replaceOnce(
+      paths["src/runtime/conversation/contract.ts"],
+      'RUNTIME_VERSION = "0.3.12"',
+      'RUNTIME_VERSION = "0.3.13"',
+    );
+    git(root, ["add", "."]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.13 without CLI bump"]);
+    git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+    const stale = await inspectDesktopRelease({ root });
+    assert.equal(stale.ok, false);
+    assert.match(stale.errors.join("\n"), /runtime transition:.*CLI 0\.6\.9 did not advance/);
+    assert.equal(stale.compatibility.runtime_transition.commit, transitionCommit);
+
+    replaceOnce(paths["package.json"], '"version": "0.6.9"', '"version": "0.6.10"');
+    replaceOnce(
+      paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.9"',
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.10"',
+    );
+    git(root, ["add", "."]);
+    git(root, ["commit", "--quiet", "-m", "advance CLI for runtime 0.3.13"]);
+    git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+    const ready = await inspectDesktopRelease({ root });
+    assert.equal(ready.ok, true, ready.errors.join("\n"));
+    assert.equal(ready.compatibility.runtime_transition.commit, transitionCommit);
+    assert.equal(ready.compatibility.runtime_transition.cli_version, "0.6.9");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Why

The pre-notarization audit caught a fail-open release bug: installed CLI 0.6.9 contains canonical runtime 0.3.12, while current source reused the same CLI 0.6.9 version for runtime 0.3.13. That would let an older sidecar look current and make Desktop repair ambiguous.

## What

- advance the CLI package, every plugin/adapter manifest, and Desktop floor to 0.6.10
- keep Desktop/runtime at 0.3.13
- make the release gate scan first-parent history to find the actual runtime transition, not only the latest public Desktop tag
- fail when one CLI version spans two runtime builds
- add a temporary-git-history regression that reproduces 0.3.12/0.6.9 → 0.3.13/0.6.9 failure and proves 0.6.10 repairs it

## Validation

- `npm run check` — 310 tests, build, typecheck, 33 public skills, package smoke
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` — 157 passed, 4 real-evidence opt-ins ignored
- `node --test tests/desktop-release-check.test.mjs` — 4 passed
- source release gate records public baseline 0.3.12/0.6.8 and first-parent transition 0.3.12/0.6.9, with current 0.3.13/0.6.10
- `git diff --check`

No provider calls or uploads. The previously signed 0.3.13 DMG is intentionally discarded and will be rebuilt only after this merges.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->