### PR TITLE
ci(desktop): reuse exact-commit CI evidence

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -13,6 +13,7 @@ on:
           - release
 
 permissions:
+  checks: read
   contents: write
 
 concurrency:
@@ -44,25 +45,50 @@ jobs:
           node-version: 22.23.0
           cache: npm
 
+      - name: Require green CI for the exact release commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          checks="$RUNNER_TEMP/release-check-runs.json"
+          gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
+            > "$checks"
+          for name in gates rust
+          do
+            if ! jq -e \
+              --arg name "$name" \
+              '[.check_runs[] | select(.name == $name and .conclusion == "success")] | length > 0' \
+              "$checks" >/dev/null
+            then
+              echo "Required ${name} check is not successful for ${GITHUB_SHA}." >&2
+              jq -r \
+                --arg name "$name" \
+                '.check_runs[] | select(.name == $name) | [.name, .status, (.conclusion // "")] | @tsv' \
+                "$checks" >&2
+              exit 1
+            fi
+          done
+
+      - name: Validate the exact release source
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          npm run desktop:release-check -- --stage source
+
       - name: Set up Bun 1.3.14
+        if: inputs.mode == 'release'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
       - name: Set up Rust
+        if: inputs.mode == 'release'
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Install locked dependencies
+        if: inputs.mode == 'release'
         run: |
           npm ci
           bun install --cwd apps/homescreen --frozen-lockfile
-
-      - name: Validate source and tests
-        run: |
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          npm run check
-          cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml
-          npm run desktop:release-check -- --stage source
 
       - name: Validate release credentials
         env:

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -58,6 +58,11 @@ app and DMG to Apple, verify the downloaded draft assets byte-for-byte, and
 publish only after every gate passes. No local Keychain or 1Password prompt is
 required during a normal release.
 
+Both modes require successful `gates` and `rust` checks for the exact `main`
+commit. The release workflow reuses that evidence instead of rerunning the full
+test suites on a fresh macOS runner; if main CI is still running, wait for it and
+dispatch again.
+
 The environment owns these secrets: `APPLE_CERTIFICATE`,
 `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`,
 `APPLE_SIGNING_IDENTITY`, `APPLE_TEAM_ID`, and

--- a/tests/desktop-release-workflow.test.mjs
+++ b/tests/desktop-release-workflow.test.mjs
@@ -16,7 +16,7 @@ test("Desktop releases are main-only, serialized, and use pinned actions", () =>
   assert.match(workflow, /group: desktop-production-release/);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.match(workflow, /environment: desktop-release/);
-  assert.match(workflow, /permissions:\n  contents: write/);
+  assert.match(workflow, /permissions:\n  checks: read\n  contents: write/);
   assert.doesNotMatch(workflow, /uses: [^\n]+@(v\d+|main|stable)\b/);
   const actionPins = [...workflow.matchAll(/uses: [^@\n]+@([0-9a-f]{40})/g)];
   assert.equal(actionPins.length, 4);
@@ -48,11 +48,15 @@ test("Desktop release automation keeps every trust gate before publication", () 
   assert.ok(workflow.indexOf("npm ci") < workflow.indexOf("secrets.APPLE_CERTIFICATE"));
   assert.match(workflow, /npm ci/);
   assert.match(workflow, /bun install --cwd apps\/homescreen --frozen-lockfile/);
+  assert.match(workflow, /commits\/\$GITHUB_SHA\/check-runs\?per_page=100/);
+  assert.match(workflow, /for name in gates rust/);
+  assert.match(workflow, /\.name == \$name and \.conclusion == "success"/);
   assert.match(workflow, /desktop:release-check -- --stage source/);
-  assert.match(workflow, /cargo test --manifest-path/);
+  assert.doesNotMatch(workflow, /npm run check/);
+  assert.doesNotMatch(workflow, /cargo test/);
   assert.match(workflow, /notarytool history/);
   assert.match(workflow, /jq -e '\.history \| type == "array"'/);
-  assert.equal([...workflow.matchAll(/if: inputs\.mode == 'release'/g)].length, 6);
+  assert.equal([...workflow.matchAll(/if: inputs\.mode == 'release'/g)].length, 9);
   assert.match(workflow, /notarytool submit "\$app_zip"/);
   assert.match(workflow, /stapler staple "\$app"/);
   assert.match(workflow, /tauri signer sign \\\n+              --private-key-path/);


### PR DESCRIPTION
## Summary
- require successful `gates` and `rust` check-runs for the exact `main` release SHA
- stop rerunning the same full Node/Rust suites serially on the macOS release runner
- skip Bun, Rust, and dependency installation entirely in credential-only `validate` mode
- keep the source lineage gate local to the release runner and keep all build/sign/notarize/publish gates unchanged

## Why
The final remote credential validation passed, but took 9m19s because it duplicated already-green exact-commit CI. This keeps the evidence boundary while making validate mode roughly a credential preflight instead of another full CI run.

## Validation
- `node --test tests/desktop-release-workflow.test.mjs`: 3 passed
- workflow YAML parse passed
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->