### PR TITLE
Bind release evidence to exact runtime versions

### DIFF
--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -49,28 +49,34 @@ never terminates them, so release qualification cannot overlap another Metal
 workload:
 
 ```sh
-npm run runtime:desktop-readiness -- --output .understudy/capture-evidence/desktop-runtime-readiness.json
+APP_VERSION=0.3.13
+npm run runtime:desktop-readiness -- \
+  --output ".understudy/capture-evidence/desktop-runtime-readiness-${APP_VERSION}.json"
 ```
 
 The output is private, contains no token values, and is not packaged. It fails
-closed if app, runtime, or model RSS is unavailable. The final notarized 0.3.7
-release evidence passes all gates:
+closed if app, runtime, or model RSS is unavailable. Evidence filenames are
+version-bound so a later run cannot silently stand in for the installed cohort.
+The last fully regenerated exact-version evidence before Desktop 0.3.13 is the
+notarized 0.3.12 release, which passes all gates:
 
 | Gate | Result | Ceiling |
 | --- | ---: | ---: |
-| Desktop HTTP ready | 310 ms | 2,500 ms |
-| Canonical runtime ready | 933 ms | 3,000 ms |
-| Restored model ready | 2,578 ms | 45,000 ms |
-| Desktop + runtime RSS | 208.375 MB | 750 MB |
-| Restored model RSS | 5.9391 GB | 32 GB |
+| Desktop HTTP ready | 309 ms | 2,500 ms |
+| Canonical runtime ready | 746 ms | 3,000 ms |
+| Restored model ready | 5,181 ms | 45,000 ms |
+| Desktop + runtime RSS | 209.266 MB | 750 MB |
+| Restored model RSS | 5.9411 GB | 32 GB |
 
 This is not a reboot-cold claim: macOS may retain model weights in its filesystem
 cache. Release qualification should repeat it on one clean install and one
 ordinary warm restart.
 
-The exact-version 0.3.7 conformance report also passes every frozen scenario:
+The exact-version 0.3.12 conformance report also passes every frozen scenario:
 basic chat, offline image, authenticated tool round, malformed-tool recovery,
 supervisor takeover, long-chat compaction, restart/resume, and cancellation.
+Desktop 0.3.13 must regenerate both reports before its release cohort is called
+qualified; passing 0.3.12 evidence is intentionally insufficient.
 
 The rebuilt debug app also passed a caller-correlated headless tool round. The
 HTTP response returned the caller's `capture_run_id`, `runtime_backend: "pi"`,
@@ -102,6 +108,8 @@ Anthropic key and catalog storage in Rust.
 The release artifact exposes the gate directly:
 
 ```sh
+APP_VERSION=0.3.13
+RUNTIME_VERSION=0.3.13
 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
 understudy runtime conformance \
   --backend pi \
@@ -111,10 +119,13 @@ understudy runtime conformance \
   --deterministic-malformed-tool \
   --deterministic-compaction \
   --require-complete \
-  --output .understudy/capture-evidence/desktop-runtime-conformance.json
+  --output ".understudy/capture-evidence/desktop-runtime-conformance-${RUNTIME_VERSION}.json"
 npm run runtime:desktop-readiness -- \
-  --output .understudy/capture-evidence/desktop-runtime-readiness.json
-understudy desktop migration-status --require-ready --json
+  --output ".understudy/capture-evidence/desktop-runtime-readiness-${APP_VERSION}.json"
+understudy desktop migration-status \
+  --conformance-evidence ".understudy/capture-evidence/desktop-runtime-conformance-${RUNTIME_VERSION}.json" \
+  --readiness-evidence ".understudy/capture-evidence/desktop-runtime-readiness-${APP_VERSION}.json" \
+  --require-ready --json
 ```
 
 For Pi or Vercel, `--slot` resolves the exact local weights path and serving

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -131,6 +131,12 @@ For a runtime migration release, regenerate the exact-version conformance and
 readiness evidence from the installed notarized app after publication. Evidence
 from an older version cannot qualify the new release cohort.
 
+Write both reports to version-bound paths, for example
+`desktop-runtime-conformance-0.3.13.json` and
+`desktop-runtime-readiness-0.3.13.json`. `understudy desktop migration-status`
+selects these exact-version defaults from the live app/runtime cohort; explicit
+paths remain available for archived or isolated evidence roots.
+
 The readiness probe is process-cold and refuses to overlap any active MLX/VLM
 server, including one it does not own. Stop those workloads explicitly first;
 the probe reports bounded process identity but never terminates an unowned

--- a/src/commands/desktop.ts
+++ b/src/commands/desktop.ts
@@ -21,8 +21,6 @@ import {
   responseError,
 } from "../internal/desktop-api.js";
 import {
-  DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE,
-  DEFAULT_DESKTOP_READINESS_EVIDENCE,
   evaluateDesktopRuntimeReleaseEvidence,
 } from "../runtime/conversation/release-gate.js";
 import { validateRuntimeTrace } from "../runtime/conversation/contract.js";
@@ -643,13 +641,11 @@ export function registerDesktopCommand(program: Command): void {
     .option("--limit <n>", "Most-recent canonical/fallback rows to inspect", positiveInteger, 250)
     .option(
       "--conformance-evidence <path>",
-      "Private executable Pi conformance report",
-      DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE,
+      "Private executable Pi report (default: version-bound runtime evidence path)",
     )
     .option(
       "--readiness-evidence <path>",
-      "Private desktop startup and memory readiness report",
-      DEFAULT_DESKTOP_READINESS_EVIDENCE,
+      "Private startup/memory report (default: version-bound app evidence path)",
     )
     .option("--require-ready", "Exit non-zero until cohort and release evidence are ready")
     .option("--json", "Output JSON")
@@ -657,8 +653,8 @@ export function registerDesktopCommand(program: Command): void {
       this: Command,
       opts: {
         limit: number;
-        conformanceEvidence: string;
-        readinessEvidence: string;
+        conformanceEvidence?: string;
+        readinessEvidence?: string;
         requireReady?: boolean;
         json?: boolean;
       },

--- a/src/runtime/conversation/release-gate.ts
+++ b/src/runtime/conversation/release-gate.ts
@@ -8,10 +8,25 @@ import {
 } from "./contract.js";
 import { loadConversationConformanceInputs } from "./conformance.js";
 
-export const DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE =
-  ".understudy/capture-evidence/desktop-runtime-conformance.json";
-export const DEFAULT_DESKTOP_READINESS_EVIDENCE =
-  ".understudy/capture-evidence/desktop-runtime-readiness.json";
+const DEFAULT_DESKTOP_EVIDENCE_ROOT = ".understudy/capture-evidence";
+
+function evidenceVersion(version: string): string {
+  const sanitized = version
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "unknown";
+}
+
+export function defaultDesktopConformanceEvidencePath(runtimeVersion: string): string {
+  const version = evidenceVersion(runtimeVersion);
+  return `${DEFAULT_DESKTOP_EVIDENCE_ROOT}/desktop-runtime-conformance-${version}.json`;
+}
+
+export function defaultDesktopReadinessEvidencePath(appVersion: string): string {
+  const version = evidenceVersion(appVersion);
+  return `${DEFAULT_DESKTOP_EVIDENCE_ROOT}/desktop-runtime-readiness-${version}.json`;
+}
 
 type EvidenceCheck = {
   path: string;
@@ -268,11 +283,11 @@ export function evaluateDesktopRuntimeReleaseEvidence(
   options: ReleaseEvidenceOptions,
 ): DesktopRuntimeReleaseEvidence {
   const conformance = conformanceEvidence(
-    options.conformance_path ?? DEFAULT_DESKTOP_CONFORMANCE_EVIDENCE,
+    options.conformance_path ?? defaultDesktopConformanceEvidencePath(options.runtime_version),
     options.runtime_version,
   );
   const readiness = readinessEvidence(
-    options.readiness_path ?? DEFAULT_DESKTOP_READINESS_EVIDENCE,
+    options.readiness_path ?? defaultDesktopReadinessEvidencePath(options.app_version),
     options.app_version,
     options.runtime_version,
   );

--- a/tests/desktop-runtime-release-gate.test.mjs
+++ b/tests/desktop-runtime-release-gate.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+  defaultDesktopConformanceEvidencePath,
+  defaultDesktopReadinessEvidencePath,
+  evaluateDesktopRuntimeReleaseEvidence,
+} from "../dist/runtime/conversation/release-gate.js";
+
+test("desktop release evidence defaults are bound to the exact app and runtime versions", () => {
+  assert.equal(
+    defaultDesktopConformanceEvidencePath("0.3.13"),
+    ".understudy/capture-evidence/desktop-runtime-conformance-0.3.13.json",
+  );
+  assert.equal(
+    defaultDesktopReadinessEvidencePath("0.3.13"),
+    ".understudy/capture-evidence/desktop-runtime-readiness-0.3.13.json",
+  );
+
+  const report = evaluateDesktopRuntimeReleaseEvidence({
+    app_version: "0.3.13",
+    runtime_version: "0.3.13",
+  });
+  assert.equal(
+    report.conformance.path,
+    resolve(".understudy/capture-evidence/desktop-runtime-conformance-0.3.13.json"),
+  );
+  assert.equal(
+    report.readiness.path,
+    resolve(".understudy/capture-evidence/desktop-runtime-readiness-0.3.13.json"),
+  );
+});
+
+test("desktop release evidence filenames sanitize non-version path characters", () => {
+  assert.equal(
+    defaultDesktopConformanceEvidencePath(" release/0.3.13 candidate "),
+    ".understudy/capture-evidence/desktop-runtime-conformance-release-0.3.13-candidate.json",
+  );
+  assert.equal(
+    defaultDesktopReadinessEvidencePath("   "),
+    ".understudy/capture-evidence/desktop-runtime-readiness-unknown.json",
+  );
+});


### PR DESCRIPTION
## What changed

- derive migration-gate evidence paths from the live app and runtime versions
- keep explicit evidence-path overrides for archived or isolated runs
- correct the removal map to identify 0.3.12 as the last fully regenerated proof
- record that 0.3.13 remains unqualified until its own reports exist

## Why

Generic filenames allowed later worktrees to expose an older report under an ambiguous path. The gate already validates embedded versions, but version-bound defaults make the filesystem and human-facing workflow match that fail-closed contract.

## Validation

- `npm run check` (314 tests, typecheck/build, 33 public skills, package smoke)
- focused release-gate and Desktop API tests
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->