### PR TITLE
feat(desktop): compare local classifiers with the frontier

### DIFF
--- a/apps/homescreen/app/components/CsvTrainingPlan.tsx
+++ b/apps/homescreen/app/components/CsvTrainingPlan.tsx
@@ -37,8 +37,8 @@ export function CsvTrainingPlan({
       </div>
       <div className="csv-training-plan-step" role="listitem">
         <span>Prove</span>
-        <strong>Held-out macro-F1</strong>
-        <small>Compare with the TF-IDF baseline</small>
+        <strong>Works across every category</strong>
+        <small>Compare with a simple baseline on separate test examples</small>
       </div>
     </div>
   );

--- a/apps/homescreen/app/components/EvaluationRadar.tsx
+++ b/apps/homescreen/app/components/EvaluationRadar.tsx
@@ -6,34 +6,45 @@ type WeakestClass = {
   support: number;
 };
 
+type FrontierEvidence = {
+  name: string;
+  accuracy: number;
+  macroF1: number;
+  weakestClass: WeakestClass;
+  latencyMs: number;
+  failureCount: number;
+  rowCount: number;
+};
+
 type Props = {
   accuracy: number;
   macroF1: number;
   baselineAccuracy: number;
   baselineMacroF1: number;
-  weakestClass?: WeakestClass;
+  weakestClass: WeakestClass;
   latencyMs: number;
   modelSizeBytes: number;
+  failureCount: number;
+  rowCount: number;
   completedRuns: number;
   requiredRuns: number;
+  frontier: FrontierEvidence;
 };
 
 type Dimension = {
   id: string;
   label: string;
-  value: string;
-  reference: string;
-  score: number;
-  needsReview: boolean;
+  localValue: string;
+  frontierValue: string;
+  localScore: number;
+  frontierScore: number;
+  winner: "local" | "frontier" | "tie";
 };
 
-const MAX_SCORE = 1.2;
-const MINIMUM_CLASS_RECALL = 0.5;
-const LATENCY_REFERENCE_MS = 100;
-const MODEL_SIZE_REFERENCE_BYTES = 1_024 * 1_024 * 1_024;
+const FAST_RESPONSE_REFERENCE_MS = 100;
 
-function percent(value: number): string {
-  return `${(value * 100).toFixed(1)}%`;
+function percent(value: number, digits = 1): string {
+  return `${(value * 100).toFixed(digits)}%`;
 }
 
 function compactBytes(bytes: number): string {
@@ -41,14 +52,19 @@ function compactBytes(bytes: number): string {
   return `${(bytes / (1_024 * 1_024 * 1_024)).toFixed(1)} GB`;
 }
 
-function higherIsBetter(value: number, reference: number): number {
-  if (!Number.isFinite(value) || !Number.isFinite(reference) || reference <= 0) return 0;
-  return Math.min(MAX_SCORE, Math.max(0, value / reference));
+function qualityScore(value: number): number {
+  return Math.min(1, Math.max(0, value));
 }
 
-function lowerIsBetter(value: number, reference: number): number {
-  if (!Number.isFinite(value) || !Number.isFinite(reference) || value <= 0 || reference <= 0) return 0;
-  return Math.min(MAX_SCORE, Math.max(0, reference / value));
+function speedScore(latencyMs: number): number {
+  if (!Number.isFinite(latencyMs) || latencyMs <= 0) return 0;
+  return Math.min(1, FAST_RESPONSE_REFERENCE_MS / latencyMs);
+}
+
+function winner(local: number, frontier: number, lowerIsBetter = false): Dimension["winner"] {
+  if (Math.abs(local - frontier) < 1e-9) return "tie";
+  if (lowerIsBetter) return local < frontier ? "local" : "frontier";
+  return local > frontier ? "local" : "frontier";
 }
 
 function point(index: number, count: number, radius: number, center: number): [number, number] {
@@ -56,18 +72,18 @@ function point(index: number, count: number, radius: number, center: number): [n
   return [center + Math.cos(angle) * radius, center + Math.sin(angle) * radius];
 }
 
-function polygonPoints(dimensions: Dimension[], radius: number, center: number): string {
+function polygonPoints(dimensions: Dimension[], key: "localScore" | "frontierScore", radius: number, center: number): string {
   return dimensions
     .map((dimension, index) => {
-      const [x, y] = point(index, dimensions.length, radius * (dimension.score / MAX_SCORE), center);
+      const [x, y] = point(index, dimensions.length, radius * dimension[key], center);
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
 }
 
-function referencePoints(count: number, radius: number, center: number): string {
+function ringPoints(count: number, radius: number, center: number): string {
   return Array.from({ length: count }, (_, index) => {
-    const [x, y] = point(index, count, radius / MAX_SCORE, center);
+    const [x, y] = point(index, count, radius, center);
     return `${x.toFixed(1)},${y.toFixed(1)}`;
   }).join(" ");
 }
@@ -80,127 +96,155 @@ export function EvaluationRadar({
   weakestClass,
   latencyMs,
   modelSizeBytes,
+  failureCount,
+  rowCount,
   completedRuns,
   requiredRuns,
+  frontier,
 }: Props) {
-  const weakestRecall = weakestClass?.recall ?? 0;
   const dimensions: Dimension[] = [
     {
       id: "accuracy",
       label: "Correct answers",
-      value: percent(accuracy),
-      reference: `simple baseline ${percent(baselineAccuracy)}`,
-      score: higherIsBetter(accuracy, baselineAccuracy),
-      needsReview: accuracy <= baselineAccuracy,
+      localValue: percent(accuracy, 2),
+      frontierValue: percent(frontier.accuracy, 2),
+      localScore: qualityScore(accuracy),
+      frontierScore: qualityScore(frontier.accuracy),
+      winner: winner(accuracy, frontier.accuracy),
     },
     {
-      id: "macro-f1",
+      id: "across-categories",
       label: "Across categories",
-      value: percent(macroF1),
-      reference: `simple baseline ${percent(baselineMacroF1)}`,
-      score: higherIsBetter(macroF1, baselineMacroF1),
-      needsReview: macroF1 <= baselineMacroF1,
+      localValue: percent(macroF1, 2),
+      frontierValue: percent(frontier.macroF1, 2),
+      localScore: qualityScore(macroF1),
+      frontierScore: qualityScore(frontier.macroF1),
+      winner: winner(macroF1, frontier.macroF1),
     },
     {
-      id: "weakest-recall",
+      id: "hardest-category",
       label: "Hardest category",
-      value: percent(weakestRecall),
-      reference: weakestClass
-        ? `${weakestClass.label} · minimum ${percent(MINIMUM_CLASS_RECALL)}`
-        : `minimum ${percent(MINIMUM_CLASS_RECALL)}`,
-      score: higherIsBetter(weakestRecall, MINIMUM_CLASS_RECALL),
-      needsReview: weakestRecall < MINIMUM_CLASS_RECALL,
+      localValue: `${percent(weakestClass.recall)} · ${weakestClass.label}`,
+      frontierValue: `${percent(frontier.weakestClass.recall)} · ${frontier.weakestClass.label}`,
+      localScore: qualityScore(weakestClass.recall),
+      frontierScore: qualityScore(frontier.weakestClass.recall),
+      winner: winner(weakestClass.recall, frontier.weakestClass.recall),
     },
     {
-      id: "latency",
-      label: "Response time",
-      value: `${latencyMs.toFixed(1)} ms`,
-      reference: `reference ≤ ${LATENCY_REFERENCE_MS} ms`,
-      score: lowerIsBetter(latencyMs, LATENCY_REFERENCE_MS),
-      needsReview: latencyMs > LATENCY_REFERENCE_MS,
-    },
-    {
-      id: "model-size",
-      label: "Space on disk",
-      value: compactBytes(modelSizeBytes),
-      reference: `reference ≤ ${compactBytes(MODEL_SIZE_REFERENCE_BYTES)}`,
-      score: lowerIsBetter(modelSizeBytes, MODEL_SIZE_REFERENCE_BYTES),
-      needsReview: modelSizeBytes > MODEL_SIZE_REFERENCE_BYTES,
-    },
-    {
-      id: "evidence",
-      label: "Test confidence",
-      value: `${completedRuns} of ${requiredRuns} checks`,
-      reference: "repeat once before relying on it",
-      score: higherIsBetter(completedRuns, requiredRuns),
-      needsReview: completedRuns < requiredRuns,
+      id: "response-time",
+      label: "Fast response",
+      localValue: `${latencyMs.toFixed(1)} ms`,
+      frontierValue: `${frontier.latencyMs.toFixed(0)} ms`,
+      localScore: speedScore(latencyMs),
+      frontierScore: speedScore(frontier.latencyMs),
+      winner: winner(latencyMs, frontier.latencyMs, true),
     },
   ];
-
+  const localWins = dimensions.filter((dimension) => dimension.winner === "local").length;
+  const frontierWins = dimensions.filter((dimension) => dimension.winner === "frontier").length;
+  const ties = dimensions.filter((dimension) => dimension.winner === "tie").length;
+  const sameEvidence = rowCount === frontier.rowCount;
   const size = 520;
   const center = size / 2;
   const radius = 166;
-  const candidatePoints = polygonPoints(dimensions, radius, center);
+  const localPoints = polygonPoints(dimensions, "localScore", radius, center);
+  const frontierPoints = polygonPoints(dimensions, "frontierScore", radius, center);
   const summary = dimensions
-    .map((dimension) => `${dimension.label}: ${dimension.value}, ${dimension.reference}`)
+    .map((dimension) => `${dimension.label}: local ${dimension.localValue}, ${frontier.name} ${dimension.frontierValue}`)
     .join(". ");
 
   return (
     <section className="evaluation-radar" aria-labelledby="evaluation-radar-title">
       <header>
         <div>
-          <span>Decision surface</span>
-          <h3 id="evaluation-radar-title">See the tradeoffs before you choose</h3>
+          <span>Same held-out examples</span>
+          <h3 id="evaluation-radar-title">Local model versus {frontier.name}</h3>
+          <p>
+            Local leads {localWins} · {frontier.name} leads {frontierWins}
+            {ties > 0 ? ` · ${ties} tied` : ""}
+          </p>
         </div>
         <div className="evaluation-radar-legend" aria-label="Chart legend">
-          <span><i className="candidate" aria-hidden="true" />This model</span>
-          <span><i className="reference" aria-hidden="true" />What good looks like</span>
+          <span><i className="local" aria-hidden="true" />Your local model</span>
+          <span><i className="frontier" aria-hidden="true" />{frontier.name}</span>
         </div>
       </header>
       <div className="evaluation-radar-layout">
         <figure>
           <svg viewBox={`0 0 ${size} ${size}`} role="img" aria-labelledby="evaluation-radar-svg-title evaluation-radar-svg-desc">
-            <title id="evaluation-radar-svg-title">Model evaluation radar</title>
-            <desc id="evaluation-radar-svg-desc">{summary}. Points inside the dashed comparison ring need review.</desc>
-            {[0.4, 0.7, 1, 1.2].map((level) => (
+            <title id="evaluation-radar-svg-title">Local and frontier model comparison radar</title>
+            <desc id="evaluation-radar-svg-desc">{summary}. Farther from the center is better.</desc>
+            {[0.25, 0.5, 0.75, 1].map((level) => (
               <polygon
                 key={level}
-                className={level === 1 ? "evaluation-radar-reference" : "evaluation-radar-grid"}
-                points={referencePoints(dimensions.length, radius * level, center)}
+                className="evaluation-radar-grid"
+                points={ringPoints(dimensions.length, radius * level, center)}
               />
             ))}
-            <polygon className="evaluation-radar-candidate" points={candidatePoints} />
             {dimensions.map((dimension, index) => {
               const [x, y] = point(index, dimensions.length, radius, center);
-              const [dotX, dotY] = point(index, dimensions.length, radius * (dimension.score / MAX_SCORE), center);
-              const [labelX, labelY] = point(index, dimensions.length, radius + 38, center);
+              const [labelX, labelY] = point(index, dimensions.length, radius + 42, center);
               const anchor = Math.abs(labelX - center) < 12 ? "middle" : labelX > center ? "start" : "end";
               return (
                 <g key={dimension.id}>
                   <line className="evaluation-radar-axis" x1={center} y1={center} x2={x} y2={y} />
-                  <circle
-                    className={dimension.needsReview ? "evaluation-radar-dot is-review" : "evaluation-radar-dot"}
-                    cx={dotX}
-                    cy={dotY}
-                    r="5"
-                  />
                   <text className="evaluation-radar-label" x={labelX} y={labelY} textAnchor={anchor} dominantBaseline="middle">
                     {dimension.label}
                   </text>
                 </g>
               );
             })}
+            <polygon className="evaluation-radar-frontier" points={frontierPoints} />
+            <polygon className="evaluation-radar-local" points={localPoints} />
+            {dimensions.flatMap((dimension, index) => {
+              const [localX, localY] = point(index, dimensions.length, radius * dimension.localScore, center);
+              const [frontierX, frontierY] = point(index, dimensions.length, radius * dimension.frontierScore, center);
+              return [
+                <circle key={`${dimension.id}-frontier`} className="evaluation-radar-dot frontier" cx={frontierX} cy={frontierY} r="5" />,
+                <circle key={`${dimension.id}-local`} className="evaluation-radar-dot local" cx={localX} cy={localY} r="5" />,
+              ];
+            })}
           </svg>
-          <figcaption>Inside the dashed ring needs review. Raw values stay visible beside the chart.</figcaption>
+          <figcaption>
+            Farther out is better. Quality uses the exact score; speed uses a 100 ms local-response reference.
+          </figcaption>
         </figure>
-        <div className="evaluation-radar-dimensions" aria-label="Evaluation dimensions">
+        <div className="evaluation-radar-dimensions" aria-label="Local and frontier comparison dimensions">
           {dimensions.map((dimension) => (
-            <div key={dimension.id} className={dimension.needsReview ? "is-review" : ""}>
+            <div key={dimension.id}>
               <span>{dimension.label}</span>
-              <strong>{dimension.value}</strong>
-              <small>{dimension.reference}</small>
+              <div>
+                <strong>{dimension.localValue}</strong>
+                <small>Your local model{dimension.winner === "local" ? " · better" : ""}</small>
+              </div>
+              <div>
+                <strong>{dimension.frontierValue}</strong>
+                <small>{frontier.name}{dimension.winner === "frontier" ? " · better" : ""}</small>
+              </div>
             </div>
           ))}
+        </div>
+      </div>
+      <div className="evaluation-radar-tradeoffs" aria-label="Practical tradeoffs">
+        <div>
+          <span>Your local model</span>
+          <strong>{failureCount} mistakes · {compactBytes(modelSizeBytes)}</strong>
+          <small>Works offline · examples stay on this Mac</small>
+        </div>
+        <div>
+          <span>{frontier.name}</span>
+          <strong>{frontier.failureCount} mistakes · no download</strong>
+          <small>Cloud required · held-out examples were sent remotely</small>
+        </div>
+        <div>
+          <span>Basic text model</span>
+          <strong>{percent(baselineAccuracy)} correct</strong>
+          <small>{percent(baselineMacroF1)} across categories</small>
+        </div>
+        <div>
+          <span>Evidence</span>
+          <strong>{sameEvidence ? `${rowCount.toLocaleString()} same examples` : "Comparison mismatch"}</strong>
+          <small>{completedRuns} of {requiredRuns} repeat checks complete</small>
         </div>
       </div>
     </section>

--- a/apps/homescreen/app/components/EvaluationRadar.tsx
+++ b/apps/homescreen/app/components/EvaluationRadar.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+type WeakestClass = {
+  label: string;
+  recall: number;
+  support: number;
+};
+
+type Props = {
+  accuracy: number;
+  macroF1: number;
+  baselineAccuracy: number;
+  baselineMacroF1: number;
+  weakestClass?: WeakestClass;
+  latencyMs: number;
+  modelSizeBytes: number;
+  completedRuns: number;
+  requiredRuns: number;
+};
+
+type Dimension = {
+  id: string;
+  label: string;
+  value: string;
+  reference: string;
+  score: number;
+  needsReview: boolean;
+};
+
+const MAX_SCORE = 1.2;
+const MINIMUM_CLASS_RECALL = 0.5;
+const LATENCY_REFERENCE_MS = 100;
+const MODEL_SIZE_REFERENCE_BYTES = 1_024 * 1_024 * 1_024;
+
+function percent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function compactBytes(bytes: number): string {
+  if (bytes < 1_024 * 1_024 * 1_024) return `${(bytes / (1_024 * 1_024)).toFixed(0)} MB`;
+  return `${(bytes / (1_024 * 1_024 * 1_024)).toFixed(1)} GB`;
+}
+
+function higherIsBetter(value: number, reference: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(reference) || reference <= 0) return 0;
+  return Math.min(MAX_SCORE, Math.max(0, value / reference));
+}
+
+function lowerIsBetter(value: number, reference: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(reference) || value <= 0 || reference <= 0) return 0;
+  return Math.min(MAX_SCORE, Math.max(0, reference / value));
+}
+
+function point(index: number, count: number, radius: number, center: number): [number, number] {
+  const angle = (-Math.PI / 2) + (index * Math.PI * 2) / count;
+  return [center + Math.cos(angle) * radius, center + Math.sin(angle) * radius];
+}
+
+function polygonPoints(dimensions: Dimension[], radius: number, center: number): string {
+  return dimensions
+    .map((dimension, index) => {
+      const [x, y] = point(index, dimensions.length, radius * (dimension.score / MAX_SCORE), center);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+function referencePoints(count: number, radius: number, center: number): string {
+  return Array.from({ length: count }, (_, index) => {
+    const [x, y] = point(index, count, radius / MAX_SCORE, center);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).join(" ");
+}
+
+export function EvaluationRadar({
+  accuracy,
+  macroF1,
+  baselineAccuracy,
+  baselineMacroF1,
+  weakestClass,
+  latencyMs,
+  modelSizeBytes,
+  completedRuns,
+  requiredRuns,
+}: Props) {
+  const weakestRecall = weakestClass?.recall ?? 0;
+  const dimensions: Dimension[] = [
+    {
+      id: "accuracy",
+      label: "Correct answers",
+      value: percent(accuracy),
+      reference: `simple baseline ${percent(baselineAccuracy)}`,
+      score: higherIsBetter(accuracy, baselineAccuracy),
+      needsReview: accuracy <= baselineAccuracy,
+    },
+    {
+      id: "macro-f1",
+      label: "Across categories",
+      value: percent(macroF1),
+      reference: `simple baseline ${percent(baselineMacroF1)}`,
+      score: higherIsBetter(macroF1, baselineMacroF1),
+      needsReview: macroF1 <= baselineMacroF1,
+    },
+    {
+      id: "weakest-recall",
+      label: "Hardest category",
+      value: percent(weakestRecall),
+      reference: weakestClass
+        ? `${weakestClass.label} · minimum ${percent(MINIMUM_CLASS_RECALL)}`
+        : `minimum ${percent(MINIMUM_CLASS_RECALL)}`,
+      score: higherIsBetter(weakestRecall, MINIMUM_CLASS_RECALL),
+      needsReview: weakestRecall < MINIMUM_CLASS_RECALL,
+    },
+    {
+      id: "latency",
+      label: "Response time",
+      value: `${latencyMs.toFixed(1)} ms`,
+      reference: `reference ≤ ${LATENCY_REFERENCE_MS} ms`,
+      score: lowerIsBetter(latencyMs, LATENCY_REFERENCE_MS),
+      needsReview: latencyMs > LATENCY_REFERENCE_MS,
+    },
+    {
+      id: "model-size",
+      label: "Space on disk",
+      value: compactBytes(modelSizeBytes),
+      reference: `reference ≤ ${compactBytes(MODEL_SIZE_REFERENCE_BYTES)}`,
+      score: lowerIsBetter(modelSizeBytes, MODEL_SIZE_REFERENCE_BYTES),
+      needsReview: modelSizeBytes > MODEL_SIZE_REFERENCE_BYTES,
+    },
+    {
+      id: "evidence",
+      label: "Test confidence",
+      value: `${completedRuns} of ${requiredRuns} checks`,
+      reference: "repeat once before relying on it",
+      score: higherIsBetter(completedRuns, requiredRuns),
+      needsReview: completedRuns < requiredRuns,
+    },
+  ];
+
+  const size = 520;
+  const center = size / 2;
+  const radius = 166;
+  const candidatePoints = polygonPoints(dimensions, radius, center);
+  const summary = dimensions
+    .map((dimension) => `${dimension.label}: ${dimension.value}, ${dimension.reference}`)
+    .join(". ");
+
+  return (
+    <section className="evaluation-radar" aria-labelledby="evaluation-radar-title">
+      <header>
+        <div>
+          <span>Decision surface</span>
+          <h3 id="evaluation-radar-title">See the tradeoffs before you choose</h3>
+        </div>
+        <div className="evaluation-radar-legend" aria-label="Chart legend">
+          <span><i className="candidate" aria-hidden="true" />This model</span>
+          <span><i className="reference" aria-hidden="true" />What good looks like</span>
+        </div>
+      </header>
+      <div className="evaluation-radar-layout">
+        <figure>
+          <svg viewBox={`0 0 ${size} ${size}`} role="img" aria-labelledby="evaluation-radar-svg-title evaluation-radar-svg-desc">
+            <title id="evaluation-radar-svg-title">Model evaluation radar</title>
+            <desc id="evaluation-radar-svg-desc">{summary}. Points inside the dashed comparison ring need review.</desc>
+            {[0.4, 0.7, 1, 1.2].map((level) => (
+              <polygon
+                key={level}
+                className={level === 1 ? "evaluation-radar-reference" : "evaluation-radar-grid"}
+                points={referencePoints(dimensions.length, radius * level, center)}
+              />
+            ))}
+            <polygon className="evaluation-radar-candidate" points={candidatePoints} />
+            {dimensions.map((dimension, index) => {
+              const [x, y] = point(index, dimensions.length, radius, center);
+              const [dotX, dotY] = point(index, dimensions.length, radius * (dimension.score / MAX_SCORE), center);
+              const [labelX, labelY] = point(index, dimensions.length, radius + 38, center);
+              const anchor = Math.abs(labelX - center) < 12 ? "middle" : labelX > center ? "start" : "end";
+              return (
+                <g key={dimension.id}>
+                  <line className="evaluation-radar-axis" x1={center} y1={center} x2={x} y2={y} />
+                  <circle
+                    className={dimension.needsReview ? "evaluation-radar-dot is-review" : "evaluation-radar-dot"}
+                    cx={dotX}
+                    cy={dotY}
+                    r="5"
+                  />
+                  <text className="evaluation-radar-label" x={labelX} y={labelY} textAnchor={anchor} dominantBaseline="middle">
+                    {dimension.label}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+          <figcaption>Inside the dashed ring needs review. Raw values stay visible beside the chart.</figcaption>
+        </figure>
+        <div className="evaluation-radar-dimensions" aria-label="Evaluation dimensions">
+          {dimensions.map((dimension) => (
+            <div key={dimension.id} className={dimension.needsReview ? "is-review" : ""}>
+              <span>{dimension.label}</span>
+              <strong>{dimension.value}</strong>
+              <small>{dimension.reference}</small>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/homescreen/app/components/EvaluationRadar.tsx
+++ b/apps/homescreen/app/components/EvaluationRadar.tsx
@@ -14,6 +14,7 @@ type FrontierEvidence = {
   latencyMs: number;
   failureCount: number;
   rowCount: number;
+  costUsd: number;
 };
 
 type Props = {
@@ -50,6 +51,12 @@ function percent(value: number, digits = 1): string {
 function compactBytes(bytes: number): string {
   if (bytes < 1_024 * 1_024 * 1_024) return `${(bytes / (1_024 * 1_024)).toFixed(0)} MB`;
   return `${(bytes / (1_024 * 1_024 * 1_024)).toFixed(1)} GB`;
+}
+
+function compactUsd(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return "cost unavailable";
+  if (value < 0.01) return `<$0.01`;
+  return `$${value.toFixed(2)}`;
 }
 
 function qualityScore(value: number): number {
@@ -233,8 +240,8 @@ export function EvaluationRadar({
         </div>
         <div>
           <span>{frontier.name}</span>
-          <strong>{frontier.failureCount} mistakes · no download</strong>
-          <small>Cloud required · held-out examples were sent remotely</small>
+          <strong>{frontier.failureCount} mistakes · {compactUsd(frontier.costUsd)} this comparison</strong>
+          <small>Cloud required · held-out examples sent with published zero data retention</small>
         </div>
         <div>
           <span>Basic text model</span>

--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -125,6 +125,7 @@ type FrontierComparison = {
     user_confirmed_remote_comparison: true;
     training_examples_uploaded: false;
     holdout_examples_uploaded: true;
+    retention_expectation: string;
   };
   heldout: {
     accuracy: number;
@@ -137,6 +138,14 @@ type FrontierComparison = {
       f1: number;
       support: number;
     }[];
+  };
+  spend: {
+    user_confirmed_spend: true;
+    approved_budget_usd: number;
+    estimated_max_cost_usd: number;
+    attributed_cost_usd: number;
+    pricing_source: string;
+    pricing_checked_at: string;
   };
   artifact_path: string;
 };
@@ -448,6 +457,8 @@ export function LocalTrainingPanel({
       runManifestPath: state.result.manifest_path,
       modelId: "glm-5.2",
       confirmRemote: true,
+      confirmSpend: true,
+      budgetUsd: 1,
       onEvent: channel,
     })
       .then((result) => {
@@ -583,7 +594,7 @@ export function LocalTrainingPanel({
             <span>Frontier reference</span>
             <strong>Compare with GLM 5.2 on the same {state.result.heldout.row_count.toLocaleString()} test examples</strong>
             <small>
-              Only held-out test examples are sent through Understudy. Training examples stay on this Mac. Cloud charges may apply.
+              Only held-out test examples are sent through Understudy; training examples stay on this Mac. Fireworks publishes zero data retention for GLM 5.2. Maximum approved spend: $1.00.
             </small>
             {frontierEvent?.message && <p>{frontierEvent.message}</p>}
             {frontierEvent?.current !== undefined && frontierEvent.total !== undefined && (
@@ -592,7 +603,7 @@ export function LocalTrainingPanel({
             {frontierError && <em>{frontierError}</em>}
           </div>
           <button type="button" className="btn primary" onClick={compareWithFrontier} disabled={comparingFrontier}>
-            {comparingFrontier ? "Comparing…" : frontierError ? "Try frontier again" : "Compare with GLM 5.2"}
+            {comparingFrontier ? "Comparing…" : frontierError ? "Try frontier again · max $1" : "Compare with GLM 5.2 · max $1"}
           </button>
         </div>
       )}
@@ -617,6 +628,7 @@ export function LocalTrainingPanel({
             latencyMs: frontierComparison.heldout.latency_ms_p50,
             failureCount: frontierComparison.heldout.failure_count,
             rowCount: frontierComparison.row_count,
+            costUsd: frontierComparison.spend.attributed_cost_usd,
           }}
         />
       )}

--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -14,6 +14,7 @@ import {
   type LocalTrainingEvent,
   type LocalTrainingState,
 } from "../lib/local-training-state.mjs";
+import { EvaluationRadar } from "./EvaluationRadar";
 import type { TrainingHaloVisual } from "./TrainingHalo";
 
 const MODERN_BERT_MODEL = "answerdotai/ModernBERT-base";
@@ -120,12 +121,6 @@ type Props = {
 
 function percent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
-}
-
-function compactBytes(bytes: number): string {
-  if (bytes < 1_024 * 1_024) return `${Math.round(bytes / 1_024)} KB`;
-  if (bytes < 1_024 * 1_024 * 1_024) return `${(bytes / (1_024 * 1_024)).toFixed(0)} MB`;
-  return `${(bytes / (1_024 * 1_024 * 1_024)).toFixed(1)} GB`;
 }
 
 function runId(): string {
@@ -485,8 +480,8 @@ export function LocalTrainingPanel({
     <div className="local-training-result">
       <div className="local-training-result-heading">
         <div>
-          <strong>Local classifier evaluated</strong>
-          <small>Held-out rows share no normalized {state.result.split_evidence.group_key} groups with training.</small>
+          <strong>Your model is ready to review</strong>
+          <small>Test examples were kept separate from training examples.</small>
         </div>
         <span>{(state.result.timings_ms.total / 1_000).toFixed(1)}s</span>
       </div>
@@ -494,23 +489,28 @@ export function LocalTrainingPanel({
         <strong>{verdict.title}</strong>
         <small>{verdict.detail}</small>
       </div>
-      <div className="local-training-metrics" aria-label="Held-out evaluation">
-        <div><span>Accuracy</span><b>{percent(state.result.heldout.accuracy)}</b><small>TF-IDF {percent(state.result.linear_baseline.accuracy)}</small></div>
-        <div><span>Macro-F1</span><b>{percent(state.result.heldout.macro_f1)}</b><small>TF-IDF {percent(state.result.linear_baseline.macro_f1)}</small></div>
-        <div><span>Latency</span><b>{state.result.heldout.latency_ms_p50.toFixed(1)} ms</b><small>median local inference</small></div>
-        <div><span>Model</span><b>{compactBytes(state.result.model.size_bytes)}</b><small>{state.result.model.resolved_id}</small></div>
-      </div>
+      <EvaluationRadar
+        accuracy={state.result.heldout.accuracy}
+        macroF1={state.result.heldout.macro_f1}
+        baselineAccuracy={state.result.linear_baseline.accuracy}
+        baselineMacroF1={state.result.linear_baseline.macro_f1}
+        weakestClass={state.result.heldout.weakest_classes[0]}
+        latencyMs={state.result.heldout.latency_ms_p50}
+        modelSizeBytes={state.result.model.size_bytes}
+        completedRuns={1}
+        requiredRuns={2}
+      />
       <div className="local-training-failures">
         <strong>Notable failures</strong>
         {state.result.heldout.failure_count === 0 ? (
-          <small>No errors in {state.result.heldout.row_count} held-out rows.</small>
+          <small>No mistakes in {state.result.heldout.row_count} test examples.</small>
         ) : (
           <>
             {state.result.heldout.failures.slice(0, 3).map((failure) => (
               <span key={failure.example_id}>{failure.expected_label} → {failure.predicted_label}</span>
             ))}
             <small>
-              {state.result.heldout.failure_count} of {state.result.heldout.row_count} held-out rows
+              {state.result.heldout.failure_count} mistakes in {state.result.heldout.row_count} test examples
               {state.result.heldout.failures_truncated ? " · showing a bounded sample" : ""}
             </small>
           </>
@@ -518,10 +518,10 @@ export function LocalTrainingPanel({
       </div>
       {state.result.heldout.weakest_classes.length > 0 && (
         <div className="local-training-weakest">
-          <strong>Weakest categories</strong>
+          <strong>Hardest categories</strong>
           {state.result.heldout.weakest_classes.slice(0, 3).map((category) => (
             <span key={category.label}>
-              {category.label} · {percent(category.recall)} recall · {category.support} rows
+              {category.label} · found {percent(category.recall)} · {category.support} test examples
             </span>
           ))}
         </div>

--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -607,7 +607,7 @@ export function LocalTrainingPanel({
           </button>
         </div>
       )}
-      {frontierComparison && frontierComparison.heldout.weakest_classes[0] && (
+      {frontierComparison && frontierComparison.heldout.weakest_classes[0] && state.result.heldout.weakest_classes[0] && (
         <EvaluationRadar
           accuracy={state.result.heldout.accuracy}
           macroF1={state.result.heldout.macro_f1}

--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -111,6 +111,44 @@ type ClassificationTrainingPreview = {
   }[];
 };
 
+type FrontierComparison = {
+  schema_version: "understudy.capture_import.frontier_classification.v1";
+  comparison_id: string;
+  status: "completed";
+  run_id: string;
+  requested_model: string;
+  served_model: string;
+  exact_same_holdout: true;
+  holdout_sha256: string;
+  row_count: number;
+  data_boundary: {
+    user_confirmed_remote_comparison: true;
+    training_examples_uploaded: false;
+    holdout_examples_uploaded: true;
+  };
+  heldout: {
+    accuracy: number;
+    macro_f1: number;
+    latency_ms_p50: number;
+    failure_count: number;
+    weakest_classes: {
+      label: string;
+      recall: number;
+      f1: number;
+      support: number;
+    }[];
+  };
+  artifact_path: string;
+};
+
+type FrontierComparisonEvent = {
+  type: "phase";
+  phase: "preparing" | "comparing" | "measuring" | "saving";
+  current?: number;
+  total?: number;
+  message?: string;
+};
+
 type Props = {
   datasetManifestPath: string;
   modelName: string;
@@ -157,6 +195,10 @@ export function LocalTrainingPanel({
   const [prediction, setPrediction] = useState<ClassificationPrediction | null>(null);
   const [predictionError, setPredictionError] = useState<string | null>(null);
   const [predicting, setPredicting] = useState(false);
+  const [frontierComparison, setFrontierComparison] = useState<FrontierComparison | null>(null);
+  const [frontierEvent, setFrontierEvent] = useState<FrontierComparisonEvent | null>(null);
+  const [frontierError, setFrontierError] = useState<string | null>(null);
+  const [comparingFrontier, setComparingFrontier] = useState(false);
   const [trainingPreview, setTrainingPreview] = useState<ClassificationTrainingPreview | null>(null);
   const [trainingPreviewIndex, setTrainingPreviewIndex] = useState(0);
   const [previousTrainingPreviewIndex, setPreviousTrainingPreviewIndex] = useState<number | null>(null);
@@ -219,6 +261,10 @@ export function LocalTrainingPanel({
     setPredictionText("");
     setPrediction(null);
     setPredictionError(null);
+    setFrontierComparison(null);
+    setFrontierEvent(null);
+    setFrontierError(null);
+    setComparingFrontier(false);
     setTrainingPreview(null);
     setTrainingPreviewIndex(0);
     trainingPreviewIndexRef.current = 0;
@@ -277,6 +323,10 @@ export function LocalTrainingPanel({
     cancellationRequested.current = false;
     setPrediction(null);
     setPredictionError(null);
+    setFrontierComparison(null);
+    setFrontierEvent(null);
+    setFrontierError(null);
+    setComparingFrontier(false);
     setTrainingPreview(null);
     setTrainingPreviewIndex(0);
     trainingPreviewIndexRef.current = 0;
@@ -376,6 +426,44 @@ export function LocalTrainingPanel({
       .then(setPrediction)
       .catch((error) => setPredictionError(String(error)))
       .finally(() => setPredicting(false));
+  };
+
+  const compareWithFrontier = () => {
+    if (!state.result || comparingFrontier) return;
+    const requestGeneration = generation.current;
+    const localRunId = state.result.run_id;
+    setComparingFrontier(true);
+    setFrontierComparison(null);
+    setFrontierError(null);
+    setFrontierEvent({
+      type: "phase",
+      phase: "preparing",
+      message: "Verifying the exact held-out examples used for the local score.",
+    });
+    const channel = new Channel<FrontierComparisonEvent>();
+    channel.onmessage = (event) => {
+      if (generation.current === requestGeneration) setFrontierEvent(event);
+    };
+    void invoke<FrontierComparison>("compare_local_classification_with_frontier", {
+      runManifestPath: state.result.manifest_path,
+      modelId: "glm-5.2",
+      confirmRemote: true,
+      onEvent: channel,
+    })
+      .then((result) => {
+        if (generation.current !== requestGeneration) return;
+        if (result.run_id !== localRunId || !result.exact_same_holdout) {
+          throw new Error("The frontier result did not match this local run.");
+        }
+        setFrontierComparison(result);
+        setFrontierEvent(null);
+      })
+      .catch((error) => {
+        if (generation.current === requestGeneration) setFrontierError(String(error));
+      })
+      .finally(() => {
+        if (generation.current === requestGeneration) setComparingFrontier(false);
+      });
   };
 
   if (state.phase === "idle") {
@@ -489,17 +577,49 @@ export function LocalTrainingPanel({
         <strong>{verdict.title}</strong>
         <small>{verdict.detail}</small>
       </div>
-      <EvaluationRadar
-        accuracy={state.result.heldout.accuracy}
-        macroF1={state.result.heldout.macro_f1}
-        baselineAccuracy={state.result.linear_baseline.accuracy}
-        baselineMacroF1={state.result.linear_baseline.macro_f1}
-        weakestClass={state.result.heldout.weakest_classes[0]}
-        latencyMs={state.result.heldout.latency_ms_p50}
-        modelSizeBytes={state.result.model.size_bytes}
-        completedRuns={1}
-        requiredRuns={2}
-      />
+      {!frontierComparison && (
+        <div className="frontier-comparison-prompt" aria-live="polite" aria-busy={comparingFrontier}>
+          <div>
+            <span>Frontier reference</span>
+            <strong>Compare with GLM 5.2 on the same {state.result.heldout.row_count.toLocaleString()} test examples</strong>
+            <small>
+              Only held-out test examples are sent through Understudy. Training examples stay on this Mac. Cloud charges may apply.
+            </small>
+            {frontierEvent?.message && <p>{frontierEvent.message}</p>}
+            {frontierEvent?.current !== undefined && frontierEvent.total !== undefined && (
+              <code>{frontierEvent.current} of {frontierEvent.total} comparison batches</code>
+            )}
+            {frontierError && <em>{frontierError}</em>}
+          </div>
+          <button type="button" className="btn primary" onClick={compareWithFrontier} disabled={comparingFrontier}>
+            {comparingFrontier ? "Comparing…" : frontierError ? "Try frontier again" : "Compare with GLM 5.2"}
+          </button>
+        </div>
+      )}
+      {frontierComparison && frontierComparison.heldout.weakest_classes[0] && (
+        <EvaluationRadar
+          accuracy={state.result.heldout.accuracy}
+          macroF1={state.result.heldout.macro_f1}
+          baselineAccuracy={state.result.linear_baseline.accuracy}
+          baselineMacroF1={state.result.linear_baseline.macro_f1}
+          weakestClass={state.result.heldout.weakest_classes[0]}
+          latencyMs={state.result.heldout.latency_ms_p50}
+          modelSizeBytes={state.result.model.size_bytes}
+          failureCount={state.result.heldout.failure_count}
+          rowCount={state.result.heldout.row_count}
+          completedRuns={1}
+          requiredRuns={2}
+          frontier={{
+            name: "GLM 5.2",
+            accuracy: frontierComparison.heldout.accuracy,
+            macroF1: frontierComparison.heldout.macro_f1,
+            weakestClass: frontierComparison.heldout.weakest_classes[0],
+            latencyMs: frontierComparison.heldout.latency_ms_p50,
+            failureCount: frontierComparison.heldout.failure_count,
+            rowCount: frontierComparison.row_count,
+          }}
+        />
+      )}
       <div className="local-training-failures">
         <strong>Notable failures</strong>
         {state.result.heldout.failure_count === 0 ? (

--- a/apps/homescreen/app/design/page.tsx
+++ b/apps/homescreen/app/design/page.tsx
@@ -20,15 +20,26 @@ export default function DesignPage() {
 
         <SectionTitle>evaluation radar · public SMS example</SectionTitle>
         <EvaluationRadar
-          accuracy={0.9949}
-          macroF1={0.9883}
+          accuracy={0.9948519948519948}
+          macroF1={0.9883231643172733}
           baselineAccuracy={0.9846}
           baselineMacroF1={0.9656}
           weakestClass={{ label: "spam", recall: 0.9697, support: 99 }}
           latencyMs={32.7}
           modelSizeBytes={602_052_062}
+          failureCount={4}
+          rowCount={777}
           completedRuns={1}
           requiredRuns={2}
+          frontier={{
+            name: "GLM 5.2",
+            accuracy: 0.9948519948519948,
+            macroF1: 0.9884240636453026,
+            weakestClass: { label: "spam", recall: 0.979798, support: 99 },
+            latencyMs: 657.3,
+            failureCount: 4,
+            rowCount: 777,
+          }}
         />
 
         {/* accent reference */}

--- a/apps/homescreen/app/design/page.tsx
+++ b/apps/homescreen/app/design/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 import { Button } from "../components/ui/Button";
+import { EvaluationRadar } from "../components/EvaluationRadar";
 
 const variants = ["primary", "secondary", "ghost", "danger", "link"] as const;
 
 export default function DesignPage() {
   return (
     <div style={{ background: "var(--color-window)", minHeight: "100vh", color: "var(--color-ink)" }}>
-      <div style={{ maxWidth: 880, margin: "0 auto", padding: "40px 32px 80px" }}>
+      <div style={{ maxWidth: 1120, margin: "0 auto", padding: "40px 32px 80px" }}>
         {/* header */}
         <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 8 }}>
           <div style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.18em", color: "var(--color-ink-muted)" }}>
@@ -14,8 +15,21 @@ export default function DesignPage() {
           </div>
         </div>
         <p style={{ color: "var(--color-ink-muted)", fontSize: 13, margin: "0 0 28px" }}>
-          Reference atom — Button — on the native token system. Lock the look, then systematize.
+          Production components on the native token system.
         </p>
+
+        <SectionTitle>evaluation radar · public SMS example</SectionTitle>
+        <EvaluationRadar
+          accuracy={0.9949}
+          macroF1={0.9883}
+          baselineAccuracy={0.9846}
+          baselineMacroF1={0.9656}
+          weakestClass={{ label: "spam", recall: 0.9697, support: 99 }}
+          latencyMs={32.7}
+          modelSizeBytes={602_052_062}
+          completedRuns={1}
+          requiredRuns={2}
+        />
 
         {/* accent reference */}
         <Surface>
@@ -60,6 +74,7 @@ export default function DesignPage() {
             </span>
           </Row>
         </Surface>
+
       </div>
     </div>
   );

--- a/apps/homescreen/app/design/page.tsx
+++ b/apps/homescreen/app/design/page.tsx
@@ -39,6 +39,7 @@ export default function DesignPage() {
             latencyMs: 657.3,
             failureCount: 4,
             rowCount: 777,
+            costUsd: 0.02,
           }}
         />
 

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -3605,6 +3605,54 @@ select,
   color: var(--text);
   font-size: 11px;
 }
+.frontier-comparison-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 15px;
+  border: 1px solid color-mix(in srgb, #a78bfa 42%, var(--border));
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 88% 42%, color-mix(in srgb, #a78bfa 8%, transparent), transparent 34%),
+    color-mix(in srgb, var(--surface) 58%, transparent);
+}
+.frontier-comparison-prompt > div {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+.frontier-comparison-prompt span {
+  color: #a78bfa;
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.frontier-comparison-prompt strong {
+  color: var(--text);
+  font-size: 12px;
+}
+.frontier-comparison-prompt small,
+.frontier-comparison-prompt p {
+  margin: 0;
+  color: var(--text-2);
+  font-size: 9px;
+  line-height: 1.45;
+}
+.frontier-comparison-prompt code {
+  color: var(--mb-cyan);
+  font-family: var(--mono);
+  font-size: 9px;
+}
+.frontier-comparison-prompt em {
+  color: var(--danger);
+  font-size: 9px;
+  font-style: normal;
+}
+.frontier-comparison-prompt > button {
+  flex: 0 0 auto;
+}
 .local-training-failures > strong,
 .local-training-predict > label {
   color: var(--text-3);
@@ -3635,7 +3683,8 @@ select,
   gap: 3px;
 }
 .evaluation-radar > header span,
-.evaluation-radar > header h3 {
+.evaluation-radar > header h3,
+.evaluation-radar > header p {
   margin: 0;
 }
 .evaluation-radar > header > div:first-child > span {
@@ -3649,6 +3698,10 @@ select,
   color: var(--text);
   font-size: 16px;
   font-weight: 620;
+}
+.evaluation-radar > header p {
+  color: var(--text-2);
+  font-size: 10px;
 }
 .evaluation-radar-legend {
   display: flex;
@@ -3669,10 +3722,8 @@ select,
   border-radius: 99px;
   background: var(--mb-cyan);
 }
-.evaluation-radar-legend i.reference {
-  height: 0;
-  border-top: 1px dashed color-mix(in srgb, var(--text) 62%, transparent);
-  background: transparent;
+.evaluation-radar-legend i.frontier {
+  background: #a78bfa;
 }
 .evaluation-radar-layout {
   display: grid;
@@ -3699,8 +3750,8 @@ select,
   text-align: center;
 }
 .evaluation-radar-grid,
-.evaluation-radar-reference,
-.evaluation-radar-candidate {
+.evaluation-radar-frontier,
+.evaluation-radar-local {
   vector-effect: non-scaling-stroke;
 }
 .evaluation-radar-grid {
@@ -3708,32 +3759,34 @@ select,
   stroke: color-mix(in srgb, var(--text-3) 18%, transparent);
   stroke-width: 1;
 }
-.evaluation-radar-reference {
-  fill: color-mix(in srgb, var(--text) 2%, transparent);
-  stroke: color-mix(in srgb, var(--text) 52%, transparent);
-  stroke-width: 1.25;
-  stroke-dasharray: 5 7;
-}
 .evaluation-radar-axis {
   stroke: color-mix(in srgb, var(--text-3) 22%, transparent);
   stroke-width: 1;
   vector-effect: non-scaling-stroke;
 }
-.evaluation-radar-candidate {
+.evaluation-radar-local {
   fill: color-mix(in srgb, var(--mb-cyan) 16%, transparent);
   stroke: var(--mb-cyan);
   stroke-width: 2;
   filter: drop-shadow(0 0 10px color-mix(in srgb, var(--mb-cyan) 24%, transparent));
 }
-.evaluation-radar-dot {
+.evaluation-radar-frontier {
+  fill: color-mix(in srgb, #a78bfa 10%, transparent);
+  stroke: #a78bfa;
+  stroke-width: 1.8;
+  stroke-dasharray: 6 5;
+}
+.evaluation-radar-dot.local {
   fill: var(--mb-cyan);
   stroke: var(--bg);
   stroke-width: 2;
   vector-effect: non-scaling-stroke;
 }
-.evaluation-radar-dot.is-review {
-  fill: var(--warning);
-  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--warning) 45%, transparent));
+.evaluation-radar-dot.frontier {
+  fill: #a78bfa;
+  stroke: var(--bg);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
 }
 .evaluation-radar-label {
   fill: var(--text-2);
@@ -3748,15 +3801,20 @@ select,
 }
 .evaluation-radar-dimensions > div {
   display: grid;
+  grid-template-columns: 1fr;
   min-width: 0;
-  gap: 3px;
+  gap: 6px;
   padding: 10px 11px;
-  border-left: 2px solid color-mix(in srgb, var(--mb-cyan) 55%, var(--border));
+  border-left: 2px solid color-mix(in srgb, var(--mb-cyan) 45%, #a78bfa 55%);
   background: color-mix(in srgb, var(--surface) 54%, transparent);
 }
-.evaluation-radar-dimensions > div.is-review {
-  border-left-color: var(--warning);
-  background: color-mix(in srgb, var(--warning) 5%, var(--surface));
+.evaluation-radar-dimensions > div > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1px;
+  min-width: 0;
+  padding-top: 5px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
 }
 .evaluation-radar-dimensions span {
   color: var(--text-3);
@@ -3778,6 +3836,39 @@ select,
   font-size: 9px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.evaluation-radar-tradeoffs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+.evaluation-radar-tradeoffs > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+  padding: 10px 11px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 48%, transparent);
+}
+.evaluation-radar-tradeoffs span {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.evaluation-radar-tradeoffs strong {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.evaluation-radar-tradeoffs small {
+  color: var(--text-2);
+  font-size: 9px;
+  line-height: 1.35;
 }
 .local-training-failures {
   display: flex;
@@ -3936,11 +4027,21 @@ select,
   .evaluation-radar > header {
     flex-direction: column;
   }
+  .frontier-comparison-prompt {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .frontier-comparison-prompt > button {
+    align-self: flex-start;
+  }
   .evaluation-radar-legend {
     justify-content: flex-start;
   }
   .evaluation-radar svg {
     width: min(100%, 360px);
+  }
+  .evaluation-radar-tradeoffs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -3587,11 +3587,6 @@ select,
   font-family: var(--mono);
   font-size: 9px;
 }
-.local-training-metrics {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 6px;
-}
 .local-training-verdict {
   display: grid;
   gap: 2px;
@@ -3610,16 +3605,6 @@ select,
   color: var(--text);
   font-size: 11px;
 }
-.local-training-metrics > div {
-  display: grid;
-  min-width: 0;
-  gap: 2px;
-  padding: 7px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--bg) 45%, transparent);
-}
-.local-training-metrics span,
 .local-training-failures > strong,
 .local-training-predict > label {
   color: var(--text-3);
@@ -3628,15 +3613,169 @@ select,
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-.local-training-metrics b {
+.evaluation-radar {
+  display: grid;
+  gap: 12px;
+  min-height: min(500px, 58vh);
+  padding: 14px 16px 16px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 30%, var(--border));
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 31% 48%, color-mix(in srgb, var(--mb-cyan) 7%, transparent), transparent 35%),
+    color-mix(in srgb, var(--bg) 46%, transparent);
+}
+.evaluation-radar > header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+.evaluation-radar > header > div:first-child {
+  display: grid;
+  gap: 3px;
+}
+.evaluation-radar > header span,
+.evaluation-radar > header h3 {
+  margin: 0;
+}
+.evaluation-radar > header > div:first-child > span {
+  color: var(--mb-cyan);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.evaluation-radar > header h3 {
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 620;
+}
+.evaluation-radar-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px 14px;
+  color: var(--text-2);
+  font-size: 10px;
+}
+.evaluation-radar-legend > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.evaluation-radar-legend i {
+  width: 20px;
+  height: 2px;
+  border-radius: 99px;
+  background: var(--mb-cyan);
+}
+.evaluation-radar-legend i.reference {
+  height: 0;
+  border-top: 1px dashed color-mix(in srgb, var(--text) 62%, transparent);
+  background: transparent;
+}
+.evaluation-radar-layout {
+  display: grid;
+  grid-template-columns: minmax(340px, 1.2fr) minmax(230px, 0.8fr);
+  align-items: center;
+  gap: 18px;
+}
+.evaluation-radar figure {
+  display: grid;
+  place-items: center;
+  gap: 2px;
+  margin: 0;
+}
+.evaluation-radar svg {
+  width: min(100%, 430px);
+  height: auto;
+  overflow: visible;
+}
+.evaluation-radar figure figcaption {
+  max-width: 420px;
+  color: var(--text-3);
+  font-size: 9px;
+  line-height: 1.45;
+  text-align: center;
+}
+.evaluation-radar-grid,
+.evaluation-radar-reference,
+.evaluation-radar-candidate {
+  vector-effect: non-scaling-stroke;
+}
+.evaluation-radar-grid {
+  fill: none;
+  stroke: color-mix(in srgb, var(--text-3) 18%, transparent);
+  stroke-width: 1;
+}
+.evaluation-radar-reference {
+  fill: color-mix(in srgb, var(--text) 2%, transparent);
+  stroke: color-mix(in srgb, var(--text) 52%, transparent);
+  stroke-width: 1.25;
+  stroke-dasharray: 5 7;
+}
+.evaluation-radar-axis {
+  stroke: color-mix(in srgb, var(--text-3) 22%, transparent);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+.evaluation-radar-candidate {
+  fill: color-mix(in srgb, var(--mb-cyan) 16%, transparent);
+  stroke: var(--mb-cyan);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 10px color-mix(in srgb, var(--mb-cyan) 24%, transparent));
+}
+.evaluation-radar-dot {
+  fill: var(--mb-cyan);
+  stroke: var(--bg);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+.evaluation-radar-dot.is-review {
+  fill: var(--warning);
+  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--warning) 45%, transparent));
+}
+.evaluation-radar-label {
+  fill: var(--text-2);
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+}
+.evaluation-radar-dimensions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.evaluation-radar-dimensions > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+  padding: 10px 11px;
+  border-left: 2px solid color-mix(in srgb, var(--mb-cyan) 55%, var(--border));
+  background: color-mix(in srgb, var(--surface) 54%, transparent);
+}
+.evaluation-radar-dimensions > div.is-review {
+  border-left-color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 5%, var(--surface));
+}
+.evaluation-radar-dimensions span {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.evaluation-radar-dimensions strong {
   overflow: hidden;
   color: var(--text);
-  font-size: 13px;
+  font-size: 15px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.local-training-metrics small {
+.evaluation-radar-dimensions small {
   overflow: hidden;
+  color: var(--text-2);
+  font-size: 9px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -3786,8 +3925,22 @@ select,
   .workload-draft-actions {
     justify-content: flex-end;
   }
-  .local-training-metrics {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .evaluation-radar {
+    min-height: auto;
+  }
+  .evaluation-radar > header,
+  .evaluation-radar-layout {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+  .evaluation-radar > header {
+    flex-direction: column;
+  }
+  .evaluation-radar-legend {
+    justify-content: flex-start;
+  }
+  .evaluation-radar svg {
+    width: min(100%, 360px);
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/apps/homescreen/app/lib/local-training-state.mjs
+++ b/apps/homescreen/app/lib/local-training-state.mjs
@@ -145,7 +145,7 @@ export function localTrainingVerdict(result) {
     return {
       tone: "neutral",
       title: "This dataset is too easy to show model value",
-      detail: "The deterministic TF-IDF baseline already scores 100% on the group-isolated holdout. Use a harder or more varied dataset before choosing a model.",
+      detail: "A simple baseline already gets at least 99% of the separate test examples right. Use a harder or more varied dataset before choosing a model.",
     };
   }
   switch (result.verdict.status) {
@@ -153,19 +153,19 @@ export function localTrainingVerdict(result) {
       return {
         tone: "positive",
         title: "Promising, needs another run",
-        detail: result.verdict.reason,
+        detail: "It beat the simple baseline and worked across every category. Repeat the test once before relying on it.",
       };
     case "improved_not_ready":
       return {
         tone: "caution",
         title: "Improved, not ready",
-        detail: result.verdict.reason,
+        detail: "It beat the simple baseline, but it still misses too many examples in at least one category.",
       };
     default:
       return {
         tone: "caution",
         title: "No model value yet",
-        detail: result.verdict.reason,
+        detail: "The trained model did not beat the much simpler baseline on the separate test examples.",
       };
   }
 }

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -335,6 +335,7 @@ pub fn run() {
             workload_drop::local_classification_training_examples,
             workload_drop::start_local_classification_training,
             workload_drop::cancel_local_classification_training,
+            workload_drop::compare_local_classification_with_frontier,
             workload_drop::predict_local_classification,
             commands::sidekick_decisions,
             commands::sidekick_events,

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -39,6 +39,20 @@ pub enum ClassificationTrainingEvent {
     },
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FrontierComparisonEvent {
+    Phase {
+        phase: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        current: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        total: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+}
+
 static TRAINING_CANCELLATIONS: OnceLock<Mutex<HashMap<String, Arc<AtomicBool>>>> = OnceLock::new();
 
 fn training_cancellations() -> &'static Mutex<HashMap<String, Arc<AtomicBool>>> {
@@ -572,6 +586,128 @@ fn validate_training_phase(
     })
 }
 
+fn validate_frontier_comparison_result(value: Value, run_id: &str) -> Result<Value, String> {
+    if value.get("schema_version").and_then(Value::as_str)
+        != Some("understudy.capture_import.frontier_classification.v1")
+        || value.get("status").and_then(Value::as_str) != Some("completed")
+        || value.get("run_id").and_then(Value::as_str) != Some(run_id)
+        || value.get("exact_same_holdout").and_then(Value::as_bool) != Some(true)
+        || value.get("requested_model").and_then(Value::as_str)
+            != value.get("served_model").and_then(Value::as_str)
+    {
+        return Err("The frontier comparison did not preserve the exact-run evidence.".into());
+    }
+    let row_count = value
+        .get("row_count")
+        .and_then(Value::as_u64)
+        .filter(|count| (1..=2_000).contains(count))
+        .ok_or_else(|| "The frontier comparison has an invalid bounded row count.".to_string())?;
+    let holdout_sha256 = value
+        .get("holdout_sha256")
+        .and_then(Value::as_str)
+        .filter(|hash| hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .ok_or_else(|| "The frontier comparison omitted its holdout hash.".to_string())?;
+    let heldout = value
+        .get("heldout")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The frontier comparison omitted held-out scores.".to_string())?;
+    for field in ["accuracy", "macro_f1"] {
+        let metric = heldout.get(field).and_then(Value::as_f64).unwrap_or(-1.0);
+        if !(0.0..=1.0).contains(&metric) {
+            return Err(format!("The frontier comparison has an invalid {field}."));
+        }
+    }
+    if heldout
+        .get("latency_ms_p50")
+        .and_then(Value::as_f64)
+        .filter(|latency| latency.is_finite() && *latency >= 0.0)
+        .is_none()
+        || heldout
+            .get("failure_count")
+            .and_then(Value::as_u64)
+            .filter(|count| *count <= row_count)
+            .is_none()
+        || heldout
+            .get("failures")
+            .and_then(Value::as_array)
+            .filter(|failures| failures.len() <= 25)
+            .is_none()
+    {
+        return Err("The frontier comparison has invalid latency or failure evidence.".into());
+    }
+    let weakest = heldout
+        .get("weakest_classes")
+        .and_then(Value::as_array)
+        .filter(|rows| !rows.is_empty() && rows.len() <= 5)
+        .ok_or_else(|| "The frontier comparison omitted weakest-category evidence.".to_string())?;
+    for category in weakest {
+        if category.get("label").and_then(Value::as_str).is_none()
+            || category.get("support").and_then(Value::as_u64).is_none()
+        {
+            return Err("The frontier comparison has invalid category evidence.".into());
+        }
+        require_metric(category, &["recall"])?;
+        require_metric(category, &["f1"])?;
+    }
+    let boundary = value
+        .get("data_boundary")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The frontier comparison omitted its data boundary.".to_string())?;
+    if boundary
+        .get("user_confirmed_remote_comparison")
+        .and_then(Value::as_bool)
+        != Some(true)
+        || boundary
+            .get("training_examples_uploaded")
+            .and_then(Value::as_bool)
+            != Some(false)
+        || boundary
+            .get("holdout_examples_uploaded")
+            .and_then(Value::as_bool)
+            != Some(true)
+    {
+        return Err("The frontier comparison returned an invalid consent boundary.".into());
+    }
+    if value
+        .get("artifact_path")
+        .and_then(Value::as_str)
+        .filter(|path| !path.is_empty())
+        .is_none()
+        || holdout_sha256.is_empty()
+    {
+        return Err("The frontier comparison omitted its immutable artifact path.".into());
+    }
+    Ok(value)
+}
+
+fn validate_frontier_phase(value: &Value) -> Result<FrontierComparisonEvent, String> {
+    if value.get("type").and_then(Value::as_str) != Some("phase") {
+        return Err("The frontier comparator returned an invalid phase event.".into());
+    }
+    let phase = value
+        .get("phase")
+        .and_then(Value::as_str)
+        .filter(|phase| ["preparing", "comparing", "measuring", "saving"].contains(phase))
+        .ok_or_else(|| "The frontier comparator returned an unknown phase.".to_string())?;
+    let current = value.get("current").and_then(Value::as_u64);
+    let total = value.get("total").and_then(Value::as_u64);
+    if current
+        .zip(total)
+        .is_some_and(|(current, total)| total == 0 || current > total)
+    {
+        return Err("The frontier comparator returned invalid measured progress.".into());
+    }
+    Ok(FrontierComparisonEvent::Phase {
+        phase: phase.to_string(),
+        current,
+        total,
+        message: value
+            .get("message")
+            .and_then(Value::as_str)
+            .map(|message| message.chars().take(240).collect()),
+    })
+}
+
 fn read_bounded(mut reader: impl Read) -> String {
     let mut retained = Vec::new();
     let mut buffer = [0_u8; 4_096];
@@ -950,6 +1086,136 @@ pub fn cancel_local_classification_training(run_id: String) -> Result<Value, Str
     };
     cancelled.store(true, Ordering::Release);
     Ok(serde_json::json!({ "status": "cancelling", "run_id": run_id }))
+}
+
+fn run_frontier_comparison(
+    run_manifest_path: String,
+    model_id: String,
+    confirm_remote: bool,
+    on_event: &Channel<FrontierComparisonEvent>,
+) -> Result<Value, String> {
+    if !confirm_remote {
+        return Err(
+            "Confirm that held-out examples may be sent to GLM 5.2. Training examples stay on this Mac."
+                .into(),
+        );
+    }
+    let canonical_manifest = PathBuf::from(run_manifest_path.trim())
+        .canonicalize()
+        .map_err(|error| format!("The local training run is unavailable: {error}"))?;
+    if !canonical_manifest.is_file() {
+        return Err("Choose a completed local training run.".into());
+    }
+    let run_manifest = std::fs::read(&canonical_manifest)
+        .map_err(|error| format!("The local training run could not be read: {error}"))?;
+    let run_manifest = serde_json::from_slice::<Value>(&run_manifest)
+        .map_err(|_| "The local training run is malformed.".to_string())?;
+    let run_id = run_manifest
+        .get("run_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "The local training run omitted its id.".to_string())?
+        .to_string();
+    validate_classification_training_result(run_manifest, &run_id)?;
+
+    let mut child = crate::bin::command("understudy")
+        .args([
+            "capture-import",
+            "compare-classification-frontier",
+            "--run-manifest",
+        ])
+        .arg(&canonical_manifest)
+        .arg("--model")
+        .arg(&model_id)
+        .arg("--confirm-remote")
+        .arg("--jsonl")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("Could not start the frontier comparison: {error}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "The frontier comparator did not expose progress output.".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "The frontier comparator did not expose diagnostic output.".to_string())?;
+    let stderr_reader = std::thread::spawn(move || read_bounded(stderr));
+    let mut result = None;
+    let mut protocol_error = None;
+    for line in BufReader::new(stdout).lines() {
+        let line =
+            line.map_err(|_| "The frontier comparator progress stream stopped.".to_string())?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value = match serde_json::from_str::<Value>(&line) {
+            Ok(value) => value,
+            Err(_) => {
+                protocol_error =
+                    Some("The frontier comparator returned malformed progress JSON.".into());
+                break;
+            }
+        };
+        match value.get("type").and_then(Value::as_str) {
+            Some("phase") => match validate_frontier_phase(&value) {
+                Ok(event) => {
+                    let _ = on_event.send(event);
+                }
+                Err(error) => {
+                    protocol_error = Some(error);
+                    break;
+                }
+            },
+            Some("result") => {
+                let Some(payload) = value.get("result").cloned() else {
+                    protocol_error = Some("The frontier comparator omitted its result.".into());
+                    break;
+                };
+                match validate_frontier_comparison_result(payload, &run_id) {
+                    Ok(value) => result = Some(value),
+                    Err(error) => {
+                        protocol_error = Some(error);
+                        break;
+                    }
+                }
+            }
+            _ => {
+                protocol_error = Some("The frontier comparator returned an unknown event.".into());
+                break;
+            }
+        }
+    }
+    if let Some(error) = protocol_error {
+        terminate_training_child(&mut child);
+        let _ = stderr_reader.join();
+        return Err(error);
+    }
+    let status = child
+        .wait()
+        .map_err(|error| format!("Could not finish the frontier comparison: {error}"))?;
+    let detail = stderr_reader
+        .join()
+        .unwrap_or_else(|_| "No diagnostic was returned.".into());
+    if !status.success() {
+        return Err(format!("Frontier comparison failed. {detail}"));
+    }
+    result.ok_or_else(|| "Frontier comparison finished without a validated result.".into())
+}
+
+#[tauri::command]
+pub async fn compare_local_classification_with_frontier(
+    run_manifest_path: String,
+    model_id: String,
+    confirm_remote: bool,
+    on_event: Channel<FrontierComparisonEvent>,
+) -> Result<Value, String> {
+    let model_id = safe_identifier(&model_id, "frontier model id")?;
+    tauri::async_runtime::spawn_blocking(move || {
+        run_frontier_comparison(run_manifest_path, model_id, confirm_remote, &on_event)
+    })
+    .await
+    .map_err(|error| format!("The frontier comparator stopped unexpectedly: {error}"))?
 }
 
 fn validate_classification_prediction(value: Value, run_id: &str) -> Result<Value, String> {

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -665,8 +665,57 @@ fn validate_frontier_comparison_result(value: Value, run_id: &str) -> Result<Val
             .get("holdout_examples_uploaded")
             .and_then(Value::as_bool)
             != Some(true)
+        || boundary
+            .get("retention_expectation")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .is_none()
     {
         return Err("The frontier comparison returned an invalid consent boundary.".into());
+    }
+    let spend = value
+        .get("spend")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The frontier comparison omitted its spend evidence.".to_string())?;
+    let approved_budget = spend
+        .get("approved_budget_usd")
+        .and_then(Value::as_f64)
+        .filter(|value| value.is_finite() && *value > 0.0 && *value <= 100.0)
+        .ok_or_else(|| "The frontier comparison has an invalid approved budget.".to_string())?;
+    let estimated_max = spend
+        .get("estimated_max_cost_usd")
+        .and_then(Value::as_f64)
+        .filter(|value| value.is_finite() && *value >= 0.0 && *value <= approved_budget)
+        .ok_or_else(|| "The frontier comparison exceeded its spend preflight.".to_string())?;
+    let attributed = spend
+        .get("attributed_cost_usd")
+        .and_then(Value::as_f64)
+        .filter(|value| value.is_finite() && *value >= 0.0 && *value <= approved_budget)
+        .ok_or_else(|| "The frontier comparison returned invalid attributed spend.".to_string())?;
+    if spend.get("user_confirmed_spend").and_then(Value::as_bool) != Some(true)
+        || spend
+            .get("input_usd_per_million_tokens")
+            .and_then(Value::as_f64)
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .is_none()
+        || spend
+            .get("output_usd_per_million_tokens")
+            .and_then(Value::as_f64)
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .is_none()
+        || spend
+            .get("pricing_source")
+            .and_then(Value::as_str)
+            .filter(|value| value.starts_with("https://fireworks.ai/"))
+            .is_none()
+        || spend
+            .get("pricing_checked_at")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .is_none()
+        || estimated_max < attributed
+    {
+        return Err("The frontier comparison returned invalid spend evidence.".into());
     }
     if value
         .get("artifact_path")
@@ -1092,12 +1141,19 @@ fn run_frontier_comparison(
     run_manifest_path: String,
     model_id: String,
     confirm_remote: bool,
+    confirm_spend: bool,
+    budget_usd: f64,
     on_event: &Channel<FrontierComparisonEvent>,
 ) -> Result<Value, String> {
     if !confirm_remote {
         return Err(
             "Confirm that held-out examples may be sent to GLM 5.2. Training examples stay on this Mac."
                 .into(),
+        );
+    }
+    if !confirm_spend || !budget_usd.is_finite() || budget_usd <= 0.0 || budget_usd > 100.0 {
+        return Err(
+            "Confirm a positive frontier spend cap of at most $100 before comparing.".into(),
         );
     }
     let canonical_manifest = PathBuf::from(run_manifest_path.trim())
@@ -1127,6 +1183,9 @@ fn run_frontier_comparison(
         .arg("--model")
         .arg(&model_id)
         .arg("--confirm-remote")
+        .arg("--confirm-spend")
+        .arg("--budget-usd")
+        .arg(budget_usd.to_string())
         .arg("--jsonl")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1208,11 +1267,20 @@ pub async fn compare_local_classification_with_frontier(
     run_manifest_path: String,
     model_id: String,
     confirm_remote: bool,
+    confirm_spend: bool,
+    budget_usd: f64,
     on_event: Channel<FrontierComparisonEvent>,
 ) -> Result<Value, String> {
     let model_id = safe_identifier(&model_id, "frontier model id")?;
     tauri::async_runtime::spawn_blocking(move || {
-        run_frontier_comparison(run_manifest_path, model_id, confirm_remote, &on_event)
+        run_frontier_comparison(
+            run_manifest_path,
+            model_id,
+            confirm_remote,
+            confirm_spend,
+            budget_usd,
+            &on_event,
+        )
     })
     .await
     .map_err(|error| format!("The frontier comparator stopped unexpectedly: {error}"))?
@@ -1633,6 +1701,64 @@ mod tests {
             validate_classification_training_result(unsafe_result, "desktop-run-123")
                 .unwrap_err()
                 .contains("group-isolated")
+        );
+    }
+
+    #[test]
+    fn accepts_only_consent_safe_budgeted_frontier_evidence() {
+        let valid = json!({
+            "schema_version": "understudy.capture_import.frontier_classification.v1",
+            "run_id": "desktop-run-123",
+            "status": "completed",
+            "requested_model": "glm-5.2",
+            "served_model": "glm-5.2",
+            "exact_same_holdout": true,
+            "holdout_sha256": "a".repeat(64),
+            "row_count": 20,
+            "data_boundary": {
+                "user_confirmed_remote_comparison": true,
+                "training_examples_uploaded": false,
+                "holdout_examples_uploaded": true,
+                "retention_expectation": "Fireworks-published zero data retention"
+            },
+            "heldout": {
+                "accuracy": 0.9,
+                "macro_f1": 0.8,
+                "latency_ms_p50": 120.0,
+                "failure_count": 2,
+                "failures": [],
+                "weakest_classes": [
+                    { "label": "travel", "recall": 0.7, "f1": 0.75, "support": 10 }
+                ]
+            },
+            "spend": {
+                "user_confirmed_spend": true,
+                "approved_budget_usd": 1.0,
+                "estimated_max_cost_usd": 0.5,
+                "attributed_cost_usd": 0.02,
+                "input_usd_per_million_tokens": 1.4,
+                "output_usd_per_million_tokens": 4.4,
+                "pricing_source": "https://fireworks.ai/models/fireworks/glm-5p2",
+                "pricing_checked_at": "2026-07-16"
+            },
+            "artifact_path": "/tmp/frontier.json"
+        });
+        assert!(validate_frontier_comparison_result(valid.clone(), "desktop-run-123").is_ok());
+
+        let mut no_spend_consent = valid.clone();
+        no_spend_consent["spend"]["user_confirmed_spend"] = json!(false);
+        assert!(
+            validate_frontier_comparison_result(no_spend_consent, "desktop-run-123")
+                .unwrap_err()
+                .contains("spend evidence")
+        );
+
+        let mut over_budget = valid;
+        over_budget["spend"]["attributed_cost_usd"] = json!(1.01);
+        assert!(
+            validate_frontier_comparison_result(over_budget, "desktop-run-123")
+                .unwrap_err()
+                .contains("attributed spend")
         );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from "./local-classifier/index.js";
 import {
   compareClassifierWithFrontier,
+  DEFAULT_FRONTIER_CLASSIFIER_BUDGET_USD,
   DEFAULT_FRONTIER_CLASSIFIER_MODEL,
 } from "./local-classifier/frontier.js";
 import { planRouteDecision } from "./route-decision.js";
@@ -306,6 +307,14 @@ function parseNonNegativeNumber(value: string): number {
   return parsed;
 }
 
+function parsePositiveNumber(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Expected a positive number, got: ${value}`);
+  }
+  return parsed;
+}
+
 function collectRepeated(value: string, previous: string[]): string[] {
   return [...previous, value];
 }
@@ -511,12 +520,24 @@ function registerCaptureImportCommands(program: Command): void {
       "--confirm-remote",
       "Confirm held-out examples may be sent to the named managed frontier model; training examples remain local",
     )
+    .option(
+      "--confirm-spend",
+      "Confirm paid frontier inference within the explicit --budget-usd cap",
+    )
+    .option(
+      "--budget-usd <usd>",
+      "Hard maximum approved frontier spend in USD",
+      parsePositiveNumber,
+      DEFAULT_FRONTIER_CLASSIFIER_BUDGET_USD,
+    )
     .option("--jsonl", "Stream machine-readable phase and terminal result events")
     .option("--json", "Output the terminal comparison artifact as JSON")
     .action(async (options: {
       runManifest: string;
       model: string;
       confirmRemote?: boolean;
+      confirmSpend?: boolean;
+      budgetUsd: number;
       jsonl?: boolean;
       json?: boolean;
     }) => {
@@ -524,6 +545,8 @@ function registerCaptureImportCommands(program: Command): void {
         runManifestPath: options.runManifest,
         modelId: options.model,
         confirmRemote: Boolean(options.confirmRemote),
+        confirmSpend: Boolean(options.confirmSpend),
+        budgetUsd: options.budgetUsd,
         onEvent: options.jsonl ? (event) => console.log(JSON.stringify(event)) : undefined,
       });
       if (options.jsonl) {
@@ -537,6 +560,7 @@ function registerCaptureImportCommands(program: Command): void {
       console.log(`capture-import compare-classification-frontier: ${result.requested_model}`);
       console.log(`same holdout: ${result.row_count} row(s), ${result.holdout_sha256}`);
       console.log(`correct answers: ${(result.heldout.accuracy * 100).toFixed(1)}%`);
+      console.log(`frontier spend: $${result.spend.attributed_cost_usd.toFixed(4)} (approved cap $${result.spend.approved_budget_usd.toFixed(2)})`);
       console.log(`artifact: ${result.artifact_path}`);
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ import {
   predictLocalClassifier,
   startLocalClassifierTraining,
 } from "./local-classifier/index.js";
+import {
+  compareClassifierWithFrontier,
+  DEFAULT_FRONTIER_CLASSIFIER_MODEL,
+} from "./local-classifier/frontier.js";
 import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
 import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
@@ -496,6 +500,44 @@ function registerCaptureImportCommands(program: Command): void {
       console.log(`prediction: ${prediction.label}`);
       console.log(`confidence: ${(prediction.scores[0]?.score ?? 0).toFixed(4)}`);
       console.log("local_only: true (input text was not retained)");
+    });
+
+  captureImport
+    .command("compare-classification-frontier")
+    .description("Compare a completed local classifier with a frontier model on the exact same holdout")
+    .requiredOption("--run-manifest <path>", "Completed local classification run manifest")
+    .option("--model <id>", "Frontier catalog model", DEFAULT_FRONTIER_CLASSIFIER_MODEL)
+    .option(
+      "--confirm-remote",
+      "Confirm held-out examples may be sent to the named managed frontier model; training examples remain local",
+    )
+    .option("--jsonl", "Stream machine-readable phase and terminal result events")
+    .option("--json", "Output the terminal comparison artifact as JSON")
+    .action(async (options: {
+      runManifest: string;
+      model: string;
+      confirmRemote?: boolean;
+      jsonl?: boolean;
+      json?: boolean;
+    }) => {
+      const result = await compareClassifierWithFrontier({
+        runManifestPath: options.runManifest,
+        modelId: options.model,
+        confirmRemote: Boolean(options.confirmRemote),
+        onEvent: options.jsonl ? (event) => console.log(JSON.stringify(event)) : undefined,
+      });
+      if (options.jsonl) {
+        console.log(JSON.stringify({ type: "result", result }));
+        return;
+      }
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`capture-import compare-classification-frontier: ${result.requested_model}`);
+      console.log(`same holdout: ${result.row_count} row(s), ${result.holdout_sha256}`);
+      console.log(`correct answers: ${(result.heldout.accuracy * 100).toFixed(1)}%`);
+      console.log(`artifact: ${result.artifact_path}`);
     });
 
   captureImport

--- a/src/local-classifier/frontier.ts
+++ b/src/local-classifier/frontier.ts
@@ -461,10 +461,15 @@ function median(values: number[]): number {
   return sorted[Math.floor(sorted.length / 2)]!;
 }
 
-function computeHeldout(rows: HoldoutRow[], predictions: Prediction[], latencyMsP50: number) {
+function computeHeldout(
+  rows: HoldoutRow[],
+  predictions: Prediction[],
+  labels: string[],
+  latencyMsP50: number,
+) {
   const predictedById = new Map(predictions.map((prediction) => [prediction.example_id, prediction.label]));
-  const labels = [...new Set(rows.map((row) => row.label))].sort();
-  const counts = Object.fromEntries(labels.map((label) => [label, { support: 0, found: 0, predicted: 0 }]));
+  const orderedLabels = [...labels].sort();
+  const counts = Object.fromEntries(orderedLabels.map((label) => [label, { support: 0, found: 0, predicted: 0 }]));
   const failures: Array<{ example_id: string; expected_label: string; predicted_label: string }> = [];
   let correct = 0;
   for (const row of rows) {
@@ -483,7 +488,7 @@ function computeHeldout(rows: HoldoutRow[], predictions: Prediction[], latencyMs
       });
     }
   }
-  const perClass = labels.map((label) => {
+  const perClass = orderedLabels.map((label) => {
     const count = counts[label]!;
     const precision = count.predicted > 0 ? count.found / count.predicted : 0;
     const recall = count.support > 0 ? count.found / count.support : 0;
@@ -660,6 +665,7 @@ export async function compareClassifierWithFrontier(
       heldout: computeHeldout(
         verified.rows,
         chunkResults.flatMap((chunk) => chunk.predictions),
+        verified.labels,
         median(latencyMs),
       ),
       usage: {

--- a/src/local-classifier/frontier.ts
+++ b/src/local-classifier/frontier.ts
@@ -13,17 +13,27 @@ import { assertCustomerScope, resolveAuth } from "../internal/http.js";
 export const FRONTIER_CLASSIFICATION_SCHEMA = "understudy.capture_import.frontier_classification.v1";
 export const FRONTIER_CLASSIFICATION_FAILURE_SCHEMA = "understudy.capture_import.frontier_classification_failure.v1";
 export const DEFAULT_FRONTIER_CLASSIFIER_MODEL = "glm-5.2";
+export const DEFAULT_FRONTIER_CLASSIFIER_BUDGET_USD = 1;
+
+const FRONTIER_PRICING = {
+  inputUsdPerMillionTokens: 1.4,
+  outputUsdPerMillionTokens: 4.4,
+  source: "https://fireworks.ai/models/fireworks/glm-5p2",
+  checkedAt: "2026-07-16",
+} as const;
 
 const RUN_SCHEMA = "understudy.capture_import.classification_run.v1";
 const MAX_HOLDOUT_BYTES = 16 * 1024 * 1024;
 const MAX_HOLDOUT_ROWS = 2_000;
 const MAX_TEXT_CHARACTERS = 4_000;
-const MAX_LABELS = 50;
+const MAX_LABELS = 128;
 const CHUNK_SIZE = 40;
 const MAX_CONCURRENCY = 4;
 const REQUEST_TIMEOUT_MS = 90_000;
-const MAX_COMPLETION_TOKENS = 4_096;
+const QUALITY_MAX_COMPLETION_TOKENS = 4_096;
+const LATENCY_MAX_COMPLETION_TOKENS = 256;
 const LATENCY_SAMPLE_COUNT = 5;
+const MAX_FRONTIER_BUDGET_USD = 100;
 const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
 
 export type FrontierClassificationPhase = "preparing" | "comparing" | "measuring" | "saving";
@@ -51,7 +61,8 @@ export type FrontierClassificationResult = {
     user_confirmed_remote_comparison: true;
     training_examples_uploaded: false;
     holdout_examples_uploaded: true;
-    destination: "Understudy managed frontier model";
+    destination: "Understudy managed GLM 5.2 on Fireworks";
+    retention_expectation: "Fireworks-published zero data retention; Understudy comparison evidence excludes holdout text";
   };
   heldout: {
     accuracy: number;
@@ -84,6 +95,16 @@ export type FrontierClassificationResult = {
     request_count: number;
     request_ids: Array<string | null>;
   };
+  spend: {
+    user_confirmed_spend: true;
+    approved_budget_usd: number;
+    estimated_max_cost_usd: number;
+    attributed_cost_usd: number;
+    input_usd_per_million_tokens: number;
+    output_usd_per_million_tokens: number;
+    pricing_source: string;
+    pricing_checked_at: string;
+  };
   gateway: {
     modes: string[];
     routes: string[];
@@ -95,6 +116,8 @@ export type CompareClassifierWithFrontierOptions = {
   runManifestPath: string;
   modelId?: string;
   confirmRemote: boolean;
+  confirmSpend: boolean;
+  budgetUsd: number;
   concurrency?: number;
   auth?: ReturnType<typeof resolveAuth>;
   fetchImpl?: typeof fetch;
@@ -128,6 +151,27 @@ type GatewayChunkResult = {
   servedModel: string;
   mode: string | null;
   route: string | null;
+};
+
+type GatewayRequest = {
+  model: string;
+  stream: false;
+  temperature: 0;
+  max_tokens: number;
+  chat_template_kwargs: { thinking: false; enable_thinking: false };
+  messages: Array<{ role: "system" | "user"; content: string }>;
+};
+
+type BudgetPreflight = {
+  approved_budget_usd: number;
+  estimated_max_cost_usd: number;
+  estimated_input_token_upper_bound: number;
+  reserved_output_tokens: number;
+  request_count: number;
+  input_usd_per_million_tokens: number;
+  output_usd_per_million_tokens: number;
+  pricing_source: string;
+  pricing_checked_at: string;
 };
 
 function sha256(value: string | Buffer): string {
@@ -262,10 +306,91 @@ function requestSignal(parent?: AbortSignal): { signal: AbortSignal; dispose: ()
   };
 }
 
+function buildGatewayRequest(
+  rows: HoldoutRow[],
+  labels: string[],
+  modelId: string,
+  maxCompletionTokens: number,
+): GatewayRequest {
+  return {
+    model: modelId,
+    stream: false,
+    temperature: 0,
+    max_tokens: maxCompletionTokens,
+    chat_template_kwargs: { thinking: false, enable_thinking: false },
+    messages: [
+      {
+        role: "system",
+        content: `Classify every input into exactly one allowed label. Return only JSON: {"predictions":[{"example_id":"...","label":"..."}]}. Preserve every example_id exactly, return one prediction per input, and use only these labels: ${labels.join(", ")}.`,
+      },
+      {
+        role: "user",
+        content: JSON.stringify({
+          examples: rows.map(({ example_id, text }) => ({ example_id, text })),
+        }),
+      },
+    ],
+  };
+}
+
+function costUsd(inputTokens: number, outputTokens: number): number {
+  return (
+    (inputTokens * FRONTIER_PRICING.inputUsdPerMillionTokens) +
+    (outputTokens * FRONTIER_PRICING.outputUsdPerMillionTokens)
+  ) / 1_000_000;
+}
+
+function formatUsdCap(value: number): string {
+  return `$${value.toFixed(value < 0.01 ? 6 : 2)}`;
+}
+
+function buildBudgetPreflight(
+  qualityChunks: HoldoutRow[][],
+  latencySamples: HoldoutRow[],
+  labels: string[],
+  modelId: string,
+  budgetUsd: number,
+): BudgetPreflight {
+  const requests = [
+    ...qualityChunks.map((rows) => buildGatewayRequest(
+      rows,
+      labels,
+      modelId,
+      QUALITY_MAX_COMPLETION_TOKENS,
+    )),
+    ...latencySamples.map((row) => buildGatewayRequest(
+      [row],
+      labels,
+      modelId,
+      LATENCY_MAX_COMPLETION_TOKENS,
+    )),
+  ];
+  // One UTF-8 byte per input token is intentionally conservative. The output
+  // side reserves every requested completion token, even though valid JSON is
+  // normally much shorter.
+  const estimatedInputTokenUpperBound = requests.reduce(
+    (sum, request) => sum + Buffer.byteLength(JSON.stringify(request), "utf8"),
+    0,
+  );
+  const reservedOutputTokens = requests.reduce((sum, request) => sum + request.max_tokens, 0);
+  return {
+    approved_budget_usd: budgetUsd,
+    estimated_max_cost_usd: costUsd(estimatedInputTokenUpperBound, reservedOutputTokens),
+    estimated_input_token_upper_bound: estimatedInputTokenUpperBound,
+    reserved_output_tokens: reservedOutputTokens,
+    request_count: requests.length,
+    input_usd_per_million_tokens: FRONTIER_PRICING.inputUsdPerMillionTokens,
+    output_usd_per_million_tokens: FRONTIER_PRICING.outputUsdPerMillionTokens,
+    pricing_source: FRONTIER_PRICING.source,
+    pricing_checked_at: FRONTIER_PRICING.checkedAt,
+  };
+}
+
 async function callGateway(
   rows: HoldoutRow[],
   labels: string[],
   modelId: string,
+  maxCompletionTokens: number,
   fetchImpl: typeof fetch,
   auth: ReturnType<typeof resolveAuth>,
   signal?: AbortSignal,
@@ -281,25 +406,7 @@ async function callGateway(
         "content-type": "application/json",
         accept: "application/json",
       },
-      body: JSON.stringify({
-        model: modelId,
-        stream: false,
-        temperature: 0,
-        max_tokens: MAX_COMPLETION_TOKENS,
-        chat_template_kwargs: { thinking: false, enable_thinking: false },
-        messages: [
-          {
-            role: "system",
-            content: `Classify every input into exactly one allowed label. Return only JSON: {"predictions":[{"example_id":"...","label":"..."}]}. Preserve every example_id exactly, return one prediction per input, and use only these labels: ${labels.join(", ")}.`,
-          },
-          {
-            role: "user",
-            content: JSON.stringify({
-              examples: rows.map(({ example_id, text }) => ({ example_id, text })),
-            }),
-          },
-        ],
-      }),
+      body: JSON.stringify(buildGatewayRequest(rows, labels, modelId, maxCompletionTokens)),
       signal: scopedSignal.signal,
     });
     const body = await response.text();
@@ -406,12 +513,22 @@ export async function compareClassifierWithFrontier(
       "Frontier comparison requires --confirm-remote after disclosing that held-out examples leave this Mac. Training examples remain local.",
     );
   }
+  if (!options.confirmSpend || !Number.isFinite(options.budgetUsd) || options.budgetUsd <= 0 ||
+      options.budgetUsd > MAX_FRONTIER_BUDGET_USD) {
+    throw new Error(
+      `Frontier comparison requires --confirm-spend and a positive --budget-usd cap of at most $${MAX_FRONTIER_BUDGET_USD} before any remote request.`,
+    );
+  }
   const modelId = options.modelId ?? DEFAULT_FRONTIER_CLASSIFIER_MODEL;
   if (!MODEL_ID_PATTERN.test(modelId)) throw new Error("The frontier model id is invalid.");
+  if (modelId !== DEFAULT_FRONTIER_CLASSIFIER_MODEL) {
+    throw new Error(`Spend-safe frontier comparison currently supports only ${DEFAULT_FRONTIER_CLASSIFIER_MODEL}.`);
+  }
   const now = options.now ?? new Date();
   const comparisonId = `frontier-${randomUUID()}`;
   let verified: VerifiedRun | null = null;
   let artifactPath: string | null = null;
+  let budgetPreflight: BudgetPreflight | null = null;
   try {
     options.onEvent?.({
       type: "phase",
@@ -424,6 +541,24 @@ export async function compareClassifierWithFrontier(
     const chunks: HoldoutRow[][] = [];
     for (let start = 0; start < verified.rows.length; start += CHUNK_SIZE) {
       chunks.push(verified.rows.slice(start, start + CHUNK_SIZE));
+    }
+    const latencySamples = verified.rows.length <= LATENCY_SAMPLE_COUNT
+      ? verified.rows
+      : Array.from({ length: LATENCY_SAMPLE_COUNT }, (_, index) =>
+        verified!.rows[Math.floor(index * (verified!.rows.length - 1) / (LATENCY_SAMPLE_COUNT - 1))]!,
+      );
+    const spendPreflight = buildBudgetPreflight(
+      chunks,
+      latencySamples,
+      verified.labels,
+      modelId,
+      options.budgetUsd,
+    );
+    budgetPreflight = spendPreflight;
+    if (spendPreflight.estimated_max_cost_usd > options.budgetUsd) {
+      throw new Error(
+        `The conservative frontier estimate is ${formatUsdCap(spendPreflight.estimated_max_cost_usd)}, above the approved ${formatUsdCap(options.budgetUsd)} cap. No remote request was sent.`,
+      );
     }
     const auth = options.auth ?? resolveAuth();
     const fetchImpl = options.fetchImpl ?? fetch;
@@ -447,6 +582,7 @@ export async function compareClassifierWithFrontier(
           chunks[chunkIndex]!,
           verified!.labels,
           modelId,
+          QUALITY_MAX_COMPLETION_TOKENS,
           fetchImpl,
           auth,
           options.signal,
@@ -471,11 +607,6 @@ export async function compareClassifierWithFrontier(
       current: 0,
       total: Math.min(LATENCY_SAMPLE_COUNT, verified.rows.length),
     });
-    const latencySamples = verified.rows.length <= LATENCY_SAMPLE_COUNT
-      ? verified.rows
-      : Array.from({ length: LATENCY_SAMPLE_COUNT }, (_, index) =>
-        verified!.rows[Math.floor(index * (verified!.rows.length - 1) / (LATENCY_SAMPLE_COUNT - 1))]!,
-      );
     const latencyMs: number[] = [];
     const latencyResults: GatewayChunkResult[] = [];
     for (let index = 0; index < latencySamples.length; index += 1) {
@@ -484,6 +615,7 @@ export async function compareClassifierWithFrontier(
         [latencySamples[index]!],
         verified.labels,
         modelId,
+        LATENCY_MAX_COMPLETION_TOKENS,
         fetchImpl,
         auth,
         options.signal,
@@ -505,6 +637,8 @@ export async function compareClassifierWithFrontier(
       message: "Saving immutable local comparison evidence.",
     });
     const allResults = [...chunkResults, ...latencyResults];
+    const promptTokens = allResults.reduce((sum, row) => sum + row.promptTokens, 0);
+    const completionTokens = allResults.reduce((sum, row) => sum + row.completionTokens, 0);
     const result: FrontierClassificationResult = {
       schema_version: FRONTIER_CLASSIFICATION_SCHEMA,
       comparison_id: comparisonId,
@@ -520,7 +654,8 @@ export async function compareClassifierWithFrontier(
         user_confirmed_remote_comparison: true,
         training_examples_uploaded: false,
         holdout_examples_uploaded: true,
-        destination: "Understudy managed frontier model",
+        destination: "Understudy managed GLM 5.2 on Fireworks",
+        retention_expectation: "Fireworks-published zero data retention; Understudy comparison evidence excludes holdout text",
       },
       heldout: computeHeldout(
         verified.rows,
@@ -528,10 +663,20 @@ export async function compareClassifierWithFrontier(
         median(latencyMs),
       ),
       usage: {
-        prompt_tokens: allResults.reduce((sum, row) => sum + row.promptTokens, 0),
-        completion_tokens: allResults.reduce((sum, row) => sum + row.completionTokens, 0),
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
         request_count: allResults.length,
         request_ids: allResults.map((row) => row.requestId),
+      },
+      spend: {
+        user_confirmed_spend: true,
+        approved_budget_usd: spendPreflight.approved_budget_usd,
+        estimated_max_cost_usd: spendPreflight.estimated_max_cost_usd,
+        attributed_cost_usd: costUsd(promptTokens, completionTokens),
+        input_usd_per_million_tokens: FRONTIER_PRICING.inputUsdPerMillionTokens,
+        output_usd_per_million_tokens: FRONTIER_PRICING.outputUsdPerMillionTokens,
+        pricing_source: FRONTIER_PRICING.source,
+        pricing_checked_at: FRONTIER_PRICING.checkedAt,
       },
       gateway: {
         modes: [...new Set(allResults.flatMap((row) => row.mode ? [row.mode] : []))].sort(),
@@ -554,6 +699,7 @@ export async function compareClassifierWithFrontier(
         exact_same_holdout: true,
         holdout_sha256: verified.holdoutSha256,
         row_count: verified.rows.length,
+        spend_preflight: budgetPreflight,
         error: error instanceof Error ? error.message.slice(0, 800) : String(error).slice(0, 800),
         artifact_path: failurePath,
       });

--- a/src/local-classifier/frontier.ts
+++ b/src/local-classifier/frontier.ts
@@ -1,0 +1,564 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+import { assertCustomerScope, resolveAuth } from "../internal/http.js";
+
+export const FRONTIER_CLASSIFICATION_SCHEMA = "understudy.capture_import.frontier_classification.v1";
+export const FRONTIER_CLASSIFICATION_FAILURE_SCHEMA = "understudy.capture_import.frontier_classification_failure.v1";
+export const DEFAULT_FRONTIER_CLASSIFIER_MODEL = "glm-5.2";
+
+const RUN_SCHEMA = "understudy.capture_import.classification_run.v1";
+const MAX_HOLDOUT_BYTES = 16 * 1024 * 1024;
+const MAX_HOLDOUT_ROWS = 2_000;
+const MAX_TEXT_CHARACTERS = 4_000;
+const MAX_LABELS = 50;
+const CHUNK_SIZE = 40;
+const MAX_CONCURRENCY = 4;
+const REQUEST_TIMEOUT_MS = 90_000;
+const MAX_COMPLETION_TOKENS = 4_096;
+const LATENCY_SAMPLE_COUNT = 5;
+const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
+
+export type FrontierClassificationPhase = "preparing" | "comparing" | "measuring" | "saving";
+
+export type FrontierClassificationEvent = {
+  type: "phase";
+  phase: FrontierClassificationPhase;
+  message: string;
+  current?: number;
+  total?: number;
+};
+
+export type FrontierClassificationResult = {
+  schema_version: typeof FRONTIER_CLASSIFICATION_SCHEMA;
+  comparison_id: string;
+  generated_at: string;
+  status: "completed";
+  run_id: string;
+  requested_model: string;
+  served_model: string;
+  exact_same_holdout: true;
+  holdout_sha256: string;
+  row_count: number;
+  data_boundary: {
+    user_confirmed_remote_comparison: true;
+    training_examples_uploaded: false;
+    holdout_examples_uploaded: true;
+    destination: "Understudy managed frontier model";
+  };
+  heldout: {
+    accuracy: number;
+    macro_f1: number;
+    latency_ms_p50: number;
+    per_class: Array<{
+      label: string;
+      precision: number;
+      recall: number;
+      f1: number;
+      support: number;
+    }>;
+    weakest_classes: Array<{
+      label: string;
+      recall: number;
+      f1: number;
+      support: number;
+    }>;
+    failures: Array<{
+      example_id: string;
+      expected_label: string;
+      predicted_label: string;
+    }>;
+    failure_count: number;
+    failures_truncated: boolean;
+  };
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    request_count: number;
+    request_ids: Array<string | null>;
+  };
+  gateway: {
+    modes: string[];
+    routes: string[];
+  };
+  artifact_path: string;
+};
+
+export type CompareClassifierWithFrontierOptions = {
+  runManifestPath: string;
+  modelId?: string;
+  confirmRemote: boolean;
+  concurrency?: number;
+  auth?: ReturnType<typeof resolveAuth>;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  onEvent?: (event: FrontierClassificationEvent) => void;
+  now?: Date;
+};
+
+type HoldoutRow = {
+  example_id: string;
+  text: string;
+  label: string;
+};
+
+type VerifiedRun = {
+  runId: string;
+  runRoot: string;
+  holdoutPath: string;
+  holdoutSha256: string;
+  labels: string[];
+  rows: HoldoutRow[];
+};
+
+type Prediction = { example_id: string; label: string };
+
+type GatewayChunkResult = {
+  predictions: Prediction[];
+  promptTokens: number;
+  completionTokens: number;
+  requestId: string | null;
+  servedModel: string;
+  mode: string | null;
+  route: string | null;
+};
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function ensurePrivateDirectory(path: string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32") chmodSync(path, 0o700);
+}
+
+function writePrivateImmutable(path: string, value: unknown): void {
+  ensurePrivateDirectory(dirname(path));
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  if (process.platform !== "win32") chmodSync(path, 0o600);
+}
+
+function parseJsonObject(path: string): Record<string, unknown> {
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (!isRecord(parsed)) throw new Error(`Expected a JSON object: ${path}`);
+  return parsed;
+}
+
+function verifyRun(pathInput: string): VerifiedRun {
+  const manifestPath = resolve(pathInput);
+  if (!statSync(manifestPath).isFile()) {
+    throw new Error(`Completed classification run not found: ${manifestPath}`);
+  }
+  const run = parseJsonObject(manifestPath);
+  if (run.schema_version !== RUN_SCHEMA || run.status !== "completed" || run.local_only !== true ||
+      !isNonEmptyString(run.run_id)) {
+    throw new Error("Frontier comparison requires a completed local classification run.");
+  }
+  if (run.manifest_path !== manifestPath) {
+    throw new Error("The selected run manifest does not match its immutable recorded path.");
+  }
+  const dataset = run.dataset;
+  const model = run.model;
+  const heldout = run.heldout;
+  if (!isRecord(dataset) || !isRecord(dataset.splits) || !isRecord(dataset.splits.holdout) ||
+      !isRecord(model) || !Array.isArray(model.labels) || !isRecord(heldout)) {
+    throw new Error("The local run omitted immutable holdout or label evidence.");
+  }
+  const holdout = dataset.splits.holdout;
+  if (!isNonEmptyString(holdout.path) || !isNonEmptyString(holdout.sha256) ||
+      !Number.isInteger(holdout.row_count) || Number(holdout.row_count) <= 0 ||
+      Number(holdout.row_count) > MAX_HOLDOUT_ROWS) {
+    throw new Error(`Frontier comparison supports 1-${MAX_HOLDOUT_ROWS} held-out examples.`);
+  }
+  const labels = model.labels;
+  if (labels.length < 2 || labels.length > MAX_LABELS || !labels.every((label) =>
+    isNonEmptyString(label) && label.length <= 80,
+  )) {
+    throw new Error("The local run has invalid bounded labels.");
+  }
+  const holdoutPath = resolve(holdout.path);
+  const datasetManifestPath = isNonEmptyString(dataset.manifest_path) ? resolve(dataset.manifest_path) : null;
+  const holdoutRelativePath = datasetManifestPath
+    ? relative(dirname(datasetManifestPath), holdoutPath)
+    : "..";
+  if (!datasetManifestPath || holdoutRelativePath.startsWith("..") || isAbsolute(holdoutRelativePath) ||
+      !statSync(holdoutPath).isFile()) {
+    throw new Error("The held-out examples are outside the immutable prepared dataset.");
+  }
+  const raw = readFileSync(holdoutPath);
+  if (raw.length > MAX_HOLDOUT_BYTES) throw new Error("The held-out examples exceed the remote comparison limit.");
+  const actualSha256 = sha256(raw);
+  if (actualSha256 !== holdout.sha256) {
+    throw new Error("The held-out examples changed after local evaluation.");
+  }
+  const allowedLabels = new Set(labels);
+  const ids = new Set<string>();
+  const rows = raw.toString("utf8").split("\n").filter(Boolean).map((line, index) => {
+    const row = JSON.parse(line) as unknown;
+    if (!isRecord(row) || !isNonEmptyString(row.example_id) || row.example_id.length > 128 ||
+        !isNonEmptyString(row.text) || row.text.length > MAX_TEXT_CHARACTERS ||
+        !isNonEmptyString(row.label) || !allowedLabels.has(row.label)) {
+      throw new Error(`Held-out row ${index + 1} is invalid or exceeds the comparison limits.`);
+    }
+    if (ids.has(row.example_id)) throw new Error(`Held-out row ${index + 1} repeats an example id.`);
+    ids.add(row.example_id);
+    return { example_id: row.example_id, text: row.text, label: row.label };
+  });
+  if (rows.length !== holdout.row_count || rows.length !== heldout.row_count) {
+    throw new Error("The held-out row count does not match the local evaluation evidence.");
+  }
+  return {
+    runId: run.run_id,
+    runRoot: dirname(manifestPath),
+    holdoutPath,
+    holdoutSha256: actualSha256,
+    labels: [...labels],
+    rows,
+  };
+}
+
+function stripJsonFence(value: string): string {
+  return value
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim();
+}
+
+function usageCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function requestSignal(parent?: AbortSignal): { signal: AbortSignal; dispose: () => void } {
+  const controller = new AbortController();
+  const abort = () => controller.abort(parent?.reason);
+  if (parent?.aborted) abort();
+  else parent?.addEventListener("abort", abort, { once: true });
+  const timeout = setTimeout(() => controller.abort(new Error("frontier request timed out")), REQUEST_TIMEOUT_MS);
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timeout);
+      parent?.removeEventListener("abort", abort);
+    },
+  };
+}
+
+async function callGateway(
+  rows: HoldoutRow[],
+  labels: string[],
+  modelId: string,
+  fetchImpl: typeof fetch,
+  auth: ReturnType<typeof resolveAuth>,
+  signal?: AbortSignal,
+): Promise<GatewayChunkResult> {
+  const url = `${auth.gatewayUrl.replace(/\/+$/, "")}/v1/chat/completions`;
+  assertCustomerScope(url);
+  const scopedSignal = requestSignal(signal);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${auth.token}`,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify({
+        model: modelId,
+        stream: false,
+        temperature: 0,
+        max_tokens: MAX_COMPLETION_TOKENS,
+        chat_template_kwargs: { thinking: false, enable_thinking: false },
+        messages: [
+          {
+            role: "system",
+            content: `Classify every input into exactly one allowed label. Return only JSON: {"predictions":[{"example_id":"...","label":"..."}]}. Preserve every example_id exactly, return one prediction per input, and use only these labels: ${labels.join(", ")}.`,
+          },
+          {
+            role: "user",
+            content: JSON.stringify({
+              examples: rows.map(({ example_id, text }) => ({ example_id, text })),
+            }),
+          },
+        ],
+      }),
+      signal: scopedSignal.signal,
+    });
+    const body = await response.text();
+    if (!response.ok) {
+      throw new Error(`frontier gateway returned ${response.status}: ${body.slice(0, 400)}`);
+    }
+    const envelope = JSON.parse(body) as Record<string, unknown>;
+    const choices = Array.isArray(envelope.choices) ? envelope.choices : [];
+    const first = choices[0] as { message?: { content?: unknown } } | undefined;
+    const content = first?.message?.content;
+    const servedModel = response.headers.get("x-understudy-effective-model") ??
+      (typeof envelope.model === "string" ? envelope.model : null);
+    if (servedModel !== modelId) {
+      throw new Error(`requested ${modelId}, but the gateway served ${String(servedModel)}`);
+    }
+    if (typeof content !== "string" || content.length === 0) {
+      throw new Error("frontier model returned no classifications");
+    }
+    const parsed = JSON.parse(stripJsonFence(content)) as unknown;
+    if (!isRecord(parsed) || !Array.isArray(parsed.predictions) || parsed.predictions.length !== rows.length) {
+      throw new Error("frontier model returned the wrong prediction count");
+    }
+    const expectedIds = new Set(rows.map((row) => row.example_id));
+    const seen = new Set<string>();
+    const predictions = parsed.predictions.map((prediction, index) => {
+      if (!isRecord(prediction) || !isNonEmptyString(prediction.example_id) ||
+          !isNonEmptyString(prediction.label) || !expectedIds.has(prediction.example_id) ||
+          !labels.includes(prediction.label) || seen.has(prediction.example_id)) {
+        throw new Error(`frontier prediction ${index + 1} has an invalid id or label`);
+      }
+      seen.add(prediction.example_id);
+      return { example_id: prediction.example_id, label: prediction.label };
+    });
+    const usage = isRecord(envelope.usage) ? envelope.usage : {};
+    return {
+      predictions,
+      promptTokens: usageCount(usage.prompt_tokens ?? usage.input_tokens),
+      completionTokens: usageCount(usage.completion_tokens ?? usage.output_tokens),
+      requestId: response.headers.get("x-understudy-request-id"),
+      servedModel,
+      mode: response.headers.get("x-understudy-mode"),
+      route: response.headers.get("x-understudy-route"),
+    };
+  } finally {
+    scopedSignal.dispose();
+  }
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)]!;
+}
+
+function computeHeldout(rows: HoldoutRow[], predictions: Prediction[], latencyMsP50: number) {
+  const predictedById = new Map(predictions.map((prediction) => [prediction.example_id, prediction.label]));
+  const labels = [...new Set(rows.map((row) => row.label))].sort();
+  const counts = Object.fromEntries(labels.map((label) => [label, { support: 0, found: 0, predicted: 0 }]));
+  const failures: Array<{ example_id: string; expected_label: string; predicted_label: string }> = [];
+  let correct = 0;
+  for (const row of rows) {
+    const predicted = predictedById.get(row.example_id);
+    if (!predicted) throw new Error(`frontier result omitted ${row.example_id}`);
+    counts[row.label]!.support += 1;
+    counts[predicted]!.predicted += 1;
+    if (predicted === row.label) {
+      correct += 1;
+      counts[row.label]!.found += 1;
+    } else {
+      failures.push({
+        example_id: row.example_id,
+        expected_label: row.label,
+        predicted_label: predicted,
+      });
+    }
+  }
+  const perClass = labels.map((label) => {
+    const count = counts[label]!;
+    const precision = count.predicted > 0 ? count.found / count.predicted : 0;
+    const recall = count.support > 0 ? count.found / count.support : 0;
+    const f1 = precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0;
+    return { label, precision, recall, f1, support: count.support };
+  });
+  return {
+    accuracy: correct / rows.length,
+    macro_f1: perClass.reduce((sum, row) => sum + row.f1, 0) / perClass.length,
+    latency_ms_p50: latencyMsP50,
+    per_class: perClass,
+    weakest_classes: [...perClass]
+      .sort((left, right) => left.recall - right.recall || left.label.localeCompare(right.label))
+      .slice(0, 5)
+      .map(({ label, recall, f1, support }) => ({ label, recall, f1, support })),
+    failures: failures.slice(0, 25),
+    failure_count: failures.length,
+    failures_truncated: failures.length > 25,
+  };
+}
+
+export async function compareClassifierWithFrontier(
+  options: CompareClassifierWithFrontierOptions,
+): Promise<FrontierClassificationResult> {
+  if (!options.confirmRemote) {
+    throw new Error(
+      "Frontier comparison requires --confirm-remote after disclosing that held-out examples leave this Mac. Training examples remain local.",
+    );
+  }
+  const modelId = options.modelId ?? DEFAULT_FRONTIER_CLASSIFIER_MODEL;
+  if (!MODEL_ID_PATTERN.test(modelId)) throw new Error("The frontier model id is invalid.");
+  const now = options.now ?? new Date();
+  const comparisonId = `frontier-${randomUUID()}`;
+  let verified: VerifiedRun | null = null;
+  let artifactPath: string | null = null;
+  try {
+    options.onEvent?.({
+      type: "phase",
+      phase: "preparing",
+      message: "Verifying the exact held-out examples used for the local score.",
+    });
+    verified = verifyRun(options.runManifestPath);
+    const comparisonRoot = join(verified.runRoot, "frontier-comparisons", modelId.replaceAll("/", "__"));
+    artifactPath = join(comparisonRoot, `${comparisonId}.json`);
+    const chunks: HoldoutRow[][] = [];
+    for (let start = 0; start < verified.rows.length; start += CHUNK_SIZE) {
+      chunks.push(verified.rows.slice(start, start + CHUNK_SIZE));
+    }
+    const auth = options.auth ?? resolveAuth();
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const chunkResults = new Array<GatewayChunkResult>(chunks.length);
+    let nextChunk = 0;
+    let completedChunks = 0;
+    options.onEvent?.({
+      type: "phase",
+      phase: "comparing",
+      message: `Comparing ${verified.rows.length.toLocaleString()} held-out examples with ${modelId}.`,
+      current: 0,
+      total: chunks.length,
+    });
+    const worker = async () => {
+      while (true) {
+        if (options.signal?.aborted) throw new Error("Frontier comparison was cancelled.");
+        const chunkIndex = nextChunk;
+        nextChunk += 1;
+        if (chunkIndex >= chunks.length) return;
+        chunkResults[chunkIndex] = await callGateway(
+          chunks[chunkIndex]!,
+          verified!.labels,
+          modelId,
+          fetchImpl,
+          auth,
+          options.signal,
+        );
+        completedChunks += 1;
+        options.onEvent?.({
+          type: "phase",
+          phase: "comparing",
+          message: `Compared ${Math.min(completedChunks * CHUNK_SIZE, verified!.rows.length).toLocaleString()} of ${verified!.rows.length.toLocaleString()} held-out examples.`,
+          current: completedChunks,
+          total: chunks.length,
+        });
+      }
+    };
+    const concurrency = Math.max(1, Math.min(options.concurrency ?? MAX_CONCURRENCY, MAX_CONCURRENCY, chunks.length));
+    await Promise.all(Array.from({ length: concurrency }, () => worker()));
+
+    options.onEvent?.({
+      type: "phase",
+      phase: "measuring",
+      message: "Measuring real frontier response time on five held-out examples.",
+      current: 0,
+      total: Math.min(LATENCY_SAMPLE_COUNT, verified.rows.length),
+    });
+    const latencySamples = verified.rows.length <= LATENCY_SAMPLE_COUNT
+      ? verified.rows
+      : Array.from({ length: LATENCY_SAMPLE_COUNT }, (_, index) =>
+        verified!.rows[Math.floor(index * (verified!.rows.length - 1) / (LATENCY_SAMPLE_COUNT - 1))]!,
+      );
+    const latencyMs: number[] = [];
+    const latencyResults: GatewayChunkResult[] = [];
+    for (let index = 0; index < latencySamples.length; index += 1) {
+      const started = performance.now();
+      const result = await callGateway(
+        [latencySamples[index]!],
+        verified.labels,
+        modelId,
+        fetchImpl,
+        auth,
+        options.signal,
+      );
+      latencyMs.push(performance.now() - started);
+      latencyResults.push(result);
+      options.onEvent?.({
+        type: "phase",
+        phase: "measuring",
+        message: `Measured ${index + 1} of ${latencySamples.length} frontier responses.`,
+        current: index + 1,
+        total: latencySamples.length,
+      });
+    }
+
+    options.onEvent?.({
+      type: "phase",
+      phase: "saving",
+      message: "Saving immutable local comparison evidence.",
+    });
+    const allResults = [...chunkResults, ...latencyResults];
+    const result: FrontierClassificationResult = {
+      schema_version: FRONTIER_CLASSIFICATION_SCHEMA,
+      comparison_id: comparisonId,
+      generated_at: now.toISOString(),
+      status: "completed",
+      run_id: verified.runId,
+      requested_model: modelId,
+      served_model: modelId,
+      exact_same_holdout: true,
+      holdout_sha256: verified.holdoutSha256,
+      row_count: verified.rows.length,
+      data_boundary: {
+        user_confirmed_remote_comparison: true,
+        training_examples_uploaded: false,
+        holdout_examples_uploaded: true,
+        destination: "Understudy managed frontier model",
+      },
+      heldout: computeHeldout(
+        verified.rows,
+        chunkResults.flatMap((chunk) => chunk.predictions),
+        median(latencyMs),
+      ),
+      usage: {
+        prompt_tokens: allResults.reduce((sum, row) => sum + row.promptTokens, 0),
+        completion_tokens: allResults.reduce((sum, row) => sum + row.completionTokens, 0),
+        request_count: allResults.length,
+        request_ids: allResults.map((row) => row.requestId),
+      },
+      gateway: {
+        modes: [...new Set(allResults.flatMap((row) => row.mode ? [row.mode] : []))].sort(),
+        routes: [...new Set(allResults.flatMap((row) => row.route ? [row.route] : []))].sort(),
+      },
+      artifact_path: artifactPath,
+    };
+    writePrivateImmutable(artifactPath, result);
+    return result;
+  } catch (error) {
+    if (verified && artifactPath) {
+      const failurePath = artifactPath.replace(/\.json$/, ".failed.json");
+      writePrivateImmutable(failurePath, {
+        schema_version: FRONTIER_CLASSIFICATION_FAILURE_SCHEMA,
+        comparison_id: comparisonId,
+        generated_at: now.toISOString(),
+        status: "failed",
+        run_id: verified.runId,
+        requested_model: modelId,
+        exact_same_holdout: true,
+        holdout_sha256: verified.holdoutSha256,
+        row_count: verified.rows.length,
+        error: error instanceof Error ? error.message.slice(0, 800) : String(error).slice(0, 800),
+        artifact_path: failurePath,
+      });
+      throw new Error(`${error instanceof Error ? error.message : String(error)} Failure evidence: ${failurePath}`);
+    }
+    throw error;
+  }
+}

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -632,6 +632,10 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(training, /compare_local_classification_with_frontier/);
   assert.match(training, /Compare with GLM 5\.2 on the same/);
   assert.match(training, /Only held-out test examples are sent through Understudy/);
+  assert.match(training, /confirmSpend: true/);
+  assert.match(training, /budgetUsd: 1/);
+  assert.match(training, /Fireworks publishes zero data retention/);
+  assert.match(training, /Maximum approved spend: \$1\.00/);
   assert.match(training, /<EvaluationRadar/);
   assert.match(training, /baselineAccuracy=\{state\.result\.linear_baseline\.accuracy\}/);
   assert.match(training, /state\.result\.heldout\.macro_f1/);
@@ -650,6 +654,10 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.doesNotMatch(trainingState, /percentage|percent/);
   assert.match(bridge, /compare-classification-frontier/);
   assert.match(bridge, /"--confirm-remote"/);
+  assert.match(bridge, /"--confirm-spend"/);
+  assert.match(bridge, /"--budget-usd"/);
+  assert.match(bridge, /approved_budget_usd/);
+  assert.match(bridge, /attributed_cost_usd/);
   assert.match(bridge, /exact_same_holdout/);
   const radar = await readFile(evaluationRadarPath, "utf8");
   assert.match(radar, /Same held-out examples/);
@@ -660,6 +668,7 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(radar, /Fast response/);
   assert.match(radar, /Your local model/);
   assert.match(radar, /Cloud required/);
+  assert.match(radar, /this comparison/);
   assert.match(radar, /same examples/);
   assert.match(radar, /aria-label="Local and frontier comparison dimensions"/);
   assert.doesNotMatch(radar, />F1<|"F1"/);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -629,6 +629,9 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(css, /prefers-reduced-motion: reduce[\s\S]*?\.local-training-example-stream/);
   assert.match(training, /cancellationRequested\.current \|\| message\.toLowerCase\(\)\.includes\("cancel"\)/);
   assert.match(training, /predict_local_classification/);
+  assert.match(training, /compare_local_classification_with_frontier/);
+  assert.match(training, /Compare with GLM 5\.2 on the same/);
+  assert.match(training, /Only held-out test examples are sent through Understudy/);
   assert.match(training, /<EvaluationRadar/);
   assert.match(training, /baselineAccuracy=\{state\.result\.linear_baseline\.accuracy\}/);
   assert.match(training, /state\.result\.heldout\.macro_f1/);
@@ -645,15 +648,21 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(trainingState, /This dataset is too easy to show model value/);
   assert.match(trainingState, /Low confidence—review this prediction/);
   assert.doesNotMatch(trainingState, /percentage|percent/);
+  assert.match(bridge, /compare-classification-frontier/);
+  assert.match(bridge, /"--confirm-remote"/);
+  assert.match(bridge, /exact_same_holdout/);
   const radar = await readFile(evaluationRadarPath, "utf8");
-  assert.match(radar, /See the tradeoffs before you choose/);
+  assert.match(radar, /Same held-out examples/);
+  assert.match(radar, /Local model versus/);
   assert.match(radar, /Correct answers/);
   assert.match(radar, /Across categories/);
   assert.match(radar, /Hardest category/);
-  assert.match(radar, /Test confidence/);
-  assert.match(radar, /simple baseline/);
-  assert.match(radar, /repeat once before relying on it/);
-  assert.match(radar, /aria-label="Evaluation dimensions"/);
+  assert.match(radar, /Fast response/);
+  assert.match(radar, /Your local model/);
+  assert.match(radar, /Cloud required/);
+  assert.match(radar, /same examples/);
+  assert.match(radar, /aria-label="Local and frontier comparison dimensions"/);
+  assert.doesNotMatch(radar, />F1<|"F1"/);
   assert.equal(
     parity.features.find((feature) => feature.id === "drop-to-workload-compilation")?.status,
     "shipped",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -19,6 +19,10 @@ const trainingHaloPath = new URL(
   "../apps/homescreen/app/components/TrainingHalo.tsx",
   import.meta.url,
 );
+const evaluationRadarPath = new URL(
+  "../apps/homescreen/app/components/EvaluationRadar.tsx",
+  import.meta.url,
+);
 const csvTrainingPlanPath = new URL(
   "../apps/homescreen/app/components/CsvTrainingPlan.tsx",
   import.meta.url,
@@ -534,8 +538,8 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(chat, /<CsvTrainingPlan/);
   assert.match(trainingPlan, /Understand/);
   assert.match(trainingPlan, /Local ModernBERT/);
-  assert.match(trainingPlan, /Held-out macro-F1/);
-  assert.match(trainingPlan, /Compare with the TF-IDF baseline/);
+  assert.match(trainingPlan, /Works across every category/);
+  assert.match(trainingPlan, /Compare with a simple baseline on separate test examples/);
   assert.match(chat, /groupColumn: mappingGroupColumn/);
   assert.match(chat, /Choose a reference column/);
   assert.match(chat, /mappingLabelColumn && !mappingGroupColumn/);
@@ -625,12 +629,13 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(css, /prefers-reduced-motion: reduce[\s\S]*?\.local-training-example-stream/);
   assert.match(training, /cancellationRequested\.current \|\| message\.toLowerCase\(\)\.includes\("cancel"\)/);
   assert.match(training, /predict_local_classification/);
-  assert.match(training, /TF-IDF \{percent\(state\.result\.linear_baseline\.accuracy\)\}/);
+  assert.match(training, /<EvaluationRadar/);
+  assert.match(training, /baselineAccuracy=\{state\.result\.linear_baseline\.accuracy\}/);
   assert.match(training, /state\.result\.heldout\.macro_f1/);
   assert.match(training, /state\.result\.heldout\.latency_ms_p50/);
   assert.match(training, /state\.result\.model\.size_bytes/);
   assert.match(training, /Notable failures/);
-  assert.match(training, /Weakest categories/);
+  assert.match(training, /Hardest categories/);
   assert.match(training, /Try a new example/);
   assert.match(training, /window\.setInterval/);
   assert.doesNotMatch(training, /Math\.random/);
@@ -640,6 +645,15 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(trainingState, /This dataset is too easy to show model value/);
   assert.match(trainingState, /Low confidence—review this prediction/);
   assert.doesNotMatch(trainingState, /percentage|percent/);
+  const radar = await readFile(evaluationRadarPath, "utf8");
+  assert.match(radar, /See the tradeoffs before you choose/);
+  assert.match(radar, /Correct answers/);
+  assert.match(radar, /Across categories/);
+  assert.match(radar, /Hardest category/);
+  assert.match(radar, /Test confidence/);
+  assert.match(radar, /simple baseline/);
+  assert.match(radar, /repeat once before relying on it/);
+  assert.match(radar, /aria-label="Evaluation dimensions"/);
   assert.equal(
     parity.features.find((feature) => feature.id === "drop-to-workload-compilation")?.status,
     "shipped",

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -637,6 +637,7 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(training, /Fireworks publishes zero data retention/);
   assert.match(training, /Maximum approved spend: \$1\.00/);
   assert.match(training, /<EvaluationRadar/);
+  assert.match(training, /frontierComparison\.heldout\.weakest_classes\[0\] && state\.result\.heldout\.weakest_classes\[0\]/);
   assert.match(training, /baselineAccuracy=\{state\.result\.linear_baseline\.accuracy\}/);
   assert.match(training, /state\.result\.heldout\.macro_f1/);
   assert.match(training, /state\.result\.heldout\.latency_ms_p50/);

--- a/tests/local-classifier-frontier.test.mjs
+++ b/tests/local-classifier-frontier.test.mjs
@@ -114,10 +114,29 @@ describe("frontier classification comparison", () => {
       compareClassifierWithFrontier({
         runManifestPath: data.runManifestPath,
         confirmRemote: false,
+        confirmSpend: true,
+        budgetUsd: 1,
         auth: fakeAuth,
         fetchImpl,
       }),
       /requires --confirm-remote/,
+    );
+    assert.equal(requests.length, 0);
+  });
+
+  it("requires explicit spend consent and a positive hard budget before reading the run", async () => {
+    const data = fixture();
+    const { fetchImpl, requests } = frontierFetch();
+    await assert.rejects(
+      compareClassifierWithFrontier({
+        runManifestPath: data.runManifestPath,
+        confirmRemote: true,
+        confirmSpend: false,
+        budgetUsd: 1,
+        auth: fakeAuth,
+        fetchImpl,
+      }),
+      /requires --confirm-spend and a positive --budget-usd cap of at most \$100/,
     );
     assert.equal(requests.length, 0);
   });
@@ -138,6 +157,8 @@ describe("frontier classification comparison", () => {
       compareClassifierWithFrontier({
         runManifestPath: data.runManifestPath,
         confirmRemote: true,
+        confirmSpend: true,
+        budgetUsd: 1,
         auth: fakeAuth,
         fetchImpl,
       }),
@@ -153,6 +174,8 @@ describe("frontier classification comparison", () => {
     const result = await compareClassifierWithFrontier({
       runManifestPath: data.runManifestPath,
       confirmRemote: true,
+      confirmSpend: true,
+      budgetUsd: 1,
       auth: fakeAuth,
       fetchImpl,
       concurrency: 1,
@@ -172,6 +195,14 @@ describe("frontier classification comparison", () => {
     assert.equal(result.heldout.failures.length, 1);
     assert.equal(result.data_boundary.training_examples_uploaded, false);
     assert.equal(result.data_boundary.holdout_examples_uploaded, true);
+    assert.match(result.data_boundary.retention_expectation, /zero data retention/);
+    assert.equal(result.spend.user_confirmed_spend, true);
+    assert.equal(result.spend.approved_budget_usd, 1);
+    assert.ok(result.spend.estimated_max_cost_usd <= result.spend.approved_budget_usd);
+    assert.ok(result.spend.attributed_cost_usd > 0);
+    assert.equal(result.spend.input_usd_per_million_tokens, 1.4);
+    assert.equal(result.spend.output_usd_per_million_tokens, 4.4);
+    assert.equal(result.spend.pricing_checked_at, "2026-07-16");
     assert.equal(requests.length, 3, "one quality batch plus two real latency probes");
     assert.ok(requests.every((request) => request.model === "glm-5.2"));
     assert.ok(requests.every((request) => request.chat_template_kwargs.thinking === false));
@@ -182,6 +213,29 @@ describe("frontier classification comparison", () => {
     assert.deepEqual(JSON.parse(readFileSync(result.artifact_path, "utf8")), result);
   });
 
+  it("fails closed before fetch when the conservative estimate exceeds the approved cap", async () => {
+    const data = fixture();
+    const { fetchImpl, requests } = frontierFetch();
+    await assert.rejects(
+      compareClassifierWithFrontier({
+        runManifestPath: data.runManifestPath,
+        confirmRemote: true,
+        confirmSpend: true,
+        budgetUsd: 0.000001,
+        fetchImpl,
+      }),
+      /above the approved \$0\.000001 cap\. No remote request was sent/,
+    );
+    assert.equal(requests.length, 0);
+    const comparisonRoot = join(dirname(data.runManifestPath), "frontier-comparisons", "glm-5.2");
+    const failures = readdirSync(comparisonRoot).filter((name) => name.endsWith(".failed.json"));
+    assert.equal(failures.length, 1);
+    const failure = JSON.parse(readFileSync(join(comparisonRoot, failures[0]), "utf8"));
+    assert.equal(failure.status, "failed");
+    assert.equal(failure.spend_preflight.approved_budget_usd, 0.000001);
+    assert.ok(failure.spend_preflight.estimated_max_cost_usd > 0.000001);
+  });
+
   it("fails closed and persists terminal evidence when the gateway serves a different model", async () => {
     const data = fixture();
     const { fetchImpl } = frontierFetch({ servedModel: "not-glm" });
@@ -189,6 +243,8 @@ describe("frontier classification comparison", () => {
       compareClassifierWithFrontier({
         runManifestPath: data.runManifestPath,
         confirmRemote: true,
+        confirmSpend: true,
+        budgetUsd: 1,
         auth: fakeAuth,
         fetchImpl,
       }),

--- a/tests/local-classifier-frontier.test.mjs
+++ b/tests/local-classifier-frontier.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  compareClassifierWithFrontier,
+  FRONTIER_CLASSIFICATION_SCHEMA,
+} from "../dist/local-classifier/frontier.js";
+
+const roots = [];
+const fakeAuth = {
+  token: "sk_test",
+  mode: "api_key",
+  gatewayUrl: "https://api.understudylabs.com",
+  orgId: "org_test",
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "understudy-frontier-classifier-"));
+  roots.push(root);
+  const datasetRoot = join(root, "dataset");
+  const runRoot = join(root, "runs", "desktop-frontier-test");
+  mkdirSync(datasetRoot, { recursive: true });
+  mkdirSync(runRoot, { recursive: true });
+  const rows = [
+    {
+      schema_version: "understudy.classification_example.v2",
+      example_id: "example-ham",
+      group_id: "a".repeat(24),
+      text: "See you at lunch",
+      label: "ham",
+    },
+    {
+      schema_version: "understudy.classification_example.v2",
+      example_id: "example-spam",
+      group_id: "b".repeat(24),
+      text: "Claim your prize now",
+      label: "spam",
+    },
+  ];
+  const holdoutRaw = `${rows.map(JSON.stringify).join("\n")}\n`;
+  const holdoutPath = join(datasetRoot, "holdout.jsonl");
+  writeFileSync(holdoutPath, holdoutRaw);
+  const datasetManifestPath = join(datasetRoot, "dataset-manifest.json");
+  writeFileSync(datasetManifestPath, "{}\n");
+  const runManifestPath = join(runRoot, "run-manifest.json");
+  const runManifest = {
+    schema_version: "understudy.capture_import.classification_run.v1",
+    run_id: "desktop-frontier-test",
+    status: "completed",
+    local_only: true,
+    manifest_path: runManifestPath,
+    dataset: {
+      manifest_path: datasetManifestPath,
+      splits: {
+        holdout: {
+          path: holdoutPath,
+          row_count: rows.length,
+          sha256: sha256(holdoutRaw),
+        },
+      },
+    },
+    model: { labels: ["ham", "spam"] },
+    heldout: { row_count: rows.length },
+  };
+  writeFileSync(runManifestPath, `${JSON.stringify(runManifest, null, 2)}\n`);
+  return { root, rows, holdoutPath, runManifestPath };
+}
+
+function frontierFetch({ servedModel = "glm-5.2" } = {}) {
+  const requests = [];
+  const fetchImpl = async (_url, init) => {
+    const request = JSON.parse(init.body);
+    requests.push(request);
+    const examples = JSON.parse(request.messages[1].content).examples;
+    const predictions = examples.map((example) => ({
+      example_id: example.example_id,
+      label: example.example_id === "example-spam" ? "ham" : "ham",
+    }));
+    return new Response(JSON.stringify({
+      model: servedModel,
+      choices: [{ message: { content: `\`\`\`json\n${JSON.stringify({ predictions })}\n\`\`\`` } }],
+      usage: { prompt_tokens: 20, completion_tokens: 8 },
+    }), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        "x-understudy-effective-model": servedModel,
+        "x-understudy-mode": "managed",
+        "x-understudy-route": "primary",
+        "x-understudy-request-id": `request-${requests.length}`,
+      },
+    });
+  };
+  return { fetchImpl, requests };
+}
+
+describe("frontier classification comparison", () => {
+  it("requires explicit remote consent before reading or sending held-out examples", async () => {
+    const data = fixture();
+    const { fetchImpl, requests } = frontierFetch();
+    await assert.rejects(
+      compareClassifierWithFrontier({
+        runManifestPath: data.runManifestPath,
+        confirmRemote: false,
+        auth: fakeAuth,
+        fetchImpl,
+      }),
+      /requires --confirm-remote/,
+    );
+    assert.equal(requests.length, 0);
+  });
+
+  it("rejects a holdout outside the immutable prepared dataset even when the path shares its prefix", async () => {
+    const data = fixture();
+    const escapedRoot = join(data.root, "dataset-escaped");
+    mkdirSync(escapedRoot, { recursive: true });
+    const escapedHoldout = join(escapedRoot, "holdout.jsonl");
+    const holdoutRaw = readFileSync(data.holdoutPath);
+    writeFileSync(escapedHoldout, holdoutRaw);
+    const manifest = JSON.parse(readFileSync(data.runManifestPath, "utf8"));
+    manifest.dataset.splits.holdout.path = escapedHoldout;
+    writeFileSync(data.runManifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    const { fetchImpl, requests } = frontierFetch();
+
+    await assert.rejects(
+      compareClassifierWithFrontier({
+        runManifestPath: data.runManifestPath,
+        confirmRemote: true,
+        auth: fakeAuth,
+        fetchImpl,
+      }),
+      /outside the immutable prepared dataset/,
+    );
+    assert.equal(requests.length, 0);
+  });
+
+  it("scores the exact immutable holdout and records bounded comparison evidence", async () => {
+    const data = fixture();
+    const { fetchImpl, requests } = frontierFetch();
+    const events = [];
+    const result = await compareClassifierWithFrontier({
+      runManifestPath: data.runManifestPath,
+      confirmRemote: true,
+      auth: fakeAuth,
+      fetchImpl,
+      concurrency: 1,
+      onEvent: (event) => events.push(event),
+      now: new Date("2026-07-15T19:00:00.000Z"),
+    });
+
+    assert.equal(result.schema_version, FRONTIER_CLASSIFICATION_SCHEMA);
+    assert.equal(result.run_id, "desktop-frontier-test");
+    assert.equal(result.requested_model, "glm-5.2");
+    assert.equal(result.served_model, "glm-5.2");
+    assert.equal(result.exact_same_holdout, true);
+    assert.equal(result.holdout_sha256, sha256(readFileSync(data.holdoutPath)));
+    assert.equal(result.row_count, 2);
+    assert.equal(result.heldout.accuracy, 0.5);
+    assert.equal(result.heldout.failure_count, 1);
+    assert.equal(result.heldout.failures.length, 1);
+    assert.equal(result.data_boundary.training_examples_uploaded, false);
+    assert.equal(result.data_boundary.holdout_examples_uploaded, true);
+    assert.equal(requests.length, 3, "one quality batch plus two real latency probes");
+    assert.ok(requests.every((request) => request.model === "glm-5.2"));
+    assert.ok(requests.every((request) => request.chat_template_kwargs.thinking === false));
+    assert.ok(requests.every((request) => !JSON.stringify(request).includes("training-only-sentinel")));
+    assert.ok(events.some((event) => event.phase === "comparing"));
+    assert.ok(events.some((event) => event.phase === "measuring"));
+    assert.ok(existsSync(result.artifact_path));
+    assert.deepEqual(JSON.parse(readFileSync(result.artifact_path, "utf8")), result);
+  });
+
+  it("fails closed and persists terminal evidence when the gateway serves a different model", async () => {
+    const data = fixture();
+    const { fetchImpl } = frontierFetch({ servedModel: "not-glm" });
+    await assert.rejects(
+      compareClassifierWithFrontier({
+        runManifestPath: data.runManifestPath,
+        confirmRemote: true,
+        auth: fakeAuth,
+        fetchImpl,
+      }),
+      /requested glm-5\.2, but the gateway served not-glm/,
+    );
+    const comparisonRoot = join(dirname(data.runManifestPath), "frontier-comparisons", "glm-5.2");
+    const failures = readdirSync(comparisonRoot).filter((name) => name.endsWith(".failed.json"));
+    assert.equal(failures.length, 1);
+    const failure = JSON.parse(readFileSync(join(comparisonRoot, failures[0]), "utf8"));
+    assert.equal(failure.status, "failed");
+    assert.equal(failure.exact_same_holdout, true);
+    assert.equal(failure.holdout_sha256, sha256(readFileSync(data.holdoutPath)));
+  });
+});

--- a/tests/local-classifier-frontier.test.mjs
+++ b/tests/local-classifier-frontier.test.mjs
@@ -78,7 +78,7 @@ function fixture() {
   return { root, rows, holdoutPath, runManifestPath };
 }
 
-function frontierFetch({ servedModel = "glm-5.2" } = {}) {
+function frontierFetch({ servedModel = "glm-5.2", spamLabel = "ham" } = {}) {
   const requests = [];
   const fetchImpl = async (_url, init) => {
     const request = JSON.parse(init.body);
@@ -86,7 +86,7 @@ function frontierFetch({ servedModel = "glm-5.2" } = {}) {
     const examples = JSON.parse(request.messages[1].content).examples;
     const predictions = examples.map((example) => ({
       example_id: example.example_id,
-      label: example.example_id === "example-spam" ? "ham" : "ham",
+      label: example.example_id === "example-spam" ? spamLabel : "ham",
     }));
     return new Response(JSON.stringify({
       model: servedModel,
@@ -211,6 +211,36 @@ describe("frontier classification comparison", () => {
     assert.ok(events.some((event) => event.phase === "measuring"));
     assert.ok(existsSync(result.artifact_path));
     assert.deepEqual(JSON.parse(readFileSync(result.artifact_path, "utf8")), result);
+  });
+
+  it("scores a valid predicted category that has no correct answers in the holdout", async () => {
+    const data = fixture();
+    const manifest = JSON.parse(readFileSync(data.runManifestPath, "utf8"));
+    manifest.model.labels.push("other");
+    writeFileSync(data.runManifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    const { fetchImpl } = frontierFetch({ spamLabel: "other" });
+    const result = await compareClassifierWithFrontier({
+      runManifestPath: data.runManifestPath,
+      confirmRemote: true,
+      confirmSpend: true,
+      budgetUsd: 1,
+      auth: fakeAuth,
+      fetchImpl,
+      concurrency: 1,
+    });
+
+    assert.equal(result.heldout.accuracy, 0.5);
+    assert.equal(result.heldout.macro_f1, 1 / 3);
+    assert.equal(result.heldout.per_class.length, 3);
+    assert.deepEqual(
+      result.heldout.per_class.find((row) => row.label === "other"),
+      { label: "other", precision: 0, recall: 0, f1: 0, support: 0 },
+    );
+    assert.deepEqual(result.heldout.failures[0], {
+      example_id: "example-spam",
+      expected_label: "spam",
+      predicted_label: "other",
+    });
   });
 
   it("fails closed before fetch when the conservative estimate exceeds the approved cap", async () => {

--- a/tests/workload-drop-state.test.mjs
+++ b/tests/workload-drop-state.test.mjs
@@ -193,7 +193,7 @@ test("one-run verdict copy is cautious and flags saturated datasets", () => {
   }), {
     tone: "caution",
     title: "Improved, not ready",
-    detail: "Weak classes remain.",
+    detail: "It beat the simple baseline, but it still misses too many examples in at least one category.",
   });
   assert.equal(localTrainingVerdict({
     linear_baseline: { accuracy: 1, macro_f1: 1 },


### PR DESCRIPTION
Adds a human-readable evaluation radar comparing the local classifier, a basic text baseline, and GLM 5.2 on the exact same immutable holdout. The remote comparison is explicit, sends no training examples, verifies the served model, records immutable evidence, and fails closed behind a conservative approved spend cap.\n\nValidation: npm run check; Next production build; cargo test (176 passing); focused frontier consent, budget, evidence, and UI lineage tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->