### PR TITLE
Inspect dropped CSVs locally

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -1371,8 +1371,8 @@ export function ChatPane({
                       type="button"
                       className="btn ghost"
                       onClick={() => {
-                        setDroppedWorkload(null);
-                        dispatchDrop({ type: "reset" });
+                        setNotice(null);
+                        resetDroppedWorkload();
                       }}
                     >
                       Dismiss

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -129,9 +129,39 @@ type DroppedWorkload = {
   truncated: boolean;
   local_only: true;
   payload_read: false;
+  artifact_root: string;
   workload_card_path: string;
 };
 type WorkloadDropEvent = { type: "validating" | "compiling" };
+type CsvInspection = {
+  schema_version: "understudy.capture_import.csv_inspection.v1";
+  source_sha256: string;
+  source_bytes: number;
+  local_only: true;
+  payload_read: true;
+  source_rows_persisted: false;
+  persisted_data: "statistics-and-label-aggregates";
+  row_count: number;
+  column_count: number;
+  duplicate_row_count: number;
+  recommended_mapping: {
+    label_column: string | null;
+    input_columns: string[];
+    confidence: "high" | "low" | "none";
+    requires_confirmation: true;
+  };
+  label_distribution: { value: string; count: number }[];
+  label_distribution_truncated: boolean;
+  training_readiness: {
+    ready: boolean;
+    status: "ready" | "needs_mapping" | "needs_data" | "needs_cleanup";
+    class_count: number;
+    minimum_examples_per_class: number | null;
+    reasons: string[];
+    warnings: string[];
+  };
+  artifact_path: string;
+};
 
 const CLOUD_SUPERVISOR_FALLBACK_NOTICE =
   "Tried to hand off to a larger cloud model, but it is unavailable. Continuing with the local model.";
@@ -234,6 +264,23 @@ function workloadReviewPrompt(workload: DroppedWorkload): string {
     JSON.stringify(metadata, null, 2),
     "Return: the benchmark goal, the smallest safe slice, one primary metric, the exact baseline/candidate comparison, and the one question that must be answered before any payload access.",
     "The source payload remains unread and local. Recommend an explicit next action before reading it.",
+  ].join("\n\n");
+}
+
+function csvInspectionReviewPrompt(inspection: CsvInspection): string {
+  return [
+    "Review this local CSV training inspection and explain the smallest honest next step.",
+    "Use only the statistics below. The CSV rows stayed local and are not included here, so do not claim you read individual examples.",
+    "First ask the user to confirm or correct the input and label columns. Then explain any data readiness blockers in plain language. Do not claim the model is trained or recommend uploading the data.",
+    JSON.stringify({
+      row_count: inspection.row_count,
+      column_count: inspection.column_count,
+      duplicate_row_count: inspection.duplicate_row_count,
+      recommended_mapping: inspection.recommended_mapping,
+      label_distribution: inspection.label_distribution,
+      label_distribution_truncated: inspection.label_distribution_truncated,
+      training_readiness: inspection.training_readiness,
+    }, null, 2),
   ].join("\n\n");
 }
 
@@ -383,6 +430,7 @@ export function ChatPane({
     INITIAL_WORKLOAD_DROP_PHASE,
   );
   const [droppedWorkload, setDroppedWorkload] = useState<DroppedWorkload | null>(null);
+  const [csvInspection, setCsvInspection] = useState<CsvInspection | null>(null);
   const [pacingMessageIndex, setPacingMessageIndex] = useState<number | null>(null);
   const [pacedRevealed, setPacedRevealed] = useState<number | null>(null);
   const [animatedMessageId, setAnimatedMessageId] = useState<string | null>(null);
@@ -439,7 +487,42 @@ export function ChatPane({
     dropRequestGeneration.current += 1;
     dropInFlight.current = false;
     setDroppedWorkload(null);
+    setCsvInspection(null);
     dispatchDrop({ type: "reset" });
+  };
+
+  const inspectDroppedCsv = () => {
+    if (
+      !droppedWorkload ||
+      droppedWorkload.source_type !== "file" ||
+      (droppedWorkload.source_kinds["csv-data"] ?? 0) !== 1 ||
+      dropInFlight.current
+    ) return;
+    dropInFlight.current = true;
+    const requestGeneration = dropRequestGeneration.current + 1;
+    dropRequestGeneration.current = requestGeneration;
+    setCsvInspection(null);
+    setErr(null);
+    setNotice(null);
+    dispatchDrop({ type: "inspection_started" });
+    void invoke<CsvInspection>("inspect_dropped_csv", {
+      path: droppedWorkload.source_path,
+      artifactRoot: droppedWorkload.artifact_root,
+    })
+      .then((result) => {
+        if (dropRequestGeneration.current !== requestGeneration) return;
+        setCsvInspection(result);
+        dispatchDrop({ type: "inspection_succeeded" });
+        setNotice("CSV inspected locally; only statistics and mapping evidence were saved.");
+      })
+      .catch((error) => {
+        if (dropRequestGeneration.current !== requestGeneration) return;
+        dispatchDrop({ type: "failed" });
+        setErr(String(error));
+      })
+      .finally(() => {
+        if (dropRequestGeneration.current === requestGeneration) dropInFlight.current = false;
+      });
   };
 
   const startStreamPacer = (messageIndex: number) => {
@@ -573,6 +656,7 @@ export function ChatPane({
         const requestGeneration = dropRequestGeneration.current + 1;
         dropRequestGeneration.current = requestGeneration;
         setDroppedWorkload(null);
+        setCsvInspection(null);
         setErr(null);
         setNotice(null);
         const channel = new Channel<WorkloadDropEvent>();
@@ -1216,6 +1300,8 @@ export function ChatPane({
                   <span />
                   {dropPhase === "validating"
                     ? "Validating one local path…"
+                    : dropPhase === "inspecting"
+                      ? "Inspecting bounded CSV contents locally…"
                     : "Building a bounded local Workload Card…"}
                 </div>
               ) : (
@@ -1237,16 +1323,49 @@ export function ChatPane({
                         <span key={kind}>{kind.replaceAll("-", " ")} · {count}</span>
                       ))}
                     </div>
+                    {csvInspection && (
+                      <div className="workload-inspection">
+                        <div className="workload-inspection-heading">
+                          <span>Training data</span>
+                          <strong>{csvInspection.training_readiness.ready ? "Ready to map" : "Needs attention"}</strong>
+                        </div>
+                        <div className="workload-draft-meta">
+                          <span>{csvInspection.row_count} rows</span>
+                          <span>{csvInspection.column_count} columns</span>
+                          <span>{csvInspection.training_readiness.class_count} labels</span>
+                          <span>local inspection</span>
+                        </div>
+                        <div className="workload-inspection-mapping">
+                          <span>{csvInspection.recommended_mapping.input_columns.join(" + ") || "Choose inputs"}</span>
+                          <b aria-hidden="true">→</b>
+                          <span>{csvInspection.recommended_mapping.label_column ?? "Choose label"}</span>
+                        </div>
+                        {csvInspection.training_readiness.reasons[0] && (
+                          <p>{csvInspection.training_readiness.reasons[0]}</p>
+                        )}
+                      </div>
+                    )}
                   </div>
                   <div className="workload-draft-actions">
+                    {droppedWorkload.source_type === "file" &&
+                      (droppedWorkload.source_kinds["csv-data"] ?? 0) === 1 &&
+                      !csvInspection && (
+                        <button type="button" className="btn primary" onClick={inspectDroppedCsv}>
+                          Inspect CSV locally
+                        </button>
+                      )}
                     <button
                       type="button"
-                      className="btn primary"
+                      className={csvInspection || (droppedWorkload.source_kinds["csv-data"] ?? 0) !== 1
+                        ? "btn primary"
+                        : "btn ghost"}
                       onClick={() => {
-                        setInput(workloadReviewPrompt(droppedWorkload));
+                        setInput(csvInspection
+                          ? csvInspectionReviewPrompt(csvInspection)
+                          : workloadReviewPrompt(droppedWorkload));
                       }}
                     >
-                      Review next steps
+                      {csvInspection ? "Ask about this dataset" : "Review next steps"}
                     </button>
                     <button
                       type="button"

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2785,6 +2785,54 @@ select,
   border-radius: 999px;
   color: var(--text-2);
 }
+.workload-inspection {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.workload-inspection-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-2);
+  font-size: 12px;
+}
+.workload-inspection-heading strong {
+  color: var(--mb-cyan);
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+.workload-inspection-mapping {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+.workload-inspection-mapping span {
+  overflow: hidden;
+  max-width: 250px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.workload-inspection-mapping b {
+  color: var(--mb-cyan);
+  font-weight: 500;
+}
+.workload-inspection p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--text-3);
+  font-size: 11px;
+  line-height: 1.45;
+}
 .workload-draft-actions {
   display: flex;
   flex: 0 0 auto;

--- a/apps/homescreen/app/lib/workload-drop-state.d.mts
+++ b/apps/homescreen/app/lib/workload-drop-state.d.mts
@@ -3,6 +3,7 @@ export type WorkloadDropPhase =
   | "hovering"
   | "validating"
   | "compiling"
+  | "inspecting"
   | "ready"
   | "failed";
 
@@ -12,6 +13,8 @@ export type WorkloadDropAction =
   | { type: "drop_received" }
   | { type: "validation_started" }
   | { type: "compilation_started" }
+  | { type: "inspection_started" }
+  | { type: "inspection_succeeded" }
   | { type: "succeeded" }
   | { type: "failed" }
   | { type: "reset" };

--- a/apps/homescreen/app/lib/workload-drop-state.mjs
+++ b/apps/homescreen/app/lib/workload-drop-state.mjs
@@ -1,6 +1,6 @@
 export const INITIAL_WORKLOAD_DROP_PHASE = "idle";
 
-const BUSY_PHASES = new Set(["validating", "compiling"]);
+const BUSY_PHASES = new Set(["validating", "compiling", "inspecting"]);
 
 /**
  * One explicit lifecycle owns the drop affordance. UI motion and copy derive
@@ -18,6 +18,10 @@ export function workloadDropReducer(phase, action) {
       return "validating";
     case "compilation_started":
       return phase === "validating" || phase === "compiling" ? "compiling" : phase;
+    case "inspection_started":
+      return phase === "ready" || phase === "failed" ? "inspecting" : phase;
+    case "inspection_succeeded":
+      return phase === "inspecting" ? "ready" : phase;
     case "succeeded":
       return BUSY_PHASES.has(phase) ? "ready" : phase;
     case "failed":
@@ -55,6 +59,11 @@ export function workloadDropStatus(phase) {
       return {
         title: "Preparing your workload",
         detail: "Indexing metadata locally · contents remain unread",
+      };
+    case "inspecting":
+      return {
+        title: "Inspecting training data",
+        detail: "Reading this CSV locally · source rows will not be copied",
       };
     default:
       return null;

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -306,6 +306,7 @@ pub fn run() {
             tool_proof::desktop_tool_proof_list,
             tool_proof::desktop_tool_proof_prepare,
             workload_drop::compile_dropped_workload,
+            workload_drop::inspect_dropped_csv,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -30,6 +30,30 @@ fn validate_compile_result(value: Value) -> Result<Value, String> {
     Ok(value)
 }
 
+fn validate_csv_inspection_result(value: Value) -> Result<Value, String> {
+    if !value.is_object() {
+        return Err("The Understudy CLI returned an invalid CSV inspection.".into());
+    }
+    if value.get("schema_version").and_then(Value::as_str)
+        != Some("understudy.capture_import.csv_inspection.v1")
+        || value.get("local_only").and_then(Value::as_bool) != Some(true)
+        || value.get("payload_read").and_then(Value::as_bool) != Some(true)
+        || value.get("source_rows_persisted").and_then(Value::as_bool) != Some(false)
+        || value.get("persisted_data").and_then(Value::as_str)
+            != Some("statistics-and-label-aggregates")
+    {
+        return Err(
+            "The CSV inspection did not preserve its local statistics-only boundary.".into(),
+        );
+    }
+    for field in ["source_sha256", "artifact_path", "recommended_mapping"] {
+        if value.get(field).is_none() {
+            return Err(format!("The CSV inspection omitted {field}."));
+        }
+    }
+    Ok(value)
+}
+
 fn bounded_detail(stderr: &[u8]) -> String {
     let detail = String::from_utf8_lossy(stderr).trim().to_string();
     if detail.is_empty() {
@@ -86,6 +110,58 @@ pub async fn compile_dropped_workload(
         .map_err(|error| format!("The workload compiler stopped unexpectedly: {error}"))?
 }
 
+fn inspect_csv(path: String, artifact_root: String) -> Result<Value, String> {
+    let canonical = PathBuf::from(path.trim())
+        .canonicalize()
+        .map_err(|error| format!("The CSV is unavailable: {error}"))?;
+    if !canonical.is_file()
+        || canonical
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| !extension.eq_ignore_ascii_case("csv"))
+            .unwrap_or(true)
+    {
+        return Err("Local training inspection requires one .csv file.".into());
+    }
+    let canonical_artifact_root = PathBuf::from(artifact_root.trim())
+        .canonicalize()
+        .map_err(|error| format!("The workload artifact root is unavailable: {error}"))?;
+    if !canonical_artifact_root.is_dir()
+        || !canonical_artifact_root.join("workload-card.json").is_file()
+    {
+        return Err("Inspect the CSV from its current Workload Card.".into());
+    }
+
+    let output = crate::bin::command("understudy")
+        .args(["capture-import", "inspect-csv", "--source"])
+        .arg(&canonical)
+        .arg("--artifact-root")
+        .arg(&canonical_artifact_root)
+        .arg("--json")
+        .output()
+        .map_err(|error| {
+            format!(
+                "Could not run the Understudy CLI ({error}). Open Status to repair the CLI, then inspect the CSV again."
+            )
+        })?;
+    if !output.status.success() {
+        return Err(format!(
+            "The Understudy CLI could not inspect this CSV. {}",
+            bounded_detail(&output.stderr)
+        ));
+    }
+    let value = serde_json::from_slice::<Value>(&output.stdout)
+        .map_err(|_| "The Understudy CLI returned malformed CSV inspection JSON.".to_string())?;
+    validate_csv_inspection_result(value)
+}
+
+#[tauri::command]
+pub async fn inspect_dropped_csv(path: String, artifact_root: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || inspect_csv(path, artifact_root))
+        .await
+        .map_err(|error| format!("The CSV inspector stopped unexpectedly: {error}"))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,6 +195,35 @@ mod tests {
         let input = vec![b'x'; 2_000];
         assert_eq!(bounded_detail(&input).chars().count(), 800);
         assert_eq!(bounded_detail(b"\n"), "No diagnostic was returned.");
+    }
+
+    #[test]
+    fn accepts_only_local_statistics_only_csv_inspections() {
+        let valid = json!({
+            "schema_version": "understudy.capture_import.csv_inspection.v1",
+            "source_sha256": "abc",
+            "artifact_path": "/tmp/csv-inspection.json",
+            "recommended_mapping": {},
+            "local_only": true,
+            "payload_read": true,
+            "source_rows_persisted": false,
+            "persisted_data": "statistics-and-label-aggregates"
+        });
+        assert!(validate_csv_inspection_result(valid).is_ok());
+
+        let unsafe_result = json!({
+            "schema_version": "understudy.capture_import.csv_inspection.v1",
+            "source_sha256": "abc",
+            "artifact_path": "/tmp/csv-inspection.json",
+            "recommended_mapping": {},
+            "local_only": true,
+            "payload_read": true,
+            "source_rows_persisted": true,
+            "persisted_data": "full-rows"
+        });
+        assert!(validate_csv_inspection_result(unsafe_result)
+            .unwrap_err()
+            .contains("statistics-only"));
     }
 
     #[test]

--- a/src/capture-import.ts
+++ b/src/capture-import.ts
@@ -66,6 +66,60 @@ export type CaptureCompileResult = {
   workload_card_path: string;
 };
 
+export type CaptureCsvColumnSummary = {
+  name: string;
+  non_empty_count: number;
+  empty_count: number;
+  unique_count: number;
+  unique_ratio: number;
+  numeric_count: number;
+  numeric_ratio: number;
+};
+
+export type CaptureCsvInspection = {
+  schema_version: "understudy.capture_import.csv_inspection.v1";
+  generated_at: string;
+  source_name: string;
+  source_path: string;
+  source_sha256: string;
+  source_bytes: number;
+  local_only: true;
+  payload_read: true;
+  source_rows_persisted: false;
+  persisted_data: "statistics-and-label-aggregates";
+  row_count: number;
+  column_count: number;
+  duplicate_row_count: number;
+  columns: CaptureCsvColumnSummary[];
+  recommended_mapping: {
+    label_column: string | null;
+    input_columns: string[];
+    confidence: "high" | "low" | "none";
+    requires_confirmation: true;
+  };
+  label_distribution: {
+    value: string;
+    count: number;
+  }[];
+  label_distribution_truncated: boolean;
+  training_readiness: {
+    ready: boolean;
+    status: "ready" | "needs_mapping" | "needs_data" | "needs_cleanup";
+    class_count: number;
+    minimum_examples_per_class: number | null;
+    reasons: string[];
+    warnings: string[];
+  };
+  limits: {
+    max_bytes: number;
+    max_rows: number;
+    max_columns: number;
+    max_field_characters: number;
+    max_reported_labels: number;
+  };
+  artifact_path: string;
+};
+
 export type CapturePreview = {
   generated_at: string;
   repo: string;
@@ -181,6 +235,12 @@ const kindOrder: CaptureSourceKind[] = [
 
 const MAX_SCAN_FILES = 5_000;
 const MAX_CAPTURE_SOURCES = 1_000;
+const MAX_CSV_BYTES = 16 * 1024 * 1024;
+const MAX_CSV_ROWS = 50_000;
+const MAX_CSV_COLUMNS = 128;
+const MAX_CSV_FIELD_CHARACTERS = 65_536;
+const MAX_REPORTED_LABELS = 50;
+const MIN_EXAMPLES_PER_CLASS = 20;
 
 export function artifactDir(repo: string): string {
   return join(repo, ".understudy", "capture-import");
@@ -428,6 +488,297 @@ export function compileCaptureImport(
     manifest_path: join(outputDir, "capture-sources.json"),
     workload_card_path: join(outputDir, "workload-card.json"),
   };
+}
+
+export function inspectCaptureCsv(
+  sourceInput: string,
+  artifactRootInput: string,
+  now = new Date(),
+): CaptureCsvInspection {
+  const source = resolve(sourceInput);
+  if (!existsSync(source)) {
+    throw new Error(`CSV source does not exist: ${source}`);
+  }
+  const sourceStat = statSync(source);
+  if (!sourceStat.isFile()) {
+    throw new Error(`CSV inspection requires one file: ${source}`);
+  }
+  if (extname(source).toLowerCase() !== ".csv") {
+    throw new Error(`CSV inspection only accepts .csv files: ${source}`);
+  }
+  if (sourceStat.size > MAX_CSV_BYTES) {
+    throw new Error(`CSV is ${sourceStat.size} bytes; the local inspection limit is ${MAX_CSV_BYTES} bytes.`);
+  }
+
+  const artifactRoot = resolve(artifactRootInput);
+  if (!existsSync(artifactRoot) || !statSync(artifactRoot).isDirectory()) {
+    throw new Error(`Capture artifact root does not exist: ${artifactRoot}`);
+  }
+
+  const bytes = readFileSync(source);
+  if (bytes.length > MAX_CSV_BYTES) {
+    throw new Error(`CSV grew beyond the ${MAX_CSV_BYTES}-byte local inspection limit while it was being read.`);
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("CSV must be valid UTF-8 before local inspection.");
+  }
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+  const records = parseCsvRecordsBounded(text).filter((record) =>
+    record.some((field) => field.trim().length > 0),
+  );
+  if (records.length < 2) {
+    throw new Error("CSV needs one header row and at least one data row.");
+  }
+
+  const headers = records[0].map((field) => field.trim());
+  if (headers.length > MAX_CSV_COLUMNS) {
+    throw new Error(`CSV has ${headers.length} columns; the local inspection limit is ${MAX_CSV_COLUMNS}.`);
+  }
+  if (headers.some((header) => header.length === 0)) {
+    throw new Error("CSV headers must not be empty.");
+  }
+  const normalizedHeaders = headers.map(normalizeHeader);
+  if (new Set(normalizedHeaders).size !== normalizedHeaders.length) {
+    throw new Error("CSV headers must be unique after case and spacing normalization.");
+  }
+
+  const rows = records.slice(1);
+  if (rows.length > MAX_CSV_ROWS) {
+    throw new Error(`CSV has more than ${MAX_CSV_ROWS} data rows; split it before local inspection.`);
+  }
+  rows.forEach((row, index) => {
+    if (row.length !== headers.length) {
+      throw new Error(
+        `CSV record ${index + 2} has ${row.length} fields; expected ${headers.length}.`,
+      );
+    }
+  });
+
+  const columns = headers.map((name, columnIndex): CaptureCsvColumnSummary => {
+    const values = rows.map((row) => row[columnIndex].trim());
+    const nonEmpty = values.filter(Boolean);
+    const numericCount = nonEmpty.filter(isFiniteNumber).length;
+    return {
+      name,
+      non_empty_count: nonEmpty.length,
+      empty_count: rows.length - nonEmpty.length,
+      unique_count: new Set(nonEmpty).size,
+      unique_ratio: ratio(new Set(nonEmpty).size, nonEmpty.length),
+      numeric_count: numericCount,
+      numeric_ratio: ratio(numericCount, nonEmpty.length),
+    };
+  });
+
+  const labelCandidate = chooseLabelColumn(headers, columns);
+  const labelIndex = labelCandidate ? headers.indexOf(labelCandidate.name) : -1;
+  const inputColumns = headers.filter((name, index) => index !== labelIndex && columns[index].non_empty_count > 0);
+  const labelCounts = new Map<string, number>();
+  if (labelIndex >= 0) {
+    for (const row of rows) {
+      const label = row[labelIndex].trim();
+      if (label) labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+    }
+  }
+  const sortedLabels = [...labelCounts.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
+  const minimumExamples = sortedLabels.length > 0
+    ? Math.min(...sortedLabels.map(([, count]) => count))
+    : null;
+  const duplicateRowCount = rows.length - new Set(rows.map((row) => JSON.stringify(row))).size;
+  const reasons: string[] = [];
+  const warnings: string[] = [];
+  let status: CaptureCsvInspection["training_readiness"]["status"] = "ready";
+
+  if (!labelCandidate) {
+    status = "needs_mapping";
+    reasons.push("Choose the column containing the expected category or label.");
+  } else if (inputColumns.length === 0) {
+    status = "needs_mapping";
+    reasons.push("Choose at least one non-label input column.");
+  } else if (labelCounts.size < 2) {
+    status = "needs_data";
+    reasons.push("At least two label values are required for classification.");
+  } else if (columns[labelIndex].empty_count > 0) {
+    status = "needs_cleanup";
+    reasons.push(`${columns[labelIndex].empty_count} row(s) have an empty label.`);
+  } else if (minimumExamples !== null && minimumExamples < MIN_EXAMPLES_PER_CLASS) {
+    status = "needs_data";
+    reasons.push(
+      `The smallest class has ${minimumExamples} row(s); collect at least ${MIN_EXAMPLES_PER_CLASS} per class for the first training run.`,
+    );
+  }
+
+  if (labelCandidate && columns[labelIndex].unique_count === columns[labelIndex].non_empty_count && rows.length >= 5) {
+    warnings.push("Every label is unique; this looks like an identifier rather than a reusable category.");
+  } else if (labelCandidate && rows.length >= MIN_EXAMPLES_PER_CLASS && columns[labelIndex].unique_ratio > 0.5) {
+    warnings.push("More than half of the labels are unique; this may be an identifier rather than a reusable category.");
+  }
+  if (duplicateRowCount > 0) {
+    warnings.push(`${duplicateRowCount} duplicate row(s) should be reviewed before splitting the dataset.`);
+  }
+  if (sortedLabels.length > MAX_REPORTED_LABELS) {
+    warnings.push(`Only the ${MAX_REPORTED_LABELS} most frequent labels are included in this summary.`);
+  }
+
+  const artifactPath = join(artifactRoot, "csv-inspection.json");
+  const inspection: CaptureCsvInspection = {
+    schema_version: "understudy.capture_import.csv_inspection.v1",
+    generated_at: now.toISOString(),
+    source_name: basename(source),
+    source_path: source,
+    source_sha256: createHash("sha256").update(bytes).digest("hex"),
+    source_bytes: bytes.length,
+    local_only: true,
+    payload_read: true,
+    source_rows_persisted: false,
+    persisted_data: "statistics-and-label-aggregates",
+    row_count: rows.length,
+    column_count: headers.length,
+    duplicate_row_count: duplicateRowCount,
+    columns,
+    recommended_mapping: {
+      label_column: labelCandidate?.name ?? null,
+      input_columns: inputColumns,
+      confidence: labelCandidate?.confidence ?? "none",
+      requires_confirmation: true,
+    },
+    label_distribution: sortedLabels
+      .slice(0, MAX_REPORTED_LABELS)
+      .map(([value, count]) => ({ value, count })),
+    label_distribution_truncated: sortedLabels.length > MAX_REPORTED_LABELS,
+    training_readiness: {
+      ready: status === "ready",
+      status,
+      class_count: labelCounts.size,
+      minimum_examples_per_class: minimumExamples,
+      reasons,
+      warnings,
+    },
+    limits: {
+      max_bytes: MAX_CSV_BYTES,
+      max_rows: MAX_CSV_ROWS,
+      max_columns: MAX_CSV_COLUMNS,
+      max_field_characters: MAX_CSV_FIELD_CHARACTERS,
+      max_reported_labels: MAX_REPORTED_LABELS,
+    },
+    artifact_path: artifactPath,
+  };
+  writeJson(artifactPath, inspection);
+  return inspection;
+}
+
+function parseCsvRecordsBounded(text: string): string[][] {
+  const records: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+  let afterQuote = false;
+
+  const append = (character: string) => {
+    field += character;
+    if (field.length > MAX_CSV_FIELD_CHARACTERS) {
+      throw new Error(`CSV field exceeds ${MAX_CSV_FIELD_CHARACTERS} characters.`);
+    }
+  };
+  const finishField = () => {
+    row.push(field);
+    field = "";
+    afterQuote = false;
+    if (row.length > MAX_CSV_COLUMNS) {
+      throw new Error(`CSV has more than ${MAX_CSV_COLUMNS} columns.`);
+    }
+  };
+  const finishRecord = () => {
+    finishField();
+    records.push(row);
+    row = [];
+    if (records.length > MAX_CSV_ROWS + 1) {
+      throw new Error(`CSV has more than ${MAX_CSV_ROWS} data rows; split it before local inspection.`);
+    }
+  };
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (quoted) {
+      if (character === '"') {
+        if (text[index + 1] === '"') {
+          append('"');
+          index += 1;
+        } else {
+          quoted = false;
+          afterQuote = true;
+        }
+      } else {
+        append(character);
+      }
+      continue;
+    }
+    if (afterQuote) {
+      if (character === ",") {
+        finishField();
+      } else if (character === "\n") {
+        finishRecord();
+      } else if (character === "\r") {
+        if (text[index + 1] === "\n") continue;
+        finishRecord();
+      } else if (character !== " " && character !== "\t") {
+        throw new Error("CSV contains characters after a closing quote.");
+      }
+      continue;
+    }
+    if (character === '"' && field.length === 0) {
+      quoted = true;
+    } else if (character === '"') {
+      throw new Error("CSV contains a quote inside an unquoted field.");
+    } else if (character === ",") {
+      finishField();
+    } else if (character === "\n") {
+      finishRecord();
+    } else if (character === "\r" && text[index + 1] === "\n") {
+      continue;
+    } else if (character === "\r") {
+      finishRecord();
+    } else {
+      append(character);
+    }
+  }
+  if (quoted) throw new Error("CSV contains an unterminated quoted field.");
+  if (field.length > 0 || row.length > 0 || afterQuote) finishRecord();
+  return records;
+}
+
+function normalizeHeader(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function chooseLabelColumn(
+  headers: string[],
+  columns: CaptureCsvColumnSummary[],
+): { name: string; confidence: "high" | "low" } | null {
+  const preferred = ["label", "target", "category", "class", "intent", "type", "status"];
+  for (const name of preferred) {
+    const index = headers.findIndex((header) => normalizeHeader(header) === name);
+    if (index >= 0) return { name: headers[index], confidence: "high" };
+  }
+  const plausible = columns
+    .map((column, index) => ({ column, index }))
+    .filter(({ column }) => column.unique_count >= 2 && column.unique_count <= 100 && column.unique_ratio <= 0.5)
+    .sort((left, right) => left.column.unique_count - right.column.unique_count || right.index - left.index);
+  return plausible[0]
+    ? { name: plausible[0].column.name, confidence: "low" }
+    : null;
+}
+
+function isFiniteNumber(value: string): boolean {
+  if (value.trim() === "") return false;
+  return Number.isFinite(Number(value));
+}
+
+function ratio(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : Number((numerator / denominator).toFixed(6));
 }
 
 function artifactReference(repo: string, path: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,13 @@ import { Command } from "commander";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { runUnderstandCheck, runUnderstandWorkloadCard } from "./understand.js";
-import { buildWorkloadCard, compileCaptureImport, previewCaptureImport, scanCaptureImport } from "./capture-import.js";
+import {
+  buildWorkloadCard,
+  compileCaptureImport,
+  inspectCaptureCsv,
+  previewCaptureImport,
+  scanCaptureImport,
+} from "./capture-import.js";
 import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
 import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
@@ -293,7 +299,7 @@ function parseNonNegativeNumber(value: string): number {
 function registerCaptureImportCommands(program: Command): void {
   const captureImport = program
     .command("capture-import")
-    .description("Scan and preview local import candidates using metadata only");
+    .description("Compile local import candidates and explicitly inspect approved data");
 
   captureImport
     .command("scan")
@@ -327,6 +333,24 @@ function registerCaptureImportCommands(program: Command): void {
       console.log(`capture-import compile: ${result.source_count} source(s) from ${result.source_name}`);
       console.log(`workload card: ${result.workload_card_path}`);
       console.log("payload_read: false");
+    });
+
+  captureImport
+    .command("inspect-csv")
+    .description("Read one bounded local CSV and write a statistics-only training inspection")
+    .requiredOption("--source <path>", "Local CSV file to inspect")
+    .requiredOption("--artifact-root <path>", "Existing private artifact root from capture-import compile")
+    .option("--json", "Output JSON")
+    .action((options: { source: string; artifactRoot: string; json?: boolean }) => {
+      const result = inspectCaptureCsv(options.source, options.artifactRoot);
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`capture-import inspect-csv: ${result.row_count} row(s), ${result.column_count} column(s)`);
+      console.log(`mapping: ${result.recommended_mapping.label_column ?? "label confirmation required"}`);
+      console.log(`artifact: ${result.artifact_path}`);
+      console.log("payload_read: true (local only; source rows were not copied)");
     });
 
   captureImport

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1999,6 +1999,115 @@ class ScoreWithFeedback:
     }
   });
 
+  it("inspects an explicitly approved CSV locally without copying source rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-csv-inspection-"));
+    try {
+      const source = join(root, "expenses.csv");
+      writeFileSync(
+        source,
+        [
+          "merchant,description,amount,category",
+          'PRIVATE_COFFEE,"team breakfast, west",24.80,meals',
+          "Harbor Air,customer visit flight,412.15,travel",
+          "Paper Finch,printer paper,37.40,office_supplies",
+          "PRIVATE_COFFEE,candidate interview coffee,18.25,meals",
+          "Metro Cab,airport transfer,56.00,travel",
+        ].join("\n"),
+      );
+      const outputRoot = join(root, "artifacts");
+      const compiledResult = run([
+        "capture-import",
+        "compile",
+        "--source",
+        source,
+        "--output-root",
+        outputRoot,
+        "--json",
+      ]);
+      assert.equal(compiledResult.status, 0, compiledResult.stderr);
+      const compiled = JSON.parse(compiledResult.stdout);
+
+      const result = run([
+        "capture-import",
+        "inspect-csv",
+        "--source",
+        source,
+        "--artifact-root",
+        compiled.artifact_root,
+        "--json",
+      ]);
+      assert.equal(result.status, 0, result.stderr);
+      const inspection = JSON.parse(result.stdout);
+      assert.equal(inspection.schema_version, "understudy.capture_import.csv_inspection.v1");
+      assert.equal(inspection.local_only, true);
+      assert.equal(inspection.payload_read, true);
+      assert.equal(inspection.source_rows_persisted, false);
+      assert.equal(inspection.persisted_data, "statistics-and-label-aggregates");
+      assert.equal(inspection.row_count, 5);
+      assert.equal(inspection.column_count, 4);
+      assert.match(inspection.source_sha256, /^[a-f0-9]{64}$/);
+      assert.equal(inspection.recommended_mapping.label_column, "category");
+      assert.equal(inspection.recommended_mapping.confidence, "high");
+      assert.deepEqual(inspection.recommended_mapping.input_columns, ["merchant", "description", "amount"]);
+      assert.deepEqual(inspection.label_distribution, [
+        { value: "meals", count: 2 },
+        { value: "travel", count: 2 },
+        { value: "office_supplies", count: 1 },
+      ]);
+      assert.equal(inspection.training_readiness.ready, false);
+      assert.equal(inspection.training_readiness.status, "needs_data");
+      assert.equal(inspection.training_readiness.minimum_examples_per_class, 1);
+      assert.deepEqual(inspection.training_readiness.warnings, []);
+
+      const saved = readFileSync(inspection.artifact_path, "utf8");
+      assert.ok(!saved.includes("PRIVATE_COFFEE"));
+      assert.ok(!saved.includes("team breakfast"));
+      if (process.platform !== "win32") {
+        assert.equal(statSync(inspection.artifact_path).mode & 0o777, 0o600);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on malformed CSV rows and unsupported payloads", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-csv-invalid-"));
+    try {
+      const artifactRoot = join(root, "artifacts");
+      mkdirSync(artifactRoot);
+      const malformed = join(root, "malformed.csv");
+      writeFileSync(malformed, "input,category\none,yes\ntwo\n");
+      const malformedResult = run([
+        "capture-import",
+        "inspect-csv",
+        "--source",
+        malformed,
+        "--artifact-root",
+        artifactRoot,
+        "--json",
+      ]);
+      assert.notEqual(malformedResult.status, 0);
+      assert.match(malformedResult.stderr, /record 3 has 1 fields; expected 2/);
+      assert.equal(existsSync(join(artifactRoot, "csv-inspection.json")), false);
+
+      const text = join(root, "not-csv.txt");
+      writeFileSync(text, "input,label\none,yes\n");
+      const textResult = run([
+        "capture-import",
+        "inspect-csv",
+        "--source",
+        text,
+        "--artifact-root",
+        artifactRoot,
+        "--json",
+      ]);
+      assert.notEqual(textResult.status, 0);
+      assert.match(textResult.stderr, /only accepts \.csv files/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("bounds a dropped directory and classifies broad local source material", () => {
     const root = mkdtempSync(join(tmpdir(), "understudy-drop-directory-"));
     try {

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -460,12 +460,16 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(chat, /new Channel<WorkloadDropEvent>/);
   assert.match(chat, /onEvent: channel/);
   assert.match(chat, /workloadDropPersonaState\(dropPhase\)/);
+  assert.match(chat, /invoke<CsvInspection>\("inspect_dropped_csv"/);
+  assert.match(chat, /Inspect CSV locally/);
+  assert.match(chat, /only statistics and mapping evidence were saved/);
   assert.doesNotMatch(chat, /useState\(false\);[\s\S]{0,120}setDropHovering/);
   assert.doesNotMatch(chat, /workload-drop-overlay/);
   assert.match(dropState, /"hovering"[\s\S]*return "listening"/);
   assert.match(dropState, /BUSY_PHASES\.has\(phase\)[\s\S]*return "thinking"/);
   assert.match(dropState, /One file or folder · stays on this Mac/);
   assert.match(dropState, /Indexing metadata locally · contents remain unread/);
+  assert.match(dropState, /Reading this CSV locally · source rows will not be copied/);
   assert.match(css, /\.persona-stage\.workload-drop-active::before/);
   assert.match(css, /@keyframes workload-intake-ring/);
   assert.match(css, /prefers-reduced-motion: reduce[\s\S]*?\.persona-stage\.workload-drop-active::before/);
@@ -486,11 +490,17 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(bridge, /WorkloadDropEvent::Validating/);
   assert.match(bridge, /WorkloadDropEvent::Compiling/);
   assert.match(bridge, /"capture-import", "compile", "--source"/);
+  assert.match(bridge, /"capture-import", "inspect-csv", "--source"/);
+  assert.match(bridge, /source_rows_persisted/);
+  assert.match(bridge, /statistics-and-label-aggregates/);
   assert.match(bridge, /value\.get\("local_only"\)/);
   assert.match(bridge, /value\.get\("payload_read"\)/);
   assert.match(compiler, /const MAX_SCAN_FILES = 5_000/);
   assert.match(compiler, /const MAX_CAPTURE_SOURCES = 1_000/);
+  assert.match(compiler, /const MAX_CSV_BYTES = 16 \* 1024 \* 1024/);
   assert.match(compiler, /payload_read: false/);
+  assert.match(compiler, /source_rows_persisted: false/);
+  assert.match(compiler, /source_sha256/);
   assert.equal(
     parity.features.find((feature) => feature.id === "drop-to-workload-compilation")?.status,
     "shipped",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -434,7 +434,7 @@ test("desktop starts fresh on launch and can reopen an exact Pi session", async 
     chat,
     /const resetDroppedWorkload = \(\) => \{[\s\S]*dropRequestGeneration\.current \+= 1;[\s\S]*dropInFlight\.current = false;[\s\S]*dispatchDrop\(\{ type: "reset" \}\);/,
   );
-  assert.equal(chat.match(/resetDroppedWorkload\(\);/g)?.length, 2);
+  assert.equal(chat.match(/resetDroppedWorkload\(\);/g)?.length, 3);
   assert.match(sidebar, /aria-label=\{showArchived \? "Archived chats" : "Recent chats"\}/);
   assert.doesNotMatch(page, /aria-label="Chat history"/);
   assert.match(commands, /pub fn chat_sessions_list/);

--- a/tests/workload-drop-state.test.mjs
+++ b/tests/workload-drop-state.test.mjs
@@ -43,6 +43,20 @@ test("busy compiler state cannot be replaced by incidental drag events", () => {
   assert.equal(workloadDropReducer("failed", { type: "reset" }), "idle");
 });
 
+test("explicit CSV inspection is a truthful thinking phase", () => {
+  let phase = workloadDropReducer("ready", { type: "inspection_started" });
+  assert.equal(phase, "inspecting");
+  assert.equal(isWorkloadDropBusy(phase), true);
+  assert.equal(workloadDropPersonaState(phase), "thinking");
+  assert.deepEqual(workloadDropStatus(phase), {
+    title: "Inspecting training data",
+    detail: "Reading this CSV locally · source rows will not be copied",
+  });
+  phase = workloadDropReducer(phase, { type: "inspection_succeeded" });
+  assert.equal(phase, "ready");
+  assert.equal(workloadDropReducer("failed", { type: "inspection_started" }), "inspecting");
+});
+
 test("out-of-order completion cannot mark an idle lifecycle ready", () => {
   assert.equal(workloadDropReducer("idle", { type: "succeeded" }), "idle");
   assert.equal(workloadDropReducer("ready", { type: "failed" }), "ready");


### PR DESCRIPTION
## What changed
- adds an explicit `Inspect CSV locally` action after metadata-only drop compilation
- reads bounded UTF-8 CSVs through the bundled CLI, never automatically
- records content SHA-256, schema/cardinality statistics, duplicates, inferred input/label mapping, category aggregates, and training-readiness gates
- persists no source rows; the private artifact contains statistics and label aggregates only
- drives the real Rive thinking state while inspection is running

## Safety limits
- 16 MiB
- 50,000 rows
- 128 columns
- 65,536 characters per field
- strict malformed-row/header/quote validation

## Verification
- `npm run check` (337 tests, skills validation, package smoke)
- `cargo test --lib` (165 passed, 4 ignored)
- `bun run build`
- debug `.app` bundle built through the updater-signing step
- packaged `.app` CLI compiled and inspected `tests/fixtures/expense-categories.csv` end to end

## Manual check
macOS exposed the test window but withheld its accessibility tree from Orca despite granted permissions, so the native drag/click visual remains a manual check. The reducer, frontend build, Tauri bridge, packaged CLI, parser, artifact contract, and failure paths are covered independently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->