### PR TITLE
fix(desktop): advertise a live local model endpoint

### DIFF
--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -9,7 +9,7 @@ use crate::db::{
 use crate::knowledge::{self, Dossier};
 use crate::mcp;
 use crate::metrics::{Machine, Metrics, MetricsReader};
-use crate::models::{self, LOCAL_BASE_URL};
+use crate::models;
 use crate::moraine::MoraineState;
 use crate::residency::{Residency, ResidencySnapshot};
 use crate::route_policy::{
@@ -33,7 +33,7 @@ pub struct StatusSnapshot {
     pub machine: Machine,
     pub metrics: Metrics,
     pub residency: ResidencySnapshot,
-    pub local_base_url: &'static str,
+    pub local_base_url: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -986,13 +986,14 @@ fn is_connected(app: &AppHandle) -> bool {
 pub fn get_status(app: AppHandle) -> StatusSnapshot {
     let reader = app.state::<MetricsReader>();
     let machine = app.state::<Machine>();
+    let residency = residency(&app);
     StatusSnapshot {
         connected: is_connected(&app),
         services: Services::snapshot(),
         machine: machine.inner().clone(),
         metrics: reader.inner().read(),
-        residency: residency(&app).snapshot(),
-        local_base_url: LOCAL_BASE_URL,
+        residency: residency.snapshot(),
+        local_base_url: residency.local_base_url(),
     }
 }
 

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -355,6 +355,22 @@ impl Residency {
         self.snapshot_from(&inner)
     }
 
+    /// Return a usable OpenAI-compatible endpoint for status/tool consumers.
+    /// Persisted slots may have moved well beyond MLX_PORT, so advertising the
+    /// fresh-install default while another port is warm sends agents to a dead
+    /// listener. Prefer the lowest-id warm slot for deterministic output and
+    /// retain the configured default only when no model is currently serving.
+    pub fn local_base_url(&self) -> String {
+        let inner = locked(&self.inner);
+        inner
+            .iter()
+            .filter(|resident| matches!(resident.state, SlotState::Warm))
+            .filter_map(|resident| resident.port.map(|port| (resident.id, port)))
+            .min_by_key(|(id, _)| *id)
+            .map(|(_, port)| format!("http://127.0.0.1:{port}/v1"))
+            .unwrap_or_else(|| models::LOCAL_BASE_URL.to_string())
+    }
+
     /// Add an empty slot; returns its id.
     pub fn add_slot(&self) -> u32 {
         let id = self.alloc_id();
@@ -914,6 +930,26 @@ mod tests {
         assert_eq!(residency.alloc_port(), MLX_PORT);
         assert_eq!(residency.alloc_port(), MLX_PORT + 1);
         assert!(models::LOCAL_BASE_URL.contains(&MLX_PORT.to_string()));
+        assert_eq!(residency.local_base_url(), models::LOCAL_BASE_URL);
+    }
+
+    #[test]
+    fn local_base_url_prefers_lowest_id_warm_slot() {
+        let residency = Residency::new(64);
+        {
+            let mut inner = locked(&residency.inner);
+            let mut later = resident(7, SlotState::Warm, 4.0);
+            later.port = Some(8096);
+            inner.push(later);
+            let mut earlier = resident(6, SlotState::Warm, 8.0);
+            earlier.port = Some(8095);
+            inner.push(earlier);
+            let mut stopped = resident(5, SlotState::Stopped, 2.0);
+            stopped.port = Some(8091);
+            inner.push(stopped);
+        }
+
+        assert_eq!(residency.local_base_url(), "http://127.0.0.1:8095/v1");
     }
 
     #[test]


### PR DESCRIPTION
## Why
`status.local_base_url` always advertised the fresh-install port even after persisted residency restored models on different ports. Agents could receive a dead endpoint despite healthy warm models.

## What
- derive `local_base_url` from the lowest-id warm slot
- retain the configured default only when no model is serving
- cover restored warm, stopped, and no-warm cases

## Verification
- `npm run check` (310 tests)
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` (158 passed, 4 explicit evidence tests ignored)
- `cargo clippy --manifest-path apps/homescreen/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->