### PR TITLE
ci: pin current action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   gates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"
           cache: npm
@@ -29,13 +29,13 @@ jobs:
       run:
         working-directory: apps/homescreen/src-tauri
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: apps/homescreen/src-tauri
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -34,12 +34,12 @@ jobs:
           exit 1
 
       - name: Check out the exact release commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Node 22.23.0
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.23.0
           cache: npm

--- a/tests/desktop-release-workflow.test.mjs
+++ b/tests/desktop-release-workflow.test.mjs
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { test } from "node:test";
 
 const workflow = readFileSync(
   new URL("../.github/workflows/desktop-release.yml", import.meta.url),
   "utf8",
 );
+const workflowRoot = new URL("../.github/workflows/", import.meta.url);
 
 test("Desktop releases are main-only, serialized, and use pinned actions", () => {
   assert.match(workflow, /workflow_dispatch:/);
@@ -19,6 +20,17 @@ test("Desktop releases are main-only, serialized, and use pinned actions", () =>
   assert.doesNotMatch(workflow, /uses: [^\n]+@(v\d+|main|stable)\b/);
   const actionPins = [...workflow.matchAll(/uses: [^@\n]+@([0-9a-f]{40})/g)];
   assert.equal(actionPins.length, 4);
+});
+
+test("Every GitHub Action is pinned by a full commit SHA", () => {
+  const files = readdirSync(workflowRoot).filter((name) => /\.ya?ml$/.test(name));
+  assert.ok(files.length >= 2);
+  for (const name of files) {
+    const source = readFileSync(new URL(name, workflowRoot), "utf8");
+    for (const match of source.matchAll(/uses: ([^\s#]+)/g)) {
+      assert.match(match[1], /@[0-9a-f]{40}$/, `${name}: ${match[1]}`);
+    }
+  }
 });
 
 test("Desktop release automation keeps every trust gate before publication", () => {


### PR DESCRIPTION
## Summary
- upgrade Desktop release checkout/setup actions to their current Node 24 generations
- replace all pre-existing floating CI action tags with reviewed full commit SHAs
- add a repository-wide regression test that rejects every non-SHA workflow action reference

## Validation
- `node --test tests/desktop-release-workflow.test.mjs`: 3 passed
- all workflow YAML parsed successfully
- `git diff --check`
- prompted by the otherwise-successful Desktop Release validate run #29364776309 annotation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->