### PR TITLE
feat(desktop): add durable local classifier run registry

### DIFF
--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -337,6 +337,8 @@ pub fn run() {
             workload_drop::cancel_local_classification_training,
             workload_drop::compare_local_classification_with_frontier,
             workload_drop::predict_local_classification,
+            workload_drop::list_local_classification_runs,
+            workload_drop::update_local_classification_run,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -92,7 +92,8 @@ fn validate_classification_run_summary(value: &Value) -> Result<(), String> {
         .get("display_name")
         .and_then(Value::as_str)
         .unwrap()
-        .len()
+        .chars()
+        .count()
         > 80
     {
         return Err("The local classifier registry returned an invalid display name.".into());
@@ -1786,6 +1787,12 @@ mod tests {
         assert!(validate_classification_run_summary(&incomplete)
             .unwrap_err()
             .contains("omitted its local model"));
+
+        let mut unicode = active.clone();
+        unicode["display_name"] = json!("🧠".repeat(80));
+        assert!(validate_classification_run_summary(&unicode).is_ok());
+        unicode["display_name"] = json!("🧠".repeat(81));
+        assert!(validate_classification_run_summary(&unicode).is_err());
 
         let mut archived = active;
         archived["archived_at"] = json!("2026-07-16T13:00:00.000Z");

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -59,6 +59,158 @@ fn training_cancellations() -> &'static Mutex<HashMap<String, Arc<AtomicBool>>> 
     TRAINING_CANCELLATIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn validate_classification_run_summary(value: &Value) -> Result<(), String> {
+    if value.get("schema_version").and_then(Value::as_str)
+        != Some("understudy.local_classifier.registry.v1")
+        || value.get("kind").and_then(Value::as_str) != Some("classifier")
+        || value.get("local_only").and_then(Value::as_bool) != Some(true)
+        || !matches!(
+            value.get("run_status").and_then(Value::as_str),
+            Some("completed" | "failed" | "cancelled")
+        )
+    {
+        return Err("The local classifier registry returned an invalid run summary.".into());
+    }
+    for field in [
+        "model_id",
+        "run_id",
+        "display_name",
+        "generated_at",
+        "updated_at",
+        "manifest_path",
+    ] {
+        let Some(text) = value.get(field).and_then(Value::as_str) else {
+            return Err(format!("The local classifier registry omitted {field}."));
+        };
+        if text.trim().is_empty() || text.len() > 4_096 {
+            return Err(format!(
+                "The local classifier registry returned an invalid {field}."
+            ));
+        }
+    }
+    if value
+        .get("display_name")
+        .and_then(Value::as_str)
+        .unwrap()
+        .len()
+        > 80
+    {
+        return Err("The local classifier registry returned an invalid display name.".into());
+    }
+    if !matches!(
+        value.get("archived_at"),
+        Some(Value::Null | Value::String(_))
+    ) {
+        return Err("The local classifier registry returned invalid archive state.".into());
+    }
+    let status = value
+        .get("run_status")
+        .and_then(Value::as_str)
+        .expect("run status was validated above");
+    if status == "completed" {
+        let model = value
+            .get("model")
+            .and_then(Value::as_object)
+            .ok_or_else(|| "The completed classifier omitted its local model.".to_string())?;
+        if model
+            .get("requested_id")
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty() && text.len() <= 4_096)
+            .is_none()
+            || model
+                .get("resolved_id")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty() && text.len() <= 4_096)
+                .is_none()
+            || model
+                .get("path")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty() && text.len() <= 4_096)
+                .is_none()
+            || model.get("size_bytes").and_then(Value::as_u64).is_none()
+            || model
+                .get("label_count")
+                .and_then(Value::as_u64)
+                .filter(|count| (2..=100_000).contains(count))
+                .is_none()
+            || model.get("available").and_then(Value::as_bool).is_none()
+        {
+            return Err("The completed classifier returned invalid model evidence.".into());
+        }
+        let evaluation = value
+            .get("evaluation")
+            .and_then(Value::as_object)
+            .ok_or_else(|| "The completed classifier omitted its evaluation.".to_string())?;
+        let row_count = evaluation
+            .get("row_count")
+            .and_then(Value::as_u64)
+            .filter(|count| *count > 0)
+            .ok_or_else(|| {
+                "The completed classifier returned an invalid holdout size.".to_string()
+            })?;
+        for field in ["accuracy", "macro_f1"] {
+            let score = evaluation
+                .get(field)
+                .and_then(Value::as_f64)
+                .filter(|score| score.is_finite() && (0.0..=1.0).contains(score));
+            if score.is_none() {
+                return Err(format!(
+                    "The completed classifier returned an invalid {field}."
+                ));
+            }
+        }
+        if evaluation
+            .get("latency_ms_p50")
+            .and_then(Value::as_f64)
+            .filter(|latency| latency.is_finite() && *latency >= 0.0)
+            .is_none()
+            || evaluation
+                .get("failure_count")
+                .and_then(Value::as_u64)
+                .filter(|count| *count <= row_count)
+                .is_none()
+            || evaluation
+                .get("verdict")
+                .and_then(Value::as_str)
+                .filter(|verdict| {
+                    matches!(*verdict, "not_better" | "improved_not_ready" | "promising")
+                })
+                .is_none()
+            || !value.get("failure").is_some_and(Value::is_null)
+        {
+            return Err("The completed classifier returned invalid evaluation evidence.".into());
+        }
+    } else if !value.get("model").is_some_and(Value::is_null)
+        || !value.get("evaluation").is_some_and(Value::is_null)
+        || value
+            .get("failure")
+            .and_then(Value::as_object)
+            .and_then(|failure| failure.get("code"))
+            .and_then(Value::as_str)
+            .filter(|code| !code.is_empty() && code.len() <= 4_096)
+            .is_none()
+    {
+        return Err("The terminal classifier returned contradictory evidence.".into());
+    }
+    Ok(())
+}
+
+fn validate_classification_run_list(value: Value, archived: bool) -> Result<Value, String> {
+    let runs = value
+        .as_array()
+        .ok_or_else(|| "The local classifier registry returned malformed JSON.".to_string())?;
+    if runs.len() > 1_000 {
+        return Err("The local classifier registry exceeded its bounded result limit.".into());
+    }
+    for run in runs {
+        validate_classification_run_summary(run)?;
+        if run.get("archived_at").is_some_and(Value::is_string) != archived {
+            return Err("The local classifier registry mixed active and archived runs.".into());
+        }
+    }
+    Ok(value)
+}
+
 fn validate_compile_result(value: Value) -> Result<Value, String> {
     if !value.is_object() {
         return Err("The Understudy CLI returned an invalid workload result.".into());
@@ -1378,6 +1530,123 @@ pub async fn predict_local_classification(
         .map_err(|error| format!("The local classifier stopped unexpectedly: {error}"))?
 }
 
+fn list_classification_runs(archived: bool, limit: u64) -> Result<Value, String> {
+    if !(1..=1_000).contains(&limit) {
+        return Err("Local classifier run limit must be between 1 and 1,000.".into());
+    }
+    let mut command = crate::bin::command("understudy");
+    command.args(["capture-import", "list-classification-runs", "--limit"]);
+    command.arg(limit.to_string());
+    if archived {
+        command.arg("--archived");
+    }
+    let output = command.arg("--json").output().map_err(|error| {
+        format!(
+            "Could not read the local classifier registry ({error}). Open Status to repair the CLI."
+        )
+    })?;
+    if !output.status.success() {
+        return Err(format!(
+            "The Understudy CLI could not read local classifiers. {}",
+            bounded_detail(&output.stderr)
+        ));
+    }
+    let value = serde_json::from_slice::<Value>(&output.stdout).map_err(|_| {
+        "The Understudy CLI returned malformed classifier registry JSON.".to_string()
+    })?;
+    validate_classification_run_list(value, archived)
+}
+
+#[tauri::command]
+pub async fn list_local_classification_runs(
+    archived: Option<bool>,
+    limit: Option<u64>,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        list_classification_runs(archived.unwrap_or(false), limit.unwrap_or(100))
+    })
+    .await
+    .map_err(|error| format!("The local classifier registry stopped unexpectedly: {error}"))?
+}
+
+fn update_classification_run(
+    run_manifest_path: String,
+    display_name: Option<String>,
+    archived: Option<bool>,
+) -> Result<Value, String> {
+    let canonical = PathBuf::from(run_manifest_path.trim())
+        .canonicalize()
+        .map_err(|error| format!("The local classifier run is unavailable: {error}"))?;
+    if !canonical.is_file()
+        || canonical.file_name().and_then(|name| name.to_str()) != Some("run-manifest.json")
+    {
+        return Err("Choose a local classifier run manifest.".into());
+    }
+    if display_name.is_none() && archived.is_none() {
+        return Err("Choose a new name, archive state, or both.".into());
+    }
+    let mut command = crate::bin::command("understudy");
+    command
+        .args(["capture-import", "classification-run", "--run-manifest"])
+        .arg(&canonical);
+    if let Some(name) = display_name {
+        let name = name.trim();
+        if name.is_empty() || name.chars().count() > 80 || name.chars().any(char::is_control) {
+            return Err(
+                "Classifier display name must contain 1 to 80 printable characters.".into(),
+            );
+        }
+        command.arg("--name").arg(name);
+    }
+    if let Some(archived) = archived {
+        command.arg(if archived { "--archive" } else { "--restore" });
+    }
+    let output = command.arg("--json").output().map_err(|error| {
+        format!(
+            "Could not update the local classifier registry ({error}). Open Status to repair the CLI."
+        )
+    })?;
+    if !output.status.success() {
+        return Err(format!(
+            "The Understudy CLI could not update this classifier. {}",
+            bounded_detail(&output.stderr)
+        ));
+    }
+    let value = serde_json::from_slice::<Value>(&output.stdout).map_err(|_| {
+        "The Understudy CLI returned malformed classifier registry JSON.".to_string()
+    })?;
+    validate_classification_run_summary(&value)?;
+    let returned_manifest = value
+        .get("manifest_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "The local classifier registry omitted its manifest path.".to_string())?;
+    let returned_manifest = PathBuf::from(returned_manifest)
+        .canonicalize()
+        .map_err(|_| "The local classifier registry returned an unavailable run.".to_string())?;
+    if returned_manifest != canonical {
+        return Err("The local classifier registry updated a different run.".into());
+    }
+    if value.get("archived_at").is_some_and(Value::is_string) != archived.unwrap_or(false)
+        && archived.is_some()
+    {
+        return Err("The local classifier registry returned the wrong archive state.".into());
+    }
+    Ok(value)
+}
+
+#[tauri::command]
+pub async fn update_local_classification_run(
+    run_manifest_path: String,
+    display_name: Option<String>,
+    archived: Option<bool>,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        update_classification_run(run_manifest_path, display_name, archived)
+    })
+    .await
+    .map_err(|error| format!("The local classifier registry stopped unexpectedly: {error}"))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1468,6 +1737,62 @@ mod tests {
         assert!(validate_compile_result(unsafe_result)
             .unwrap_err()
             .contains("metadata-only"));
+    }
+
+    #[test]
+    fn accepts_only_bounded_local_classifier_registry_summaries() {
+        let active = json!({
+            "schema_version": "understudy.local_classifier.registry.v1",
+            "model_id": "classifier.desktop-run-123",
+            "kind": "classifier",
+            "run_id": "desktop-run-123",
+            "display_name": "Spam detector",
+            "run_status": "completed",
+            "archived_at": null,
+            "generated_at": "2026-07-16T12:00:00.000Z",
+            "updated_at": "2026-07-16T12:00:00.000Z",
+            "local_only": true,
+            "manifest_path": "/tmp/run-manifest.json",
+            "model": {
+                "requested_id": "answerdotai/ModernBERT-base",
+                "resolved_id": "answerdotai/ModernBERT-base",
+                "path": "/tmp/model",
+                "size_bytes": 123,
+                "label_count": 2,
+                "available": true
+            },
+            "evaluation": {
+                "row_count": 20,
+                "accuracy": 0.9,
+                "macro_f1": 0.875,
+                "latency_ms_p50": 12.5,
+                "failure_count": 2,
+                "verdict": "promising"
+            },
+            "timing_ms": 1000,
+            "failure": null
+        });
+        assert!(validate_classification_run_summary(&active).is_ok());
+        assert!(validate_classification_run_list(json!([active.clone()]), false).is_ok());
+
+        let mut remote = active.clone();
+        remote["local_only"] = json!(false);
+        assert!(validate_classification_run_summary(&remote)
+            .unwrap_err()
+            .contains("invalid run summary"));
+
+        let mut incomplete = active.clone();
+        incomplete["model"] = Value::Null;
+        assert!(validate_classification_run_summary(&incomplete)
+            .unwrap_err()
+            .contains("omitted its local model"));
+
+        let mut archived = active;
+        archived["archived_at"] = json!("2026-07-16T13:00:00.000Z");
+        assert!(validate_classification_run_list(json!([archived.clone()]), true).is_ok());
+        assert!(validate_classification_run_list(json!([archived]), false)
+            .unwrap_err()
+            .contains("mixed active and archived"));
     }
 
     #[test]

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ import {
   startLocalClassifierTraining,
 } from "./local-classifier/index.js";
 import {
+  getLocalClassifierRun,
+  listLocalClassifierRuns,
+  updateLocalClassifierRun,
+} from "./local-classifier/registry.js";
+import {
   compareClassifierWithFrontier,
   DEFAULT_FRONTIER_CLASSIFIER_BUDGET_USD,
   DEFAULT_FRONTIER_CLASSIFIER_MODEL,
@@ -509,6 +514,67 @@ function registerCaptureImportCommands(program: Command): void {
       console.log(`prediction: ${prediction.label}`);
       console.log(`confidence: ${(prediction.scores[0]?.score ?? 0).toFixed(4)}`);
       console.log("local_only: true (input text was not retained)");
+    });
+
+  captureImport
+    .command("list-classification-runs")
+    .description("List durable local classifier runs without reading training examples")
+    .option("--capture-root <path>", "Private capture-import root; defaults under ~/.understudy")
+    .option("--archived", "List archived runs instead of active runs")
+    .option("--limit <count>", "Maximum runs to return", parsePositiveInteger, 100)
+    .option("--json", "Output JSON")
+    .action((options: { captureRoot?: string; archived?: boolean; limit: number; json?: boolean }) => {
+      const runs = listLocalClassifierRuns({
+        captureRoot: options.captureRoot,
+        archived: Boolean(options.archived),
+        limit: options.limit,
+      });
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(runs, null, 2));
+        return;
+      }
+      if (runs.length === 0) {
+        console.log(options.archived ? "No archived local classifiers." : "No local classifiers yet.");
+        return;
+      }
+      for (const run of runs) {
+        const accuracy = run.evaluation ? `${(run.evaluation.accuracy * 100).toFixed(1)}% correct` : run.run_status;
+        console.log(`${run.display_name}\t${accuracy}\t${run.manifest_path}`);
+      }
+    });
+
+  captureImport
+    .command("classification-run")
+    .description("Read or update rename/archive metadata for one immutable local classifier run")
+    .requiredOption("--run-manifest <path>", "Local classification run manifest")
+    .option("--name <name>", "Human-readable local display name")
+    .option("--archive", "Hide this run from the active model list")
+    .option("--restore", "Return this run to the active model list")
+    .option("--json", "Output JSON")
+    .action((options: {
+      runManifest: string;
+      name?: string;
+      archive?: boolean;
+      restore?: boolean;
+      json?: boolean;
+    }) => {
+      if (options.archive && options.restore) {
+        throw new Error("Choose either --archive or --restore, not both.");
+      }
+      const changed = options.name !== undefined || options.archive || options.restore;
+      const run = changed
+        ? updateLocalClassifierRun({
+          runManifestPath: options.runManifest,
+          displayName: options.name,
+          archived: options.archive ? true : options.restore ? false : undefined,
+        })
+        : getLocalClassifierRun(options.runManifest);
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(run, null, 2));
+        return;
+      }
+      console.log(`${run.display_name}: ${run.run_status}${run.archived_at ? " (archived)" : ""}`);
+      console.log(`manifest: ${run.manifest_path}`);
     });
 
   captureImport

--- a/src/local-classifier/registry.ts
+++ b/src/local-classifier/registry.ts
@@ -17,7 +17,9 @@ const REGISTRY_SCHEMA = "understudy.local_classifier.registry.v1";
 const LIFECYCLE_SCHEMA = "understudy.local_classifier.lifecycle.v1";
 const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const MAX_CAPTURE_ROOTS = 2_000;
-const MAX_RUNS_PER_CAPTURE = 2_000;
+const MAX_DATASETS_PER_CAPTURE = 2_000;
+const MAX_RUNS_PER_DATASET = 2_000;
+const MAX_SCANNED_RUNS = 10_000;
 const COMPLETED_VERDICTS = new Set(["not_better", "improved_not_ready", "promising"]);
 
 type RunStatus = "completed" | "failed" | "cancelled";
@@ -114,6 +116,10 @@ function isFiniteNonNegative(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
+function characterCount(value: string): number {
+  return Array.from(value).length;
+}
+
 function isSafeNonNegativeInteger(value: unknown): value is number {
   return Number.isSafeInteger(value) && Number(value) >= 0;
 }
@@ -165,7 +171,7 @@ function readLifecycle(manifestPath: string, runId: string, generatedAt: string)
   }
   const value = parseJson(path);
   if (!isRecord(value) || value.schema_version !== LIFECYCLE_SCHEMA || value.run_id !== runId ||
-      !isNonEmptyString(value.display_name) || value.display_name.length > 80 ||
+      !isNonEmptyString(value.display_name) || characterCount(value.display_name) > 80 ||
       !(value.archived_at === null || (isNonEmptyString(value.archived_at) && !Number.isNaN(Date.parse(value.archived_at)))) ||
       !isNonEmptyString(value.updated_at) || Number.isNaN(Date.parse(value.updated_at))) {
     throw new Error(`The lifecycle record for ${runId} is malformed.`);
@@ -264,17 +270,23 @@ export function listLocalClassifierRuns(
     throw new Error("Classification run list limit must be between 1 and 1,000.");
   }
   const runs: LocalClassifierRunSummary[] = [];
-  for (const capturePath of childDirectories(captureRoot, MAX_CAPTURE_ROOTS)) {
-    const trainingRoot = join(capturePath, "training-runs");
-    for (const runPath of childDirectories(trainingRoot, MAX_RUNS_PER_CAPTURE)) {
-      const manifestPath = join(runPath, "run-manifest.json");
-      if (!existsSync(manifestPath) || !statSync(manifestPath).isFile()) continue;
-      try {
-        const item = summary(manifestPath);
-        if (Boolean(item.archived_at) === Boolean(options.archived)) runs.push(item);
-      } catch {
-        // Registry discovery is resilient to an unrelated corrupt or partial
-        // directory. Opening a specific run still fails closed with the exact error.
+  let scannedRuns = 0;
+  captures: for (const capturePath of childDirectories(captureRoot, MAX_CAPTURE_ROOTS)) {
+    const classificationRoot = join(capturePath, "classification");
+    for (const datasetPath of childDirectories(classificationRoot, MAX_DATASETS_PER_CAPTURE)) {
+      const trainingRoot = join(datasetPath, "training-runs");
+      for (const runPath of childDirectories(trainingRoot, MAX_RUNS_PER_DATASET)) {
+        scannedRuns += 1;
+        if (scannedRuns > MAX_SCANNED_RUNS) break captures;
+        const manifestPath = join(runPath, "run-manifest.json");
+        if (!existsSync(manifestPath) || !statSync(manifestPath).isFile()) continue;
+        try {
+          const item = summary(manifestPath);
+          if (Boolean(item.archived_at) === Boolean(options.archived)) runs.push(item);
+        } catch {
+          // Registry discovery is resilient to an unrelated corrupt or partial
+          // directory. Opening a specific run still fails closed with the exact error.
+        }
       }
     }
   }
@@ -304,7 +316,7 @@ export function updateLocalClassifierRun(
   let displayName = current.display_name;
   if (options.displayName !== undefined) {
     displayName = options.displayName.trim();
-    if (displayName.length < 1 || displayName.length > 80 || /[\u0000-\u001f\u007f]/.test(displayName)) {
+    if (characterCount(displayName) < 1 || characterCount(displayName) > 80 || /[\u0000-\u001f\u007f]/.test(displayName)) {
       throw new Error("Classifier display name must contain 1 to 80 printable characters.");
     }
   }

--- a/src/local-classifier/registry.ts
+++ b/src/local-classifier/registry.ts
@@ -1,0 +1,328 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { globalConfigDir } from "../config/paths.js";
+
+const RUN_SCHEMA = "understudy.capture_import.classification_run.v1";
+const REGISTRY_SCHEMA = "understudy.local_classifier.registry.v1";
+const LIFECYCLE_SCHEMA = "understudy.local_classifier.lifecycle.v1";
+const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const MAX_CAPTURE_ROOTS = 2_000;
+const MAX_RUNS_PER_CAPTURE = 2_000;
+const COMPLETED_VERDICTS = new Set(["not_better", "improved_not_ready", "promising"]);
+
+type RunStatus = "completed" | "failed" | "cancelled";
+
+type RunManifest = {
+  schema_version?: unknown;
+  run_id?: unknown;
+  generated_at?: unknown;
+  status?: unknown;
+  local_only?: unknown;
+  data_boundary?: { dataset_uploaded?: unknown; telemetry_sent?: unknown };
+  model?: {
+    requested_id?: unknown;
+    resolved_id?: unknown;
+    path?: unknown;
+    size_bytes?: unknown;
+    labels?: unknown;
+  } | null;
+  heldout?: {
+    row_count?: unknown;
+    accuracy?: unknown;
+    macro_f1?: unknown;
+    latency_ms_p50?: unknown;
+    failure_count?: unknown;
+  } | null;
+  verdict?: { status?: unknown } | null;
+  timings_ms?: { total?: unknown };
+  manifest_path?: unknown;
+  error?: { code?: unknown; message?: unknown };
+};
+
+type LifecycleRecord = {
+  schema_version: typeof LIFECYCLE_SCHEMA;
+  run_id: string;
+  display_name: string;
+  archived_at: string | null;
+  updated_at: string;
+};
+
+export type LocalClassifierRunSummary = {
+  schema_version: typeof REGISTRY_SCHEMA;
+  model_id: string;
+  kind: "classifier";
+  run_id: string;
+  display_name: string;
+  run_status: RunStatus;
+  archived_at: string | null;
+  generated_at: string;
+  updated_at: string;
+  local_only: true;
+  manifest_path: string;
+  model: null | {
+    requested_id: string;
+    resolved_id: string;
+    path: string;
+    size_bytes: number;
+    label_count: number;
+    available: boolean;
+  };
+  evaluation: null | {
+    row_count: number;
+    accuracy: number;
+    macro_f1: number;
+    latency_ms_p50: number;
+    failure_count: number;
+    verdict: string;
+  };
+  timing_ms: number | null;
+  failure: null | { code: string; message: string };
+};
+
+export type ListLocalClassifierRunsOptions = {
+  captureRoot?: string;
+  archived?: boolean;
+  limit?: number;
+};
+
+export type UpdateLocalClassifierRunOptions = {
+  runManifestPath: string;
+  displayName?: string;
+  archived?: boolean;
+  now?: Date;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isSafeNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function isMetric(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+function parseJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+function defaultCaptureRoot(): string {
+  return join(globalConfigDir(), "capture-imports");
+}
+
+function lifecyclePath(manifestPath: string): string {
+  return join(dirname(manifestPath), "lifecycle.json");
+}
+
+function validateManifest(path: string): { manifest: RunManifest; runId: string; status: RunStatus } {
+  const canonicalPath = resolve(path);
+  const value = parseJson(canonicalPath);
+  if (!isRecord(value)) throw new Error("The local classifier run manifest is malformed.");
+  const manifest = value as RunManifest;
+  if (manifest.schema_version !== RUN_SCHEMA || manifest.local_only !== true ||
+      manifest.data_boundary?.dataset_uploaded !== false || manifest.data_boundary.telemetry_sent !== false ||
+      !isNonEmptyString(manifest.run_id) || !RUN_ID_PATTERN.test(manifest.run_id) ||
+      !["completed", "failed", "cancelled"].includes(String(manifest.status)) ||
+      resolve(String(manifest.manifest_path)) !== canonicalPath) {
+    throw new Error("The local classifier run manifest failed its local evidence contract.");
+  }
+  if (!isNonEmptyString(manifest.generated_at) || Number.isNaN(Date.parse(manifest.generated_at))) {
+    throw new Error("The local classifier run manifest omitted its creation time.");
+  }
+  return { manifest, runId: manifest.run_id, status: manifest.status as RunStatus };
+}
+
+function readLifecycle(manifestPath: string, runId: string, generatedAt: string): LifecycleRecord {
+  const path = lifecyclePath(manifestPath);
+  if (!existsSync(path)) {
+    return {
+      schema_version: LIFECYCLE_SCHEMA,
+      run_id: runId,
+      display_name: runId,
+      archived_at: null,
+      updated_at: generatedAt,
+    };
+  }
+  const value = parseJson(path);
+  if (!isRecord(value) || value.schema_version !== LIFECYCLE_SCHEMA || value.run_id !== runId ||
+      !isNonEmptyString(value.display_name) || value.display_name.length > 80 ||
+      !(value.archived_at === null || (isNonEmptyString(value.archived_at) && !Number.isNaN(Date.parse(value.archived_at)))) ||
+      !isNonEmptyString(value.updated_at) || Number.isNaN(Date.parse(value.updated_at))) {
+    throw new Error(`The lifecycle record for ${runId} is malformed.`);
+  }
+  return value as LifecycleRecord;
+}
+
+function summary(path: string): LocalClassifierRunSummary {
+  const { manifest, runId, status } = validateManifest(path);
+  const generatedAt = String(manifest.generated_at);
+  const lifecycle = readLifecycle(path, runId, generatedAt);
+  let model: LocalClassifierRunSummary["model"] = null;
+  if (manifest.model !== null && isRecord(manifest.model) &&
+      isNonEmptyString(manifest.model.requested_id) && isNonEmptyString(manifest.model.resolved_id) &&
+      isNonEmptyString(manifest.model.path) && isSafeNonNegativeInteger(manifest.model.size_bytes) &&
+      resolve(manifest.model.path) === join(dirname(resolve(path)), "model") &&
+      Array.isArray(manifest.model.labels) && manifest.model.labels.length >= 2 &&
+      manifest.model.labels.every(isNonEmptyString) &&
+      new Set(manifest.model.labels).size === manifest.model.labels.length) {
+    model = {
+      requested_id: manifest.model.requested_id,
+      resolved_id: manifest.model.resolved_id,
+      path: resolve(manifest.model.path),
+      size_bytes: manifest.model.size_bytes,
+      label_count: manifest.model.labels.length,
+      available: existsSync(resolve(manifest.model.path)) && statSync(resolve(manifest.model.path)).isDirectory(),
+    };
+  }
+  let evaluation: LocalClassifierRunSummary["evaluation"] = null;
+  if (manifest.heldout !== null && isRecord(manifest.heldout) && manifest.verdict !== null &&
+      isRecord(manifest.verdict) && isNonEmptyString(manifest.verdict.status) &&
+      COMPLETED_VERDICTS.has(manifest.verdict.status) &&
+      isSafeNonNegativeInteger(manifest.heldout.row_count) && manifest.heldout.row_count > 0 &&
+      isMetric(manifest.heldout.accuracy) && isMetric(manifest.heldout.macro_f1) &&
+      isFiniteNonNegative(manifest.heldout.latency_ms_p50) &&
+      isSafeNonNegativeInteger(manifest.heldout.failure_count) &&
+      manifest.heldout.failure_count <= manifest.heldout.row_count) {
+    evaluation = {
+      row_count: manifest.heldout.row_count,
+      accuracy: manifest.heldout.accuracy,
+      macro_f1: manifest.heldout.macro_f1,
+      latency_ms_p50: manifest.heldout.latency_ms_p50,
+      failure_count: manifest.heldout.failure_count,
+      verdict: manifest.verdict.status,
+    };
+  }
+  const failure = manifest.error && isNonEmptyString(manifest.error.code) && isNonEmptyString(manifest.error.message)
+    ? { code: manifest.error.code, message: manifest.error.message }
+    : null;
+  if (status === "completed" && (model === null || evaluation === null)) {
+    throw new Error("The completed local classifier omitted model or evaluation evidence.");
+  }
+  if (status === "completed" && failure !== null) {
+    throw new Error("The completed local classifier contains contradictory failure evidence.");
+  }
+  if (status !== "completed" && (manifest.model !== null || manifest.heldout !== null || manifest.verdict !== null)) {
+    throw new Error("The terminal local classifier run contains contradictory completion evidence.");
+  }
+  if (status !== "completed" && failure === null) {
+    throw new Error("The terminal local classifier run omitted its failure evidence.");
+  }
+  return {
+    schema_version: REGISTRY_SCHEMA,
+    model_id: `classifier.${runId}`,
+    kind: "classifier",
+    run_id: runId,
+    display_name: lifecycle.display_name,
+    run_status: status,
+    archived_at: lifecycle.archived_at,
+    generated_at: generatedAt,
+    updated_at: lifecycle.updated_at,
+    local_only: true,
+    manifest_path: resolve(path),
+    model,
+    evaluation,
+    timing_ms: isFiniteNonNegative(manifest.timings_ms?.total) ? manifest.timings_ms.total : null,
+    failure,
+  };
+}
+
+function childDirectories(path: string, maximum: number): string[] {
+  if (!existsSync(path) || !statSync(path).isDirectory()) return [];
+  return readdirSync(path, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .slice(0, maximum)
+    .map((entry) => join(path, entry.name));
+}
+
+export function listLocalClassifierRuns(
+  options: ListLocalClassifierRunsOptions = {},
+): LocalClassifierRunSummary[] {
+  const captureRoot = resolve(options.captureRoot ?? defaultCaptureRoot());
+  const limit = options.limit ?? 100;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 1_000) {
+    throw new Error("Classification run list limit must be between 1 and 1,000.");
+  }
+  const runs: LocalClassifierRunSummary[] = [];
+  for (const capturePath of childDirectories(captureRoot, MAX_CAPTURE_ROOTS)) {
+    const trainingRoot = join(capturePath, "training-runs");
+    for (const runPath of childDirectories(trainingRoot, MAX_RUNS_PER_CAPTURE)) {
+      const manifestPath = join(runPath, "run-manifest.json");
+      if (!existsSync(manifestPath) || !statSync(manifestPath).isFile()) continue;
+      try {
+        const item = summary(manifestPath);
+        if (Boolean(item.archived_at) === Boolean(options.archived)) runs.push(item);
+      } catch {
+        // Registry discovery is resilient to an unrelated corrupt or partial
+        // directory. Opening a specific run still fails closed with the exact error.
+      }
+    }
+  }
+  return runs
+    .sort((left, right) => right.updated_at.localeCompare(left.updated_at) || right.run_id.localeCompare(left.run_id))
+    .slice(0, limit);
+}
+
+export function getLocalClassifierRun(runManifestPath: string): LocalClassifierRunSummary {
+  const canonical = resolve(runManifestPath);
+  if (!existsSync(canonical) || !statSync(canonical).isFile()) {
+    throw new Error("The local classifier run is unavailable.");
+  }
+  return summary(canonical);
+}
+
+export function updateLocalClassifierRun(
+  options: UpdateLocalClassifierRunOptions,
+): LocalClassifierRunSummary {
+  const canonical = resolve(options.runManifestPath);
+  const { manifest, runId } = validateManifest(canonical);
+  if (options.displayName === undefined && options.archived === undefined) {
+    throw new Error("Choose a new display name, archive state, or both.");
+  }
+  const generatedAt = String(manifest.generated_at);
+  const current = readLifecycle(canonical, runId, generatedAt);
+  let displayName = current.display_name;
+  if (options.displayName !== undefined) {
+    displayName = options.displayName.trim();
+    if (displayName.length < 1 || displayName.length > 80 || /[\u0000-\u001f\u007f]/.test(displayName)) {
+      throw new Error("Classifier display name must contain 1 to 80 printable characters.");
+    }
+  }
+  const updatedAt = (options.now ?? new Date()).toISOString();
+  const next: LifecycleRecord = {
+    schema_version: LIFECYCLE_SCHEMA,
+    run_id: runId,
+    display_name: displayName,
+    archived_at: options.archived === undefined
+      ? current.archived_at
+      : options.archived ? updatedAt : null,
+    updated_at: updatedAt,
+  };
+  const path = lifecyclePath(canonical);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(temporary, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+  chmodSync(temporary, 0o600);
+  renameSync(temporary, path);
+  return summary(canonical);
+}

--- a/tests/local-classifier-registry.test.mjs
+++ b/tests/local-classifier-registry.test.mjs
@@ -26,7 +26,14 @@ function runFixture({ runId = "desktop-run-1", status = "completed", generatedAt
   const root = mkdtempSync(join(tmpdir(), "understudy-classifier-registry-"));
   roots.push(root);
   const captureRoot = join(root, "capture-imports");
-  const runRoot = join(captureRoot, "capture-a", "training-runs", runId);
+  const runRoot = join(
+    captureRoot,
+    "capture-a",
+    "classification",
+    "1234567890abcdef",
+    "training-runs",
+    runId,
+  );
   const modelPath = join(runRoot, "model");
   mkdirSync(modelPath, { recursive: true });
   writeFileSync(join(modelPath, "weights.bin"), "synthetic weights only");
@@ -127,9 +134,18 @@ describe("local classifier run registry", () => {
 
   it("rejects unsafe names and invalid list bounds", () => {
     const data = runFixture();
+    const unicodeName = "🧠".repeat(80);
+    assert.equal(updateLocalClassifierRun({
+      runManifestPath: data.manifestPath,
+      displayName: unicodeName,
+    }).display_name, unicodeName);
     assert.throws(() => updateLocalClassifierRun({
       runManifestPath: data.manifestPath,
       displayName: "bad\nname",
+    }), /printable characters/);
+    assert.throws(() => updateLocalClassifierRun({
+      runManifestPath: data.manifestPath,
+      displayName: "🧠".repeat(81),
     }), /printable characters/);
     assert.throws(() => updateLocalClassifierRun({ runManifestPath: data.manifestPath }), /Choose a new display name/);
     assert.throws(() => listLocalClassifierRuns({ captureRoot: data.captureRoot, limit: 0 }), /between 1 and 1,000/);

--- a/tests/local-classifier-registry.test.mjs
+++ b/tests/local-classifier-registry.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  getLocalClassifierRun,
+  listLocalClassifierRuns,
+  updateLocalClassifierRun,
+} from "../dist/local-classifier/registry.js";
+
+const roots = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function runFixture({ runId = "desktop-run-1", status = "completed", generatedAt = "2026-07-16T12:00:00.000Z" } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "understudy-classifier-registry-"));
+  roots.push(root);
+  const captureRoot = join(root, "capture-imports");
+  const runRoot = join(captureRoot, "capture-a", "training-runs", runId);
+  const modelPath = join(runRoot, "model");
+  mkdirSync(modelPath, { recursive: true });
+  writeFileSync(join(modelPath, "weights.bin"), "synthetic weights only");
+  const manifestPath = join(runRoot, "run-manifest.json");
+  const completed = status === "completed";
+  const manifest = {
+    schema_version: "understudy.capture_import.classification_run.v1",
+    run_id: runId,
+    generated_at: generatedAt,
+    status,
+    local_only: true,
+    data_boundary: {
+      dataset_uploaded: false,
+      telemetry_sent: false,
+      model_download_required: true,
+    },
+    model: completed ? {
+      requested_id: "answerdotai/ModernBERT-base",
+      resolved_id: "answerdotai/ModernBERT-base",
+      path: modelPath,
+      sha256: sha256("synthetic weights only"),
+      size_bytes: 22,
+      labels: ["synthetic-a", "synthetic-b"],
+    } : null,
+    heldout: completed ? {
+      row_count: 20,
+      accuracy: 0.9,
+      macro_f1: 0.875,
+      latency_ms_p50: 12.5,
+      failure_count: 2,
+    } : null,
+    verdict: completed ? { status: "promising" } : null,
+    timings_ms: { total: 1_234 },
+    manifest_path: manifestPath,
+    ...(completed ? {} : { error: { code: status, message: `Synthetic ${status} run.` } }),
+  };
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+  return { root, captureRoot, runRoot, modelPath, manifestPath };
+}
+
+describe("local classifier run registry", () => {
+  it("discovers completed local runs without copying label values into the summary", () => {
+    const data = runFixture();
+    const runs = listLocalClassifierRuns({ captureRoot: data.captureRoot });
+
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].model_id, "classifier.desktop-run-1");
+    assert.equal(runs[0].display_name, "desktop-run-1");
+    assert.equal(runs[0].run_status, "completed");
+    assert.equal(runs[0].local_only, true);
+    assert.equal(runs[0].model.label_count, 2);
+    assert.equal(runs[0].model.available, true);
+    assert.equal(runs[0].evaluation.accuracy, 0.9);
+    assert.equal(runs[0].evaluation.failure_count, 2);
+    assert.doesNotMatch(JSON.stringify(runs), /synthetic-a|synthetic-b/);
+  });
+
+  it("renames, archives, and restores through a private sidecar without changing immutable evidence", () => {
+    const data = runFixture();
+    const immutableBefore = readFileSync(data.manifestPath);
+    const archived = updateLocalClassifierRun({
+      runManifestPath: data.manifestPath,
+      displayName: "Spam detector",
+      archived: true,
+      now: new Date("2026-07-16T13:00:00.000Z"),
+    });
+
+    assert.equal(archived.display_name, "Spam detector");
+    assert.equal(archived.archived_at, "2026-07-16T13:00:00.000Z");
+    assert.deepEqual(readFileSync(data.manifestPath), immutableBefore);
+    assert.equal(listLocalClassifierRuns({ captureRoot: data.captureRoot }).length, 0);
+    assert.equal(listLocalClassifierRuns({ captureRoot: data.captureRoot, archived: true })[0].display_name, "Spam detector");
+    if (process.platform !== "win32") {
+      assert.equal(statSync(join(data.runRoot, "lifecycle.json")).mode & 0o777, 0o600);
+    }
+
+    const restored = updateLocalClassifierRun({
+      runManifestPath: data.manifestPath,
+      archived: false,
+      now: new Date("2026-07-16T14:00:00.000Z"),
+    });
+    assert.equal(restored.archived_at, null);
+    assert.equal(restored.display_name, "Spam detector");
+    assert.equal(listLocalClassifierRuns({ captureRoot: data.captureRoot }).length, 1);
+  });
+
+  it("shows terminal runs for restart recovery and fails closed when a selected sidecar is malformed", () => {
+    const failed = runFixture({ runId: "desktop-failed", status: "failed" });
+    const run = listLocalClassifierRuns({ captureRoot: failed.captureRoot })[0];
+    assert.equal(run.run_status, "failed");
+    assert.equal(run.model, null);
+    assert.equal(run.failure.code, "failed");
+
+    writeFileSync(join(failed.runRoot, "lifecycle.json"), "{}\n");
+    assert.equal(listLocalClassifierRuns({ captureRoot: failed.captureRoot }).length, 0);
+    assert.throws(() => getLocalClassifierRun(failed.manifestPath), /lifecycle record.*malformed/);
+  });
+
+  it("rejects unsafe names and invalid list bounds", () => {
+    const data = runFixture();
+    assert.throws(() => updateLocalClassifierRun({
+      runManifestPath: data.manifestPath,
+      displayName: "bad\nname",
+    }), /printable characters/);
+    assert.throws(() => updateLocalClassifierRun({ runManifestPath: data.manifestPath }), /Choose a new display name/);
+    assert.throws(() => listLocalClassifierRuns({ captureRoot: data.captureRoot, limit: 0 }), /between 1 and 1,000/);
+  });
+
+  it("exposes list and lifecycle updates through the public CLI", () => {
+    const data = runFixture();
+    const list = spawnSync(process.execPath, [
+      resolve("dist/bin.js"),
+      "capture-import",
+      "list-classification-runs",
+      "--capture-root",
+      data.captureRoot,
+      "--json",
+    ], { encoding: "utf8" });
+    assert.equal(list.status, 0, list.stderr);
+    const listed = JSON.parse(list.stdout);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].run_id, "desktop-run-1");
+    assert.doesNotMatch(list.stdout, /synthetic-a|synthetic-b/);
+
+    const archive = spawnSync(process.execPath, [
+      resolve("dist/bin.js"),
+      "capture-import",
+      "classification-run",
+      "--run-manifest",
+      data.manifestPath,
+      "--name",
+      "Inbox filter",
+      "--archive",
+      "--json",
+    ], { encoding: "utf8" });
+    assert.equal(archive.status, 0, archive.stderr);
+    const archived = JSON.parse(archive.stdout);
+    assert.equal(archived.display_name, "Inbox filter");
+    assert.ok(archived.archived_at);
+  });
+});


### PR DESCRIPTION
## What changed
- derive a bounded local classifier registry from immutable training manifests
- persist rename/archive/restore state in a private owner-only sidecar without mutating run evidence
- expose the lifecycle through the public CLI and thin Tauri commands for the next desktop UI slice
- omit label values and training examples from registry summaries

## Safety
- local-only contract is revalidated at the CLI and Tauri boundaries
- completed runs require consistent model/evaluation evidence; terminal runs fail closed on contradictory evidence
- no telemetry, uploads, customer data, or prototype payloads

## Verification
- `npm run check` (379 tests, package smoke)
- `cargo clippy --manifest-path apps/homescreen/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` (173 passed, 4 ignored)
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->