### PR TITLE
feat(desktop): integrate guarded remote training proof

### DIFF
--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -15,6 +15,10 @@ import {
   type LocalTrainingState,
 } from "../lib/local-training-state.mjs";
 import { EvaluationRadar } from "./EvaluationRadar";
+import {
+  RemoteTrainingPanel,
+  type RemoteTrainingCapabilities,
+} from "./RemoteTrainingPanel";
 import type { TrainingHaloVisual } from "./TrainingHalo";
 
 const MODERN_BERT_MODEL = "answerdotai/ModernBERT-base";
@@ -167,6 +171,13 @@ type Props = {
   onVisualChange?: (visual: TrainingHaloVisual | null) => void;
 };
 
+type RemoteCapabilitiesEnvelope = {
+  schema_version: "understudy.remote_training.capabilities.v1";
+  enabled: boolean;
+  reason?: string;
+  capabilities?: RemoteTrainingCapabilities;
+};
+
 function percent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
@@ -213,6 +224,11 @@ export function LocalTrainingPanel({
   const [trainingPreviewIndex, setTrainingPreviewIndex] = useState(0);
   const [previousTrainingPreviewIndex, setPreviousTrainingPreviewIndex] = useState<number | null>(null);
   const [haloProgress, setHaloProgress] = useState({ epochs: 3, completedEpochs: 0 });
+  const [remoteCapabilityState, setRemoteCapabilityState] = useState<"checking" | "available" | "unavailable">("checking");
+  const [remoteCapabilities, setRemoteCapabilities] = useState<RemoteTrainingCapabilities | null>(null);
+  const [remoteActive, setRemoteActive] = useState(false);
+  const [remoteVisual, setRemoteVisual] = useState<TrainingHaloVisual | null>(null);
+  const [forceLocal, setForceLocal] = useState(false);
   const [clockMs, setClockMs] = useState(() => Date.now());
   const generation = useRef(0);
   const activeRunId = useRef<string | null>(null);
@@ -223,7 +239,8 @@ export function LocalTrainingPanel({
   const runStartedAt = useRef<number | null>(null);
   const trainingStartedAt = useRef<number | null>(null);
   const lastEpochCompletedAt = useRef<number | null>(null);
-  const active = isLocalTrainingActive(state);
+  const localActive = isLocalTrainingActive(state);
+  const active = localActive || remoteActive;
   const phaseCopy = localTrainingPhaseCopy(state.phase);
   const measuredProgress = localTrainingProgress(state.event);
   const timing = localTrainingTiming({
@@ -245,6 +262,10 @@ export function LocalTrainingPanel({
   }, [onActiveChange, onVisualChange]);
 
   useEffect(() => {
+    if (remoteVisual) {
+      onVisualChange?.(remoteVisual);
+      return;
+    }
     if (state.phase === "idle" || state.phase === "failed" || state.phase === "cancelled") {
       onVisualChange?.(null);
       return;
@@ -259,7 +280,7 @@ export function LocalTrainingPanel({
       modelName,
       done: state.phase === "completed",
     });
-  }, [haloProgress, modelName, onVisualChange, state.phase, state.runId]);
+  }, [haloProgress, modelName, onVisualChange, remoteVisual, state.phase, state.runId]);
 
   useEffect(() => {
     generation.current += 1;
@@ -281,11 +302,39 @@ export function LocalTrainingPanel({
     trainingPreviewIndexRef.current = 0;
     setPreviousTrainingPreviewIndex(null);
     setHaloProgress({ epochs: 3, completedEpochs: 0 });
+    setRemoteActive(false);
+    setRemoteVisual(null);
+    setForceLocal(false);
     runStartedAt.current = null;
     trainingStartedAt.current = null;
     lastEpochCompletedAt.current = null;
     setClockMs(Date.now());
     if (previewFadeTimer.current !== null) window.clearTimeout(previewFadeTimer.current);
+  }, [datasetManifestPath]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setRemoteCapabilityState("checking");
+    setRemoteCapabilities(null);
+    void invoke<RemoteCapabilitiesEnvelope>("remote_training_capabilities")
+      .then((envelope) => {
+        if (cancelled) return;
+        const hasProvider = envelope.enabled && envelope.capabilities?.providers.some(
+          (provider) => provider.enabled && provider.base_models.length > 0,
+        );
+        if (hasProvider && envelope.capabilities) {
+          setRemoteCapabilities(envelope.capabilities);
+          setRemoteCapabilityState("available");
+        } else {
+          setRemoteCapabilityState("unavailable");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setRemoteCapabilityState("unavailable");
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [datasetManifestPath]);
 
   useEffect(() => () => {
@@ -410,13 +459,19 @@ export function LocalTrainingPanel({
   }, [active, datasetManifestPath]);
 
   useEffect(() => {
-    if (!autoStart || state.phase !== "idle" || autoStartedManifest.current === datasetManifestPath) return;
+    if (
+      !autoStart ||
+      state.phase !== "idle" ||
+      remoteCapabilityState === "checking" ||
+      (remoteCapabilityState === "available" && !forceLocal) ||
+      autoStartedManifest.current === datasetManifestPath
+    ) return;
     const timer = window.setTimeout(() => {
       autoStartedManifest.current = datasetManifestPath;
       startTraining();
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [autoStart, datasetManifestPath, startTraining, state.phase]);
+  }, [autoStart, datasetManifestPath, forceLocal, remoteCapabilityState, startTraining, state.phase]);
 
   const cancelTraining = () => {
     if (!activeRunId.current || !active) return;
@@ -480,6 +535,22 @@ export function LocalTrainingPanel({
   };
 
   if (state.phase === "idle") {
+    if (remoteCapabilityState === "checking" && autoStart) return null;
+    if (remoteCapabilityState === "available" && remoteCapabilities && !forceLocal) {
+      return (
+        <RemoteTrainingPanel
+          datasetManifestPath={datasetManifestPath}
+          modelName={modelName}
+          capabilities={remoteCapabilities}
+          onTrainLocal={() => {
+            setForceLocal(true);
+            startTraining();
+          }}
+          onActiveChange={setRemoteActive}
+          onVisualChange={setRemoteVisual}
+        />
+      );
+    }
     if (autoStart) return null;
     return (
       <div className="local-training-start">

--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -320,7 +320,7 @@ export function LocalTrainingPanel({
       .then((envelope) => {
         if (cancelled) return;
         const hasProvider = envelope.enabled && envelope.capabilities?.providers.some(
-          (provider) => provider.enabled && provider.base_models.length > 0,
+          (provider) => provider.enabled && provider.model_profiles.length > 0,
         );
         if (hasProvider && envelope.capabilities) {
           setRemoteCapabilities(envelope.capabilities);
@@ -667,7 +667,7 @@ export function LocalTrainingPanel({
             <span>Frontier reference</span>
             <strong>Compare with GLM 5.2 on the same {state.result.heldout.row_count.toLocaleString()} test examples</strong>
             <small>
-              Only held-out test examples are sent through Understudy; training examples stay on this Mac. Fireworks publishes zero data retention for GLM 5.2. Maximum approved spend: $1.00.
+              Only held-out test examples are sent through Understudy; training examples stay on this Mac. The active inference vendor remains behind Understudy's authenticated service boundary. Maximum approved spend: $1.00.
             </small>
             {frontierEvent?.message && <p>{frontierEvent.message}</p>}
             {frontierEvent?.current !== undefined && frontierEvent.total !== undefined && (

--- a/apps/homescreen/app/components/RemoteTrainingPanel.tsx
+++ b/apps/homescreen/app/components/RemoteTrainingPanel.tsx
@@ -5,10 +5,15 @@ import { Channel, invoke } from "@tauri-apps/api/core";
 import type { TrainingHaloVisual } from "./TrainingHalo";
 
 export type RemoteTrainingProvider = {
-  id: "fake" | "fireworks";
+  id: "fake" | "managed";
   enabled: boolean;
   label: string;
-  base_models: string[];
+  model_profiles: Array<{
+    id: "understudy/auto" | "understudy/fast" | "understudy/balanced" | "understudy/quality";
+    label: string;
+    summary: string;
+    recommended: boolean;
+  }>;
 };
 
 export type RemoteTrainingCapabilities = {
@@ -38,8 +43,8 @@ type RemoteArtifact = {
 type RemotePlan = {
   schema_version: "understudy.remote_training.plan.v1";
   plan_id: string;
-  provider: "fake" | "fireworks";
-  base_model: string;
+  provider: "fake" | "managed";
+  model_profile: RemoteTrainingProvider["model_profiles"][number]["id"];
   frontier_model: string;
   output_model_name: string;
   artifacts: RemoteArtifact[];
@@ -82,7 +87,6 @@ type HumanMetric = {
 
 type RemoteResult = {
   outcome: "promoted" | "needs_work" | "failed" | "cancelled";
-  provider: "fake" | "fireworks";
   output_model?: string;
   endpoint?: string;
   spend_usd: number;
@@ -126,17 +130,12 @@ function bytes(value: number): string {
 }
 
 function providerDefault(providers: RemoteTrainingProvider[]): RemoteTrainingProvider {
-  return providers.find((provider) => provider.id === "fireworks") ?? providers[0];
+  return providers.find((provider) => provider.id === "managed") ?? providers[0];
 }
 
-function baseModelDefault(provider: RemoteTrainingProvider): string {
-  return provider.base_models.find((model) => model.endsWith("/gemma-4-26b-a4b-it"))
-    ?? provider.base_models.find((model) => model.includes("/gemma-4-"))
-    ?? provider.base_models[0];
-}
-
-function modelLabel(model: string): string {
-  return model.split("/").at(-1)?.replaceAll("-", " ") ?? model;
+function profileDefault(provider: RemoteTrainingProvider) {
+  return provider.model_profiles.find((profile) => profile.recommended)
+    ?? provider.model_profiles[0];
 }
 
 function visualPhase(phase: string): TrainingHaloVisual["phase"] {
@@ -155,10 +154,14 @@ export function RemoteTrainingPanel({
   onVisualChange,
 }: Props) {
   const providers = useMemo(
-    () => capabilities.providers.filter((provider) => provider.enabled && provider.base_models.length > 0),
+    () => capabilities.providers.filter((provider) => provider.enabled && provider.model_profiles.length > 0),
     [capabilities.providers],
   );
-  const [providerId, setProviderId] = useState<RemoteTrainingProvider["id"]>(() => providerDefault(providers).id);
+  const [providerId] = useState<RemoteTrainingProvider["id"]>(() => providerDefault(providers).id);
+  const initialProvider = providerDefault(providers);
+  const [profileId, setProfileId] = useState<RemoteTrainingProvider["model_profiles"][number]["id"]>(
+    () => profileDefault(initialProvider).id,
+  );
   const [stage, setStage] = useState<Stage>("recovering");
   const [plan, setPlan] = useState<RemotePlan | null>(null);
   const [run, setRun] = useState<RemoteRunReceipt | null>(null);
@@ -172,7 +175,8 @@ export function RemoteTrainingPanel({
   const polling = useRef(false);
   const stopped = useRef(false);
   const provider = providers.find((candidate) => candidate.id === providerId) ?? providers[0];
-  const baseModel = provider ? baseModelDefault(provider) : "";
+  const profile = provider?.model_profiles.find((candidate) => candidate.id === profileId)
+    ?? (provider ? profileDefault(provider) : undefined);
   const active = stage === "preparing" || stage === "starting" || stage === "running";
   const latestEvent = events.at(-1);
 
@@ -248,11 +252,12 @@ export function RemoteTrainingPanel({
     if (!provider || stage !== "choice") return;
     setStage("preparing");
     setError(null);
-    const maximumSpend = Math.min(provider.id === "fake" ? 1 : 3, capabilities.limits.max_budget_usd);
+    if (!profile) return;
+    const maximumSpend = Math.min(provider.id === "fake" ? 1 : 500, capabilities.limits.max_budget_usd);
     void invoke<RemotePlan>("prepare_remote_classification_training", {
       manifestPath: datasetManifestPath,
       provider: provider.id,
-      baseModel,
+      modelProfile: profile.id,
       frontierModel: "glm-5.2",
       maximumSpendUsd: maximumSpend,
     })
@@ -264,7 +269,7 @@ export function RemoteTrainingPanel({
         setError(String(cause));
         setStage("failed");
       });
-  }, [baseModel, capabilities.limits.max_budget_usd, datasetManifestPath, provider, stage]);
+  }, [capabilities.limits.max_budget_usd, datasetManifestPath, profile, provider, stage]);
 
   const poll = useCallback(async (receipt: RemoteRunReceipt) => {
     if (polling.current || stopped.current) return;
@@ -342,15 +347,15 @@ export function RemoteTrainingPanel({
           <strong>Train a larger model without tying up this Mac</strong>
           <small>Understudy prepares everything locally first. Nothing uploads until you review the exact artifacts and budget.</small>
         </div>
-        {providers.length > 1 && (
+        {provider && provider.model_profiles.length > 1 && (
           <label>
-            <span>Provider</span>
-            <select value={providerId} onChange={(event) => setProviderId(event.target.value as RemoteTrainingProvider["id"])}>
-              {providers.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.label}</option>)}
+            <span>Model</span>
+            <select value={profile?.id} onChange={(event) => setProfileId(event.target.value as typeof profileId)}>
+              {provider.model_profiles.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.label}</option>)}
             </select>
           </label>
         )}
-        {provider && <small>Selected model · {modelLabel(baseModel)}</small>}
+        {profile && <small>{profile.summary}</small>}
         <div className="remote-training-actions">
           <button type="button" className="btn primary" onClick={prepare}>
             {provider?.id === "fake" ? "Try the no-spend cloud proof" : "Review remote training"}
@@ -384,7 +389,7 @@ export function RemoteTrainingPanel({
         </div>
         <div className="remote-training-consent">
           <label><input type="checkbox" checked={confirmUpload} onChange={(event) => setConfirmUpload(event.target.checked)} /><span>Upload only these three private split artifacts.</span></label>
-          <label><input type="checkbox" checked={confirmSpend} onChange={(event) => setConfirmSpend(event.target.checked)} /><span>Train with {provider?.label}; stop when its reported estimate reaches ${plan.maximum_spend_usd.toFixed(2)}.</span></label>
+          <label><input type="checkbox" checked={confirmSpend} onChange={(event) => setConfirmSpend(event.target.checked)} /><span>Use Understudy managed training; stop when its reported estimate reaches ${plan.maximum_spend_usd.toFixed(2)}.</span></label>
           <label><input type="checkbox" checked={confirmDeployment} onChange={(event) => setConfirmDeployment(event.target.checked)} /><span>Create a temporary endpoint for held-out comparison, then always remove it.</span></label>
         </div>
         <div className="remote-training-actions">
@@ -430,7 +435,7 @@ export function RemoteTrainingPanel({
           : { eyebrow: "Run ended", title: "Remote training did not complete" };
     return (
       <div className={`remote-training-result ${result.outcome}`}>
-        <div><span>{terminalCopy.eyebrow}</span><strong>{terminalCopy.title}</strong><small>Provider-reported training cost: ${result.spend_usd.toFixed(2)}</small></div>
+        <div><span>{terminalCopy.eyebrow}</span><strong>{terminalCopy.title}</strong><small>Reported training cost: ${result.spend_usd.toFixed(2)}</small></div>
         <div className="remote-training-metrics">
           {result.metrics.map((metric) => <article key={metric.id}><span>{metric.label}</span><strong>{metric.display_value}</strong><small>{metric.explanation}</small></article>)}
         </div>

--- a/apps/homescreen/app/components/RemoteTrainingPanel.tsx
+++ b/apps/homescreen/app/components/RemoteTrainingPanel.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Channel, invoke } from "@tauri-apps/api/core";
+import type { TrainingHaloVisual } from "./TrainingHalo";
+
+export type RemoteTrainingProvider = {
+  id: "fake" | "fireworks";
+  enabled: boolean;
+  label: string;
+  base_models: string[];
+};
+
+export type RemoteTrainingCapabilities = {
+  schema_version: "understudy-train-v1";
+  service: "train.understudylabs.com";
+  providers: RemoteTrainingProvider[];
+  limits: {
+    max_active_runs_per_org: 1;
+    max_upload_bytes: number;
+    max_budget_usd: number;
+  };
+  privacy: {
+    private_uploads: true;
+    raw_rows_in_telemetry: false;
+    provider_upload_requires_explicit_consent: true;
+  };
+};
+
+type RemoteArtifact = {
+  artifact_role: "train" | "validation" | "heldout";
+  file_name: string;
+  row_count: number;
+  sha256: string;
+  size_bytes: number;
+};
+
+type RemotePlan = {
+  schema_version: "understudy.remote_training.plan.v1";
+  plan_id: string;
+  provider: "fake" | "fireworks";
+  base_model: string;
+  frontier_model: string;
+  output_model_name: string;
+  artifacts: RemoteArtifact[];
+  epochs: number;
+  maximum_spend_usd: number;
+  maximum_runtime_seconds: number;
+  plan_path: string;
+};
+
+type RemoteRunReceipt = {
+  schema_version: "understudy.remote_training.run.v1";
+  run_id: string;
+  run_manifest_path: string;
+};
+
+type RemoteTrainingEvent = {
+  schema_version?: "understudy-train-v1";
+  sequence?: number;
+  type?: string;
+  phase: "queued" | "upload" | "training" | "evaluation" | "deployment" | "cleanup" | "terminal" | string;
+  message: string;
+  progress?: {
+    completed: number;
+    total: number;
+    unit: "steps" | "epochs" | "examples" | "seconds";
+  };
+  eve?: {
+    decision: "observe" | "retry" | "wait" | "ask_user" | "stop";
+    reason_code: string;
+  };
+};
+
+type HumanMetric = {
+  id: "correct_answers" | "coverage_across_categories" | "improvement_over_base" | "frontier_gap" | "speed";
+  label: string;
+  value: number;
+  display_value: string;
+  explanation: string;
+};
+
+type RemoteResult = {
+  outcome: "promoted" | "needs_work" | "failed" | "cancelled";
+  provider: "fake" | "fireworks";
+  output_model?: string;
+  endpoint?: string;
+  spend_usd: number;
+  metrics: HumanMetric[];
+  failures: { input_summary: string; expected: string; actual: string }[];
+};
+
+type RemotePoll = {
+  schema_version: "understudy.remote_training.poll.v1";
+  run_id: string;
+  events: RemoteTrainingEvent[];
+  status: {
+    workflow_status: "pending" | "running" | "completed" | "failed" | "cancelled" | "paused";
+    result?: RemoteResult;
+  };
+  run_manifest_path: string;
+};
+
+type UploadEvent = {
+  type: "phase";
+  phase: "preparing" | "uploading";
+  current: number;
+  total: number;
+  message: string;
+};
+
+type Props = {
+  datasetManifestPath: string;
+  modelName: string;
+  capabilities: RemoteTrainingCapabilities;
+  onTrainLocal: () => void;
+  onActiveChange: (active: boolean) => void;
+  onVisualChange: (visual: TrainingHaloVisual | null) => void;
+};
+
+type Stage = "recovering" | "choice" | "preparing" | "confirm" | "starting" | "running" | "terminal" | "failed";
+
+function bytes(value: number): string {
+  if (value < 1024 * 1024) return `${Math.max(1, Math.round(value / 1024))} KB`;
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function providerDefault(providers: RemoteTrainingProvider[]): RemoteTrainingProvider {
+  return providers.find((provider) => provider.id === "fake") ?? providers[0];
+}
+
+function visualPhase(phase: string): TrainingHaloVisual["phase"] {
+  if (phase === "training") return "training";
+  if (phase === "evaluation") return "evaluating";
+  if (phase === "deployment" || phase === "cleanup") return "saving";
+  return "preparing";
+}
+
+export function RemoteTrainingPanel({
+  datasetManifestPath,
+  modelName,
+  capabilities,
+  onTrainLocal,
+  onActiveChange,
+  onVisualChange,
+}: Props) {
+  const providers = useMemo(
+    () => capabilities.providers.filter((provider) => provider.enabled && provider.base_models.length > 0),
+    [capabilities.providers],
+  );
+  const [providerId, setProviderId] = useState<RemoteTrainingProvider["id"]>(() => providerDefault(providers).id);
+  const [stage, setStage] = useState<Stage>("recovering");
+  const [plan, setPlan] = useState<RemotePlan | null>(null);
+  const [run, setRun] = useState<RemoteRunReceipt | null>(null);
+  const [events, setEvents] = useState<RemoteTrainingEvent[]>([]);
+  const [uploadEvent, setUploadEvent] = useState<UploadEvent | null>(null);
+  const [result, setResult] = useState<RemoteResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmUpload, setConfirmUpload] = useState(false);
+  const [confirmSpend, setConfirmSpend] = useState(false);
+  const [confirmDeployment, setConfirmDeployment] = useState(false);
+  const polling = useRef(false);
+  const stopped = useRef(false);
+  const provider = providers.find((candidate) => candidate.id === providerId) ?? providers[0];
+  const active = stage === "preparing" || stage === "starting" || stage === "running";
+  const latestEvent = events.at(-1);
+
+  useEffect(() => {
+    onActiveChange(active);
+  }, [active, onActiveChange]);
+
+  useEffect(() => {
+    if (!active && !(stage === "terminal" && result?.outcome === "promoted")) {
+      onVisualChange(null);
+      return;
+    }
+    const eventPhase = latestEvent?.phase ?? (stage === "starting" ? "upload" : "queued");
+    const epochProgress = latestEvent?.progress?.unit === "epochs" ? latestEvent.progress : null;
+    const done = stage === "terminal" && result?.outcome === "promoted";
+    onVisualChange({
+      phase: done ? "completed" : visualPhase(eventPhase),
+      epochs: Math.max(1, plan?.epochs ?? 3),
+      completedEpochs: done
+        ? Math.max(1, plan?.epochs ?? 3)
+        : epochProgress
+          ? Math.min(epochProgress.total, epochProgress.completed)
+          : eventPhase === "evaluation" || eventPhase === "deployment" || eventPhase === "cleanup"
+            ? Math.max(1, plan?.epochs ?? 3)
+            : 0,
+      stepFraction: null,
+      modelId: plan?.output_model_name ?? `remote.${providerId}`,
+      modelName,
+      done,
+    });
+  }, [active, latestEvent, modelName, onVisualChange, plan, providerId, result, stage]);
+
+  useEffect(() => () => {
+    stopped.current = true;
+    onActiveChange(false);
+    onVisualChange(null);
+  }, [onActiveChange, onVisualChange]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStage("recovering");
+    setPlan(null);
+    setRun(null);
+    setEvents([]);
+    setUploadEvent(null);
+    setResult(null);
+    setError(null);
+    setConfirmUpload(false);
+    setConfirmSpend(false);
+    setConfirmDeployment(false);
+    stopped.current = false;
+    void invoke<RemoteRunReceipt | null>("existing_remote_classification_training", {
+      manifestPath: datasetManifestPath,
+    })
+      .then((receipt) => {
+        if (cancelled) return;
+        if (receipt) {
+          setRun(receipt);
+          setStage("running");
+        } else {
+          setStage("choice");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStage("choice");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetManifestPath]);
+
+  const prepare = useCallback(() => {
+    if (!provider || stage !== "choice") return;
+    setStage("preparing");
+    setError(null);
+    const maximumSpend = Math.min(provider.id === "fake" ? 1 : 3, capabilities.limits.max_budget_usd);
+    void invoke<RemotePlan>("prepare_remote_classification_training", {
+      manifestPath: datasetManifestPath,
+      provider: provider.id,
+      baseModel: provider.base_models[0],
+      frontierModel: "glm-5.2",
+      maximumSpendUsd: maximumSpend,
+    })
+      .then((prepared) => {
+        setPlan(prepared);
+        setStage("confirm");
+      })
+      .catch((cause) => {
+        setError(String(cause));
+        setStage("failed");
+      });
+  }, [capabilities.limits.max_budget_usd, datasetManifestPath, provider, stage]);
+
+  const poll = useCallback(async (receipt: RemoteRunReceipt) => {
+    if (polling.current || stopped.current) return;
+    polling.current = true;
+    try {
+      const update = await invoke<RemotePoll>("remote_training_poll", {
+        runManifestPath: receipt.run_manifest_path,
+      });
+      if (update.events.length > 0) {
+        setEvents((current) => [...current, ...update.events].slice(-100));
+      }
+      if (update.status.workflow_status === "completed" && update.status.result) {
+        setResult(update.status.result);
+        setStage("terminal");
+      } else if (update.status.workflow_status === "failed" || update.status.workflow_status === "cancelled") {
+        setResult(update.status.result ?? null);
+        setError(update.status.workflow_status === "cancelled" ? "Remote training stopped safely." : "The remote workflow did not finish.");
+        setStage(update.status.workflow_status === "cancelled" ? "terminal" : "failed");
+      }
+    } catch (cause) {
+      setError(`Connection interrupted: ${String(cause)}. The durable job is still safe; retrying.`);
+    } finally {
+      polling.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (stage !== "running" || !run) return;
+    void poll(run);
+    const timer = window.setInterval(() => void poll(run), 1_500);
+    return () => window.clearInterval(timer);
+  }, [poll, run, stage]);
+
+  const start = () => {
+    if (!plan || stage !== "confirm" || !confirmUpload || !confirmSpend || !confirmDeployment) return;
+    setStage("starting");
+    setError(null);
+    setEvents([]);
+    const channel = new Channel<UploadEvent>();
+    channel.onmessage = setUploadEvent;
+    void invoke<RemoteRunReceipt>("start_remote_classification_training", {
+      planPath: plan.plan_path,
+      confirmUpload,
+      confirmSpend,
+      confirmTemporaryDeployment: confirmDeployment,
+      onEvent: channel,
+    })
+      .then((receipt) => {
+        setRun(receipt);
+        setUploadEvent(null);
+        setStage("running");
+      })
+      .catch((cause) => {
+        setError(String(cause));
+        setStage("failed");
+      });
+  };
+
+  const cancel = () => {
+    if (!run) return;
+    void invoke("cancel_remote_training", { runManifestPath: run.run_manifest_path })
+      .then(() => setError("Stop requested. Eve is preserving cleanup before the run ends."))
+      .catch((cause) => setError(String(cause)));
+  };
+
+  if (stage === "recovering") {
+    return <div className="remote-training-state" aria-live="polite"><strong>Checking the last remote run</strong><small>Looking only at protected run evidence on this Mac.</small></div>;
+  }
+
+  if (stage === "choice") {
+    return (
+      <div className="remote-training-choice">
+        <div>
+          <span>Experimental cloud training</span>
+          <strong>Train a larger Gemma without tying up this Mac</strong>
+          <small>Understudy prepares everything locally first. Nothing uploads until you review the exact artifacts and budget.</small>
+        </div>
+        {providers.length > 1 && (
+          <label>
+            <span>Provider</span>
+            <select value={providerId} onChange={(event) => setProviderId(event.target.value as RemoteTrainingProvider["id"])}>
+              {providers.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.label}</option>)}
+            </select>
+          </label>
+        )}
+        <div className="remote-training-actions">
+          <button type="button" className="btn primary" onClick={prepare}>
+            {provider?.id === "fake" ? "Try the no-spend cloud proof" : "Review remote training"}
+          </button>
+          <button type="button" className="btn ghost" onClick={onTrainLocal}>Train on this Mac</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === "preparing") {
+    return <div className="remote-training-state" aria-live="polite"><strong>Preparing locally</strong><small>Verifying split hashes and producing private upload artifacts. Nothing is leaving this Mac.</small></div>;
+  }
+
+  if (stage === "confirm" && plan) {
+    const totalBytes = plan.artifacts.reduce((sum, artifact) => sum + artifact.size_bytes, 0);
+    return (
+      <div className="remote-training-confirm">
+        <div className="remote-training-confirm-heading">
+          <div><span>Ready for consent</span><strong>{plan.output_model_name}</strong></div>
+          <small>{plan.artifacts.reduce((sum, artifact) => sum + artifact.row_count, 0).toLocaleString()} split rows · {bytes(totalBytes)}</small>
+        </div>
+        <div className="remote-training-artifacts">
+          {plan.artifacts.map((artifact) => (
+            <div key={artifact.artifact_role}>
+              <strong>{artifact.artifact_role}</strong>
+              <span>{artifact.row_count.toLocaleString()} rows · {bytes(artifact.size_bytes)}</span>
+              <code>{artifact.sha256.slice(0, 12)}</code>
+            </div>
+          ))}
+        </div>
+        <div className="remote-training-consent">
+          <label><input type="checkbox" checked={confirmUpload} onChange={(event) => setConfirmUpload(event.target.checked)} /><span>Upload only these three private split artifacts.</span></label>
+          <label><input type="checkbox" checked={confirmSpend} onChange={(event) => setConfirmSpend(event.target.checked)} /><span>Train with {provider?.label}; never spend more than ${plan.maximum_spend_usd.toFixed(2)}.</span></label>
+          <label><input type="checkbox" checked={confirmDeployment} onChange={(event) => setConfirmDeployment(event.target.checked)} /><span>Create a temporary endpoint for held-out comparison, then remove it unless the model earns promotion.</span></label>
+        </div>
+        <div className="remote-training-actions">
+          <button type="button" className="btn primary" disabled={!confirmUpload || !confirmSpend || !confirmDeployment} onClick={start}>Upload & train · max ${plan.maximum_spend_usd.toFixed(2)}</button>
+          <button type="button" className="btn ghost" onClick={() => setStage("choice")}>Back</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === "starting" || stage === "running") {
+    const status = uploadEvent?.message ?? latestEvent?.message ?? "The durable training workflow is starting.";
+    const progress = uploadEvent
+      ? `${uploadEvent.current} of ${uploadEvent.total} approved artifacts`
+      : latestEvent?.progress
+        ? `${latestEvent.progress.completed} of ${latestEvent.progress.total} ${latestEvent.progress.unit}`
+        : null;
+    return (
+      <div className="remote-training-running" aria-live="polite" aria-busy="true">
+        <div>
+          <span className="local-training-pulse" aria-hidden="true" />
+          <div><strong>{latestEvent?.phase === "training" ? "Training remotely" : latestEvent?.phase === "evaluation" ? "Proving the model" : "Starting remote training"}</strong><small>{status}</small>{progress && <code>{progress}</code>}</div>
+          {run && <button type="button" className="btn ghost" onClick={cancel}>Cancel</button>}
+        </div>
+        {latestEvent?.eve && latestEvent.eve.decision !== "observe" && (
+          <p>Eve chose to {latestEvent.eve.decision.replace("_", " ")} · {latestEvent.eve.reason_code}</p>
+        )}
+        {error && <p className="remote-training-warning">{error}</p>}
+        <ol>
+          {events.slice(-4).map((event, index) => <li key={`${event.sequence ?? index}:${event.type ?? event.phase}`}>{event.message}</li>)}
+        </ol>
+      </div>
+    );
+  }
+
+  if (stage === "terminal" && result) {
+    return (
+      <div className={`remote-training-result ${result.outcome}`}>
+        <div><span>{result.outcome === "promoted" ? "Ready to use" : "Review complete"}</span><strong>{result.outcome === "promoted" ? "This model earned promotion" : "This model needs another pass"}</strong><small>Actual provider spend: ${result.spend_usd.toFixed(2)}</small></div>
+        <div className="remote-training-metrics">
+          {result.metrics.map((metric) => <article key={metric.id}><span>{metric.label}</span><strong>{metric.display_value}</strong><small>{metric.explanation}</small></article>)}
+        </div>
+        {result.failures.length > 0 && <div className="remote-training-failures"><strong>Where it still fails</strong>{result.failures.slice(0, 3).map((failure, index) => <p key={index}>{failure.expected} expected · {failure.actual} returned · {failure.input_summary}</p>)}</div>}
+        {result.outcome === "promoted" && result.endpoint && <div className="remote-training-endpoint"><span>Private endpoint</span><code>{result.endpoint}</code></div>}
+        <div className="remote-training-actions"><button type="button" className="btn ghost" onClick={() => { setPlan(null); setRun(null); setEvents([]); setResult(null); setError(null); setStage("choice"); }}>Start another run</button></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="remote-training-state failed" role="alert">
+      <div><strong>Remote training did not start</strong><small>{error ?? "The local dataset is intact and no further work will run."}</small></div>
+      <div className="remote-training-actions"><button type="button" className="btn primary" onClick={() => setStage("choice")}>Try again</button><button type="button" className="btn ghost" onClick={onTrainLocal}>Train on this Mac</button></div>
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/RemoteTrainingPanel.tsx
+++ b/apps/homescreen/app/components/RemoteTrainingPanel.tsx
@@ -126,7 +126,17 @@ function bytes(value: number): string {
 }
 
 function providerDefault(providers: RemoteTrainingProvider[]): RemoteTrainingProvider {
-  return providers.find((provider) => provider.id === "fake") ?? providers[0];
+  return providers.find((provider) => provider.id === "fireworks") ?? providers[0];
+}
+
+function baseModelDefault(provider: RemoteTrainingProvider): string {
+  return provider.base_models.find((model) => model.endsWith("/gemma-4-26b-a4b-it"))
+    ?? provider.base_models.find((model) => model.includes("/gemma-4-"))
+    ?? provider.base_models[0];
+}
+
+function modelLabel(model: string): string {
+  return model.split("/").at(-1)?.replaceAll("-", " ") ?? model;
 }
 
 function visualPhase(phase: string): TrainingHaloVisual["phase"] {
@@ -162,6 +172,7 @@ export function RemoteTrainingPanel({
   const polling = useRef(false);
   const stopped = useRef(false);
   const provider = providers.find((candidate) => candidate.id === providerId) ?? providers[0];
+  const baseModel = provider ? baseModelDefault(provider) : "";
   const active = stage === "preparing" || stage === "starting" || stage === "running";
   const latestEvent = events.at(-1);
 
@@ -241,7 +252,7 @@ export function RemoteTrainingPanel({
     void invoke<RemotePlan>("prepare_remote_classification_training", {
       manifestPath: datasetManifestPath,
       provider: provider.id,
-      baseModel: provider.base_models[0],
+      baseModel,
       frontierModel: "glm-5.2",
       maximumSpendUsd: maximumSpend,
     })
@@ -253,7 +264,7 @@ export function RemoteTrainingPanel({
         setError(String(cause));
         setStage("failed");
       });
-  }, [capabilities.limits.max_budget_usd, datasetManifestPath, provider, stage]);
+  }, [baseModel, capabilities.limits.max_budget_usd, datasetManifestPath, provider, stage]);
 
   const poll = useCallback(async (receipt: RemoteRunReceipt) => {
     if (polling.current || stopped.current) return;
@@ -328,7 +339,7 @@ export function RemoteTrainingPanel({
       <div className="remote-training-choice">
         <div>
           <span>Experimental cloud training</span>
-          <strong>Train a larger Gemma without tying up this Mac</strong>
+          <strong>Train a larger model without tying up this Mac</strong>
           <small>Understudy prepares everything locally first. Nothing uploads until you review the exact artifacts and budget.</small>
         </div>
         {providers.length > 1 && (
@@ -339,6 +350,7 @@ export function RemoteTrainingPanel({
             </select>
           </label>
         )}
+        {provider && <small>Selected model · {modelLabel(baseModel)}</small>}
         <div className="remote-training-actions">
           <button type="button" className="btn primary" onClick={prepare}>
             {provider?.id === "fake" ? "Try the no-spend cloud proof" : "Review remote training"}
@@ -372,8 +384,8 @@ export function RemoteTrainingPanel({
         </div>
         <div className="remote-training-consent">
           <label><input type="checkbox" checked={confirmUpload} onChange={(event) => setConfirmUpload(event.target.checked)} /><span>Upload only these three private split artifacts.</span></label>
-          <label><input type="checkbox" checked={confirmSpend} onChange={(event) => setConfirmSpend(event.target.checked)} /><span>Train with {provider?.label}; never spend more than ${plan.maximum_spend_usd.toFixed(2)}.</span></label>
-          <label><input type="checkbox" checked={confirmDeployment} onChange={(event) => setConfirmDeployment(event.target.checked)} /><span>Create a temporary endpoint for held-out comparison, then remove it unless the model earns promotion.</span></label>
+          <label><input type="checkbox" checked={confirmSpend} onChange={(event) => setConfirmSpend(event.target.checked)} /><span>Train with {provider?.label}; stop when its reported estimate reaches ${plan.maximum_spend_usd.toFixed(2)}.</span></label>
+          <label><input type="checkbox" checked={confirmDeployment} onChange={(event) => setConfirmDeployment(event.target.checked)} /><span>Create a temporary endpoint for held-out comparison, then always remove it.</span></label>
         </div>
         <div className="remote-training-actions">
           <button type="button" className="btn primary" disabled={!confirmUpload || !confirmSpend || !confirmDeployment} onClick={start}>Upload & train · max ${plan.maximum_spend_usd.toFixed(2)}</button>
@@ -409,14 +421,21 @@ export function RemoteTrainingPanel({
   }
 
   if (stage === "terminal" && result) {
+    const terminalCopy = result.outcome === "promoted"
+      ? { eyebrow: "Ready to use", title: "This model earned promotion" }
+      : result.outcome === "needs_work"
+        ? { eyebrow: "Review complete", title: "This model needs another pass" }
+        : result.outcome === "cancelled"
+          ? { eyebrow: "Stopped safely", title: "Remote training was cancelled" }
+          : { eyebrow: "Run ended", title: "Remote training did not complete" };
     return (
       <div className={`remote-training-result ${result.outcome}`}>
-        <div><span>{result.outcome === "promoted" ? "Ready to use" : "Review complete"}</span><strong>{result.outcome === "promoted" ? "This model earned promotion" : "This model needs another pass"}</strong><small>Actual provider spend: ${result.spend_usd.toFixed(2)}</small></div>
+        <div><span>{terminalCopy.eyebrow}</span><strong>{terminalCopy.title}</strong><small>Provider-reported training cost: ${result.spend_usd.toFixed(2)}</small></div>
         <div className="remote-training-metrics">
           {result.metrics.map((metric) => <article key={metric.id}><span>{metric.label}</span><strong>{metric.display_value}</strong><small>{metric.explanation}</small></article>)}
         </div>
         {result.failures.length > 0 && <div className="remote-training-failures"><strong>Where it still fails</strong>{result.failures.slice(0, 3).map((failure, index) => <p key={index}>{failure.expected} expected · {failure.actual} returned · {failure.input_summary}</p>)}</div>}
-        {result.outcome === "promoted" && result.endpoint && <div className="remote-training-endpoint"><span>Private endpoint</span><code>{result.endpoint}</code></div>}
+        {result.outcome === "promoted" && result.output_model && <div className="remote-training-endpoint"><span>Private trained model</span><code>{result.output_model}</code>{result.endpoint && <small>Serving is active through the authenticated Understudy endpoint.</small>}</div>}
         <div className="remote-training-actions"><button type="button" className="btn ghost" onClick={() => { setPlan(null); setRun(null); setEvents([]); setResult(null); setError(null); setStage("choice"); }}>Start another run</button></div>
       </div>
     );

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -3468,6 +3468,193 @@ select,
   font-size: 10px;
   line-height: 1.4;
 }
+.remote-training-choice,
+.remote-training-confirm,
+.remote-training-running,
+.remote-training-result,
+.remote-training-state {
+  display: grid;
+  gap: 12px;
+  width: 100%;
+  margin-top: 7px;
+  padding-top: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--mb-cyan) 24%, var(--border));
+}
+.remote-training-choice > div:first-child,
+.remote-training-state,
+.remote-training-state > div:first-child,
+.remote-training-result > div:first-child {
+  display: grid;
+  gap: 4px;
+}
+.remote-training-choice span,
+.remote-training-confirm-heading span,
+.remote-training-result > div:first-child > span,
+.remote-training-endpoint span {
+  color: var(--mb-cyan);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.remote-training-choice strong,
+.remote-training-confirm strong,
+.remote-training-running strong,
+.remote-training-result strong,
+.remote-training-state strong {
+  color: var(--text);
+}
+.remote-training-choice small,
+.remote-training-confirm small,
+.remote-training-running small,
+.remote-training-result small,
+.remote-training-state small {
+  color: var(--text-3);
+  font-size: 11px;
+  line-height: 1.5;
+}
+.remote-training-choice > label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-2);
+  font-size: 11px;
+}
+.remote-training-choice select {
+  min-width: 260px;
+  height: 34px;
+  padding: 0 30px 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+}
+.remote-training-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.remote-training-actions .btn.primary {
+  border-color: color-mix(in srgb, var(--mb-cyan) 45%, transparent);
+  background: color-mix(in srgb, var(--mb-cyan) 88%, white 12%);
+  color: #071113;
+}
+.remote-training-confirm-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+}
+.remote-training-confirm-heading > div {
+  display: grid;
+  gap: 3px;
+}
+.remote-training-artifacts,
+.remote-training-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+.remote-training-artifacts > div,
+.remote-training-metrics > article {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--surface) 62%, transparent);
+}
+.remote-training-artifacts span,
+.remote-training-artifacts code,
+.remote-training-metrics span {
+  overflow: hidden;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.remote-training-consent {
+  display: grid;
+  gap: 7px;
+  padding: 11px;
+  border: 1px solid color-mix(in srgb, #a78bfa 32%, var(--border));
+  border-radius: 10px;
+  background: color-mix(in srgb, #a78bfa 5%, transparent);
+}
+.remote-training-consent label {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  color: var(--text-2);
+  font-size: 11px;
+  line-height: 1.45;
+}
+.remote-training-consent input {
+  margin-top: 2px;
+  accent-color: var(--mb-cyan);
+}
+.remote-training-running > div:first-child {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.remote-training-running > div:first-child > div {
+  display: grid;
+  flex: 1 1 auto;
+  gap: 3px;
+}
+.remote-training-running code,
+.remote-training-endpoint code {
+  color: var(--mb-cyan);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+.remote-training-running ol {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-3);
+  font-size: 10px;
+}
+.remote-training-running p,
+.remote-training-failures p {
+  margin: 0;
+  color: var(--text-3);
+  font-size: 10px;
+}
+.remote-training-warning,
+.remote-training-state.failed small {
+  color: var(--warning) !important;
+}
+.remote-training-result.promoted {
+  border-color: color-mix(in srgb, var(--success) 42%, var(--border));
+}
+.remote-training-metrics {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+.remote-training-metrics article > strong {
+  font-size: 18px;
+}
+.remote-training-failures,
+.remote-training-endpoint {
+  display: grid;
+  gap: 5px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+@media (max-width: 720px) {
+  .remote-training-artifacts {
+    grid-template-columns: 1fr;
+  }
+  .remote-training-confirm-heading,
+  .remote-training-running > div:first-child {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
 .local-training-running {
   display: grid;
   gap: 0;

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4658,6 +4658,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-updater",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio"] }
 sha2 = "0.10"

--- a/apps/homescreen/src-tauri/src/chat.rs
+++ b/apps/homescreen/src-tauri/src/chat.rs
@@ -73,6 +73,11 @@ pub(crate) const MAX_TOOL_ROUNDS: usize = 4;
 const CHAT_CONNECT_TIMEOUT_SECS: u64 = 10;
 const CHAT_REQUEST_TIMEOUT_SECS: u64 = 600;
 const SMALL_FIRST_SUPERVISOR_PROMPT: &str = "Judge whether the smaller student's partial answer is correct, relevant, safe, and using tools appropriately. INTERRUPT factual errors, invented evidence, wrong tool arguments, irrelevant refusals, or confident claims unsupported by tool results so the teacher can correct them. NUDGE only when a short concrete correction can let the student continue. CONTINUE when the partial is sound, including when a sound answer is complete. Never use STOP for an incorrect, incomplete, irrelevant, or otherwise correctable answer; STOP is reserved for a turn that must end without any teacher response. Give one concise, specific reason for every INTERRUPT or NUDGE.";
+const UNDERSTUDY_DESKTOP_CONTEXT: &str = r#"You are the Understudy Desktop agent for Understudy Labs, founded by Aamir Poonawalla and Luis Manrique. Understudy helps teams improve complete production AI routes -- the harness, model, and supply path -- from real work. It turns traces and expert judgment into workload-specific evals, optimization or training evidence, routing decisions, and specialist models the team can own.
+
+Work local-first. Inspect before changing, measure before optimizing, compare against the incumbent or frontier route, and ask before uploading data, downloading large artifacts, spending money, or invoking hosted training.
+
+`understudy-agent-tools` is your preinstalled Understudy skill. Enter it through its root skill name, `understudy`. At the start of an Understudy, product, AI-workload, evaluation, optimization, routing, or training task, use the `understudy_agent_tools` tool with command `skills_inspect` and name `understudy`, then follow its progressive-disclosure routing. Use `skills_search` and `skills_inspect` to load only the specialist knowledge needed for the current stage. For company or product questions, route to `product-knowledge`. For repository questions, inspect the relevant local files and tools before answering; do not guess from the model's prior knowledge."#;
 
 #[derive(Deserialize)]
 struct ModelCard {
@@ -98,7 +103,7 @@ fn system_prompt_for(model: &str) -> String {
         .find(|card| card.id == model_id)
         .and_then(|card| card.alias_for.as_deref())
         .unwrap_or(&model_id);
-    cards
+    let model_prompt = cards
         .iter()
         .find(|card| card.id == target_id)
         .and_then(|card| card.system_prompt.clone())
@@ -108,7 +113,8 @@ fn system_prompt_for(model: &str) -> String {
                 .find(|card| card.id == "default")
                 .and_then(|card| card.system_prompt.clone())
         })
-        .unwrap_or_else(|| "You are an AI assistant in the Understudy desktop app.".to_string())
+        .unwrap_or_else(|| "You are an AI assistant in the Understudy desktop app.".to_string());
+    format!("{model_prompt}\n\n{UNDERSTUDY_DESKTOP_CONTEXT}")
 }
 
 pub(crate) fn tool_schemas() -> Vec<Value> {
@@ -1430,6 +1436,16 @@ mod tests {
         let sparse_prompt = system_prompt_for("gemma-4-26b-a4b-it-qat-mlx-vlm-understudy");
         assert!(sparse_prompt.contains("with 8-bit routers"));
         assert!(!sparse_prompt.contains("self-distillation"));
+    }
+
+    #[test]
+    fn desktop_prompt_restores_identity_and_progressive_skill_disclosure() {
+        let prompt = system_prompt_for("unknown-model");
+        assert!(prompt.contains("Aamir Poonawalla and Luis Manrique"));
+        assert!(prompt.contains("`understudy-agent-tools` is your preinstalled Understudy skill"));
+        assert!(prompt.contains("command `skills_inspect` and name `understudy`"));
+        assert!(prompt.contains("route to `product-knowledge`"));
+        assert!(prompt.contains("Work local-first"));
     }
 
     fn image_message() -> (ChatMsg, String) {

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod mcp;
 mod metrics;
 mod models;
 mod moraine;
+mod remote_training;
 mod residency;
 mod rlm;
 mod route_policy;
@@ -341,6 +342,12 @@ pub fn run() {
             workload_drop::update_local_classification_run,
             workload_drop::repeat_local_classification_evaluation,
             workload_drop::export_local_classification_predictions,
+            remote_training::remote_training_capabilities,
+            remote_training::prepare_remote_classification_training,
+            remote_training::existing_remote_classification_training,
+            remote_training::start_remote_classification_training,
+            remote_training::remote_training_poll,
+            remote_training::cancel_remote_training,
             commands::sidekick_decisions,
             commands::sidekick_events,
             commands::sidekick_session_summaries,

--- a/apps/homescreen/src-tauri/src/remote_training.rs
+++ b/apps/homescreen/src-tauri/src/remote_training.rs
@@ -1,0 +1,1340 @@
+use reqwest::{Client, Method, Url};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tauri::ipc::Channel;
+use tokio_util::io::ReaderStream;
+
+const DATASET_SCHEMA: &str = "understudy.capture_import.classification_dataset.v2";
+const PLAN_SCHEMA: &str = "understudy.remote_training.plan.v1";
+const RUN_SCHEMA: &str = "understudy.remote_training.run.v1";
+const API_SCHEMA: &str = "understudy-train-v1";
+const DEFAULT_TRAIN_API_BASE: &str = "https://train.understudylabs.com/api/train/v1";
+const MAX_MANIFEST_BYTES: u64 = 1_048_576;
+// Keep the first remote-training slice bounded. Split conversion is deliberately
+// local and currently buffers one source split at a time, so a multi-gigabyte
+// ceiling would turn a friendly desktop flow into memory pressure.
+const MAX_SPLIT_BYTES: u64 = 256 * 1024 * 1024;
+
+#[derive(Debug, Clone, Deserialize)]
+struct DatasetManifest {
+    schema_version: String,
+    dataset_id: String,
+    source_sha256: String,
+    mapping_sha256: String,
+    local_only: bool,
+    network_required: bool,
+    mapping_confirmation: String,
+    labels: Vec<String>,
+    mapping: DatasetMapping,
+    split_policy: SplitPolicy,
+    splits: DatasetSplits,
+    artifact_root: String,
+    manifest_path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DatasetMapping {
+    group_column: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SplitPolicy {
+    name: String,
+    group_normalization: String,
+    no_group_overlap: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DatasetSplits {
+    train: DatasetSplit,
+    dev: DatasetSplit,
+    holdout: DatasetSplit,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DatasetSplit {
+    path: String,
+    row_count: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ClassificationExample {
+    schema_version: String,
+    example_id: String,
+    group_id: String,
+    text: String,
+    label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RemoteArtifact {
+    artifact_role: String,
+    path: String,
+    file_name: String,
+    row_count: u64,
+    sha256: String,
+    size_bytes: u64,
+    content_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RemoteTrainingPlan {
+    schema_version: String,
+    plan_id: String,
+    created_at: String,
+    source_manifest_path: String,
+    source_dataset_id: String,
+    workload_name: String,
+    provider: String,
+    base_model: String,
+    output_model_name: String,
+    frontier_model: String,
+    labels: Vec<String>,
+    group_field: String,
+    split_hash: String,
+    artifacts: Vec<RemoteArtifact>,
+    epochs: u64,
+    lora_rank: u64,
+    max_context_length: u64,
+    maximum_spend_usd: f64,
+    maximum_runtime_seconds: u64,
+    maximum_eval_examples: u64,
+    minimum_accuracy: f64,
+    minimum_improvement_over_base: f64,
+    plan_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RemoteTrainingRun {
+    schema_version: String,
+    run_id: String,
+    plan_path: String,
+    status_url: String,
+    events_url: String,
+    run_token: String,
+    next_after: i64,
+    run_manifest_path: String,
+}
+
+fn remote_training_enabled() -> bool {
+    std::env::var("UNDERSTUDY_REMOTE_TRAINING_EXPERIMENT")
+        .ok()
+        .is_some_and(|value| value == "true")
+}
+
+fn train_api_base() -> Result<Url, String> {
+    let raw = std::env::var("UNDERSTUDY_TRAIN_API_BASE")
+        .unwrap_or_else(|_| DEFAULT_TRAIN_API_BASE.to_string());
+    let trimmed = raw.trim_end_matches('/');
+    let url = Url::parse(&format!("{trimmed}/"))
+        .map_err(|_| "The remote training API URL is invalid.".to_string())?;
+    let local_http =
+        url.scheme() == "http" && matches!(url.host_str(), Some("127.0.0.1" | "localhost"));
+    if url.scheme() != "https" && !local_http {
+        return Err("Remote training requires HTTPS, except on localhost.".into());
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("The remote training API URL cannot contain credentials.".into());
+    }
+    Ok(url)
+}
+
+fn api_url(path: &str) -> Result<Url, String> {
+    train_api_base()?
+        .join(path.trim_start_matches('/'))
+        .map_err(|_| "The remote training API path is invalid.".to_string())
+}
+
+fn api_credentials() -> Result<crate::creds::ResolvedCredentials, String> {
+    crate::creds::resolve()
+        .ok_or_else(|| "Sign in to Understudy before starting private remote training.".to_string())
+}
+
+fn client() -> Result<Client, String> {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(60))
+        .user_agent(concat!("Understudy-Desktop/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|_| "Could not initialize the remote training connection.".to_string())
+}
+
+async fn api_json(method: Method, url: Url, body: Option<&Value>) -> Result<Value, String> {
+    let credentials = api_credentials()?;
+    let mut request = client()?
+        .request(method, url)
+        .bearer_auth(credentials.api_key)
+        .header("accept", "application/json");
+    if let Some(body) = body {
+        request = request.json(body);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|_| "The remote training service could not be reached.".to_string())?;
+    let status = response.status();
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|_| "The remote training service returned an unreadable response.".to_string())?;
+    let value = serde_json::from_slice::<Value>(&bytes)
+        .map_err(|_| format!("The remote training service returned malformed JSON ({status})."))?;
+    if !status.is_success() {
+        let message = value
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str)
+            .or_else(|| value.get("message").and_then(Value::as_str))
+            .unwrap_or("The remote training request was rejected.");
+        return Err(message.chars().take(500).collect());
+    }
+    Ok(value)
+}
+
+#[tauri::command]
+pub async fn remote_training_capabilities() -> Result<Value, String> {
+    if !remote_training_enabled() {
+        return Ok(json!({
+            "schema_version": "understudy.remote_training.capabilities.v1",
+            "enabled": false,
+            "reason": "Remote training is an off-by-default experiment."
+        }));
+    }
+    if crate::creds::resolve().is_none() {
+        return Ok(json!({
+            "schema_version": "understudy.remote_training.capabilities.v1",
+            "enabled": false,
+            "reason": "Sign in to Understudy to use private remote training."
+        }));
+    }
+    let capabilities = api_json(Method::GET, api_url("capabilities")?, None).await?;
+    Ok(json!({
+        "schema_version": "understudy.remote_training.capabilities.v1",
+        "enabled": true,
+        "capabilities": capabilities
+    }))
+}
+
+#[tauri::command]
+pub async fn prepare_remote_classification_training(
+    manifest_path: String,
+    provider: String,
+    base_model: String,
+    frontier_model: String,
+    maximum_spend_usd: f64,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        prepare_remote_plan(
+            &manifest_path,
+            &provider,
+            &base_model,
+            &frontier_model,
+            maximum_spend_usd,
+        )
+    })
+    .await
+    .map_err(|error| format!("Remote training preparation stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+pub async fn existing_remote_classification_training(
+    manifest_path: String,
+) -> Result<Option<Value>, String> {
+    tauri::async_runtime::spawn_blocking(move || find_existing_run(&manifest_path))
+        .await
+        .map_err(|error| format!("Remote training recovery stopped unexpectedly: {error}"))?
+}
+
+fn find_existing_run(manifest_path: &str) -> Result<Option<Value>, String> {
+    let canonical_manifest = PathBuf::from(manifest_path.trim())
+        .canonicalize()
+        .map_err(|_| "The prepared dataset is unavailable.".to_string())?;
+    if fs::metadata(&canonical_manifest)
+        .map_err(|_| "The prepared dataset is unavailable.".to_string())?
+        .len()
+        > MAX_MANIFEST_BYTES
+    {
+        return Err("The prepared dataset manifest is unexpectedly large.".into());
+    }
+    let manifest: DatasetManifest = serde_json::from_slice(
+        &fs::read(&canonical_manifest)
+            .map_err(|_| "The prepared dataset could not be read.".to_string())?,
+    )
+    .map_err(|_| "The prepared dataset manifest is malformed.".to_string())?;
+    validate_manifest(&manifest, &canonical_manifest)?;
+    let artifact_root = PathBuf::from(&manifest.artifact_root)
+        .canonicalize()
+        .map_err(|_| "The prepared dataset artifact root is unavailable.".to_string())?;
+    let remote_root = artifact_root.join("remote-training");
+    if !remote_root.is_dir() {
+        return Ok(None);
+    }
+
+    let mut candidates = fs::read_dir(&remote_root)
+        .map_err(|_| "Saved remote training runs could not be inspected.".to_string())?
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let run_path = entry.path().join("run.json");
+            let modified = run_path.metadata().ok()?.modified().ok()?;
+            Some((modified, run_path))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| right.0.cmp(&left.0));
+    candidates.truncate(500);
+
+    for (_, run_path) in candidates {
+        let Some(run_path) = run_path.to_str() else {
+            continue;
+        };
+        let Ok(run) = read_run(run_path) else {
+            continue;
+        };
+        let Ok(plan_path) = PathBuf::from(&run.plan_path).canonicalize() else {
+            continue;
+        };
+        if !plan_path.starts_with(&remote_root) {
+            continue;
+        }
+        let Ok(plan_bytes) = fs::read(&plan_path) else {
+            continue;
+        };
+        let Ok(plan) = serde_json::from_slice::<RemoteTrainingPlan>(&plan_bytes) else {
+            continue;
+        };
+        if plan.schema_version != PLAN_SCHEMA
+            || PathBuf::from(&plan.source_manifest_path)
+                .canonicalize()
+                .ok()
+                .as_deref()
+                != Some(canonical_manifest.as_path())
+        {
+            continue;
+        }
+        return serde_json::to_value(run)
+            .map(Some)
+            .map_err(|_| "The saved remote run could not be returned.".to_string());
+    }
+    Ok(None)
+}
+
+fn prepare_remote_plan(
+    manifest_path: &str,
+    provider: &str,
+    base_model: &str,
+    frontier_model: &str,
+    maximum_spend_usd: f64,
+) -> Result<Value, String> {
+    if !matches!(provider, "fake" | "fireworks") {
+        return Err("Choose an available remote training provider.".into());
+    }
+    for (name, value) in [
+        ("base model", base_model),
+        ("frontier model", frontier_model),
+    ] {
+        if value.trim().is_empty() || value.chars().count() > 240 {
+            return Err(format!("The {name} is invalid."));
+        }
+    }
+    if !maximum_spend_usd.is_finite() || maximum_spend_usd <= 0.0 || maximum_spend_usd > 100.0 {
+        return Err("The remote training budget must be between $0 and $100.".into());
+    }
+
+    let canonical_manifest = PathBuf::from(manifest_path.trim())
+        .canonicalize()
+        .map_err(|error| format!("The prepared dataset is unavailable: {error}"))?;
+    if fs::metadata(&canonical_manifest)
+        .map_err(|error| format!("The prepared dataset is unavailable: {error}"))?
+        .len()
+        > MAX_MANIFEST_BYTES
+    {
+        return Err("The prepared dataset manifest is unexpectedly large.".into());
+    }
+    let manifest: DatasetManifest = serde_json::from_slice(
+        &fs::read(&canonical_manifest)
+            .map_err(|error| format!("The prepared dataset could not be read: {error}"))?,
+    )
+    .map_err(|_| "The prepared dataset manifest is malformed.".to_string())?;
+    validate_manifest(&manifest, &canonical_manifest)?;
+    let artifact_root = PathBuf::from(&manifest.artifact_root)
+        .canonicalize()
+        .map_err(|_| "The prepared dataset artifact root is unavailable.".to_string())?;
+
+    let mut groups_by_split: HashMap<&str, HashSet<String>> = HashMap::new();
+    let mut verified_rows: HashMap<&str, Vec<ClassificationExample>> = HashMap::new();
+    for (name, split) in [
+        ("train", &manifest.splits.train),
+        ("validation", &manifest.splits.dev),
+        ("heldout", &manifest.splits.holdout),
+    ] {
+        let rows = verify_split(split, &artifact_root, &manifest.labels)?;
+        groups_by_split.insert(name, rows.iter().map(|row| row.group_id.clone()).collect());
+        verified_rows.insert(name, rows);
+    }
+    for (left, right) in [
+        ("train", "validation"),
+        ("train", "heldout"),
+        ("validation", "heldout"),
+    ] {
+        if groups_by_split[left]
+            .iter()
+            .any(|group| groups_by_split[right].contains(group))
+        {
+            return Err(format!(
+                "The prepared dataset has leakage-group overlap between {left} and {right}."
+            ));
+        }
+    }
+
+    let plan_id = random_uuid()?;
+    let plan_root = artifact_root.join("remote-training").join(&plan_id);
+    create_private_directory(&plan_root)?;
+    let instruction = format!(
+        "Classify the user's text. Reply with exactly one label from this list: {}.",
+        manifest.labels.join(", ")
+    );
+    let mut artifacts = Vec::new();
+    for role in ["train", "validation", "heldout"] {
+        let rows = verified_rows
+            .remove(role)
+            .ok_or_else(|| format!("The {role} split is unavailable."))?;
+        let file_name = format!("{role}.jsonl");
+        let path = plan_root.join(&file_name);
+        let mut content = String::new();
+        for row in &rows {
+            let transformed = if role == "heldout" {
+                json!({ "input": row.text, "target": row.label })
+            } else {
+                json!({
+                    "messages": [
+                        { "role": "system", "content": instruction },
+                        { "role": "user", "content": row.text },
+                        { "role": "assistant", "content": row.label }
+                    ]
+                })
+            };
+            content.push_str(
+                &serde_json::to_string(&transformed)
+                    .map_err(|_| "A remote training row could not be encoded.".to_string())?,
+            );
+            content.push('\n');
+        }
+        write_private_new(&path, content.as_bytes())?;
+        artifacts.push(RemoteArtifact {
+            artifact_role: role.to_string(),
+            path: path.display().to_string(),
+            file_name,
+            row_count: rows.len() as u64,
+            sha256: sha256_bytes(content.as_bytes()),
+            size_bytes: content.len() as u64,
+            content_type: "application/x-ndjson".to_string(),
+        });
+    }
+    let split_hash = sha256_bytes(
+        artifacts
+            .iter()
+            .map(|artifact| artifact.sha256.as_str())
+            .collect::<Vec<_>>()
+            .join("\0")
+            .as_bytes(),
+    );
+    let plan_path = plan_root.join("plan.json");
+    let output_model_name = format!("understudy-{}", safe_model_segment(&manifest.dataset_id));
+    let plan = RemoteTrainingPlan {
+        schema_version: PLAN_SCHEMA.to_string(),
+        plan_id,
+        created_at: timestamp(),
+        source_manifest_path: canonical_manifest.display().to_string(),
+        source_dataset_id: manifest.dataset_id.clone(),
+        workload_name: format!(
+            "classification-{}",
+            safe_model_segment(&manifest.dataset_id)
+        ),
+        provider: provider.to_string(),
+        base_model: base_model.to_string(),
+        output_model_name,
+        frontier_model: frontier_model.to_string(),
+        labels: manifest.labels.clone(),
+        group_field: manifest.mapping.group_column.clone(),
+        split_hash,
+        artifacts,
+        epochs: 3,
+        lora_rank: 16,
+        max_context_length: 4_096,
+        maximum_spend_usd,
+        maximum_runtime_seconds: 7_200,
+        maximum_eval_examples: 200,
+        minimum_accuracy: 0.80,
+        minimum_improvement_over_base: 0.02,
+        plan_path: plan_path.display().to_string(),
+    };
+    write_private_new(
+        &plan_path,
+        &serde_json::to_vec_pretty(&plan)
+            .map_err(|_| "The remote training plan could not be encoded.".to_string())?,
+    )?;
+    serde_json::to_value(plan)
+        .map_err(|_| "The remote training plan could not be returned.".to_string())
+}
+
+fn validate_manifest(manifest: &DatasetManifest, path: &Path) -> Result<(), String> {
+    if manifest.schema_version != DATASET_SCHEMA
+        || !manifest.local_only
+        || manifest.network_required
+        || manifest.mapping_confirmation != "caller-provided"
+    {
+        return Err(
+            "Prepare a fresh local-only classification dataset before remote training.".into(),
+        );
+    }
+    let declared_path = PathBuf::from(&manifest.manifest_path)
+        .canonicalize()
+        .map_err(|_| "The dataset's declared manifest path is unavailable.".to_string())?;
+    if declared_path != path {
+        return Err("The dataset manifest path does not match the selected file.".into());
+    }
+    if !valid_hash(&manifest.source_sha256)
+        || !valid_hash(&manifest.mapping_sha256)
+        || manifest.dataset_id.is_empty()
+        || manifest.dataset_id.len() > 128
+        || manifest.labels.len() < 2
+        || manifest.labels.len() > 512
+        || manifest
+            .labels
+            .iter()
+            .any(|label| label.trim().is_empty() || label.chars().count() > 160)
+    {
+        return Err("The dataset manifest has invalid immutable metadata or labels.".into());
+    }
+    if manifest.split_policy.name != "deterministic-stratified-group-aware-v2"
+        || manifest.split_policy.group_normalization != "casefold-reference-stripping-v1"
+        || !manifest.split_policy.no_group_overlap
+        || manifest.mapping.group_column.trim().is_empty()
+    {
+        return Err("Remote training requires the verified group-aware split policy.".into());
+    }
+    Ok(())
+}
+
+fn verify_split(
+    split: &DatasetSplit,
+    artifact_root: &Path,
+    labels: &[String],
+) -> Result<Vec<ClassificationExample>, String> {
+    if split.row_count == 0 || !valid_hash(&split.sha256) {
+        return Err("A prepared dataset split has invalid immutable evidence.".into());
+    }
+    let path = PathBuf::from(&split.path)
+        .canonicalize()
+        .map_err(|_| "A prepared dataset split is unavailable.".to_string())?;
+    if !path.starts_with(artifact_root) {
+        return Err("A prepared dataset split escaped its private artifact root.".into());
+    }
+    let metadata =
+        fs::metadata(&path).map_err(|_| "A prepared dataset split is unavailable.".to_string())?;
+    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > MAX_SPLIT_BYTES {
+        return Err("A prepared dataset split has an unsupported size.".into());
+    }
+    let bytes = fs::read(&path)
+        .map_err(|error| format!("A prepared dataset split could not be read: {error}"))?;
+    if sha256_bytes(&bytes) != split.sha256 {
+        return Err("A prepared dataset split changed after local preparation.".into());
+    }
+    let content = std::str::from_utf8(&bytes)
+        .map_err(|_| "A prepared dataset split is not UTF-8 JSONL.".to_string())?;
+    let allowed_labels: HashSet<&str> = labels.iter().map(String::as_str).collect();
+    let rows = content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .enumerate()
+        .map(|(index, line)| {
+            let row: ClassificationExample = serde_json::from_str(line)
+                .map_err(|_| format!("Prepared split row {} is malformed.", index + 1))?;
+            if row.schema_version != "understudy.classification_example.v2"
+                || row.example_id.trim().is_empty()
+                || row.group_id.trim().is_empty()
+                || row.text.trim().is_empty()
+                || !allowed_labels.contains(row.label.as_str())
+            {
+                return Err(format!(
+                    "Prepared split row {} does not match the verified classification schema.",
+                    index + 1
+                ));
+            }
+            Ok(row)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    if rows.len() as u64 != split.row_count {
+        return Err("A prepared dataset split row count changed after preparation.".into());
+    }
+    Ok(rows)
+}
+
+#[tauri::command]
+pub async fn start_remote_classification_training(
+    plan_path: String,
+    confirm_upload: bool,
+    confirm_spend: bool,
+    confirm_temporary_deployment: bool,
+    on_event: Channel<Value>,
+) -> Result<Value, String> {
+    if !remote_training_enabled() {
+        return Err("Remote training is disabled in this Desktop build.".into());
+    }
+    if !confirm_upload || !confirm_spend {
+        return Err("Confirm the exact upload and maximum spend before remote training.".into());
+    }
+    let plan = read_verified_plan(&plan_path)?;
+    let capabilities = api_json(Method::GET, api_url("capabilities")?, None).await?;
+    validate_capabilities(&capabilities, &plan)?;
+    send_event(
+        &on_event,
+        "preparing",
+        0,
+        plan.artifacts.len() as u64,
+        "Re-verifying the exact approved artifacts on this Mac.",
+    );
+    let mut uploads = Vec::new();
+    let mut uploaded_pathnames = Vec::new();
+    let result = async {
+        for (index, artifact) in plan.artifacts.iter().enumerate() {
+            verify_remote_artifact(artifact)?;
+            send_event(
+                &on_event,
+                "uploading",
+                index as u64,
+                plan.artifacts.len() as u64,
+                &format!("Uploading the approved {} split.", artifact.artifact_role),
+            );
+            let intent = api_json(
+                Method::POST,
+                api_url("upload-intents")?,
+                Some(&json!({
+                    "schema_version": API_SCHEMA,
+                    "artifact_role": artifact.artifact_role,
+                    "file_name": artifact.file_name,
+                    "sha256": artifact.sha256,
+                    "size_bytes": artifact.size_bytes,
+                    "content_type": artifact.content_type
+                })),
+            )
+            .await?;
+            upload_artifact(artifact, &intent).await?;
+            let upload = intent
+                .get("upload")
+                .cloned()
+                .ok_or_else(|| "The training service omitted the upload reference.".to_string())?;
+            if let Some(pathname) = upload.get("pathname").and_then(Value::as_str) {
+                uploaded_pathnames.push(pathname.to_string());
+            }
+            uploads.push(upload);
+            send_event(
+                &on_event,
+                "uploading",
+                (index + 1) as u64,
+                plan.artifacts.len() as u64,
+                &format!("Uploaded the approved {} split.", artifact.artifact_role),
+            );
+        }
+        let request_id = random_uuid()?;
+        let run = api_json(
+            Method::POST,
+            api_url("runs")?,
+            Some(&json!({
+                "schema_version": API_SCHEMA,
+                "request_id": request_id,
+                "workload_name": plan.workload_name,
+                "task": {
+                    "kind": "text_classification",
+                    "input_field": "input",
+                    "target_field": "target",
+                    "labels": plan.labels
+                },
+                "provider": plan.provider,
+                "base_model": plan.base_model,
+                "output_model_name": plan.output_model_name,
+                "uploads": uploads,
+                "split": {
+                    "train_rows": artifact_rows(&plan, "train")?,
+                    "validation_rows": artifact_rows(&plan, "validation")?,
+                    "heldout_rows": artifact_rows(&plan, "heldout")?,
+                    "split_hash": plan.split_hash,
+                    "group_field": plan.group_field
+                },
+                "training": {
+                    "epochs": plan.epochs,
+                    "lora_rank": plan.lora_rank,
+                    "max_context_length": plan.max_context_length
+                },
+                "budget": {
+                    "max_usd": plan.maximum_spend_usd,
+                    "max_runtime_seconds": plan.maximum_runtime_seconds,
+                    "max_eval_examples": plan.maximum_eval_examples
+                },
+                "promotion": {
+                    "minimum_accuracy": plan.minimum_accuracy,
+                    "minimum_improvement_over_base": plan.minimum_improvement_over_base,
+                    "compare_to_frontier": true,
+                    "frontier_model": plan.frontier_model
+                },
+                "consent": {
+                    "approved_at": timestamp(),
+                    "upload_confirmed": true,
+                    "train_confirmed": true,
+                    "deploy_for_evaluation_confirmed": confirm_temporary_deployment,
+                    "approved_artifact_sha256": plan.artifacts
+                        .iter()
+                        .map(|artifact| artifact.sha256.clone())
+                        .collect::<Vec<_>>()
+                }
+            })),
+        )
+        .await?;
+        let record = persist_run(&plan, &run)?;
+        send_event(
+            &on_event,
+            "queued",
+            1,
+            1,
+            "The durable remote training workflow is queued.",
+        );
+        serde_json::to_value(record)
+            .map_err(|_| "The remote training run could not be returned.".to_string())
+    }
+    .await;
+
+    if result.is_err() && !uploaded_pathnames.is_empty() {
+        let _ = api_json(
+            Method::DELETE,
+            api_url("uploads")?,
+            Some(&json!({
+                "schema_version": API_SCHEMA,
+                "pathnames": uploaded_pathnames
+            })),
+        )
+        .await;
+    }
+    result
+}
+
+fn read_verified_plan(path: &str) -> Result<RemoteTrainingPlan, String> {
+    let canonical = PathBuf::from(path.trim())
+        .canonicalize()
+        .map_err(|_| "The remote training plan is unavailable.".to_string())?;
+    let plan: RemoteTrainingPlan = serde_json::from_slice(
+        &fs::read(&canonical)
+            .map_err(|_| "The remote training plan could not be read.".to_string())?,
+    )
+    .map_err(|_| "The remote training plan is malformed.".to_string())?;
+    if plan.schema_version != PLAN_SCHEMA
+        || PathBuf::from(&plan.plan_path)
+            .canonicalize()
+            .ok()
+            .as_deref()
+            != Some(canonical.as_path())
+        || !matches!(plan.provider.as_str(), "fake" | "fireworks")
+        || plan.artifacts.len() != 3
+        || plan.maximum_spend_usd <= 0.0
+        || plan.maximum_spend_usd > 100.0
+    {
+        return Err("The remote training plan failed its immutable boundary checks.".into());
+    }
+    let mut roles = HashSet::new();
+    for artifact in &plan.artifacts {
+        roles.insert(artifact.artifact_role.as_str());
+        verify_remote_artifact(artifact)?;
+    }
+    if roles != HashSet::from(["train", "validation", "heldout"]) {
+        return Err("The remote training plan must contain three distinct split artifacts.".into());
+    }
+    Ok(plan)
+}
+
+fn verify_remote_artifact(artifact: &RemoteArtifact) -> Result<(), String> {
+    let path = PathBuf::from(&artifact.path)
+        .canonicalize()
+        .map_err(|_| format!("The {} artifact is unavailable.", artifact.artifact_role))?;
+    let plan_root = path
+        .parent()
+        .ok_or_else(|| "A remote training artifact has no private root.".to_string())?;
+    if plan_root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_none()
+        || plan_root
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|value| value.to_str())
+            != Some("remote-training")
+    {
+        return Err("A remote training artifact escaped its private plan root.".into());
+    }
+    let bytes = fs::read(&path)
+        .map_err(|_| format!("The {} artifact could not be read.", artifact.artifact_role))?;
+    if bytes.len() as u64 != artifact.size_bytes || sha256_bytes(&bytes) != artifact.sha256 {
+        return Err(format!(
+            "The {} artifact changed after approval.",
+            artifact.artifact_role
+        ));
+    }
+    if bytes.iter().filter(|byte| **byte == b'\n').count() as u64 != artifact.row_count {
+        return Err(format!(
+            "The {} artifact row count changed after approval.",
+            artifact.artifact_role
+        ));
+    }
+    Ok(())
+}
+
+fn validate_capabilities(value: &Value, plan: &RemoteTrainingPlan) -> Result<(), String> {
+    if value.get("schema_version").and_then(Value::as_str) != Some(API_SCHEMA)
+        || value
+            .get("privacy")
+            .and_then(|privacy| privacy.get("private_uploads"))
+            .and_then(Value::as_bool)
+            != Some(true)
+        || value
+            .get("privacy")
+            .and_then(|privacy| privacy.get("raw_rows_in_telemetry"))
+            .and_then(Value::as_bool)
+            != Some(false)
+    {
+        return Err("The remote training service did not confirm its privacy contract.".into());
+    }
+    let provider = value
+        .get("providers")
+        .and_then(Value::as_array)
+        .and_then(|providers| {
+            providers
+                .iter()
+                .find(|provider| provider.get("id").and_then(Value::as_str) == Some(&plan.provider))
+        })
+        .ok_or_else(|| "The planned remote training provider is unavailable.".to_string())?;
+    if provider.get("enabled").and_then(Value::as_bool) != Some(true)
+        || !provider
+            .get("base_models")
+            .and_then(Value::as_array)
+            .is_some_and(|models| {
+                models
+                    .iter()
+                    .any(|model| model.as_str() == Some(&plan.base_model))
+            })
+    {
+        return Err("The planned provider or base model is disabled.".into());
+    }
+    let max_budget = value
+        .get("limits")
+        .and_then(|limits| limits.get("max_budget_usd"))
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0);
+    if plan.maximum_spend_usd > max_budget {
+        return Err("The approved budget exceeds the current service limit.".into());
+    }
+    Ok(())
+}
+
+async fn upload_artifact(artifact: &RemoteArtifact, intent: &Value) -> Result<(), String> {
+    if intent.get("schema_version").and_then(Value::as_str) != Some(API_SCHEMA)
+        || intent.get("method").and_then(Value::as_str) != Some("PUT")
+        || intent
+            .get("upload")
+            .and_then(|upload| upload.get("sha256"))
+            .and_then(Value::as_str)
+            != Some(&artifact.sha256)
+    {
+        return Err("The training service returned an invalid upload intent.".into());
+    }
+    let url = intent
+        .get("presigned_url")
+        .and_then(Value::as_str)
+        .and_then(|value| Url::parse(value).ok())
+        .filter(|url| url.scheme() == "https")
+        .ok_or_else(|| "The training service returned an unsafe upload URL.".to_string())?;
+    let file = tokio::fs::File::open(&artifact.path)
+        .await
+        .map_err(|_| format!("The {} artifact is unavailable.", artifact.artifact_role))?;
+    let mut request = client()?
+        .put(url)
+        .header("content-length", artifact.size_bytes)
+        .body(reqwest::Body::wrap_stream(ReaderStream::new(file)));
+    if let Some(headers) = intent.get("required_headers").and_then(Value::as_object) {
+        for (name, value) in headers {
+            let header_name = reqwest::header::HeaderName::from_bytes(name.as_bytes())
+                .map_err(|_| "The upload intent contained an invalid header name.".to_string())?;
+            let header_value = value.as_str().ok_or_else(|| {
+                "The upload intent contained an invalid header value.".to_string()
+            })?;
+            request = request.header(header_name, header_value);
+        }
+    }
+    let response = request.send().await.map_err(|_| {
+        format!(
+            "The {} artifact upload was interrupted.",
+            artifact.artifact_role
+        )
+    })?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "The {} artifact upload failed ({}).",
+            artifact.artifact_role,
+            response.status()
+        ));
+    }
+    Ok(())
+}
+
+fn persist_run(plan: &RemoteTrainingPlan, value: &Value) -> Result<RemoteTrainingRun, String> {
+    if value.get("schema_version").and_then(Value::as_str) != Some(API_SCHEMA)
+        || value.get("status").and_then(Value::as_str) != Some("queued")
+    {
+        return Err("The training service returned an invalid run receipt.".into());
+    }
+    let plan_root = PathBuf::from(&plan.plan_path)
+        .parent()
+        .ok_or_else(|| "The remote training plan has no private root.".to_string())?
+        .to_path_buf();
+    let run_path = plan_root.join("run.json");
+    let record = RemoteTrainingRun {
+        schema_version: RUN_SCHEMA.to_string(),
+        run_id: required_string(value, "run_id")?,
+        plan_path: plan.plan_path.clone(),
+        status_url: required_string(value, "status_url")?,
+        events_url: required_string(value, "events_url")?,
+        run_token: required_string(value, "run_token")?,
+        next_after: -1,
+        run_manifest_path: run_path.display().to_string(),
+    };
+    validate_control_plane_url(&record.status_url)?;
+    validate_control_plane_url(&record.events_url)?;
+    write_private_new(
+        &run_path,
+        &serde_json::to_vec_pretty(&record)
+            .map_err(|_| "The remote run receipt could not be encoded.".to_string())?,
+    )?;
+    Ok(record)
+}
+
+#[tauri::command]
+pub async fn remote_training_poll(run_manifest_path: String) -> Result<Value, String> {
+    let mut run = read_run(&run_manifest_path)?;
+    let events_url = Url::parse(&run.events_url)
+        .map_err(|_| "The saved remote event URL is invalid.".to_string())?;
+    let mut events_url = events_url;
+    events_url
+        .query_pairs_mut()
+        .append_pair("after", &run.next_after.to_string());
+    let events = run_api_json(Method::GET, events_url, &run.run_token, None).await?;
+    if let Some(next_after) = events.get("next_after").and_then(Value::as_i64) {
+        run.next_after = next_after;
+        replace_private_json(Path::new(&run.run_manifest_path), &run)?;
+    }
+    let status = run_api_json(
+        Method::GET,
+        Url::parse(&run.status_url)
+            .map_err(|_| "The saved remote status URL is invalid.".to_string())?,
+        &run.run_token,
+        None,
+    )
+    .await?;
+    Ok(json!({
+        "schema_version": "understudy.remote_training.poll.v1",
+        "run_id": run.run_id,
+        "events": events.get("events").cloned().unwrap_or_else(|| json!([])),
+        "status": status,
+        "run_manifest_path": run.run_manifest_path
+    }))
+}
+
+#[tauri::command]
+pub async fn cancel_remote_training(run_manifest_path: String) -> Result<Value, String> {
+    let run = read_run(&run_manifest_path)?;
+    let action_url = format!("{}/actions", run.status_url.trim_end_matches('/'));
+    run_api_json(
+        Method::POST,
+        Url::parse(&action_url)
+            .map_err(|_| "The saved remote action URL is invalid.".to_string())?,
+        &run.run_token,
+        Some(&json!({ "action": "cancel" })),
+    )
+    .await
+}
+
+async fn run_api_json(
+    method: Method,
+    url: Url,
+    run_token: &str,
+    body: Option<&Value>,
+) -> Result<Value, String> {
+    validate_control_plane_url(url.as_str())?;
+    let credentials = api_credentials()?;
+    let mut request = client()?
+        .request(method, url)
+        .bearer_auth(credentials.api_key)
+        .header("x-understudy-train-run-token", run_token)
+        .header("accept", "application/json");
+    if let Some(body) = body {
+        request = request.json(body);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|_| "The remote training service could not be reached.".to_string())?;
+    let status = response.status();
+    let value = response
+        .json::<Value>()
+        .await
+        .map_err(|_| "The remote training service returned malformed JSON.".to_string())?;
+    if !status.is_success() {
+        return Err(value
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or("The remote training request was rejected.")
+            .chars()
+            .take(500)
+            .collect());
+    }
+    Ok(value)
+}
+
+fn read_run(path: &str) -> Result<RemoteTrainingRun, String> {
+    let canonical = PathBuf::from(path.trim())
+        .canonicalize()
+        .map_err(|_| "The remote training run is unavailable.".to_string())?;
+    let run: RemoteTrainingRun = serde_json::from_slice(
+        &fs::read(&canonical)
+            .map_err(|_| "The remote training run could not be read.".to_string())?,
+    )
+    .map_err(|_| "The remote training run is malformed.".to_string())?;
+    if run.schema_version != RUN_SCHEMA
+        || run.run_token.len() < 32
+        || PathBuf::from(&run.run_manifest_path)
+            .canonicalize()
+            .ok()
+            .as_deref()
+            != Some(canonical.as_path())
+    {
+        return Err("The remote training run failed its local integrity checks.".into());
+    }
+    validate_control_plane_url(&run.status_url)?;
+    validate_control_plane_url(&run.events_url)?;
+    Ok(run)
+}
+
+fn validate_control_plane_url(value: &str) -> Result<(), String> {
+    let url = Url::parse(value)
+        .map_err(|_| "The remote training service returned an invalid URL.".to_string())?;
+    let base = train_api_base()?;
+    if url.scheme() != base.scheme()
+        || url.host_str() != base.host_str()
+        || url.port_or_known_default() != base.port_or_known_default()
+        || !url.path().starts_with(base.path())
+    {
+        return Err("The remote training service returned an unexpected control-plane URL.".into());
+    }
+    Ok(())
+}
+
+fn required_string(value: &Value, key: &str) -> Result<String, String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty() && value.chars().count() <= 2_048)
+        .map(str::to_string)
+        .ok_or_else(|| format!("The training service omitted {key}."))
+}
+
+fn artifact_rows(plan: &RemoteTrainingPlan, role: &str) -> Result<u64, String> {
+    plan.artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_role == role)
+        .map(|artifact| artifact.row_count)
+        .ok_or_else(|| format!("The remote training plan omitted {role}."))
+}
+
+fn send_event(channel: &Channel<Value>, phase: &str, current: u64, total: u64, message: &str) {
+    let _ = channel.send(json!({
+        "type": "phase",
+        "phase": phase,
+        "current": current,
+        "total": total,
+        "message": message
+    }));
+}
+
+fn safe_model_segment(value: &str) -> String {
+    let mut output = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    while output.contains("--") {
+        output = output.replace("--", "-");
+    }
+    output.trim_matches('-').chars().take(48).collect()
+}
+
+fn valid_hash(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+fn random_uuid() -> Result<String, String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|_| "Secure randomness is unavailable for the training run.".to_string())?;
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Ok(format!(
+        "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+        u32::from_be_bytes(bytes[0..4].try_into().unwrap()),
+        u16::from_be_bytes(bytes[4..6].try_into().unwrap()),
+        u16::from_be_bytes(bytes[6..8].try_into().unwrap()),
+        u16::from_be_bytes(bytes[8..10].try_into().unwrap()),
+        u64::from_be_bytes([
+            0, 0, bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+        ])
+    ))
+}
+
+fn timestamp() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+fn create_private_directory(path: &Path) -> Result<(), String> {
+    fs::create_dir_all(path).map_err(|error| {
+        format!("Could not create the private remote training directory: {error}")
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("Could not protect the remote training directory: {error}"))?;
+    }
+    Ok(())
+}
+
+fn write_private_new(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("Could not create a private training artifact: {error}"))?;
+    file.write_all(bytes)
+        .map_err(|error| format!("Could not write a private training artifact: {error}"))?;
+    file.sync_all()
+        .map_err(|error| format!("Could not finish a private training artifact: {error}"))?;
+    Ok(())
+}
+
+fn replace_private_json(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    let temporary = path.with_extension("json.tmp");
+    if temporary.exists() {
+        fs::remove_file(&temporary)
+            .map_err(|_| "Could not replace the local remote-training state.".to_string())?;
+    }
+    write_private_new(
+        &temporary,
+        &serde_json::to_vec_pretty(value)
+            .map_err(|_| "The local remote-training state could not be encoded.".to_string())?,
+    )?;
+    fs::rename(&temporary, path)
+        .map_err(|_| "Could not replace the local remote-training state.".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn fixture() -> (PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "understudy-remote-training-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let labels = vec!["ham".to_string(), "spam".to_string()];
+        let mut splits = serde_json::Map::new();
+        for (name, offset) in [("train", 0), ("dev", 10), ("holdout", 20)] {
+            let content = (0..6)
+                .map(|index| {
+                    serde_json::to_string(&json!({
+                        "schema_version": "understudy.classification_example.v2",
+                        "example_id": format!("{name}-{index}"),
+                        "group_id": format!("group-{}", offset + index),
+                        "text": format!("Message {}", offset + index),
+                        "label": labels[index % labels.len()]
+                    }))
+                    .unwrap()
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n";
+            let path = root.join(format!("{name}.jsonl"));
+            fs::write(&path, &content).unwrap();
+            splits.insert(
+                name.to_string(),
+                json!({
+                    "path": path,
+                    "row_count": 6,
+                    "sha256": sha256_bytes(content.as_bytes())
+                }),
+            );
+        }
+        let manifest_path = root.join("dataset-manifest.json");
+        let manifest = json!({
+            "schema_version": DATASET_SCHEMA,
+            "dataset_id": "sms-intent-test",
+            "source_sha256": "a".repeat(64),
+            "mapping_sha256": "b".repeat(64),
+            "local_only": true,
+            "network_required": false,
+            "mapping_confirmation": "caller-provided",
+            "labels": labels,
+            "mapping": { "group_column": "sender" },
+            "split_policy": {
+                "name": "deterministic-stratified-group-aware-v2",
+                "group_normalization": "casefold-reference-stripping-v1",
+                "no_group_overlap": true
+            },
+            "splits": splits,
+            "artifact_root": root,
+            "manifest_path": manifest_path
+        });
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        (manifest_path, root)
+    }
+
+    #[test]
+    fn prepares_private_chat_and_heldout_artifacts_without_uploading() {
+        let (manifest_path, root) = fixture();
+        let value = prepare_remote_plan(
+            manifest_path.to_str().unwrap(),
+            "fake",
+            "understudy/fake-gemma",
+            "glm-5.2",
+            3.0,
+        )
+        .unwrap();
+        let plan: RemoteTrainingPlan = serde_json::from_value(value).unwrap();
+        assert_eq!(plan.artifacts.len(), 3);
+        let train = fs::read_to_string(
+            &plan
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.artifact_role == "train")
+                .unwrap()
+                .path,
+        )
+        .unwrap();
+        assert!(train.contains("\"messages\""));
+        assert!(!train.contains("\"group_id\""));
+        let heldout = fs::read_to_string(
+            &plan
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.artifact_role == "heldout")
+                .unwrap()
+                .path,
+        )
+        .unwrap();
+        assert!(heldout.contains("\"input\""));
+        assert!(heldout.contains("\"target\""));
+        assert!(read_verified_plan(&plan.plan_path).is_ok());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn detects_artifact_changes_after_local_approval() {
+        let (manifest_path, root) = fixture();
+        let value = prepare_remote_plan(
+            manifest_path.to_str().unwrap(),
+            "fake",
+            "understudy/fake-gemma",
+            "glm-5.2",
+            3.0,
+        )
+        .unwrap();
+        let plan: RemoteTrainingPlan = serde_json::from_value(value).unwrap();
+        fs::write(&plan.artifacts[0].path, b"changed\n").unwrap();
+        let error = read_verified_plan(&plan.plan_path).unwrap_err();
+        assert!(
+            error.contains("changed after approval"),
+            "unexpected tamper error: {error}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn recovers_the_latest_durable_run_from_the_dataset_root() {
+        let (manifest_path, root) = fixture();
+        let value = prepare_remote_plan(
+            manifest_path.to_str().unwrap(),
+            "fake",
+            "understudy/fake-gemma",
+            "glm-5.2",
+            3.0,
+        )
+        .unwrap();
+        let plan: RemoteTrainingPlan = serde_json::from_value(value).unwrap();
+        let run_path = PathBuf::from(&plan.plan_path)
+            .parent()
+            .unwrap()
+            .join("run.json");
+        let status_url = train_api_base()
+            .unwrap()
+            .join("runs/00000000-0000-4000-8000-000000000001")
+            .unwrap()
+            .to_string();
+        let run = RemoteTrainingRun {
+            schema_version: RUN_SCHEMA.to_string(),
+            run_id: "00000000-0000-4000-8000-000000000001".to_string(),
+            plan_path: plan.plan_path,
+            status_url: status_url.clone(),
+            events_url: format!("{status_url}/events"),
+            run_token: "x".repeat(48),
+            next_after: -1,
+            run_manifest_path: run_path.display().to_string(),
+        };
+        write_private_new(&run_path, &serde_json::to_vec_pretty(&run).unwrap()).unwrap();
+
+        let recovered = find_existing_run(manifest_path.to_str().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            recovered.get("run_id").and_then(Value::as_str),
+            Some("00000000-0000-4000-8000-000000000001")
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/apps/homescreen/src-tauri/src/remote_training.rs
+++ b/apps/homescreen/src-tauri/src/remote_training.rs
@@ -287,7 +287,7 @@ fn find_existing_run(manifest_path: &str) -> Result<Option<Value>, String> {
             Some((modified, run_path))
         })
         .collect::<Vec<_>>();
-    candidates.sort_by(|left, right| right.0.cmp(&left.0));
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.0));
     candidates.truncate(500);
 
     for (_, run_path) in candidates {

--- a/apps/homescreen/src-tauri/src/remote_training.rs
+++ b/apps/homescreen/src-tauri/src/remote_training.rs
@@ -19,7 +19,8 @@ const MAX_MANIFEST_BYTES: u64 = 1_048_576;
 // Keep the first remote-training slice bounded. Split conversion is deliberately
 // local and currently buffers one source split at a time, so a multi-gigabyte
 // ceiling would turn a friendly desktop flow into memory pressure.
-const MAX_SPLIT_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_SPLIT_BYTES: u64 = 150 * 1024 * 1024;
+const MAX_REMOTE_ARTIFACT_BYTES: u64 = 150 * 1024 * 1024;
 
 #[derive(Debug, Clone, Deserialize)]
 struct DatasetManifest {
@@ -425,6 +426,12 @@ fn prepare_remote_plan(
             );
             content.push('\n');
         }
+        if content.len() as u64 > MAX_REMOTE_ARTIFACT_BYTES {
+            let _ = fs::remove_dir_all(&plan_root);
+            return Err(format!(
+                "The prepared {role} artifact is larger than the remote training upload limit."
+            ));
+        }
         write_private_new(&path, content.as_bytes())?;
         artifacts.push(RemoteArtifact {
             artifact_role: role.to_string(),
@@ -445,7 +452,13 @@ fn prepare_remote_plan(
             .as_bytes(),
     );
     let plan_path = plan_root.join("plan.json");
-    let output_model_name = format!("understudy-{}", safe_model_segment(&manifest.dataset_id));
+    let dataset_segment = safe_model_segment(&manifest.dataset_id);
+    if dataset_segment.is_empty() {
+        let _ = fs::remove_dir_all(&plan_root);
+        return Err("The dataset name cannot form a safe remote model name.".into());
+    }
+    let model_segment = dataset_segment.chars().take(42).collect::<String>();
+    let output_model_name = format!("understudy-{model_segment}-{}", &plan_id[..8]);
     let plan = RemoteTrainingPlan {
         schema_version: PLAN_SCHEMA.to_string(),
         plan_id,
@@ -783,6 +796,12 @@ fn verify_remote_artifact(artifact: &RemoteArtifact) -> Result<(), String> {
             artifact.artifact_role
         ));
     }
+    if artifact.size_bytes > MAX_REMOTE_ARTIFACT_BYTES {
+        return Err(format!(
+            "The {} artifact is larger than the remote training upload limit.",
+            artifact.artifact_role
+        ));
+    }
     if bytes.iter().filter(|byte| **byte == b'\n').count() as u64 != artifact.row_count {
         return Err(format!(
             "The {} artifact row count changed after approval.",
@@ -835,6 +854,19 @@ fn validate_capabilities(value: &Value, plan: &RemoteTrainingPlan) -> Result<(),
         .unwrap_or(0.0);
     if plan.maximum_spend_usd > max_budget {
         return Err("The approved budget exceeds the current service limit.".into());
+    }
+    let max_upload_bytes = value
+        .get("limits")
+        .and_then(|limits| limits.get("max_upload_bytes"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if max_upload_bytes == 0
+        || plan
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.size_bytes > max_upload_bytes)
+    {
+        return Err("A prepared artifact exceeds the current service upload limit.".into());
     }
     Ok(())
 }
@@ -1167,16 +1199,12 @@ fn replace_private_json(path: &Path, value: &impl Serialize) -> Result<(), Strin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn fixture() -> (PathBuf, PathBuf) {
         let root = std::env::temp_dir().join(format!(
             "understudy-remote-training-test-{}-{}",
             std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            random_uuid().unwrap()
         ));
         fs::create_dir_all(&root).unwrap();
         let labels = vec!["ham".to_string(), "spam".to_string()];
@@ -1270,7 +1298,38 @@ mod tests {
         .unwrap();
         assert!(heldout.contains("\"input\""));
         assert!(heldout.contains("\"target\""));
+        assert!(plan.output_model_name.starts_with("understudy-sms-intent-test-"));
+        assert!(plan.output_model_name.len() <= 64);
         assert!(read_verified_plan(&plan.plan_path).is_ok());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn repeated_plans_use_distinct_provider_model_names() {
+        let (manifest_path, root) = fixture();
+        let first: RemoteTrainingPlan = serde_json::from_value(
+            prepare_remote_plan(
+                manifest_path.to_str().unwrap(),
+                "fake",
+                "understudy/fake-gemma",
+                "glm-5.2",
+                3.0,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let second: RemoteTrainingPlan = serde_json::from_value(
+            prepare_remote_plan(
+                manifest_path.to_str().unwrap(),
+                "fake",
+                "understudy/fake-gemma",
+                "glm-5.2",
+                3.0,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_ne!(first.output_model_name, second.output_model_name);
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/apps/homescreen/src-tauri/src/remote_training.rs
+++ b/apps/homescreen/src-tauri/src/remote_training.rs
@@ -11,7 +11,7 @@ use tauri::ipc::Channel;
 use tokio_util::io::ReaderStream;
 
 const DATASET_SCHEMA: &str = "understudy.capture_import.classification_dataset.v2";
-const PLAN_SCHEMA: &str = "understudy.remote_training.plan.v1";
+const PLAN_SCHEMA: &str = "understudy.remote_training.plan.v2";
 const RUN_SCHEMA: &str = "understudy.remote_training.run.v1";
 const API_SCHEMA: &str = "understudy-train-v1";
 const DEFAULT_TRAIN_API_BASE: &str = "https://train.understudylabs.com/api/train/v1";
@@ -94,7 +94,7 @@ struct RemoteTrainingPlan {
     source_dataset_id: String,
     workload_name: String,
     provider: String,
-    base_model: String,
+    model_profile: String,
     output_model_name: String,
     frontier_model: String,
     labels: Vec<String>,
@@ -227,7 +227,7 @@ pub async fn remote_training_capabilities() -> Result<Value, String> {
 pub async fn prepare_remote_classification_training(
     manifest_path: String,
     provider: String,
-    base_model: String,
+    model_profile: String,
     frontier_model: String,
     maximum_spend_usd: f64,
 ) -> Result<Value, String> {
@@ -235,7 +235,7 @@ pub async fn prepare_remote_classification_training(
         prepare_remote_plan(
             &manifest_path,
             &provider,
-            &base_model,
+            &model_profile,
             &frontier_model,
             maximum_spend_usd,
         )
@@ -328,23 +328,29 @@ fn find_existing_run(manifest_path: &str) -> Result<Option<Value>, String> {
 fn prepare_remote_plan(
     manifest_path: &str,
     provider: &str,
-    base_model: &str,
+    model_profile: &str,
     frontier_model: &str,
     maximum_spend_usd: f64,
 ) -> Result<Value, String> {
-    if !matches!(provider, "fake" | "fireworks") {
+    if !matches!(provider, "fake" | "managed") {
         return Err("Choose an available remote training provider.".into());
     }
+    if !matches!(
+        model_profile,
+        "understudy/auto" | "understudy/fast" | "understudy/balanced" | "understudy/quality"
+    ) {
+        return Err("Choose an available Understudy training profile.".into());
+    }
     for (name, value) in [
-        ("base model", base_model),
+        ("training profile", model_profile),
         ("frontier model", frontier_model),
     ] {
         if value.trim().is_empty() || value.chars().count() > 240 {
             return Err(format!("The {name} is invalid."));
         }
     }
-    if !maximum_spend_usd.is_finite() || maximum_spend_usd <= 0.0 || maximum_spend_usd > 100.0 {
-        return Err("The remote training budget must be between $0 and $100.".into());
+    if !maximum_spend_usd.is_finite() || maximum_spend_usd <= 0.0 || maximum_spend_usd > 500.0 {
+        return Err("The remote training budget must be between $0 and $500.".into());
     }
 
     let canonical_manifest = PathBuf::from(manifest_path.trim())
@@ -470,7 +476,7 @@ fn prepare_remote_plan(
             safe_model_segment(&manifest.dataset_id)
         ),
         provider: provider.to_string(),
-        base_model: base_model.to_string(),
+        model_profile: model_profile.to_string(),
         output_model_name,
         frontier_model: frontier_model.to_string(),
         labels: manifest.labels.clone(),
@@ -670,7 +676,7 @@ pub async fn start_remote_classification_training(
                     "labels": plan.labels
                 },
                 "provider": plan.provider,
-                "base_model": plan.base_model,
+                "model_profile": plan.model_profile,
                 "output_model_name": plan.output_model_name,
                 "uploads": uploads,
                 "split": {
@@ -751,10 +757,10 @@ fn read_verified_plan(path: &str) -> Result<RemoteTrainingPlan, String> {
             .ok()
             .as_deref()
             != Some(canonical.as_path())
-        || !matches!(plan.provider.as_str(), "fake" | "fireworks")
+        || !matches!(plan.provider.as_str(), "fake" | "managed")
         || plan.artifacts.len() != 3
         || plan.maximum_spend_usd <= 0.0
-        || plan.maximum_spend_usd > 100.0
+        || plan.maximum_spend_usd > 500.0
     {
         return Err("The remote training plan failed its immutable boundary checks.".into());
     }
@@ -837,15 +843,15 @@ fn validate_capabilities(value: &Value, plan: &RemoteTrainingPlan) -> Result<(),
         .ok_or_else(|| "The planned remote training provider is unavailable.".to_string())?;
     if provider.get("enabled").and_then(Value::as_bool) != Some(true)
         || !provider
-            .get("base_models")
+            .get("model_profiles")
             .and_then(Value::as_array)
-            .is_some_and(|models| {
-                models
-                    .iter()
-                    .any(|model| model.as_str() == Some(&plan.base_model))
+            .is_some_and(|profiles| {
+                profiles.iter().any(|profile| {
+                    profile.get("id").and_then(Value::as_str) == Some(&plan.model_profile)
+                })
             })
     {
-        return Err("The planned provider or base model is disabled.".into());
+        return Err("The planned Understudy training profile is unavailable.".into());
     }
     let max_budget = value
         .get("limits")
@@ -1269,7 +1275,7 @@ mod tests {
         let value = prepare_remote_plan(
             manifest_path.to_str().unwrap(),
             "fake",
-            "understudy/fake-gemma",
+            "understudy/auto",
             "glm-5.2",
             3.0,
         )
@@ -1298,7 +1304,9 @@ mod tests {
         .unwrap();
         assert!(heldout.contains("\"input\""));
         assert!(heldout.contains("\"target\""));
-        assert!(plan.output_model_name.starts_with("understudy-sms-intent-test-"));
+        assert!(plan
+            .output_model_name
+            .starts_with("understudy-sms-intent-test-"));
         assert!(plan.output_model_name.len() <= 64);
         assert!(read_verified_plan(&plan.plan_path).is_ok());
         fs::remove_dir_all(root).unwrap();
@@ -1311,7 +1319,7 @@ mod tests {
             prepare_remote_plan(
                 manifest_path.to_str().unwrap(),
                 "fake",
-                "understudy/fake-gemma",
+                "understudy/auto",
                 "glm-5.2",
                 3.0,
             )
@@ -1322,7 +1330,7 @@ mod tests {
             prepare_remote_plan(
                 manifest_path.to_str().unwrap(),
                 "fake",
-                "understudy/fake-gemma",
+                "understudy/auto",
                 "glm-5.2",
                 3.0,
             )
@@ -1339,7 +1347,7 @@ mod tests {
         let value = prepare_remote_plan(
             manifest_path.to_str().unwrap(),
             "fake",
-            "understudy/fake-gemma",
+            "understudy/auto",
             "glm-5.2",
             3.0,
         )
@@ -1360,7 +1368,7 @@ mod tests {
         let value = prepare_remote_plan(
             manifest_path.to_str().unwrap(),
             "fake",
-            "understudy/fake-gemma",
+            "understudy/auto",
             "glm-5.2",
             3.0,
         )

--- a/skills/product-knowledge/SKILL.md
+++ b/skills/product-knowledge/SKILL.md
@@ -12,6 +12,10 @@ the cheapest route that meets the quality gate.
 Use this skill for product explanations, onboarding copy, agent-facing help, and UI feature
 descriptions. Keep the answer concrete and tied to product surfaces the user can inspect.
 
+For company identity, history, and the durable product narrative, read
+[`reference.md`](reference.md). Keep the always-on explanation compact; load this
+skill when the user needs the fuller story.
+
 ## Safety Gates
 
 Do not claim Understudy uploads data, spends money, creates accounts, downloads models,
@@ -41,7 +45,7 @@ node dist/bin.js status --json
 
 - **Desktop app** — local control plane for chat, model serving, traces, evals, usage, account setup, and training workflows.
 - **Local serving** — warm MLX slots for Understudy-suffixed local models, with first-run bootstrap for runtimes and model downloads.
-- **Chat harness** — custom Rust execution layer that streams answers, reasoning, tool calls, tool results, and sidekick activity to the UI.
+- **Chat harness** — a Pi AgentSession sidecar that streams answers, reasoning, guarded tool calls, tool results, and compaction evidence to the native UI.
 - **Fusion sidekick** — a smaller local model lane used for bounded read-only work while the main lane keeps planning, ambiguity, and final review.
 - **Evals / rollout lab** — run task suites across model candidates and harness modes, watch each rollout, persist scores, and inspect failures.
 - **Candidate results** — Test Results-style view that groups model-family task outcomes into passed, failed, running, skipped, score, latency, and drilldown rows.

--- a/skills/product-knowledge/reference.md
+++ b/skills/product-knowledge/reference.md
@@ -1,0 +1,56 @@
+# Understudy company and product reference
+
+Use this reference when a user needs more than the compact Desktop identity prompt.
+Prefer the current public website for launch-sensitive wording; this file records the
+durable facts and product frame that should remain available offline.
+
+## Company
+
+- Understudy Labs was founded by Aamir Poonawalla and Luis Manrique.
+- Aamir and Luis developed the grounding methodology together at Instacart before
+  forming Understudy Labs.
+- The company's focus is improving AI systems from the real work people already do,
+  with domain experts defining what good means and learning systems turning that
+  judgment into reusable evidence.
+
+Do not invent founder biographies, customer claims, fundraising language, dates, or
+benchmark results. For externally published copy, verify against
+<https://understudylabs.com>.
+
+## Product frame
+
+Understudy optimizes the complete production route, not only a model ID:
+
+1. Capture the existing workload and production evidence.
+2. Evaluate the incumbent route on a frozen, workload-specific slice.
+3. Optimize the harness or prompt before escalating to training.
+4. Compare candidate models and suppliers against the incumbent or frontier route.
+5. Train only when the evidence supports it.
+6. Deploy the cheapest route that clears the quality gate, while retaining a control
+   slice and a fallback.
+
+The route can include the prompt, tools, policy, model, compression, supplier,
+gateway, and deployment shape. Understudy should make the quality, latency, cost,
+privacy, and ownership tradeoffs inspectable instead of hiding them behind one score.
+
+## Product surfaces
+
+- `understudy-agent-tools` is the preinstalled Understudy skill and CLI product used
+  by coding agents and Understudy Desktop.
+- The root `understudy` skill progressively routes an agent to one specialist skill
+  at a time.
+- Desktop is the local control plane for chat, models, evidence, evaluation, and
+  training workflows.
+- The CLI owns durable behavior and can be used without Desktop.
+- Hosted inference or training is an optional authenticated extension of the local
+  control plane, never an implicit upload path.
+
+## Explanation rules
+
+- Say what evidence is used and what remains local.
+- Distinguish a workload-specific result from a universal benchmark.
+- Compare against the current incumbent or frontier route before claiming an
+  improvement.
+- Treat prompt optimization, model sweeps, fine-tuning, and deployment as rungs in
+  one measured loop rather than separate products.
+- Ask before provider spend, uploads, model downloads, or hosted execution.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -133,9 +133,10 @@ Identify the developer's current stage and load exactly one:
   installed the plugin, or asks "where do I start?" and `~/.understudy/profile.json`
   is missing → [`../onboard/SKILL.md`](../onboard/SKILL.md) (backgrounds a small
   model, profiles the machine, interviews, writes the profile).
-- **Product explanation / onboarding copy** — the developer asks what
-  Understudy is, how Desktop, local serving, Fusion sidekick, candidate results,
-  rollout lab, or training workflows work →
+- **Product explanation / company context / onboarding copy** — the developer
+  asks what Understudy is, who Aamir Poonawalla and Luis Manrique are, how the
+  company began, or how Desktop, local serving, candidate results, rollout lab,
+  or training workflows work →
   [`../product-knowledge/SKILL.md`](../product-knowledge/SKILL.md).
 - **Workload unclear** — the repo has prompts, traces, datasets, eval rows, or
   LLM call sites, but the task, data shape, request/response path, or success

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -35,6 +35,7 @@ import {
   enforceShellToolCall,
   piCommandGuardExtension,
 } from "./command-guard.js";
+import { packagePath } from "../../internal/package-root.js";
 
 function runtimeHome(): string {
   return resolve(
@@ -597,6 +598,7 @@ async function createPiRuntimeSession(options: {
       .filter(Boolean)
       .join("\n\n") ||
     "You are the Understudy conversation runtime. Use only explicitly provided tools.";
+  const understudyRootSkill = packagePath("skills", "understudy", "SKILL.md");
   const resourceLoader = new DefaultResourceLoader({
     cwd,
     agentDir: join(root, "agent"),
@@ -615,6 +617,11 @@ async function createPiRuntimeSession(options: {
     // Keep user/project extensions disabled. Inline runtime extensions above
     // still load, so the safety boundary is deterministic and app-owned.
     noExtensions: true,
+    // The packaged Understudy orchestrator is the one preinstalled skill.
+    // `noSkills` keeps project/user skills disabled while additional paths
+    // remain loadable by Pi. The app-owned system prompt tells the model to
+    // disclose specialist instructions through the restricted CLI tool.
+    additionalSkillPaths: [understudyRootSkill],
     noSkills: true,
     noPromptTemplates: true,
     noThemes: true,

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -679,7 +679,8 @@ test("desktop compiles one dropped path through the bounded public CLI", async (
   assert.match(training, /Only held-out test examples are sent through Understudy/);
   assert.match(training, /confirmSpend: true/);
   assert.match(training, /budgetUsd: 1/);
-  assert.match(training, /Fireworks publishes zero data retention/);
+  assert.match(training, /active inference vendor remains behind Understudy's authenticated service boundary/);
+  assert.doesNotMatch(training, /Fireworks/);
   assert.match(training, /Maximum approved spend: \$1\.00/);
   assert.match(training, /<EvaluationRadar/);
   assert.match(training, /frontierComparison\.heldout\.weakest_classes\[0\] && state\.result\.heldout\.weakest_classes\[0\]/);

--- a/tests/remote-training-desktop.test.mjs
+++ b/tests/remote-training-desktop.test.mjs
@@ -20,16 +20,20 @@ test("remote training remains an off-by-default explicit-consent experiment", as
   assert.match(native, /sha256_bytes\(&bytes\) != artifact\.sha256/);
   assert.match(native, /leakage-group overlap/);
   assert.match(native, /raw_rows_in_telemetry/);
+  assert.match(native, /max_upload_bytes/);
   assert.match(native, /Method::DELETE,[\s\S]*api_url\("uploads"\)/);
   assert.match(native, /existing_remote_classification_training/);
 
   assert.match(panel, /Nothing uploads until you review the exact artifacts and budget/);
   assert.match(panel, /Upload only these three private split artifacts/);
-  assert.match(panel, /never spend more than/);
+  assert.match(panel, /reported estimate reaches/);
   assert.match(panel, /temporary endpoint for held-out comparison/);
+  assert.match(panel, /then always remove it/);
   assert.match(panel, /remote_training_poll/);
   assert.match(panel, /cancel_remote_training/);
   assert.match(panel, /Where it still fails/);
+  assert.match(panel, /gemma-4-26b-a4b-it/);
+  assert.match(panel, /provider\.id === "fireworks"/);
 
   assert.match(localPanel, /remote_training_capabilities/);
   assert.match(localPanel, /remoteCapabilityState === "available" && !forceLocal/);

--- a/tests/remote-training-desktop.test.mjs
+++ b/tests/remote-training-desktop.test.mjs
@@ -32,8 +32,11 @@ test("remote training remains an off-by-default explicit-consent experiment", as
   assert.match(panel, /remote_training_poll/);
   assert.match(panel, /cancel_remote_training/);
   assert.match(panel, /Where it still fails/);
-  assert.match(panel, /gemma-4-26b-a4b-it/);
-  assert.match(panel, /provider\.id === "fireworks"/);
+  assert.match(panel, /understudy\/auto/);
+  assert.match(panel, /provider\.id === "managed"/);
+  assert.doesNotMatch(panel, /fireworks/i);
+  assert.doesNotMatch(panel, /gemma-4/i);
+  assert.match(native, /"model_profiles"/);
 
   assert.match(localPanel, /remote_training_capabilities/);
   assert.match(localPanel, /remoteCapabilityState === "available" && !forceLocal/);

--- a/tests/remote-training-desktop.test.mjs
+++ b/tests/remote-training-desktop.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const root = new URL("../", import.meta.url);
+const read = (path) => readFile(new URL(path, root), "utf8");
+
+test("remote training remains an off-by-default explicit-consent experiment", async () => {
+  const [native, panel, localPanel, tauriLib] = await Promise.all([
+    read("apps/homescreen/src-tauri/src/remote_training.rs"),
+    read("apps/homescreen/app/components/RemoteTrainingPanel.tsx"),
+    read("apps/homescreen/app/components/LocalTrainingPanel.tsx"),
+    read("apps/homescreen/src-tauri/src/lib.rs"),
+  ]);
+
+  assert.match(native, /UNDERSTUDY_REMOTE_TRAINING_EXPERIMENT/);
+  assert.match(native, /Remote training is an off-by-default experiment/);
+  assert.match(native, /if !confirm_upload \|\| !confirm_spend/);
+  assert.match(native, /confirm_temporary_deployment/);
+  assert.match(native, /sha256_bytes\(&bytes\) != artifact\.sha256/);
+  assert.match(native, /leakage-group overlap/);
+  assert.match(native, /raw_rows_in_telemetry/);
+  assert.match(native, /Method::DELETE,[\s\S]*api_url\("uploads"\)/);
+  assert.match(native, /existing_remote_classification_training/);
+
+  assert.match(panel, /Nothing uploads until you review the exact artifacts and budget/);
+  assert.match(panel, /Upload only these three private split artifacts/);
+  assert.match(panel, /never spend more than/);
+  assert.match(panel, /temporary endpoint for held-out comparison/);
+  assert.match(panel, /remote_training_poll/);
+  assert.match(panel, /cancel_remote_training/);
+  assert.match(panel, /Where it still fails/);
+
+  assert.match(localPanel, /remote_training_capabilities/);
+  assert.match(localPanel, /remoteCapabilityState === "available" && !forceLocal/);
+  assert.match(panel, /Train on this Mac/);
+  assert.match(tauriLib, /remote_training::start_remote_classification_training/);
+});


### PR DESCRIPTION
## Outcome

Integrates the native Desktop app with the authenticated Understudy remote-training control plane while keeping local training as the default-safe fallback. The app prepares and hashes every split locally, requires explicit artifact/spend/evaluation consent, and reconnects to durable workflow progress after restart.

## UX and safety

- defaults to `Automatic`, which lets Understudy choose from models the platform just validated as ready and LoRA-tunable
- also exposes human-readable model choices such as Gemma and Qwen without exposing the current training/inference vendor or raw provider resources
- remote training remains off unless `UNDERSTUDY_REMOTE_TRAINING_EXPERIMENT` is explicitly enabled
- enforces server-advertised upload and per-user budget limits before transfer
- generates collision-resistant private model names per run
- describes spend as a service-reported estimate, not a guaranteed local meter
- makes temporary evaluation teardown explicit and shows a promoted private model without implying a serving endpoint exists
- preserves exact local artifact hashes, group-isolated splits, cancellation, and durable receipts

## Verification

- Rust library suite: 183 passed, 4 environment-gated tests ignored
- Desktop remote-training contract test passed
- Desktop Next.js production build passed
- Rust formatting and diff checks clean

## Dependency

The isolated Understudy Platform service landed in [understudylabs/understudy-platform#410](https://github.com/understudylabs/understudy-platform/pull/410). Keep the Desktop experiment disabled for every organization until [understudylabs/understudy-platform#411](https://github.com/understudylabs/understudy-platform/pull/411) is merged, deployed with server-only training credentials and exact WorkOS user/org allowlists, and one reviewed paid smoke proves adapter loading, paired heldout inference, and terminal cleanup.