### PR TITLE
Give trained models stable canonical identities

### DIFF
--- a/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
+++ b/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
@@ -23,6 +23,24 @@ type LocalClassifierRun = {
   schema_version: "understudy.local_classifier.registry.v1";
   model_id: string;
   kind: "classifier";
+  identity: {
+    schema_version: "understudy.model_identity.v1";
+    id: string;
+    kind: "classifier";
+    display_name: string;
+    tint: { palette_id: string; rgb: [number, number, number]; css: string };
+    lineage: {
+      training_run_id: string;
+      requested_base_model_id: string | null;
+      resolved_base_model_id: string | null;
+    };
+    artifact: { path: string | null; size_bytes: number | null; available: boolean };
+    certification: {
+      status: "evaluated" | "files_unavailable" | "terminal";
+      local_only: true;
+      evaluated_at: string | null;
+    };
+  };
   run_id: string;
   display_name: string;
   run_status: RunStatus;
@@ -57,6 +75,7 @@ type ClassificationPrediction = {
   label: string;
   scores: { label: string; score: number }[];
   model_id: string;
+  base_model_id: string;
   local_only: true;
 };
 
@@ -223,8 +242,9 @@ export function LocalClassifierLibraryDialog({
                 type="button"
                 aria-current={run.run_id === selected?.run_id ? "true" : undefined}
                 onClick={() => setSelectedRunId(run.run_id)}
+                style={{ "--model-identity-tint": run.identity.tint.css } as React.CSSProperties}
               >
-                <strong>{run.display_name}</strong>
+                <strong><i aria-hidden="true" />{run.display_name}</strong>
                 <span>{runStatus(run)} · {compactDate(run.updated_at)}</span>
                 {run.evaluation && <small>{(run.evaluation.accuracy * 100).toFixed(1)}% correct</small>}
               </button>
@@ -235,9 +255,9 @@ export function LocalClassifierLibraryDialog({
             {selected ? (
               <>
                 <div className="classifier-library-title-row">
-                  <div>
+                  <div style={{ "--model-identity-tint": selected.identity.tint.css } as React.CSSProperties}>
                     <span>{runStatus(selected)}</span>
-                    <h3>{selected.display_name}</h3>
+                    <h3><i aria-hidden="true" />{selected.display_name}</h3>
                   </div>
                   <button type="button" className="btn ghost" onClick={() => setRenameOpen((value) => !value)} disabled={busy}>
                     <PencilIcon aria-hidden="true" /> Rename

--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -93,6 +93,7 @@ type ClassificationPrediction = {
   label: string;
   scores: { label: string; score: number }[];
   model_id: string;
+  base_model_id: string;
   local_only: true;
 };
 
@@ -254,10 +255,11 @@ export function LocalTrainingPanel({
       epochs: haloProgress.epochs,
       completedEpochs: state.phase === "completed" ? haloProgress.epochs : haloProgress.completedEpochs,
       stepFraction: null,
+      modelId: `classifier.${state.runId}`,
       modelName,
       done: state.phase === "completed",
     });
-  }, [haloProgress, modelName, onVisualChange, state.phase]);
+  }, [haloProgress, modelName, onVisualChange, state.phase, state.runId]);
 
   useEffect(() => {
     generation.current += 1;
@@ -686,7 +688,7 @@ export function LocalTrainingPanel({
           <output>
             <strong>{prediction.label}</strong>
             {topScore && <span>{percent(topScore.score)} confidence</span>}
-            <small>Predicted locally with {prediction.model_id}</small>
+            <small>Predicted locally with {modelName}</small>
             {confidenceWarning && <em>{confidenceWarning}</em>}
           </output>
         )}

--- a/apps/homescreen/app/components/TrainingHalo.tsx
+++ b/apps/homescreen/app/components/TrainingHalo.tsx
@@ -6,26 +6,19 @@ import {
   type PersonaColor,
   type PersonaState,
 } from "@/components/ai-elements/persona";
+import { modelIdentityTint } from "../../../../src/model-identity";
 
 type Rgb = [number, number, number];
 
 const AMBER: Rgb = [242, 179, 76];
 const VIOLET: Rgb = [167, 139, 250];
 const GREEN: Rgb = [110, 231, 160];
-const IDENTITY_PALETTE: Rgb[] = [
-  [158, 219, 211],
-  [103, 232, 249],
-  [167, 139, 250],
-  [242, 179, 76],
-  [217, 119, 87],
-  [244, 114, 182],
-];
-
 export type TrainingHaloVisual = {
   phase: "preparing" | "downloading" | "training" | "evaluating" | "saving" | "completed";
   epochs: number;
   completedEpochs: number;
   stepFraction: number | null;
+  modelId: string;
   modelName: string;
   done: boolean;
 };
@@ -43,15 +36,6 @@ export function learnColor(progress: number): Rgb {
   return clamped < 0.5
     ? mixRgb(AMBER, VIOLET, clamped * 2)
     : mixRgb(VIOLET, GREEN, (clamped - 0.5) * 2);
-}
-
-export function identityTint(name: string): Rgb {
-  let hash = 2_166_136_261;
-  for (let index = 0; index < name.length; index += 1) {
-    hash ^= name.charCodeAt(index);
-    hash = Math.imul(hash, 16_777_619);
-  }
-  return IDENTITY_PALETTE[(hash >>> 0) % IDENTITY_PALETTE.length];
 }
 
 function toPersonaColor([red, green, blue]: Rgb): PersonaColor {
@@ -75,7 +59,7 @@ export function TrainingHalo({
   const [birthTint, setBirthTint] = useState<Rgb | null>(null);
   const epochs = Math.max(1, visual.epochs);
   const completedEpochs = Math.min(epochs, Math.max(0, visual.completedEpochs));
-  const identity = useMemo(() => identityTint(visual.modelName), [visual.modelName]);
+  const identity = useMemo(() => modelIdentityTint(visual.modelId).rgb, [visual.modelId]);
 
   useEffect(() => {
     if (!visual.done) {

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -4758,12 +4758,26 @@ select,
 }
 
 .classifier-library-list strong {
+  display: flex;
+  align-items: center;
+  gap: 7px;
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
   font-weight: 590;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.classifier-library-list strong > i,
+.classifier-library-title-row h3 > i {
+  display: block;
+  width: 7px;
+  height: 7px;
+  flex: 0 0 7px;
+  border-radius: 999px;
+  background: var(--model-identity-tint, var(--mb-cyan));
+  box-shadow: 0 0 10px color-mix(in srgb, var(--model-identity-tint, var(--mb-cyan)) 52%, transparent);
 }
 
 .classifier-library-list span,
@@ -4818,6 +4832,9 @@ select,
 }
 
 .classifier-library-title-row h3 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   overflow: hidden;
   margin: 0;
   color: var(--text);

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -59,6 +59,144 @@ fn training_cancellations() -> &'static Mutex<HashMap<String, Arc<AtomicBool>>> 
     TRAINING_CANCELLATIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn expected_model_identity_tint(model_id: &str) -> (&'static str, [u64; 3]) {
+    const PALETTE: [(&str, [u64; 3]); 6] = [
+        ("mint", [158, 219, 211]),
+        ("cyan", [103, 232, 249]),
+        ("violet", [167, 139, 250]),
+        ("amber", [242, 179, 76]),
+        ("clay", [217, 119, 87]),
+        ("rose", [244, 114, 182]),
+    ];
+    let mut hash = 2_166_136_261_u32;
+    for code_unit in model_id.encode_utf16() {
+        hash ^= u32::from(code_unit);
+        hash = hash.wrapping_mul(16_777_619);
+    }
+    PALETTE[hash as usize % PALETTE.len()]
+}
+
+fn validate_classifier_identity(value: &Value, status: &str) -> Result<(), String> {
+    let identity = value
+        .get("identity")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The local classifier registry omitted canonical identity.".to_string())?;
+    let model_id = value
+        .get("model_id")
+        .and_then(Value::as_str)
+        .expect("model id is validated before identity");
+    let run_id = value
+        .get("run_id")
+        .and_then(Value::as_str)
+        .expect("run id is validated before identity");
+    let display_name = value
+        .get("display_name")
+        .and_then(Value::as_str)
+        .expect("display name is validated before identity");
+    if identity.get("schema_version").and_then(Value::as_str)
+        != Some("understudy.model_identity.v1")
+        || identity.get("kind").and_then(Value::as_str) != Some("classifier")
+        || identity.get("id").and_then(Value::as_str) != Some(model_id)
+        || identity.get("display_name").and_then(Value::as_str) != Some(display_name)
+        || model_id != format!("classifier.{run_id}")
+    {
+        return Err(
+            "The local classifier registry returned inconsistent canonical identity.".into(),
+        );
+    }
+
+    let tint = identity
+        .get("tint")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The local classifier identity omitted its tint.".to_string())?;
+    let (palette_id, rgb) = expected_model_identity_tint(model_id);
+    let returned_rgb = tint
+        .get("rgb")
+        .and_then(Value::as_array)
+        .filter(|channels| channels.len() == 3)
+        .and_then(|channels| {
+            Some([
+                channels[0].as_u64()?,
+                channels[1].as_u64()?,
+                channels[2].as_u64()?,
+            ])
+        });
+    let expected_css = format!("rgb({} {} {})", rgb[0], rgb[1], rgb[2]);
+    if tint.get("palette_id").and_then(Value::as_str) != Some(palette_id)
+        || returned_rgb != Some(rgb)
+        || tint.get("css").and_then(Value::as_str) != Some(expected_css.as_str())
+    {
+        return Err("The local classifier identity returned a non-canonical tint.".into());
+    }
+
+    let lineage = identity
+        .get("lineage")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The local classifier identity omitted lineage.".to_string())?;
+    if lineage.get("training_run_id").and_then(Value::as_str) != Some(run_id) {
+        return Err("The local classifier identity returned inconsistent lineage.".into());
+    }
+    let artifact = identity
+        .get("artifact")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The local classifier identity omitted artifact evidence.".to_string())?;
+    let certification = identity
+        .get("certification")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The local classifier identity omitted certification.".to_string())?;
+    if certification.get("local_only").and_then(Value::as_bool) != Some(true) {
+        return Err("The local classifier identity returned non-local certification.".into());
+    }
+
+    if status == "completed" {
+        let model = value
+            .get("model")
+            .and_then(Value::as_object)
+            .expect("completed model is validated before identity");
+        let available = model
+            .get("available")
+            .and_then(Value::as_bool)
+            .expect("model availability is validated before identity");
+        let expected_certification = if available {
+            "evaluated"
+        } else {
+            "files_unavailable"
+        };
+        if lineage.get("requested_base_model_id") != model.get("requested_id")
+            || lineage.get("resolved_base_model_id") != model.get("resolved_id")
+            || artifact.get("path") != model.get("path")
+            || artifact.get("size_bytes") != model.get("size_bytes")
+            || artifact.get("available").and_then(Value::as_bool) != Some(available)
+            || certification.get("status").and_then(Value::as_str) != Some(expected_certification)
+            || certification
+                .get("evaluated_at")
+                .and_then(Value::as_str)
+                .filter(|timestamp| !timestamp.is_empty() && timestamp.len() <= 128)
+                .is_none()
+        {
+            return Err(
+                "The local classifier identity returned contradictory completion evidence.".into(),
+            );
+        }
+    } else if !lineage
+        .get("requested_base_model_id")
+        .is_some_and(Value::is_null)
+        || !lineage
+            .get("resolved_base_model_id")
+            .is_some_and(Value::is_null)
+        || !artifact.get("path").is_some_and(Value::is_null)
+        || !artifact.get("size_bytes").is_some_and(Value::is_null)
+        || artifact.get("available").and_then(Value::as_bool) != Some(false)
+        || certification.get("status").and_then(Value::as_str) != Some("terminal")
+        || !certification
+            .get("evaluated_at")
+            .is_some_and(Value::is_null)
+    {
+        return Err("The terminal classifier identity returned contradictory evidence.".into());
+    }
+    Ok(())
+}
+
 fn validate_classification_run_summary(value: &Value) -> Result<(), String> {
     if value.get("schema_version").and_then(Value::as_str)
         != Some("understudy.local_classifier.registry.v1")
@@ -193,7 +331,7 @@ fn validate_classification_run_summary(value: &Value) -> Result<(), String> {
     {
         return Err("The terminal classifier returned contradictory evidence.".into());
     }
-    Ok(())
+    validate_classifier_identity(value, status)
 }
 
 fn validate_classification_run_list(value: Value, archived: bool) -> Result<Value, String> {
@@ -1439,14 +1577,20 @@ pub async fn compare_local_classification_with_frontier(
     .map_err(|error| format!("The frontier comparator stopped unexpectedly: {error}"))?
 }
 
-fn validate_classification_prediction(value: Value, run_id: &str) -> Result<Value, String> {
+fn validate_classification_prediction(
+    value: Value,
+    run_id: &str,
+    base_model_id: &str,
+) -> Result<Value, String> {
+    let expected_model_id = format!("classifier.{run_id}");
     if value.get("schema_version").and_then(Value::as_str)
         != Some("understudy.capture_import.classification_prediction.v1")
         || value.get("run_id").and_then(Value::as_str) != Some(run_id)
         || value.get("local_only").and_then(Value::as_bool) != Some(true)
         || value.get("label").and_then(Value::as_str).is_none()
         || value.get("text_sha256").and_then(Value::as_str).is_none()
-        || value.get("model_id").and_then(Value::as_str).is_none()
+        || value.get("model_id").and_then(Value::as_str) != Some(expected_model_id.as_str())
+        || value.get("base_model_id").and_then(Value::as_str) != Some(base_model_id)
     {
         return Err("The local classifier returned an invalid prediction.".into());
     }
@@ -1483,6 +1627,13 @@ fn predict_classification(run_manifest_path: String, text: String) -> Result<Val
         .get("run_id")
         .and_then(Value::as_str)
         .ok_or_else(|| "The local training run omitted its id.".to_string())?;
+    let base_model_id = run_manifest
+        .get("model")
+        .and_then(Value::as_object)
+        .and_then(|model| model.get("resolved_id"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| "The local training run omitted its base model.".to_string())?
+        .to_string();
     validate_classification_training_result(run_manifest.clone(), run_id)?;
     let text = text.trim();
     if text.is_empty() || text.chars().count() > 4_000 {
@@ -1518,7 +1669,7 @@ fn predict_classification(run_manifest_path: String, text: String) -> Result<Val
     }
     let value = serde_json::from_slice::<Value>(&output.stdout)
         .map_err(|_| "The local classifier returned malformed JSON.".to_string())?;
-    validate_classification_prediction(value, run_id)
+    validate_classification_prediction(value, run_id, &base_model_id)
 }
 
 #[tauri::command]
@@ -1746,6 +1897,32 @@ mod tests {
             "schema_version": "understudy.local_classifier.registry.v1",
             "model_id": "classifier.desktop-run-123",
             "kind": "classifier",
+            "identity": {
+                "schema_version": "understudy.model_identity.v1",
+                "id": "classifier.desktop-run-123",
+                "kind": "classifier",
+                "display_name": "Spam detector",
+                "tint": {
+                    "palette_id": "cyan",
+                    "rgb": [103, 232, 249],
+                    "css": "rgb(103 232 249)"
+                },
+                "lineage": {
+                    "training_run_id": "desktop-run-123",
+                    "requested_base_model_id": "answerdotai/ModernBERT-base",
+                    "resolved_base_model_id": "answerdotai/ModernBERT-base"
+                },
+                "artifact": {
+                    "path": "/tmp/model",
+                    "size_bytes": 123,
+                    "available": true
+                },
+                "certification": {
+                    "status": "evaluated",
+                    "local_only": true,
+                    "evaluated_at": "2026-07-16T12:00:00.000Z"
+                }
+            },
             "run_id": "desktop-run-123",
             "display_name": "Spam detector",
             "run_status": "completed",
@@ -1790,9 +1967,17 @@ mod tests {
 
         let mut unicode = active.clone();
         unicode["display_name"] = json!("🧠".repeat(80));
+        unicode["identity"]["display_name"] = unicode["display_name"].clone();
         assert!(validate_classification_run_summary(&unicode).is_ok());
         unicode["display_name"] = json!("🧠".repeat(81));
+        unicode["identity"]["display_name"] = unicode["display_name"].clone();
         assert!(validate_classification_run_summary(&unicode).is_err());
+
+        let mut drifted_tint = active.clone();
+        drifted_tint["identity"]["tint"]["palette_id"] = json!("clay");
+        assert!(validate_classification_run_summary(&drifted_tint)
+            .unwrap_err()
+            .contains("non-canonical tint"));
 
         let mut archived = active;
         archived["archived_at"] = json!("2026-07-16T13:00:00.000Z");
@@ -2102,12 +2287,23 @@ mod tests {
             "text_sha256": "abc",
             "label": "travel",
             "scores": [{ "label": "travel", "score": 0.8 }],
-            "model_id": "answerdotai/ModernBERT-base",
+            "model_id": "classifier.desktop-run-123",
+            "base_model_id": "answerdotai/ModernBERT-base",
             "local_only": true
         });
-        assert!(validate_classification_prediction(valid.clone(), "desktop-run-123").is_ok());
+        assert!(validate_classification_prediction(
+            valid.clone(),
+            "desktop-run-123",
+            "answerdotai/ModernBERT-base"
+        )
+        .is_ok());
         let mut unsafe_result = valid;
         unsafe_result["local_only"] = json!(false);
-        assert!(validate_classification_prediction(unsafe_result, "desktop-run-123").is_err());
+        assert!(validate_classification_prediction(
+            unsafe_result,
+            "desktop-run-123",
+            "answerdotai/ModernBERT-base"
+        )
+        .is_err());
     }
 }

--- a/src/local-classifier/index.ts
+++ b/src/local-classifier/index.ts
@@ -183,6 +183,7 @@ export type ClassificationPrediction = {
   label: string;
   scores: Array<{ label: string; score: number }>;
   model_id: string;
+  base_model_id: string;
   latency_ms: number;
   local_only: true;
 };
@@ -1037,7 +1038,14 @@ function validatePrediction(value: unknown, run: ClassificationTrainingRunManife
       Math.abs(total - 1) > 0.001 || value.label !== (value.scores[0] as Record<string, unknown>).label) {
     throw new Error("Classifier prediction scores are not normalized and ranked.");
   }
-  return value as ClassificationPrediction;
+  const runtimePrediction = value as Omit<ClassificationPrediction, "model_id" | "base_model_id"> & {
+    model_id: string;
+  };
+  return {
+    ...runtimePrediction,
+    model_id: `classifier.${run.run_id}`,
+    base_model_id: runtimePrediction.model_id,
+  };
 }
 
 export function predictLocalClassifier(options: PredictLocalClassifierOptions): ClassificationPrediction {

--- a/src/local-classifier/registry.ts
+++ b/src/local-classifier/registry.ts
@@ -11,6 +11,10 @@ import {
 import { dirname, join, resolve } from "node:path";
 
 import { globalConfigDir } from "../config/paths.js";
+import {
+  createClassifierModelIdentity,
+  type CanonicalModelIdentity,
+} from "../model-identity.js";
 
 const RUN_SCHEMA = "understudy.capture_import.classification_run.v1";
 const REGISTRY_SCHEMA = "understudy.local_classifier.registry.v1";
@@ -63,6 +67,7 @@ export type LocalClassifierRunSummary = {
   schema_version: typeof REGISTRY_SCHEMA;
   model_id: string;
   kind: "classifier";
+  identity: CanonicalModelIdentity;
   run_id: string;
   display_name: string;
   run_status: RunStatus;
@@ -233,10 +238,24 @@ function summary(path: string): LocalClassifierRunSummary {
   if (status !== "completed" && failure === null) {
     throw new Error("The terminal local classifier run omitted its failure evidence.");
   }
+  const modelId = `classifier.${runId}`;
+  const identity = createClassifierModelIdentity({
+    modelId,
+    displayName: lifecycle.display_name,
+    runId,
+    requestedBaseModelId: model?.requested_id ?? null,
+    resolvedBaseModelId: model?.resolved_id ?? null,
+    artifactPath: model?.path ?? null,
+    artifactSizeBytes: model?.size_bytes ?? null,
+    artifactAvailable: model?.available ?? false,
+    runStatus: status,
+    evaluatedAt: status === "completed" ? generatedAt : null,
+  });
   return {
     schema_version: REGISTRY_SCHEMA,
-    model_id: `classifier.${runId}`,
+    model_id: modelId,
     kind: "classifier",
+    identity,
     run_id: runId,
     display_name: lifecycle.display_name,
     run_status: status,

--- a/src/model-identity.ts
+++ b/src/model-identity.ts
@@ -1,0 +1,99 @@
+export const MODEL_IDENTITY_SCHEMA = "understudy.model_identity.v1" as const;
+
+export type ModelIdentityRgb = [number, number, number];
+
+export type ModelIdentityTint = {
+  palette_id: string;
+  rgb: ModelIdentityRgb;
+  css: string;
+};
+
+export type ModelIdentityCertification = {
+  status: "evaluated" | "files_unavailable" | "terminal";
+  local_only: true;
+  evaluated_at: string | null;
+};
+
+export type CanonicalModelIdentity = {
+  schema_version: typeof MODEL_IDENTITY_SCHEMA;
+  id: string;
+  kind: "classifier";
+  display_name: string;
+  tint: ModelIdentityTint;
+  lineage: {
+    training_run_id: string;
+    requested_base_model_id: string | null;
+    resolved_base_model_id: string | null;
+  };
+  artifact: {
+    path: string | null;
+    size_bytes: number | null;
+    available: boolean;
+  };
+  certification: ModelIdentityCertification;
+};
+
+const MODEL_IDENTITY_PALETTE: ReadonlyArray<{
+  id: string;
+  rgb: ModelIdentityRgb;
+}> = [
+  { id: "mint", rgb: [158, 219, 211] },
+  { id: "cyan", rgb: [103, 232, 249] },
+  { id: "violet", rgb: [167, 139, 250] },
+  { id: "amber", rgb: [242, 179, 76] },
+  { id: "clay", rgb: [217, 119, 87] },
+  { id: "rose", rgb: [244, 114, 182] },
+];
+
+export function modelIdentityTint(modelId: string): ModelIdentityTint {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < modelId.length; index += 1) {
+    hash ^= modelId.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  const selected = MODEL_IDENTITY_PALETTE[(hash >>> 0) % MODEL_IDENTITY_PALETTE.length];
+  const rgb: ModelIdentityRgb = [...selected.rgb];
+  return {
+    palette_id: selected.id,
+    rgb,
+    css: `rgb(${rgb[0]} ${rgb[1]} ${rgb[2]})`,
+  };
+}
+
+export function createClassifierModelIdentity(input: {
+  modelId: string;
+  displayName: string;
+  runId: string;
+  requestedBaseModelId: string | null;
+  resolvedBaseModelId: string | null;
+  artifactPath: string | null;
+  artifactSizeBytes: number | null;
+  artifactAvailable: boolean;
+  runStatus: "completed" | "failed" | "cancelled";
+  evaluatedAt: string | null;
+}): CanonicalModelIdentity {
+  return {
+    schema_version: MODEL_IDENTITY_SCHEMA,
+    id: input.modelId,
+    kind: "classifier",
+    display_name: input.displayName,
+    tint: modelIdentityTint(input.modelId),
+    lineage: {
+      training_run_id: input.runId,
+      requested_base_model_id: input.requestedBaseModelId,
+      resolved_base_model_id: input.resolvedBaseModelId,
+    },
+    artifact: {
+      path: input.artifactPath,
+      size_bytes: input.artifactSizeBytes,
+      available: input.artifactAvailable,
+    },
+    certification: {
+      status: input.runStatus !== "completed"
+        ? "terminal"
+        : input.artifactAvailable ? "evaluated" : "files_unavailable",
+      local_only: true,
+      evaluated_at: input.runStatus === "completed" ? input.evaluatedAt : null,
+    },
+  };
+}

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -572,7 +572,8 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(css, /@keyframes workload-intake-ring/);
   assert.match(css, /prefers-reduced-motion: reduce[\s\S]*?\.persona-stage\.workload-drop-active::before/);
   assert.match(chat, /<TrainingHalo/);
-  assert.match(trainingHalo, /export function identityTint/);
+  assert.match(trainingHalo, /modelIdentityTint\(visual\.modelId\)/);
+  assert.match(training, /modelId: `classifier\.\$\{state\.runId\}`/);
   assert.match(trainingHalo, /const AMBER/);
   assert.match(trainingHalo, /const VIOLET/);
   assert.match(trainingHalo, /const GREEN/);

--- a/tests/local-classifier-registry.test.mjs
+++ b/tests/local-classifier-registry.test.mjs
@@ -11,6 +11,7 @@ import {
   listLocalClassifierRuns,
   updateLocalClassifierRun,
 } from "../dist/local-classifier/registry.js";
+import { modelIdentityTint } from "../dist/model-identity.js";
 
 const roots = [];
 
@@ -81,6 +82,12 @@ describe("local classifier run registry", () => {
 
     assert.equal(runs.length, 1);
     assert.equal(runs[0].model_id, "classifier.desktop-run-1");
+    assert.equal(runs[0].identity.id, "classifier.desktop-run-1");
+    assert.equal(runs[0].identity.display_name, "desktop-run-1");
+    assert.equal(runs[0].identity.lineage.requested_base_model_id, "answerdotai/ModernBERT-base");
+    assert.equal(runs[0].identity.artifact.available, true);
+    assert.equal(runs[0].identity.certification.status, "evaluated");
+    assert.deepEqual(runs[0].identity.tint, modelIdentityTint("classifier.desktop-run-1"));
     assert.equal(runs[0].display_name, "desktop-run-1");
     assert.equal(runs[0].run_status, "completed");
     assert.equal(runs[0].local_only, true);
@@ -102,6 +109,8 @@ describe("local classifier run registry", () => {
     });
 
     assert.equal(archived.display_name, "Spam detector");
+    assert.equal(archived.identity.display_name, "Spam detector");
+    assert.deepEqual(archived.identity.tint, modelIdentityTint("classifier.desktop-run-1"));
     assert.equal(archived.archived_at, "2026-07-16T13:00:00.000Z");
     assert.deepEqual(readFileSync(data.manifestPath), immutableBefore);
     assert.equal(listLocalClassifierRuns({ captureRoot: data.captureRoot }).length, 0);
@@ -117,6 +126,7 @@ describe("local classifier run registry", () => {
     });
     assert.equal(restored.archived_at, null);
     assert.equal(restored.display_name, "Spam detector");
+    assert.deepEqual(restored.identity.tint, archived.identity.tint);
     assert.equal(listLocalClassifierRuns({ captureRoot: data.captureRoot }).length, 1);
   });
 
@@ -126,6 +136,8 @@ describe("local classifier run registry", () => {
     assert.equal(run.run_status, "failed");
     assert.equal(run.model, null);
     assert.equal(run.failure.code, "failed");
+    assert.equal(run.identity.certification.status, "terminal");
+    assert.equal(run.identity.artifact.path, null);
 
     writeFileSync(join(failed.runRoot, "lifecycle.json"), "{}\n");
     assert.equal(listLocalClassifierRuns({ captureRoot: failed.captureRoot }).length, 0);

--- a/tests/local-classifier.test.mjs
+++ b/tests/local-classifier.test.mjs
@@ -154,6 +154,8 @@ describe("local classifier training backend", () => {
     assert.equal(prediction.schema_version, "understudy.capture_import.classification_prediction.v1");
     assert.equal(prediction.text_sha256, sha256(text));
     assert.equal(prediction.label, "meals");
+    assert.equal(prediction.model_id, "classifier.expense-demo");
+    assert.equal(prediction.base_model_id, result.model.resolved_id);
     assert.equal(prediction.local_only, true);
     assert.doesNotMatch(JSON.stringify(prediction), /new cafe/);
     assert.equal(existsSync(join(dirname(result.manifest_path), ".prediction-requests")), false);


### PR DESCRIPTION
## Summary
- add one canonical classifier identity with stable id, lifelong tint, lineage, artifact state, and certification
- key the TrainingHalo birth color to classifier run identity rather than the editable display name
- show the same identity tint in the trained-model library and verify the contract at the Tauri boundary

## Verification
- npm test: 380 passed
- npm run skills:validate: 34 passed
- npm run package:smoke
- Desktop Next production build
- cargo test: 173 passed, 4 ignored
- cargo fmt --check
- live local registry smoke: 12 runs, canonical lineage and tint returned
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->