### PR TITLE
fix(desktop): make first-run setup coherent

### DIFF
--- a/apps/homescreen/app/components/AccountPane.tsx
+++ b/apps/homescreen/app/components/AccountPane.tsx
@@ -12,7 +12,13 @@ const APP_ICONS: { id: AppIconId; label: string; src: string }[] = [
   { id: "paper", label: "Paper", src: "/brand/app-icons/paper.png" },
 ];
 
-export function AccountPane() {
+export function AccountPane({
+  onSignedIn,
+  prioritizeSignIn = false,
+}: {
+  onSignedIn?: () => void;
+  prioritizeSignIn?: boolean;
+} = {}) {
   const [status, setStatus] = useState<Any | null>(null);
   const [keys, setKeys] = useState<Any | null>(null);
   const [platforms, setPlatforms] = useState<Any[] | null>(null);
@@ -80,6 +86,7 @@ export function AccountPane() {
       setCode("");
       setCodeSent(false);
       refresh();
+      onSignedIn?.();
     } catch (e) {
       setErr(String(e));
     } finally {
@@ -107,6 +114,25 @@ export function AccountPane() {
     }
   };
 
+  const signInCard = (
+    <div className="card account-sign-in-card">
+      <div className="card-title" style={{ marginBottom: 4 }}>Sign in / create account</div>
+      <div className="card-sub" style={{ marginBottom: 10 }}>
+        Use GLM 5.2 immediately while Understudy prepares private local chat.
+      </div>
+      <div className="chat-input" style={{ padding: 0 }}>
+        <input className="assign-select" style={{ flex: 1 }} placeholder="you@example.com" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <button className="btn primary" disabled={busy || !email.includes("@")} onClick={sendCode}>{busy ? "…" : "Send code"}</button>
+      </div>
+      {codeSent && (
+        <div className="chat-input" style={{ padding: 0, marginTop: 8 }}>
+          <input className="assign-select" style={{ flex: 1 }} placeholder="one-time code" value={code} onChange={(e) => setCode(e.target.value)} />
+          <button className="btn primary" disabled={busy || !code.trim()} onClick={signIn}>Sign in</button>
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <>
       <div className="pane-head">
@@ -115,6 +141,7 @@ export function AccountPane() {
       </div>
       <div className="pane-body">
         {err && <div className="card err">{err}</div>}
+        {!signedIn && prioritizeSignIn ? signInCard : null}
 
         <div className="card">
           <div className="card-title" style={{ marginBottom: 4 }}>App icon</div>
@@ -148,19 +175,7 @@ export function AccountPane() {
         )}
 
         {!signedIn ? (
-          <div className="card">
-            <div className="card-title" style={{ marginBottom: 8 }}>Sign in / create account</div>
-            <div className="chat-input" style={{ padding: 0 }}>
-              <input className="assign-select" style={{ flex: 1 }} placeholder="you@example.com" value={email} onChange={(e) => setEmail(e.target.value)} />
-              <button className="btn primary" disabled={busy || !email.includes("@")} onClick={sendCode}>{busy ? "…" : "Send code"}</button>
-            </div>
-            {codeSent && (
-              <div className="chat-input" style={{ padding: 0, marginTop: 8 }}>
-                <input className="assign-select" style={{ flex: 1 }} placeholder="one-time code" value={code} onChange={(e) => setCode(e.target.value)} />
-                <button className="btn primary" disabled={busy || !code.trim()} onClick={signIn}>Sign in</button>
-              </div>
-            )}
-          </div>
+          prioritizeSignIn ? null : signInCard
         ) : (
           <>
             <div className="card">

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -407,6 +407,7 @@ export function ChatPane({
   onHistoryChanged,
   onStreamingChange,
   onTrainingChange,
+  onNeedsSignIn,
 }: {
   resetToken: number;
   activeSessionId: string | null;
@@ -415,6 +416,7 @@ export function ChatPane({
   onHistoryChanged?: () => void;
   onStreamingChange?: (streaming: boolean) => void;
   onTrainingChange?: (active: boolean) => void;
+  onNeedsSignIn?: () => void;
 }) {
   const [initialSession] = useState(() => {
     const restore = activeSessionId !== null;
@@ -430,6 +432,7 @@ export function ChatPane({
   const [notice, setNotice] = useState<string | null>(null);
   const [choices, setChoices] = useState<ModelChoice[]>([CLOUD_MODEL]);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const [gatewaySignedIn, setGatewaySignedIn] = useState<boolean | null>(null);
   const [thinkingPending, setThinkingPending] = useState<{ slotId: number; thinking: boolean } | null>(null);
   const [personaReady, setPersonaReady] = useState(false);
   const [personaCycle, setPersonaCycle] = useState(0);
@@ -592,11 +595,13 @@ export function ChatPane({
 
   const refreshModels = async () => {
     try {
-      const [residency, snapshots, anthropicStatus] = await Promise.all([
+      const [residency, snapshots, anthropicStatus, accountStatus] = await Promise.all([
         invoke<ResidencySnapshot>("get_residency"),
         invoke<SnapshotModel[]>("list_snapshot_models"),
         invoke<AnthropicStatus>("anthropic_status").catch(() => ({ present: false, source: null })),
+        invoke<{ signed_in?: boolean }>("account_status").catch(() => ({ signed_in: false })),
       ]);
+      setGatewaySignedIn(Boolean(accountStatus.signed_in));
       const anthropic: ModelChoice[] = anthropicStatus.present
         ? (await invoke<AnthropicModel[]>("anthropic_models").catch(() => [])).map((model) => ({
             id: `anthropic:${model.id}`,
@@ -641,6 +646,7 @@ export function ChatPane({
         return resolved.selectedId;
       });
     } catch {
+      setGatewaySignedIn(false);
       setChoices((current) =>
         current.length === 1 && current[0]?.id === CLOUD_MODEL.id ? current : [CLOUD_MODEL],
       );
@@ -893,15 +899,26 @@ export function ChatPane({
   const send = async (text: string, files: FileUIPart[] = []) => {
     const clean = text.trim();
     if ((!clean && files.length === 0) || streaming) return;
-    setInput("");
     setErr(null);
     setNotice(null);
 
     const choice = selectedChoice;
+    if (choice.route === "cloud") {
+      const signedIn = gatewaySignedIn ?? Boolean(
+        (await invoke<{ signed_in?: boolean }>("account_status").catch(() => ({ signed_in: false }))).signed_in,
+      );
+      setGatewaySignedIn(signedIn);
+      if (!signedIn) {
+        setNotice("Sign in to use GLM 5.2, or choose the private local model after it finishes downloading.");
+        onNeedsSignIn?.();
+        return;
+      }
+    }
     if (choice.route === "local" && choice.slotId == null) {
       setErr("No local model is warm. Open Serving, warm a local model slot, then send again.");
       return;
     }
+    setInput("");
     if (choice.route === "local" && !choice.active) {
       setErr("The selected local model is still loading. Try again in a moment.");
       return;

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -918,11 +918,11 @@ export function ChatPane({
       setErr("No local model is warm. Open Serving, warm a local model slot, then send again.");
       return;
     }
-    setInput("");
     if (choice.route === "local" && !choice.active) {
       setErr("The selected local model is still loading. Try again in a moment.");
       return;
     }
+    setInput("");
 
     let attachments: ChatAttachment[] = [];
     if (files.length > 0) {

--- a/apps/homescreen/app/components/ModelDownloadNotice.tsx
+++ b/apps/homescreen/app/components/ModelDownloadNotice.tsx
@@ -52,6 +52,10 @@ type DefaultLocalModelPreparation = {
   state: string;
 };
 
+type AccountStatus = {
+  signed_in?: boolean;
+};
+
 function formatBytes(bytes: number) {
   if (bytes < 1024 * 1024) return `${Math.max(0, bytes / 1024).toFixed(0)} KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -62,7 +66,15 @@ function fallbackModelName(modelId: string) {
   return modelId.split("/").at(-1) || modelId;
 }
 
-export function ModelDownloadNotice({ quiet = false }: { quiet?: boolean }) {
+export function ModelDownloadNotice({
+  quiet = false,
+  starterDownloadRequest = 0,
+  onOpenAccount,
+}: {
+  quiet?: boolean;
+  starterDownloadRequest?: number;
+  onOpenAccount?: (downloadAfterSignIn: boolean) => void;
+}) {
   const [rows, setRows] = useState<DownloadProgress[]>([]);
   const [models, setModels] = useState<SnapshotModel[]>([]);
   const [residency, setResidency] = useState<ResidencySnapshot>({ slots: [] });
@@ -73,6 +85,8 @@ export function ModelDownloadNotice({ quiet = false }: { quiet?: boolean }) {
   const [prepareError, setPrepareError] = useState<string | null>(null);
   const [starterPromptDismissed, setStarterPromptDismissed] = useState(false);
   const [starterReadyVisible, setStarterReadyVisible] = useState(false);
+  const [signedIn, setSignedIn] = useState<boolean | null>(null);
+  const [setupPromptDismissed, setSetupPromptDismissed] = useState(false);
   const initialized = useRef(false);
   const starterPrepareAttempted = useRef(false);
   const starterPrepareInFlight = useRef(false);
@@ -81,6 +95,7 @@ export function ModelDownloadNotice({ quiet = false }: { quiet?: boolean }) {
   const dismissed = useRef(new Set<string>());
   const hideTimer = useRef<number | null>(null);
   const starterHideTimer = useRef<number | null>(null);
+  const observedDownloadRequest = useRef(starterDownloadRequest);
 
   const clearHideTimer = useCallback(() => {
     if (hideTimer.current !== null) {
@@ -133,10 +148,12 @@ export function ModelDownloadNotice({ quiet = false }: { quiet?: boolean }) {
       invoke<DownloadProgress[]>("list_snapshot_downloads"),
       invoke<SnapshotModel[]>("list_snapshot_models"),
       invoke<ResidencySnapshot>("get_residency"),
+      invoke<AccountStatus>("account_status").catch(() => ({ signed_in: false })),
     ])
-      .then(([nextRows, nextModels, nextResidency]) => {
+      .then(([nextRows, nextModels, nextResidency, account]) => {
         setModels(nextModels);
         setResidency(nextResidency);
+        setSignedIn(Boolean(account.signed_in));
         ingest(nextRows);
       })
       .catch(() => {});
@@ -191,6 +208,27 @@ export function ModelDownloadNotice({ quiet = false }: { quiet?: boolean }) {
     }
   }, [refresh, starter?.id]);
 
+  const startStarterDownload = useCallback(async () => {
+    if (!starter?.id || actionBusy) return;
+    setActionBusy(true);
+    setActionError(null);
+    try {
+      await invoke("start_snapshot_download", { modelId: starter.id });
+      await refresh();
+    } catch (error) {
+      setActionError({ id: `starter:${starter.id}`, message: String(error) });
+    } finally {
+      setActionBusy(false);
+    }
+  }, [actionBusy, refresh, starter?.id]);
+
+  useEffect(() => {
+    if (starterDownloadRequest === observedDownloadRequest.current) return;
+    observedDownloadRequest.current = starterDownloadRequest;
+    setSetupPromptDismissed(true);
+    void startStarterDownload();
+  }, [startStarterDownload, starterDownloadRequest]);
+
   const shouldAutoPrepare = shouldPrepareStarter({
     starter,
     slots: residency.slots,
@@ -237,6 +275,39 @@ export function ModelDownloadNotice({ quiet = false }: { quiet?: boolean }) {
   // independent download/startup lifecycle continues to be polled, but it must
   // not compete for attention or auto-start while that flow is on screen.
   if (quiet) return null;
+
+  const needsFirstRunSetup =
+    signedIn === false &&
+    !starter?.cached &&
+    !starterLoading &&
+    !starterRunning &&
+    !row &&
+    !setupPromptDismissed;
+
+  if (needsFirstRunSetup) {
+    const starterLabel = starter?.short_name || starter?.name || "Understudy Small";
+    return (
+      <OperationNotice
+        className="model-download-notice first-run-setup-notice"
+        state="idle"
+        icon="download"
+        title="Set up Understudy"
+        message="Sign in for GLM 5.2 now and prepare private local chat"
+        meta={starter ? `${starterLabel} · ${starter.approx_gb.toFixed(1)} GB one-time download` : "GLM 5.2 · Understudy account"}
+        actionLabel="Set up"
+        actionDisabled={!onOpenAccount}
+        onAction={() => onOpenAccount?.(Boolean(starter))}
+        secondaryActionLabel={starter ? (actionBusy ? "Starting…" : "Local only") : null}
+        secondaryActionDisabled={actionBusy}
+        onSecondaryAction={() => {
+          setSetupPromptDismissed(true);
+          void startStarterDownload();
+        }}
+        dismissLabel="Not now"
+        onDismiss={() => setSetupPromptDismissed(true)}
+      />
+    );
+  }
 
   if (!row && !offerStarterDownload && !prepareBusy && !starterLoading && !prepareError && !starterReadyVisible) {
     return null;
@@ -302,14 +373,7 @@ export function ModelDownloadNotice({ quiet = false }: { quiet?: boolean }) {
           meta={starter.incomplete ? "Resume download · partial files kept" : "One-time download · stays on this Mac"}
           actionLabel={actionBusy ? "Starting…" : starterDownloadError ? "Retry" : starter.incomplete ? "Resume" : "Download"}
           actionDisabled={actionBusy}
-          onAction={() => {
-            setActionBusy(true);
-            setActionError(null);
-            invoke("start_snapshot_download", { modelId: starter.id })
-              .then(() => refresh())
-              .catch((error) => setActionError({ id: `starter:${starter.id}`, message: String(error) }))
-              .finally(() => setActionBusy(false));
-          }}
+          onAction={() => void startStarterDownload()}
           dismissLabel="Dismiss starter model download"
           onDismiss={() => setStarterPromptDismissed(true)}
         />

--- a/apps/homescreen/app/components/OperationNotice.tsx
+++ b/apps/homescreen/app/components/OperationNotice.tsx
@@ -28,6 +28,9 @@ type OperationNoticeProps = {
   actionLabel?: string | null;
   actionDisabled?: boolean;
   onAction?: () => void;
+  secondaryActionLabel?: string | null;
+  secondaryActionDisabled?: boolean;
+  onSecondaryAction?: () => void;
   dismissLabel: string;
   dismissDisabled?: boolean;
   onDismiss: () => void;
@@ -44,6 +47,9 @@ export function OperationNotice({
   actionLabel,
   actionDisabled = false,
   onAction,
+  secondaryActionLabel,
+  secondaryActionDisabled = false,
+  onSecondaryAction,
   dismissLabel,
   dismissDisabled = false,
   onDismiss,
@@ -88,6 +94,16 @@ export function OperationNotice({
         ) : null}
       </div>
       <div className="operation-notice-actions">
+        {secondaryActionLabel && onSecondaryAction ? (
+          <button
+            type="button"
+            className="operation-notice-action is-secondary"
+            disabled={secondaryActionDisabled}
+            onClick={onSecondaryAction}
+          >
+            {secondaryActionLabel}
+          </button>
+        ) : null}
         {actionLabel && onAction ? (
           <button
             type="button"

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -4173,6 +4173,15 @@ select,
   font-size: 10px;
   white-space: nowrap;
 }
+.operation-notice-action.is-secondary {
+  border-color: var(--border);
+  background: transparent;
+  color: var(--text-2);
+}
+.operation-notice-action.is-secondary:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--mb-cyan) 26%, var(--border));
+  color: var(--text);
+}
 .operation-notice-action:hover:not(:disabled) {
   border-color: var(--mb-cyan);
 }

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -32,6 +32,11 @@ export default function Page() {
   const [chatTrainingActive, setChatTrainingActive] = useState(false);
   const [activeChatSessionId, setActiveChatSessionId] = useState<string | null>(null);
   const [requestedChatSession, setRequestedChatSession] = useState<ChatSessionRequest | null>(null);
+  const [starterDownloadRequest, setStarterDownloadRequest] = useState(0);
+  const [signInIntent, setSignInIntent] = useState<{
+    returnToChat: boolean;
+    downloadAfterSignIn: boolean;
+  } | null>(null);
   const status = useStatus();
   const connected = status.snap?.connected ?? false;
 
@@ -154,6 +159,20 @@ export default function Page() {
     setChatResetToken((token) => token + 1);
   };
 
+  const openFirstRunSignIn = useCallback((downloadAfterSignIn: boolean) => {
+    setSignInIntent({ returnToChat: true, downloadAfterSignIn });
+    setPane("account");
+  }, []);
+
+  const finishSignIn = useCallback(() => {
+    if (!signInIntent) return;
+    if (signInIntent.downloadAfterSignIn) {
+      setStarterDownloadRequest((request) => request + 1);
+    }
+    if (signInIntent.returnToChat) setPane("chat");
+    setSignInIntent(null);
+  }, [signInIntent]);
+
   // Inbound: a coding agent (via the local server) can drive the GUI to a pane.
   useEffect(() => {
     if (!isTauri()) return;
@@ -230,7 +249,11 @@ export default function Page() {
       <DownloadQrButton />
       <div className="operation-notice-stack">
         <RuntimeRepairPrompt quiet={chatTrainingActive} />
-        <ModelDownloadNotice quiet={chatTrainingActive} />
+        <ModelDownloadNotice
+          quiet={chatTrainingActive}
+          starterDownloadRequest={starterDownloadRequest}
+          onOpenAccount={openFirstRunSignIn}
+        />
       </div>
       <Sidebar
         active={pane}
@@ -267,13 +290,19 @@ export default function Page() {
             onHistoryChanged={refreshChatHistory}
             onStreamingChange={setChatStreaming}
             onTrainingChange={setChatTrainingActive}
+            onNeedsSignIn={() => openFirstRunSignIn(false)}
           />
         )}
         {pane === "models" && <ModelsPane />}
         {pane === "capture" && <CapturePane />}
         {pane === "rlm" && <RlmPane />}
         {isTrainingPane(pane) && <TrainingPane section={pane} />}
-        {pane === "account" && <AccountPane />}
+        {pane === "account" && (
+          <AccountPane
+            onSignedIn={signInIntent ? finishSignIn : undefined}
+            prioritizeSignIn={Boolean(signInIntent)}
+          />
+        )}
         {pane === "usage" && <UsagePane status={status} />}
         {pane === "traces" && <TracesPane />}
       </main>

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -429,6 +429,10 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.match(chat, /invoke<\{ signed_in\?: boolean \}>\("account_status"\)/);
   assert.match(chat, /if \(!signedIn\)/);
   assert.match(chat, /onNeedsSignIn\?\.\(\)/);
+  const sendStart = chat.indexOf("const send = async");
+  const localLoadingGuard = chat.indexOf('if (choice.route === "local" && !choice.active)', sendStart);
+  const draftClear = chat.indexOf('setInput("");', sendStart);
+  assert.ok(localLoadingGuard > sendStart && draftClear > localLoadingGuard);
   assert.match(native, /commands::prepare_default_local_model/);
   assert.match(repair, /understudy models runtime repair/);
   assert.match(repair, /understudy runtime repair/);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -45,6 +45,10 @@ const modelDownloadNoticePath = new URL(
   "../apps/homescreen/app/components/ModelDownloadNotice.tsx",
   import.meta.url,
 );
+const accountPanePath = new URL(
+  "../apps/homescreen/app/components/AccountPane.tsx",
+  import.meta.url,
+);
 const runtimeRepairLibPath = new URL(
   "../apps/homescreen/app/lib/runtime-repair.ts",
   import.meta.url,
@@ -357,11 +361,13 @@ test("desktop offers an explicit signed update check from macOS menus", async ()
 });
 
 test("desktop has one shared managed-operation notice surface", async () => {
-  const [page, prompt, operationNotice, downloadNotice, repair, bootstrap, native] = await Promise.all([
+  const [page, prompt, operationNotice, downloadNotice, accountPane, chat, repair, bootstrap, native] = await Promise.all([
     readFile(pagePath, "utf8"),
     readFile(runtimeRepairPromptPath, "utf8"),
     readFile(operationNoticePath, "utf8"),
     readFile(modelDownloadNoticePath, "utf8"),
+    readFile(accountPanePath, "utf8"),
+    readFile(chatPath, "utf8"),
     readFile(runtimeRepairLibPath, "utf8"),
     readFile(
       new URL("../apps/homescreen/src-tauri/src/bootstrap.rs", import.meta.url),
@@ -372,7 +378,7 @@ test("desktop has one shared managed-operation notice surface", async () => {
 
   assert.match(page, /<RuntimeRepairPrompt quiet=\{chatTrainingActive\}\s*\/>/);
   assert.match(prompt, /if \(quiet \|\| !prompt\) return null/);
-  assert.match(page, /<ModelDownloadNotice quiet=\{chatTrainingActive\}\s*\/>/);
+  assert.match(page, /<ModelDownloadNotice[\s\S]*?quiet=\{chatTrainingActive\}[\s\S]*?onOpenAccount=\{openFirstRunSignIn\}[\s\S]*?\/>/);
   assert.match(downloadNotice, /if \(quiet\) return null/);
   assert.match(downloadNotice, /quiet \|\| !shouldAutoPrepare/);
   assert.match(page, /className="operation-notice-stack"/);
@@ -408,6 +414,21 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.match(downloadNotice, /One-time download · stays on this Mac/);
   assert.match(downloadNotice, /Starting local model/);
   assert.match(downloadNotice, /Selected for chat/);
+  assert.match(downloadNotice, /title="Set up Understudy"/);
+  assert.match(downloadNotice, /Sign in for GLM 5\.2 now and prepare private local chat/);
+  assert.match(downloadNotice, /secondaryActionLabel=\{starter \? \(actionBusy \? "Starting…" : "Local only"\) : null\}/);
+  assert.match(downloadNotice, /starterDownloadRequest/);
+  assert.match(operationNotice, /secondaryActionLabel/);
+  assert.match(page, /downloadAfterSignIn/);
+  assert.match(page, /setStarterDownloadRequest\(\(request\) => request \+ 1\)/);
+  assert.match(accountPane, /onSignedIn\?\.\(\)/);
+  assert.match(accountPane, /prioritizeSignIn \? signInCard : null/);
+  assert.match(accountPane, /Use GLM 5\.2 immediately while Understudy prepares private local chat/);
+  assert.match(page, /prioritizeSignIn=\{Boolean\(signInIntent\)\}/);
+  assert.match(chat, /gatewaySignedIn \?\? Boolean\(/);
+  assert.match(chat, /invoke<\{ signed_in\?: boolean \}>\("account_status"\)/);
+  assert.match(chat, /if \(!signedIn\)/);
+  assert.match(chat, /onNeedsSignIn\?\.\(\)/);
   assert.match(native, /commands::prepare_default_local_model/);
   assert.match(repair, /understudy models runtime repair/);
   assert.match(repair, /understudy runtime repair/);


### PR DESCRIPTION
## What changed

- route signed-out cold starts into the existing Understudy email-code sign-in flow
- preserve the user draft instead of surfacing a cloud authentication error
- return to chat after sign-in and start the explicitly accepted 3.6 GB `understudy-small` download
- keep GLM 5.2 available immediately while the private local model downloads and warms
- offer a local-only path and share the existing operation notice surface

## Root cause

Cloud fallback, sign-in, and starter-model download already existed, but they were three disconnected flows. A new user could see GLM 5.2 selected before authentication and had to discover Account and Models independently.

## Validation

- `node --test tests/model-selection.test.mjs tests/starter-model.test.mjs tests/desktop-ui-lineage.test.mjs` (27/27)
- `npm run build`
- `npm test` (380/380)
- `cargo test --lib` (175 passed, 4 ignored)
- `bun install --frozen-lockfile && bun run build` in `apps/homescreen`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->