### PR TITLE
Fix completed supervisor nudges as replacements

### DIFF
--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -481,7 +481,7 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
 
     let mut event_ids = HashSet::new();
     let mut pending_tools: HashMap<&str, &str> = HashMap::new();
-    let mut interrupt_markers = HashSet::new();
+    let mut intervention_markers = HashSet::new();
     let mut interrupted_markers = HashSet::new();
     let mut terminal_seen = false;
 
@@ -586,12 +586,12 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
                 {
                     return Err("interrupt/nudge verdict requires a reason".to_string());
                 }
-                if matches!(verdict, RuntimeVerdict::Interrupt) {
+                if matches!(verdict, RuntimeVerdict::Interrupt | RuntimeVerdict::Nudge) {
                     let marker = marker_id
                         .as_deref()
                         .filter(|value| !value.trim().is_empty())
-                        .ok_or_else(|| "interrupt verdict requires marker_id".to_string())?;
-                    interrupt_markers.insert(marker);
+                        .ok_or_else(|| "interrupt/nudge verdict requires marker_id".to_string())?;
+                    intervention_markers.insert(marker);
                 }
                 if let Some(target) = handoff_target.as_deref() {
                     if !matches!(target, "local" | "remote") {
@@ -626,7 +626,7 @@ pub(crate) fn validate_trace(events: &[RuntimeEventEnvelope]) -> Result<(), Stri
                 marker_id, reason, ..
             } => {
                 required(reason, "student_interruption.reason")?;
-                if !interrupt_markers.contains(marker_id.as_str()) {
+                if !intervention_markers.contains(marker_id.as_str()) {
                     return Err(format!(
                         "student interruption {marker_id} has no supervisor verdict"
                     ));
@@ -809,22 +809,22 @@ mod tests {
     }
 
     #[test]
-    fn accepts_linked_supervisor_takeover() {
+    fn accepts_linked_supervisor_nudge_takeover() {
         let events = vec![
             envelope(
                 0,
                 RuntimeEvent::SupervisorVerdict {
-                    verdict: RuntimeVerdict::Interrupt,
+                    verdict: RuntimeVerdict::Nudge,
                     source: "model".to_string(),
                     supervisor_model: "understudy-supervisor".to_string(),
                     marker_id: Some("marker-1".to_string()),
                     reason: Some("wrong tool".to_string()),
-                    probabilities: Some(json!({"interrupt": -0.1})),
+                    probabilities: Some(json!({"nudge": -0.1})),
                     probability_kind: Some("logprob".to_string()),
                     boundary_ordinal: Some(0),
                     after_chars: Some(7),
                     decision_phase: Some(RuntimeDecisionPhase::Streaming),
-                    raw: Some("interrupt: wrong tool".to_string()),
+                    raw: Some("nudge: wrong tool".to_string()),
                     error: None,
                     failure_kind: None,
                     handoff_target: Some("local".to_string()),
@@ -846,14 +846,14 @@ mod tests {
                     reason: "correct it".to_string(),
                     teacher_model: "teacher".to_string(),
                     from_partial_chars: 7,
-                    output_mode: TeacherOutputMode::Append,
+                    output_mode: TeacherOutputMode::Replace,
                 },
             ),
         ];
         validate_trace(&events).unwrap();
         let serialized = serde_json::to_value(&events[0]).unwrap();
         assert_eq!(serialized["data"]["probability_kind"], json!("logprob"));
-        assert_eq!(serialized["data"]["probabilities"]["interrupt"], -0.1);
+        assert_eq!(serialized["data"]["probabilities"]["nudge"], -0.1);
         assert_eq!(
             serialized["data"]["supervisor_model"],
             json!("understudy-supervisor")

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -380,7 +380,7 @@ export function validateRuntimeTrace(values: readonly unknown[]): RuntimeEventEn
   const runtimeId = requiredString(first, "runtime_id");
   const eventIds = new Set<string>();
   const pendingTools = new Map<string, string>();
-  const interruptMarkers = new Set<string>();
+  const interventionMarkers = new Set<string>();
   const interruptedMarkers = new Set<string>();
   let terminalSeen = false;
 
@@ -584,13 +584,15 @@ export function validateRuntimeTrace(values: readonly unknown[]): RuntimeEventEn
           }
         }
       }
-      if (verdict === "interrupt") {
-        interruptMarkers.add(requiredString(data, "marker_id", "supervisor_verdict.marker_id"));
+      if (verdict === "interrupt" || verdict === "nudge") {
+        interventionMarkers.add(
+          requiredString(data, "marker_id", "supervisor_verdict.marker_id"),
+        );
       }
     } else if (event === "student_interruption") {
       const marker = requiredString(data, "marker_id", "student_interruption.marker_id");
       requiredString(data, "reason", "student_interruption.reason");
-      if (!interruptMarkers.has(marker)) {
+      if (!interventionMarkers.has(marker)) {
         throw new Error(`student interruption ${marker} has no supervisor verdict`);
       }
       interruptedMarkers.add(marker);

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -1285,7 +1285,7 @@ async function runPiSupervisedConversation(
     const markerId = segment.markerId;
     const reason = segment.decision.reason;
     if (!markerId || !reason) {
-      throw new Error("interrupt verdict lost its marker or reason");
+      throw new Error("intervention verdict lost its marker or reason");
     }
     await writer.emit("student_interruption", {
       marker_id: markerId,

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -534,6 +534,10 @@ export function teacherOutputMode(studentCompleted: boolean): "append" | "replac
   return studentCompleted ? "replace" : "append";
 }
 
+export function shouldResumeNudgedStudent(studentCompleted: boolean): boolean {
+  return !studentCompleted;
+}
+
 async function createPiRuntimeSession(options: {
   request: RuntimeRunRequest;
   target: RuntimeProviderTarget;
@@ -1260,7 +1264,10 @@ async function runPiSupervisedConversation(
     if (segment.terminal || segment.decision.verdict === "continue" || segment.decision.verdict === "stop") {
       return;
     }
-    if (segment.decision.verdict === "nudge") {
+    if (
+      segment.decision.verdict === "nudge" &&
+      shouldResumeNudgedStudent(segment.studentCompleted)
+    ) {
       markerOrdinal += 1;
       nudges += 1;
       messages = [

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -22,6 +22,7 @@ import {
   supervisorHandoffTarget,
   teacherContinuationBoundary,
   teacherOutputMode,
+  shouldResumeNudgedStudent,
 } from "../dist/runtime/conversation/pi-runtime.js";
 import {
   parseRuntimeRequest,
@@ -1068,11 +1069,52 @@ test("teacher continuation inserts only a missing word boundary", () => {
 test("teacher output replaces only a completed rejected answer", () => {
   assert.equal(teacherOutputMode(false), "append");
   assert.equal(teacherOutputMode(true), "replace");
+  assert.equal(shouldResumeNudgedStudent(false), true);
+  assert.equal(shouldResumeNudgedStudent(true), false);
 });
 
 test("every supervisor decision gets a stable labelable marker", () => {
   assert.equal(supervisorDecisionMarker("run-1", 3, 0, false), "run-1:verdict:3");
   assert.equal(supervisorDecisionMarker("run-1", 3, 2, true), "run-1:intervention:2");
+});
+
+test("a completed nudge can link replacement continuation evidence", () => {
+  const envelope = (sequence, event, data) => ({
+    schema_version: "understudy-conversation-runtime-event-v1",
+    event_id: `run-completed-nudge:${sequence}`,
+    run_id: "run-completed-nudge",
+    session_id: "session-completed-nudge",
+    runtime_id: "pi-agent-session",
+    sequence,
+    emitted_at: "2026-07-14T00:00:00Z",
+    event,
+    data,
+  });
+  assert.doesNotThrow(() =>
+    validateRuntimeTrace([
+      envelope(0, "supervisor_verdict", {
+        verdict: "nudge",
+        source: "model",
+        supervisor_model: "supervisor-model",
+        marker_id: "run-completed-nudge:intervention:0",
+        reason: "Replace the incorrect structured field.",
+        decision_phase: "final",
+      }),
+      envelope(1, "student_interruption", {
+        marker_id: "run-completed-nudge:intervention:0",
+        reason: "Replace the incorrect structured field.",
+        partial_text: '{"answer":"wrong"}',
+        after_chars: 18,
+      }),
+      envelope(2, "teacher_continuation", {
+        marker_id: "run-completed-nudge:intervention:0",
+        reason: "Replace the incorrect structured field.",
+        teacher_model: "teacher-model",
+        from_partial_chars: 18,
+        output_mode: "replace",
+      }),
+    ]),
+  );
 });
 
 test("canonical verdict evidence rejects impossible positive logprobs", () => {


### PR DESCRIPTION
## Summary
- route a final-answer NUDGE through teacher replacement instead of appending a second structured answer
- let canonical Node and Desktop validators link nudge intervention markers to student interruption and teacher continuation
- add regression coverage for completed-nudge replacement evidence

## Why
The live grocery buyer smoke produced two concatenated JSON objects after the supervisor correctly nudged one field. The corrected replacement path then exposed that Desktop only accepted interrupt markers, not nudge markers. This keeps the original verdict and reason while producing one parseable replacement answer.

## Verification
- npm run check (315 tests, typecheck, 33 skill validations, package smoke)
- cargo test (160 passed, 4 ignored)
- cargo clippy --all-targets --all-features -- -D warnings
- targeted Node and Rust completed-nudge tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->