### PR TITLE
Desktop 0.3.18: remove always-on-top pin and expose update checks

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.14"
+    "version": "0.6.15"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.14"
+    "version": "0.6.15"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Fixed
 
+- **Desktop window controls are simpler and updates are easier to verify.**
+  Desktop/runtime 0.3.18 and CLI 0.6.15 remove the persisted always-on-top
+  titlebar pin and its native capability. The macOS application menu and
+  menu-bar tray now both expose **Check for Updates…**, with current,
+  available, and failed checks reported through the shared operation notice.
+  Automatic availability checks still run at launch and every 15 minutes.
+
 - **Desktop chat is direct by default and releases can update in place.**
   Desktop/runtime 0.3.17 and CLI 0.6.14 stop attaching the experimental
   supervisor to ordinary model-picker turns. Explicit evaluation and agent API

--- a/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
+++ b/apps/homescreen/app/components/RuntimeRepairPrompt.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -8,6 +9,7 @@ import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { OperationNotice } from "./OperationNotice";
 import {
   CONVERSATION_RUNTIME_REPAIR_REQUEST,
+  DESKTOP_DOWNLOAD_URL,
   MLX_REPAIR_REQUEST,
   isConversationRuntimeError,
   isMissingMlxVlmError,
@@ -22,6 +24,14 @@ import {
 
 const HEALTH_REFRESH_MS = 15 * 60 * 1_000;
 const SUCCESS_VISIBLE_MS = 2_400;
+
+const MANUAL_UPDATE_PROMPT: RepairPrompt = {
+  runtime: "desktop",
+  title: "Checking for updates",
+  reason: "Contacting the signed Understudy release channel.",
+  command: DESKTOP_DOWNLOAD_URL,
+  actionLabel: "Check again",
+};
 
 type NativeRepairProgress = {
   operation: string;
@@ -54,6 +64,7 @@ export function RuntimeRepairPrompt() {
   const [progress, setProgress] = useState<RepairProgress>(IDLE_PROGRESS);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const successTimer = useRef<number | null>(null);
+  const updateCheckInFlight = useRef(false);
   const busy = progress.status === "running";
 
   const refreshHealth = useCallback(async (): Promise<DesktopHealth | null> => {
@@ -67,6 +78,73 @@ export function RuntimeRepairPrompt() {
       return null;
     }
   }, []);
+
+  const checkForUpdates = useCallback(async () => {
+    if (busy || updateCheckInFlight.current) return;
+    updateCheckInFlight.current = true;
+    if (successTimer.current !== null) {
+      window.clearTimeout(successTimer.current);
+      successTimer.current = null;
+    }
+    setPrompt(MANUAL_UPDATE_PROMPT);
+    setProgress({
+      status: "running",
+      message: "Checking the signed update channel…",
+      detail: "This usually takes a few seconds",
+      step: 0,
+      total: 1,
+      startedAt: Date.now(),
+    });
+    try {
+      const [update, currentVersion] = await Promise.all([
+        check({ timeout: 10_000 }),
+        getVersion().catch(() => null),
+      ]);
+      if (update) {
+        setPrompt({
+          runtime: "desktop",
+          title: "Understudy Desktop update available",
+          reason: `${currentVersion ?? "installed"} → ${update.version}`,
+          command: DESKTOP_DOWNLOAD_URL,
+          actionLabel: "Install update",
+        });
+        setProgress(IDLE_PROGRESS);
+        return;
+      }
+
+      setProgress({
+        status: "success",
+        message: "Understudy is up to date",
+        detail: currentVersion ? `Version ${currentVersion}` : "No newer signed release found",
+        step: 1,
+        total: 1,
+        startedAt: null,
+      });
+      successTimer.current = window.setTimeout(() => {
+        successTimer.current = null;
+        void refreshHealth().finally(() => setProgress(IDLE_PROGRESS));
+      }, SUCCESS_VISIBLE_MS);
+    } catch (error) {
+      const detail = String(error);
+      setPrompt({
+        runtime: "desktop",
+        title: "Update check failed",
+        reason: detail,
+        command: DESKTOP_DOWNLOAD_URL,
+        actionLabel: "Open downloads",
+      });
+      setProgress({
+        status: "error",
+        message: "Update check failed",
+        detail,
+        step: 0,
+        total: 1,
+        startedAt: null,
+      });
+    } finally {
+      updateCheckInFlight.current = false;
+    }
+  }, [busy, refreshHealth]);
 
   useEffect(() => {
     if (!busy || progress.startedAt === null) {
@@ -87,6 +165,16 @@ export function RuntimeRepairPrompt() {
     },
     [],
   );
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    const unlisten = listen("check-for-updates", () => {
+      void checkForUpdates();
+    });
+    return () => {
+      void unlisten.then((remove) => remove());
+    };
+  }, [checkForUpdates]);
 
   useEffect(() => {
     void refreshHealth();

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -251,30 +251,6 @@ select,
   background: var(--surface-2);
   color: var(--text);
 }
-.titlebar-pin {
-  position: fixed;
-  z-index: 30;
-  top: 9px;
-  left: calc(var(--traffic-left) + 76px);
-  display: inline-grid;
-  place-content: center;
-  width: 30px;
-  height: 30px;
-  border: 0;
-  border-radius: var(--r-control);
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
-  color: var(--text-2);
-}
-.titlebar-pin.with-chat-controls {
-  left: calc(var(--traffic-left) + 114px);
-}
-.titlebar-pin:hover {
-  background: var(--surface-2);
-  color: var(--text);
-}
-.titlebar-pin.pinned {
-  color: var(--text);
-}
 .titlebar-qr {
   position: fixed;
   z-index: 30;

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -2,8 +2,7 @@
 import { useEffect, useState } from "react";
 import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
-import { HistoryIcon, PanelLeftIcon, PinIcon, PinOffIcon, SquarePenIcon } from "lucide-react";
+import { HistoryIcon, PanelLeftIcon, SquarePenIcon } from "lucide-react";
 import { Sidebar, type PaneId } from "./components/Sidebar";
 import { StatusPane } from "./components/StatusPane";
 import { ModelsPane } from "./components/ModelsPane";
@@ -24,7 +23,6 @@ export default function Page() {
   const [railOpen, setRailOpen] = useState(false);
   const [chatResetToken, setChatResetToken] = useState(0);
   const [chatHistoryToken, setChatHistoryToken] = useState(0);
-  const [pinned, setPinned] = useState(false);
   const status = useStatus();
   const connected = status.snap?.connected ?? false;
 
@@ -68,33 +66,6 @@ export default function Page() {
       u.then((f) => f());
     };
   }, []);
-
-  useEffect(() => {
-    let saved = false;
-    try {
-      saved = localStorage.getItem("understudy.alwaysOnTop") === "1";
-    } catch {
-      // Storage can be unavailable in browser-only development.
-    }
-    if (!saved) return;
-    setPinned(true);
-    getCurrentWindow()
-      .setAlwaysOnTop(true)
-      .catch(() => setPinned(false));
-  }, []);
-
-  const togglePin = () => {
-    const next = !pinned;
-    setPinned(next);
-    try {
-      localStorage.setItem("understudy.alwaysOnTop", next ? "1" : "0");
-    } catch {
-      // Best effort; the window behavior still works for this session.
-    }
-    getCurrentWindow()
-      .setAlwaysOnTop(next)
-      .catch(() => setPinned(!next));
-  };
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -142,20 +113,6 @@ export default function Page() {
           </button>
         </>
       )}
-      <button
-        type="button"
-        className={"titlebar-pin" + (pane === "chat" ? " with-chat-controls" : "") + (pinned ? " pinned" : "")}
-        aria-label={pinned ? "Unpin window (always on top)" : "Pin window always on top"}
-        aria-pressed={pinned}
-        title={pinned ? "Unpin window" : "Keep window on top"}
-        onClick={togglePin}
-      >
-        {pinned ? (
-          <PinOffIcon aria-hidden="true" size={15} strokeWidth={2} />
-        ) : (
-          <PinIcon aria-hidden="true" size={15} strokeWidth={2} />
-        )}
-      </button>
       <DownloadQrButton />
       <div className="operation-notice-stack">
         <RuntimeRepairPrompt />

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.17",
+  "version": "0.3.18",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.17"
+version = "0.3.18"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/capabilities/default.json
+++ b/apps/homescreen/src-tauri/capabilities/default.json
@@ -6,7 +6,6 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
-    "core:window:allow-set-always-on-top",
     "opener:default",
     "updater:default"
   ]

--- a/apps/homescreen/src-tauri/gen/schemas/capabilities.json
+++ b/apps/homescreen/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Capability for the main window","local":true,"windows":["main"],"permissions":["core:default","core:window:allow-start-dragging","core:window:allow-set-always-on-top","opener:default","updater:default"]}}
+{"default":{"identifier":"default","description":"Capability for the main window","local":true,"windows":["main"],"permissions":["core:default","core:window:allow-start-dragging","opener:default","updater:default"]}}

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.14";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.15";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.17";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.18";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -30,15 +30,24 @@ mod supervision_tiebreaker;
 mod tool_proof;
 mod workload_drop;
 
-use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+use tauri::menu::{Menu, MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
+
+const CHECK_FOR_UPDATES_MENU_ID: &str = "check-for-updates";
+const CHECK_FOR_UPDATES_TRAY_ID: &str = "tray-check-for-updates";
+const CHECK_FOR_UPDATES_EVENT: &str = "check-for-updates";
 
 fn show_window(app: &tauri::AppHandle) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
         let _ = w.set_focus();
     }
+}
+
+fn request_update_check(app: &tauri::AppHandle) {
+    show_window(app);
+    let _ = app.emit(CHECK_FOR_UPDATES_EVENT, ());
 }
 
 #[tauri::command]
@@ -50,6 +59,43 @@ fn restart_app(app: tauri::AppHandle) {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .menu(|app| {
+            let app_menu = SubmenuBuilder::new(app, "Understudy")
+                .about(None)
+                .text(CHECK_FOR_UPDATES_MENU_ID, "Check for Updates…")
+                .separator()
+                .services()
+                .separator()
+                .hide()
+                .hide_others()
+                .show_all()
+                .separator()
+                .quit()
+                .build()?;
+            let edit_menu = SubmenuBuilder::new(app, "Edit")
+                .undo()
+                .redo()
+                .separator()
+                .cut()
+                .copy()
+                .paste()
+                .select_all()
+                .build()?;
+            let window_menu = SubmenuBuilder::new(app, "Window")
+                .minimize()
+                .fullscreen()
+                .separator()
+                .bring_all_to_front()
+                .build()?;
+            MenuBuilder::new(app)
+                .items(&[&app_menu, &edit_menu, &window_menu])
+                .build()
+        })
+        .on_menu_event(|app, event| {
+            if event.id().as_ref() == CHECK_FOR_UPDATES_MENU_ID {
+                request_update_check(app);
+            }
+        })
         .setup(|app| {
             #[cfg(desktop)]
             app.handle()
@@ -106,6 +152,13 @@ pub fn run() {
 
             // Menu-bar tray.
             let show = MenuItem::with_id(app, "show", "Show Understudy", true, None::<&str>)?;
+            let updates = MenuItem::with_id(
+                app,
+                CHECK_FOR_UPDATES_TRAY_ID,
+                "Check for Updates…",
+                true,
+                None::<&str>,
+            )?;
             let conn = MenuItem::with_id(
                 app,
                 "connect",
@@ -120,9 +173,13 @@ pub fn run() {
                 true,
                 None::<&str>,
             )?;
-            let sep = PredefinedMenuItem::separator(app)?;
+            let update_sep = PredefinedMenuItem::separator(app)?;
+            let quit_sep = PredefinedMenuItem::separator(app)?;
             let quit = MenuItem::with_id(app, "quit", "Quit Understudy", true, None::<&str>)?;
-            let menu = Menu::with_items(app, &[&show, &conn, &disc, &sep, &quit])?;
+            let menu = Menu::with_items(
+                app,
+                &[&show, &updates, &update_sep, &conn, &disc, &quit_sep, &quit],
+            )?;
 
             let icon = app
                 .default_window_icon()
@@ -135,6 +192,7 @@ pub fn run() {
                 .menu(&menu)
                 .on_menu_event(|app, event| match event.id.as_ref() {
                     "show" => show_window(app),
+                    CHECK_FOR_UPDATES_TRAY_ID => request_update_check(app),
                     "connect" => {
                         let _ = bin::command("moraine").arg("up").status();
                     }

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/docs/desktop-product-parity.json
+++ b/docs/desktop-product-parity.json
@@ -135,7 +135,7 @@
     {
       "id": "signed-in-app-updates",
       "status": "shipped",
-      "evidence": "Desktop checks the canonical GitHub release endpoint, downloads only Tauri-signature-verified macOS updater archives, shows progress through the shared managed-operation notice, installs and restarts in place, and falls back to the signed manual download when automatic installation fails."
+      "evidence": "Desktop checks the canonical GitHub release endpoint at launch and every 15 minutes, while both the native macOS application menu and menu-bar tray expose an explicit Check for Updates action. It downloads only Tauri-signature-verified macOS updater archives, shows checks and install progress through the shared managed-operation notice, installs and restarts in place, and falls back to the signed manual download when automatic installation fails."
     },
     {
       "id": "durable-image-and-chat-persistence",
@@ -186,11 +186,6 @@
       "id": "reading-pace-streaming",
       "status": "shipped",
       "evidence": "Chat keeps the full canonical stream as its persistence and evidence source while revealing only the latest answer at a brisk reading rate with bounded elastic catch-up. Direct simulations show a 20-character-per-second provider stays within two characters of live display, while a 1,000-character local burst drains within two seconds after Done. A visible Show full answer escape hatch appears only beyond a 300-character backlog, reduced-motion and understudy.pacing=off disable pacing, and teacher ReplaceChunk events reset the hidden buffer so rejected student text cannot leak into the correction."
-    },
-    {
-      "id": "always-on-top-window-pin",
-      "status": "shipped",
-      "evidence": "The canonical titlebar exposes the reviewed user-controlled always-on-top pin, persists the preference locally, restores it on launch, reports its pressed state accessibly, and reverts the UI if the native window operation fails."
     },
     {
       "id": "heavy-model-preflight-and-process-reconciliation",

--- a/docs/dev-run/desktop-runtime-removal-map.md
+++ b/docs/dev-run/desktop-runtime-removal-map.md
@@ -49,7 +49,7 @@ never terminates them, so release qualification cannot overlap another Metal
 workload:
 
 ```sh
-APP_VERSION=0.3.17
+APP_VERSION=0.3.18
 npm run runtime:desktop-readiness -- \
   --output ".understudy/capture-evidence/desktop-runtime-readiness-${APP_VERSION}.json"
 ```
@@ -57,7 +57,7 @@ npm run runtime:desktop-readiness -- \
 The output is private, contains no token values, and is not packaged. It fails
 closed if app, runtime, or model RSS is unavailable. Evidence filenames are
 version-bound so a later run cannot silently stand in for the installed cohort.
-The last fully regenerated exact-version evidence before Desktop 0.3.17 is the
+The last fully regenerated exact-version evidence before Desktop 0.3.18 is the
 notarized 0.3.12 release, which passes all gates:
 
 | Gate | Result | Ceiling |
@@ -75,7 +75,7 @@ ordinary warm restart.
 The exact-version 0.3.12 conformance report also passes every frozen scenario:
 basic chat, offline image, authenticated tool round, malformed-tool recovery,
 supervisor takeover, long-chat compaction, restart/resume, and cancellation.
-Desktop 0.3.17 must regenerate both reports before its release cohort is called
+Desktop 0.3.18 must regenerate both reports before its release cohort is called
 qualified; passing 0.3.12 evidence is intentionally insufficient.
 
 The rebuilt debug app also passed a caller-correlated headless tool round. The
@@ -108,8 +108,8 @@ Anthropic key and catalog storage in Rust.
 The release artifact exposes the gate directly:
 
 ```sh
-APP_VERSION=0.3.17
-RUNTIME_VERSION=0.3.17
+APP_VERSION=0.3.18
+RUNTIME_VERSION=0.3.18
 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
 understudy runtime conformance \
   --backend pi \

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -196,8 +196,8 @@ readiness evidence from the installed notarized app after publication. Evidence
 from an older version cannot qualify the new release cohort.
 
 Write both reports to version-bound paths, for example
-`desktop-runtime-conformance-0.3.17.json` and
-`desktop-runtime-readiness-0.3.17.json`. `understudy desktop migration-status`
+`desktop-runtime-conformance-0.3.18.json` and
+`desktop-runtime-readiness-0.3.18.json`. `understudy desktop migration-status`
 selects these exact-version defaults from the live app/runtime cohort; explicit
 paths remain available for archived or isolated evidence roots.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.17";
+export const RUNTIME_VERSION = "0.3.18";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -2559,7 +2559,7 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       model: "conformance-cli",
     });
     assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
-    assert.equal(cliReport.metadata.runtime_version, "0.3.17");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.18");
     assert.equal(
       cliReport.metadata.event_schema,
       "understudy-conversation-runtime-event-v1",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -98,7 +98,7 @@ function writeReleaseEvidence() {
     adapter_id: "pi",
     generated_at: "2026-07-12T20:00:00.000Z",
     metadata: {
-      runtime_version: "0.3.17",
+      runtime_version: "0.3.18",
       event_schema: "understudy-conversation-runtime-event-v1",
       network_mode: "offline",
       provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
@@ -142,7 +142,7 @@ function writeReleaseEvidence() {
     },
     app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
     runtime: {
-      runtime_version: "0.3.17",
+      runtime_version: "0.3.18",
       event_schema: "understudy-conversation-runtime-event-v1",
       ready_ms: 700,
       rss_mb: 120,
@@ -244,7 +244,7 @@ before(async () => {
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
         app_version: "0.3.2",
-        runtime_version: "0.3.17",
+        runtime_version: "0.3.18",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,
@@ -271,7 +271,7 @@ before(async () => {
         run_id: `cohort-run-${index}`,
         runtime_backend: "pi",
         app_version: "0.3.2",
-        runtime_version: "0.3.17",
+        runtime_version: "0.3.18",
         session_id: `cohort-session-${index}`,
         status: "ok",
         prompt_tokens: cohortFailure === "token-mismatch" && index === 0 ? 11 : 10,

--- a/tests/desktop-release-check.test.mjs
+++ b/tests/desktop-release-check.test.mjs
@@ -132,97 +132,97 @@ test("release history rejects one CLI version for two runtime builds", async () 
     git(root, ["config", "user.name", "Understudy Release Test"]);
     git(root, ["config", "user.email", "release-test@invalid.example"]);
 
-    replaceOnce(paths["package.json"], '"version": "0.6.14"', '"version": "0.6.13"');
+    replaceOnce(paths["package.json"], '"version": "0.6.15"', '"version": "0.6.14"');
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.15"',
       'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.14"',
-      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.13"',
     );
     replaceOnce(
       paths["apps/homescreen/package.json"],
+      '"version": "0.3.18"',
       '"version": "0.3.17"',
-      '"version": "0.3.16"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/tauri.conf.json"],
+      '"version": "0.3.18"',
       '"version": "0.3.17"',
-      '"version": "0.3.16"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.toml"],
+      'version = "0.3.18"',
       'version = "0.3.17"',
-      'version = "0.3.16"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.lock"],
+      'name = "understudy"\nversion = "0.3.18"',
       'name = "understudy"\nversion = "0.3.17"',
-      'name = "understudy"\nversion = "0.3.16"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
+      'RUNTIME_VERSION: &str = "0.3.18"',
       'RUNTIME_VERSION: &str = "0.3.17"',
-      'RUNTIME_VERSION: &str = "0.3.16"',
     );
     replaceOnce(
       paths["src/runtime/conversation/contract.ts"],
+      'RUNTIME_VERSION = "0.3.18"',
       'RUNTIME_VERSION = "0.3.17"',
-      'RUNTIME_VERSION = "0.3.16"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "runtime 0.3.16 and CLI 0.6.13"]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.17 and CLI 0.6.14"]);
     const transitionCommit = git(root, ["rev-parse", "HEAD"]);
 
     replaceOnce(
       paths["apps/homescreen/package.json"],
-      '"version": "0.3.16"',
       '"version": "0.3.17"',
+      '"version": "0.3.18"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/tauri.conf.json"],
-      '"version": "0.3.16"',
       '"version": "0.3.17"',
+      '"version": "0.3.18"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.toml"],
-      'version = "0.3.16"',
       'version = "0.3.17"',
+      'version = "0.3.18"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.lock"],
-      'name = "understudy"\nversion = "0.3.16"',
       'name = "understudy"\nversion = "0.3.17"',
+      'name = "understudy"\nversion = "0.3.18"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
-      'RUNTIME_VERSION: &str = "0.3.16"',
       'RUNTIME_VERSION: &str = "0.3.17"',
+      'RUNTIME_VERSION: &str = "0.3.18"',
     );
     replaceOnce(
       paths["src/runtime/conversation/contract.ts"],
-      'RUNTIME_VERSION = "0.3.16"',
       'RUNTIME_VERSION = "0.3.17"',
+      'RUNTIME_VERSION = "0.3.18"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "runtime 0.3.17 without CLI bump"]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.18 without CLI bump"]);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     const stale = await inspectDesktopRelease({ root });
     assert.equal(stale.ok, false);
-    assert.match(stale.errors.join("\n"), /runtime transition:.*CLI 0\.6\.13 did not advance/);
+    assert.match(stale.errors.join("\n"), /runtime transition:.*CLI 0\.6\.14 did not advance/);
     assert.equal(stale.compatibility.runtime_transition.commit, transitionCommit);
 
-    replaceOnce(paths["package.json"], '"version": "0.6.13"', '"version": "0.6.14"');
+    replaceOnce(paths["package.json"], '"version": "0.6.14"', '"version": "0.6.15"');
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
-      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.13"',
       'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.14"',
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.15"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "advance CLI for runtime 0.3.17"]);
+    git(root, ["commit", "--quiet", "-m", "advance CLI for runtime 0.3.18"]);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     const ready = await inspectDesktopRelease({ root });
     assert.equal(ready.ok, true, ready.errors.join("\n"));
     assert.equal(ready.compatibility.runtime_transition.commit, transitionCommit);
-    assert.equal(ready.compatibility.runtime_transition.cli_version, "0.6.13");
+    assert.equal(ready.compatibility.runtime_transition.cli_version, "0.6.14");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -22,6 +22,10 @@ const runtimeRepairLibPath = new URL(
   "../apps/homescreen/app/lib/runtime-repair.ts",
   import.meta.url,
 );
+const tauriLibPath = new URL(
+  "../apps/homescreen/src-tauri/src/lib.rs",
+  import.meta.url,
+);
 const attachmentLibPath = new URL(
   "../apps/homescreen/app/lib/chat-attachments.ts",
   import.meta.url,
@@ -194,20 +198,36 @@ test("cold-start cloud fallback yields to local without overriding a human choic
   assert.match(selection, /preferredLocalId/);
 });
 
-test("desktop restores the reviewed persisted always-on-top pin", async () => {
-  const [page, permissions] = await Promise.all([
+test("desktop omits the always-on-top pin and its capability", async () => {
+  const [page, css, permissions] = await Promise.all([
     readFile(new URL("../apps/homescreen/app/page.tsx", import.meta.url), "utf8"),
+    readFile(cssPath, "utf8"),
     readFile(
       new URL("../apps/homescreen/src-tauri/capabilities/default.json", import.meta.url),
       "utf8",
     ),
   ]);
 
-  assert.match(page, /understudy\.alwaysOnTop/);
-  assert.match(page, /setAlwaysOnTop\(true\)/);
-  assert.match(page, /setAlwaysOnTop\(next\)/);
-  assert.match(page, /aria-pressed=\{pinned\}/);
-  assert.match(permissions, /core:window:allow-set-always-on-top/);
+  assert.doesNotMatch(page, /understudy\.alwaysOnTop/);
+  assert.doesNotMatch(page, /setAlwaysOnTop/);
+  assert.doesNotMatch(page, /PinIcon|PinOffIcon|titlebar-pin/);
+  assert.doesNotMatch(css, /\.titlebar-pin/);
+  assert.doesNotMatch(permissions, /core:window:allow-set-always-on-top/);
+});
+
+test("desktop offers an explicit signed update check from macOS menus", async () => {
+  const [native, prompt] = await Promise.all([
+    readFile(tauriLibPath, "utf8"),
+    readFile(runtimeRepairPromptPath, "utf8"),
+  ]);
+
+  assert.match(native, /SubmenuBuilder::new\(app, "Understudy"\)/);
+  assert.match(native, /"Check for Updates…"/);
+  assert.match(native, /CHECK_FOR_UPDATES_TRAY_ID/);
+  assert.match(native, /app\.emit\(CHECK_FOR_UPDATES_EVENT/);
+  assert.match(prompt, /listen\("check-for-updates"/);
+  assert.match(prompt, /Understudy is up to date/);
+  assert.match(prompt, /const HEALTH_REFRESH_MS = 15 \* 60 \* 1_000/);
 });
 
 test("desktop has one shared managed-operation notice surface", async () => {
@@ -533,7 +553,6 @@ test("desktop migration claims stay tied to explicit product parity", async () =
     "drop-to-workload-compilation",
     "model-card-transparency",
     "reading-pace-streaming",
-    "always-on-top-window-pin",
     "heavy-model-preflight-and-process-reconciliation",
     "native-runtime-deletion",
   ]) {


### PR DESCRIPTION
## Summary
- remove the titlebar always-on-top pin, its persisted state, CSS, and Tauri permission
- add native macOS and tray **Check for Updates…** actions
- route explicit checks through the shared operation notice and signed Tauri updater
- preserve automatic update-health checks at launch, after 2.5 seconds, and every 15 minutes
- bump Desktop/runtime to 0.3.18 and CLI/adapters to 0.6.15

## Verification
- `npm test` (324 passed)
- `npm run skills:validate`
- `npm run package:smoke`
- `bun install --frozen-lockfile`
- `bun run build`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (161 passed, 4 ignored fixture-only)
- `npm run desktop:release-check -- --stage source --allow-dirty --allow-unmerged`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->