### PR TITLE
Record Desktop API chats in route metrics

### DIFF
--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -447,6 +447,97 @@ fn record_chat_run(app: &AppHandle, input: ChatRunInput) {
     );
 }
 
+pub(crate) fn agent_runtime_prompt_tokens(request: &Value) -> Option<u64> {
+    request
+        .get("messages")
+        .and_then(Value::as_array)
+        .map(|messages| approximate_messages_tokens(messages))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agent_runtime_chat_run_input(
+    run_id: &str,
+    session_id: &str,
+    model: &str,
+    supervised: bool,
+    result: Option<&crate::conversation_sidecar::SidecarRunResult>,
+    fallback_prompt_tokens: Option<u64>,
+    fallback_elapsed_ms: u64,
+    local_mem_gb: Option<f64>,
+    gateway_available: bool,
+    status: &str,
+    error: Option<String>,
+) -> ChatRunInput {
+    let prompt_tokens = result
+        .and_then(|run| sidecar_usage_tokens(run.usage.as_ref(), "prompt_tokens"))
+        .or(fallback_prompt_tokens);
+    let completion_tokens = result.map(|run| {
+        sidecar_usage_tokens(run.usage.as_ref(), "completion_tokens")
+            .unwrap_or_else(|| approximate_token_count(&run.content))
+    });
+    let compacted = result.is_some_and(|run| run.compacted);
+
+    ChatRunInput {
+        run_id: run_id.to_string(),
+        runtime_backend: "pi".to_string(),
+        session_id: session_id.to_string(),
+        route: "local".to_string(),
+        model: model.to_string(),
+        elapsed_ms: Some(
+            result
+                .map(|run| run.elapsed_ms)
+                .unwrap_or(fallback_elapsed_ms),
+        ),
+        prompt_tokens,
+        completion_tokens,
+        tool_calls: result.map(|run| run.tool_calls).unwrap_or(0),
+        sidekick_spawned: supervised,
+        gateway_used: false,
+        compacted,
+        compaction_reason: compacted.then(|| "runtime_compaction_boundary".to_string()),
+        context_tokens_before: result
+            .map(|run| run.context_tokens_before)
+            .or(fallback_prompt_tokens),
+        local_mem_gb,
+        gateway_available,
+        gateway_avoided: gateway_available,
+        status: status.to_string(),
+        error: (status != "ok").then_some(error).flatten(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_agent_runtime_run(
+    app: &AppHandle,
+    run_id: &str,
+    session_id: &str,
+    model: &str,
+    supervised: bool,
+    result: Option<&crate::conversation_sidecar::SidecarRunResult>,
+    fallback_prompt_tokens: Option<u64>,
+    fallback_elapsed_ms: u64,
+    status: &str,
+    error: Option<String>,
+) {
+    let gateway_available = credentials().is_some();
+    record_chat_run(
+        app,
+        agent_runtime_chat_run_input(
+            run_id,
+            session_id,
+            model,
+            supervised,
+            result,
+            fallback_prompt_tokens,
+            fallback_elapsed_ms,
+            local_resident_mem_gb(app),
+            gateway_available,
+            status,
+            error,
+        ),
+    );
+}
+
 fn local_resident_mem_gb(app: &AppHandle) -> Option<f64> {
     let memory = app
         .state::<Residency>()
@@ -1420,5 +1511,86 @@ mod tests {
     #[test]
     fn approximate_tokens_never_claim_char_precision() {
         assert_eq!(approximate_token_count("one two three"), 3);
+    }
+
+    #[test]
+    fn agent_runtime_success_preserves_canonical_route_accounting() {
+        let result = crate::conversation_sidecar::SidecarRunResult {
+            content: "the final answer".to_string(),
+            usage: Some(json!({
+                "prompt_tokens": 144,
+                "completion_tokens": 23,
+            })),
+            tool_calls: 2,
+            elapsed_ms: 987,
+            compacted: true,
+            context_tokens_before: 32_000,
+        };
+        let input = agent_runtime_chat_run_input(
+            "run-api-1",
+            "session-api-1",
+            "understudy-4b",
+            true,
+            Some(&result),
+            Some(11),
+            1_500,
+            Some(9.5),
+            true,
+            "ok",
+            Some("must not leak".to_string()),
+        );
+
+        assert_eq!(input.run_id, "run-api-1");
+        assert_eq!(input.session_id, "session-api-1");
+        assert_eq!(input.runtime_backend, "pi");
+        assert_eq!(input.route, "local");
+        assert_eq!(input.model, "understudy-4b");
+        assert_eq!(input.elapsed_ms, Some(987));
+        assert_eq!(input.prompt_tokens, Some(144));
+        assert_eq!(input.completion_tokens, Some(23));
+        assert_eq!(input.tool_calls, 2);
+        assert!(input.sidekick_spawned);
+        assert!(!input.gateway_used);
+        assert!(input.compacted);
+        assert_eq!(
+            input.compaction_reason.as_deref(),
+            Some("runtime_compaction_boundary")
+        );
+        assert_eq!(input.context_tokens_before, Some(32_000));
+        assert_eq!(input.local_mem_gb, Some(9.5));
+        assert!(input.gateway_available);
+        assert!(input.gateway_avoided);
+        assert_eq!(input.status, "ok");
+        assert_eq!(input.error, None);
+    }
+
+    #[test]
+    fn agent_runtime_failure_uses_fallback_accounting() {
+        let input = agent_runtime_chat_run_input(
+            "run-api-2",
+            "session-api-2",
+            "understudy-12b",
+            false,
+            None,
+            Some(41),
+            212,
+            None,
+            false,
+            "cancelled",
+            Some("conversation runtime cancelled: user requested".to_string()),
+        );
+
+        assert_eq!(input.elapsed_ms, Some(212));
+        assert_eq!(input.prompt_tokens, Some(41));
+        assert_eq!(input.completion_tokens, None);
+        assert_eq!(input.tool_calls, 0);
+        assert!(!input.sidekick_spawned);
+        assert!(!input.compacted);
+        assert_eq!(input.context_tokens_before, Some(41));
+        assert_eq!(input.status, "cancelled");
+        assert_eq!(
+            input.error.as_deref(),
+            Some("conversation runtime cancelled: user requested")
+        );
     }
 }

--- a/apps/homescreen/src-tauri/src/conversation_sidecar.rs
+++ b/apps/homescreen/src-tauri/src/conversation_sidecar.rs
@@ -162,7 +162,7 @@ pub(crate) enum SidecarAttempt {
     FailedAfterOutput(String),
 }
 
-fn is_runtime_cancellation(error: &str) -> bool {
+pub(crate) fn is_runtime_cancellation(error: &str) -> bool {
     error.starts_with("conversation runtime cancelled:")
 }
 

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -354,18 +354,63 @@ async fn agent_conversation_turn(
         },
     )
     .map_err(|error| (StatusCode::BAD_REQUEST, error))?;
+    let model = request
+        .get("model")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "conversation runtime request is missing its model".to_string(),
+            )
+        })?
+        .to_string();
+    let supervised = request.get("supervision").is_some();
+    let prompt_tokens = crate::chat::agent_runtime_prompt_tokens(&request);
     let reservation = crate::conversation_sidecar::reserve_agent_run(&session_id, &run_id)
         .map_err(|error| (StatusCode::CONFLICT, error))?;
 
     let (events_tx, events_rx) =
         tokio::sync::mpsc::unbounded_channel::<crate::conversation_runtime::RuntimeEventEnvelope>();
     let app = ctx.app.clone();
+    let run_id_for_task = run_id.clone();
+    let session_id_for_task = session_id.clone();
     tauri::async_runtime::spawn(async move {
-        if let Err((error, _)) =
-            crate::conversation_sidecar::execute_agent_run(&app, request, &events_tx, reservation)
-                .await
+        let started = std::time::Instant::now();
+        match crate::conversation_sidecar::execute_agent_run(&app, request, &events_tx, reservation)
+            .await
         {
-            eprintln!("understudy desktop API conversation run failed: {error}");
+            Ok(result) => crate::chat::record_agent_runtime_run(
+                &app,
+                &run_id_for_task,
+                &session_id_for_task,
+                &model,
+                supervised,
+                Some(&result),
+                prompt_tokens,
+                started.elapsed().as_millis() as u64,
+                "ok",
+                None,
+            ),
+            Err((error, _)) => {
+                let status = if crate::conversation_sidecar::is_runtime_cancellation(&error) {
+                    "cancelled"
+                } else {
+                    "error"
+                };
+                crate::chat::record_agent_runtime_run(
+                    &app,
+                    &run_id_for_task,
+                    &session_id_for_task,
+                    &model,
+                    supervised,
+                    None,
+                    prompt_tokens,
+                    started.elapsed().as_millis() as u64,
+                    status,
+                    Some(error.clone()),
+                );
+                eprintln!("understudy desktop API conversation run failed: {error}");
+            }
         }
     });
 


### PR DESCRIPTION
What changed

- Record versioned Desktop API conversation turns in the same SQLite route ledger as GUI turns.
- Preserve exact run, session, and model identity plus token, tool, supervision, compaction, latency, memory, and terminal status evidence.
- Classify cancellations separately from runtime errors.

Why

Canonical API traces were persisted but omitted from the v1 metrics chat-routes endpoint, leaving exact-release migration cohorts at zero despite successful API turns.

Validation

- Rust library tests: 160 passed, 4 ignored.
- Strict Rust clippy passed.
- Full npm check: 314 tests, typecheck, 33 skill validations, package smoke.
- Git diff check passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->