### PR TITLE
Desktop: add a local trained-model library

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -33,6 +33,7 @@ import {
   PromptInputActionAddAttachments,
   PromptInputActionMenu,
   PromptInputActionMenuContent,
+  PromptInputActionMenuItem,
   PromptInputActionMenuTrigger,
   PromptInputBody,
   PromptInputSubmit,
@@ -82,9 +83,10 @@ import { ModelCardDrawer } from "./ModelCardDrawer";
 import { CsvProfile } from "./CsvProfile";
 import { CsvTrainingPlan } from "./CsvTrainingPlan";
 import { LocalTrainingPanel } from "./LocalTrainingPanel";
+import { LocalClassifierLibraryDialog } from "./LocalClassifierLibraryDialog";
 import { TrainingHalo, type TrainingHaloVisual } from "./TrainingHalo";
 import type { FileUIPart } from "ai";
-import { ArrowDownIcon } from "lucide-react";
+import { ArrowDownIcon, LibraryBigIcon } from "lucide-react";
 
 type Role = "user" | "assistant";
 type ToolTrace = {
@@ -446,6 +448,7 @@ export function ChatPane({
   const [classificationDataset, setClassificationDataset] = useState<ClassificationDataset | null>(null);
   const [localTrainingActive, setLocalTrainingActive] = useState(false);
   const [trainingHaloVisual, setTrainingHaloVisual] = useState<TrainingHaloVisual | null>(null);
+  const [classifierLibraryOpen, setClassifierLibraryOpen] = useState(false);
   const [pacingMessageIndex, setPacingMessageIndex] = useState<number | null>(null);
   const [pacedRevealed, setPacedRevealed] = useState<number | null>(null);
   const [animatedMessageId, setAnimatedMessageId] = useState<string | null>(null);
@@ -1552,6 +1555,10 @@ export function ChatPane({
               <PromptInputActionMenuTrigger tooltip="Add image or file" />
               <PromptInputActionMenuContent>
                 <PromptInputActionAddAttachments label="Add image or file" />
+                <PromptInputActionMenuItem onSelect={() => setClassifierLibraryOpen(true)}>
+                  <LibraryBigIcon aria-hidden="true" />
+                  Trained models
+                </PromptInputActionMenuItem>
               </PromptInputActionMenuContent>
             </PromptInputActionMenu>
             <ModelPicker
@@ -1596,6 +1603,7 @@ export function ChatPane({
           </div>
         </PromptInput>
       </div>
+      <LocalClassifierLibraryDialog open={classifierLibraryOpen} onOpenChange={setClassifierLibraryOpen} />
     </div>
   );
 }

--- a/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
+++ b/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import {
+  ArchiveIcon,
+  ArchiveRestoreIcon,
+  FolderOpenIcon,
+  PencilIcon,
+} from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "./base-ui/dialog";
+
+type RunStatus = "completed" | "failed" | "cancelled";
+
+type LocalClassifierRun = {
+  schema_version: "understudy.local_classifier.registry.v1";
+  model_id: string;
+  kind: "classifier";
+  run_id: string;
+  display_name: string;
+  run_status: RunStatus;
+  archived_at: string | null;
+  generated_at: string;
+  updated_at: string;
+  local_only: true;
+  manifest_path: string;
+  model: null | {
+    requested_id: string;
+    resolved_id: string;
+    path: string;
+    size_bytes: number;
+    label_count: number;
+    available: boolean;
+  };
+  evaluation: null | {
+    row_count: number;
+    accuracy: number;
+    macro_f1: number;
+    latency_ms_p50: number;
+    failure_count: number;
+    verdict: string;
+  };
+  timing_ms: number | null;
+  failure: null | { code: string; message: string };
+};
+
+type ClassificationPrediction = {
+  schema_version: "understudy.capture_import.classification_prediction.v1";
+  run_id: string;
+  label: string;
+  scores: { label: string; score: number }[];
+  model_id: string;
+  local_only: true;
+};
+
+function compactBytes(bytes: number): string {
+  if (bytes < 1024 ** 2) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(0)} MB`;
+  return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+}
+
+function compactDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Saved locally";
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
+}
+
+function runStatus(run: LocalClassifierRun): string {
+  if (run.run_status === "completed") return run.model?.available ? "Ready" : "Files unavailable";
+  return run.run_status === "cancelled" ? "Stopped" : "Did not finish";
+}
+
+export function LocalClassifierLibraryDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [archived, setArchived] = useState(false);
+  const [runs, setRuns] = useState<LocalClassifierRun[]>([]);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [displayName, setDisplayName] = useState("");
+  const [predictionText, setPredictionText] = useState("");
+  const [prediction, setPrediction] = useState<ClassificationPrediction | null>(null);
+  const requestGeneration = useRef(0);
+
+  const selected = useMemo(
+    () => runs.find((run) => run.run_id === selectedRunId) ?? runs[0] ?? null,
+    [runs, selectedRunId],
+  );
+
+  const loadRuns = useCallback(async (showArchived: boolean, preferredRunId?: string | null) => {
+    const generation = requestGeneration.current + 1;
+    requestGeneration.current = generation;
+    setLoading(true);
+    setError(null);
+    try {
+      if (!isTauri()) throw new Error("Trained models are available in the Desktop app.");
+      const next = await invoke<LocalClassifierRun[]>("list_local_classification_runs", {
+        archived: showArchived,
+        limit: 100,
+      });
+      if (requestGeneration.current !== generation) return;
+      setRuns(next);
+      setSelectedRunId((current) => {
+        const preferred = preferredRunId ?? current;
+        return next.some((run) => run.run_id === preferred) ? preferred : next[0]?.run_id ?? null;
+      });
+    } catch (loadError) {
+      if (requestGeneration.current === generation) {
+        setRuns([]);
+        setSelectedRunId(null);
+        setError(String(loadError));
+      }
+    } finally {
+      if (requestGeneration.current === generation) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      requestGeneration.current += 1;
+      return;
+    }
+    void loadRuns(archived);
+  }, [archived, loadRuns, open]);
+
+  useEffect(() => {
+    setDisplayName(selected?.display_name ?? "");
+    setRenameOpen(false);
+    setPredictionText("");
+    setPrediction(null);
+  }, [selected?.run_id, selected?.display_name]);
+
+  const updateRun = async (update: { displayName?: string; archived?: boolean }) => {
+    if (!selected || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await invoke<LocalClassifierRun>("update_local_classification_run", {
+        runManifestPath: selected.manifest_path,
+        displayName: update.displayName,
+        archived: update.archived,
+      });
+      setRenameOpen(false);
+      await loadRuns(archived, update.archived === archived ? selected.run_id : null);
+    } catch (updateError) {
+      setError(String(updateError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const predict = async () => {
+    if (!selected?.model?.available || !predictionText.trim() || busy) return;
+    setBusy(true);
+    setPrediction(null);
+    setError(null);
+    try {
+      const result = await invoke<ClassificationPrediction>("predict_local_classification", {
+        runManifestPath: selected.manifest_path,
+        text: predictionText.trim(),
+      });
+      setPrediction(result);
+    } catch (predictionError) {
+      setError(String(predictionError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reveal = async () => {
+    if (!selected || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await revealItemInDir(selected.model?.available ? selected.model.path : selected.manifest_path);
+    } catch (revealError) {
+      setError(String(revealError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const topScore = prediction?.scores.find((score) => score.label === prediction.label);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="classifier-library-dialog">
+        <DialogHeader className="classifier-library-header">
+          <DialogTitle>Trained models</DialogTitle>
+          <DialogDescription>Local task models saved on this Mac. They never appear in the chat-model picker.</DialogDescription>
+        </DialogHeader>
+
+        <div className="classifier-library-tabs" aria-label="Trained model views">
+          <button type="button" aria-pressed={!archived} onClick={() => setArchived(false)}>Active</button>
+          <button type="button" aria-pressed={archived} onClick={() => setArchived(true)}>Archived</button>
+        </div>
+
+        <div className="classifier-library-body">
+          <nav className="classifier-library-list" aria-label={archived ? "Archived trained models" : "Active trained models"}>
+            {loading ? (
+              <div className="classifier-library-empty">Reading local runs…</div>
+            ) : runs.length === 0 ? (
+              <div className="classifier-library-empty">
+                {archived ? "No archived models." : "Drop a labeled CSV to train your first task model."}
+              </div>
+            ) : runs.map((run) => (
+              <button
+                key={run.run_id}
+                type="button"
+                aria-current={run.run_id === selected?.run_id ? "true" : undefined}
+                onClick={() => setSelectedRunId(run.run_id)}
+              >
+                <strong>{run.display_name}</strong>
+                <span>{runStatus(run)} · {compactDate(run.updated_at)}</span>
+                {run.evaluation && <small>{(run.evaluation.accuracy * 100).toFixed(1)}% correct</small>}
+              </button>
+            ))}
+          </nav>
+
+          <section className="classifier-library-detail" aria-live="polite">
+            {selected ? (
+              <>
+                <div className="classifier-library-title-row">
+                  <div>
+                    <span>{runStatus(selected)}</span>
+                    <h3>{selected.display_name}</h3>
+                  </div>
+                  <button type="button" className="btn ghost" onClick={() => setRenameOpen((value) => !value)} disabled={busy}>
+                    <PencilIcon aria-hidden="true" /> Rename
+                  </button>
+                </div>
+
+                {renameOpen && (
+                  <form
+                    className="classifier-library-rename"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      if (displayName.trim() && displayName.trim() !== selected.display_name) {
+                        void updateRun({ displayName: displayName.trim() });
+                      }
+                    }}
+                  >
+                    <input
+                      value={displayName}
+                      onChange={(event) => setDisplayName(Array.from(event.target.value).slice(0, 80).join(""))}
+                      autoFocus
+                    />
+                    <button type="submit" className="btn primary" disabled={busy || !displayName.trim() || displayName.trim() === selected.display_name}>Save</button>
+                  </form>
+                )}
+
+                {selected.evaluation && selected.model ? (
+                  <div className="classifier-library-facts">
+                    <div><span>Correct answers</span><strong>{(selected.evaluation.accuracy * 100).toFixed(1)}%</strong></div>
+                    <div><span>Separate test examples</span><strong>{selected.evaluation.row_count.toLocaleString()}</strong></div>
+                    <div><span>Local response</span><strong>{selected.evaluation.latency_ms_p50.toFixed(1)} ms</strong></div>
+                    <div><span>Space on disk</span><strong>{compactBytes(selected.model.size_bytes)}</strong></div>
+                  </div>
+                ) : (
+                  <div className="classifier-library-terminal">
+                    <strong>{runStatus(selected)}</strong>
+                    <p>{selected.failure?.message ?? "This run has no completed model artifact."}</p>
+                  </div>
+                )}
+
+                {selected.run_status === "completed" && (
+                  <form
+                    className="classifier-library-predict"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      void predict();
+                    }}
+                  >
+                    <label htmlFor={`library-predict-${selected.run_id}`}>Try this model</label>
+                    <div>
+                      <input
+                        id={`library-predict-${selected.run_id}`}
+                        value={predictionText}
+                        maxLength={4_000}
+                        onChange={(event) => {
+                          setPredictionText(event.target.value);
+                          setPrediction(null);
+                        }}
+                        placeholder={selected.model?.available ? "Enter a new example" : "Model files are unavailable"}
+                        disabled={!selected.model?.available || busy}
+                      />
+                      <button type="submit" className="btn primary" disabled={!selected.model?.available || !predictionText.trim() || busy}>
+                        {busy ? "Working…" : "Run locally"}
+                      </button>
+                    </div>
+                    {prediction && (
+                      <output>
+                        <strong>{prediction.label}</strong>
+                        {topScore && <span>{(topScore.score * 100).toFixed(1)}% confidence</span>}
+                      </output>
+                    )}
+                  </form>
+                )}
+
+                <div className="classifier-library-actions">
+                  <button type="button" className="btn ghost" onClick={() => void reveal()} disabled={busy}>
+                    <FolderOpenIcon aria-hidden="true" /> Show files
+                  </button>
+                  <button
+                    type="button"
+                    className="btn ghost"
+                    onClick={() => void updateRun({ archived: !archived })}
+                    disabled={busy}
+                  >
+                    {archived ? <ArchiveRestoreIcon aria-hidden="true" /> : <ArchiveIcon aria-hidden="true" />}
+                    {archived ? "Restore" : "Archive"}
+                  </button>
+                </div>
+                {error && <p className="classifier-library-error" role="alert">{error}</p>}
+              </>
+            ) : !loading && (
+              <div className="classifier-library-detail-empty">
+                {error ?? "Select a local task model to inspect or try it."}
+              </div>
+            )}
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -4662,6 +4662,292 @@ select,
   padding: 18px !important;
 }
 
+.classifier-library-dialog {
+  width: min(820px, calc(100vw - 32px));
+  max-width: 820px !important;
+  max-height: calc(100vh - 32px);
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 12px !important;
+  overflow: hidden;
+  border-color: color-mix(in srgb, var(--mb-cyan) 22%, rgba(255, 255, 255, 0.12)) !important;
+  background: color-mix(in srgb, var(--bg) 96%, #07171e) !important;
+  padding: 18px !important;
+}
+
+.classifier-library-header {
+  gap: 5px !important;
+  padding-right: 30px;
+}
+
+.classifier-library-header [data-slot="dialog-title"] {
+  color: var(--text);
+  font-size: 19px;
+}
+
+.classifier-library-header [data-slot="dialog-description"] {
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.classifier-library-tabs {
+  display: flex;
+  width: fit-content;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+}
+
+.classifier-library-tabs button {
+  border: 0;
+  border-radius: 6px;
+  padding: 6px 11px;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.classifier-library-tabs button[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--mb-cyan) 12%, var(--surface));
+  color: var(--mb-cyan);
+}
+
+.classifier-library-body {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.72fr) minmax(0, 1.55fr);
+  min-height: 360px;
+  max-height: min(590px, calc(100vh - 170px));
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 45%, transparent);
+}
+
+.classifier-library-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--border);
+  padding: 7px;
+}
+
+.classifier-library-list > button {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 9px 10px;
+  background: transparent;
+  color: var(--text-3);
+  text-align: left;
+}
+
+.classifier-library-list > button:hover,
+.classifier-library-list > button:focus-visible {
+  background: color-mix(in srgb, var(--surface-2) 82%, transparent);
+  color: var(--text-2);
+  outline: none;
+}
+
+.classifier-library-list > button[aria-current="true"] {
+  border-color: color-mix(in srgb, var(--mb-cyan) 30%, var(--border));
+  background: color-mix(in srgb, var(--mb-cyan) 7%, var(--surface));
+}
+
+.classifier-library-list strong {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 590;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.classifier-library-list span,
+.classifier-library-list small {
+  overflow: hidden;
+  font: 10px/1.35 var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.classifier-library-list small { color: var(--mb-cyan); }
+
+.classifier-library-empty,
+.classifier-library-detail-empty {
+  display: grid;
+  min-height: 140px;
+  place-items: center;
+  padding: 24px;
+  color: var(--text-3);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.classifier-library-detail {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 18px;
+}
+
+.classifier-library-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.classifier-library-title-row > div {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.classifier-library-title-row span {
+  color: var(--mb-cyan);
+  font: 9px/1.2 var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.classifier-library-title-row h3 {
+  overflow: hidden;
+  margin: 0;
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.classifier-library-title-row .btn,
+.classifier-library-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.classifier-library-title-row svg,
+.classifier-library-actions svg { width: 13px; height: 13px; }
+
+.classifier-library-rename,
+.classifier-library-predict > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px;
+}
+
+.classifier-library-rename input,
+.classifier-library-predict input {
+  min-width: 0;
+  height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 65%, transparent);
+  color: var(--text);
+  padding: 0 10px;
+  font-size: 11px;
+  outline: none;
+}
+
+.classifier-library-rename input:focus,
+.classifier-library-predict input:focus {
+  border-color: color-mix(in srgb, var(--mb-cyan) 58%, var(--border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--mb-cyan) 10%, transparent);
+}
+
+.classifier-library-facts {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.classifier-library-facts > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+  border-right: 1px solid var(--border);
+}
+
+.classifier-library-facts > div:last-child { border-right: 0; }
+.classifier-library-facts span { color: var(--text-3); font: 9px/1.3 var(--mono); }
+.classifier-library-facts strong { color: var(--text); font-size: 14px; font-weight: 600; }
+
+.classifier-library-terminal {
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--warning) 35%, var(--border));
+  border-radius: 9px;
+}
+
+.classifier-library-terminal p {
+  margin: 5px 0 0;
+  color: var(--text-3);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.classifier-library-predict {
+  display: grid;
+  gap: 7px;
+  padding-top: 2px;
+}
+
+.classifier-library-predict > label {
+  color: var(--text-2);
+  font-size: 11px;
+  font-weight: 560;
+}
+
+.classifier-library-predict output {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-height: 28px;
+  border-radius: 7px;
+  padding: 7px 9px;
+  background: color-mix(in srgb, var(--mb-cyan) 8%, transparent);
+}
+
+.classifier-library-predict output strong { color: var(--mb-cyan); font-size: 13px; }
+.classifier-library-predict output span { color: var(--text-3); font: 9px/1.3 var(--mono); }
+
+.classifier-library-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.classifier-library-error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+@media (max-width: 720px) {
+  .classifier-library-body { grid-template-columns: 1fr; overflow-y: auto; }
+  .classifier-library-list { max-height: 160px; border-right: 0; border-bottom: 1px solid var(--border); }
+  .classifier-library-detail { overflow: visible; }
+  .classifier-library-facts { grid-template-columns: 1fr 1fr; }
+  .classifier-library-facts > div:nth-child(2) { border-right: 0; }
+  .classifier-library-facts > div:nth-child(-n + 2) { border-bottom: 1px solid var(--border); }
+}
+
 .model-card-title-row,
 .model-card-certification,
 .model-card-context,

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -15,6 +15,10 @@ const tauriConfigPath = new URL(
   import.meta.url,
 );
 const chatPath = new URL("../apps/homescreen/app/components/ChatPane.tsx", import.meta.url);
+const classifierLibraryPath = new URL(
+  "../apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx",
+  import.meta.url,
+);
 const trainingHaloPath = new URL(
   "../apps/homescreen/app/components/TrainingHalo.tsx",
   import.meta.url,
@@ -677,6 +681,30 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
     parity.features.find((feature) => feature.id === "drop-to-workload-compilation")?.status,
     "shipped",
   );
+});
+
+test("trained-model library is restart-safe and stays separate from chat models", async () => {
+  const [chat, library, css, tauri] = await Promise.all([
+    readFile(chatPath, "utf8"),
+    readFile(classifierLibraryPath, "utf8"),
+    readFile(cssPath, "utf8"),
+    readFile(tauriLibPath, "utf8"),
+  ]);
+
+  assert.match(chat, /PromptInputActionMenuItem[\s\S]*?Trained models/);
+  assert.match(library, /"list_local_classification_runs"/);
+  assert.match(library, /"update_local_classification_run"/);
+  assert.match(library, /"predict_local_classification"/);
+  assert.match(library, /revealItemInDir/);
+  assert.match(library, /They never appear in the chat-model picker/);
+  assert.match(library, /Correct answers/);
+  assert.match(library, /Separate test examples/);
+  assert.match(library, /Archived/);
+  assert.match(library, /source rows will not be copied|Local task models saved on this Mac/);
+  assert.doesNotMatch(library, /training examples|raw rows|source payload/i);
+  assert.match(css, /\.classifier-library-dialog/);
+  assert.match(tauri, /workload_drop::list_local_classification_runs/);
+  assert.match(tauri, /workload_drop::update_local_classification_run/);
 });
 
 test("desktop model downloads are app-owned, pausable, and resumable", async () => {


### PR DESCRIPTION
## What changed
- adds a compact Trained models dialog to the existing composer + menu
- lists active and archived local classifier runs from the restart-safe registry
- supports rename, archive/restore, reveal files, and real local predictions
- keeps task classifiers out of the chat-model picker and never reads training rows

## Validation
- npm run check (380 tests, 34 public skills, package smoke)
- npm run build in apps/homescreen
- focused desktop UI lineage tests
- live local registry: 12 runs discovered, 6 model artifacts available
- live Banking77 prediction: declined_cash_withdrawal on a fresh example, local only
- visual pass at 1280x720; dialog remains above the fold

## Privacy
No uploads, remote calls, telemetry, training examples, customer data, or design-sandbox payloads are added.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->