### PR TITLE
Desktop: move chat history into the sidebar

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -893,6 +893,10 @@ export function ChatPane({
       onHistoryChanged?.();
     } catch (error) {
       setNotice(`Saved chat could not be opened: ${String(error)}`);
+    } finally {
+      // A missing or damaged saved session must not permanently disable
+      // persistence for whatever conversation the user starts next.
+      setSessionHydrated(true);
     }
   };
 

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -55,6 +55,7 @@ import {
   type ChatAttachmentUpload,
 } from "../lib/chat-attachments";
 import { modelShortName, type SnapshotAlias } from "../lib/model-aliases";
+import type { ChatSessionRequest } from "../lib/chat-history";
 import { resolveChatModelSelection } from "../lib/model-selection.mjs";
 import {
   SKIP_HINT_THRESHOLD,
@@ -134,12 +135,6 @@ type PersistedChatSession = {
   messages: Msg[];
   updated_at: string;
 };
-type ChatSessionSummary = {
-  session_id: string;
-  title: string;
-  message_count: number;
-  updated_at: string;
-};
 type LocalModelChoice = {
   id: string;
   modelId: string;
@@ -185,17 +180,6 @@ const CLOUD_MODEL: ModelChoice = {
 // This survives ChatPane remounts while the app is open (for example, after
 // visiting Models) but resets with the webview on a new app launch.
 let activeChatSessionId: string | null = null;
-
-function chatHistoryTime(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "Saved chat";
-  return date.toLocaleString([], {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
 
 function compactBytes(bytes: number): string {
   if (bytes < 1_024) return `${bytes} B`;
@@ -340,7 +324,17 @@ function ChatScrollTracker({
   );
 }
 
-export function ChatPane({ resetToken, historyToken }: { resetToken: number; historyToken: number }) {
+export function ChatPane({
+  resetToken,
+  requestedSession,
+  onSessionChange,
+  onHistoryChanged,
+}: {
+  resetToken: number;
+  requestedSession: ChatSessionRequest | null;
+  onSessionChange?: (sessionId: string) => void;
+  onHistoryChanged?: () => void;
+}) {
   const [initialSession] = useState(() => {
     const restore = activeChatSessionId !== null;
     const sessionId = activeChatSessionId ?? crypto.randomUUID();
@@ -362,16 +356,13 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
   const [introThinking, setIntroThinking] = useState(true);
   const [sidekickEvents, setSidekickEvents] = useState<SidekickEvent[]>([]);
   const [sessionHydrated, setSessionHydrated] = useState(!initialSession.restore);
-  const [historyOpen, setHistoryOpen] = useState(false);
-  const [historyLoading, setHistoryLoading] = useState(false);
-  const [historySessions, setHistorySessions] = useState<ChatSessionSummary[]>([]);
   const [dropHovering, setDropHovering] = useState(false);
   const [dropRunning, setDropRunning] = useState(false);
   const [droppedWorkload, setDroppedWorkload] = useState<DroppedWorkload | null>(null);
   const [pacingMessageIndex, setPacingMessageIndex] = useState<number | null>(null);
   const [pacedRevealed, setPacedRevealed] = useState<number | null>(null);
   const observedResetToken = useRef(false);
-  const observedHistoryToken = useRef(false);
+  const observedSessionRequest = useRef<number | null>(null);
   const dropInFlight = useRef(false);
   const dropRequestGeneration = useRef(0);
   const selectedModelUserOwned = useRef(false);
@@ -580,7 +571,7 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
     // A cold launch intentionally begins with a new blank session. If the user
     // merely navigated away from Chat and back, restore the active session by
     // its exact ID instead of whichever historical chat happens to be newest.
-    if (!initialSession.restore) return;
+    if (!initialSession.restore || requestedSession) return;
     let cancelled = false;
     invoke<PersistedChatSession | null>("chat_session_get", {
       sessionId: initialSession.sessionId,
@@ -608,12 +599,18 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
       invoke("chat_session_save", {
         sessionId,
         messages: persistableChatMessages(messages),
-      }).catch(() => {
-        setNotice("This chat could not be saved for restart; the current turn is unaffected.");
-      });
+      })
+        .then(() => onHistoryChanged?.())
+        .catch(() => {
+          setNotice("This chat could not be saved for restart; the current turn is unaffected.");
+        });
     }, 150);
     return () => window.clearTimeout(timer);
-  }, [messages, sessionHydrated, sessionId, streaming]);
+  }, [messages, onHistoryChanged, sessionHydrated, sessionId, streaming]);
+
+  useEffect(() => {
+    onSessionChange?.(sessionId);
+  }, [onSessionChange, sessionId]);
 
   useEffect(() => {
     setIntroThinking(true);
@@ -829,10 +826,12 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
       void invoke("chat_session_save", {
         sessionId,
         messages: persistableChatMessages(messages),
-      }).catch(() => {
-        // The debounced save normally ran already. Starting a new chat should
-        // remain available if this final best-effort flush fails.
-      });
+      })
+        .then(() => onHistoryChanged?.())
+        .catch(() => {
+          // The debounced save normally ran already. Starting a new chat should
+          // remain available if this final best-effort flush fails.
+        });
     }
     const nextSessionId = crypto.randomUUID();
     activeChatSessionId = nextSessionId;
@@ -842,7 +841,6 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
     setNotice(null);
     setSessionId(nextSessionId);
     setSessionHydrated(true);
-    setHistoryOpen(false);
     setAssistantSpeaking(false);
     resetDroppedWorkload();
     setPersonaReady(false);
@@ -858,30 +856,11 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
     restartChat();
   }, [resetToken]);
 
-  const showHistory = () => {
+  const restoreHistorySession = async (historySessionId: string) => {
     if (streaming) {
       setNotice("Finish or stop the current turn before opening another chat.");
       return;
     }
-    setHistoryOpen(true);
-    setHistoryLoading(true);
-    invoke<ChatSessionSummary[]>("chat_sessions_list", { limit: 30 })
-      .then(setHistorySessions)
-      .catch((error) => setNotice(`Chat history could not be loaded: ${String(error)}`))
-      .finally(() => setHistoryLoading(false));
-  };
-
-  useEffect(() => {
-    if (!observedHistoryToken.current) {
-      observedHistoryToken.current = true;
-      return;
-    }
-    showHistory();
-  }, [historyToken]);
-
-  const restoreHistorySession = async (historySessionId: string) => {
-    if (streaming) return;
-    setHistoryLoading(true);
     setErr(null);
     setNotice(null);
     try {
@@ -906,17 +885,22 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
       activeChatSessionId = saved.session_id;
       setSessionId(saved.session_id);
       setMessages(restored);
+      setSessionHydrated(true);
       setInput("");
       setAssistantSpeaking(false);
       resetDroppedWorkload();
-      setHistoryOpen(false);
       setPersonaCycle((value) => value + 1);
+      onHistoryChanged?.();
     } catch (error) {
       setNotice(`Saved chat could not be opened: ${String(error)}`);
-    } finally {
-      setHistoryLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!requestedSession || observedSessionRequest.current === requestedSession.requestId) return;
+    observedSessionRequest.current = requestedSession.requestId;
+    void restoreHistorySession(requestedSession.sessionId);
+  }, [requestedSession]);
 
   const setThinking = async (thinking: boolean) => {
     if (selectedChoice.route !== "local") return;
@@ -992,52 +976,6 @@ export function ChatPane({ resetToken, historyToken }: { resetToken: number; his
         <div className="workload-drop-overlay" role="status">
           <div className="workload-drop-overlay-title">Drop one file or folder</div>
           <div>Metadata only · stays on this Mac</div>
-        </div>
-      )}
-      {historyOpen && (
-        <div
-          className="chat-history-overlay"
-          role="presentation"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) setHistoryOpen(false);
-          }}
-        >
-          <section className="chat-history-panel" role="dialog" aria-modal="true" aria-labelledby="chat-history-title">
-            <header className="chat-history-header">
-              <div>
-                <h2 id="chat-history-title">Chat history</h2>
-                <p>Open an earlier conversation on this Mac.</p>
-              </div>
-              <button type="button" aria-label="Close chat history" onClick={() => setHistoryOpen(false)}>
-                ×
-              </button>
-            </header>
-            <div className="chat-history-list">
-              {historyLoading && historySessions.length === 0 ? (
-                <div className="chat-history-empty">Loading…</div>
-              ) : historySessions.length === 0 ? (
-                <div className="chat-history-empty">No earlier chats yet.</div>
-              ) : (
-                historySessions.map((saved) => (
-                  <button
-                    type="button"
-                    className={"chat-history-row" + (saved.session_id === sessionId ? " current" : "")}
-                    key={saved.session_id}
-                    onClick={() => void restoreHistorySession(saved.session_id)}
-                    disabled={historyLoading}
-                  >
-                    <span className="chat-history-row-title">
-                      {saved.title.trim().replace(/\s+/g, " ") || "Untitled chat"}
-                    </span>
-                    <span className="chat-history-row-meta">
-                      {chatHistoryTime(saved.updated_at)} · {saved.message_count} message{saved.message_count === 1 ? "" : "s"}
-                      {saved.session_id === sessionId ? " · current" : ""}
-                    </span>
-                  </button>
-                ))
-              )}
-            </div>
-          </section>
         </div>
       )}
       <div className={"persona-stage" + (personaReady ? " persona-ready" : "")} aria-hidden="true">

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react";
+import { MessageSquareIcon } from "lucide-react";
+import { chatHistoryTime, type ChatSessionSummary } from "../lib/chat-history";
 
 export type PaneId =
   | "status"
@@ -16,143 +17,68 @@ export type PaneId =
   | "training-rl"
   | "training-jobs";
 
-const ICONS: Record<PaneId, ReactNode> = {
-  status: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M1 8h3l2-5 3 10 2-5h4" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" strokeLinecap="round" />
-    </svg>
-  ),
-  chat: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M2 3h12v8H6l-3 3v-3H2z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
-    </svg>
-  ),
-  models: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <rect x="2" y="2" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.3" />
-      <rect x="9" y="2" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.3" />
-      <rect x="2" y="9" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.3" />
-      <rect x="9" y="9" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.3" />
-    </svg>
-  ),
-  capture: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M2.5 4.5h4l1.2-1.5h5.8v9.5h-11z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
-      <path d="M5 8h6M8 5.5v5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" opacity=".72" />
-    </svg>
-  ),
-  rlm: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M6.5 2h3M8 2v4.2l4 6.3c.5.8 0 1.5-.9 1.5H4.9c-.9 0-1.4-.7-.9-1.5l4-6.3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M5.5 10.5h5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" opacity=".72" />
-    </svg>
-  ),
-  "training-evals": (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M2 11.5 5.5 8l2 2 5-5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M2 14h12" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-    </svg>
-  ),
-  "training-optimization": (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M3 12.5c2.7 0 2.7-9 5-9s2.3 9 5 9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-      <path d="M2 8h12" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" opacity=".65" />
-    </svg>
-  ),
-  "training-datasets": (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <ellipse cx="8" cy="3.5" rx="5" ry="1.8" stroke="currentColor" strokeWidth="1.3" />
-      <path d="M3 3.5v4c0 1 2.2 1.8 5 1.8s5-.8 5-1.8v-4M3 7.5v4c0 1 2.2 1.8 5 1.8s5-.8 5-1.8v-4" stroke="currentColor" strokeWidth="1.3" />
-    </svg>
-  ),
-  "training-finetuning": (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M3 13h10M5 13V5.5L8 3l3 2.5V13" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M6.5 8h3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-    </svg>
-  ),
-  "training-rl": (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M2.5 12.5 8 3l5.5 9.5H2.5Z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
-      <path d="M8 7v2.2M8 11.5h.01" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-    </svg>
-  ),
-  "training-jobs": (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M3 4h10M3 8h10M3 12h6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-    </svg>
-  ),
-  account: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <circle cx="8" cy="5.5" r="2.5" stroke="currentColor" strokeWidth="1.3" />
-      <path d="M3 14c.7-2.5 2.7-4 5-4s4.3 1.5 5 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-    </svg>
-  ),
-  usage: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M2 13V3M2 13h12M5 13V9M8 13V6M11 13V8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-    </svg>
-  ),
-  traces: (
-    <svg viewBox="0 0 16 16" fill="none" className="nav-icon">
-      <path d="M2 3h12M2 8h12M2 13h8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-    </svg>
-  ),
-};
-
-const SERVING_NAV: { id: PaneId; label: string }[] = [
-  { id: "chat", label: "Chat" },
-  { id: "status", label: "Status" },
-  { id: "models", label: "Models" },
-  { id: "rlm", label: "Experiments" },
-];
-
-// Keep the implementation available to agents and deep links while the human
-// navigation stays focused on the four product-level jobs reviewed in Train.
-const TRAINING_NAV: { id: PaneId; label: string }[] = [
-];
+const AccountIcon = () => (
+  <svg viewBox="0 0 16 16" fill="none" className="nav-icon" aria-hidden="true">
+    <circle cx="8" cy="5.5" r="2.5" stroke="currentColor" strokeWidth="1.3" />
+    <path d="M3 14c.7-2.5 2.7-4 5-4s4.3 1.5 5 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+  </svg>
+);
 
 export function Sidebar({
   active,
   onSelect,
   connected,
+  sessions,
+  activeSessionId,
+  historyLoading,
+  onSelectSession,
 }: {
   active: PaneId;
   onSelect: (id: PaneId) => void;
   connected: boolean;
+  sessions: ChatSessionSummary[];
+  activeSessionId: string | null;
+  historyLoading: boolean;
+  onSelectSession: (sessionId: string) => void;
 }) {
   return (
     <aside className="sidebar">
-      <div className="nav-section">Serving</div>
-      {SERVING_NAV.map((n) => (
-        <div
-          key={n.id}
-          className={"nav-item" + (active === n.id ? " active" : "")}
-          onClick={() => onSelect(n.id)}
-        >
-          {ICONS[n.id]}
-          {n.label}
-        </div>
-      ))}
-
-      {TRAINING_NAV.length > 0 && <div className="nav-section">Training</div>}
-      {TRAINING_NAV.map((n) => (
-        <div
-          key={n.id}
-          className={"nav-item" + (active === n.id ? " active" : "")}
-          onClick={() => onSelect(n.id)}
-        >
-          {ICONS[n.id]}
-          {n.label}
-        </div>
-      ))}
+      <div className="nav-section">Chats</div>
+      <nav className="chat-nav-list" aria-label="Recent chats">
+        {historyLoading && sessions.length === 0 ? (
+          <div className="chat-nav-empty">Loading chats…</div>
+        ) : sessions.length === 0 ? (
+          <div className="chat-nav-empty">No saved chats yet.</div>
+        ) : (
+          sessions.map((session) => (
+            <button
+              type="button"
+              key={session.session_id}
+              className={
+                "chat-nav-item" +
+                (active === "chat" && activeSessionId === session.session_id ? " active" : "")
+              }
+              onClick={() => onSelectSession(session.session_id)}
+              title={session.title}
+            >
+              <MessageSquareIcon className="nav-icon" aria-hidden="true" size={16} strokeWidth={1.6} />
+              <span className="chat-nav-copy">
+                <span className="chat-nav-title">
+                  {session.title.trim().replace(/\s+/g, " ") || "Untitled chat"}
+                </span>
+                <span className="chat-nav-time">{chatHistoryTime(session.updated_at)}</span>
+              </span>
+            </button>
+          ))
+        )}
+      </nav>
 
       <div className="nav-spacer" />
       <button
         className={"nav-account" + (active === "account" ? " active" : "")}
         onClick={() => onSelect("account")}
       >
-        {ICONS.account}
+        <AccountIcon />
         <span className="nav-account-copy">
           <span>Account</span>
           <span className="nav-account-status">

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -233,24 +233,6 @@ select,
   background: var(--surface-2);
   color: var(--text);
 }
-.titlebar-chat-history {
-  position: fixed;
-  z-index: 30;
-  top: 9px;
-  left: calc(var(--traffic-left) + 76px);
-  display: inline-grid;
-  place-content: center;
-  width: 30px;
-  height: 30px;
-  border: 0;
-  border-radius: var(--r-control);
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
-  color: var(--text-2);
-}
-.titlebar-chat-history:hover {
-  background: var(--surface-2);
-  color: var(--text);
-}
 .titlebar-qr {
   position: fixed;
   z-index: 30;
@@ -381,27 +363,79 @@ select,
   padding: 14px 10px 6px;
 }
 
-.nav-item {
+.chat-nav-list {
+  display: grid;
+  gap: 4px;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.chat-nav-list::-webkit-scrollbar {
+  display: none;
+}
+
+.chat-nav-item {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 10px;
+  width: 100%;
+  min-height: 49px;
+  padding: 8px 10px;
   border-radius: var(--r-control);
+  background: transparent;
   color: var(--text-2);
   cursor: pointer;
   border: 1px solid transparent;
   user-select: none;
+  text-align: left;
 }
 
-.nav-item:hover {
+.chat-nav-item:hover {
   background: var(--hover);
   color: var(--text);
 }
 
-.nav-item.active {
+.chat-nav-item.active {
   background: var(--surface-2);
   border-color: var(--border);
   color: var(--text);
+}
+
+.chat-nav-item:focus {
+  outline: none;
+}
+
+.chat-nav-item:focus-visible {
+  border-color: color-mix(in srgb, var(--mb-cyan) 62%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--mb-cyan) 22%, transparent);
+}
+
+.chat-nav-copy {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.chat-nav-title,
+.chat-nav-time {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-nav-title {
+  font-size: 12px;
+  color: inherit;
+}
+
+.chat-nav-time,
+.chat-nav-empty {
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.chat-nav-empty {
+  padding: 9px 10px;
 }
 
 .nav-icon {
@@ -1915,105 +1949,6 @@ select,
   display: flex;
   flex-direction: column;
   min-height: 0;
-}
-.chat-history-overlay {
-  position: fixed;
-  z-index: 75;
-  inset: 0;
-  display: grid;
-  place-items: start center;
-  padding: calc(var(--titlebar-h) + 24px) 18px 18px;
-  background: color-mix(in srgb, var(--c-window) 74%, transparent);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-}
-.chat-history-panel {
-  width: min(480px, 100%);
-  max-height: min(620px, calc(100vh - var(--titlebar-h) - 48px));
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  border: 1px solid var(--border-strong);
-  border-radius: 16px;
-  background: var(--surface);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
-}
-.chat-history-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 18px;
-  border-bottom: 1px solid var(--border);
-}
-.chat-history-header h2 {
-  margin: 0;
-  color: var(--text);
-  font-size: 16px;
-  font-weight: 600;
-}
-.chat-history-header p {
-  margin: 4px 0 0;
-  color: var(--text-3);
-  font-size: 12px;
-}
-.chat-history-header button {
-  display: grid;
-  place-content: center;
-  width: 28px;
-  height: 28px;
-  border: 0;
-  border-radius: var(--r-control);
-  background: transparent;
-  color: var(--text-3);
-  font-size: 20px;
-  line-height: 1;
-}
-.chat-history-header button:hover {
-  background: var(--hover);
-  color: var(--text);
-}
-.chat-history-list {
-  min-height: 90px;
-  overflow: auto;
-  padding: 8px;
-}
-.chat-history-row {
-  display: grid;
-  gap: 5px;
-  width: 100%;
-  border: 0;
-  border-radius: 10px;
-  background: transparent;
-  color: var(--text);
-  padding: 11px 12px;
-  text-align: left;
-}
-.chat-history-row:hover,
-.chat-history-row.current {
-  background: var(--surface-2);
-}
-.chat-history-row:disabled {
-  opacity: 0.65;
-}
-.chat-history-row-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 13px;
-  font-weight: 500;
-}
-.chat-history-row-meta {
-  color: var(--text-3);
-  font-family: var(--mono);
-  font-size: 10px;
-}
-.chat-history-empty {
-  display: grid;
-  place-content: center;
-  min-height: 110px;
-  color: var(--text-3);
-  font-size: 12px;
 }
 .ai-chat {
   padding: var(--titlebar-h) 24px 24px;

--- a/apps/homescreen/app/lib/chat-history.ts
+++ b/apps/homescreen/app/lib/chat-history.ts
@@ -1,0 +1,39 @@
+export type ChatSessionSummary = {
+  session_id: string;
+  title: string;
+  message_count: number;
+  updated_at: string;
+};
+
+export type ChatSessionRequest = {
+  sessionId: string;
+  requestId: number;
+};
+
+export function chatHistoryTime(value: string, now = new Date()): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Saved chat";
+
+  const elapsedMs = now.getTime() - date.getTime();
+  if (elapsedMs >= 0 && elapsedMs < 5 * 60 * 1_000) return "Just now";
+
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (sameDay) return "Today";
+
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  const wasYesterday =
+    date.getFullYear() === yesterday.getFullYear() &&
+    date.getMonth() === yesterday.getMonth() &&
+    date.getDate() === yesterday.getDate();
+  if (wasYesterday) return "Yesterday";
+
+  return date.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    ...(date.getFullYear() === now.getFullYear() ? {} : { year: "numeric" }),
+  });
+}

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -1,8 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
-import { isTauri } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { HistoryIcon, PanelLeftIcon, SquarePenIcon } from "lucide-react";
+import { PanelLeftIcon, SquarePenIcon } from "lucide-react";
 import { Sidebar, type PaneId } from "./components/Sidebar";
 import { StatusPane } from "./components/StatusPane";
 import { ModelsPane } from "./components/ModelsPane";
@@ -17,14 +17,42 @@ import { RlmPane } from "./components/RlmPane";
 import { RuntimeRepairPrompt } from "./components/RuntimeRepairPrompt";
 import { ModelDownloadNotice } from "./components/ModelDownloadNotice";
 import { useStatus } from "./lib/useStatus";
+import type { ChatSessionRequest, ChatSessionSummary } from "./lib/chat-history";
 
 export default function Page() {
   const [pane, setPane] = useState<PaneId>("chat");
   const [railOpen, setRailOpen] = useState(false);
   const [chatResetToken, setChatResetToken] = useState(0);
-  const [chatHistoryToken, setChatHistoryToken] = useState(0);
+  const [chatHistory, setChatHistory] = useState<ChatSessionSummary[]>([]);
+  const [chatHistoryLoading, setChatHistoryLoading] = useState(false);
+  const [activeChatSessionId, setActiveChatSessionId] = useState<string | null>(null);
+  const [requestedChatSession, setRequestedChatSession] = useState<ChatSessionRequest | null>(null);
   const status = useStatus();
   const connected = status.snap?.connected ?? false;
+
+  const refreshChatHistory = useCallback(() => {
+    if (!isTauri()) {
+      setChatHistory([]);
+      setChatHistoryLoading(false);
+      return;
+    }
+    setChatHistoryLoading(true);
+    invoke<ChatSessionSummary[]>("chat_sessions_list", { limit: 30 })
+      .then(setChatHistory)
+      .catch(() => setChatHistory([]))
+      .finally(() => setChatHistoryLoading(false));
+  }, []);
+
+  const handleChatSessionChange = useCallback((sessionId: string) => {
+    setActiveChatSessionId(sessionId);
+    setRequestedChatSession((current) =>
+      current?.sessionId === sessionId ? null : current,
+    );
+  }, []);
+
+  useEffect(() => {
+    if (railOpen) refreshChatHistory();
+  }, [railOpen, refreshChatHistory]);
 
   const newChat = () => {
     if (pane !== "chat") return;
@@ -102,15 +130,6 @@ export default function Page() {
           >
             <SquarePenIcon aria-hidden="true" size={15} strokeWidth={2} />
           </button>
-          <button
-            type="button"
-            className="titlebar-chat-history"
-            aria-label="Chat history"
-            title="Chat history"
-            onClick={() => setChatHistoryToken((token) => token + 1)}
-          >
-            <HistoryIcon aria-hidden="true" size={15} strokeWidth={2} />
-          </button>
         </>
       )}
       <DownloadQrButton />
@@ -122,13 +141,29 @@ export default function Page() {
         active={pane}
         onSelect={(next) => {
           setPane(next);
-          setRailOpen(false);
         }}
         connected={connected}
+        sessions={chatHistory}
+        activeSessionId={activeChatSessionId}
+        historyLoading={chatHistoryLoading}
+        onSelectSession={(sessionId) => {
+          setPane("chat");
+          setRequestedChatSession((current) => ({
+            sessionId,
+            requestId: (current?.requestId ?? 0) + 1,
+          }));
+        }}
       />
       <main className="content">
         {pane === "status" && <StatusPane status={status} />}
-        {pane === "chat" && <ChatPane resetToken={chatResetToken} historyToken={chatHistoryToken} />}
+        {pane === "chat" && (
+          <ChatPane
+            resetToken={chatResetToken}
+            requestedSession={requestedChatSession}
+            onSessionChange={handleChatSessionChange}
+            onHistoryChanged={refreshChatHistory}
+          />
+        )}
         {pane === "models" && <ModelsPane />}
         {pane === "capture" && <CapturePane />}
         {pane === "rlm" && <RlmPane />}

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -155,17 +155,16 @@ test("public desktop preserves the reviewed Train interaction language", async (
   );
   assert.match(chat, /msg\.stage === "cloud_fallback_local"/);
 
-  const serving = sidebar.match(
-    /const SERVING_NAV:[\s\S]*?= \[([\s\S]*?)\n\];/,
-  )?.[1];
-  assert.ok(serving, "SERVING_NAV remains statically auditable");
-  assert.match(serving, /label: "Chat"/);
-  assert.match(serving, /label: "Status"/);
-  assert.match(serving, /label: "Models"/);
-  assert.match(serving, /label: "Experiments"/);
-  assert.doesNotMatch(serving, /label: "Capture"/);
-  assert.doesNotMatch(serving, /label: "Traces"/);
-  assert.doesNotMatch(serving, /label: "Usage"/);
+  assert.match(sidebar, /<div className="nav-section">Chats<\/div>/);
+  assert.match(sidebar, /aria-label="Recent chats"/);
+  assert.match(sidebar, /sessions\.map\(\(session\) =>/);
+  assert.match(sidebar, /onSelectSession\(session\.session_id\)/);
+  assert.match(sidebar, /onSelect\("account"\)/);
+  assert.doesNotMatch(sidebar, /SERVING_NAV/);
+  assert.doesNotMatch(sidebar, /label: "Status"/);
+  assert.doesNotMatch(sidebar, /label: "Models"/);
+  assert.doesNotMatch(sidebar, /label: "Experiments"/);
+  assert.doesNotMatch(page, /titlebar-chat-history/);
 });
 
 test("reading pace is quiet, optional, and safe across teacher replacement", async () => {
@@ -313,16 +312,17 @@ test("desktop persists image references and retains them with chat history", asy
 });
 
 test("desktop starts fresh on launch and can reopen an exact Pi session", async () => {
-  const [chat, page, commands] = await Promise.all([
+  const [chat, page, sidebar, commands] = await Promise.all([
     readFile(chatPath, "utf8"),
     readFile(pagePath, "utf8"),
+    readFile(sidebarPath, "utf8"),
     readFile(new URL("../apps/homescreen/src-tauri/src/commands.rs", import.meta.url), "utf8"),
   ]);
 
   assert.match(chat, /let activeChatSessionId: string \| null = null/);
   assert.match(chat, /const restore = activeChatSessionId !== null/);
   assert.doesNotMatch(chat, /invoke<PersistedChatSession \| null>\("chat_session_latest"\)/);
-  assert.match(chat, /"chat_sessions_list"/);
+  assert.match(page, /"chat_sessions_list"/);
   assert.match(chat, /"chat_session_get"/);
   assert.match(chat, /activeChatSessionId = saved\.session_id/);
   assert.match(
@@ -330,7 +330,8 @@ test("desktop starts fresh on launch and can reopen an exact Pi session", async 
     /const resetDroppedWorkload = \(\) => \{[\s\S]*dropRequestGeneration\.current \+= 1;[\s\S]*dropInFlight\.current = false;[\s\S]*setDropRunning\(false\);/,
   );
   assert.equal(chat.match(/resetDroppedWorkload\(\);/g)?.length, 2);
-  assert.match(page, /aria-label="Chat history"/);
+  assert.match(sidebar, /aria-label="Recent chats"/);
+  assert.doesNotMatch(page, /aria-label="Chat history"/);
   assert.match(commands, /pub fn chat_sessions_list/);
   assert.match(commands, /pub fn chat_session_get/);
 });

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -327,6 +327,10 @@ test("desktop starts fresh on launch and can reopen an exact Pi session", async 
   assert.match(chat, /activeChatSessionId = saved\.session_id/);
   assert.match(
     chat,
+    /const restoreHistorySession = async[\s\S]*?finally \{[\s\S]*?setSessionHydrated\(true\);/,
+  );
+  assert.match(
+    chat,
     /const resetDroppedWorkload = \(\) => \{[\s\S]*dropRequestGeneration\.current \+= 1;[\s\S]*dropInFlight\.current = false;[\s\S]*setDropRunning\(false\);/,
   );
   assert.equal(chat.match(/resetDroppedWorkload\(\);/g)?.length, 2);


### PR DESCRIPTION
## What changed
- replace the product nav with persisted recent chats
- restore saved transcripts directly from the rail
- keep Account at the bottom and preserve the collapsible shell
- remove the duplicate titlebar history button and modal
- keep Status, Models, and Experiments available to internal routes without showing them in human navigation

## Verification
- `bun x tsc --noEmit`
- `bun run build`
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` (161 passed, 4 ignored)
- `npm run check` (324 tests passed)
- native Tauri QA: open/collapse rail, restore saved chat, new chat, Account round trip

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->