### PR TITLE
chore(release): prepare Desktop 0.3.21

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.17"
+    "version": "0.6.18"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.17"
+    "version": "0.6.18"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.20",
+  "version": "0.3.21",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.20"
+version = "0.3.21"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.17";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.18";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.20";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.21";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -196,8 +196,8 @@ readiness evidence from the installed notarized app after publication. Evidence
 from an older version cannot qualify the new release cohort.
 
 Write both reports to version-bound paths, for example
-`desktop-runtime-conformance-0.3.20.json` and
-`desktop-runtime-readiness-0.3.20.json`. `understudy desktop migration-status`
+`desktop-runtime-conformance-0.3.21.json` and
+`desktop-runtime-readiness-0.3.21.json`. `understudy desktop migration-status`
 selects these exact-version defaults from the live app/runtime cohort; explicit
 paths remain available for archived or isolated evidence roots.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.20";
+export const RUNTIME_VERSION = "0.3.21";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/conversation-runtime.test.mjs
+++ b/tests/conversation-runtime.test.mjs
@@ -2559,7 +2559,7 @@ test("Pi and Vercel execute the identical frozen conformance inputs", async () =
       model: "conformance-cli",
     });
     assert.equal(cliReport.metadata.runtime_id, "understudy-conversation-sidecar");
-    assert.equal(cliReport.metadata.runtime_version, "0.3.20");
+    assert.equal(cliReport.metadata.runtime_version, "0.3.21");
     assert.equal(
       cliReport.metadata.event_schema,
       "understudy-conversation-runtime-event-v1",

--- a/tests/desktop-api.test.mjs
+++ b/tests/desktop-api.test.mjs
@@ -98,7 +98,7 @@ function writeReleaseEvidence() {
     adapter_id: "pi",
     generated_at: "2026-07-12T20:00:00.000Z",
     metadata: {
-      runtime_version: "0.3.20",
+      runtime_version: "0.3.21",
       event_schema: "understudy-conversation-runtime-event-v1",
       network_mode: "offline",
       provider: { base_url: "http://127.0.0.1:9000/v1", model: "understudy-small" },
@@ -142,7 +142,7 @@ function writeReleaseEvidence() {
     },
     app: { version: "0.3.2", ready_ms: 200, rss_mb: 100 },
     runtime: {
-      runtime_version: "0.3.20",
+      runtime_version: "0.3.21",
       event_schema: "understudy-conversation-runtime-event-v1",
       ready_ms: 700,
       rss_mb: 120,
@@ -244,7 +244,7 @@ before(async () => {
       response.end(JSON.stringify({
         schema_version: "understudy.chat_route_metrics.v1",
         app_version: "0.3.2",
-        runtime_version: "0.3.20",
+        runtime_version: "0.3.21",
         observed_row_limit: ready ? 100 : 99,
         required_canonical_runtime_rows: 100,
         remaining_canonical_runtime_rows: ready ? 0 : 1,
@@ -271,7 +271,7 @@ before(async () => {
         run_id: `cohort-run-${index}`,
         runtime_backend: "pi",
         app_version: "0.3.2",
-        runtime_version: "0.3.20",
+        runtime_version: "0.3.21",
         session_id: `cohort-session-${index}`,
         status: "ok",
         prompt_tokens: cohortFailure === "token-mismatch" && index === 0 ? 11 : 10,

--- a/tests/desktop-release-check.test.mjs
+++ b/tests/desktop-release-check.test.mjs
@@ -132,97 +132,97 @@ test("release history rejects one CLI version for two runtime builds", async () 
     git(root, ["config", "user.name", "Understudy Release Test"]);
     git(root, ["config", "user.email", "release-test@invalid.example"]);
 
-    replaceOnce(paths["package.json"], '"version": "0.6.17"', '"version": "0.6.16"');
+    replaceOnce(paths["package.json"], '"version": "0.6.18"', '"version": "0.6.17"');
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.18"',
       'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.17"',
-      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.16"',
     );
     replaceOnce(
       paths["apps/homescreen/package.json"],
+      '"version": "0.3.21"',
       '"version": "0.3.20"',
-      '"version": "0.3.19"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/tauri.conf.json"],
+      '"version": "0.3.21"',
       '"version": "0.3.20"',
-      '"version": "0.3.19"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.toml"],
+      'version = "0.3.21"',
       'version = "0.3.20"',
-      'version = "0.3.19"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.lock"],
+      'name = "understudy"\nversion = "0.3.21"',
       'name = "understudy"\nversion = "0.3.20"',
-      'name = "understudy"\nversion = "0.3.19"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
+      'RUNTIME_VERSION: &str = "0.3.21"',
       'RUNTIME_VERSION: &str = "0.3.20"',
-      'RUNTIME_VERSION: &str = "0.3.19"',
     );
     replaceOnce(
       paths["src/runtime/conversation/contract.ts"],
+      'RUNTIME_VERSION = "0.3.21"',
       'RUNTIME_VERSION = "0.3.20"',
-      'RUNTIME_VERSION = "0.3.19"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "runtime 0.3.19 and CLI 0.6.16"]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.20 and CLI 0.6.17"]);
     const transitionCommit = git(root, ["rev-parse", "HEAD"]);
 
     replaceOnce(
       paths["apps/homescreen/package.json"],
-      '"version": "0.3.19"',
       '"version": "0.3.20"',
+      '"version": "0.3.21"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/tauri.conf.json"],
-      '"version": "0.3.19"',
       '"version": "0.3.20"',
+      '"version": "0.3.21"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.toml"],
-      'version = "0.3.19"',
       'version = "0.3.20"',
+      'version = "0.3.21"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/Cargo.lock"],
-      'name = "understudy"\nversion = "0.3.19"',
       'name = "understudy"\nversion = "0.3.20"',
+      'name = "understudy"\nversion = "0.3.21"',
     );
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/conversation_runtime.rs"],
-      'RUNTIME_VERSION: &str = "0.3.19"',
       'RUNTIME_VERSION: &str = "0.3.20"',
+      'RUNTIME_VERSION: &str = "0.3.21"',
     );
     replaceOnce(
       paths["src/runtime/conversation/contract.ts"],
-      'RUNTIME_VERSION = "0.3.19"',
       'RUNTIME_VERSION = "0.3.20"',
+      'RUNTIME_VERSION = "0.3.21"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "runtime 0.3.20 without CLI bump"]);
+    git(root, ["commit", "--quiet", "-m", "runtime 0.3.21 without CLI bump"]);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     const stale = await inspectDesktopRelease({ root });
     assert.equal(stale.ok, false);
-    assert.match(stale.errors.join("\n"), /runtime transition:.*CLI 0\.6\.16 did not advance/);
+    assert.match(stale.errors.join("\n"), /runtime transition:.*CLI 0\.6\.17 did not advance/);
     assert.equal(stale.compatibility.runtime_transition.commit, transitionCommit);
 
-    replaceOnce(paths["package.json"], '"version": "0.6.16"', '"version": "0.6.17"');
+    replaceOnce(paths["package.json"], '"version": "0.6.17"', '"version": "0.6.18"');
     replaceOnce(
       paths["apps/homescreen/src-tauri/src/bootstrap.rs"],
-      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.16"',
       'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.17"',
+      'MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.18"',
     );
     git(root, ["add", "."]);
-    git(root, ["commit", "--quiet", "-m", "advance CLI for runtime 0.3.20"]);
+    git(root, ["commit", "--quiet", "-m", "advance CLI for runtime 0.3.21"]);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     const ready = await inspectDesktopRelease({ root });
     assert.equal(ready.ok, true, ready.errors.join("\n"));
     assert.equal(ready.compatibility.runtime_transition.commit, transitionCommit);
-    assert.equal(ready.compatibility.runtime_transition.cli_version, "0.6.16");
+    assert.equal(ready.compatibility.runtime_transition.cli_version, "0.6.17");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Release

Prepare Understudy Desktop 0.3.21 and CLI/runtime 0.6.18 for the reversible chat archive and smooth-streaming update.

## Version contract

- Desktop/runtime: `0.3.21`
- bundled CLI/plugin surfaces: `0.6.18`
- minimum compatible CLI: `0.6.18`

## Validation

- targeted release, conversation runtime, and Desktop API tests: 51 passed
- `npm ci` and root build passed
- `git diff --check` passed
- source release checker reaches only its expected pre-merge guard: HEAD must equal `origin/main`

After merge, the automated Desktop Release workflow will build, sign, notarize, staple, Gatekeeper-check, checksum-round-trip, and publish the exact merged commit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->