### PR TITLE
feat: add scoped eval cohort CLI

### DIFF
--- a/skills/ingest-traces/SKILL.md
+++ b/skills/ingest-traces/SKILL.md
@@ -43,12 +43,25 @@ Identify the source shape first:
   existing tooling (`aws s3`, `rclone`, `wrangler`); pull to a local staging
   dir.
 - **Provider log export**: JSONL/CSV of historical calls.
-- **Understudy capture export**: gateway capture files. Note the access
-  limits: `captures export <request-id>` exports **one request at a time**,
-  writes metadata only unless run with `--include-payload --yes` (payloads may
-  contain prompts/completions), and platform-side bulk export requires
-  elevated platform-administrator access — plan on per-request exports or ask
-  your platform administrator for a bulk dump.
+- **Understudy frozen cohort**: select only workload-scoped, redacted capture
+  metadata; review it; freeze the exact references; then materialize that
+  auditable cohort locally:
+
+  ```sh
+  understudy evals catalog --project <slug> --workload <name> \
+    --from <iso> --to <iso> --limit 50 --seed <seed> \
+    --out .understudy/evals/catalog.json --json
+  understudy evals cohort create --project <slug> --workload <name> \
+    --from-catalog .understudy/evals/catalog.json --name <name> --json
+  understudy evals cohort export <cohort-id> --project <slug> \
+    --workload <name> --out .understudy/evals/<cohort-id> --yes
+  ```
+
+  The catalog contains metadata and content hashes, never prompt/response
+  bodies. The export is limited to the immutable cohort, verifies every
+  downloaded body against its server-recorded SHA-256, and writes no signed
+  URLs to disk. Do not bypass this with a project-wide R2 dump when the hosted
+  cohort API is available.
   Captures may carry either `workload_id` or the older `placement_id` — read
   both.
 

--- a/skills/ingest-traces/SKILL.md
+++ b/skills/ingest-traces/SKILL.md
@@ -44,8 +44,18 @@ Identify the source shape first:
   dir.
 - **Provider log export**: JSONL/CSV of historical calls.
 - **Understudy frozen cohort**: select only workload-scoped, redacted capture
-  metadata; review it; freeze the exact references; then materialize that
-  auditable cohort locally:
+  metadata, review the summary, freeze the exact references, and materialize
+  that auditable cohort locally:
+
+  ```sh
+  understudy evals create --project <slug> --workload <name> \
+    --last 14d --name <name>
+  ```
+
+  The command shows how many eligible captures it found and asks before it
+  freezes or downloads anything. Use `--yes` for non-interactive automation.
+  Use the lower-level commands when the developer needs to inspect or edit the
+  redacted selection before freezing it:
 
   ```sh
   understudy evals catalog --project <slug> --workload <name> \

--- a/src/commands/evals.ts
+++ b/src/commands/evals.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { confirm } from "@inquirer/prompts";
 import { Command } from "commander";
 import kleur from "kleur";
 import { z } from "zod";
@@ -82,10 +83,44 @@ interface CohortExportOpts extends WorkloadOpts {
   out: string;
   yes?: boolean;
 }
+interface GuidedCreateOpts extends WorkloadOpts {
+  name: string;
+  description?: string;
+  last: string;
+  limit: string;
+  seed: string;
+  requestedModel?: string;
+  servedModel?: string;
+  statusCode?: string;
+  requiresTools?: boolean;
+  requiresStructuredOutput?: boolean;
+  out?: string;
+  download: boolean;
+  yes?: boolean;
+}
 
 export function registerEvalsCommand(program: Command): void {
   const evals = program.command("evals")
     .description("Select, freeze, and materialize workload-scoped evaluation cohorts.");
+
+  addWorkloadOptions(evals.command("create")
+    .description("Create a frozen eval set from a recent workload window.")
+    .requiredOption("--name <name>", "Cohort name.")
+    .option("--description <text>", "Why these captures were selected.")
+    .option("--last <duration>", "Recent window, such as 14d or 12h (max 31d).", "14d")
+    .option("--limit <n>", "Candidate limit, max 500.", "50")
+    .option("--seed <seed>", "Deterministic sample seed.", "understudy-eval-catalog-v1")
+    .option("--requested-model <id>", "Filter by requested model.")
+    .option("--served-model <id>", "Filter by served model.")
+    .option("--status-code <code>", "Filter by HTTP status code.")
+    .option("--requires-tools", "Require a trace containing tools.")
+    .option("--requires-structured-output", "Require structured output.")
+    .option("--out <directory>", "Destination directory (default: .understudy/evals/<name>).")
+    .option("--no-download", "Freeze the cohort without downloading trace bodies.")
+    .option("--yes", "Approve freezing and local trace download without prompting."))
+    .action(async function (this: Command, opts: GuidedCreateOpts) {
+      await runAction(this, () => runGuidedCreate(this, opts));
+    });
 
   addWorkloadOptions(evals.command("catalog")
     .description("List redacted capture candidates for one workload.")
@@ -137,24 +172,67 @@ async function resolveContext(opts: WorkloadOpts) {
   return { project, workload, base };
 }
 
-async function runCatalog(cmd: Command, opts: CatalogOpts): Promise<void> {
-  const limit = Number(opts.limit);
-  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
-    throw new Error(`Expected --limit between 1 and 500, got: ${opts.limit}`);
+async function runGuidedCreate(cmd: Command, opts: GuidedCreateOpts): Promise<void> {
+  if (isJsonMode(cmd) && !opts.yes) {
+    throw new Error("JSON mode cannot prompt. Re-run with --yes to approve freezing and local trace download.");
   }
-  if (opts.statusCode !== undefined) {
-    const status = Number(opts.statusCode);
-    if (!Number.isInteger(status) || status < 100 || status > 599) {
-      throw new Error(`Expected --status-code between 100 and 599, got: ${opts.statusCode}`);
+  const windowMs = parseDuration(opts.last);
+  const to = new Date();
+  const from = new Date(to.getTime() - windowMs);
+  const catalog = await fetchCatalog(opts, from.toISOString(), to.toISOString());
+  if (catalog.response.captures.length === 0) {
+    throw new Error(`No eligible captures found for ${catalog.workload.name} in the last ${opts.last}.`);
+  }
+
+  if (!isJsonMode(cmd)) {
+    printCatalogSummary(catalog.workload.name, catalog.response.captures);
+  }
+  if (!opts.yes) {
+    const approved = await confirm({
+      message: `Freeze these ${catalog.response.captures.length} captures as “${opts.name}”?`,
+      default: true,
+    });
+    if (!approved) throw new Error("Cohort creation cancelled.");
+  }
+
+  const cohort = await createCohort(catalog, opts.name, opts.description);
+  let materialized: Awaited<ReturnType<typeof materializeCohort>> | undefined;
+  let shouldDownload = opts.download;
+  if (shouldDownload) {
+    if (!opts.yes) {
+      shouldDownload = await confirm({
+        message: "Download trace bodies locally? They may contain prompts, completions, and tool payloads.",
+        default: false,
+      });
     }
   }
+  if (shouldDownload) {
+    materialized = await materializeCohort(catalog, cohort.id, opts.out ?? join(".understudy", "evals", safeFileStem(opts.name)));
+  }
+
+  const payload = {
+    ok: true,
+    project_id: catalog.project.projectId,
+    workload_id: catalog.workload.id,
+    selection: catalog.response.selection,
+    cohort,
+    materialized,
+  };
+  if (isJsonMode(cmd)) process.stdout.write(`${JSON.stringify(payload)}\n`);
+  else {
+    process.stdout.write(`${kleur.green("✓")} Froze cohort ${cohort.id} (${cohort.capture_count} captures).\n`);
+    if (materialized) {
+      process.stdout.write(`${kleur.green("✓")} Materialized verified traces at ${materialized.output}\n`);
+      process.stdout.write(`${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`);
+    }
+  }
+}
+
+async function fetchCatalog(opts: Omit<CatalogOpts, "from" | "to">, from: string, to: string) {
+  const limit = parseLimit(opts.limit);
+  validateStatusCode(opts.statusCode);
   const { project, workload, base } = await resolveContext(opts);
-  const params = new URLSearchParams({
-    from: parseIsoOption("--from", opts.from),
-    to: parseIsoOption("--to", opts.to),
-    limit: String(limit),
-    sample_seed: opts.seed,
-  });
+  const params = new URLSearchParams({ from, to, limit: String(limit), sample_seed: opts.seed });
   if (opts.requestedModel) params.set("requested_model", opts.requestedModel);
   if (opts.servedModel) params.set("served_model", opts.servedModel);
   if (opts.statusCode) params.set("status_code", opts.statusCode);
@@ -164,10 +242,54 @@ async function runCatalog(cmd: Command, opts: CatalogOpts): Promise<void> {
     { url: `${base}/eval-capture-catalog?${params}`, orgId: project.auth.orgId },
     CatalogResponseSchema,
   );
+  return { project, workload, base, response: response.data };
+}
+
+async function createCohort(
+  context: Awaited<ReturnType<typeof fetchCatalog>>,
+  name: string,
+  description?: string,
+) {
+  const response = await request({
+    url: `${context.base}/eval-cohorts`, method: "POST", orgId: context.project.auth.orgId,
+    body: {
+      name,
+      selection: { source: "explicit_capture_references", description, sampling_seed: context.response.selection.sample_seed },
+      captures: context.response.captures.map(({ capture_key, request_id, content_sha256 }) => ({ capture_key, request_id, content_sha256 })),
+    },
+  }, CohortSchema);
+  return response.data;
+}
+
+async function materializeCohort(
+  context: Awaited<ReturnType<typeof fetchCatalog>>,
+  cohortId: string,
+  out: string,
+) {
+  const response = await request(
+    { url: `${context.base}/eval-cohorts/${encodeURIComponent(cohortId)}/export`, method: "POST", body: {}, orgId: context.project.auth.orgId },
+    CohortExportSchema,
+  );
+  return downloadExport(response.data, context.workload.id, out);
+}
+
+function printCatalogSummary(workloadName: string, captures: z.infer<typeof CatalogItemSchema>[]): void {
+  const models = new Set(captures.map((capture) => capture.served_model));
+  const errors = captures.filter((capture) => capture.status_code >= 400).length;
+  const tools = captures.filter((capture) => capture.has_tools).length;
+  process.stdout.write(`Found ${captures.length} eligible captures for ${workloadName}: ${models.size} served model(s), ${errors} error(s), ${tools} with tools.\n`);
+}
+
+async function runCatalog(cmd: Command, opts: CatalogOpts): Promise<void> {
+  const { project, workload, response } = await fetchCatalog(
+    opts,
+    parseIsoOption("--from", opts.from),
+    parseIsoOption("--to", opts.to),
+  );
   const payload = {
     project_id: project.projectId,
     workload_id: workload.id,
-    ...response.data,
+    ...response,
   };
   if (opts.out) {
     writeJson(opts.out, payload);
@@ -219,10 +341,19 @@ async function runCohortExport(cmd: Command, cohortId: string, opts: CohortExpor
     { url: `${base}/eval-cohorts/${encodeURIComponent(cohortId)}/export`, method: "POST", body: {}, orgId: project.auth.orgId },
     CohortExportSchema,
   );
-  const outputDir = resolve(opts.out);
+  const payload = await downloadExport(response.data, workload.id, opts.out);
+  if (isJsonMode(cmd)) process.stdout.write(`${JSON.stringify({ ok: true, ...payload })}\n`);
+  else {
+    process.stdout.write(`${kleur.green("✓")} Materialized ${payload.count} frozen captures at ${payload.output}\n`);
+    process.stdout.write(`${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`);
+  }
+}
+
+async function downloadExport(exportData: z.infer<typeof CohortExportSchema>, workloadId: string, out: string) {
+  const outputDir = resolve(out);
   mkdirSync(outputDir, { recursive: true });
   const files: Array<{ request_id: string; path: string; content_sha256: string }> = [];
-  for (const capture of response.data.captures) {
+  for (const capture of exportData.captures) {
     const download = await fetch(capture.url, { headers: { Accept: "application/x-ndjson" } });
     if (!download.ok) throw new Error(`Capture ${capture.request_id} download failed with status ${download.status}.`);
     const bytes = new Uint8Array(await download.arrayBuffer());
@@ -235,19 +366,14 @@ async function runCohortExport(cmd: Command, cohortId: string, opts: CohortExpor
   const localManifest = join(outputDir, "cohort-manifest.json");
   writeJson(localManifest, {
     schema_version: "understudy.eval-cohort-materialization.v1",
-    cohort_id: response.data.cohort_id,
-    cohort_sha256: response.data.cohort_sha256,
-    workload_id: workload.id,
+    cohort_id: exportData.cohort_id,
+    cohort_sha256: exportData.cohort_sha256,
+    workload_id: workloadId,
     capture_count: files.length,
     privacy: { local_only: true, upload_performed: false },
     captures: files,
   });
-  const payload = { ok: true, output: outputDir, manifest: localManifest, count: files.length, cohort_sha256: response.data.cohort_sha256 };
-  if (isJsonMode(cmd)) process.stdout.write(`${JSON.stringify(payload)}\n`);
-  else {
-    process.stdout.write(`${kleur.green("✓")} Materialized ${files.length} frozen captures at ${outputDir}\n`);
-    process.stdout.write(`${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`);
-  }
+  return { output: outputDir, manifest: localManifest, count: files.length, cohort_sha256: exportData.cohort_sha256 };
 }
 
 function writeJson(path: string, value: unknown): void {
@@ -260,6 +386,33 @@ function parseIsoOption(name: string, value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) throw new Error(`${name} must be an ISO-8601 timestamp.`);
   return date.toISOString();
+}
+
+function parseLimit(value: string): number {
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new Error(`Expected --limit between 1 and 500, got: ${value}`);
+  }
+  return limit;
+}
+
+function validateStatusCode(value?: string): void {
+  if (value === undefined) return;
+  const status = Number(value);
+  if (!Number.isInteger(status) || status < 100 || status > 599) {
+    throw new Error(`Expected --status-code between 100 and 599, got: ${value}`);
+  }
+}
+
+function parseDuration(value: string): number {
+  const match = /^(\d+)(h|d)$/.exec(value);
+  if (!match) throw new Error("--last must be a duration such as 12h or 14d.");
+  const amount = Number(match[1]);
+  const durationMs = amount * (match[2] === "d" ? 86_400_000 : 3_600_000);
+  if (amount < 1 || durationMs > 31 * 86_400_000) {
+    throw new Error("--last must be between 1h and 31d.");
+  }
+  return durationMs;
 }
 
 function safeFileStem(value: string): string {

--- a/src/commands/evals.ts
+++ b/src/commands/evals.ts
@@ -108,7 +108,7 @@ export function registerEvalsCommand(program: Command): void {
     .requiredOption("--name <name>", "Cohort name.")
     .option("--description <text>", "Why these captures were selected.")
     .option("--last <duration>", "Recent window, such as 14d or 12h (max 31d).", "14d")
-    .option("--limit <n>", "Candidate limit, max 500.", "50")
+    .option("--limit <n>", "Candidate limit, max 100.", "50")
     .option("--seed <seed>", "Deterministic sample seed.", "understudy-eval-catalog-v1")
     .option("--requested-model <id>", "Filter by requested model.")
     .option("--served-model <id>", "Filter by served model.")
@@ -126,7 +126,7 @@ export function registerEvalsCommand(program: Command): void {
     .description("List redacted capture candidates for one workload.")
     .requiredOption("--from <iso>", "Inclusive ISO-8601 window start.")
     .requiredOption("--to <iso>", "Exclusive ISO-8601 window end (max 31 days).")
-    .option("--limit <n>", "Candidate limit, max 500.", "50")
+    .option("--limit <n>", "Candidate limit, max 100.", "50")
     .option("--seed <seed>", "Deterministic sample seed.", "understudy-eval-catalog-v1")
     .option("--requested-model <id>", "Filter by requested model.")
     .option("--served-model <id>", "Filter by served model.")
@@ -353,13 +353,18 @@ async function downloadExport(exportData: z.infer<typeof CohortExportSchema>, wo
   const outputDir = resolve(out);
   mkdirSync(outputDir, { recursive: true });
   const files: Array<{ request_id: string; path: string; content_sha256: string }> = [];
+  const fileNames = new Set<string>();
   for (const capture of exportData.captures) {
     const download = await fetch(capture.url, { headers: { Accept: "application/x-ndjson" } });
     if (!download.ok) throw new Error(`Capture ${capture.request_id} download failed with status ${download.status}.`);
     const bytes = new Uint8Array(await download.arrayBuffer());
     const digest = createHash("sha256").update(bytes).digest("hex");
     if (digest !== capture.content_sha256) throw new Error(`Capture ${capture.request_id} failed SHA-256 verification.`);
-    const fileName = `${safeFileStem(capture.request_id)}.jsonl`;
+    const stem = safeFileStem(capture.request_id);
+    let fileName = `${stem}.jsonl`;
+    if (fileNames.has(fileName)) fileName = `${stem}-${capture.content_sha256.slice(0, 12)}.jsonl`;
+    if (fileNames.has(fileName)) throw new Error(`Capture ${capture.request_id} collides with another local filename.`);
+    fileNames.add(fileName);
     writeFileSync(join(outputDir, fileName), bytes);
     files.push({ request_id: capture.request_id, path: fileName, content_sha256: digest });
   }
@@ -390,8 +395,8 @@ function parseIsoOption(name: string, value: string): string {
 
 function parseLimit(value: string): number {
   const limit = Number(value);
-  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
-    throw new Error(`Expected --limit between 1 and 500, got: ${value}`);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error(`Expected --limit between 1 and 100, got: ${value}`);
   }
   return limit;
 }

--- a/src/commands/evals.ts
+++ b/src/commands/evals.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { Command } from "commander";
+import kleur from "kleur";
+import { z } from "zod";
+
+import { request } from "../internal/http.js";
+import { isJsonMode, runAction } from "../internal/output.js";
+import { resolveProject, type ProjectResolutionOptions } from "../internal/projects.js";
+import { resolveWorkload } from "../internal/workloads.js";
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const CatalogItemSchema = z.object({
+  capture_key: z.string(),
+  request_id: z.string(),
+  content_sha256: Sha256Schema,
+  captured_at: z.string(),
+  provider: z.string(),
+  requested_model: z.string(),
+  served_model: z.string(),
+  status_code: z.number().int(),
+  latency_ms: z.number().nonnegative(),
+  has_tools: z.boolean(),
+  has_structured_output: z.boolean(),
+});
+const CatalogResponseSchema = z.object({
+  captures: z.array(CatalogItemSchema),
+  selection: z.object({
+    from: z.string(),
+    to: z.string(),
+    limit: z.number().int().positive(),
+    sample_seed: z.string(),
+    requested_model: z.string().nullable(),
+    served_model: z.string().nullable(),
+    status_code: z.number().int().nullable(),
+    requires_tools: z.boolean(),
+    requires_structured_output: z.boolean(),
+  }),
+});
+const CohortSchema = z.object({
+  id: z.string(),
+  workload_id: z.string(),
+  name: z.string(),
+  capture_count: z.number().int().positive(),
+  cohort_sha256: Sha256Schema,
+  created_at: z.string(),
+}).passthrough();
+const CohortExportSchema = z.object({
+  export_id: z.string(),
+  cohort_id: z.string(),
+  cohort_sha256: Sha256Schema,
+  expires_at: z.string(),
+  captures: z.array(z.object({
+    request_id: z.string(),
+    content_sha256: Sha256Schema,
+    url: z.string().url(),
+  })).min(1).max(500),
+});
+
+interface WorkloadOpts extends ProjectResolutionOptions {
+  workload: string;
+}
+interface CatalogOpts extends WorkloadOpts {
+  from: string;
+  to: string;
+  limit: string;
+  seed: string;
+  requestedModel?: string;
+  servedModel?: string;
+  statusCode?: string;
+  requiresTools?: boolean;
+  requiresStructuredOutput?: boolean;
+  out?: string;
+}
+interface CohortCreateOpts extends WorkloadOpts {
+  fromCatalog: string;
+  name: string;
+  description?: string;
+}
+interface CohortExportOpts extends WorkloadOpts {
+  out: string;
+  yes?: boolean;
+}
+
+export function registerEvalsCommand(program: Command): void {
+  const evals = program.command("evals")
+    .description("Select, freeze, and materialize workload-scoped evaluation cohorts.");
+
+  addWorkloadOptions(evals.command("catalog")
+    .description("List redacted capture candidates for one workload.")
+    .requiredOption("--from <iso>", "Inclusive ISO-8601 window start.")
+    .requiredOption("--to <iso>", "Exclusive ISO-8601 window end (max 31 days).")
+    .option("--limit <n>", "Candidate limit, max 500.", "50")
+    .option("--seed <seed>", "Deterministic sample seed.", "understudy-eval-catalog-v1")
+    .option("--requested-model <id>", "Filter by requested model.")
+    .option("--served-model <id>", "Filter by served model.")
+    .option("--status-code <code>", "Filter by HTTP status code.")
+    .option("--requires-tools", "Require a trace containing tools.")
+    .option("--requires-structured-output", "Require structured output.")
+    .option("--out <path>", "Also write the redacted catalog to a local JSON file."))
+    .action(async function (this: Command, opts: CatalogOpts) {
+      await runAction(this, () => runCatalog(this, opts));
+    });
+
+  const cohort = evals.command("cohort").description("Create or materialize immutable cohorts.");
+  addWorkloadOptions(cohort.command("create")
+    .description("Freeze an exact cohort from a saved redacted catalog.")
+    .requiredOption("--from-catalog <path>", "Catalog JSON written by `understudy evals catalog --out`.")
+    .requiredOption("--name <name>", "Cohort name.")
+    .option("--description <text>", "Why these captures were selected."))
+    .action(async function (this: Command, opts: CohortCreateOpts) {
+      await runAction(this, () => runCohortCreate(this, opts));
+    });
+
+  addWorkloadOptions(cohort.command("export <cohort-id>")
+    .description("Download one frozen cohort to a local gitignored directory.")
+    .requiredOption("--out <directory>", "Destination directory under .understudy/.")
+    .option("--yes", "Confirm files may contain prompts, completions, and tool payloads."))
+    .action(async function (this: Command, cohortId: string, opts: CohortExportOpts) {
+      await runAction(this, () => runCohortExport(this, cohortId, opts));
+    });
+}
+
+function addWorkloadOptions(command: Command): Command {
+  return command
+    .requiredOption("--workload <name-or-id>", "Workload name or id.")
+    .option("--project-id <id>", "Project id from `understudy projects list --json`.")
+    .option("--project <slug>", "Project slug to resolve to an id.")
+    .option("--org <id>", "Org id (default: local config or only credential org).");
+}
+
+async function resolveContext(opts: WorkloadOpts) {
+  const project = await resolveProject(opts);
+  const workload = await resolveWorkload(project, opts.workload);
+  const base = `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads/${encodeURIComponent(workload.id)}`;
+  return { project, workload, base };
+}
+
+async function runCatalog(cmd: Command, opts: CatalogOpts): Promise<void> {
+  const limit = Number(opts.limit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new Error(`Expected --limit between 1 and 500, got: ${opts.limit}`);
+  }
+  if (opts.statusCode !== undefined) {
+    const status = Number(opts.statusCode);
+    if (!Number.isInteger(status) || status < 100 || status > 599) {
+      throw new Error(`Expected --status-code between 100 and 599, got: ${opts.statusCode}`);
+    }
+  }
+  const { project, workload, base } = await resolveContext(opts);
+  const params = new URLSearchParams({
+    from: parseIsoOption("--from", opts.from),
+    to: parseIsoOption("--to", opts.to),
+    limit: String(limit),
+    sample_seed: opts.seed,
+  });
+  if (opts.requestedModel) params.set("requested_model", opts.requestedModel);
+  if (opts.servedModel) params.set("served_model", opts.servedModel);
+  if (opts.statusCode) params.set("status_code", opts.statusCode);
+  if (opts.requiresTools) params.set("requires_tools", "true");
+  if (opts.requiresStructuredOutput) params.set("requires_structured_output", "true");
+  const response = await request(
+    { url: `${base}/eval-capture-catalog?${params}`, orgId: project.auth.orgId },
+    CatalogResponseSchema,
+  );
+  const payload = {
+    project_id: project.projectId,
+    workload_id: workload.id,
+    ...response.data,
+  };
+  if (opts.out) {
+    writeJson(opts.out, payload);
+  }
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+  } else {
+    process.stdout.write(`${kleur.green("✓")} Found ${payload.captures.length} eligible captures for ${workload.name}.\n`);
+    if (opts.out) process.stdout.write(`Saved redacted catalog: ${resolve(opts.out)}\n`);
+  }
+}
+
+async function runCohortCreate(cmd: Command, opts: CohortCreateOpts): Promise<void> {
+  const catalog = CatalogResponseSchema.parse(JSON.parse(readFileSync(opts.fromCatalog, "utf8")));
+  if (catalog.captures.length === 0) throw new Error("The saved catalog has no captures to freeze.");
+  const { project, workload, base } = await resolveContext(opts);
+  const response = await request(
+    {
+      url: `${base}/eval-cohorts`,
+      method: "POST",
+      orgId: project.auth.orgId,
+      body: {
+        name: opts.name,
+        selection: {
+          source: "explicit_capture_references",
+          description: opts.description,
+          sampling_seed: catalog.selection.sample_seed,
+        },
+        captures: catalog.captures.map((capture) => ({
+          capture_key: capture.capture_key,
+          request_id: capture.request_id,
+          content_sha256: capture.content_sha256,
+        })),
+      },
+    },
+    CohortSchema,
+  );
+  const payload = { ok: true, project_id: project.projectId, workload_id: workload.id, cohort: response.data };
+  if (isJsonMode(cmd)) process.stdout.write(`${JSON.stringify(payload)}\n`);
+  else process.stdout.write(`${kleur.green("✓")} Froze cohort ${response.data.id} (${response.data.capture_count} captures, sha256=${response.data.cohort_sha256}).\n`);
+}
+
+async function runCohortExport(cmd: Command, cohortId: string, opts: CohortExportOpts): Promise<void> {
+  if (!opts.yes) {
+    throw new Error("Cohort files may contain prompts/completions. Re-run with --yes to download them locally.");
+  }
+  const { project, workload, base } = await resolveContext(opts);
+  const response = await request(
+    { url: `${base}/eval-cohorts/${encodeURIComponent(cohortId)}/export`, method: "POST", body: {}, orgId: project.auth.orgId },
+    CohortExportSchema,
+  );
+  const outputDir = resolve(opts.out);
+  mkdirSync(outputDir, { recursive: true });
+  const files: Array<{ request_id: string; path: string; content_sha256: string }> = [];
+  for (const capture of response.data.captures) {
+    const download = await fetch(capture.url, { headers: { Accept: "application/x-ndjson" } });
+    if (!download.ok) throw new Error(`Capture ${capture.request_id} download failed with status ${download.status}.`);
+    const bytes = new Uint8Array(await download.arrayBuffer());
+    const digest = createHash("sha256").update(bytes).digest("hex");
+    if (digest !== capture.content_sha256) throw new Error(`Capture ${capture.request_id} failed SHA-256 verification.`);
+    const fileName = `${safeFileStem(capture.request_id)}.jsonl`;
+    writeFileSync(join(outputDir, fileName), bytes);
+    files.push({ request_id: capture.request_id, path: fileName, content_sha256: digest });
+  }
+  const localManifest = join(outputDir, "cohort-manifest.json");
+  writeJson(localManifest, {
+    schema_version: "understudy.eval-cohort-materialization.v1",
+    cohort_id: response.data.cohort_id,
+    cohort_sha256: response.data.cohort_sha256,
+    workload_id: workload.id,
+    capture_count: files.length,
+    privacy: { local_only: true, upload_performed: false },
+    captures: files,
+  });
+  const payload = { ok: true, output: outputDir, manifest: localManifest, count: files.length, cohort_sha256: response.data.cohort_sha256 };
+  if (isJsonMode(cmd)) process.stdout.write(`${JSON.stringify(payload)}\n`);
+  else {
+    process.stdout.write(`${kleur.green("✓")} Materialized ${files.length} frozen captures at ${outputDir}\n`);
+    process.stdout.write(`${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`);
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  const absolute = resolve(path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function parseIsoOption(name: string, value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) throw new Error(`${name} must be an ISO-8601 timestamp.`);
+  return date.toISOString();
+}
+
+function safeFileStem(value: string): string {
+  const safe = value.replace(/[^a-zA-Z0-9._-]/g, "_");
+  if (!safe || safe === "." || safe === "..") throw new Error(`Unsafe request id: ${value}`);
+  return safe;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
 import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
 import { registerCapturesCommand } from "./commands/captures.js";
+import { registerEvalsCommand } from "./commands/evals.js";
 import { registerDaemonCommand } from "./commands/daemon.js";
 import { registerDesktopCommand } from "./commands/desktop.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
@@ -845,6 +846,7 @@ export function buildProgram(): Command {
   registerProjectsCommand(program);
   registerWorkloadsCommand(program);
   registerCapturesCommand(program);
+  registerEvalsCommand(program);
   registerGatewayCommand(program);
   registerRoutesCommand(program);
   registerSetupCommand(program);

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1818,6 +1818,35 @@ class ScoreWithFeedback:
     });
   });
 
+  it("creates and downloads a recent eval cohort in one command", async () => {
+    await withHostedFixture(async ({ home, repo, requests }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const outputDir = join(repo, ".understudy", "evals", "model-parity");
+      const created = await runWithEnvAsync([
+        "--json", "evals", "create", "--project", "rehearsal", "--workload", "classify",
+        "--last", "7d", "--name", "model-parity", "--out", outputDir, "--yes",
+      ], env, repo);
+      assert.equal(created.status, 0, created.stderr);
+      const payload = JSON.parse(created.stdout);
+      assert.equal(payload.cohort.id, "evc_123");
+      assert.equal(payload.materialized.count, 1);
+      assert.match(readFileSync(join(outputDir, "req_123.jsonl"), "utf8"), /SECRET_PROMPT/);
+      assert.doesNotMatch(created.stdout, /SECRET_PROMPT|SECRET_COMPLETION/);
+
+      const catalogRequest = requests.find((entry) => entry.path.includes("eval-capture-catalog"));
+      const catalogUrl = new URL(`http://fixture${catalogRequest.path}${catalogRequest.search}`);
+      const windowMs = Date.parse(catalogUrl.searchParams.get("to")) - Date.parse(catalogUrl.searchParams.get("from"));
+      assert.equal(windowMs, 7 * 24 * 60 * 60 * 1000);
+
+      const blocked = await runWithEnvAsync([
+        "--json", "evals", "create", "--project", "rehearsal", "--workload", "classify",
+        "--name", "blocked",
+      ], env, repo);
+      assert.notEqual(blocked.status, 0);
+      assert.match(blocked.stderr, /JSON mode cannot prompt/);
+    });
+  });
+
   it("runs gateway health and probes without printing secrets", async () => {
     await withHostedFixture(async ({ home, repo, gatewayUrl, requests }) => {
       const env = { HOME: home, USERPROFILE: home, UPSTREAM_TEST_KEY: "provider_secret_value" };

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -143,6 +143,10 @@ async function withHostedFixture(fn) {
       res.writeHead(status, { "content-type": "application/json", ...headers });
       res.end(JSON.stringify(value));
     };
+    const sendBytes = (status, value, headers = {}) => {
+      res.writeHead(status, { "content-type": "application/x-ndjson", ...headers });
+      res.end(value);
+    };
 
     if (req.method === "GET" && url.pathname === "/healthz") return send(200, { ok: true });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects") return send(200, { projects: state.projects, cursor: null });
@@ -174,6 +178,60 @@ async function withHostedFixture(fn) {
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify/captures") return send(200, { captures: state.captures, truncated: false, cursor: null });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/captures/req_123") return send(200, { capture: state.captures[0] });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify/captures/req_123") return send(200, { capture: state.captures[0] });
+    const evalBase = "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify";
+    const rawCapture = `${JSON.stringify(state.captures[0])}\n`;
+    const rawCaptureSha = createHash("sha256").update(rawCapture).digest("hex");
+    if (req.method === "GET" && url.pathname === `${evalBase}/eval-capture-catalog`) {
+      return send(200, {
+        captures: [{
+          capture_key: "org_1/proj_1/key_1/2026/06/07/req_123.jsonl",
+          request_id: "req_123",
+          content_sha256: rawCaptureSha,
+          captured_at: "2026-06-07T00:00:00Z",
+          provider: "anthropic",
+          requested_model: "claude-test",
+          served_model: "claude-test-upstream",
+          status_code: 200,
+          latency_ms: 42,
+          has_tools: true,
+          has_structured_output: true,
+        }],
+        selection: {
+          from: url.searchParams.get("from"),
+          to: url.searchParams.get("to"),
+          limit: Number(url.searchParams.get("limit")),
+          sample_seed: url.searchParams.get("sample_seed"),
+          requested_model: null,
+          served_model: null,
+          status_code: null,
+          requires_tools: url.searchParams.get("requires_tools") === "true",
+          requires_structured_output: url.searchParams.get("requires_structured_output") === "true",
+        },
+      });
+    }
+    if (req.method === "POST" && url.pathname === `${evalBase}/eval-cohorts`) {
+      return send(201, {
+        id: "evc_123",
+        org_id: "org_1",
+        project_id: "proj_1",
+        workload_id: "usp_classify",
+        name: body.name,
+        selection: body.selection,
+        capture_count: body.captures.length,
+        cohort_sha256: "a".repeat(64),
+        created_at: "2026-06-07T01:00:00Z",
+      });
+    }
+    if (req.method === "POST" && url.pathname === `${evalBase}/eval-cohorts/evc_123/export`) {
+      return send(201, {
+        export_id: "eve_123",
+        cohort_id: "evc_123",
+        cohort_sha256: "a".repeat(64),
+        expires_at: "2026-06-07T02:00:00Z",
+        captures: [{ request_id: "req_123", content_sha256: rawCaptureSha, url: `${gatewayUrl}/eval-capture-req_123` }],
+      });
+    }
+    if (req.method === "GET" && url.pathname === "/eval-capture-req_123") return sendBytes(200, rawCapture);
     if (req.method === "POST" && (url.pathname === "/v1/messages" || url.pathname === "/v1/chat/completions")) return send(200, { ok: true, content: "SECRET_COMPLETION" }, { "x-understudy-request-id": "req_probe" });
     return send(404, { message: `${req.method} ${url.pathname}` });
   });
@@ -1713,6 +1771,50 @@ class ScoreWithFeedback:
       const blockedJson = await runWithEnvAsync(["--json", "captures", "export", "req_123", "--out", join(repo, "full-json.json"), "--include-payload"], env, repo);
       assert.notEqual(blockedJson.status, 0, "json mode must still require --yes for payload export");
       assert.match(blockedJson.stderr, /may contain prompts\/completions/);
+    });
+  });
+
+  it("selects, freezes, and materializes a workload-scoped eval cohort", async () => {
+    await withHostedFixture(async ({ home, repo, requests }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const catalogPath = join(repo, ".understudy", "evals", "catalog.json");
+      const catalog = await runWithEnvAsync([
+        "--json", "evals", "catalog", "--project", "rehearsal", "--workload", "classify",
+        "--from", "2026-06-01T00:00:00Z", "--to", "2026-06-08T00:00:00Z",
+        "--limit", "50", "--seed", "cedar-july", "--requires-tools", "--out", catalogPath,
+      ], env, repo);
+      assert.equal(catalog.status, 0, catalog.stderr);
+      assert.doesNotMatch(catalog.stdout, /SECRET_PROMPT|SECRET_COMPLETION/);
+      assert.equal(JSON.parse(catalog.stdout).captures[0].request_id, "req_123");
+      assert.doesNotMatch(readFileSync(catalogPath, "utf8"), /SECRET_PROMPT|SECRET_COMPLETION/);
+
+      const create = await runWithEnvAsync([
+        "--json", "evals", "cohort", "create", "--project", "rehearsal", "--workload", "classify",
+        "--from-catalog", catalogPath, "--name", "cedar-july",
+      ], env, repo);
+      assert.equal(create.status, 0, create.stderr);
+      assert.equal(JSON.parse(create.stdout).cohort.id, "evc_123");
+      const createRequest = requests.find((entry) => entry.path.endsWith("/eval-cohorts") && entry.method === "POST");
+      assert.equal(createRequest.body.captures[0].request_id, "req_123");
+
+      const blocked = await runWithEnvAsync([
+        "evals", "cohort", "export", "evc_123", "--project", "rehearsal", "--workload", "classify",
+        "--out", join(repo, ".understudy", "evals", "evc_123"),
+      ], env, repo);
+      assert.notEqual(blocked.status, 0);
+      assert.match(blocked.stderr, /Re-run with --yes/);
+
+      const outputDir = join(repo, ".understudy", "evals", "evc_123");
+      const exported = await runWithEnvAsync([
+        "--json", "evals", "cohort", "export", "evc_123", "--project", "rehearsal", "--workload", "classify",
+        "--out", outputDir, "--yes",
+      ], env, repo);
+      assert.equal(exported.status, 0, exported.stderr);
+      assert.match(readFileSync(join(outputDir, "req_123.jsonl"), "utf8"), /SECRET_PROMPT/);
+      const manifest = JSON.parse(readFileSync(join(outputDir, "cohort-manifest.json"), "utf8"));
+      assert.equal(manifest.cohort_id, "evc_123");
+      assert.equal(manifest.privacy.local_only, true);
+      assert.doesNotMatch(JSON.stringify(manifest), /https?:\/\//);
     });
   });
 


### PR DESCRIPTION
## Summary

- add `understudy evals catalog` for bounded redacted workload capture selection
- add `understudy evals cohort create` to freeze reviewed capture references
- add `understudy evals cohort export` with SHA-256 verification and URL-free local manifests
- update `ingest-traces` to use the hosted cohort workflow

## User impact

Customers can use their existing `sk_*` authentication to select production cases, freeze a reproducible eval cohort, and materialize only those approved traces locally. Raw payload download requires explicit confirmation.

## Validation

- `npm run check`
- `git diff --check`