### PR TITLE
Fix updater signing key collision in Desktop release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -199,7 +199,7 @@ jobs:
           tar -czf "$updater" -C "$(dirname "$app")" "$(basename "$app")"
           (
             cd apps/homescreen
-            bun run tauri signer sign \
+            env -u TAURI_SIGNING_PRIVATE_KEY bun run tauri signer sign \
               --private-key-path "$UNDERSTUDY_UPDATER_KEY" \
               "$updater"
           )

--- a/tests/desktop-release-workflow.test.mjs
+++ b/tests/desktop-release-workflow.test.mjs
@@ -59,7 +59,10 @@ test("Desktop release automation keeps every trust gate before publication", () 
   assert.equal([...workflow.matchAll(/if: inputs\.mode == 'release'/g)].length, 9);
   assert.match(workflow, /notarytool submit "\$app_zip"/);
   assert.match(workflow, /stapler staple "\$app"/);
-  assert.match(workflow, /tauri signer sign \\\n+              --private-key-path/);
+  assert.match(
+    workflow,
+    /env -u TAURI_SIGNING_PRIVATE_KEY bun run tauri signer sign \\\n+              --private-key-path/,
+  );
   assert.doesNotMatch(workflow, /tauri signer sign -- \\/);
   assert.match(workflow, /desktop:updater-manifest/);
   assert.match(workflow, /desktop:release-check -- --stage signed/);


### PR DESCRIPTION
## Summary
- unset the inherited `TAURI_SIGNING_PRIVATE_KEY` only around the explicit `tauri signer sign --private-key-path` invocation
- retain the file-backed key and password handling used by the protected release environment
- add a regression assertion for the exact non-conflicting command

## Evidence
Production release run [29372029721](https://github.com/understudylabs/understudy-agent-tools/actions/runs/29372029721) built, signed, notarized, and stapled the app, then failed closed before publication because Tauri rejected simultaneous environment and CLI private-key inputs.

## Verification
- `node --test tests/desktop-release-workflow.test.mjs`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->