### PR TITLE
Desktop: fix trained-model warning border

### DIFF
--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -4886,7 +4886,7 @@ select,
 
 .classifier-library-terminal {
   padding: 12px;
-  border: 1px solid color-mix(in srgb, var(--warning) 35%, var(--border));
+  border: 1px solid color-mix(in srgb, var(--c-warn) 35%, var(--border));
   border-radius: 9px;
 }
 


### PR DESCRIPTION
Follow-up to #260 and its Devin review thread.

- replaces the undefined warning token with the canonical theme token
- restores the intended border on failed or unavailable classifier callouts

Validated with desktop UI lineage tests, TypeScript typecheck, and diff check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->