### PR TITLE
ci(desktop): automate signed releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,264 @@
+name: Desktop Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Validate credentials, or build and publish the current version
+        required: true
+        type: choice
+        default: validate
+        options:
+          - validate
+          - release
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-production-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Sign, notarize, and publish
+    runs-on: macos-15
+    timeout-minutes: 90
+    environment: desktop-release
+
+    steps:
+      - name: Refuse non-main releases
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Desktop releases must run from main, not ${GITHUB_REF}." >&2
+          exit 1
+
+      - name: Check out the exact release commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node 22.23.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.23.0
+          cache: npm
+
+      - name: Set up Bun 1.3.14
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Install locked dependencies
+        run: |
+          npm ci
+          bun install --cwd apps/homescreen --frozen-lockfile
+
+      - name: Validate source and tests
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          npm run check
+          cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml
+          npm run desktop:release-check -- --stage source
+
+      - name: Validate release credentials
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          for name in \
+            APPLE_CERTIFICATE \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_ID \
+            APPLE_PASSWORD \
+            APPLE_SIGNING_IDENTITY \
+            APPLE_TEAM_ID \
+            TAURI_SIGNING_PRIVATE_KEY
+          do
+            if [[ -z "${!name:-}" ]]; then
+              echo "The desktop-release environment is missing ${name}." >&2
+              exit 1
+            fi
+          done
+
+      - name: Import the Apple signing identity
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          keychain="$RUNNER_TEMP/understudy-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+          certificate="$RUNNER_TEMP/understudy-developer-id.p12"
+          updater_key="$RUNNER_TEMP/understudy-updater.key"
+          echo "::add-mask::$keychain_password"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 -D > "$certificate"
+          printf '%s' "$TAURI_SIGNING_PRIVATE_KEY" > "$updater_key"
+          chmod 600 "$certificate" "$updater_key"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security default-keychain -s "$keychain"
+          security import "$certificate" \
+            -k "$keychain" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$keychain_password" "$keychain"
+          security find-identity -v -p codesigning "$keychain"
+          {
+            echo "UNDERSTUDY_RELEASE_KEYCHAIN=$keychain"
+            echo "UNDERSTUDY_UPDATER_KEY=$updater_key"
+            echo "TAURI_SIGNING_PRIVATE_KEY=$updater_key"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate Apple notarization credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          history="$RUNNER_TEMP/notary-history.json"
+          xcrun notarytool history \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --output-format json > "$history"
+          jq -e '.history | type == "array"' "$history" >/dev/null
+
+      - name: Build signed Desktop artifacts
+        if: inputs.mode == 'release'
+        working-directory: apps/homescreen
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+        run: bun run tauri build --bundles app,dmg
+
+      - name: Notarize and staple the app
+        if: inputs.mode == 'release'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          version="$(node -p "require('./apps/homescreen/package.json').version")"
+          app="$PWD/apps/homescreen/src-tauri/target/release/bundle/macos/Understudy.app"
+          app_zip="$RUNNER_TEMP/Understudy-${version}.app.zip"
+          ditto -c -k --keepParent "$app" "$app_zip"
+          xcrun notarytool submit "$app_zip" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait --output-format json
+          xcrun stapler staple "$app"
+
+      - name: Rebuild and sign the updater archive
+        if: inputs.mode == 'release'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+        run: |
+          app="$PWD/apps/homescreen/src-tauri/target/release/bundle/macos/Understudy.app"
+          updater="$PWD/apps/homescreen/src-tauri/target/release/bundle/macos/Understudy.app.tar.gz"
+          rm -f "$updater" "${updater}.sig"
+          tar -czf "$updater" -C "$(dirname "$app")" "$(basename "$app")"
+          (
+            cd apps/homescreen
+            bun run tauri signer sign \
+              --private-key-path "$UNDERSTUDY_UPDATER_KEY" \
+              "$updater"
+          )
+          npm run desktop:updater-manifest
+          npm run desktop:release-check -- --stage signed
+
+      - name: Notarize and staple the DMG
+        if: inputs.mode == 'release'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          version="$(node -p "require('./apps/homescreen/package.json').version")"
+          dmg="$PWD/apps/homescreen/src-tauri/target/release/bundle/dmg/Understudy_${version}_aarch64.dmg"
+          xcrun notarytool submit "$dmg" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait --output-format json
+          xcrun stapler staple "$dmg"
+          npm run desktop:release-check -- --stage notarized
+
+      - name: Upload a draft and verify the public bytes
+        if: inputs.mode == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(node -p "require('./apps/homescreen/package.json').version")"
+          tag="desktop-v${version}-mvp"
+          commit="$(git rev-parse HEAD)"
+          dmg="$PWD/apps/homescreen/src-tauri/target/release/bundle/dmg/Understudy_${version}_aarch64.dmg"
+          updater="$PWD/apps/homescreen/src-tauri/target/release/bundle/macos/Understudy.app.tar.gz"
+          updater_sig="${updater}.sig"
+          updater_manifest="$(dirname "$updater")/latest.json"
+          download_dir="$RUNNER_TEMP/downloaded-release"
+          mkdir -p "$download_dir"
+          gh release create "$tag" \
+            "$dmg" "$updater" "$updater_sig" "$updater_manifest" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$commit" \
+            --title "Understudy Desktop v${version}" \
+            --generate-notes \
+            --draft
+          gh release download "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "Understudy_${version}_aarch64.dmg" \
+            --pattern "Understudy.app.tar.gz" \
+            --pattern "Understudy.app.tar.gz.sig" \
+            --pattern "latest.json" \
+            --dir "$download_dir"
+          downloaded="$download_dir/Understudy_${version}_aarch64.dmg"
+          test "$(shasum -a 256 "$dmg" | awk '{print $1}')" = \
+            "$(shasum -a 256 "$downloaded" | awk '{print $1}')"
+          test "$(shasum -a 256 "$updater" | awk '{print $1}')" = \
+            "$(shasum -a 256 "$download_dir/Understudy.app.tar.gz" | awk '{print $1}')"
+          cmp "$updater_sig" "$download_dir/Understudy.app.tar.gz.sig"
+          cmp "$updater_manifest" "$download_dir/latest.json"
+          xcrun stapler validate "$downloaded"
+          spctl --assess \
+            --type open \
+            --context context:primary-signature \
+            --verbose=2 \
+            "$downloaded"
+
+      - name: Publish the verified release
+        if: inputs.mode == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(node -p "require('./apps/homescreen/package.json').version")"
+          tag="desktop-v${version}-mvp"
+          gh release edit "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false \
+            --latest
+          echo "### Understudy Desktop ${version}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published https://github.com/${GITHUB_REPOSITORY}/releases/tag/${tag}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove temporary signing material
+        if: always()
+        run: |
+          rm -f \
+            "$RUNNER_TEMP/understudy-developer-id.p12" \
+            "$RUNNER_TEMP/understudy-updater.key"
+          if [[ -n "${UNDERSTUDY_RELEASE_KEYCHAIN:-}" ]]; then
+            security delete-keychain "$UNDERSTUDY_RELEASE_KEYCHAIN" || true
+          fi

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -48,6 +48,24 @@ and secret-shaped strings.
 
 ## Desktop release
 
+The normal production path is the **Desktop Release** GitHub Actions workflow.
+Run its `validate` mode from `main` to check the remote certificate and Apple
+credentials without building or publishing. After the version-bump PR is green,
+run `release` mode. The serialized workflow
+uses the protected `desktop-release` environment to build on Apple silicon,
+import an ephemeral Developer ID identity, sign the Tauri updater, submit the
+app and DMG to Apple, verify the downloaded draft assets byte-for-byte, and
+publish only after every gate passes. No local Keychain or 1Password prompt is
+required during a normal release.
+
+The environment owns these secrets: `APPLE_CERTIFICATE`,
+`APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`,
+`APPLE_SIGNING_IDENTITY`, `APPLE_TEAM_ID`, and
+`TAURI_SIGNING_PRIVATE_KEY`. Rotate them deliberately; never copy them into
+workflow inputs, logs, repository variables, or committed files.
+
+The commands below remain the local break-glass path.
+
 Desktop releases must come from the exact merged `origin/main` commit. The
 release check fails closed if the worktree is dirty, `HEAD` differs from the
 locally fetched `origin/main`, any of the six desktop/runtime version sources
@@ -116,7 +134,7 @@ xcrun stapler staple "$app"
 rm -f "$updater" "${updater}.sig"
 tar -czf "$updater" -C "$(dirname "$app")" "$(basename "$app")"
 cd apps/homescreen
-bun run tauri signer sign -- \
+bun run tauri signer sign \
   --private-key-path "$TAURI_SIGNING_PRIVATE_KEY" \
   "$updater"
 cd ../..

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,9 +18,10 @@ contact channel listed on the organization profile.
 - Treat `.env*`, shell history, local credential files, and provider config as
   non-release material.
 - Treat the Tauri updater private key as permanent production signing material.
-  Store it in the production secrets vault, never in GitHub or a checkout, and
-  publish only its public key. Losing or rotating it strands clients that trust
-  the embedded public key.
+  Keep its durable backup in the production secrets vault and its automation
+  copy only in the protected GitHub `desktop-release` environment; never write
+  it to a checkout or repository variable, and publish only its public key.
+  Losing or rotating it strands clients that trust the embedded public key.
 - If a secret appears in output or a committed file, stop and rotate it before
   continuing.
 
@@ -33,6 +34,16 @@ contact channel listed on the organization profile.
   metadata.
 - Public release checks should inspect built packages for ignored docs, env
   files, private paths, and secret-shaped strings.
+
+## Release Automation
+
+Normal Desktop releases use the protected GitHub `desktop-release`
+environment. Apple credentials, the base64 PKCS#12 Developer ID identity, and
+the Tauri updater private key are encrypted environment secrets. The workflow
+imports both keys into runner-temporary paths, deletes them in an `always()`
+cleanup step, and publishes only after it re-downloads and verifies the draft
+release assets. Maintainers must not paste signing material into workflow
+dispatch inputs, logs, repository variables, or committed files.
 
 ## Local Artifact Safety
 

--- a/tests/desktop-release-workflow.test.mjs
+++ b/tests/desktop-release-workflow.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/desktop-release.yml", import.meta.url),
+  "utf8",
+);
+
+test("Desktop releases are main-only, serialized, and use pinned actions", () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /default: validate/);
+  assert.match(workflow, /- validate\n          - release/);
+  assert.match(workflow, /github\.ref != 'refs\/heads\/main'/);
+  assert.match(workflow, /group: desktop-production-release/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /environment: desktop-release/);
+  assert.match(workflow, /permissions:\n  contents: write/);
+  assert.doesNotMatch(workflow, /uses: [^\n]+@(v\d+|main|stable)\b/);
+  const actionPins = [...workflow.matchAll(/uses: [^@\n]+@([0-9a-f]{40})/g)];
+  assert.equal(actionPins.length, 4);
+});
+
+test("Desktop release automation keeps every trust gate before publication", () => {
+  for (const secret of [
+    "APPLE_CERTIFICATE",
+    "APPLE_CERTIFICATE_PASSWORD",
+    "APPLE_ID",
+    "APPLE_PASSWORD",
+    "APPLE_SIGNING_IDENTITY",
+    "APPLE_TEAM_ID",
+    "TAURI_SIGNING_PRIVATE_KEY",
+  ]) {
+    assert.match(workflow, new RegExp(`secrets\\.${secret}`));
+  }
+  assert.ok(workflow.indexOf("npm ci") < workflow.indexOf("secrets.APPLE_CERTIFICATE"));
+  assert.match(workflow, /npm ci/);
+  assert.match(workflow, /bun install --cwd apps\/homescreen --frozen-lockfile/);
+  assert.match(workflow, /desktop:release-check -- --stage source/);
+  assert.match(workflow, /cargo test --manifest-path/);
+  assert.match(workflow, /notarytool history/);
+  assert.match(workflow, /jq -e '\.history \| type == "array"'/);
+  assert.equal([...workflow.matchAll(/if: inputs\.mode == 'release'/g)].length, 6);
+  assert.match(workflow, /notarytool submit "\$app_zip"/);
+  assert.match(workflow, /stapler staple "\$app"/);
+  assert.match(workflow, /tauri signer sign \\\n+              --private-key-path/);
+  assert.doesNotMatch(workflow, /tauri signer sign -- \\/);
+  assert.match(workflow, /desktop:updater-manifest/);
+  assert.match(workflow, /desktop:release-check -- --stage signed/);
+  assert.match(workflow, /notarytool submit "\$dmg"/);
+  assert.match(workflow, /desktop:release-check -- --stage notarized/);
+  assert.match(workflow, /gh release create/);
+  assert.match(workflow, /--draft/);
+  assert.match(workflow, /gh release download/);
+  assert.match(workflow, /xcrun stapler validate "\$downloaded"/);
+  assert.match(workflow, /spctl --assess/);
+  assert.ok(workflow.indexOf("gh release download") < workflow.indexOf("gh release edit"));
+});


### PR DESCRIPTION
## Summary
- add a main-only, serialized Desktop Release workflow with safe `validate` and production `release` modes
- build on Apple silicon, import an ephemeral Developer ID identity, sign the Tauri updater, notarize/staple app and DMG, and publish only after re-downloading and verifying draft assets
- pin every workflow action by commit SHA and scope release secrets away from dependency installation/test steps
- correct the local Tauri signer command and document the GitHub Actions path plus break-glass path
- provision the protected `desktop-release` environment with the seven required encrypted secrets and a protected-branches policy

## Validation
- `npm test`: 321 passed
- `node --test tests/desktop-release-workflow.test.mjs`: 2 passed
- Ruby YAML parse passed
- `git diff --check`
- protected environment and secret-name inventory verified through the GitHub API

## Rollout
After merge, run **Desktop Release** on `main` in `validate` mode. This imports the remote certificate and checks Apple notarization authentication without building or publishing. Future version bumps use `release` mode for the complete production path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->