### PR TITLE
Fix desktop frontier comparison streaming

### DIFF
--- a/apps/homescreen/src-tauri/src/workload_drop.rs
+++ b/apps/homescreen/src-tauri/src/workload_drop.rs
@@ -699,7 +699,7 @@ const TRAINING_PHASES: [&str; 5] = [
 
 fn safe_identifier(value: &str, name: &str) -> Result<String, String> {
     let value = value.trim();
-    if value.len() < 8
+    if value.is_empty()
         || value.len() > 128
         || !value
             .bytes()
@@ -2519,6 +2519,16 @@ mod tests {
                 .unwrap_err()
                 .contains("attributed spend")
         );
+    }
+
+    #[test]
+    fn accepts_the_configured_frontier_model_id() {
+        assert_eq!(
+            safe_identifier("glm-5.2", "frontier model id").as_deref(),
+            Ok("glm-5.2"),
+        );
+        assert!(safe_identifier("", "frontier model id").is_err());
+        assert!(safe_identifier("glm 5.2", "frontier model id").is_err());
     }
 
     #[test]

--- a/src/local-classifier/frontier.ts
+++ b/src/local-classifier/frontier.ts
@@ -155,10 +155,9 @@ type GatewayChunkResult = {
 
 type GatewayRequest = {
   model: string;
-  stream: false;
+  stream: true;
   temperature: 0;
   max_tokens: number;
-  chat_template_kwargs: { thinking: false; enable_thinking: false };
   messages: Array<{ role: "system" | "user"; content: string }>;
 };
 
@@ -314,10 +313,9 @@ function buildGatewayRequest(
 ): GatewayRequest {
   return {
     model: modelId,
-    stream: false,
+    stream: true,
     temperature: 0,
     max_tokens: maxCompletionTokens,
-    chat_template_kwargs: { thinking: false, enable_thinking: false },
     messages: [
       {
         role: "system",
@@ -331,6 +329,74 @@ function buildGatewayRequest(
       },
     ],
   };
+}
+
+async function readGatewayStream(response: Response): Promise<{
+  content: string;
+  promptTokens: number;
+  completionTokens: number;
+  servedModel: string | null;
+}> {
+  if (!response.body) throw new Error("frontier gateway returned an empty stream.");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let content = "";
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let servedModel: string | null = null;
+  let finished = false;
+
+  const consumeLine = (rawLine: string) => {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (!line.startsWith("data:")) return;
+    const payload = line.slice("data:".length).trimStart();
+    if (!payload) return;
+    if (payload === "[DONE]") {
+      finished = true;
+      return;
+    }
+    let chunk: unknown;
+    try {
+      chunk = JSON.parse(payload) as unknown;
+    } catch {
+      throw new Error("frontier gateway returned malformed stream JSON.");
+    }
+    if (!isRecord(chunk)) throw new Error("frontier gateway returned a malformed stream event.");
+    if (isRecord(chunk.error)) {
+      const message = typeof chunk.error.message === "string" ? chunk.error.message : "unknown error";
+      throw new Error(`frontier gateway stream failed: ${message}`);
+    }
+    if (typeof chunk.model === "string" && chunk.model) servedModel = chunk.model;
+    const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
+    const first = choices[0];
+    if (isRecord(first) && isRecord(first.delta) && typeof first.delta.content === "string") {
+      content += first.delta.content;
+    }
+    const usage = isRecord(chunk.usage) ? chunk.usage : {};
+    promptTokens = usageCount(usage.prompt_tokens ?? usage.input_tokens) || promptTokens;
+    completionTokens = usageCount(usage.completion_tokens ?? usage.output_tokens) || completionTokens;
+  };
+  const consumeAvailableLines = () => {
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) consumeLine(line);
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      consumeAvailableLines();
+    }
+    buffer += decoder.decode();
+    if (buffer) consumeLine(buffer);
+  } finally {
+    reader.releaseLock();
+  }
+  if (!finished) throw new Error("frontier gateway stream ended before its terminal event.");
+  return { content, promptTokens, completionTokens, servedModel };
 }
 
 function costUsd(inputTokens: number, outputTokens: number): number {
@@ -404,28 +470,25 @@ async function callGateway(
       headers: {
         authorization: `Bearer ${auth.token}`,
         "content-type": "application/json",
-        accept: "application/json",
+        accept: "text/event-stream",
       },
       body: JSON.stringify(buildGatewayRequest(rows, labels, modelId, maxCompletionTokens)),
       signal: scopedSignal.signal,
     });
-    const body = await response.text();
     if (!response.ok) {
+      const body = await response.text();
       throw new Error(`frontier gateway returned ${response.status}: ${body.slice(0, 400)}`);
     }
-    const envelope = JSON.parse(body) as Record<string, unknown>;
-    const choices = Array.isArray(envelope.choices) ? envelope.choices : [];
-    const first = choices[0] as { message?: { content?: unknown } } | undefined;
-    const content = first?.message?.content;
+    const stream = await readGatewayStream(response);
     const servedModel = response.headers.get("x-understudy-effective-model") ??
-      (typeof envelope.model === "string" ? envelope.model : null);
+      stream.servedModel;
     if (servedModel !== modelId) {
       throw new Error(`requested ${modelId}, but the gateway served ${String(servedModel)}`);
     }
-    if (typeof content !== "string" || content.length === 0) {
+    if (!stream.content) {
       throw new Error("frontier model returned no classifications");
     }
-    const parsed = JSON.parse(stripJsonFence(content)) as unknown;
+    const parsed = JSON.parse(stripJsonFence(stream.content)) as unknown;
     if (!isRecord(parsed) || !Array.isArray(parsed.predictions) || parsed.predictions.length !== rows.length) {
       throw new Error("frontier model returned the wrong prediction count");
     }
@@ -440,11 +503,10 @@ async function callGateway(
       seen.add(prediction.example_id);
       return { example_id: prediction.example_id, label: prediction.label };
     });
-    const usage = isRecord(envelope.usage) ? envelope.usage : {};
     return {
       predictions,
-      promptTokens: usageCount(usage.prompt_tokens ?? usage.input_tokens),
-      completionTokens: usageCount(usage.completion_tokens ?? usage.output_tokens),
+      promptTokens: stream.promptTokens,
+      completionTokens: stream.completionTokens,
       requestId: response.headers.get("x-understudy-request-id"),
       servedModel,
       mode: response.headers.get("x-understudy-mode"),

--- a/tests/local-classifier-frontier.test.mjs
+++ b/tests/local-classifier-frontier.test.mjs
@@ -88,14 +88,17 @@ function frontierFetch({ servedModel = "glm-5.2", spamLabel = "ham" } = {}) {
       example_id: example.example_id,
       label: example.example_id === "example-spam" ? spamLabel : "ham",
     }));
-    return new Response(JSON.stringify({
-      model: servedModel,
-      choices: [{ message: { content: `\`\`\`json\n${JSON.stringify({ predictions })}\n\`\`\`` } }],
-      usage: { prompt_tokens: 20, completion_tokens: 8 },
-    }), {
+    const content = `\`\`\`json\n${JSON.stringify({ predictions })}\n\`\`\``;
+    const split = Math.ceil(content.length / 2);
+    const stream = [
+      { model: servedModel, choices: [{ delta: { content: content.slice(0, split) } }] },
+      { choices: [{ delta: { content: content.slice(split) } }] },
+      { choices: [{ delta: {} }], usage: { prompt_tokens: 20, completion_tokens: 8 } },
+    ].map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("") + "data: [DONE]\n\n";
+    return new Response(stream, {
       status: 200,
       headers: {
-        "content-type": "application/json",
+        "content-type": "text/event-stream",
         "x-understudy-effective-model": servedModel,
         "x-understudy-mode": "managed",
         "x-understudy-route": "primary",
@@ -205,7 +208,8 @@ describe("frontier classification comparison", () => {
     assert.equal(result.spend.pricing_checked_at, "2026-07-16");
     assert.equal(requests.length, 3, "one quality batch plus two real latency probes");
     assert.ok(requests.every((request) => request.model === "glm-5.2"));
-    assert.ok(requests.every((request) => request.chat_template_kwargs.thinking === false));
+    assert.ok(requests.every((request) => request.stream === true));
+    assert.ok(requests.every((request) => !("chat_template_kwargs" in request)));
     assert.ok(requests.every((request) => !JSON.stringify(request).includes("training-only-sentinel")));
     assert.ok(events.some((event) => event.phase === "comparing"));
     assert.ok(events.some((event) => event.phase === "measuring"));


### PR DESCRIPTION
## Summary
- accept the cataloged `glm-5.2` model ID in native desktop validation
- send desktop frontier comparisons as gateway-compatible SSE requests
- aggregate streamed response content and usage while retaining served-model validation

## Root cause
The desktop app rejected `glm-5.2` because native validation imposed an arbitrary eight-character minimum. After that was corrected, the comparison client sent a buffered request with a provider-specific field that the gateway rejected.

## Validation
- `npm run check`
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml`
- desktop smoke test of the streamed comparison flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->