### PR TITLE
Prepare deterministic local training datasets

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -144,6 +144,15 @@ type CsvInspection = {
   row_count: number;
   column_count: number;
   duplicate_row_count: number;
+  columns: {
+    name: string;
+    non_empty_count: number;
+    empty_count: number;
+    unique_count: number;
+    unique_ratio: number;
+    numeric_count: number;
+    numeric_ratio: number;
+  }[];
   recommended_mapping: {
     label_column: string | null;
     input_columns: string[];
@@ -161,6 +170,29 @@ type CsvInspection = {
     warnings: string[];
   };
   artifact_path: string;
+};
+type ClassificationDataset = {
+  schema_version: "understudy.capture_import.classification_dataset.v1";
+  dataset_id: string;
+  source_sha256: string;
+  mapping_sha256: string;
+  local_only: true;
+  network_required: false;
+  mapping_confirmation: "caller-provided";
+  source_rows_persisted_as_transformed_examples: true;
+  row_count: number;
+  mapping: {
+    input_columns: string[];
+    label_column: string;
+    text_template: "named-fields-v1";
+  };
+  labels: string[];
+  splits: {
+    train: { path: string; row_count: number; sha256: string };
+    dev: { path: string; row_count: number; sha256: string };
+    holdout: { path: string; row_count: number; sha256: string };
+  };
+  manifest_path: string;
 };
 
 const CLOUD_SUPERVISOR_FALLBACK_NOTICE =
@@ -267,7 +299,12 @@ function workloadReviewPrompt(workload: DroppedWorkload): string {
   ].join("\n\n");
 }
 
-function csvInspectionReviewPrompt(inspection: CsvInspection): string {
+function csvInspectionReviewPrompt(
+  inspection: CsvInspection,
+  inputColumns: string[],
+  labelColumn: string,
+  dataset: ClassificationDataset | null,
+): string {
   return [
     "Review this local CSV training inspection and explain the smallest honest next step.",
     "Use only the statistics below. The CSV rows stayed local and are not included here, so do not claim you read individual examples.",
@@ -276,10 +313,19 @@ function csvInspectionReviewPrompt(inspection: CsvInspection): string {
       row_count: inspection.row_count,
       column_count: inspection.column_count,
       duplicate_row_count: inspection.duplicate_row_count,
-      recommended_mapping: inspection.recommended_mapping,
+      selected_mapping: {
+        input_columns: inputColumns,
+        label_column: labelColumn || null,
+        caller_prepared: Boolean(dataset),
+      },
       label_distribution: inspection.label_distribution,
       label_distribution_truncated: inspection.label_distribution_truncated,
       training_readiness: inspection.training_readiness,
+      prepared_splits: dataset ? {
+        train: dataset.splits.train.row_count,
+        dev: dataset.splits.dev.row_count,
+        holdout: dataset.splits.holdout.row_count,
+      } : null,
     }, null, 2),
   ].join("\n\n");
 }
@@ -431,6 +477,9 @@ export function ChatPane({
   );
   const [droppedWorkload, setDroppedWorkload] = useState<DroppedWorkload | null>(null);
   const [csvInspection, setCsvInspection] = useState<CsvInspection | null>(null);
+  const [mappingInputColumns, setMappingInputColumns] = useState<string[]>([]);
+  const [mappingLabelColumn, setMappingLabelColumn] = useState("");
+  const [classificationDataset, setClassificationDataset] = useState<ClassificationDataset | null>(null);
   const [pacingMessageIndex, setPacingMessageIndex] = useState<number | null>(null);
   const [pacedRevealed, setPacedRevealed] = useState<number | null>(null);
   const [animatedMessageId, setAnimatedMessageId] = useState<string | null>(null);
@@ -488,6 +537,9 @@ export function ChatPane({
     dropInFlight.current = false;
     setDroppedWorkload(null);
     setCsvInspection(null);
+    setMappingInputColumns([]);
+    setMappingLabelColumn("");
+    setClassificationDataset(null);
     dispatchDrop({ type: "reset" });
   };
 
@@ -502,6 +554,9 @@ export function ChatPane({
     const requestGeneration = dropRequestGeneration.current + 1;
     dropRequestGeneration.current = requestGeneration;
     setCsvInspection(null);
+    setMappingInputColumns([]);
+    setMappingLabelColumn("");
+    setClassificationDataset(null);
     setErr(null);
     setNotice(null);
     dispatchDrop({ type: "inspection_started" });
@@ -512,8 +567,47 @@ export function ChatPane({
       .then((result) => {
         if (dropRequestGeneration.current !== requestGeneration) return;
         setCsvInspection(result);
+        setMappingInputColumns(result.recommended_mapping.input_columns);
+        setMappingLabelColumn(result.recommended_mapping.label_column ?? "");
         dispatchDrop({ type: "inspection_succeeded" });
         setNotice("CSV inspected locally; only statistics and mapping evidence were saved.");
+      })
+      .catch((error) => {
+        if (dropRequestGeneration.current !== requestGeneration) return;
+        dispatchDrop({ type: "failed" });
+        setErr(String(error));
+      })
+      .finally(() => {
+        if (dropRequestGeneration.current === requestGeneration) dropInFlight.current = false;
+      });
+  };
+
+  const prepareDroppedClassification = () => {
+    if (
+      !droppedWorkload ||
+      !csvInspection ||
+      !mappingLabelColumn ||
+      mappingInputColumns.length === 0 ||
+      dropInFlight.current
+    ) return;
+    dropInFlight.current = true;
+    const requestGeneration = dropRequestGeneration.current + 1;
+    dropRequestGeneration.current = requestGeneration;
+    setClassificationDataset(null);
+    setErr(null);
+    setNotice(null);
+    dispatchDrop({ type: "dataset_started" });
+    void invoke<ClassificationDataset>("prepare_dropped_csv_classification", {
+      path: droppedWorkload.source_path,
+      artifactRoot: droppedWorkload.artifact_root,
+      inputColumns: mappingInputColumns,
+      labelColumn: mappingLabelColumn,
+    })
+      .then((result) => {
+        if (dropRequestGeneration.current !== requestGeneration) return;
+        setClassificationDataset(result);
+        dispatchDrop({ type: "dataset_succeeded" });
+        setNotice("Local train, dev, and holdout datasets are ready; nothing was uploaded.");
       })
       .catch((error) => {
         if (dropRequestGeneration.current !== requestGeneration) return;
@@ -657,6 +751,9 @@ export function ChatPane({
         dropRequestGeneration.current = requestGeneration;
         setDroppedWorkload(null);
         setCsvInspection(null);
+        setMappingInputColumns([]);
+        setMappingLabelColumn("");
+        setClassificationDataset(null);
         setErr(null);
         setNotice(null);
         const channel = new Channel<WorkloadDropEvent>();
@@ -1302,6 +1399,8 @@ export function ChatPane({
                     ? "Validating one local path…"
                     : dropPhase === "inspecting"
                       ? "Inspecting bounded CSV contents locally…"
+                    : dropPhase === "preparing_dataset"
+                      ? "Writing deterministic local train, dev, and holdout examples…"
                     : "Building a bounded local Workload Card…"}
                 </div>
               ) : (
@@ -1336,12 +1435,68 @@ export function ChatPane({
                           <span>local inspection</span>
                         </div>
                         <div className="workload-inspection-mapping">
-                          <span>{csvInspection.recommended_mapping.input_columns.join(" + ") || "Choose inputs"}</span>
+                          <span>{mappingInputColumns.join(" + ") || "Choose inputs"}</span>
                           <b aria-hidden="true">→</b>
-                          <span>{csvInspection.recommended_mapping.label_column ?? "Choose label"}</span>
+                          <span>{mappingLabelColumn || "Choose label"}</span>
                         </div>
                         {csvInspection.training_readiness.reasons[0] && (
                           <p>{csvInspection.training_readiness.reasons[0]}</p>
+                        )}
+                        {!classificationDataset ? (
+                          <div className="workload-mapping">
+                            <label>
+                              <span>Label</span>
+                              <select
+                                value={mappingLabelColumn}
+                                onChange={(event) => {
+                                  const label = event.target.value;
+                                  setMappingLabelColumn(label);
+                                  setMappingInputColumns((columns) => columns.filter((column) => column !== label));
+                                  setClassificationDataset(null);
+                                }}
+                              >
+                                <option value="">Choose label</option>
+                                {csvInspection.columns.map((column) => (
+                                  <option key={column.name} value={column.name}>{column.name}</option>
+                                ))}
+                              </select>
+                            </label>
+                            <div className="workload-mapping-inputs" role="group" aria-label="Input columns">
+                              <span>Inputs</span>
+                              <div>
+                                {csvInspection.columns.map((column) => {
+                                  const selected = mappingInputColumns.includes(column.name);
+                                  const unavailable = column.name === mappingLabelColumn;
+                                  return (
+                                    <button
+                                      key={column.name}
+                                      type="button"
+                                      className={selected ? "selected" : ""}
+                                      disabled={unavailable}
+                                      aria-pressed={selected}
+                                      onClick={() => {
+                                        setMappingInputColumns((columns) => selected
+                                          ? columns.filter((name) => name !== column.name)
+                                          : [...columns, column.name]);
+                                        setClassificationDataset(null);
+                                      }}
+                                    >
+                                      {column.name}
+                                    </button>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                            <small>Preparing the dataset saves transformed examples locally. Nothing is uploaded.</small>
+                          </div>
+                        ) : (
+                          <div className="workload-dataset-ready">
+                            <strong>Local dataset ready</strong>
+                            <span>
+                              {classificationDataset.splits.train.row_count} train · {classificationDataset.splits.dev.row_count} dev · {classificationDataset.splits.holdout.row_count} holdout
+                            </span>
+                            <small>Holdout stays reserved for final validation.</small>
+                          </div>
                         )}
                       </div>
                     )}
@@ -1354,14 +1509,34 @@ export function ChatPane({
                           Inspect CSV locally
                         </button>
                       )}
+                    {csvInspection && !classificationDataset && (
+                      <button
+                        type="button"
+                        className="btn primary"
+                        disabled={
+                          !mappingLabelColumn ||
+                          mappingInputColumns.length === 0 ||
+                          (mappingLabelColumn === csvInspection.recommended_mapping.label_column &&
+                            !csvInspection.training_readiness.ready)
+                        }
+                        onClick={prepareDroppedClassification}
+                      >
+                        Prepare local dataset
+                      </button>
+                    )}
                     <button
                       type="button"
-                      className={csvInspection || (droppedWorkload.source_kinds["csv-data"] ?? 0) !== 1
+                      className={classificationDataset || (droppedWorkload.source_kinds["csv-data"] ?? 0) !== 1
                         ? "btn primary"
                         : "btn ghost"}
                       onClick={() => {
                         setInput(csvInspection
-                          ? csvInspectionReviewPrompt(csvInspection)
+                          ? csvInspectionReviewPrompt(
+                              csvInspection,
+                              mappingInputColumns,
+                              mappingLabelColumn,
+                              classificationDataset,
+                            )
                           : workloadReviewPrompt(droppedWorkload));
                       }}
                     >

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2833,6 +2833,85 @@ select,
   font-size: 11px;
   line-height: 1.45;
 }
+.workload-mapping {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 9px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--bg) 38%, transparent);
+}
+.workload-mapping label,
+.workload-mapping-inputs {
+  display: grid;
+  gap: 5px;
+}
+.workload-mapping label > span,
+.workload-mapping-inputs > span {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.workload-mapping select {
+  min-width: 0;
+  height: 30px;
+  padding: 0 28px 0 9px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 11px;
+}
+.workload-mapping-inputs > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  max-height: 92px;
+  overflow-y: auto;
+}
+.workload-mapping-inputs button {
+  padding: 4px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 9px;
+  cursor: pointer;
+}
+.workload-mapping-inputs button.selected {
+  border-color: color-mix(in srgb, var(--mb-cyan) 55%, var(--border));
+  background: color-mix(in srgb, var(--mb-cyan) 11%, transparent);
+  color: var(--mb-cyan);
+}
+.workload-mapping-inputs button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.workload-mapping small,
+.workload-dataset-ready small {
+  color: var(--text-3);
+  font-size: 10px;
+  line-height: 1.4;
+}
+.workload-dataset-ready {
+  display: grid;
+  gap: 3px;
+  margin-top: 4px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 32%, var(--border));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--mb-cyan) 6%, transparent);
+  color: var(--text-2);
+  font-size: 11px;
+}
+.workload-dataset-ready strong {
+  color: var(--mb-cyan);
+  font-size: 12px;
+}
 .workload-draft-actions {
   display: flex;
   flex: 0 0 auto;

--- a/apps/homescreen/app/lib/workload-drop-state.d.mts
+++ b/apps/homescreen/app/lib/workload-drop-state.d.mts
@@ -4,6 +4,7 @@ export type WorkloadDropPhase =
   | "validating"
   | "compiling"
   | "inspecting"
+  | "preparing_dataset"
   | "ready"
   | "failed";
 
@@ -15,6 +16,8 @@ export type WorkloadDropAction =
   | { type: "compilation_started" }
   | { type: "inspection_started" }
   | { type: "inspection_succeeded" }
+  | { type: "dataset_started" }
+  | { type: "dataset_succeeded" }
   | { type: "succeeded" }
   | { type: "failed" }
   | { type: "reset" };

--- a/apps/homescreen/app/lib/workload-drop-state.mjs
+++ b/apps/homescreen/app/lib/workload-drop-state.mjs
@@ -1,6 +1,6 @@
 export const INITIAL_WORKLOAD_DROP_PHASE = "idle";
 
-const BUSY_PHASES = new Set(["validating", "compiling", "inspecting"]);
+const BUSY_PHASES = new Set(["validating", "compiling", "inspecting", "preparing_dataset"]);
 
 /**
  * One explicit lifecycle owns the drop affordance. UI motion and copy derive
@@ -22,6 +22,10 @@ export function workloadDropReducer(phase, action) {
       return phase === "ready" || phase === "failed" ? "inspecting" : phase;
     case "inspection_succeeded":
       return phase === "inspecting" ? "ready" : phase;
+    case "dataset_started":
+      return phase === "ready" || phase === "failed" ? "preparing_dataset" : phase;
+    case "dataset_succeeded":
+      return phase === "preparing_dataset" ? "ready" : phase;
     case "succeeded":
       return BUSY_PHASES.has(phase) ? "ready" : phase;
     case "failed":
@@ -64,6 +68,11 @@ export function workloadDropStatus(phase) {
       return {
         title: "Inspecting training data",
         detail: "Reading this CSV locally · source rows will not be copied",
+      };
+    case "preparing_dataset":
+      return {
+        title: "Preparing local dataset",
+        detail: "Writing deterministic train, dev, and holdout examples on this Mac",
       };
     default:
       return null;

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -307,6 +307,7 @@ pub fn run() {
             tool_proof::desktop_tool_proof_prepare,
             workload_drop::compile_dropped_workload,
             workload_drop::inspect_dropped_csv,
+            workload_drop::prepare_dropped_csv_classification,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -54,6 +54,38 @@ fn validate_csv_inspection_result(value: Value) -> Result<Value, String> {
     Ok(value)
 }
 
+fn validate_classification_dataset_result(value: Value) -> Result<Value, String> {
+    if !value.is_object() {
+        return Err("The Understudy CLI returned an invalid classification dataset.".into());
+    }
+    if value.get("schema_version").and_then(Value::as_str)
+        != Some("understudy.capture_import.classification_dataset.v1")
+        || value.get("local_only").and_then(Value::as_bool) != Some(true)
+        || value.get("network_required").and_then(Value::as_bool) != Some(false)
+        || value.get("mapping_confirmation").and_then(Value::as_str) != Some("caller-provided")
+        || value
+            .get("source_rows_persisted_as_transformed_examples")
+            .and_then(Value::as_bool)
+            != Some(true)
+    {
+        return Err(
+            "The classification dataset did not preserve its explicit local-only boundary.".into(),
+        );
+    }
+    for field in [
+        "dataset_id",
+        "source_sha256",
+        "mapping_sha256",
+        "splits",
+        "manifest_path",
+    ] {
+        if value.get(field).is_none() {
+            return Err(format!("The classification dataset omitted {field}."));
+        }
+    }
+    Ok(value)
+}
+
 fn bounded_detail(stderr: &[u8]) -> String {
     let detail = String::from_utf8_lossy(stderr).trim().to_string();
     if detail.is_empty() {
@@ -162,6 +194,76 @@ pub async fn inspect_dropped_csv(path: String, artifact_root: String) -> Result<
         .map_err(|error| format!("The CSV inspector stopped unexpectedly: {error}"))?
 }
 
+fn prepare_classification(
+    path: String,
+    artifact_root: String,
+    input_columns: Vec<String>,
+    label_column: String,
+) -> Result<Value, String> {
+    let canonical = PathBuf::from(path.trim())
+        .canonicalize()
+        .map_err(|error| format!("The CSV is unavailable: {error}"))?;
+    let canonical_artifact_root = PathBuf::from(artifact_root.trim())
+        .canonicalize()
+        .map_err(|error| format!("The workload artifact root is unavailable: {error}"))?;
+    if !canonical.is_file()
+        || canonical
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| !extension.eq_ignore_ascii_case("csv"))
+            .unwrap_or(true)
+        || !canonical_artifact_root.join("workload-card.json").is_file()
+        || !canonical_artifact_root
+            .join("csv-inspection.json")
+            .is_file()
+    {
+        return Err("Prepare training data from the current inspected CSV.".into());
+    }
+    if input_columns.is_empty() || input_columns.len() > 127 || label_column.trim().is_empty() {
+        return Err("Choose one label and at least one bounded input column.".into());
+    }
+
+    let mut command = crate::bin::command("understudy");
+    command
+        .args(["capture-import", "prepare-classification", "--source"])
+        .arg(&canonical)
+        .arg("--artifact-root")
+        .arg(&canonical_artifact_root)
+        .arg("--label-column")
+        .arg(label_column.trim());
+    for column in input_columns {
+        command.arg("--input-column").arg(column);
+    }
+    let output = command.arg("--json").output().map_err(|error| {
+        format!(
+            "Could not run the Understudy CLI ({error}). Open Status to repair the CLI, then prepare the dataset again."
+        )
+    })?;
+    if !output.status.success() {
+        return Err(format!(
+            "The Understudy CLI could not prepare this dataset. {}",
+            bounded_detail(&output.stderr)
+        ));
+    }
+    let value = serde_json::from_slice::<Value>(&output.stdout)
+        .map_err(|_| "The Understudy CLI returned malformed dataset JSON.".to_string())?;
+    validate_classification_dataset_result(value)
+}
+
+#[tauri::command]
+pub async fn prepare_dropped_csv_classification(
+    path: String,
+    artifact_root: String,
+    input_columns: Vec<String>,
+    label_column: String,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        prepare_classification(path, artifact_root, input_columns, label_column)
+    })
+    .await
+    .map_err(|error| format!("The dataset preparer stopped unexpectedly: {error}"))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,6 +326,39 @@ mod tests {
         assert!(validate_csv_inspection_result(unsafe_result)
             .unwrap_err()
             .contains("statistics-only"));
+    }
+
+    #[test]
+    fn accepts_only_explicit_local_classification_datasets() {
+        let valid = json!({
+            "schema_version": "understudy.capture_import.classification_dataset.v1",
+            "dataset_id": "dataset",
+            "source_sha256": "source",
+            "mapping_sha256": "mapping",
+            "splits": {},
+            "manifest_path": "/tmp/manifest.json",
+            "local_only": true,
+            "network_required": false,
+            "mapping_confirmation": "caller-provided",
+            "source_rows_persisted_as_transformed_examples": true
+        });
+        assert!(validate_classification_dataset_result(valid).is_ok());
+
+        let unsafe_result = json!({
+            "schema_version": "understudy.capture_import.classification_dataset.v1",
+            "dataset_id": "dataset",
+            "source_sha256": "source",
+            "mapping_sha256": "mapping",
+            "splits": {},
+            "manifest_path": "/tmp/manifest.json",
+            "local_only": false,
+            "network_required": true,
+            "mapping_confirmation": "inferred",
+            "source_rows_persisted_as_transformed_examples": true
+        });
+        assert!(validate_classification_dataset_result(unsafe_result)
+            .unwrap_err()
+            .contains("local-only"));
     }
 
     #[test]

--- a/src/capture-import.ts
+++ b/src/capture-import.ts
@@ -120,6 +120,48 @@ export type CaptureCsvInspection = {
   artifact_path: string;
 };
 
+export type CaptureClassificationDataset = {
+  schema_version: "understudy.capture_import.classification_dataset.v1";
+  dataset_id: string;
+  generated_at: string;
+  source_path: string;
+  source_sha256: string;
+  mapping_sha256: string;
+  local_only: true;
+  network_required: false;
+  mapping_confirmation: "caller-provided";
+  source_rows_persisted_as_transformed_examples: true;
+  row_count: number;
+  mapping: {
+    input_columns: string[];
+    label_column: string;
+    text_template: "named-fields-v1";
+  };
+  labels: string[];
+  label_distribution: { value: string; count: number }[];
+  split_policy: {
+    name: "deterministic-stratified-v1";
+    allocation: "per-label-rounded-dev-and-holdout-then-train-remainder";
+    target_train_ratio: 0.7;
+    target_dev_ratio: 0.15;
+    target_holdout_ratio: 0.15;
+    holdout_reserved_for_final_validation: true;
+  };
+  splits: {
+    train: CaptureClassificationSplit;
+    dev: CaptureClassificationSplit;
+    holdout: CaptureClassificationSplit;
+  };
+  artifact_root: string;
+  manifest_path: string;
+};
+
+export type CaptureClassificationSplit = {
+  path: string;
+  row_count: number;
+  sha256: string;
+};
+
 export type CapturePreview = {
   generated_at: string;
   repo: string;
@@ -604,6 +646,9 @@ export function inspectCaptureCsv(
   } else if (columns[labelIndex].empty_count > 0) {
     status = "needs_cleanup";
     reasons.push(`${columns[labelIndex].empty_count} row(s) have an empty label.`);
+  } else if (duplicateRowCount > 0) {
+    status = "needs_cleanup";
+    reasons.push(`${duplicateRowCount} duplicate row(s) must be resolved before splitting the dataset.`);
   } else if (minimumExamples !== null && minimumExamples < MIN_EXAMPLES_PER_CLASS) {
     status = "needs_data";
     reasons.push(
@@ -668,6 +713,206 @@ export function inspectCaptureCsv(
   };
   writeJson(artifactPath, inspection);
   return inspection;
+}
+
+export function prepareCaptureClassificationDataset(
+  sourceInput: string,
+  artifactRootInput: string,
+  inputColumnsInput: string[],
+  labelColumnInput: string,
+  now = new Date(),
+): CaptureClassificationDataset {
+  const source = resolve(sourceInput);
+  const artifactRoot = resolve(artifactRootInput);
+  const inspectionPath = join(artifactRoot, "csv-inspection.json");
+  if (!existsSync(inspectionPath)) {
+    throw new Error("Inspect this CSV locally before confirming its training mapping.");
+  }
+  const inspection = JSON.parse(readFileSync(inspectionPath, "utf8")) as Partial<CaptureCsvInspection>;
+  if (inspection.schema_version !== "understudy.capture_import.csv_inspection.v1") {
+    throw new Error("The CSV inspection has an unsupported schema version.");
+  }
+
+  const { bytes, headers, rows } = readCsvForTraining(source);
+  const sourceSha256 = createHash("sha256").update(bytes).digest("hex");
+  if (inspection.source_sha256 !== sourceSha256) {
+    throw new Error("The CSV changed after inspection; inspect it again before preparing training data.");
+  }
+
+  const headerByNormalized = new Map(headers.map((header) => [normalizeHeader(header), header]));
+  const labelColumn = headerByNormalized.get(normalizeHeader(labelColumnInput));
+  if (!labelColumn) {
+    throw new Error(`Unknown label column: ${labelColumnInput}`);
+  }
+  const inputColumns = [...new Set(inputColumnsInput.map((column) =>
+    headerByNormalized.get(normalizeHeader(column)),
+  ))].filter((column): column is string => Boolean(column));
+  if (inputColumns.length !== new Set(inputColumnsInput.map(normalizeHeader)).size) {
+    throw new Error("Every input column must match one inspected CSV header.");
+  }
+  if (inputColumns.length === 0) {
+    throw new Error("Choose at least one input column.");
+  }
+  if (inputColumns.includes(labelColumn)) {
+    throw new Error("The label column cannot also be an input column.");
+  }
+
+  const labelIndex = headers.indexOf(labelColumn);
+  const inputIndexes = inputColumns.map((column) => headers.indexOf(column));
+  const duplicateRowCount = rows.length - new Set(rows.map((row) => JSON.stringify(row))).size;
+  if (duplicateRowCount > 0) {
+    throw new Error(`${duplicateRowCount} duplicate row(s) must be resolved before splitting the dataset.`);
+  }
+
+  type Example = {
+    schema_version: "understudy.classification_example.v1";
+    example_id: string;
+    text: string;
+    label: string;
+  };
+  const groups = new Map<string, Example[]>();
+  rows.forEach((row, rowIndex) => {
+    const label = row[labelIndex].trim();
+    if (!label) throw new Error(`CSV record ${rowIndex + 2} has an empty label.`);
+    const text = inputIndexes
+      .map((index) => ({ name: headers[index], value: row[index].trim() }))
+      .filter(({ value }) => value.length > 0)
+      .map(({ name, value }) => `${name}: ${value}`)
+      .join("\n");
+    if (!text) throw new Error(`CSV record ${rowIndex + 2} has no mapped input text.`);
+    const example: Example = {
+      schema_version: "understudy.classification_example.v1",
+      example_id: createHash("sha256")
+        .update(`${sourceSha256}\0${rowIndex}\0${JSON.stringify(row)}`)
+        .digest("hex")
+        .slice(0, 24),
+      text,
+      label,
+    };
+    const group = groups.get(label) ?? [];
+    group.push(example);
+    groups.set(label, group);
+  });
+  if (groups.size < 2) {
+    throw new Error("At least two label values are required for classification.");
+  }
+  const undersized = [...groups.entries()]
+    .filter(([, examples]) => examples.length < MIN_EXAMPLES_PER_CLASS);
+  if (undersized.length > 0) {
+    const preview = undersized
+      .slice(0, 20)
+      .map(([label, examples]) => `${label.slice(0, 80)} (${examples.length})`)
+      .join(", ");
+    const remainder = undersized.length > 20 ? `, plus ${undersized.length - 20} more` : "";
+    throw new Error(
+      `Each class needs at least ${MIN_EXAMPLES_PER_CLASS} rows before splitting: ${preview}${remainder}`,
+    );
+  }
+
+  const labels = [...groups.keys()].sort((left, right) => left.localeCompare(right));
+  const mapping = {
+    input_columns: inputColumns,
+    label_column: labelColumn,
+    text_template: "named-fields-v1" as const,
+  };
+  const mappingSha256 = createHash("sha256").update(JSON.stringify(mapping)).digest("hex");
+  const datasetId = createHash("sha256")
+    .update(`${sourceSha256}\0${mappingSha256}`)
+    .digest("hex")
+    .slice(0, 16);
+  const datasetRoot = join(artifactRoot, "classification", datasetId);
+  mkdirSync(datasetRoot, { recursive: true, mode: 0o700 });
+  setPrivateMode(datasetRoot, 0o700);
+  const splitRows = { train: [] as Example[], dev: [] as Example[], holdout: [] as Example[] };
+  for (const label of labels) {
+    const ranked = [...groups.get(label)!].sort((left, right) =>
+      stableExampleRank(sourceSha256, left).localeCompare(stableExampleRank(sourceSha256, right)),
+    );
+    const devCount = Math.max(1, Math.round(ranked.length * 0.15));
+    const holdoutCount = Math.max(1, Math.round(ranked.length * 0.15));
+    splitRows.dev.push(...ranked.slice(0, devCount));
+    splitRows.holdout.push(...ranked.slice(devCount, devCount + holdoutCount));
+    splitRows.train.push(...ranked.slice(devCount + holdoutCount));
+  }
+
+  const splitArtifacts = Object.fromEntries(
+    Object.entries(splitRows).map(([name, examples]) => {
+      const ordered = examples.sort((left, right) => left.example_id.localeCompare(right.example_id));
+      const path = join(datasetRoot, `${name}.jsonl`);
+      const content = ordered.map((example) => JSON.stringify(example)).join("\n") + "\n";
+      writePrivateText(path, content);
+      return [name, {
+        path,
+        row_count: ordered.length,
+        sha256: createHash("sha256").update(content).digest("hex"),
+      }];
+    }),
+  ) as CaptureClassificationDataset["splits"];
+  const manifestPath = join(datasetRoot, "dataset-manifest.json");
+  const dataset: CaptureClassificationDataset = {
+    schema_version: "understudy.capture_import.classification_dataset.v1",
+    dataset_id: datasetId,
+    generated_at: now.toISOString(),
+    source_path: source,
+    source_sha256: sourceSha256,
+    mapping_sha256: mappingSha256,
+    local_only: true,
+    network_required: false,
+    mapping_confirmation: "caller-provided",
+    source_rows_persisted_as_transformed_examples: true,
+    row_count: rows.length,
+    mapping,
+    labels,
+    label_distribution: labels.map((value) => ({ value, count: groups.get(value)!.length })),
+    split_policy: {
+      name: "deterministic-stratified-v1",
+      allocation: "per-label-rounded-dev-and-holdout-then-train-remainder",
+      target_train_ratio: 0.7,
+      target_dev_ratio: 0.15,
+      target_holdout_ratio: 0.15,
+      holdout_reserved_for_final_validation: true,
+    },
+    splits: splitArtifacts,
+    artifact_root: datasetRoot,
+    manifest_path: manifestPath,
+  };
+  writeJson(manifestPath, dataset);
+  return dataset;
+}
+
+function readCsvForTraining(source: string): { bytes: Buffer; headers: string[]; rows: string[][] } {
+  if (!existsSync(source) || !statSync(source).isFile() || extname(source).toLowerCase() !== ".csv") {
+    throw new Error(`Training dataset preparation requires one .csv file: ${source}`);
+  }
+  const bytes = readFileSync(source);
+  if (bytes.length > MAX_CSV_BYTES) {
+    throw new Error(`CSV exceeds the ${MAX_CSV_BYTES}-byte local preparation limit.`);
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("CSV must be valid UTF-8 before local preparation.");
+  }
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+  const records = parseCsvRecordsBounded(text).filter((record) =>
+    record.some((field) => field.trim().length > 0),
+  );
+  if (records.length < 2) throw new Error("CSV needs one header row and at least one data row.");
+  const headers = records[0].map((field) => field.trim());
+  const rows = records.slice(1);
+  rows.forEach((row, index) => {
+    if (row.length !== headers.length) {
+      throw new Error(`CSV record ${index + 2} has ${row.length} fields; expected ${headers.length}.`);
+    }
+  });
+  return { bytes, headers, rows };
+}
+
+function stableExampleRank(sourceSha256: string, example: { example_id: string; label: string }): string {
+  return createHash("sha256")
+    .update(`${sourceSha256}\0${example.label}\0${example.example_id}`)
+    .digest("hex");
 }
 
 function parseCsvRecordsBounded(text: string): string[][] {
@@ -914,6 +1159,11 @@ function walkBounded(root: string, maxFiles: number): { files: string[]; truncat
 
 function writeJson(path: string, payload: unknown): void {
   writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  setPrivateMode(path, 0o600);
+}
+
+function writePrivateText(path: string, content: string): void {
+  writeFileSync(path, content, { encoding: "utf8", mode: 0o600 });
   setPrivateMode(path, 0o600);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   buildWorkloadCard,
   compileCaptureImport,
   inspectCaptureCsv,
+  prepareCaptureClassificationDataset,
   previewCaptureImport,
   scanCaptureImport,
 } from "./capture-import.js";
@@ -296,6 +297,10 @@ function parseNonNegativeNumber(value: string): number {
   return parsed;
 }
 
+function collectRepeated(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 function registerCaptureImportCommands(program: Command): void {
   const captureImport = program
     .command("capture-import")
@@ -351,6 +356,39 @@ function registerCaptureImportCommands(program: Command): void {
       console.log(`mapping: ${result.recommended_mapping.label_column ?? "label confirmation required"}`);
       console.log(`artifact: ${result.artifact_path}`);
       console.log("payload_read: true (local only; source rows were not copied)");
+    });
+
+  captureImport
+    .command("prepare-classification")
+    .description("Transform an inspected CSV into deterministic local train, dev, and holdout JSONL")
+    .requiredOption("--source <path>", "Inspected local CSV file")
+    .requiredOption("--artifact-root <path>", "Existing private artifact root from capture-import compile")
+    .requiredOption("--label-column <name>", "Caller-confirmed label column")
+    .option("--input-column <name>", "Caller-confirmed input column; repeat for multiple columns", collectRepeated, [])
+    .option("--json", "Output JSON")
+    .action((options: {
+      source: string;
+      artifactRoot: string;
+      labelColumn: string;
+      inputColumn: string[];
+      json?: boolean;
+    }) => {
+      const result = prepareCaptureClassificationDataset(
+        options.source,
+        options.artifactRoot,
+        options.inputColumn,
+        options.labelColumn,
+      );
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`capture-import prepare-classification: ${result.row_count} row(s)`);
+      console.log(
+        `splits: train ${result.splits.train.row_count}, dev ${result.splits.dev.row_count}, holdout ${result.splits.holdout.row_count}`,
+      );
+      console.log(`manifest: ${result.manifest_path}`);
+      console.log("local_only: true (transformed examples were persisted locally)");
     });
 
   captureImport

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -2062,9 +2062,112 @@ class ScoreWithFeedback:
       const saved = readFileSync(inspection.artifact_path, "utf8");
       assert.ok(!saved.includes("PRIVATE_COFFEE"));
       assert.ok(!saved.includes("team breakfast"));
+      const prepare = run([
+        "capture-import",
+        "prepare-classification",
+        "--source",
+        source,
+        "--artifact-root",
+        compiled.artifact_root,
+        "--input-column",
+        "merchant",
+        "--input-column",
+        "description",
+        "--label-column",
+        "category",
+        "--json",
+      ]);
+      assert.notEqual(prepare.status, 0);
+      assert.match(prepare.stderr, /Each class needs at least 20 rows/);
       if (process.platform !== "win32") {
         assert.equal(statSync(inspection.artifact_path).mode & 0o777, 0o600);
       }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepares deterministic stratified classification splits from a confirmed mapping", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-classification-dataset-"));
+    try {
+      const source = join(root, "expenses.csv");
+      const labels = ["meals", "office_supplies", "travel"];
+      const rows = Array.from({ length: 90 }, (_, index) => {
+        const label = labels[index % labels.length];
+        return `merchant-${index},expense ${index},${(index + 1).toFixed(2)},${label}`;
+      });
+      writeFileSync(source, ["merchant,description,amount,category", ...rows].join("\n"));
+      const outputRoot = join(root, "artifacts");
+      const compiledResult = run([
+        "capture-import", "compile", "--source", source, "--output-root", outputRoot, "--json",
+      ]);
+      assert.equal(compiledResult.status, 0, compiledResult.stderr);
+      const compiled = JSON.parse(compiledResult.stdout);
+      const inspectionResult = run([
+        "capture-import", "inspect-csv", "--source", source, "--artifact-root", compiled.artifact_root, "--json",
+      ]);
+      assert.equal(inspectionResult.status, 0, inspectionResult.stderr);
+      assert.equal(JSON.parse(inspectionResult.stdout).training_readiness.ready, true);
+
+      const args = [
+        "capture-import",
+        "prepare-classification",
+        "--source",
+        source,
+        "--artifact-root",
+        compiled.artifact_root,
+        "--input-column",
+        "merchant",
+        "--input-column",
+        "description",
+        "--input-column",
+        "amount",
+        "--label-column",
+        "category",
+        "--json",
+      ];
+      const result = run(args);
+      assert.equal(result.status, 0, result.stderr);
+      const dataset = JSON.parse(result.stdout);
+      assert.equal(dataset.schema_version, "understudy.capture_import.classification_dataset.v1");
+      assert.equal(dataset.local_only, true);
+      assert.equal(dataset.network_required, false);
+      assert.equal(dataset.mapping_confirmation, "caller-provided");
+      assert.equal(dataset.source_rows_persisted_as_transformed_examples, true);
+      assert.equal(dataset.row_count, 90);
+      assert.deepEqual(dataset.mapping, {
+        input_columns: ["merchant", "description", "amount"],
+        label_column: "category",
+        text_template: "named-fields-v1",
+      });
+      assert.deepEqual(dataset.labels, labels);
+      assert.equal(dataset.splits.train.row_count, 60);
+      assert.equal(dataset.splits.dev.row_count, 15);
+      assert.equal(dataset.splits.holdout.row_count, 15);
+
+      const splitRows = Object.fromEntries(Object.entries(dataset.splits).map(([name, split]) => [
+        name,
+        readFileSync(split.path, "utf8").trim().split("\n").map(JSON.parse),
+      ]));
+      const allIds = Object.values(splitRows).flat().map((row) => row.example_id);
+      assert.equal(new Set(allIds).size, 90);
+      for (const rowsForSplit of Object.values(splitRows)) {
+        assert.deepEqual([...new Set(rowsForSplit.map((row) => row.label))].sort(), labels);
+        assert.ok(rowsForSplit.every((row) => row.schema_version === "understudy.classification_example.v1"));
+        assert.ok(rowsForSplit.every((row) => row.text.includes("merchant:")));
+      }
+      const repeated = run(args);
+      assert.equal(repeated.status, 0, repeated.stderr);
+      const repeatedDataset = JSON.parse(repeated.stdout);
+      assert.equal(repeatedDataset.dataset_id, dataset.dataset_id);
+      assert.equal(repeatedDataset.splits.train.sha256, dataset.splits.train.sha256);
+      assert.equal(repeatedDataset.splits.dev.sha256, dataset.splits.dev.sha256);
+      assert.equal(repeatedDataset.splits.holdout.sha256, dataset.splits.holdout.sha256);
+
+      writeFileSync(source, ["merchant,description,amount,category", ...rows, "late,row,1.00,meals"].join("\n"));
+      const changed = run(args);
+      assert.notEqual(changed.status, 0);
+      assert.match(changed.stderr, /changed after inspection/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -462,6 +462,9 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(chat, /workloadDropPersonaState\(dropPhase\)/);
   assert.match(chat, /invoke<CsvInspection>\("inspect_dropped_csv"/);
   assert.match(chat, /Inspect CSV locally/);
+  assert.match(chat, /prepare_dropped_csv_classification/);
+  assert.match(chat, /Prepare local dataset/);
+  assert.match(chat, /Holdout stays reserved for final validation/);
   assert.match(chat, /only statistics and mapping evidence were saved/);
   assert.doesNotMatch(chat, /useState\(false\);[\s\S]{0,120}setDropHovering/);
   assert.doesNotMatch(chat, /workload-drop-overlay/);
@@ -470,6 +473,7 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(dropState, /One file or folder · stays on this Mac/);
   assert.match(dropState, /Indexing metadata locally · contents remain unread/);
   assert.match(dropState, /Reading this CSV locally · source rows will not be copied/);
+  assert.match(dropState, /Writing deterministic train, dev, and holdout examples on this Mac/);
   assert.match(css, /\.persona-stage\.workload-drop-active::before/);
   assert.match(css, /@keyframes workload-intake-ring/);
   assert.match(css, /prefers-reduced-motion: reduce[\s\S]*?\.persona-stage\.workload-drop-active::before/);
@@ -491,6 +495,7 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(bridge, /WorkloadDropEvent::Compiling/);
   assert.match(bridge, /"capture-import", "compile", "--source"/);
   assert.match(bridge, /"capture-import", "inspect-csv", "--source"/);
+  assert.match(bridge, /"capture-import", "prepare-classification", "--source"/);
   assert.match(bridge, /source_rows_persisted/);
   assert.match(bridge, /statistics-and-label-aggregates/);
   assert.match(bridge, /value\.get\("local_only"\)/);
@@ -501,6 +506,9 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(compiler, /payload_read: false/);
   assert.match(compiler, /source_rows_persisted: false/);
   assert.match(compiler, /source_sha256/);
+  assert.match(compiler, /deterministic-stratified-v1/);
+  assert.match(compiler, /holdout_reserved_for_final_validation: true/);
+  assert.match(compiler, /source_rows_persisted_as_transformed_examples: true/);
   assert.equal(
     parity.features.find((feature) => feature.id === "drop-to-workload-compilation")?.status,
     "shipped",

--- a/tests/workload-drop-state.test.mjs
+++ b/tests/workload-drop-state.test.mjs
@@ -57,6 +57,15 @@ test("explicit CSV inspection is a truthful thinking phase", () => {
   assert.equal(workloadDropReducer("failed", { type: "inspection_started" }), "inspecting");
 });
 
+test("classification dataset preparation stays busy until local splits exist", () => {
+  let phase = workloadDropReducer("ready", { type: "dataset_started" });
+  assert.equal(phase, "preparing_dataset");
+  assert.equal(workloadDropPersonaState(phase), "thinking");
+  assert.match(workloadDropStatus(phase)?.detail ?? "", /train, dev, and holdout/);
+  phase = workloadDropReducer(phase, { type: "dataset_succeeded" });
+  assert.equal(phase, "ready");
+});
+
 test("out-of-order completion cannot mark an idle lifecycle ready", () => {
   assert.equal(workloadDropReducer("idle", { type: "succeeded" }), "idle");
   assert.equal(workloadDropReducer("ready", { type: "failed" }), "ready");


### PR DESCRIPTION
## What changed

- adds explicit label and input-column mapping to the inspected CSV flow
- binds preparation to the inspected source SHA and fails closed if the file changes
- writes deterministic, stratified train/dev/holdout JSONL plus immutable hashes
- requires two classes, at least 20 examples per class, and no duplicate or empty mapped rows
- keeps all transformed examples local and reserves holdout for final validation
- stops at a real dataset artifact; this does not pretend a model was trained

## Verification

- npm run check: 339 tests passed, 34 public skills validated, npm package smoke passed
- npm run build
- npm run typecheck
- affected test rerun: 97 passed
- cargo test --lib: 166 passed, 4 ignored
- cargo test workload_drop --lib: 5 passed
- cargo fmt --check
- desktop bun run build
- git diff --check

## Stack

- base: #250
- prerequisite: #249
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->