### PR TITLE
fix(desktop): remove startup CLI status polling

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.24"
+    "version": "0.6.25"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.24"
+    "version": "0.6.25"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.27",
+  "version": "0.3.28",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.27"
+version = "0.3.28"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/account.rs
+++ b/apps/homescreen/src-tauri/src/account.rs
@@ -16,55 +16,44 @@ fn run_json(args: &[&str]) -> Result<Value> {
     Ok(serde_json::from_str(&s).unwrap_or(Value::Null))
 }
 
-/// Signed-in status. The native credentials reader (`crate::creds`, same
-/// resolution order as the CLI) is the source of truth for *whether* we are
-/// signed in; the `understudy status --json` shim contributes project-scoped
-/// fields (project_slug, telemetry) when the CLI is installed. When the CLI
-/// is missing, the status is synthesized natively so the app never shows
-/// "not connected" for a signed-in user just because the CLI isn't on PATH.
+/// Signed-in status for launch-critical UI.
+///
+/// This must remain a native, in-process read. Chat refreshes model choices
+/// every few seconds and asks for account availability in the same pass. The
+/// bundled Node CLI takes roughly a second and hundreds of MB to cold-start;
+/// shelling out here made every refresh block the Tauri command thread and
+/// could beachball Desktop during first launch.
+///
+/// Project-scoped CLI details belong on explicit diagnostic surfaces, not in
+/// the hot path that only needs to know whether the gateway is available.
 pub fn status() -> Result<Value> {
-    let native = crate::creds::resolve();
-    match run_json(&["status", "--json"]) {
-        Ok(mut value) if value.is_object() => {
-            if let (Some(resolved), Some(obj)) = (&native, value.as_object_mut()) {
-                let signed_in = obj
-                    .get("signed_in")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false);
-                if !signed_in {
-                    // The CLI (or its cwd) missed credentials the app can
-                    // resolve — e.g. an orgs-map-only file with an older CLI.
-                    obj.insert("signed_in".into(), json!(true));
-                    obj.insert("auth_mode".into(), json!(resolved.auth_mode));
-                }
-                for (key, fill) in [
-                    ("gateway_url", json!(resolved.gateway_url)),
-                    ("api_key_suffix", json!(resolved.api_key_suffix())),
-                    ("org_id", json!(resolved.org_id)),
-                ] {
-                    let missing = obj.get(key).map(|v| v.is_null()).unwrap_or(true);
-                    if missing && !fill.is_null() {
-                        obj.insert(key.into(), fill);
-                    }
-                }
-            }
-            Ok(value)
-        }
-        Ok(_) | Err(_) if native.is_some() => {
-            let resolved = native.expect("checked is_some");
-            Ok(json!({
-                "ok": true,
-                "configured": false,
-                "signed_in": true,
-                "auth_mode": resolved.auth_mode,
-                "org_id": resolved.org_id,
-                "project_slug": null,
-                "api_key_suffix": resolved.api_key_suffix(),
-                "gateway_url": resolved.gateway_url,
-                "source": "app-native",
-            }))
-        }
-        other => other,
+    Ok(status_from(crate::creds::resolve()))
+}
+
+fn status_from(credentials: Option<crate::creds::ResolvedCredentials>) -> Value {
+    match credentials {
+        Some(resolved) => json!({
+            "ok": true,
+            "configured": true,
+            "signed_in": true,
+            "auth_mode": resolved.auth_mode,
+            "org_id": resolved.org_id,
+            "project_slug": null,
+            "api_key_suffix": resolved.api_key_suffix(),
+            "gateway_url": resolved.gateway_url,
+            "source": "app-native",
+        }),
+        None => json!({
+            "ok": true,
+            "configured": false,
+            "signed_in": false,
+            "auth_mode": null,
+            "org_id": null,
+            "project_slug": null,
+            "api_key_suffix": null,
+            "gateway_url": crate::creds::DEFAULT_GATEWAY_URL,
+            "source": "app-native",
+        }),
     }
 }
 pub fn platforms() -> Result<Value> {
@@ -84,4 +73,35 @@ pub fn login_code(code: &str) -> Result<String> {
 }
 pub fn logout() -> Result<String> {
     out_string(&["logout"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::creds::ResolvedCredentials;
+
+    #[test]
+    fn native_status_reports_gateway_availability_without_cli() {
+        let value = status_from(Some(ResolvedCredentials {
+            gateway_url: "https://gateway.example".into(),
+            api_key: "sk_test_1234".into(),
+            auth_mode: "api_key",
+            org_id: Some("org_test".into()),
+        }));
+
+        assert_eq!(value["signed_in"], true);
+        assert_eq!(value["configured"], true);
+        assert_eq!(value["api_key_suffix"], "1234");
+        assert_eq!(value["source"], "app-native");
+    }
+
+    #[test]
+    fn native_status_reports_signed_out_without_error() {
+        let value = status_from(None);
+
+        assert_eq!(value["ok"], true);
+        assert_eq!(value["signed_in"], false);
+        assert_eq!(value["configured"], false);
+        assert_eq!(value["gateway_url"], crate::creds::DEFAULT_GATEWAY_URL);
+    }
 }

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -1,4 +1,3 @@
-use crate::account;
 use crate::bin;
 use crate::models::{self, SnapshotInfo};
 use futures_util::StreamExt;
@@ -25,7 +24,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.24";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.25";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {
@@ -166,7 +165,10 @@ pub fn status() -> BootstrapStatus {
             &["--help"],
         ),
         mlx: mlx_status(),
-        account_connected: account::status().is_ok(),
+        // Account availability is a native credential read. Do not call the
+        // bundled CLI from this diagnostic snapshot: bootstrap status may be
+        // refreshed repeatedly while the Status pane is open.
+        account_connected: crate::creds::resolve().is_some(),
         models_dir: models_dir().to_string_lossy().into_owned(),
         local_models: models::list(),
         snapshots,

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.27";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.28";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.24",
+      "version": "0.6.25",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.27";
+export const RUNTIME_VERSION = "0.3.28";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -361,7 +361,7 @@ test("desktop offers an explicit signed update check from macOS menus", async ()
 });
 
 test("desktop has one shared managed-operation notice surface", async () => {
-  const [page, prompt, operationNotice, downloadNotice, accountPane, chat, repair, bootstrap, native] = await Promise.all([
+  const [page, prompt, operationNotice, downloadNotice, accountPane, chat, repair, bootstrap, account, native] = await Promise.all([
     readFile(pagePath, "utf8"),
     readFile(runtimeRepairPromptPath, "utf8"),
     readFile(operationNoticePath, "utf8"),
@@ -371,6 +371,10 @@ test("desktop has one shared managed-operation notice surface", async () => {
     readFile(runtimeRepairLibPath, "utf8"),
     readFile(
       new URL("../apps/homescreen/src-tauri/src/bootstrap.rs", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../apps/homescreen/src-tauri/src/account.rs", import.meta.url),
       "utf8",
     ),
     readFile(tauriLibPath, "utf8"),
@@ -427,6 +431,11 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.match(page, /prioritizeSignIn=\{Boolean\(signInIntent\)\}/);
   assert.match(chat, /gatewaySignedIn \?\? Boolean\(/);
   assert.match(chat, /invoke<\{ signed_in\?: boolean \}>\("account_status"\)/);
+  assert.doesNotMatch(
+    account,
+    /run_json\(&\["status",\s*"--json"\]\)/,
+    "the frequently-polled account status path must not cold-start the bundled CLI",
+  );
   assert.match(chat, /if \(!signedIn\)/);
   assert.match(chat, /onNeedsSignIn\?\.\(\)/);
   const sendStart = chat.indexOf("const send = async");


### PR DESCRIPTION
## Summary
- keep account availability checks native and in-process
- remove repeated bundled Node CLI cold starts from chat/bootstrap refresh paths
- add regression coverage for the hot path
- bump Desktop to 0.3.28 and bundled CLI to 0.6.25

## Root cause
Desktop refreshed account/model state every 2.5 seconds. The account check synchronously cold-started the bundled Node CLI, costing roughly one second and hundreds of MB per poll, which could beachball first launch. The local model itself was loaded only once.

## Verification
- 178 Rust tests passed (4 ignored)
- 380 root tests passed
- 20 focused Desktop lineage tests passed
- TypeScript typecheck passed
- Next production build passed
- source release check passed
- version compatibility verification passed
- git diff --check passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->