### PR TITLE
fix(desktop): start local and inspect dropped tables

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.20"
+    "version": "0.6.21"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.20"
+    "version": "0.6.21"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -73,6 +73,7 @@ import {
 import {
   INITIAL_WORKLOAD_DROP_PHASE,
   isWorkloadDropBusy,
+  shouldInspectDroppedTable,
   workloadDropPersonaState,
   workloadDropReducer,
   workloadDropStatus,
@@ -736,10 +737,17 @@ export function ChatPane({
           .then(async (result) => {
             if (disposed || dropRequestGeneration.current !== requestGeneration) return;
             setDroppedWorkload(result);
-            const isCsv = result.source_type === "file" && (result.source_kinds["csv-data"] ?? 0) === 1;
-            if (isCsv) {
+            const inspectTable = shouldInspectDroppedTable(result);
+            if (inspectTable) {
               dispatchDrop({ type: "inspection_started" });
-              await inspectCsvWorkload(result, requestGeneration);
+              try {
+                await inspectCsvWorkload(result, requestGeneration);
+              } catch (error) {
+                const extensionless = !result.source_name.includes(".");
+                if (!extensionless) throw error;
+                dispatchDrop({ type: "succeeded" });
+                setNotice("Workload draft created locally; this extensionless file is not a supported table.");
+              }
             } else {
               dispatchDrop({ type: "succeeded" });
               setNotice(

--- a/apps/homescreen/app/components/ModelDownloadNotice.tsx
+++ b/apps/homescreen/app/components/ModelDownloadNotice.tsx
@@ -2,6 +2,11 @@
 
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  defaultStarterModel,
+  shouldOfferStarterDownload,
+  shouldPrepareStarter,
+} from "../lib/starter-model.mjs";
 import { OperationNotice, type OperationNoticeState } from "./OperationNotice";
 
 const POLL_MS = 1_000;
@@ -27,6 +32,24 @@ type SnapshotModel = {
   id: string;
   short_name?: string | null;
   name: string;
+  approx_gb: number;
+  default_rung: boolean;
+  cached: boolean;
+  incomplete: boolean;
+};
+
+type ResidencySnapshot = {
+  slots: {
+    id: number;
+    model_id?: string | null;
+    state: string;
+  }[];
+};
+
+type DefaultLocalModelPreparation = {
+  model_id: string;
+  slot_id: number;
+  state: string;
 };
 
 function formatBytes(bytes: number) {
@@ -42,13 +65,22 @@ function fallbackModelName(modelId: string) {
 export function ModelDownloadNotice() {
   const [rows, setRows] = useState<DownloadProgress[]>([]);
   const [models, setModels] = useState<SnapshotModel[]>([]);
+  const [residency, setResidency] = useState<ResidencySnapshot>({ slots: [] });
   const [visibleId, setVisibleId] = useState<string | null>(null);
   const [actionBusy, setActionBusy] = useState(false);
   const [actionError, setActionError] = useState<{ id: string; message: string } | null>(null);
+  const [prepareBusy, setPrepareBusy] = useState(false);
+  const [prepareError, setPrepareError] = useState<string | null>(null);
+  const [starterPromptDismissed, setStarterPromptDismissed] = useState(false);
+  const [starterReadyVisible, setStarterReadyVisible] = useState(false);
   const initialized = useRef(false);
+  const starterPrepareAttempted = useRef(false);
+  const starterPrepareInFlight = useRef(false);
+  const previousStarterState = useRef<string | null>(null);
   const previousStatuses = useRef(new Map<string, DownloadStatus>());
   const dismissed = useRef(new Set<string>());
   const hideTimer = useRef<number | null>(null);
+  const starterHideTimer = useRef<number | null>(null);
 
   const clearHideTimer = useCallback(() => {
     if (hideTimer.current !== null) {
@@ -97,18 +129,24 @@ export function ModelDownloadNotice() {
 
   const refresh = useCallback(() => {
     if (!isTauri()) return Promise.resolve();
-    return invoke<DownloadProgress[]>("list_snapshot_downloads").then(ingest).catch(() => {});
+    return Promise.all([
+      invoke<DownloadProgress[]>("list_snapshot_downloads"),
+      invoke<SnapshotModel[]>("list_snapshot_models"),
+      invoke<ResidencySnapshot>("get_residency"),
+    ])
+      .then(([nextRows, nextModels, nextResidency]) => {
+        setModels(nextModels);
+        setResidency(nextResidency);
+        ingest(nextRows);
+      })
+      .catch(() => {});
   }, [ingest]);
 
   useEffect(() => {
     if (!isTauri()) return;
-    // The download notice only needs display names. The full bootstrap
-    // diagnostic starts several CLI/runtime probes and used to block the
-    // macOS webview during first paint. The catalog is already available from
-    // the bounded, cache-backed snapshot command.
-    void invoke<SnapshotModel[]>("list_snapshot_models")
-      .then(setModels)
-      .catch(() => {});
+    // These are bounded in-memory/SQLite reads. Heavy CLI/runtime probes stay
+    // out of first paint; local warm-up is delayed below and runs through a
+    // spawn_blocking Tauri command.
     void refresh();
     const timer = window.setInterval(() => void refresh(), POLL_MS);
     return () => window.clearInterval(timer);
@@ -117,9 +155,67 @@ export function ModelDownloadNotice() {
   useEffect(
     () => () => {
       clearHideTimer();
+      if (starterHideTimer.current !== null) window.clearTimeout(starterHideTimer.current);
     },
     [clearHideTimer],
   );
+
+  const starter = useMemo(() => defaultStarterModel(models), [models]);
+  const starterSlot = useMemo(
+    () => residency.slots.find((slot) => slot.model_id === starter?.id) ?? null,
+    [residency.slots, starter?.id],
+  );
+
+  const prepareStarter = useCallback(async () => {
+    if (!starter?.id || starterPrepareInFlight.current) return;
+    starterPrepareAttempted.current = true;
+    starterPrepareInFlight.current = true;
+    setPrepareBusy(true);
+    setPrepareError(null);
+    try {
+      const prepared = await invoke<DefaultLocalModelPreparation>("prepare_default_local_model");
+      await refresh();
+      if (prepared.model_id === starter.id && prepared.state === "running") {
+        setStarterReadyVisible(true);
+        if (starterHideTimer.current !== null) window.clearTimeout(starterHideTimer.current);
+        starterHideTimer.current = window.setTimeout(() => {
+          setStarterReadyVisible(false);
+          starterHideTimer.current = null;
+        }, TERMINAL_VISIBLE_MS);
+      }
+    } catch (error) {
+      setPrepareError(String(error));
+    } finally {
+      starterPrepareInFlight.current = false;
+      setPrepareBusy(false);
+    }
+  }, [refresh, starter?.id]);
+
+  const shouldAutoPrepare = shouldPrepareStarter({
+    starter,
+    slots: residency.slots,
+    attempted: starterPrepareAttempted.current,
+    dismissed: starterPromptDismissed,
+  });
+
+  useEffect(() => {
+    if (!isTauri() || !shouldAutoPrepare) return;
+    const timer = window.setTimeout(() => void prepareStarter(), 1_500);
+    return () => window.clearTimeout(timer);
+  }, [prepareStarter, shouldAutoPrepare]);
+
+  useEffect(() => {
+    const state = starterSlot?.state ?? null;
+    if (previousStarterState.current === "loading" && state === "running") {
+      setStarterReadyVisible(true);
+      if (starterHideTimer.current !== null) window.clearTimeout(starterHideTimer.current);
+      starterHideTimer.current = window.setTimeout(() => {
+        setStarterReadyVisible(false);
+        starterHideTimer.current = null;
+      }, TERMINAL_VISIBLE_MS);
+    }
+    previousStarterState.current = state;
+  }, [starterSlot?.state]);
 
   const row = rows.find((candidate) => candidate.id === visibleId) ?? null;
   const activeCount = rows.filter((candidate) => candidate.status === "running").length;
@@ -129,7 +225,93 @@ export function ModelDownloadNotice() {
     return model?.short_name || model?.name || fallbackModelName(row.model_id);
   }, [models, row]);
 
-  if (!row) return null;
+  const offerStarterDownload = shouldOfferStarterDownload({
+    starter,
+    slots: residency.slots,
+    dismissed: starterPromptDismissed,
+  });
+  const starterLoading = starterSlot?.state === "loading";
+  const starterRunning = starterSlot?.state === "running";
+
+  if (!row && !offerStarterDownload && !prepareBusy && !starterLoading && !prepareError && !starterReadyVisible) {
+    return null;
+  }
+
+  if (!row || ((prepareBusy || starterLoading || starterReadyVisible) && row.model_id === starter?.id && row.status === "done")) {
+    const starterLabel = starter?.short_name || starter?.name || "Understudy Small";
+    if (prepareError) {
+      return (
+        <OperationNotice
+          className="model-download-notice"
+          state="error"
+          icon="download"
+          title="Local model needs attention"
+          message={prepareError}
+          meta={starterLabel}
+          actionLabel={prepareBusy ? "Working…" : "Retry"}
+          actionDisabled={prepareBusy}
+          onAction={() => void prepareStarter()}
+          dismissLabel="Dismiss local model status"
+          onDismiss={() => setPrepareError(null)}
+        />
+      );
+    }
+    if (prepareBusy || starterLoading) {
+      return (
+        <OperationNotice
+          className="model-download-notice"
+          state="running"
+          icon="download"
+          title="Starting local model"
+          message={starterLabel}
+          meta="Loading on this Mac"
+          dismissLabel="Dismiss local model status"
+          dismissDisabled
+          onDismiss={() => {}}
+        />
+      );
+    }
+    if (starterReadyVisible || starterRunning) {
+      return (
+        <OperationNotice
+          className="model-download-notice"
+          state="success"
+          icon="download"
+          title="Local model ready"
+          message={starterLabel}
+          meta="Selected for chat"
+          dismissLabel="Dismiss local model status"
+          onDismiss={() => setStarterReadyVisible(false)}
+        />
+      );
+    }
+    if (offerStarterDownload && starter) {
+      const starterDownloadError = actionError?.id === `starter:${starter.id}` ? actionError.message : null;
+      return (
+        <OperationNotice
+          className="model-download-notice"
+          state={starterDownloadError ? "error" : "idle"}
+          icon="download"
+          title={starterDownloadError ? "Model download needs attention" : "Start with a local model"}
+          message={starterDownloadError || `${starter.short_name || starter.name} · ${starter.approx_gb.toFixed(1)} GB`}
+          meta={starter.incomplete ? "Resume download · partial files kept" : "One-time download · stays on this Mac"}
+          actionLabel={actionBusy ? "Starting…" : starterDownloadError ? "Retry" : starter.incomplete ? "Resume" : "Download"}
+          actionDisabled={actionBusy}
+          onAction={() => {
+            setActionBusy(true);
+            setActionError(null);
+            invoke("start_snapshot_download", { modelId: starter.id })
+              .then(() => refresh())
+              .catch((error) => setActionError({ id: `starter:${starter.id}`, message: String(error) }))
+              .finally(() => setActionBusy(false));
+          }}
+          dismissLabel="Dismiss starter model download"
+          onDismiss={() => setStarterPromptDismissed(true)}
+        />
+      );
+    }
+    return null;
+  }
 
   const total = row.total_bytes ?? null;
   const percent = total ? Math.min(100, (row.downloaded_bytes / total) * 100) : null;

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -109,9 +109,7 @@ export function Sidebar({
         {historyLoading && visibleSessions.length === 0 ? (
           <div className="chat-nav-empty">Loading chats…</div>
         ) : visibleSessions.length === 0 ? (
-          <div className="chat-nav-empty">
-            {showArchived ? "No archived chats." : "No saved chats yet."}
-          </div>
+          showArchived ? <div className="chat-nav-empty">No archived chats.</div> : null
         ) : (
           visibleSessions.map((session) => {
             const isActive = active === "chat" && activeSessionId === session.session_id;

--- a/apps/homescreen/app/lib/starter-model.d.mts
+++ b/apps/homescreen/app/lib/starter-model.d.mts
@@ -1,0 +1,31 @@
+export type StarterModel = {
+  id: string;
+  short_name?: string | null;
+  name: string;
+  approx_gb: number;
+  default_rung: boolean;
+  cached: boolean;
+  incomplete: boolean;
+};
+
+export type StarterResidencySlot = {
+  model_id?: string | null;
+  state: string;
+};
+
+export function defaultStarterModel(models: StarterModel[]): StarterModel | null;
+
+export function hasActiveLocalModel(slots: StarterResidencySlot[]): boolean;
+
+export function shouldPrepareStarter(options: {
+  starter: StarterModel | null;
+  slots: StarterResidencySlot[];
+  attempted: boolean;
+  dismissed: boolean;
+}): boolean;
+
+export function shouldOfferStarterDownload(options: {
+  starter: StarterModel | null;
+  slots: StarterResidencySlot[];
+  dismissed: boolean;
+}): boolean;

--- a/apps/homescreen/app/lib/starter-model.mjs
+++ b/apps/homescreen/app/lib/starter-model.mjs
@@ -1,0 +1,27 @@
+const ACTIVE_SLOT_STATES = new Set(["loading", "running"]);
+
+export function defaultStarterModel(models) {
+  return models.find((model) => model.default_rung) ?? null;
+}
+
+export function hasActiveLocalModel(slots) {
+  return slots.some((slot) => ACTIVE_SLOT_STATES.has(slot.state));
+}
+
+export function shouldPrepareStarter({ starter, slots, attempted, dismissed }) {
+  return Boolean(
+    starter?.cached &&
+      !attempted &&
+      !dismissed &&
+      !hasActiveLocalModel(slots),
+  );
+}
+
+export function shouldOfferStarterDownload({ starter, slots, dismissed }) {
+  return Boolean(
+    starter &&
+      !starter.cached &&
+      !dismissed &&
+      !hasActiveLocalModel(slots),
+  );
+}

--- a/apps/homescreen/app/lib/workload-drop-state.d.mts
+++ b/apps/homescreen/app/lib/workload-drop-state.d.mts
@@ -24,6 +24,12 @@ export type WorkloadDropAction =
 
 export const INITIAL_WORKLOAD_DROP_PHASE: WorkloadDropPhase;
 
+export function shouldInspectDroppedTable(workload: {
+  source_type?: string | null;
+  source_name?: string | null;
+  source_kinds?: Record<string, number> | null;
+} | null): boolean;
+
 export function workloadDropReducer(
   phase: WorkloadDropPhase,
   action: WorkloadDropAction,

--- a/apps/homescreen/app/lib/workload-drop-state.mjs
+++ b/apps/homescreen/app/lib/workload-drop-state.mjs
@@ -1,5 +1,16 @@
 export const INITIAL_WORKLOAD_DROP_PHASE = "idle";
 
+export function shouldInspectDroppedTable(workload) {
+  if (!workload || workload.source_type !== "file") return false;
+  if ((workload.source_kinds?.["csv-data"] ?? 0) === 1) return true;
+  const name = String(workload.source_name ?? "").trim().toLowerCase();
+  if (/\.(?:csv|tsv|tab)$/.test(name)) return true;
+  // Several public datasets ship as extensionless tab-delimited files. An
+  // explicit file drop may be probed locally; unsupported extensionless files
+  // fall back to the generic metadata-only Workload Card.
+  return name.length > 0 && !name.includes(".");
+}
+
 const BUSY_PHASES = new Set(["validating", "compiling", "inspecting", "preparing_dataset"]);
 
 /**
@@ -67,7 +78,7 @@ export function workloadDropStatus(phase) {
     case "inspecting":
       return {
         title: "Inspecting training data",
-        detail: "Reading this CSV locally · source rows will not be copied",
+        detail: "Reading this table locally · source rows will not be copied",
       };
     case "preparing_dataset":
       return {

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.23",
+  "version": "0.3.24",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.23"
+version = "0.3.24"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -25,7 +25,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.20";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.21";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/commands.rs
+++ b/apps/homescreen/src-tauri/src/commands.rs
@@ -1123,6 +1123,85 @@ pub fn list_snapshot_models() -> Vec<models::SnapshotInfo> {
     models::snapshots()
 }
 
+#[derive(Serialize, Clone)]
+pub struct DefaultLocalModelPreparation {
+    pub model_id: String,
+    pub slot_id: u32,
+    pub state: String,
+}
+
+/// Make the catalog's certified onboarding rung the first local chat model.
+///
+/// Download consent stays in the UI because the snapshot is several GB. Once
+/// the weights are present, this command idempotently reuses or creates a slot
+/// and starts the model off the webview thread. It never displaces a local
+/// model the user already has running or loading.
+#[tauri::command]
+pub async fn prepare_default_local_model(
+    app: AppHandle,
+) -> Result<DefaultLocalModelPreparation, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let starter = models::snapshots()
+            .into_iter()
+            .find(|snapshot| snapshot.default_rung)
+            .ok_or_else(|| "model catalog has no default local rung".to_string())?;
+        if !starter.cached {
+            return Err(format!("{} is not downloaded yet", starter.id));
+        }
+
+        let manager = residency(&app);
+        let current = manager.snapshot();
+        if let Some(active) = current
+            .slots
+            .iter()
+            .find(|slot| slot.state == "running" || slot.state == "loading")
+        {
+            return Ok(DefaultLocalModelPreparation {
+                model_id: active
+                    .model_id
+                    .clone()
+                    .unwrap_or_else(|| starter.id.clone()),
+                slot_id: active.id,
+                state: active.state.clone(),
+            });
+        }
+
+        let existing_slot = current
+            .slots
+            .iter()
+            .find(|slot| slot.model_id.as_deref() == Some(starter.id.as_str()))
+            .map(|slot| slot.id);
+        let slot_id = existing_slot.unwrap_or_else(|| manager.add_slot());
+        if existing_slot.is_none() {
+            if let Err(error) = manager.assign(slot_id, &starter.id) {
+                let _ = manager.remove(slot_id);
+                commit(&app);
+                return Err(error.to_string());
+            }
+        }
+
+        if let Err(error) = manager.warm(&app, slot_id) {
+            commit(&app);
+            return Err(error.to_string());
+        }
+        commit(&app);
+        let state = manager
+            .snapshot()
+            .slots
+            .into_iter()
+            .find(|slot| slot.id == slot_id)
+            .map(|slot| slot.state)
+            .unwrap_or_else(|| "running".to_string());
+        Ok(DefaultLocalModelPreparation {
+            model_id: starter.id,
+            slot_id,
+            state,
+        })
+    })
+    .await
+    .map_err(|error| format!("default local model task failed: {error}"))?
+}
+
 #[tauri::command]
 pub fn mlx_runtime_status() -> models::MlxRuntimeStatus {
     models::mlx_runtime_status()

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.23";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.24";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -249,6 +249,7 @@ pub fn run() {
             commands::disconnect,
             commands::list_models,
             commands::list_snapshot_models,
+            commands::prepare_default_local_model,
             commands::mlx_runtime_status,
             commands::set_app_icon,
             commands::bootstrap_status,

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -219,14 +219,8 @@ fn inspect_csv(path: String, artifact_root: String) -> Result<Value, String> {
     let canonical = PathBuf::from(path.trim())
         .canonicalize()
         .map_err(|error| format!("The CSV is unavailable: {error}"))?;
-    if !canonical.is_file()
-        || canonical
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .map(|extension| !extension.eq_ignore_ascii_case("csv"))
-            .unwrap_or(true)
-    {
-        return Err("Local training inspection requires one .csv file.".into());
+    if !canonical.is_file() {
+        return Err("Local training inspection requires one delimited text file.".into());
     }
     let canonical_artifact_root = PathBuf::from(artifact_root.trim())
         .canonicalize()
@@ -281,17 +275,12 @@ fn prepare_classification(
         .canonicalize()
         .map_err(|error| format!("The workload artifact root is unavailable: {error}"))?;
     if !canonical.is_file()
-        || canonical
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .map(|extension| !extension.eq_ignore_ascii_case("csv"))
-            .unwrap_or(true)
         || !canonical_artifact_root.join("workload-card.json").is_file()
         || !canonical_artifact_root
             .join("csv-inspection.json")
             .is_file()
     {
-        return Err("Prepare training data from the current inspected CSV.".into());
+        return Err("Prepare training data from the current inspected table.".into());
     }
     if input_columns.is_empty()
         || input_columns.len() > 127

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,10 +1,54 @@
 # Design QA
 
+## Dropped CSV structure review and target selection
+
 Final result: **passed**
 
-- Flow: dropped CSV structure review and target selection
 - Reference: Shimmer post-drop analysis (`CleanShot 2026-07-15 at 13.36.23@2x.png`)
 - Implementation: native Desktop dev build at 1180 x 820 (`6d400cb9-edb3-4d4f-a010-3b3e0b8d329c-screenshot.png`)
 - Dataset: `personal_finance_dataset_8000_extended.csv` (8,000 rows, 15 columns)
 
 The implementation preserves Shimmer's austere file summary, compact profile cards, and cyan/purple visual grammar while keeping the real animated Rive persona visible above the analysis. All 15 columns, target choice, and primary action remain above the fold with no internal scroll. The second-stage capture (`e3d49f63-5889-4cfd-9617-f8b6d5f2d5fe-screenshot.png`) confirms the cards disappear after target selection, the cyan Rive orb becomes the training focus, and the complete training heading and action render without clipping or overlap. The step labels and primary actions are intentional functional controls; the tiny reset and explanatory mapping copy have been removed.
+
+## Empty-chat sidebar
+
+- Source visual truth: `<local-attachment>/CleanShot 2026-07-15 at 15.52.54@2x.png`
+- Implementation screenshot: `<private-temp>/dcb8232b-4c1e-4d1c-8d0e-934ac32d4faf-screenshot.png`
+- Full-view comparison: `<private-temp>/understudy-empty-sidebar-comparison.png`
+- Viewport: 1292 x 932 logical pixels at 2x scale
+- State: native Tauri app, dark theme, navigation expanded, active chat history empty, cached default local model running
+
+## Findings
+
+No actionable P0, P1, or P2 differences remain for the requested change. The active empty-chat rail keeps its existing width, header, archive control, account status, colors, and typography while removing only `No saved chats yet.`. Archived-history mode retains its useful `No archived chats.` explanation.
+
+Required fidelity surfaces:
+
+- Fonts and typography: existing app font family, weights, capitalization, and hierarchy are unchanged.
+- Spacing and layout rhythm: the rail, header, archive icon, account footer, composer, and persona retain the source layout; removing the sentence creates intentional quiet space without shifting persistent controls.
+- Colors and visual tokens: dark surfaces, muted labels, cyan-ready composer treatment, borders, and white Rive persona remain on the existing product tokens.
+- Image quality and asset fidelity: the production Rive persona is retained; no substitute or newly drawn asset was introduced.
+- Copy and content: the redundant active-empty-state sentence is absent. The screenshot's red review annotation is source markup, not application content.
+
+## Open Questions
+
+None for this scoped change.
+
+## Focused Region Comparison
+
+A separate crop was not needed: the sidebar is legible at full resolution in the combined same-size comparison, and the sole target is the presence or absence of one short line directly beneath `CHATS`.
+
+## Comparison History
+
+- Initial source finding: the active empty-state sentence consumed attention without adding an action.
+- Fix: `Sidebar.tsx` now renders no active empty-state copy while preserving the archived empty-state message.
+- Post-fix evidence: the same-size native screenshot and combined comparison show an empty active rail with the header, archive control, and account footer intact.
+
+## Implementation Checklist
+
+- [x] Remove only the active empty-chat sentence.
+- [x] Preserve archived empty-state guidance.
+- [x] Verify the native app at the source image dimensions and state.
+- [x] Confirm the cached default local model is running and selected.
+
+final result: passed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.20",
+      "version": "0.6.21",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/scripts/desktop-e2e-harness.mjs
+++ b/scripts/desktop-e2e-harness.mjs
@@ -366,14 +366,15 @@ async function captureScreenshot(command, output, cwd, events) {
   return output;
 }
 
-function validateCsv(path) {
+function validateTable(path) {
   const canonical = realpathSync(path);
   const metadata = statSync(canonical);
-  if (!metadata.isFile() || extname(canonical).toLowerCase() !== ".csv") {
-    throw new Error("Desktop E2E requires one local .csv file");
+  const extension = extname(canonical).toLowerCase();
+  if (!metadata.isFile() || !["", ".csv", ".tsv", ".tab", ".txt"].includes(extension)) {
+    throw new Error("Desktop E2E requires one local delimited text file");
   }
   if (metadata.size > MAX_CSV_BYTES) {
-    throw new Error(`CSV exceeds the harness limit of ${MAX_CSV_BYTES} bytes`);
+    throw new Error(`Table exceeds the harness limit of ${MAX_CSV_BYTES} bytes`);
   }
   return { path: canonical, bytes: metadata.size };
 }
@@ -458,7 +459,7 @@ export async function runDesktopE2EHarness({
 
   transition("idle");
   try {
-    const source = validateCsv(csvPath);
+    const source = validateTable(csvPath);
     const sourceSha256 = await sha256File(source.path);
     transition("launching", mode === "fake" ? "CI desktop API test double" : "real Desktop");
     if (mode === "fake") {
@@ -761,7 +762,7 @@ Modes:
                 drag/drop events or assert Rive animation/rendered pixels.
 
 Options:
-  --csv path                         Source CSV (required).
+  --csv path                         Source CSV, TSV, TXT, or extensionless delimited table (required).
   --output path                      Private local evidence directory.
   --capability path                  Existing Desktop API capability file for real mode.
   --app-command-json '["cmd",...]'  Launch command for real mode.

--- a/src/capture-import.ts
+++ b/src/capture-import.ts
@@ -134,6 +134,9 @@ export type CaptureClassificationDataset = {
   network_required: false;
   mapping_confirmation: "caller-provided";
   source_rows_persisted_as_transformed_examples: true;
+  source_row_count: number;
+  duplicate_rows_removed: number;
+  unusable_rows_removed: number;
   row_count: number;
   mapping: {
     input_columns: string[];
@@ -552,11 +555,8 @@ export function inspectCaptureCsv(
   if (!sourceStat.isFile()) {
     throw new Error(`CSV inspection requires one file: ${source}`);
   }
-  if (extname(source).toLowerCase() !== ".csv") {
-    throw new Error(`CSV inspection only accepts .csv files: ${source}`);
-  }
   if (sourceStat.size > MAX_CSV_BYTES) {
-    throw new Error(`CSV is ${sourceStat.size} bytes; the local inspection limit is ${MAX_CSV_BYTES} bytes.`);
+    throw new Error(`Table is ${sourceStat.size} bytes; the local inspection limit is ${MAX_CSV_BYTES} bytes.`);
   }
 
   const artifactRoot = resolve(artifactRootInput);
@@ -564,44 +564,24 @@ export function inspectCaptureCsv(
     throw new Error(`Capture artifact root does not exist: ${artifactRoot}`);
   }
 
-  const bytes = readFileSync(source);
-  if (bytes.length > MAX_CSV_BYTES) {
-    throw new Error(`CSV grew beyond the ${MAX_CSV_BYTES}-byte local inspection limit while it was being read.`);
-  }
-  let text: string;
-  try {
-    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  } catch {
-    throw new Error("CSV must be valid UTF-8 before local inspection.");
-  }
-  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
-  const records = parseCsvRecordsBounded(text).filter((record) =>
-    record.some((field) => field.trim().length > 0),
-  );
-  if (records.length < 2) {
-    throw new Error("CSV needs one header row and at least one data row.");
-  }
-
-  const headers = records[0].map((field) => field.trim());
+  const { bytes, headers, rows } = readDelimitedTable(source);
   if (headers.length > MAX_CSV_COLUMNS) {
-    throw new Error(`CSV has ${headers.length} columns; the local inspection limit is ${MAX_CSV_COLUMNS}.`);
+    throw new Error(`Table has ${headers.length} columns; the local inspection limit is ${MAX_CSV_COLUMNS}.`);
   }
   if (headers.some((header) => header.length === 0)) {
-    throw new Error("CSV headers must not be empty.");
+    throw new Error("Table headers must not be empty.");
   }
   const normalizedHeaders = headers.map(normalizeHeader);
   if (new Set(normalizedHeaders).size !== normalizedHeaders.length) {
-    throw new Error("CSV headers must be unique after case and spacing normalization.");
+    throw new Error("Table headers must be unique after case and spacing normalization.");
   }
-
-  const rows = records.slice(1);
   if (rows.length > MAX_CSV_ROWS) {
-    throw new Error(`CSV has more than ${MAX_CSV_ROWS} data rows; split it before local inspection.`);
+    throw new Error(`Table has more than ${MAX_CSV_ROWS} data rows; split it before local inspection.`);
   }
   rows.forEach((row, index) => {
     if (row.length !== headers.length) {
       throw new Error(
-        `CSV record ${index + 2} has ${row.length} fields; expected ${headers.length}.`,
+        `Table record ${index + 1} has ${row.length} fields; expected ${headers.length}.`,
       );
     }
   });
@@ -670,9 +650,6 @@ export function inspectCaptureCsv(
   } else if (columns[labelIndex].empty_count > 0) {
     status = "needs_cleanup";
     reasons.push(`${columns[labelIndex].empty_count} row(s) have an empty label.`);
-  } else if (duplicateRowCount > 0) {
-    status = "needs_cleanup";
-    reasons.push(`${duplicateRowCount} duplicate row(s) must be resolved before splitting the dataset.`);
   } else if (minimumExamples !== null && minimumExamples < MIN_EXAMPLES_PER_CLASS) {
     status = "needs_data";
     reasons.push(
@@ -686,7 +663,16 @@ export function inspectCaptureCsv(
     warnings.push("More than half of the labels are unique; this may be an identifier rather than a reusable category.");
   }
   if (duplicateRowCount > 0) {
-    warnings.push(`${duplicateRowCount} duplicate row(s) should be reviewed before splitting the dataset.`);
+    warnings.push(`${duplicateRowCount} exact duplicate row(s) will be removed before splitting the dataset.`);
+  }
+  if (groupColumn) {
+    const groupIndex = headers.indexOf(groupColumn);
+    const unusableGroupCount = rows.filter((row) =>
+      !normalizeClassificationGroup(row[groupIndex]),
+    ).length;
+    if (unusableGroupCount > 0) {
+      warnings.push(`${unusableGroupCount} row(s) with no usable ${groupColumn} value will be removed before splitting.`);
+    }
   }
   if (sortedLabels.length > MAX_REPORTED_LABELS) {
     warnings.push(`Only the ${MAX_REPORTED_LABELS} most frequent labels are included in this summary.`);
@@ -793,10 +779,17 @@ export function prepareCaptureClassificationDataset(
   const labelIndex = headers.indexOf(labelColumn);
   const groupIndex = headers.indexOf(groupColumn);
   const inputIndexes = inputColumns.map((column) => headers.indexOf(column));
-  const duplicateRowCount = rows.length - new Set(rows.map((row) => JSON.stringify(row))).size;
-  if (duplicateRowCount > 0) {
-    throw new Error(`${duplicateRowCount} duplicate row(s) must be resolved before splitting the dataset.`);
-  }
+  const sourceRowCount = rows.length;
+  const seenRows = new Set<string>();
+  const uniqueRows = rows
+    .map((row, sourceIndex) => ({ row, sourceIndex }))
+    .filter(({ row }) => {
+      const key = JSON.stringify(row);
+      if (seenRows.has(key)) return false;
+      seenRows.add(key);
+      return true;
+    });
+  const duplicateRowsRemoved = sourceRowCount - uniqueRows.length;
 
   type Example = {
     schema_version: "understudy.classification_example.v2";
@@ -807,12 +800,14 @@ export function prepareCaptureClassificationDataset(
   };
   const groupsByLabel = new Map<string, Map<string, Example[]>>();
   const groupOwners = new Map<string, string>();
-  rows.forEach((row, rowIndex) => {
+  let unusableRowsRemoved = 0;
+  uniqueRows.forEach(({ row, sourceIndex }) => {
     const label = row[labelIndex].trim();
-    if (!label) throw new Error(`CSV record ${rowIndex + 2} has an empty label.`);
+    if (!label) throw new Error(`Table record ${sourceIndex + 1} has an empty label.`);
     const normalizedGroup = normalizeClassificationGroup(row[groupIndex]);
     if (!normalizedGroup) {
-      throw new Error(`CSV record ${rowIndex + 2} has no usable leakage group value.`);
+      unusableRowsRemoved += 1;
+      return;
     }
     const groupId = createHash("sha256").update(normalizedGroup).digest("hex").slice(0, 24);
     const existingOwner = groupOwners.get(groupId);
@@ -827,11 +822,14 @@ export function prepareCaptureClassificationDataset(
       .filter(({ value }) => value.length > 0)
       .map(({ name, value }) => `${name}: ${value}`)
       .join("\n");
-    if (!text) throw new Error(`CSV record ${rowIndex + 2} has no mapped input text.`);
+    if (!text) {
+      unusableRowsRemoved += 1;
+      return;
+    }
     const example: Example = {
       schema_version: "understudy.classification_example.v2",
       example_id: createHash("sha256")
-        .update(`${sourceSha256}\0${rowIndex}\0${JSON.stringify(row)}`)
+        .update(`${sourceSha256}\0${sourceIndex}\0${JSON.stringify(row)}`)
         .digest("hex")
         .slice(0, 24),
       group_id: groupId,
@@ -940,6 +938,10 @@ export function prepareCaptureClassificationDataset(
     }),
   ) as CaptureClassificationDataset["splits"];
   const manifestPath = join(datasetRoot, "dataset-manifest.json");
+  const retainedRowCount = [...groupsByLabel.values()].reduce(
+    (total, groups) => total + [...groups.values()].reduce((count, examples) => count + examples.length, 0),
+    0,
+  );
   const dataset: CaptureClassificationDataset = {
     schema_version: "understudy.capture_import.classification_dataset.v2",
     dataset_id: datasetId,
@@ -951,7 +953,10 @@ export function prepareCaptureClassificationDataset(
     network_required: false,
     mapping_confirmation: "caller-provided",
     source_rows_persisted_as_transformed_examples: true,
-    row_count: rows.length,
+    source_row_count: sourceRowCount,
+    duplicate_rows_removed: duplicateRowsRemoved,
+    unusable_rows_removed: unusableRowsRemoved,
+    row_count: retainedRowCount,
     mapping,
     labels,
     label_distribution: labels.map((value) => ({ value, count: labelCounts.get(value)! })),
@@ -975,32 +980,83 @@ export function prepareCaptureClassificationDataset(
 }
 
 function readCsvForTraining(source: string): { bytes: Buffer; headers: string[]; rows: string[][] } {
-  if (!existsSync(source) || !statSync(source).isFile() || extname(source).toLowerCase() !== ".csv") {
-    throw new Error(`Training dataset preparation requires one .csv file: ${source}`);
+  if (!existsSync(source) || !statSync(source).isFile()) {
+    throw new Error(`Training dataset preparation requires one delimited text file: ${source}`);
   }
+  return readDelimitedTable(source);
+}
+
+function readDelimitedTable(source: string): { bytes: Buffer; headers: string[]; rows: string[][] } {
   const bytes = readFileSync(source);
   if (bytes.length > MAX_CSV_BYTES) {
-    throw new Error(`CSV exceeds the ${MAX_CSV_BYTES}-byte local preparation limit.`);
+    throw new Error(`Table exceeds the ${MAX_CSV_BYTES}-byte local preparation limit.`);
   }
   let text: string;
   try {
     text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
-    throw new Error("CSV must be valid UTF-8 before local preparation.");
+    throw new Error("Table must be valid UTF-8 before local inspection.");
   }
   if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
-  const records = parseCsvRecordsBounded(text).filter((record) =>
+  const delimiter = detectTableDelimiter(source, text);
+  const records = parseCsvRecordsBounded(text, delimiter).filter((record) =>
     record.some((field) => field.trim().length > 0),
   );
-  if (records.length < 2) throw new Error("CSV needs one header row and at least one data row.");
-  const headers = records[0].map((field) => field.trim());
-  const rows = records.slice(1);
-  rows.forEach((row, index) => {
-    if (row.length !== headers.length) {
-      throw new Error(`CSV record ${index + 2} has ${row.length} fields; expected ${headers.length}.`);
+  if (records.length < 2) throw new Error("Table needs at least two non-empty rows.");
+  const width = records[0].length;
+  records.forEach((row, index) => {
+    if (row.length !== width) {
+      throw new Error(`Table record ${index + 1} has ${row.length} fields; expected ${width}.`);
     }
   });
+  const sourceHeader = looksLikeHeaderRow(records);
+  const headers = sourceHeader
+    ? records[0].map((field) => field.trim())
+    : inferredHeaders(records);
+  const rows = sourceHeader ? records.slice(1) : records;
   return { bytes, headers, rows };
+}
+
+function detectTableDelimiter(source: string, text: string): "," | "\t" {
+  const extension = extname(source).toLowerCase();
+  if (extension === ".tsv" || extension === ".tab") return "\t";
+  if (extension === ".csv") return ",";
+  if (extension && extension !== ".txt") {
+    throw new Error(`Local table inspection supports .csv, .tsv, .tab, .txt, or extensionless files: ${source}`);
+  }
+  const lines = text.split(/\r?\n/).filter((line) => line.trim()).slice(0, 20);
+  if (lines.length < 2) throw new Error("Table needs at least two non-empty rows.");
+  const tabCounts = lines.map((line) => (line.match(/\t/g) ?? []).length);
+  if (tabCounts[0] > 0 && tabCounts.every((count) => count === tabCounts[0])) return "\t";
+  const commaCounts = lines.map((line) => (line.match(/,/g) ?? []).length);
+  if (commaCounts[0] > 0 && commaCounts.every((count) => count === commaCounts[0])) return ",";
+  throw new Error("This file does not have a consistent comma or tab-delimited shape.");
+}
+
+function looksLikeHeaderRow(records: string[][]): boolean {
+  const first = records[0].map((field) => field.trim());
+  if (first.some((field) => !/^[\p{L}_][\p{L}\p{N}_ .-]{0,63}$/u.test(field))) return false;
+  if (new Set(first.map(normalizeHeader)).size !== first.length) return false;
+  return !first.some((field, column) =>
+    records.slice(1, 21).some((row) => row[column]?.trim().toLowerCase() === field.toLowerCase()),
+  );
+}
+
+function inferredHeaders(records: string[][]): string[] {
+  if (records[0].length === 2) {
+    const firstValues = records.map((row) => row[0].trim()).filter(Boolean);
+    const secondValues = records.map((row) => row[1].trim()).filter(Boolean);
+    const firstUnique = new Set(firstValues).size;
+    const secondUnique = new Set(secondValues).size;
+    if (
+      firstUnique >= 2 &&
+      firstUnique <= Math.min(100, Math.max(3, Math.floor(records.length / 4))) &&
+      secondUnique > firstUnique
+    ) {
+      return ["label", "text"];
+    }
+  }
+  return records[0].map((_, index) => `column_${index + 1}`);
 }
 
 function stableGroupRank(sourceSha256: string, label: string, groupId: string): string {
@@ -1021,7 +1077,7 @@ function normalizeClassificationGroup(value: string): string {
     .trim();
 }
 
-function parseCsvRecordsBounded(text: string): string[][] {
+function parseCsvRecordsBounded(text: string, delimiter: "," | "\t" = ","): string[][] {
   const records: string[][] = [];
   let row: string[] = [];
   let field = "";
@@ -1068,7 +1124,7 @@ function parseCsvRecordsBounded(text: string): string[][] {
       continue;
     }
     if (afterQuote) {
-      if (character === ",") {
+      if (character === delimiter) {
         finishField();
       } else if (character === "\n") {
         finishRecord();
@@ -1080,11 +1136,12 @@ function parseCsvRecordsBounded(text: string): string[][] {
       }
       continue;
     }
-    if (character === '"' && field.length === 0) {
+    if (character === '"' && field.length === 0 && delimiter === ",") {
       quoted = true;
     } else if (character === '"') {
-      throw new Error("CSV contains a quote inside an unquoted field.");
-    } else if (character === ",") {
+      if (delimiter === ",") throw new Error("CSV contains a quote inside an unquoted field.");
+      append(character);
+    } else if (character === delimiter) {
       finishField();
     } else if (character === "\n") {
       finishRecord();

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,8 +347,8 @@ function registerCaptureImportCommands(program: Command): void {
 
   captureImport
     .command("inspect-csv")
-    .description("Read one bounded local CSV and write a statistics-only training inspection")
-    .requiredOption("--source <path>", "Local CSV file to inspect")
+    .description("Read one bounded local delimited table and write a statistics-only training inspection")
+    .requiredOption("--source <path>", "Local CSV, TSV, tab, text, or extensionless table to inspect")
     .requiredOption("--artifact-root <path>", "Existing private artifact root from capture-import compile")
     .option("--json", "Output JSON")
     .action((options: { source: string; artifactRoot: string; json?: boolean }) => {
@@ -365,8 +365,8 @@ function registerCaptureImportCommands(program: Command): void {
 
   captureImport
     .command("prepare-classification")
-    .description("Transform an inspected CSV into deterministic local train, dev, and holdout JSONL")
-    .requiredOption("--source <path>", "Inspected local CSV file")
+    .description("Transform an inspected table into deterministic local train, dev, and holdout JSONL")
+    .requiredOption("--source <path>", "Inspected local delimited table")
     .requiredOption("--artifact-root <path>", "Existing private artifact root from capture-import compile")
     .requiredOption("--label-column <name>", "Caller-confirmed label column")
     .requiredOption("--group-column <name>", "Caller-confirmed merchant, payee, or description leakage group")

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.23";
+export const RUNTIME_VERSION = "0.3.24";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -2098,6 +2098,56 @@ class ScoreWithFeedback:
     }
   });
 
+  it("recognizes a headerless extensionless tab dataset after an explicit drop", () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-tabular-inspection-"));
+    try {
+      const source = join(root, "SMSSpamCollection");
+      const rows = Array.from({ length: 48 }, (_, index) => {
+        const first = String.fromCharCode(97 + Math.floor(index / 26));
+        const second = String.fromCharCode(97 + (index % 26));
+        return `${index % 2 === 0 ? "ham" : "spam"}\tmessage token ${first}${second} for local classification`;
+      });
+      writeFileSync(source, [...rows, rows[0], "ham\t!!!"].join("\n"));
+      const outputRoot = join(root, "artifacts");
+      const compiledResult = run([
+        "capture-import", "compile", "--source", source, "--output-root", outputRoot, "--json",
+      ]);
+      assert.equal(compiledResult.status, 0, compiledResult.stderr);
+      const compiled = JSON.parse(compiledResult.stdout);
+      assert.equal(compiled.source_kinds["local-file"], 1);
+      assert.equal(compiled.payload_read, false);
+
+      const inspectionResult = run([
+        "capture-import", "inspect-csv", "--source", source,
+        "--artifact-root", compiled.artifact_root, "--json",
+      ]);
+      assert.equal(inspectionResult.status, 0, inspectionResult.stderr);
+      const inspection = JSON.parse(inspectionResult.stdout);
+      assert.equal(inspection.row_count, 50);
+      assert.equal(inspection.duplicate_row_count, 1);
+      assert.deepEqual(inspection.columns.map((column) => column.name), ["label", "text"]);
+      assert.equal(inspection.recommended_mapping.label_column, "label");
+      assert.deepEqual(inspection.recommended_mapping.input_columns, ["text"]);
+      assert.equal(inspection.recommended_mapping.group_column, "text");
+      assert.equal(inspection.training_readiness.ready, true);
+      assert.match(inspection.training_readiness.warnings.join(" "), /duplicate row.*will be removed/);
+
+      const preparedResult = run([
+        "capture-import", "prepare-classification", "--source", source,
+        "--artifact-root", compiled.artifact_root,
+        "--input-column", "text", "--label-column", "label", "--group-column", "text", "--json",
+      ]);
+      assert.equal(preparedResult.status, 0, preparedResult.stderr);
+      const prepared = JSON.parse(preparedResult.stdout);
+      assert.equal(prepared.source_row_count, 50);
+      assert.equal(prepared.duplicate_rows_removed, 1);
+      assert.equal(prepared.unusable_rows_removed, 1);
+      assert.equal(prepared.row_count, 48);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("prepares deterministic stratified classification splits from a confirmed mapping", () => {
     const root = mkdtempSync(join(tmpdir(), "understudy-classification-dataset-"));
     try {
@@ -2228,7 +2278,7 @@ class ScoreWithFeedback:
       assert.match(malformedResult.stderr, /record 3 has 1 fields; expected 2/);
       assert.equal(existsSync(join(artifactRoot, "csv-inspection.json")), false);
 
-      const text = join(root, "not-csv.txt");
+      const text = join(root, "not-table.bin");
       writeFileSync(text, "input,label\none,yes\n");
       const textResult = run([
         "capture-import",
@@ -2240,7 +2290,7 @@ class ScoreWithFeedback:
         "--json",
       ]);
       assert.notEqual(textResult.status, 0);
-      assert.match(textResult.stderr, /only accepts \.csv files/);
+      assert.match(textResult.stderr, /supports \.csv, \.tsv, \.tab, \.txt, or extensionless files/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/desktop-e2e-harness.test.mjs
+++ b/tests/desktop-e2e-harness.test.mjs
@@ -91,6 +91,35 @@ test("Desktop E2E harness prepares identical private splits through fake and lau
   }
 });
 
+test("Desktop E2E harness accepts the extensionless tabular shape used by public UCI datasets", async () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-desktop-e2e-tabular-"));
+  const source = join(root, "SMSSpamCollection");
+  const rows = Array.from({ length: 48 }, (_, index) => {
+    const first = String.fromCharCode(97 + Math.floor(index / 26));
+    const second = String.fromCharCode(97 + (index % 26));
+    return `${index % 2 === 0 ? "ham" : "spam"}\tmessage token ${first}${second} for local classification`;
+  });
+  writeFileSync(source, `${rows.join("\n")}\n`);
+  try {
+    const report = await runDesktopE2EHarness({
+      mode: "fake",
+      csvPath: source,
+      outputRoot: join(root, "run"),
+      acceptRecommendedMapping: true,
+    });
+    assert.equal(report.ok, true, report.errors.join("\n"));
+    assert.equal(report.terminal_state, "ready");
+    assert.deepEqual(report.dataset.mapping, {
+      input_columns: ["text"],
+      label_column: "label",
+      group_column: "text",
+      text_template: "named-fields-v1",
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("Desktop E2E harness stops honestly when the CSV has too little repeated signal", async () => {
   const root = mkdtempSync(join(tmpdir(), "understudy-desktop-e2e-small-"));
   try {

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -341,7 +341,7 @@ test("desktop offers an explicit signed update check from macOS menus", async ()
 });
 
 test("desktop has one shared managed-operation notice surface", async () => {
-  const [page, prompt, operationNotice, downloadNotice, repair, bootstrap] = await Promise.all([
+  const [page, prompt, operationNotice, downloadNotice, repair, bootstrap, native] = await Promise.all([
     readFile(pagePath, "utf8"),
     readFile(runtimeRepairPromptPath, "utf8"),
     readFile(operationNoticePath, "utf8"),
@@ -351,6 +351,7 @@ test("desktop has one shared managed-operation notice surface", async () => {
       new URL("../apps/homescreen/src-tauri/src/bootstrap.rs", import.meta.url),
       "utf8",
     ),
+    readFile(tauriLibPath, "utf8"),
   ]);
 
   assert.match(page, /<RuntimeRepairPrompt\s*\/>/);
@@ -383,6 +384,12 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.doesNotMatch(downloadNotice, /bootstrap_status|BootstrapStatus/);
   assert.match(downloadNotice, /"cancel_snapshot_download"/);
   assert.match(downloadNotice, /"start_snapshot_download"/);
+  assert.match(downloadNotice, /"prepare_default_local_model"/);
+  assert.match(downloadNotice, /Start with a local model/);
+  assert.match(downloadNotice, /One-time download · stays on this Mac/);
+  assert.match(downloadNotice, /Starting local model/);
+  assert.match(downloadNotice, /Selected for chat/);
+  assert.match(native, /commands::prepare_default_local_model/);
   assert.match(repair, /understudy models runtime repair/);
   assert.match(repair, /understudy runtime repair/);
   assert.match(repair, /Runtime reconnecting/);
@@ -472,6 +479,7 @@ test("desktop starts fresh on launch and can reopen an exact Pi session", async 
   );
   assert.equal(chat.match(/resetDroppedWorkload\(\);/g)?.length, 2);
   assert.match(sidebar, /aria-label=\{showArchived \? "Archived chats" : "Recent chats"\}/);
+  assert.doesNotMatch(sidebar, /No saved chats yet/);
   assert.doesNotMatch(page, /aria-label="Chat history"/);
   assert.match(commands, /pub fn chat_sessions_list/);
   assert.match(commands, /pub fn chat_session_get/);
@@ -500,8 +508,10 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(chat, /workloadDropPersonaState\(dropPhase\)/);
   assert.match(chat, /droppedWorkload && !classificationDataset[\s\S]*\? "listening"/);
   assert.match(chat, /invoke<CsvInspection>\("inspect_dropped_csv"/);
-  assert.match(chat, /const isCsv = result\.source_type === "file"/);
-  assert.match(chat, /dispatchDrop\(\{ type: "inspection_started" \}\);\s*await inspectCsvWorkload/);
+  assert.match(chat, /const inspectTable = shouldInspectDroppedTable\(result\)/);
+  assert.match(chat, /dispatchDrop\(\{ type: "inspection_started" \}\);[\s\S]*await inspectCsvWorkload/);
+  assert.match(dropState, /export function shouldInspectDroppedTable/);
+  assert.match(dropState, /\\\.\(\?:csv\|tsv\|tab\)/);
   assert.match(chat, /<CsvProfile/);
   assert.match(chat, /rowCount=\{csvInspection\.row_count\}/);
   assert.match(chat, /prepare_dropped_csv_classification/);
@@ -528,7 +538,7 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(dropState, /BUSY_PHASES\.has\(phase\)[\s\S]*return "thinking"/);
   assert.match(dropState, /One file or folder · stays on this Mac/);
   assert.match(dropState, /Indexing metadata locally · contents remain unread/);
-  assert.match(dropState, /Reading this CSV locally · source rows will not be copied/);
+  assert.match(dropState, /Reading this table locally · source rows will not be copied/);
   assert.match(dropState, /Writing deterministic train, dev, and holdout examples on this Mac/);
   assert.match(css, /\.persona-stage\.workload-drop-active::before/);
   assert.match(css, /@keyframes workload-intake-ring/);

--- a/tests/starter-model.test.mjs
+++ b/tests/starter-model.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  defaultStarterModel,
+  hasActiveLocalModel,
+  shouldOfferStarterDownload,
+  shouldPrepareStarter,
+} from "../apps/homescreen/app/lib/starter-model.mjs";
+
+const starter = {
+  id: "gemma-4-e2b-it-qat-mlx-vlm-understudy",
+  default_rung: true,
+  cached: true,
+  incomplete: false,
+};
+
+test("the catalog default rung is the local starter model", () => {
+  assert.equal(
+    defaultStarterModel([{ id: "larger", default_rung: false }, starter])?.id,
+    starter.id,
+  );
+});
+
+test("a cached starter automatically prepares only when no local model is active", () => {
+  assert.equal(
+    shouldPrepareStarter({ starter, slots: [], attempted: false, dismissed: false }),
+    true,
+  );
+  for (const state of ["loading", "running"]) {
+    assert.equal(hasActiveLocalModel([{ state }]), true);
+    assert.equal(
+      shouldPrepareStarter({ starter, slots: [{ state }], attempted: false, dismissed: false }),
+      false,
+    );
+  }
+  assert.equal(
+    shouldPrepareStarter({ starter, slots: [], attempted: true, dismissed: false }),
+    false,
+  );
+});
+
+test("an uncached starter is offered explicitly instead of downloading silently", () => {
+  const uncached = { ...starter, cached: false };
+  assert.equal(
+    shouldOfferStarterDownload({ starter: uncached, slots: [], dismissed: false }),
+    true,
+  );
+  assert.equal(
+    shouldPrepareStarter({ starter: uncached, slots: [], attempted: false, dismissed: false }),
+    false,
+  );
+  assert.equal(
+    shouldOfferStarterDownload({ starter: uncached, slots: [], dismissed: true }),
+    false,
+  );
+  assert.equal(
+    shouldOfferStarterDownload({
+      starter: { ...uncached, incomplete: true },
+      slots: [],
+      dismissed: false,
+    }),
+    true,
+  );
+});

--- a/tests/workload-drop-state.test.mjs
+++ b/tests/workload-drop-state.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   INITIAL_WORKLOAD_DROP_PHASE,
   isWorkloadDropBusy,
+  shouldInspectDroppedTable,
   workloadDropPersonaState,
   workloadDropReducer,
   workloadDropStatus,
@@ -59,7 +60,7 @@ test("explicit CSV inspection is a truthful thinking phase", () => {
   assert.equal(workloadDropPersonaState(phase), "thinking");
   assert.deepEqual(workloadDropStatus(phase), {
     title: "Inspecting training data",
-    detail: "Reading this CSV locally · source rows will not be copied",
+    detail: "Reading this table locally · source rows will not be copied",
   });
   phase = workloadDropReducer(phase, { type: "inspection_succeeded" });
   assert.equal(phase, "ready");
@@ -86,6 +87,21 @@ test("classification dataset preparation stays busy until local splits exist", (
 test("out-of-order completion cannot mark an idle lifecycle ready", () => {
   assert.equal(workloadDropReducer("idle", { type: "succeeded" }), "idle");
   assert.equal(workloadDropReducer("ready", { type: "failed" }), "ready");
+});
+
+test("extensionless and common delimited files enter local table inspection", () => {
+  for (const source_name of ["expenses.csv", "messages.tsv", "SMSSpamCollection"]) {
+    assert.equal(shouldInspectDroppedTable({
+      source_name,
+      source_type: "file",
+      source_kinds: { "local-file": 1 },
+    }), true);
+  }
+  assert.equal(shouldInspectDroppedTable({
+    source_name: "notes.md",
+    source_type: "file",
+    source_kinds: { document: 1 },
+  }), false);
 });
 
 test("local training follows only real runner phases and measured progress", () => {


### PR DESCRIPTION
## What

- keep the active empty chat sidebar visually empty instead of spending space on a placeholder sentence
- select and warm the certified cached 2B starter model when Desktop has no active local model
- show an explicit one-time starter-model download when the 2B is not cached
- inspect CSV, TSV, tab, text, and extensionless delimited drops through the real local analysis path
- infer the UCI SMS Spam Collection's headerless label/text columns and deterministically remove exact duplicates
- bump Desktop to 0.3.24 and the bundled CLI/runtime to 0.6.21

## Why

Production 0.3.23 could start on GLM 5.2 even when the certified 2B starter was already cached because the chat model list only included warm/loading slots and nothing initiated starter residency. Native file-drop events were captured correctly, but extensionless tab-delimited datasets fell through to a generic workload card because the post-drop parser only recognized .csv.

## Verification

- `npm run check`: 366 Node tests, typecheck, production build, 34 public skills, package smoke
- Rust: 169 passed, 4 ignored
- Desktop source release check for 0.3.24 passed
- exact extensionless UCI SMS Spam Collection: 5,574 source rows; inferred label/text; prepared 5,169 deduplicated rows; train/dev/holdout group isolation passed
- isolated native Desktop QA: cached 2B auto-warmed and the empty sidebar matched the production frame
- `git diff --check` and design QA passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->