### PR TITLE
Release Desktop 0.3.15

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.11"
+    "version": "0.6.12"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.11"
+    "version": "0.6.12"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Fixed
 
+- **Completed supervisor nudges replace the student answer cleanly.**
+  Desktop/runtime 0.3.15 and CLI 0.6.12 preserve the original nudge verdict,
+  interruption reason, and teacher continuation while replacing a completed
+  structured answer instead of appending a second payload. Streaming nudges
+  can still resume the student in place.
+
 - **Desktop API conversations now count toward the exact-release migration
   cohort.** Desktop/runtime 0.3.14 and CLI 0.6.11 record versioned API turns in
   the same local route ledger as GUI turns, including caller-owned run and

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.14",
+  "version": "0.3.15",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.14"
+version = "0.3.15"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.11";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.12";
 const UNDERSTUDY_INSTALLER_URL: &str =
     "https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh";
 

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.14";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.15";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -49,7 +49,7 @@ never terminates them, so release qualification cannot overlap another Metal
 workload:
 
 ```sh
-APP_VERSION=0.3.14
+APP_VERSION=0.3.15
 npm run runtime:desktop-readiness -- \
   --output ".understudy/capture-evidence/desktop-runtime-readiness-${APP_VERSION}.json"
 ```
@@ -57,7 +57,7 @@ npm run runtime:desktop-readiness -- \
 The output is private, contains no token values, and is not packaged. It fails
 closed if app, runtime, or model RSS is unavailable. Evidence filenames are
 version-bound so a later run cannot silently stand in for the installed cohort.
-The last fully regenerated exact-version evidence before Desktop 0.3.14 is the
+The last fully regenerated exact-version evidence before Desktop 0.3.15 is the
 notarized 0.3.12 release, which passes all gates:
 
 | Gate | Result | Ceiling |
@@ -75,7 +75,7 @@ ordinary warm restart.
 The exact-version 0.3.12 conformance report also passes every frozen scenario:
 basic chat, offline image, authenticated tool round, malformed-tool recovery,
 supervisor takeover, long-chat compaction, restart/resume, and cancellation.
-Desktop 0.3.14 must regenerate both reports before its release cohort is called
+Desktop 0.3.15 must regenerate both reports before its release cohort is called
 qualified; passing 0.3.12 evidence is intentionally insufficient.
 
 The rebuilt debug app also passed a caller-correlated headless tool round. The
@@ -108,8 +108,8 @@ Anthropic key and catalog storage in Rust.
 The release artifact exposes the gate directly:
 
 ```sh
-APP_VERSION=0.3.14
-RUNTIME_VERSION=0.3.14
+APP_VERSION=0.3.15
+RUNTIME_VERSION=0.3.15
 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
 understudy runtime conformance \
   --backend pi \

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -132,8 +132,8 @@ readiness evidence from the installed notarized app after publication. Evidence
 from an older version cannot qualify the new release cohort.
 
 Write both reports to version-bound paths, for example
-`desktop-runtime-conformance-0.3.14.json` and
-`desktop-runtime-readiness-0.3.14.json`. `understudy desktop migration-status`
+`desktop-runtime-conformance-0.3.15.json` and
+`desktop-runtime-readiness-0.3.15.json`. `understudy desktop migration-status`
 selects these exact-version defaults from the live app/runtime cohort; explicit
 paths remain available for archived or isolated evidence roots.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.14";
+export const RUNTIME_VERSION = "0.3.15";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -2559,7 +2559,7 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       model: "conformance-cli",
     });
     assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
-    assert.equal(cliReport.metadata.runtime_version, "0.3.14");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.15");
     assert.equal(
       cliReport.metadata.event_schema,
       "understudy-conversation-runtime-event-v1",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -98,7 +98,7 @@ function writeReleaseEvidence() {
     adapter_id: "pi",
     generated_at: "2026-07-12T20:00:00.000Z",
     metadata: {
-      runtime_version: "0.3.14",
+      runtime_version: "0.3.15",
       event_schema: "understudy-conversation-runtime-event-v1",
       network_mode: "offline",
       provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
@@ -142,7 +142,7 @@ function writeReleaseEvidence() {
     },
     app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
     runtime: {
-      runtime_version: "0.3.14",
+      runtime_version: "0.3.15",
       event_schema: "understudy-conversation-runtime-event-v1",
       ready_ms: 700,
       rss_mb: 120,
@@ -244,7 +244,7 @@ before(async () => {
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
         app_version: "0.3.2",
-        runtime_version: "0.3.14",
+        runtime_version: "0.3.15",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,
@@ -271,7 +271,7 @@ before(async () => {
         run_id: `cohort-run-${index}`,
         runtime_backend: "pi",
         app_version: "0.3.2",
-        runtime_version: "0.3.14",
+        runtime_version: "0.3.15",
         session_id: `cohort-session-${index}`,
         status: "ok",
         prompt_tokens: cohortFailure === "token-mismatch" && index === 0 ? 11 : 10,

--- a/tests/desktop-release-check.test.mjs
+++ b/tests/desktop-release-check.test.mjs
@@ -121,97 +121,97 @@ test("release history rejects one CLI version for two runtime builds", async () 
     git(root, ["config", "user.name", "Understudy Release Test"]);
     git(root, ["config", "user.email", "release-test@invalid.example"]);
 
-    replaceOnce(paths["package.json"], '"version": "0.6.11"', '"version": "0.6.10"');
+    replaceOnce(paths["package.json"], '"version": "0.6.12"', '"version": "0.6.11"');
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.12"',
       'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.11"',
-      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.10"',
     );
     replaceOnce(
       paths["apps/homescreen/package.json"],
+      '"version": "0.3.15"',
       '"version": "0.3.14"',
-      '"version": "0.3.13"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/tauri.conf.json"],
+      '"version": "0.3.15"',
       '"version": "0.3.14"',
-      '"version": "0.3.13"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.toml"],
+      'version = "0.3.15"',
       'version = "0.3.14"',
-      'version = "0.3.13"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.lock"],
+      'name = "understudy"\nversion = "0.3.15"',
       'name = "understudy"\nversion = "0.3.14"',
-      'name = "understudy"\nversion = "0.3.13"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
+      'RUNTIME_VERSION: &str = "0.3.15"',
       'RUNTIME_VERSION: &str = "0.3.14"',
-      'RUNTIME_VERSION: &str = "0.3.13"',
     );
     replaceOnce(
       paths["src/runtime/conversation/contract.ts"],
+      'RUNTIME_VERSION = "0.3.15"',
       'RUNTIME_VERSION = "0.3.14"',
-      'RUNTIME_VERSION = "0.3.13"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "runtime 0.3.13 and CLI 0.6.10"]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.14 and CLI 0.6.11"]);
     const transitionCommit = git(root, ["rev-parse", "HEAD"]);
 
     replaceOnce(
       paths["apps/homescreen/package.json"],
-      '"version": "0.3.13"',
       '"version": "0.3.14"',
+      '"version": "0.3.15"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/tauri.conf.json"],
-      '"version": "0.3.13"',
       '"version": "0.3.14"',
+      '"version": "0.3.15"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.toml"],
-      'version = "0.3.13"',
       'version = "0.3.14"',
+      'version = "0.3.15"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.lock"],
-      'name = "understudy"\nversion = "0.3.13"',
       'name = "understudy"\nversion = "0.3.14"',
+      'name = "understudy"\nversion = "0.3.15"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
-      'RUNTIME_VERSION: &str = "0.3.13"',
       'RUNTIME_VERSION: &str = "0.3.14"',
+      'RUNTIME_VERSION: &str = "0.3.15"',
     );
     replaceOnce(
       paths["src/runtime/conversation/contract.ts"],
-      'RUNTIME_VERSION = "0.3.13"',
       'RUNTIME_VERSION = "0.3.14"',
+      'RUNTIME_VERSION = "0.3.15"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "runtime 0.3.14 without CLI bump"]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.15 without CLI bump"]);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     const stale = await inspectDesktopRelease({ root });
     assert.equal(stale.ok, false);
-    assert.match(stale.errors.join("\n"), /runtime transition:.*CLI 0\.6\.10 did not advance/);
+    assert.match(stale.errors.join("\n"), /runtime transition:.*CLI 0\.6\.11 did not advance/);
     assert.equal(stale.compatibility.runtime_transition.commit, transitionCommit);
 
-    replaceOnce(paths["package.json"], '"version": "0.6.10"', '"version": "0.6.11"');
+    replaceOnce(paths["package.json"], '"version": "0.6.11"', '"version": "0.6.12"');
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
-      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.10"',
       'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.11"',
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.12"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "advance CLI for runtime 0.3.14"]);
+    git(root, ["commit", "--quiet", "-m", "advance CLI for runtime 0.3.15"]);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     const ready = await inspectDesktopRelease({ root });
     assert.equal(ready.ok, true, ready.errors.join("\n"));
     assert.equal(ready.compatibility.runtime_transition.commit, transitionCommit);
-    assert.equal(ready.compatibility.runtime_transition.cli_version, "0.6.10");
+    assert.equal(ready.compatibility.runtime_transition.cli_version, "0.6.11");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/desktop-runtime-release-gate.test.mjs
+++ b/tests/desktop-runtime-release-gate.test.mjs
@@ -10,32 +10,32 @@ import {
 
 test("desktop release evidence defaults are bound to the exact app and runtime versions", () => {
   assert.equal(
-    defaultDesktopConformanceEvidencePath("0.3.14"),
-    ".understudy/capture-evidence/desktop-runtime-conformance-0.3.14.json",
+    defaultDesktopConformanceEvidencePath("0.3.15"),
+    ".understudy/capture-evidence/desktop-runtime-conformance-0.3.15.json",
   );
   assert.equal(
-    defaultDesktopReadinessEvidencePath("0.3.14"),
-    ".understudy/capture-evidence/desktop-runtime-readiness-0.3.14.json",
+    defaultDesktopReadinessEvidencePath("0.3.15"),
+    ".understudy/capture-evidence/desktop-runtime-readiness-0.3.15.json",
   );
 
   const report = evaluateDesktopRuntimeReleaseEvidence({
-    app_version: "0.3.14",
-    runtime_version: "0.3.14",
+    app_version: "0.3.15",
+    runtime_version: "0.3.15",
   });
   assert.equal(
     report.conformance.path,
-    resolve(".understudy/capture-evidence/desktop-runtime-conformance-0.3.14.json"),
+    resolve(".understudy/capture-evidence/desktop-runtime-conformance-0.3.15.json"),
   );
   assert.equal(
     report.readiness.path,
-    resolve(".understudy/capture-evidence/desktop-runtime-readiness-0.3.14.json"),
+    resolve(".understudy/capture-evidence/desktop-runtime-readiness-0.3.15.json"),
   );
 });
 
 test("desktop release evidence filenames sanitize non-version path characters", () => {
   assert.equal(
-    defaultDesktopConformanceEvidencePath(" release/0.3.14 candidate "),
-    ".understudy/capture-evidence/desktop-runtime-conformance-release-0.3.14-candidate.json",
+    defaultDesktopConformanceEvidencePath(" release/0.3.15 candidate "),
+    ".understudy/capture-evidence/desktop-runtime-conformance-release-0.3.15-candidate.json",
   );
   assert.equal(
     defaultDesktopReadinessEvidencePath("   "),


### PR DESCRIPTION
## Summary
- ship the completed-nudge replacement fix as Desktop/runtime 0.3.15
- advance the bundled CLI and every agent adapter to 0.6.12
- keep exact-version release evidence and compatibility tests pinned to the patch

## Validation
- `npm run check` (315 tests, typecheck, 33 public skills, package smoke)
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` (160 passed, 4 ignored)
- `cargo clippy --manifest-path apps/homescreen/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->