### PR TITLE
Fail cold readiness beside active MLX servers

### DIFF
--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -43,8 +43,10 @@ not be used to complete the monitor.
 
 ## Acceptance evidence
 
-Run the local readiness probe only after stopping the desktop app and its warm
-model processes:
+Run the local readiness probe only after stopping the desktop app and every
+MLX/VLM model-server process. The probe fails closed on unrelated servers and
+never terminates them, so release qualification cannot overlap another Metal
+workload:
 
 ```sh
 npm run runtime:desktop-readiness -- --output .understudy/capture-evidence/desktop-runtime-readiness.json

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -130,3 +130,8 @@ gh release edit "$tag" --repo understudylabs/understudy-agent-tools \
 For a runtime migration release, regenerate the exact-version conformance and
 readiness evidence from the installed notarized app after publication. Evidence
 from an older version cannot qualify the new release cohort.
+
+The readiness probe is process-cold and refuses to overlap any active MLX/VLM
+server, including one it does not own. Stop those workloads explicitly first;
+the probe reports bounded process identity but never terminates an unowned
+server, preventing a release check from colliding with another Metal workload.

--- a/scripts/desktop-runtime-readiness.mjs
+++ b/scripts/desktop-runtime-readiness.mjs
@@ -6,6 +6,11 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  findActiveMlxServers,
+  formatActiveMlxServers,
+} from "./desktop-runtime-safety.mjs";
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const appBinary = resolve(
   process.env.UNDERSTUDY_DESKTOP_BINARY ||
@@ -26,7 +31,7 @@ if (process.argv.includes("--help")) {
   process.stdout.write(
     "usage: node scripts/desktop-runtime-readiness.mjs [--output <private-json>]\n" +
       "\n" +
-      "Run after stopping Understudy and its warm model processes. The probe launches the\n" +
+      "Run after stopping Understudy and every MLX/VLM model-server process. The probe launches the\n" +
       "debug app bundle, cold-starts the managed runtime, measures restored models, and\n" +
       "leaves the measured app running. No provider calls are made.\n",
   );
@@ -139,6 +144,20 @@ if (!existsSync(database)) {
 }
 if (await healthReady()) {
   throw new Error(`desktop is already serving at ${baseUrl}; stop it before a cold readiness run`);
+}
+
+// A process-cold release claim must not overlap another MLX/VLM workload. Even
+// an unrelated model server consumes unified memory and Metal allocations, so
+// starting restored Desktop slots beside it can invalidate the measurement or
+// destabilize macOS. Detect every exact MLX/VLM server entrypoint, report only
+// bounded process metadata, and leave unowned processes untouched.
+const activeMlxServers = findActiveMlxServers(
+  run("ps", ["-ww", "-axo", "pid=,ppid=,command="]),
+);
+if (activeMlxServers.length > 0) {
+  throw new Error(
+    `MLX/VLM server processes are already active (${formatActiveMlxServers(activeMlxServers)}); stop them before process-cold readiness. The harness will not terminate unowned model servers.`,
+  );
 }
 
 const warmBefore = sqliteRows(

--- a/scripts/desktop-runtime-safety.mjs
+++ b/scripts/desktop-runtime-safety.mjs
@@ -1,0 +1,82 @@
+import { basename } from "node:path";
+
+const MLX_SERVER_EXECUTABLES = new Set([
+  "mlx-vlm-server",
+  "mlx_vlm.server",
+  "mlx_vlm.server.py",
+]);
+
+export function parseProcessTable(raw) {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/))
+    .filter(Boolean)
+    .map((match) => ({
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      command: match[3].trim(),
+    }));
+}
+
+function commandTokens(command) {
+  return command.trim().split(/\s+/).filter(Boolean);
+}
+
+function flagValue(tokens, flag) {
+  const index = tokens.indexOf(flag);
+  return index >= 0 ? tokens[index + 1] ?? null : null;
+}
+
+export function inspectMlxServerProcess(process) {
+  const tokens = commandTokens(process.command);
+  const launcher = basename(tokens[0] ?? "");
+  const launchedByPython = /^python(?:\d+(?:\.\d+)*)?$/.test(launcher);
+  const executableIndex = tokens.findIndex((token) =>
+    MLX_SERVER_EXECUTABLES.has(basename(token)),
+  );
+  const moduleIndex = tokens.findIndex(
+    (token, index) => token === "mlx_vlm.server" && tokens[index - 1] === "-m",
+  );
+  const directEntrypoint =
+    executableIndex === 0 || (launchedByPython && executableIndex === 1);
+  const pythonModule = launchedByPython && moduleIndex >= 2;
+  if (!directEntrypoint && !pythonModule) return null;
+
+  return {
+    pid: process.pid,
+    ppid: process.ppid,
+    model: flagValue(tokens, "--model"),
+    port: flagValue(tokens, "--port"),
+  };
+}
+
+export function findActiveMlxServers(raw) {
+  return parseProcessTable(raw)
+    .map(inspectMlxServerProcess)
+    .filter(Boolean);
+}
+
+export function modelDisplayName(model) {
+  if (!model) return null;
+  const cacheSegment = model
+    .split(/[\\/]/)
+    .find((segment) => segment.startsWith("models--"));
+  if (cacheSegment) {
+    return cacheSegment.slice("models--".length).replaceAll("--", "/");
+  }
+  return basename(model);
+}
+
+export function formatActiveMlxServers(servers) {
+  return servers
+    .map((server) => {
+      const model = modelDisplayName(server.model);
+      const details = [
+        `pid ${server.pid}`,
+        server.port ? `port ${server.port}` : null,
+        model ? `model ${model}` : null,
+      ].filter(Boolean);
+      return details.join(", ");
+    })
+    .join("; ");
+}

--- a/tests/desktop-runtime-readiness.test.mjs
+++ b/tests/desktop-runtime-readiness.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  findActiveMlxServers,
+  formatActiveMlxServers,
+  inspectMlxServerProcess,
+  modelDisplayName,
+  parseProcessTable,
+} from "../scripts/desktop-runtime-safety.mjs";
+
+const processTable = `
+  120     1 /usr/bin/python3 -m mlx_vlm.server --host 127.0.0.1 --port 8096 --model /models/understudy-small
+  121   120 /Users/test/.local/bin/mlx_vlm.server --port 8000 --model /models/other
+  122     1 /bin/zsh -c rg mlx_vlm.server scripts
+  123     1 node dist/runtime/conversation/sidecar.js --port 0
+`;
+
+test("readiness safety finds exact MLX/VLM server entrypoints without matching shell text", () => {
+  const processes = parseProcessTable(processTable);
+  assert.equal(processes.length, 4);
+  assert.deepEqual(findActiveMlxServers(processTable), [
+    {
+      pid: 120,
+      ppid: 1,
+      model: "/models/understudy-small",
+      port: "8096",
+    },
+    {
+      pid: 121,
+      ppid: 120,
+      model: "/models/other",
+      port: "8000",
+    },
+  ]);
+  assert.equal(inspectMlxServerProcess(processes[2]), null);
+});
+
+test("readiness safety reports bounded process identity and never emits a command line", () => {
+  const servers = findActiveMlxServers(processTable);
+  const rendered = formatActiveMlxServers(servers);
+  assert.equal(
+    rendered,
+    "pid 120, port 8096, model understudy-small; pid 121, port 8000, model other",
+  );
+  assert.doesNotMatch(rendered, /--host|python3|mlx_vlm/);
+  assert.equal(
+    modelDisplayName(
+      "/Users/example/.cache/huggingface/hub/models--mlx-community--gemma-4-31b-it-8bit/snapshots/hash",
+    ),
+    "mlx-community/gemma-4-31b-it-8bit",
+  );
+  assert.doesNotMatch(rendered, /Users|models\//);
+});


### PR DESCRIPTION
## What changed

- refuse process-cold Desktop readiness while any MLX/VLM server is active
- report only bounded PID, port, and model identity
- never terminate an unowned model process
- document the release qualification requirement

## Why

The readiness harness restored Desktop model slots without checking for unrelated MLX servers. That could invalidate startup and memory evidence or overlap Metal workloads on the same Mac.

## Validation

- `npm run check` (312 tests, typecheck/build, 33 public skills, package smoke)
- live fail-closed probe against an unrelated MLX/VLM process; the process remained running
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->