### PR TITLE
fix(ci): tolerate missing status utilities

### DIFF
--- a/scripts/automationbench-fusion-status.mjs
+++ b/scripts/automationbench-fusion-status.mjs
@@ -21,11 +21,18 @@ function argValue(args, name) {
 
 function run(command, args) {
   const result = spawnSync(command, args, { encoding: "utf8", stdio: "pipe" });
+  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  const stderr = [
+    typeof result.stderr === "string" ? result.stderr.trim() : "",
+    result.error instanceof Error ? result.error.message : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
   return {
     ok: result.status === 0,
     status: result.status,
-    stdout: result.stdout.trim(),
-    stderr: result.stderr.trim(),
+    stdout,
+    stderr,
   };
 }
 

--- a/tests/automationbench-handoff-runner.test.mjs
+++ b/tests/automationbench-handoff-runner.test.mjs
@@ -99,6 +99,31 @@ describe("automationbench handoff runner", () => {
     assert.equal(payload.results.length, 1);
   });
 
+  it("reports missing status utilities instead of crashing", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        ...statusRunner.slice(1),
+        "--session",
+        "missing-understudy-test-session",
+        "--log",
+        join(dir, "missing.log"),
+        "--out-dir",
+        join(dir, "missing-results"),
+        "--json",
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PATH: dir },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.tmux.active, false);
+    assert.match(payload.tmux.error, /spawnSync tmux ENOENT/);
+    assert.deepEqual(payload.processes, []);
+  });
+
   it("prints local Fusion rollout demo status", () => {
     const outDir = join(dir, "demo");
     const runDir = join(outDir, "fusion-demo-test");


### PR DESCRIPTION
## Summary
- make the read-only AutomationBench status helper tolerate a missing `tmux` or `pgrep` executable
- preserve the execution error as bounded status evidence instead of dereferencing absent output buffers
- add a deterministic regression test with an empty `PATH`, matching the macOS GitHub-hosted release runner

## Validation
- `node --test tests/automationbench-handoff-runner.test.mjs`: 19 passed
- `git diff --check`
- reproduces and fixes Desktop Release validate run #29364187293

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->