### PR TITLE
feat(desktop): complete local classifier lifecycle

### DIFF
--- a/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
+++ b/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
@@ -6,8 +6,10 @@ import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
   ArchiveIcon,
   ArchiveRestoreIcon,
+  FileDownIcon,
   FolderOpenIcon,
   PencilIcon,
+  RefreshCcwIcon,
 } from "lucide-react";
 import {
   Dialog,
@@ -65,6 +67,12 @@ type LocalClassifierRun = {
     failure_count: number;
     verdict: string;
   };
+  repeat_validation: null | {
+    count: number;
+    latest_at: string;
+    latest_status: "reproduced" | "drift_detected";
+    latest_artifact_path: string;
+  };
   timing_ms: number | null;
   failure: null | { code: string; message: string };
 };
@@ -77,6 +85,19 @@ type ClassificationPrediction = {
   model_id: string;
   base_model_id: string;
   local_only: true;
+};
+
+type RepeatEvaluation = {
+  schema_version: "understudy.local_classifier.repeat_evaluation.v1";
+  verdict: { status: "reproduced" | "drift_detected"; reason: string };
+  artifact_path: string;
+};
+
+type PredictionExport = {
+  schema_version: "understudy.local_classifier.prediction_export.v1";
+  predicted_row_count: number;
+  skipped_row_count: number;
+  output_path: string;
 };
 
 function compactBytes(bytes: number): string {
@@ -113,6 +134,7 @@ export function LocalClassifierLibraryDialog({
   const [displayName, setDisplayName] = useState("");
   const [predictionText, setPredictionText] = useState("");
   const [prediction, setPrediction] = useState<ClassificationPrediction | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const requestGeneration = useRef(0);
 
   const selected = useMemo(
@@ -161,6 +183,7 @@ export function LocalClassifierLibraryDialog({
     setRenameOpen(false);
     setPredictionText("");
     setPrediction(null);
+    setNotice(null);
   }, [selected?.run_id, selected?.display_name]);
 
   const updateRun = async (update: { displayName?: string; archived?: boolean }) => {
@@ -208,6 +231,44 @@ export function LocalClassifierLibraryDialog({
       await revealItemInDir(selected.model?.available ? selected.model.path : selected.manifest_path);
     } catch (revealError) {
       setError(String(revealError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const repeatEvaluation = async () => {
+    if (!selected?.model?.available || busy) return;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await invoke<RepeatEvaluation>("repeat_local_classification_evaluation", {
+        runManifestPath: selected.manifest_path,
+      });
+      setNotice(result.verdict.status === "reproduced"
+        ? "Quality rechecked on the same saved test examples — result reproduced."
+        : "The saved model changed on the same test examples. Review the new evidence before use.");
+      await loadRuns(archived, selected.run_id);
+    } catch (repeatError) {
+      setError(String(repeatError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const exportPredictions = async () => {
+    if (!selected?.model?.available || busy) return;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await invoke<PredictionExport>("export_local_classification_predictions", {
+        runManifestPath: selected.manifest_path,
+      });
+      setNotice(`${result.predicted_row_count.toLocaleString()} rows labeled locally. The CSV is ready.`);
+      await revealItemInDir(result.output_path);
+    } catch (exportError) {
+      setError(String(exportError));
     } finally {
       setBusy(false);
     }
@@ -284,12 +345,22 @@ export function LocalClassifierLibraryDialog({
                 )}
 
                 {selected.evaluation && selected.model ? (
-                  <div className="classifier-library-facts">
-                    <div><span>Correct answers</span><strong>{(selected.evaluation.accuracy * 100).toFixed(1)}%</strong></div>
-                    <div><span>Separate test examples</span><strong>{selected.evaluation.row_count.toLocaleString()}</strong></div>
-                    <div><span>Local response</span><strong>{selected.evaluation.latency_ms_p50.toFixed(1)} ms</strong></div>
-                    <div><span>Space on disk</span><strong>{compactBytes(selected.model.size_bytes)}</strong></div>
-                  </div>
+                  <>
+                    <div className="classifier-library-facts">
+                      <div><span>Correct answers</span><strong>{(selected.evaluation.accuracy * 100).toFixed(1)}%</strong></div>
+                      <div><span>Separate test examples</span><strong>{selected.evaluation.row_count.toLocaleString()}</strong></div>
+                      <div><span>Local response</span><strong>{selected.evaluation.latency_ms_p50.toFixed(1)} ms</strong></div>
+                      <div><span>Space on disk</span><strong>{compactBytes(selected.model.size_bytes)}</strong></div>
+                    </div>
+                    {selected.repeat_validation && (
+                      <p className={`classifier-library-validation ${selected.repeat_validation.latest_status}`}>
+                        {selected.repeat_validation.latest_status === "reproduced"
+                          ? `Quality reproduced ${selected.repeat_validation.count === 1 ? "once" : `${selected.repeat_validation.count} times`}`
+                          : "Latest quality recheck changed"}
+                        <span> · {compactDate(selected.repeat_validation.latest_at)}</span>
+                      </p>
+                    )}
+                  </>
                 ) : (
                   <div className="classifier-library-terminal">
                     <strong>{runStatus(selected)}</strong>
@@ -332,6 +403,16 @@ export function LocalClassifierLibraryDialog({
                 )}
 
                 <div className="classifier-library-actions">
+                  {selected.run_status === "completed" && selected.model?.available && (
+                    <>
+                      <button type="button" className="btn ghost" onClick={() => void repeatEvaluation()} disabled={busy}>
+                        <RefreshCcwIcon aria-hidden="true" /> Re-check quality
+                      </button>
+                      <button type="button" className="btn ghost" onClick={() => void exportPredictions()} disabled={busy}>
+                        <FileDownIcon aria-hidden="true" /> Export labeled CSV
+                      </button>
+                    </>
+                  )}
                   <button type="button" className="btn ghost" onClick={() => void reveal()} disabled={busy}>
                     <FolderOpenIcon aria-hidden="true" /> Show files
                   </button>
@@ -345,6 +426,7 @@ export function LocalClassifierLibraryDialog({
                     {archived ? "Restore" : "Archive"}
                   </button>
                 </div>
+                {notice && <p className="classifier-library-notice" role="status">{notice}</p>}
                 {error && <p className="classifier-library-error" role="alert">{error}</p>}
               </>
             ) : !loading && (

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -4901,6 +4901,15 @@ select,
 .classifier-library-facts span { color: var(--text-3); font: 9px/1.3 var(--mono); }
 .classifier-library-facts strong { color: var(--text); font-size: 14px; font-weight: 600; }
 
+.classifier-library-validation {
+  margin: -5px 0 0;
+  color: var(--mb-cyan);
+  font: 9px/1.4 var(--mono);
+}
+
+.classifier-library-validation.drift_detected { color: var(--c-warn); }
+.classifier-library-validation span { color: var(--text-3); }
+
 .classifier-library-terminal {
   padding: 12px;
   border: 1px solid color-mix(in srgb, var(--c-warn) 35%, var(--border));
@@ -4941,12 +4950,20 @@ select,
 
 .classifier-library-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   gap: 7px;
   margin-top: auto;
   padding-top: 8px;
   border-top: 1px solid var(--border);
+}
+
+.classifier-library-notice {
+  margin: 0;
+  color: var(--mb-cyan);
+  font-size: 10px;
+  line-height: 1.45;
 }
 
 .classifier-library-error {

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -339,6 +339,8 @@ pub fn run() {
             workload_drop::predict_local_classification,
             workload_drop::list_local_classification_runs,
             workload_drop::update_local_classification_run,
+            workload_drop::repeat_local_classification_evaluation,
+            workload_drop::export_local_classification_predictions,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/residency.rs
+++ b/apps/homescreen/src-tauri/src/residency.rs
@@ -436,6 +436,15 @@ impl Residency {
         Ok(matches!(r.state, SlotState::Warm))
     }
 
+    fn is_warming_or_warm(&self, slot_id: u32) -> anyhow::Result<bool> {
+        let inner = locked(&self.inner);
+        let r = inner
+            .iter()
+            .find(|r| r.id == slot_id)
+            .ok_or_else(|| anyhow::anyhow!("slot not found: {slot_id}"))?;
+        Ok(matches!(r.state, SlotState::Loading | SlotState::Warm))
+    }
+
     pub fn remove(&self, slot_id: u32) -> anyhow::Result<()> {
         let mut inner = locked(&self.inner);
         if let Some(idx) = inner.iter().position(|r| r.id == slot_id) {
@@ -497,6 +506,13 @@ impl Residency {
     /// Warm a slot: enforce a conservative runtime budget, spawn mlx_vlm.server,
     /// and poll until ready. Heavy checkpoints are exclusive by construction.
     pub fn warm(&self, app: &AppHandle, slot_id: u32) -> anyhow::Result<()> {
+        // Warm is an idempotent, single-flight operation. Startup restoration,
+        // the Desktop starter notice, and agent-facing APIs can all request the
+        // same slot around launch. Joining an existing load is success, not an
+        // actionable error, and avoids repeating the runtime probe.
+        if self.is_warming_or_warm(slot_id)? {
+            return Ok(());
+        }
         let runtime = crate::models::mlx_runtime_status();
         if !runtime.available {
             emit_mlx_repair(app, &runtime.detail);
@@ -513,11 +529,8 @@ impl Residency {
                 .iter()
                 .find(|r| r.id == slot_id)
                 .ok_or_else(|| anyhow::anyhow!("slot not found: {slot_id}"))?;
-            if matches!(r.state, SlotState::Warm) {
+            if matches!(r.state, SlotState::Warm | SlotState::Loading) {
                 return Ok(());
-            }
-            if matches!(r.state, SlotState::Loading) {
-                anyhow::bail!("slot {slot_id} is already loading");
             }
             if r.model_path.is_none() {
                 anyhow::bail!("slot has no model assigned");
@@ -565,6 +578,12 @@ impl Residency {
                 .iter_mut()
                 .find(|r| r.id == slot_id)
                 .ok_or_else(|| anyhow::anyhow!("slot not found: {slot_id}"))?;
+            // A second caller may have won the race while this caller was
+            // doing memory and manifest preflight. Do not spawn another
+            // server or compete for the same port.
+            if matches!(r.state, SlotState::Warm | SlotState::Loading) {
+                return Ok(());
+            }
             let port = r.port.unwrap_or_else(|| self.alloc_port());
             r.port = Some(port);
             r.state = SlotState::Loading;
@@ -1045,6 +1064,21 @@ mod tests {
         assert_eq!(residency.used_gb_locked(&inner, Some(2)), 22.8);
         drop(inner);
         assert_eq!(residency.snapshot().used_gb, 45.6);
+    }
+
+    #[test]
+    fn warming_or_warm_slots_are_single_flight() {
+        let residency = Residency::new(64);
+        {
+            let mut inner = locked(&residency.inner);
+            inner.push(resident(1, SlotState::Loading, 4.0));
+            inner.push(resident(2, SlotState::Warm, 4.0));
+            inner.push(resident(3, SlotState::Stopped, 4.0));
+        }
+
+        assert!(residency.is_warming_or_warm(1).unwrap());
+        assert!(residency.is_warming_or_warm(2).unwrap());
+        assert!(!residency.is_warming_or_warm(3).unwrap());
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -101,6 +101,11 @@ pub fn router(ctx: Ctx) -> Router {
         .route("/v1/metrics/chat-routes", get(chat_route_metrics))
         .route("/v1/models", get(models))
         .route("/v1/models/catalog", get(snapshots))
+        .route("/v1/classifiers", get(agent_classifiers))
+        .route(
+            "/v1/classifiers/:model_id/predict",
+            post(agent_classifier_predict),
+        )
         .route("/v1/residency", get(residency))
         .route("/v1/residency/slots", post(residency_add_slot))
         .route("/v1/residency/assign", post(residency_assign))
@@ -260,7 +265,7 @@ async fn agent_capabilities(
 fn agent_capabilities_value() -> Value {
     json!({
         "schema_version": "understudy.desktop_api.v2",
-        "api_version": "2.2.0",
+        "api_version": "2.3.0",
         "event_schema": crate::conversation_runtime::EVENT_SCHEMA,
         "runtime": {
             "id": "understudy-conversation-runtime",
@@ -279,12 +284,15 @@ fn agent_capabilities_value() -> Value {
             "model_downloads": true,
             "model_residency": true,
             "migration_observation": true,
+            "local_task_models": true,
         },
         "endpoints": {
             "status": "/v1/status",
             "migration_status": "/v1/metrics/chat-routes",
             "models": "/v1/models",
             "model_catalog": "/v1/models/catalog",
+            "classifiers": "/v1/classifiers",
+            "classifier_predict": "/v1/classifiers/{model_id}/predict",
             "residency": "/v1/residency",
             "residency_add_slot": "/v1/residency/slots",
             "residency_assign": "/v1/residency/assign",
@@ -562,6 +570,98 @@ async fn status(State(ctx): State<Ctx>, h: HeaderMap) -> Result<Json<Value>, (St
 async fn models(State(ctx): State<Ctx>, h: HeaderMap) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
     Ok(Json(json!(crate::commands::list_models())))
+}
+
+fn classifier_manifest_for_model(registry: &Value, model_id: &str) -> Result<String, String> {
+    let runs = registry
+        .as_array()
+        .ok_or_else(|| "The local classifier registry returned malformed JSON.".to_string())?;
+    let run = runs
+        .iter()
+        .find(|run| run.get("model_id").and_then(Value::as_str) == Some(model_id))
+        .ok_or_else(|| format!("unknown local classifier: {model_id}"))?;
+    if run.get("run_status").and_then(Value::as_str) != Some("completed")
+        || run
+            .get("model")
+            .and_then(Value::as_object)
+            .and_then(|model| model.get("available"))
+            .and_then(Value::as_bool)
+            != Some(true)
+    {
+        return Err(format!("local classifier is not ready: {model_id}"));
+    }
+    run.get("manifest_path")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| "The local classifier registry omitted its manifest path.".to_string())
+}
+
+fn public_classifier_registry(mut registry: Value) -> Result<Value, String> {
+    let runs = registry
+        .as_array_mut()
+        .ok_or_else(|| "The local classifier registry returned malformed JSON.".to_string())?;
+    for run in runs {
+        let Some(run) = run.as_object_mut() else {
+            return Err("The local classifier registry returned malformed JSON.".into());
+        };
+        run.remove("manifest_path");
+        if let Some(model) = run.get_mut("model").and_then(Value::as_object_mut) {
+            model.remove("path");
+        }
+        if let Some(artifact) = run
+            .get_mut("identity")
+            .and_then(Value::as_object_mut)
+            .and_then(|identity| identity.get_mut("artifact"))
+            .and_then(Value::as_object_mut)
+        {
+            artifact.remove("path");
+        }
+        if let Some(repeat) = run
+            .get_mut("repeat_validation")
+            .and_then(Value::as_object_mut)
+        {
+            repeat.remove("latest_artifact_path");
+        }
+    }
+    Ok(registry)
+}
+
+async fn agent_classifiers(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let registry =
+        blocking(|| crate::workload_drop::list_classification_runs(false, 1_000)).await?;
+    Ok(Json(
+        public_classifier_registry(registry).map_err(|error| (StatusCode::BAD_GATEWAY, error))?,
+    ))
+}
+
+#[derive(serde::Deserialize)]
+struct AgentClassifierPredictBody {
+    text: String,
+}
+
+async fn agent_classifier_predict(
+    State(ctx): State<Ctx>,
+    Path(model_id): Path<String>,
+    h: HeaderMap,
+    Json(body): Json<AgentClassifierPredictBody>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    validate_agent_id(&model_id, "model_id")?;
+    let lookup_model_id = model_id.clone();
+    let manifest = blocking(move || {
+        let registry = crate::workload_drop::list_classification_runs(false, 1_000)?;
+        classifier_manifest_for_model(&registry, &lookup_model_id)
+    })
+    .await
+    .map_err(|(_, error)| (StatusCode::NOT_FOUND, error))?;
+    let text = body.text;
+    let prediction =
+        blocking(move || crate::workload_drop::predict_classification(manifest, text)).await?;
+    Ok(Json(prediction))
 }
 async fn snapshots(
     State(ctx): State<Ctx>,
@@ -1215,6 +1315,18 @@ fn tools() -> Vec<Value> {
         ("status", "Local runtime status: services, warm slots, metrics.", empty_schema()),
         ("list_models", "List locally cached models.", empty_schema()),
         ("list_snapshot_models", "Bundled local MLX snapshot catalog.", empty_schema()),
+        ("list_task_models", "List completed local task classifiers without exposing filesystem paths.", empty_schema()),
+        (
+            "classify_with_model",
+            "Classify one text example with a completed local task model. Input stays on this Mac and is not retained.",
+            obj_schema(
+                json!({
+                    "model_id": { "type": "string", "description": "Canonical classifier id from list_task_models, such as classifier.my-run." },
+                    "text": { "type": "string", "minLength": 1, "maxLength": 4000 }
+                }),
+                &["model_id", "text"],
+            ),
+        ),
         ("residency", "Warm-slot residency (which models are loaded).", empty_schema()),
         ("knowledge_dossiers", "Bundled public per-model dossiers.", empty_schema()),
         ("local_benchmarks", "Local live benchmark rows.", empty_schema()),
@@ -1427,6 +1539,25 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
         "status" => json!(call_blocking(move || Ok::<_, String>(c::status_snapshot(&app))).await?),
         "list_models" => json!(c::list_models()),
         "list_snapshot_models" => json!(c::list_snapshot_models()),
+        "list_task_models" => {
+            let registry =
+                call_blocking(|| crate::workload_drop::list_classification_runs(false, 1_000))
+                    .await?;
+            public_classifier_registry(registry)?
+        }
+        "classify_with_model" => {
+            let model_id = required_str(args, "model_id")?;
+            let text = required_str(args, "text")?;
+            validate_agent_id(&model_id, "model_id").map_err(|(_, error)| error)?;
+            let lookup_model_id = model_id.clone();
+            let manifest = call_blocking(move || {
+                let registry = crate::workload_drop::list_classification_runs(false, 1_000)?;
+                classifier_manifest_for_model(&registry, &lookup_model_id)
+            })
+            .await?;
+            call_blocking(move || crate::workload_drop::predict_classification(manifest, text))
+                .await?
+        }
         "residency" => json!(c::get_residency(app)),
         "add_slot" => {
             let slot_id = call_blocking(move || c::add_slot(app)).await?;
@@ -1745,7 +1876,13 @@ mod tests {
     fn agent_capabilities_advertise_the_versioned_control_plane() {
         let capabilities = agent_capabilities_value();
         assert_eq!(capabilities["schema_version"], "understudy.desktop_api.v2");
-        assert_eq!(capabilities["api_version"], "2.2.0");
+        assert_eq!(capabilities["api_version"], "2.3.0");
+        assert_eq!(capabilities["features"]["local_task_models"], true);
+        assert_eq!(capabilities["endpoints"]["classifiers"], "/v1/classifiers");
+        assert_eq!(
+            capabilities["endpoints"]["classifier_predict"],
+            "/v1/classifiers/{model_id}/predict"
+        );
         assert_eq!(
             capabilities["features"]["supervision_correction_export"],
             true
@@ -1831,6 +1968,7 @@ mod tests {
         assert_eq!(required_of("start_model_download"), ["model_id"]);
         assert_eq!(required_of("cancel_model_download"), ["download_id"]);
         assert_eq!(required_of("chat_completion"), ["slot_id", "prompt"]);
+        assert_eq!(required_of("classify_with_model"), ["model_id", "text"]);
         let chat = tools
             .iter()
             .find(|tool| tool["name"] == "chat_completion")
@@ -1857,5 +1995,29 @@ mod tests {
         // Args-optional tools stay unconstrained.
         assert!(required_of("run_fusion_benchmark").is_empty());
         assert!(required_of("list_traces").is_empty());
+    }
+
+    #[test]
+    fn task_model_api_resolves_canonical_identity_and_hides_local_paths() {
+        let registry = json!([{
+            "model_id": "classifier.demo-run",
+            "run_status": "completed",
+            "manifest_path": "/private/run-manifest.json",
+            "model": { "available": true, "path": "/private/model" },
+            "identity": { "artifact": { "available": true, "path": "/private/model" } },
+            "repeat_validation": { "latest_artifact_path": "/private/evaluation.json" }
+        }]);
+        assert_eq!(
+            classifier_manifest_for_model(&registry, "classifier.demo-run").unwrap(),
+            "/private/run-manifest.json"
+        );
+        assert!(classifier_manifest_for_model(&registry, "classifier.missing").is_err());
+        let public = public_classifier_registry(registry).unwrap();
+        assert!(public[0].get("manifest_path").is_none());
+        assert!(public[0]["model"].get("path").is_none());
+        assert!(public[0]["identity"]["artifact"].get("path").is_none());
+        assert!(public[0]["repeat_validation"]
+            .get("latest_artifact_path")
+            .is_none());
     }
 }

--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -242,6 +242,39 @@ fn validate_classification_run_summary(value: &Value) -> Result<(), String> {
     ) {
         return Err("The local classifier registry returned invalid archive state.".into());
     }
+    if let Some(repeat) = value.get("repeat_validation") {
+        if !repeat.is_null() {
+            let repeat = repeat.as_object().ok_or_else(|| {
+                "The local classifier registry returned invalid repeat-validation evidence."
+                    .to_string()
+            })?;
+            if repeat
+                .get("count")
+                .and_then(Value::as_u64)
+                .filter(|count| (1..=1_000).contains(count))
+                .is_none()
+                || repeat
+                    .get("latest_at")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.is_empty() && text.len() <= 128)
+                    .is_none()
+                || !matches!(
+                    repeat.get("latest_status").and_then(Value::as_str),
+                    Some("reproduced" | "drift_detected")
+                )
+                || repeat
+                    .get("latest_artifact_path")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.is_empty() && text.len() <= 4_096)
+                    .is_none()
+            {
+                return Err(
+                    "The local classifier registry returned invalid repeat-validation evidence."
+                        .into(),
+                );
+            }
+        }
+    }
     let status = value
         .get("run_status")
         .and_then(Value::as_str)
@@ -1612,7 +1645,10 @@ fn validate_classification_prediction(
     Ok(value)
 }
 
-fn predict_classification(run_manifest_path: String, text: String) -> Result<Value, String> {
+pub(crate) fn predict_classification(
+    run_manifest_path: String,
+    text: String,
+) -> Result<Value, String> {
     let canonical_manifest = PathBuf::from(run_manifest_path.trim())
         .canonicalize()
         .map_err(|error| format!("The local training run is unavailable: {error}"))?;
@@ -1682,7 +1718,7 @@ pub async fn predict_local_classification(
         .map_err(|error| format!("The local classifier stopped unexpectedly: {error}"))?
 }
 
-fn list_classification_runs(archived: bool, limit: u64) -> Result<Value, String> {
+pub(crate) fn list_classification_runs(archived: bool, limit: u64) -> Result<Value, String> {
     if !(1..=1_000).contains(&limit) {
         return Err("Local classifier run limit must be between 1 and 1,000.".into());
     }
@@ -1797,6 +1833,212 @@ pub async fn update_local_classification_run(
     })
     .await
     .map_err(|error| format!("The local classifier registry stopped unexpectedly: {error}"))?
+}
+
+fn completed_run_manifest(run_manifest_path: &str) -> Result<PathBuf, String> {
+    let canonical = PathBuf::from(run_manifest_path.trim())
+        .canonicalize()
+        .map_err(|error| format!("The local classifier run is unavailable: {error}"))?;
+    if !canonical.is_file()
+        || canonical.file_name().and_then(|name| name.to_str()) != Some("run-manifest.json")
+    {
+        return Err("Choose a completed local classifier run manifest.".into());
+    }
+    let raw = std::fs::read(&canonical)
+        .map_err(|error| format!("The local classifier run could not be read: {error}"))?;
+    let manifest = serde_json::from_slice::<Value>(&raw)
+        .map_err(|_| "The local classifier run is malformed.".to_string())?;
+    let run_id = manifest
+        .get("run_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "The local classifier run omitted its id.".to_string())?
+        .to_string();
+    validate_classification_training_result(manifest, &run_id)?;
+    Ok(canonical)
+}
+
+fn validate_repeat_classification_evaluation(value: Value) -> Result<Value, String> {
+    if value.get("schema_version").and_then(Value::as_str)
+        != Some("understudy.local_classifier.repeat_evaluation.v1")
+        || value.get("local_only").and_then(Value::as_bool) != Some(true)
+        || value
+            .get("data_boundary")
+            .and_then(Value::as_object)
+            .and_then(|boundary| boundary.get("dataset_uploaded"))
+            .and_then(Value::as_bool)
+            != Some(false)
+        || value
+            .get("data_boundary")
+            .and_then(Value::as_object)
+            .and_then(|boundary| boundary.get("telemetry_sent"))
+            .and_then(Value::as_bool)
+            != Some(false)
+        || !matches!(
+            value
+                .get("verdict")
+                .and_then(Value::as_object)
+                .and_then(|verdict| verdict.get("status"))
+                .and_then(Value::as_str),
+            Some("reproduced" | "drift_detected")
+        )
+    {
+        return Err("The repeat evaluation returned invalid local evidence.".into());
+    }
+    for field in ["run_id", "model_id", "generated_at", "artifact_path"] {
+        if value
+            .get(field)
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty() && text.len() <= 4_096)
+            .is_none()
+        {
+            return Err(format!("The repeat evaluation omitted {field}."));
+        }
+    }
+    let repeat = value
+        .get("repeat")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The repeat evaluation omitted its measured result.".to_string())?;
+    for score in ["accuracy", "macro_f1"] {
+        if repeat
+            .get(score)
+            .and_then(Value::as_f64)
+            .filter(|value| value.is_finite() && (0.0..=1.0).contains(value))
+            .is_none()
+        {
+            return Err(format!("The repeat evaluation returned invalid {score}."));
+        }
+    }
+    Ok(value)
+}
+
+fn repeat_classification_evaluation(run_manifest_path: String) -> Result<Value, String> {
+    let canonical = completed_run_manifest(&run_manifest_path)?;
+    let output = crate::bin::command("understudy")
+        .args([
+            "capture-import",
+            "repeat-classification-evaluation",
+            "--run-manifest",
+        ])
+        .arg(&canonical)
+        .arg("--json")
+        .output()
+        .map_err(|error| {
+            format!(
+                "Could not repeat this classifier evaluation ({error}). Open Status to repair the CLI."
+            )
+        })?;
+    if !output.status.success() {
+        return Err(format!(
+            "The repeat evaluation failed. {}",
+            bounded_detail(&output.stderr)
+        ));
+    }
+    let value = serde_json::from_slice::<Value>(&output.stdout)
+        .map_err(|_| "The repeat evaluation returned malformed JSON.".to_string())?;
+    validate_repeat_classification_evaluation(value)
+}
+
+#[tauri::command]
+pub async fn repeat_local_classification_evaluation(
+    run_manifest_path: String,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        repeat_classification_evaluation(run_manifest_path)
+    })
+    .await
+    .map_err(|error| format!("The repeat evaluation stopped unexpectedly: {error}"))?
+}
+
+fn validate_classification_prediction_export(value: Value) -> Result<Value, String> {
+    if value.get("schema_version").and_then(Value::as_str)
+        != Some("understudy.local_classifier.prediction_export.v1")
+        || value.get("local_only").and_then(Value::as_bool) != Some(true)
+        || value
+            .get("data_boundary")
+            .and_then(Value::as_object)
+            .and_then(|boundary| boundary.get("dataset_uploaded"))
+            .and_then(Value::as_bool)
+            != Some(false)
+        || value
+            .get("data_boundary")
+            .and_then(Value::as_object)
+            .and_then(|boundary| boundary.get("telemetry_sent"))
+            .and_then(Value::as_bool)
+            != Some(false)
+    {
+        return Err("The prediction export returned invalid local evidence.".into());
+    }
+    let row_count = value
+        .get("row_count")
+        .and_then(Value::as_u64)
+        .filter(|count| *count <= 10_000)
+        .ok_or_else(|| "The prediction export returned an invalid row count.".to_string())?;
+    let predicted = value
+        .get("predicted_row_count")
+        .and_then(Value::as_u64)
+        .filter(|count| *count <= row_count)
+        .ok_or_else(|| "The prediction export returned an invalid labeled count.".to_string())?;
+    let skipped = value
+        .get("skipped_row_count")
+        .and_then(Value::as_u64)
+        .filter(|count| *count <= row_count)
+        .ok_or_else(|| "The prediction export returned an invalid skipped count.".to_string())?;
+    if predicted + skipped != row_count {
+        return Err("The prediction export row counts do not reconcile.".into());
+    }
+    for field in [
+        "run_id",
+        "model_id",
+        "source_path",
+        "output_path",
+        "manifest_path",
+    ] {
+        if value
+            .get(field)
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty() && text.len() <= 4_096)
+            .is_none()
+        {
+            return Err(format!("The prediction export omitted {field}."));
+        }
+    }
+    Ok(value)
+}
+
+fn export_classification_predictions(run_manifest_path: String) -> Result<Value, String> {
+    let canonical = completed_run_manifest(&run_manifest_path)?;
+    let output = crate::bin::command("understudy")
+        .args([
+            "capture-import",
+            "export-classification-predictions",
+            "--run-manifest",
+        ])
+        .arg(&canonical)
+        .arg("--json")
+        .output()
+        .map_err(|error| {
+            format!("Could not export local predictions ({error}). Open Status to repair the CLI.")
+        })?;
+    if !output.status.success() {
+        return Err(format!(
+            "The prediction export failed. {}",
+            bounded_detail(&output.stderr)
+        ));
+    }
+    let value = serde_json::from_slice::<Value>(&output.stdout)
+        .map_err(|_| "The prediction export returned malformed JSON.".to_string())?;
+    validate_classification_prediction_export(value)
+}
+
+#[tauri::command]
+pub async fn export_local_classification_predictions(
+    run_manifest_path: String,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        export_classification_predictions(run_manifest_path)
+    })
+    .await
+    .map_err(|error| format!("The prediction export stopped unexpectedly: {error}"))?
 }
 
 #[cfg(test)]

--- a/src/capture-import.ts
+++ b/src/capture-import.ts
@@ -986,6 +986,10 @@ function readCsvForTraining(source: string): { bytes: Buffer; headers: string[];
   return readDelimitedTable(source);
 }
 
+export function readCaptureDelimitedTable(sourceInput: string): { bytes: Buffer; headers: string[]; rows: string[][] } {
+  return readDelimitedTable(resolve(sourceInput));
+}
+
 function readDelimitedTable(source: string): { bytes: Buffer; headers: string[]; rows: string[][] } {
   const bytes = readFileSync(source);
   if (bytes.length > MAX_CSV_BYTES) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ import {
   updateLocalClassifierRun,
 } from "./local-classifier/registry.js";
 import {
+  exportLocalClassifierPredictions,
+  repeatLocalClassifierEvaluation,
+} from "./local-classifier/lifecycle.js";
+import {
   compareClassifierWithFrontier,
   DEFAULT_FRONTIER_CLASSIFIER_BUDGET_USD,
   DEFAULT_FRONTIER_CLASSIFIER_MODEL,
@@ -514,6 +518,75 @@ function registerCaptureImportCommands(program: Command): void {
       console.log(`prediction: ${prediction.label}`);
       console.log(`confidence: ${(prediction.scores[0]?.score ?? 0).toFixed(4)}`);
       console.log("local_only: true (input text was not retained)");
+    });
+
+  captureImport
+    .command("repeat-classification-evaluation")
+    .description("Re-run a saved classifier on its exact immutable holdout and persist new evidence")
+    .requiredOption("--run-manifest <path>", "Completed local classification run manifest")
+    .option("--evaluation-id <id>", "Immutable repeat-evaluation identifier")
+    .option("--runtime-root <path>", "Content-addressed local lifecycle runtime root")
+    .option("--max-length <tokens>", "Maximum input token length", parsePositiveInteger)
+    .option("--json", "Output JSON")
+    .action((options: {
+      runManifest: string;
+      evaluationId?: string;
+      runtimeRoot?: string;
+      maxLength?: number;
+      json?: boolean;
+    }) => {
+      const result = repeatLocalClassifierEvaluation({
+        runManifestPath: options.runManifest,
+        evaluationId: options.evaluationId,
+        runtimeRoot: options.runtimeRoot,
+        maxLength: options.maxLength,
+      });
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`repeat evaluation: ${result.verdict.status}`);
+      console.log(`correct answers: ${(result.repeat.accuracy * 100).toFixed(1)}%`);
+      console.log(`artifact: ${result.artifact_path}`);
+      console.log("local_only: true (holdout examples were not uploaded)");
+    });
+
+  captureImport
+    .command("export-classification-predictions")
+    .description("Append local classifier labels to a bounded CSV and write an evidence sidecar")
+    .requiredOption("--run-manifest <path>", "Completed local classification run manifest")
+    .option("--source <path>", "CSV/TSV to label; defaults to the original training source")
+    .option("--input-column <columns...>", "Source columns to combine; defaults to the confirmed training mapping")
+    .option("--output <path>", "Destination CSV; defaults under the immutable local run")
+    .option("--runtime-root <path>", "Content-addressed local lifecycle runtime root")
+    .option("--max-length <tokens>", "Maximum input token length", parsePositiveInteger)
+    .option("--json", "Output JSON")
+    .action((options: {
+      runManifest: string;
+      source?: string;
+      inputColumn?: string[];
+      output?: string;
+      runtimeRoot?: string;
+      maxLength?: number;
+      json?: boolean;
+    }) => {
+      const result = exportLocalClassifierPredictions({
+        runManifestPath: options.runManifest,
+        sourcePath: options.source,
+        inputColumns: options.inputColumn,
+        outputPath: options.output,
+        runtimeRoot: options.runtimeRoot,
+        maxLength: options.maxLength,
+      });
+      if (commandJsonEnabled(program, options)) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`prediction export: ${result.predicted_row_count.toLocaleString()} labeled row(s)`);
+      if (result.skipped_row_count > 0) console.log(`skipped empty rows: ${result.skipped_row_count.toLocaleString()}`);
+      console.log(`output: ${result.output_path}`);
+      console.log(`evidence: ${result.manifest_path}`);
+      console.log("local_only: true (source and predictions were not uploaded)");
     });
 
   captureImport

--- a/src/local-classifier/lifecycle-runtime-source.ts
+++ b/src/local-classifier/lifecycle-runtime-source.ts
@@ -1,0 +1,224 @@
+export const localClassifierLifecycleRuntimeSource = String.raw`#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), flush=True)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return value
+
+
+def synchronize(torch: Any, device: Any) -> None:
+    if device.type == "mps":
+        torch.mps.synchronize()
+    elif device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def load_model(run: dict[str, Any]) -> tuple[Any, Any, Any, list[str]]:
+    model = run.get("model")
+    if run.get("status") != "completed" or not isinstance(model, dict):
+        raise ValueError("lifecycle operations require a completed classification run")
+    model_path = Path(str(model.get("path", "")))
+    if not model_path.is_dir():
+        raise ValueError("the completed classifier model artifact is missing")
+    labels = model.get("labels")
+    if not isinstance(labels, list) or len(labels) < 2 or any(not isinstance(label, str) or not label for label in labels):
+        raise ValueError("the completed classifier labels are invalid")
+
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(str(model_path), local_files_only=True)
+    classifier = AutoModelForSequenceClassification.from_pretrained(str(model_path), local_files_only=True)
+    classifier.eval()
+    if torch.backends.mps.is_available():
+        device = torch.device("mps")
+    elif torch.cuda.is_available():
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+    classifier.to(device)
+    return torch, tokenizer, classifier, device, labels
+
+
+def infer(torch: Any, tokenizer: Any, model: Any, device: Any, text: str, max_length: int) -> tuple[int, list[float], float]:
+    encoded = tokenizer(text, truncation=True, max_length=max_length, return_tensors="pt")
+    encoded = {key: tensor.to(device) for key, tensor in encoded.items()}
+    with torch.no_grad():
+        synchronize(torch, device)
+        started = time.perf_counter()
+        logits = model(**encoded).logits[0]
+        probabilities = torch.softmax(logits, dim=-1)
+        synchronize(torch, device)
+        latency_ms = (time.perf_counter() - started) * 1000
+    predicted = int(torch.argmax(probabilities).item())
+    return predicted, [float(value.item()) for value in probabilities], latency_ms
+
+
+def safe_ratio(numerator: float, denominator: float) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def classification_metrics(expected: list[int], predicted: list[int], labels: list[str]) -> dict[str, Any]:
+    matrix = [[0 for _ in labels] for _ in labels]
+    for gold, guess in zip(expected, predicted, strict=True):
+        matrix[gold][guess] += 1
+    per_class: list[dict[str, Any]] = []
+    f1_values: list[float] = []
+    for index, label in enumerate(labels):
+        true_positive = matrix[index][index]
+        false_positive = sum(matrix[row][index] for row in range(len(labels)) if row != index)
+        false_negative = sum(matrix[index][column] for column in range(len(labels)) if column != index)
+        precision = safe_ratio(true_positive, true_positive + false_positive)
+        recall = safe_ratio(true_positive, true_positive + false_negative)
+        f1 = safe_ratio(2 * precision * recall, precision + recall)
+        support = sum(matrix[index])
+        f1_values.append(f1)
+        per_class.append({
+            "label": label,
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "support": support,
+        })
+    correct = sum(1 for gold, guess in zip(expected, predicted, strict=True) if gold == guess)
+    return {
+        "accuracy": safe_ratio(correct, len(expected)),
+        "macro_f1": safe_ratio(sum(f1_values), len(f1_values)),
+        "per_class": per_class,
+        "confusion_matrix": {"labels": labels, "rows": matrix},
+    }
+
+
+def evaluate(request: dict[str, Any]) -> None:
+    run = read_json(Path(request["run_manifest_path"]))
+    torch, tokenizer, model, device, labels = load_model(run)
+    holdout_path = Path(request["holdout_path"])
+    raw = holdout_path.read_bytes()
+    if sha256_bytes(raw) != request["holdout_sha256"]:
+        raise ValueError("the immutable holdout changed before repeat evaluation")
+    rows: list[dict[str, Any]] = []
+    for line in raw.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict) or any(not isinstance(row.get(key), str) or not row[key] for key in ("example_id", "group_id", "text", "label")):
+            raise ValueError("the immutable holdout contains an invalid row")
+        rows.append(row)
+    if len(rows) != int(request["holdout_row_count"]):
+        raise ValueError("the immutable holdout row count changed")
+
+    label_to_id = {label: index for index, label in enumerate(labels)}
+    expected_ids: list[int] = []
+    predicted_ids: list[int] = []
+    latencies: list[float] = []
+    failures: list[dict[str, Any]] = []
+    prediction_digest = hashlib.sha256()
+    for row in rows:
+        expected = label_to_id.get(row["label"])
+        if expected is None:
+            raise ValueError("the immutable holdout contains an unknown label")
+        predicted, _, latency_ms = infer(torch, tokenizer, model, device, row["text"], int(request["max_length"]))
+        expected_ids.append(expected)
+        predicted_ids.append(predicted)
+        latencies.append(latency_ms)
+        prediction_digest.update(f'{row["example_id"]}\0{row["label"]}\0{labels[predicted]}\n'.encode("utf-8"))
+        if predicted != expected and len(failures) < 25:
+            failures.append({
+                "example_id": row["example_id"],
+                "group_id": row["group_id"],
+                "text_sha256": sha256_bytes(row["text"].encode("utf-8")),
+                "expected_label": row["label"],
+                "predicted_label": labels[predicted],
+            })
+    metrics = classification_metrics(expected_ids, predicted_ids, labels)
+    failure_count = sum(1 for expected, predicted in zip(expected_ids, predicted_ids, strict=True) if expected != predicted)
+    weakest_classes = sorted(
+        (
+            {"label": item["label"], "recall": item["recall"], "f1": item["f1"], "support": item["support"]}
+            for item in metrics["per_class"]
+        ),
+        key=lambda item: (item["recall"], item["f1"], item["label"]),
+    )[:5]
+    emit({
+        "schema_version": "understudy.local_classifier.repeat_evaluation.runtime.v1",
+        "run_id": run["run_id"],
+        "row_count": len(rows),
+        "accuracy": metrics["accuracy"],
+        "macro_f1": metrics["macro_f1"],
+        "latency_ms_p50": statistics.median(latencies) if latencies else 0.0,
+        "per_class": metrics["per_class"],
+        "weakest_classes": weakest_classes,
+        "confusion_matrix": metrics["confusion_matrix"],
+        "failures": failures,
+        "failure_count": failure_count,
+        "failures_truncated": failure_count > len(failures),
+        "predictions_sha256": prediction_digest.hexdigest(),
+        "device": str(device),
+        "local_only": True,
+    })
+
+
+def predict_batch(request: dict[str, Any]) -> None:
+    run = read_json(Path(request["run_manifest_path"]))
+    torch, tokenizer, model, device, labels = load_model(run)
+    rows = request.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("batch prediction rows must be an array")
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("row_index"), int) or not isinstance(row.get("text"), str) or not row["text"]:
+            raise ValueError("batch prediction contains an invalid row")
+        predicted, probabilities, latency_ms = infer(torch, tokenizer, model, device, row["text"], int(request["max_length"]))
+        results.append({
+            "row_index": row["row_index"],
+            "label": labels[predicted],
+            "confidence": probabilities[predicted],
+            "latency_ms": latency_ms,
+        })
+    emit({
+        "schema_version": "understudy.local_classifier.batch_prediction.runtime.v1",
+        "run_id": run["run_id"],
+        "row_count": len(results),
+        "rows": results,
+        "device": str(device),
+        "local_only": True,
+    })
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("evaluate", "predict-batch"))
+    parser.add_argument("--request-stdin", action="store_true", required=True)
+    args = parser.parse_args()
+    request = json.loads(sys.stdin.read())
+    if not isinstance(request, dict):
+        raise ValueError("lifecycle request must be a JSON object")
+    if args.command == "evaluate":
+        evaluate(request)
+    else:
+        predict_batch(request)
+
+
+if __name__ == "__main__":
+    main()
+`;

--- a/src/local-classifier/lifecycle.ts
+++ b/src/local-classifier/lifecycle.ts
@@ -1,0 +1,558 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
+
+import { readCaptureDelimitedTable } from "../capture-import.js";
+import {
+  DEFAULT_CLASSIFIER_RUNTIME_PACKAGES,
+  type ClassificationTrainingRunManifest,
+  type LocalClassifierRunnerOverride,
+} from "./index.js";
+import { localClassifierLifecycleRuntimeSource } from "./lifecycle-runtime-source.js";
+import { getLocalClassifierRun } from "./registry.js";
+
+const RUN_SCHEMA = "understudy.capture_import.classification_run.v1";
+const DATASET_SCHEMA = "understudy.capture_import.classification_dataset.v2";
+const REPEAT_RUNTIME_SCHEMA = "understudy.local_classifier.repeat_evaluation.runtime.v1";
+const REPEAT_SCHEMA = "understudy.local_classifier.repeat_evaluation.v1";
+const BATCH_RUNTIME_SCHEMA = "understudy.local_classifier.batch_prediction.runtime.v1";
+const EXPORT_SCHEMA = "understudy.local_classifier.prediction_export.v1";
+const MAX_EXPORT_ROWS = 10_000;
+const MAX_RUNTIME_BUFFER_BYTES = 64 * 1024 * 1024;
+const EVIDENCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+type DatasetManifest = {
+  schema_version: typeof DATASET_SCHEMA;
+  source_path: string;
+  source_sha256: string;
+  mapping_sha256: string;
+  mapping: {
+    input_columns: string[];
+    label_column: string;
+    group_column: string;
+    text_template: "named-fields-v1";
+  };
+  labels: string[];
+  splits: {
+    holdout: { path: string; row_count: number; sha256: string };
+  };
+};
+
+type RuntimePack = {
+  cacheRoot: string;
+  path: string;
+  sha256: string;
+  packages: readonly string[];
+};
+
+type RuntimeEvaluation = {
+  schema_version: typeof REPEAT_RUNTIME_SCHEMA;
+  run_id: string;
+  row_count: number;
+  accuracy: number;
+  macro_f1: number;
+  latency_ms_p50: number;
+  per_class: Array<{ label: string; precision: number; recall: number; f1: number; support: number }>;
+  weakest_classes: Array<{ label: string; recall: number; f1: number; support: number }>;
+  confusion_matrix: { labels: string[]; rows: number[][] };
+  failures: Array<{
+    example_id: string;
+    group_id: string;
+    text_sha256: string;
+    expected_label: string;
+    predicted_label: string;
+  }>;
+  failure_count: number;
+  failures_truncated: boolean;
+  predictions_sha256: string;
+  device: string;
+  local_only: true;
+};
+
+export type RepeatLocalClassifierEvaluationOptions = {
+  runManifestPath: string;
+  evaluationId?: string;
+  runtimeRoot?: string;
+  maxLength?: number;
+  uvBinary?: string;
+  runtimePackages?: readonly string[];
+  runnerOverride?: LocalClassifierRunnerOverride;
+  now?: Date;
+};
+
+export type RepeatLocalClassifierEvaluation = {
+  schema_version: typeof REPEAT_SCHEMA;
+  evaluation_id: string;
+  run_id: string;
+  model_id: string;
+  generated_at: string;
+  local_only: true;
+  data_boundary: { dataset_uploaded: false; telemetry_sent: false };
+  holdout: { path: string; row_count: number; sha256: string };
+  initial: { accuracy: number; macro_f1: number; failure_count: number };
+  repeat: RuntimeEvaluation;
+  comparison: {
+    accuracy_delta: number;
+    macro_f1_delta: number;
+    failure_count_delta: number;
+    matches_initial_metrics: boolean;
+  };
+  verdict: {
+    status: "reproduced" | "drift_detected";
+    reason: string;
+  };
+  runtime: { runtime_sha256: string; device: string };
+  artifact_path: string;
+};
+
+export type ExportLocalClassifierPredictionsOptions = {
+  runManifestPath: string;
+  sourcePath?: string;
+  inputColumns?: string[];
+  outputPath?: string;
+  runtimeRoot?: string;
+  maxLength?: number;
+  uvBinary?: string;
+  runtimePackages?: readonly string[];
+  runnerOverride?: LocalClassifierRunnerOverride;
+  now?: Date;
+};
+
+export type LocalClassifierPredictionExport = {
+  schema_version: typeof EXPORT_SCHEMA;
+  run_id: string;
+  model_id: string;
+  generated_at: string;
+  local_only: true;
+  data_boundary: { dataset_uploaded: false; telemetry_sent: false };
+  source_path: string;
+  source_sha256: string;
+  input_columns: string[];
+  row_count: number;
+  predicted_row_count: number;
+  skipped_row_count: number;
+  output_path: string;
+  manifest_path: string;
+};
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isMetric(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+function isNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function ensurePrivateDirectory(path: string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32") chmodSync(path, 0o700);
+}
+
+function writePrivateImmutable(path: string, value: string | Buffer): void {
+  ensurePrivateDirectory(dirname(path));
+  writeFileSync(path, value, { flag: "wx", mode: 0o600 });
+  if (process.platform !== "win32") chmodSync(path, 0o600);
+}
+
+function writePrivateAtomic(path: string, value: string): void {
+  ensurePrivateDirectory(dirname(path));
+  if (existsSync(path)) throw new Error(`Refusing to overwrite an existing local artifact: ${path}`);
+  const temporary = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(temporary, value, { flag: "wx", mode: 0o600 });
+  if (process.platform !== "win32") chmodSync(temporary, 0o600);
+  renameSync(temporary, path);
+}
+
+function parseObject(path: string): Record<string, unknown> {
+  const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (!isRecord(value)) throw new Error(`Expected a JSON object: ${path}`);
+  return value;
+}
+
+function directoryEvidence(path: string): { sha256: string; sizeBytes: number } {
+  const digest = createHash("sha256");
+  let sizeBytes = 0;
+  const visit = (root: string, relativeRoot = "") => {
+    for (const entry of readdirSync(root, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name))) {
+      const absolute = join(root, entry.name);
+      const relative = relativeRoot ? `${relativeRoot}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        visit(absolute, relative);
+      } else if (entry.isFile()) {
+        const nameBytes = Buffer.from(relative, "utf8");
+        const payload = readFileSync(absolute);
+        const length = Buffer.alloc(8);
+        length.writeBigUInt64BE(BigInt(nameBytes.length));
+        digest.update(length).update(nameBytes);
+        length.writeBigUInt64BE(BigInt(payload.length));
+        digest.update(length).update(payload);
+        sizeBytes += payload.length;
+      }
+    }
+  };
+  visit(path);
+  return { sha256: digest.digest("hex"), sizeBytes };
+}
+
+function readCompletedRun(runManifestPath: string): {
+  manifestPath: string;
+  run: ClassificationTrainingRunManifest;
+  dataset: DatasetManifest;
+} {
+  const manifestPath = resolve(runManifestPath);
+  const summary = getLocalClassifierRun(manifestPath);
+  if (summary.run_status !== "completed" || !summary.model?.available) {
+    throw new Error("Lifecycle operations require a completed classifier whose model files are available.");
+  }
+  const run = parseObject(manifestPath) as unknown as ClassificationTrainingRunManifest;
+  if (run.schema_version !== RUN_SCHEMA || run.status !== "completed" || !run.model || !run.runtime || !run.heldout ||
+      run.local_only !== true || run.data_boundary.dataset_uploaded !== false || run.data_boundary.telemetry_sent !== false ||
+      resolve(run.manifest_path) !== manifestPath || resolve(run.model.path) !== join(dirname(manifestPath), "model")) {
+    throw new Error("The completed classifier failed its immutable local evidence contract.");
+  }
+  const modelEvidence = directoryEvidence(run.model.path);
+  if (modelEvidence.sha256 !== run.model.sha256 || modelEvidence.sizeBytes !== run.model.size_bytes) {
+    throw new Error("The saved classifier changed after its immutable run was recorded.");
+  }
+  const datasetPath = resolve(run.dataset.manifest_path);
+  const dataset = parseObject(datasetPath) as unknown as DatasetManifest;
+  if (dataset.schema_version !== DATASET_SCHEMA ||
+      dataset.source_sha256 !== run.dataset.source_sha256 || dataset.mapping_sha256 !== run.dataset.mapping_sha256 ||
+      !isString(dataset.source_path) || !isRecord(dataset.mapping) || dataset.mapping.text_template !== "named-fields-v1" ||
+      !Array.isArray(dataset.mapping.input_columns) || !dataset.mapping.input_columns.every(isString) ||
+      !Array.isArray(dataset.labels) || JSON.stringify(dataset.labels) !== JSON.stringify(run.model.labels) ||
+      !isRecord(dataset.splits?.holdout)) {
+    throw new Error("The classifier dataset manifest no longer matches the completed run.");
+  }
+  const holdout = dataset.splits.holdout;
+  const holdoutPath = resolve(holdout.path);
+  if (!existsSync(holdoutPath) || !statSync(holdoutPath).isFile() || sha256(readFileSync(holdoutPath)) !== holdout.sha256 ||
+      holdout.sha256 !== run.dataset.splits.holdout.sha256 || holdout.row_count !== run.dataset.splits.holdout.row_count) {
+    throw new Error("The immutable classifier holdout is unavailable or changed.");
+  }
+  return { manifestPath, run, dataset };
+}
+
+function prepareRuntimePack(runtimeRootInput: string, packages: readonly string[]): RuntimePack {
+  if (packages.length === 0 || !packages.every((value) => /^[A-Za-z0-9_.-]+==[^=\s]+$/.test(value))) {
+    throw new Error("Classifier lifecycle dependencies must use exact package==version pins.");
+  }
+  const cacheRoot = resolve(runtimeRootInput);
+  const sourceSha256 = sha256(localClassifierLifecycleRuntimeSource);
+  const runtimeSha256 = sha256(JSON.stringify({
+    schema_version: "understudy.local_classifier.lifecycle_runtime.v1",
+    python: "3.12",
+    packages,
+    source_sha256: sourceSha256,
+  }));
+  const root = join(cacheRoot, "lifecycle-runtime-packs", runtimeSha256);
+  ensurePrivateDirectory(root);
+  const path = join(root, "classifier_lifecycle_runtime.py");
+  const specPath = join(root, "runtime-spec.json");
+  const spec = {
+    schema_version: "understudy.local_classifier.lifecycle_runtime.v1",
+    runtime_sha256: runtimeSha256,
+    python: "3.12",
+    packages,
+    source_sha256: sourceSha256,
+    system_python_required: false,
+  };
+  if (!existsSync(path)) writePrivateImmutable(path, localClassifierLifecycleRuntimeSource);
+  else if (sha256(readFileSync(path)) !== sourceSha256) throw new Error(`Content-addressed lifecycle runtime was modified: ${path}`);
+  if (!existsSync(specPath)) writePrivateImmutable(specPath, `${JSON.stringify(spec, null, 2)}\n`);
+  else if (JSON.stringify(parseObject(specPath)) !== JSON.stringify(spec)) throw new Error(`Content-addressed lifecycle runtime spec was modified: ${specPath}`);
+  return { cacheRoot, path, sha256: runtimeSha256, packages };
+}
+
+function runtimeEnvironment(cacheRoot: string): NodeJS.ProcessEnv {
+  const cache = join(cacheRoot, "cache");
+  ensurePrivateDirectory(cache);
+  return {
+    ...process.env,
+    HF_HUB_DISABLE_TELEMETRY: "1",
+    TRANSFORMERS_NO_ADVISORY_WARNINGS: "1",
+    DO_NOT_TRACK: "1",
+    TOKENIZERS_PARALLELISM: "false",
+    UV_CACHE_DIR: join(cache, "uv"),
+    HF_HOME: join(cache, "huggingface"),
+    HF_HUB_CACHE: join(cache, "huggingface", "hub"),
+    TORCH_HOME: join(cache, "torch"),
+  };
+}
+
+function runLifecycleRuntime(
+  command: "evaluate" | "predict-batch",
+  request: unknown,
+  pack: RuntimePack,
+  uvBinary: string,
+  override?: LocalClassifierRunnerOverride,
+): unknown {
+  const invocation = override
+    ? { command: override.command, args: [...(override.args ?? []), command, "--request-stdin"] }
+    : {
+      command: uvBinary,
+      args: [
+        "run", "--isolated", "--managed-python", "--python", "3.12", "--no-project",
+        ...pack.packages.flatMap((dependency) => ["--with", dependency]),
+        "python", pack.path, command, "--request-stdin",
+      ],
+    };
+  const result = spawnSync(invocation.command, invocation.args, {
+    env: runtimeEnvironment(pack.cacheRoot),
+    input: JSON.stringify(request),
+    encoding: "utf8",
+    maxBuffer: MAX_RUNTIME_BUFFER_BYTES,
+  });
+  if (result.status !== 0) {
+    const detail = result.stderr?.trim() || result.error?.message || `exit ${result.status}`;
+    throw new Error(`Local classifier ${command} failed: ${detail}`);
+  }
+  const line = result.stdout.trim().split("\n").filter(Boolean).at(-1) ?? "null";
+  return JSON.parse(line) as unknown;
+}
+
+function validateRuntimeEvaluation(value: unknown, run: ClassificationTrainingRunManifest): RuntimeEvaluation {
+  if (!isRecord(value) || value.schema_version !== REPEAT_RUNTIME_SCHEMA || value.run_id !== run.run_id ||
+      value.local_only !== true || value.row_count !== run.dataset.splits.holdout.row_count ||
+      !isMetric(value.accuracy) || !isMetric(value.macro_f1) || !isNonNegative(value.latency_ms_p50) ||
+      !Array.isArray(value.per_class) || !Array.isArray(value.weakest_classes) || !isRecord(value.confusion_matrix) ||
+      !Array.isArray(value.failures) || !Number.isSafeInteger(value.failure_count) || Number(value.failure_count) < 0 ||
+      typeof value.failures_truncated !== "boolean" || !isString(value.predictions_sha256) ||
+      !/^[a-f0-9]{64}$/.test(value.predictions_sha256) || !isString(value.device)) {
+    throw new Error("The lifecycle runtime returned invalid repeat-evaluation evidence.");
+  }
+  const labels = run.model!.labels;
+  const perClass = new Map<string, Record<string, unknown>>();
+  for (const item of value.per_class) {
+    if (!isRecord(item) || !isString(item.label) || perClass.has(item.label) || !isMetric(item.precision) ||
+        !isMetric(item.recall) || !isMetric(item.f1) || !Number.isSafeInteger(item.support) || Number(item.support) < 0) {
+      throw new Error("Repeat evaluation returned invalid per-class evidence.");
+    }
+    perClass.set(item.label, item);
+  }
+  if (JSON.stringify([...perClass.keys()].sort()) !== JSON.stringify([...labels].sort())) {
+    throw new Error("Repeat evaluation did not cover every classifier label.");
+  }
+  const matrix = value.confusion_matrix;
+  if (!Array.isArray(matrix.labels) || JSON.stringify(matrix.labels) !== JSON.stringify(labels) ||
+      !Array.isArray(matrix.rows) || matrix.rows.length !== labels.length ||
+      !matrix.rows.every((row) => Array.isArray(row) && row.length === labels.length && row.every((count) => Number.isSafeInteger(count) && Number(count) >= 0))) {
+    throw new Error("Repeat evaluation returned an invalid confusion matrix.");
+  }
+  const rows = matrix.rows as number[][];
+  const total = rows.flat().reduce((sum, count) => sum + count, 0);
+  const correct = rows.reduce((sum, row, index) => sum + row[index], 0);
+  const macroF1 = [...perClass.values()].reduce((sum, item) => sum + Number(item.f1), 0) / labels.length;
+  if (total !== value.row_count || Math.abs(correct / total - value.accuracy) > 1e-9 || Math.abs(macroF1 - value.macro_f1) > 1e-9 ||
+      Number(value.failure_count) !== total - correct || value.failures.length > Math.min(25, Number(value.failure_count)) ||
+      value.failures_truncated !== (Number(value.failure_count) > value.failures.length)) {
+    throw new Error("Repeat-evaluation metrics do not reconcile with their evidence.");
+  }
+  return value as unknown as RuntimeEvaluation;
+}
+
+function defaultRuntimeRoot(manifestPath: string): string {
+  return join(dirname(dirname(manifestPath)), "..", "training-runtime");
+}
+
+function evidenceId(prefix: string, now: Date): string {
+  return `${prefix}-${now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z")}`;
+}
+
+export function repeatLocalClassifierEvaluation(
+  options: RepeatLocalClassifierEvaluationOptions,
+): RepeatLocalClassifierEvaluation {
+  const { manifestPath, run, dataset } = readCompletedRun(options.runManifestPath);
+  const now = options.now ?? new Date();
+  const evaluationId = options.evaluationId ?? evidenceId("repeat", now);
+  if (!EVIDENCE_ID_PATTERN.test(evaluationId)) {
+    throw new Error("Evaluation id must contain only letters, numbers, dots, underscores, and hyphens.");
+  }
+  const maxLength = options.maxLength ?? run.training.max_length;
+  if (!Number.isInteger(maxLength) || maxLength < 8 || maxLength > 8192) {
+    throw new Error("Repeat-evaluation max length must be an integer between 8 and 8192.");
+  }
+  const pack = prepareRuntimePack(
+    options.runtimeRoot ?? defaultRuntimeRoot(manifestPath),
+    options.runtimePackages ?? DEFAULT_CLASSIFIER_RUNTIME_PACKAGES,
+  );
+  const holdout = dataset.splits.holdout;
+  const runtime = validateRuntimeEvaluation(runLifecycleRuntime("evaluate", {
+    schema_version: "understudy.local_classifier.repeat_evaluation_request.v1",
+    run_manifest_path: manifestPath,
+    holdout_path: resolve(holdout.path),
+    holdout_sha256: holdout.sha256,
+    holdout_row_count: holdout.row_count,
+    max_length: maxLength,
+    local_only: true,
+  }, pack, options.uvBinary ?? "uv", options.runnerOverride), run);
+  const accuracyDelta = runtime.accuracy - run.heldout!.accuracy;
+  const macroF1Delta = runtime.macro_f1 - run.heldout!.macro_f1;
+  const failureCountDelta = runtime.failure_count - run.heldout!.failure_count;
+  const matches = Math.abs(accuracyDelta) <= 1e-9 && Math.abs(macroF1Delta) <= 1e-9 && failureCountDelta === 0;
+  const artifactPath = join(dirname(manifestPath), "evaluations", evaluationId, "evaluation.json");
+  const artifact: RepeatLocalClassifierEvaluation = {
+    schema_version: REPEAT_SCHEMA,
+    evaluation_id: evaluationId,
+    run_id: run.run_id,
+    model_id: `classifier.${run.run_id}`,
+    generated_at: now.toISOString(),
+    local_only: true,
+    data_boundary: { dataset_uploaded: false, telemetry_sent: false },
+    holdout: { path: resolve(holdout.path), row_count: holdout.row_count, sha256: holdout.sha256 },
+    initial: {
+      accuracy: run.heldout!.accuracy,
+      macro_f1: run.heldout!.macro_f1,
+      failure_count: run.heldout!.failure_count,
+    },
+    repeat: runtime,
+    comparison: {
+      accuracy_delta: accuracyDelta,
+      macro_f1_delta: macroF1Delta,
+      failure_count_delta: failureCountDelta,
+      matches_initial_metrics: matches,
+    },
+    verdict: {
+      status: matches ? "reproduced" : "drift_detected",
+      reason: matches
+        ? "The saved model reproduced its original results on the exact immutable holdout."
+        : "The saved model changed on the exact immutable holdout; inspect runtime and hardware evidence before use.",
+    },
+    runtime: { runtime_sha256: pack.sha256, device: runtime.device },
+    artifact_path: artifactPath,
+  };
+  writePrivateImmutable(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  return artifact;
+}
+
+function normalizeHeader(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function escapeCsv(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value;
+}
+
+export function exportLocalClassifierPredictions(
+  options: ExportLocalClassifierPredictionsOptions,
+): LocalClassifierPredictionExport {
+  const { manifestPath, run, dataset } = readCompletedRun(options.runManifestPath);
+  const sourcePath = resolve(options.sourcePath ?? dataset.source_path);
+  const { bytes, headers, rows } = readCaptureDelimitedTable(sourcePath);
+  if (rows.length > MAX_EXPORT_ROWS) {
+    throw new Error(`Prediction export supports at most ${MAX_EXPORT_ROWS.toLocaleString()} rows per file.`);
+  }
+  if (!options.sourcePath && sha256(bytes) !== dataset.source_sha256) {
+    throw new Error("The original training CSV changed; choose a new source explicitly or restore the original file.");
+  }
+  const headerMap = new Map(headers.map((header) => [normalizeHeader(header), header]));
+  const requestedColumns = options.inputColumns?.length ? options.inputColumns : dataset.mapping.input_columns;
+  const inputColumns = [...new Set(requestedColumns.map((column) => headerMap.get(normalizeHeader(column))))]
+    .filter((column): column is string => Boolean(column));
+  if (inputColumns.length !== new Set(requestedColumns.map(normalizeHeader)).size || inputColumns.length === 0) {
+    throw new Error("Every prediction input column must match one source header.");
+  }
+  const indexes = inputColumns.map((column) => headers.indexOf(column));
+  const pending = rows.map((row, rowIndex) => ({
+    row_index: rowIndex,
+    text: indexes
+      .map((index) => ({ name: headers[index], value: row[index]?.trim() ?? "" }))
+      .filter(({ value }) => value.length > 0)
+      .map(({ name, value }) => `${name}: ${value}`)
+      .join("\n"),
+  })).filter((row) => row.text.length > 0);
+  const maxLength = options.maxLength ?? run.training.max_length;
+  if (!Number.isInteger(maxLength) || maxLength < 8 || maxLength > 8192) {
+    throw new Error("Prediction-export max length must be an integer between 8 and 8192.");
+  }
+  const pack = prepareRuntimePack(
+    options.runtimeRoot ?? defaultRuntimeRoot(manifestPath),
+    options.runtimePackages ?? DEFAULT_CLASSIFIER_RUNTIME_PACKAGES,
+  );
+  const value = runLifecycleRuntime("predict-batch", {
+    schema_version: "understudy.local_classifier.batch_prediction_request.v1",
+    run_manifest_path: manifestPath,
+    rows: pending,
+    max_length: maxLength,
+    local_only: true,
+  }, pack, options.uvBinary ?? "uv", options.runnerOverride);
+  if (!isRecord(value) || value.schema_version !== BATCH_RUNTIME_SCHEMA || value.run_id !== run.run_id ||
+      value.local_only !== true || value.row_count !== pending.length || !Array.isArray(value.rows) || value.rows.length !== pending.length) {
+    throw new Error("The lifecycle runtime returned invalid batch predictions.");
+  }
+  const predictions = new Map<number, { label: string; confidence: number }>();
+  for (const item of value.rows) {
+    if (!isRecord(item) || !Number.isSafeInteger(item.row_index) || Number(item.row_index) < 0 || Number(item.row_index) >= rows.length ||
+        predictions.has(Number(item.row_index)) || !isString(item.label) || !run.model!.labels.includes(item.label) ||
+        !isMetric(item.confidence) || !isNonNegative(item.latency_ms)) {
+      throw new Error("The lifecycle runtime returned an invalid batch-prediction row.");
+    }
+    predictions.set(Number(item.row_index), { label: item.label, confidence: item.confidence });
+  }
+  const now = options.now ?? new Date();
+  const sourceStem = basename(sourcePath, extname(sourcePath)).replace(/[^A-Za-z0-9._-]+/g, "-").slice(0, 80) || "dataset";
+  const outputPath = resolve(options.outputPath ?? join(
+    dirname(manifestPath),
+    "exports",
+    `${sourceStem}-predictions-${now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z")}.csv`,
+  ));
+  const outputHeaders = [...headers, "understudy_label", "understudy_confidence", "understudy_model_id"];
+  const outputRows = rows.map((row, rowIndex) => {
+    const prediction = predictions.get(rowIndex);
+    return [
+      ...row,
+      prediction?.label ?? "",
+      prediction ? prediction.confidence.toFixed(6) : "",
+      prediction ? `classifier.${run.run_id}` : "",
+    ];
+  });
+  const csv = [outputHeaders, ...outputRows].map((row) => row.map(escapeCsv).join(",")).join("\n") + "\n";
+  writePrivateAtomic(outputPath, csv);
+  const exportManifestPath = `${outputPath}.understudy.json`;
+  const artifact: LocalClassifierPredictionExport = {
+    schema_version: EXPORT_SCHEMA,
+    run_id: run.run_id,
+    model_id: `classifier.${run.run_id}`,
+    generated_at: now.toISOString(),
+    local_only: true,
+    data_boundary: { dataset_uploaded: false, telemetry_sent: false },
+    source_path: sourcePath,
+    source_sha256: sha256(bytes),
+    input_columns: inputColumns,
+    row_count: rows.length,
+    predicted_row_count: predictions.size,
+    skipped_row_count: rows.length - predictions.size,
+    output_path: outputPath,
+    manifest_path: exportManifestPath,
+  };
+  try {
+    writePrivateAtomic(exportManifestPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  } catch (error) {
+    // The CSV is the valuable user artifact. If its evidence sidecar cannot be
+    // committed, remove neither file and surface the exact repair path.
+    throw new Error(`Predictions were written to ${outputPath}, but evidence could not be saved: ${String(error)}`);
+  }
+  return artifact;
+}

--- a/src/local-classifier/registry.ts
+++ b/src/local-classifier/registry.ts
@@ -24,6 +24,7 @@ const MAX_CAPTURE_ROOTS = 2_000;
 const MAX_DATASETS_PER_CAPTURE = 2_000;
 const MAX_RUNS_PER_DATASET = 2_000;
 const MAX_SCANNED_RUNS = 10_000;
+const MAX_REPEAT_EVALUATIONS = 1_000;
 const COMPLETED_VERDICTS = new Set(["not_better", "improved_not_ready", "promising"]);
 
 type RunStatus = "completed" | "failed" | "cancelled";
@@ -91,6 +92,12 @@ export type LocalClassifierRunSummary = {
     latency_ms_p50: number;
     failure_count: number;
     verdict: string;
+  };
+  repeat_validation: null | {
+    count: number;
+    latest_at: string;
+    latest_status: "reproduced" | "drift_detected";
+    latest_artifact_path: string;
   };
   timing_ms: number | null;
   failure: null | { code: string; message: string };
@@ -184,6 +191,42 @@ function readLifecycle(manifestPath: string, runId: string, generatedAt: string)
   return value as LifecycleRecord;
 }
 
+function readRepeatValidation(manifestPath: string, runId: string): LocalClassifierRunSummary["repeat_validation"] {
+  const root = join(dirname(manifestPath), "evaluations");
+  if (!existsSync(root) || !statSync(root).isDirectory()) return null;
+  const evidence = readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .slice(0, MAX_REPEAT_EVALUATIONS)
+    .map((entry) => join(root, entry.name, "evaluation.json"))
+    .filter((path) => existsSync(path) && statSync(path).isFile())
+    .map((path) => {
+      const value = parseJson(path);
+      if (!isRecord(value) || value.schema_version !== "understudy.local_classifier.repeat_evaluation.v1" ||
+          value.run_id !== runId || value.model_id !== `classifier.${runId}` || value.local_only !== true ||
+          !isNonEmptyString(value.generated_at) || Number.isNaN(Date.parse(value.generated_at)) ||
+          !isRecord(value.data_boundary) || value.data_boundary.dataset_uploaded !== false ||
+          value.data_boundary.telemetry_sent !== false || !isRecord(value.verdict) ||
+          !["reproduced", "drift_detected"].includes(String(value.verdict.status)) ||
+          resolve(String(value.artifact_path)) !== resolve(path)) {
+        throw new Error(`Repeat-evaluation evidence for ${runId} is malformed.`);
+      }
+      return {
+        generatedAt: value.generated_at as string,
+        status: value.verdict.status as "reproduced" | "drift_detected",
+        path: resolve(path),
+      };
+    });
+  if (evidence.length === 0) return null;
+  evidence.sort((left, right) => right.generatedAt.localeCompare(left.generatedAt) || right.path.localeCompare(left.path));
+  return {
+    count: evidence.length,
+    latest_at: evidence[0].generatedAt,
+    latest_status: evidence[0].status,
+    latest_artifact_path: evidence[0].path,
+  };
+}
+
 function summary(path: string): LocalClassifierRunSummary {
   const { manifest, runId, status } = validateManifest(path);
   const generatedAt = String(manifest.generated_at);
@@ -266,6 +309,7 @@ function summary(path: string): LocalClassifierRunSummary {
     manifest_path: resolve(path),
     model,
     evaluation,
+    repeat_validation: status === "completed" ? readRepeatValidation(path, runId) : null,
     timing_ms: isFiniteNonNegative(manifest.timings_ms?.total) ? manifest.timings_ms.total : null,
     failure,
   };

--- a/tests/fixtures/local-classifier-lifecycle-fake-runner.mjs
+++ b/tests/fixtures/local-classifier-lifecycle-fake-runner.mjs
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const command = args.find((value) => value === "evaluate" || value === "predict-batch");
+const request = JSON.parse(readFileSync(0, "utf8"));
+const run = JSON.parse(readFileSync(request.run_manifest_path, "utf8"));
+
+if (command === "evaluate") {
+  const holdout = readFileSync(request.holdout_path, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+  const labels = run.model.labels;
+  const support = holdout.length / labels.length;
+  process.stdout.write(`${JSON.stringify({
+    schema_version: "understudy.local_classifier.repeat_evaluation.runtime.v1",
+    run_id: run.run_id,
+    row_count: holdout.length,
+    accuracy: 1,
+    macro_f1: 1,
+    latency_ms_p50: 1.5,
+    per_class: labels.map((label) => ({ label, precision: 1, recall: 1, f1: 1, support })),
+    weakest_classes: labels.map((label) => ({ label, recall: 1, f1: 1, support })),
+    confusion_matrix: { labels, rows: labels.map((_, index) => labels.map((__, column) => index === column ? support : 0)) },
+    failures: [],
+    failure_count: 0,
+    failures_truncated: false,
+    predictions_sha256: createHash("sha256").update("synthetic predictions").digest("hex"),
+    device: "cpu-test",
+    local_only: true,
+  })}\n`);
+} else if (command === "predict-batch") {
+  process.stdout.write(`${JSON.stringify({
+    schema_version: "understudy.local_classifier.batch_prediction.runtime.v1",
+    run_id: run.run_id,
+    row_count: request.rows.length,
+    rows: request.rows.map((row, index) => ({
+      row_index: row.row_index,
+      label: run.model.labels[index % run.model.labels.length],
+      confidence: 0.8,
+      latency_ms: 1.25,
+    })),
+    device: "cpu-test",
+    local_only: true,
+  })}\n`);
+} else {
+  process.stderr.write("unknown lifecycle command\n");
+  process.exitCode = 2;
+}

--- a/tests/local-classifier-registry.test.mjs
+++ b/tests/local-classifier-registry.test.mjs
@@ -78,6 +78,18 @@ function runFixture({ runId = "desktop-run-1", status = "completed", generatedAt
 describe("local classifier run registry", () => {
   it("discovers completed local runs without copying label values into the summary", () => {
     const data = runFixture();
+    const repeatPath = join(data.runRoot, "evaluations", "repeat-1", "evaluation.json");
+    mkdirSync(join(data.runRoot, "evaluations", "repeat-1"), { recursive: true });
+    writeFileSync(repeatPath, `${JSON.stringify({
+      schema_version: "understudy.local_classifier.repeat_evaluation.v1",
+      run_id: "desktop-run-1",
+      model_id: "classifier.desktop-run-1",
+      generated_at: "2026-07-16T13:00:00.000Z",
+      local_only: true,
+      data_boundary: { dataset_uploaded: false, telemetry_sent: false },
+      verdict: { status: "reproduced" },
+      artifact_path: repeatPath,
+    }, null, 2)}\n`);
     const runs = listLocalClassifierRuns({ captureRoot: data.captureRoot });
 
     assert.equal(runs.length, 1);
@@ -95,6 +107,12 @@ describe("local classifier run registry", () => {
     assert.equal(runs[0].model.available, true);
     assert.equal(runs[0].evaluation.accuracy, 0.9);
     assert.equal(runs[0].evaluation.failure_count, 2);
+    assert.deepEqual(runs[0].repeat_validation, {
+      count: 1,
+      latest_at: "2026-07-16T13:00:00.000Z",
+      latest_status: "reproduced",
+      latest_artifact_path: repeatPath,
+    });
     assert.doesNotMatch(JSON.stringify(runs), /synthetic-a|synthetic-b/);
   });
 

--- a/tests/local-classifier.test.mjs
+++ b/tests/local-classifier.test.mjs
@@ -11,9 +11,14 @@ import {
   startLocalClassifierTraining,
   trainLocalClassifier,
 } from "../dist/local-classifier/index.js";
+import {
+  exportLocalClassifierPredictions,
+  repeatLocalClassifierEvaluation,
+} from "../dist/local-classifier/lifecycle.js";
 
 const roots = [];
 const fakeRunner = resolve("tests/fixtures/local-classifier-fake-runner.mjs");
+const fakeLifecycleRunner = resolve("tests/fixtures/local-classifier-lifecycle-fake-runner.mjs");
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -27,6 +32,9 @@ function fixture({ schema = "understudy.capture_import.classification_dataset.v2
   const root = mkdtempSync(join(tmpdir(), "understudy-local-classifier-"));
   roots.push(root);
   const labels = ["meals", "travel"];
+  const sourcePath = join(root, "expenses.csv");
+  const sourceContent = "merchant,description,label\nmerchant-a,lunch,meals\nmerchant-b,flight,travel\n";
+  writeFileSync(sourcePath, sourceContent);
   const splits = {};
   const groupNames = {
     train: ["merchant-a", "merchant-b"],
@@ -52,8 +60,15 @@ function fixture({ schema = "understudy.capture_import.classification_dataset.v2
   const manifest = {
     schema_version: schema,
     dataset_id: "dataset-test-v2",
-    source_sha256: "a".repeat(64),
+    source_path: sourcePath,
+    source_sha256: sha256(sourceContent),
     mapping_sha256: "b".repeat(64),
+    mapping: {
+      input_columns: ["merchant", "description"],
+      label_column: "label",
+      group_column: "merchant",
+      text_template: "named-fields-v1",
+    },
     labels,
     split_policy: {
       name: "deterministic-stratified-group-aware-v2",
@@ -65,7 +80,7 @@ function fixture({ schema = "understudy.capture_import.classification_dataset.v2
     artifact_root: artifactRoot,
   };
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
-  return { root, artifactRoot, manifestPath, manifest };
+  return { root, artifactRoot, manifestPath, manifest, sourcePath, sourceContent };
 }
 
 describe("local classifier training backend", () => {
@@ -159,6 +174,38 @@ describe("local classifier training backend", () => {
     assert.equal(prediction.local_only, true);
     assert.doesNotMatch(JSON.stringify(prediction), /new cafe/);
     assert.equal(existsSync(join(dirname(result.manifest_path), ".prediction-requests")), false);
+
+    const repeat = repeatLocalClassifierEvaluation({
+      runManifestPath: result.manifest_path,
+      evaluationId: "repeat-test-1",
+      runtimeRoot,
+      runnerOverride: { command: process.execPath, args: [fakeLifecycleRunner] },
+      now: new Date("2026-07-15T13:00:00.000Z"),
+    });
+    assert.equal(repeat.verdict.status, "reproduced");
+    assert.equal(repeat.comparison.matches_initial_metrics, true);
+    assert.equal(repeat.repeat.predictions_sha256.length, 64);
+    assert.equal(JSON.parse(readFileSync(repeat.artifact_path, "utf8")).evaluation_id, "repeat-test-1");
+    assert.throws(() => repeatLocalClassifierEvaluation({
+      runManifestPath: result.manifest_path,
+      evaluationId: "repeat-test-1",
+      runtimeRoot,
+      runnerOverride: { command: process.execPath, args: [fakeLifecycleRunner] },
+    }), /Refusing to overwrite|EEXIST/);
+
+    const exported = exportLocalClassifierPredictions({
+      runManifestPath: result.manifest_path,
+      runtimeRoot,
+      runnerOverride: { command: process.execPath, args: [fakeLifecycleRunner] },
+      now: new Date("2026-07-15T14:00:00.000Z"),
+    });
+    assert.equal(exported.predicted_row_count, 2);
+    assert.equal(exported.skipped_row_count, 0);
+    assert.equal(exported.model_id, "classifier.expense-demo");
+    const exportedCsv = readFileSync(exported.output_path, "utf8");
+    assert.match(exportedCsv, /understudy_label,understudy_confidence,understudy_model_id/);
+    assert.match(exportedCsv, /meals,0\.800000,classifier\.expense-demo/);
+    assert.equal(JSON.parse(readFileSync(exported.manifest_path, "utf8")).source_sha256, sha256(data.sourceContent));
 
     const runtimePack = join(runtimeRoot, "runtime-packs", readdirSync(join(runtimeRoot, "runtime-packs"))[0]);
     const runtimeSpecPath = join(runtimePack, "runtime-spec.json");


### PR DESCRIPTION
## What changed
- repeat a saved classifier on its exact immutable holdout and persist fail-closed evidence
- export a locally labeled CSV with an evidence sidecar
- surface both actions in the trained-model library
- expose completed classifiers through bearer-protected REST and MCP tools without leaking filesystem paths

## Verification
- `npm run check`
- `npm --prefix apps/homescreen run build`
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` (174 passed, 4 ignored)
- `npm run desktop:bundle-cli:smoke`
- `git diff --check`

All data, inference, repeat evaluation, and exports stay local; no raw examples are sent to telemetry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->