### PR TITLE
Desktop: add quiet reader-position outline

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -5,12 +5,10 @@ import { Channel, invoke, isTauri } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import {
   MessageScroller,
-  MessageScrollerButton,
   MessageScrollerContent,
   MessageScrollerItem,
   MessageScrollerProvider,
   MessageScrollerViewport,
-  useMessageScrollerVisibility,
 } from "@/app/components/base-ui/message-scroller";
 import {
   Message,
@@ -85,8 +83,9 @@ import { CsvTrainingPlan } from "./CsvTrainingPlan";
 import { LocalTrainingPanel } from "./LocalTrainingPanel";
 import { LocalClassifierLibraryDialog } from "./LocalClassifierLibraryDialog";
 import { TrainingHalo, type TrainingHaloVisual } from "./TrainingHalo";
+import { ChatScrollControls } from "./ChatScrollControls";
 import type { FileUIPart } from "ai";
-import { ArrowDownIcon, LibraryBigIcon } from "lucide-react";
+import { LibraryBigIcon } from "lucide-react";
 
 type Role = "user" | "assistant";
 type ToolTrace = {
@@ -366,36 +365,6 @@ function ChatToolTrace({ tool }: { tool: ToolTrace }) {
         )}
       </ToolContent>
     </Tool>
-  );
-}
-
-function ChatScrollTracker({
-  anchorIds,
-  streaming,
-}: {
-  anchorIds: string[];
-  streaming: boolean;
-}) {
-  const { currentAnchorId, visibleMessageIds } = useMessageScrollerVisibility();
-  if (anchorIds.length === 0) return null;
-
-  const anchorIndex = currentAnchorId ? anchorIds.indexOf(currentAnchorId) : -1;
-  const currentTurn = Math.max(0, anchorIndex) + 1;
-  const visibleLabel = `${visibleMessageIds.length} message${visibleMessageIds.length === 1 ? "" : "s"} visible`;
-
-  return (
-    <MessageScrollerButton
-      className="chat-scroll-tracker"
-      aria-label={`Turn ${currentTurn} of ${anchorIds.length}. ${visibleLabel}. Jump to latest.`}
-      title="Jump to latest"
-    >
-      {streaming && <span className="chat-scroll-live-dot" aria-hidden="true" />}
-      <span className="chat-scroll-turn">Turn {currentTurn} of {anchorIds.length}</span>
-      <span className="chat-scroll-latest">
-        Latest
-        <ArrowDownIcon aria-hidden="true" size={13} strokeWidth={2} />
-      </span>
-    </MessageScrollerButton>
   );
 }
 
@@ -1251,8 +1220,13 @@ export function ChatPane({
     })),
     [messages, sessionId],
   );
-  const turnAnchorIds = useMemo(
-    () => transcriptRows.filter((row) => row.message.role === "user").map((row) => row.id),
+  const turnAnchors = useMemo(
+    () => transcriptRows
+      .filter((row) => row.message.role === "user")
+      .map((row, index) => ({
+        id: row.id,
+        label: row.message.content.replace(/\s+/g, " ").trim() || `Turn ${index + 1}`,
+      })),
     [transcriptRows],
   );
 
@@ -1549,7 +1523,7 @@ export function ChatPane({
           )}
             </MessageScrollerContent>
           </MessageScrollerViewport>
-          <ChatScrollTracker anchorIds={turnAnchorIds} streaming={streaming} />
+          <ChatScrollControls anchors={turnAnchors} streaming={streaming} />
         </MessageScroller>
       </MessageScrollerProvider>
 

--- a/apps/homescreen/app/components/ChatScrollControls.tsx
+++ b/apps/homescreen/app/components/ChatScrollControls.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { memo, useMemo } from "react";
+import { ArrowDownIcon } from "lucide-react";
+
+import {
+  MessageScrollerButton,
+  useMessageScroller,
+  useMessageScrollerVisibility,
+} from "@/app/components/base-ui/message-scroller";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/app/components/base-ui/hover-card";
+
+export type ChatTurnAnchor = {
+  id: string;
+  label: string;
+};
+
+function sameTurnAnchors(previous: ChatTurnAnchor[], next: ChatTurnAnchor[]) {
+  return previous.length === next.length && previous.every((anchor, index) => (
+    anchor.id === next[index]?.id && anchor.label === next[index]?.label
+  ));
+}
+
+export const ChatScrollControls = memo(function ChatScrollControls({
+  anchors,
+  streaming,
+}: {
+  anchors: ChatTurnAnchor[];
+  streaming: boolean;
+}) {
+  const { scrollToMessage } = useMessageScroller();
+  const { currentAnchorId, visibleMessageIds } = useMessageScrollerVisibility();
+  const visibleIds = useMemo(() => new Set(visibleMessageIds), [visibleMessageIds]);
+  const positionTicks = useMemo(() => {
+    const maximumTicks = 12;
+    if (anchors.length <= maximumTicks) return anchors;
+
+    const sampledIndexes = new Set<number>([0, anchors.length - 1]);
+    for (let index = 1; index < maximumTicks - 1; index += 1) {
+      sampledIndexes.add(Math.round(index * (anchors.length - 1) / (maximumTicks - 1)));
+    }
+    if (currentAnchorId) {
+      const currentIndex = anchors.findIndex((anchor) => anchor.id === currentAnchorId);
+      if (currentIndex >= 0 && !sampledIndexes.has(currentIndex)) {
+        const replaceableIndex = [...sampledIndexes]
+          .filter((index) => index !== 0 && index !== anchors.length - 1)
+          .sort((left, right) => (
+            Math.abs(left - currentIndex) - Math.abs(right - currentIndex)
+          ))[0];
+        if (replaceableIndex !== undefined) sampledIndexes.delete(replaceableIndex);
+        sampledIndexes.add(currentIndex);
+      }
+    }
+
+    return [...sampledIndexes]
+      .sort((left, right) => left - right)
+      .map((index) => anchors[index])
+      .filter((anchor): anchor is ChatTurnAnchor => Boolean(anchor));
+  }, [anchors, currentAnchorId]);
+
+  if (anchors.length === 0) return null;
+
+  const anchorIndex = currentAnchorId
+    ? anchors.findIndex((anchor) => anchor.id === currentAnchorId)
+    : -1;
+  const currentTurn = Math.max(0, anchorIndex) + 1;
+  const visibleLabel = `${visibleMessageIds.length} message${visibleMessageIds.length === 1 ? "" : "s"} visible`;
+
+  return (
+    <>
+      {anchors.length > 1 && (
+        <HoverCard openDelay={160} closeDelay={120}>
+          <HoverCardTrigger asChild>
+            <button
+              type="button"
+              className="chat-scroll-outline-trigger"
+              aria-label={`Open conversation outline. Turn ${currentTurn} of ${anchors.length}.`}
+            >
+              {positionTicks.map((anchor) => (
+                <span
+                  key={anchor.id}
+                  className="chat-scroll-outline-tick"
+                  data-current={anchor.id === currentAnchorId}
+                  data-visible={visibleIds.has(anchor.id)}
+                  aria-hidden="true"
+                />
+              ))}
+            </button>
+          </HoverCardTrigger>
+          <HoverCardContent
+            side="left"
+            align="center"
+            sideOffset={10}
+            className="chat-scroll-outline-card"
+          >
+            <div className="chat-scroll-outline-heading">
+              <span>Conversation</span>
+              <span>{currentTurn} / {anchors.length}</span>
+            </div>
+            <div className="chat-scroll-outline-list">
+              {anchors.map((anchor, index) => (
+                <button
+                  key={anchor.id}
+                  type="button"
+                  className="chat-scroll-outline-item"
+                  aria-current={anchor.id === currentAnchorId ? "location" : undefined}
+                  onClick={() => {
+                    scrollToMessage(anchor.id, {
+                      align: "start",
+                      behavior: "smooth",
+                    });
+                  }}
+                >
+                  <span aria-hidden="true">{String(index + 1).padStart(2, "0")}</span>
+                  <span>{anchor.label}</span>
+                </button>
+              ))}
+            </div>
+          </HoverCardContent>
+        </HoverCard>
+      )}
+      <MessageScrollerButton
+        className="chat-scroll-tracker"
+        aria-label={`Turn ${currentTurn} of ${anchors.length}. ${visibleLabel}. Jump to latest.`}
+        title="Jump to latest"
+      >
+        {streaming && <span className="chat-scroll-live-dot" aria-hidden="true" />}
+        <span className="chat-scroll-turn">Turn {currentTurn} of {anchors.length}</span>
+        <span className="chat-scroll-latest">
+          Latest
+          <ArrowDownIcon aria-hidden="true" size={13} strokeWidth={2} />
+        </span>
+      </MessageScrollerButton>
+    </>
+  );
+}, (previous, next) => (
+  previous.streaming === next.streaming && sameTurnAnchors(previous.anchors, next.anchors)
+));

--- a/apps/homescreen/app/design/page.tsx
+++ b/apps/homescreen/app/design/page.tsx
@@ -1,8 +1,29 @@
 "use client";
 import { Button } from "../components/ui/Button";
 import { EvaluationRadar } from "../components/EvaluationRadar";
+import { ChatScrollControls } from "../components/ChatScrollControls";
+import {
+  MessageScroller,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from "../components/base-ui/message-scroller";
 
 const variants = ["primary", "secondary", "ghost", "danger", "link"] as const;
+const transcriptDemo = [
+  { id: "outline-1", role: "user", content: "What changed in the latest training run?" },
+  { id: "outline-2", role: "assistant", content: "The held-out errors dropped, with the largest improvement on ambiguous merchant names. The model still needs another run before promotion." },
+  { id: "outline-3", role: "user", content: "Where does it still fail?" },
+  { id: "outline-4", role: "assistant", content: "Most remaining misses are rare categories with fewer than twenty examples. Travel and subscriptions are the two weakest groups." },
+  { id: "outline-5", role: "user", content: "How does it compare with the cloud model?" },
+  { id: "outline-6", role: "assistant", content: "It matches the cloud model on common categories, responds much faster locally, and trails on the smallest categories. The next sweep should target those failure areas." },
+  { id: "outline-7", role: "user", content: "What should we do next?" },
+  { id: "outline-8", role: "assistant", content: "Add examples for the two weakest groups, repeat the same frozen holdout, and promote only if the gains survive a second run." },
+] as const;
+const transcriptAnchors = transcriptDemo
+  .filter((message) => message.role === "user")
+  .map((message) => ({ id: message.id, label: message.content }));
 
 export default function DesignPage() {
   return (
@@ -42,6 +63,48 @@ export default function DesignPage() {
             costUsd: 0.02,
           }}
         />
+
+        <SectionTitle>message scroller · reader position</SectionTitle>
+        <div
+          style={{
+            height: 420,
+            marginBottom: 28,
+            overflow: "hidden",
+            border: "1px solid var(--color-rule)",
+            borderRadius: 12,
+            background: "var(--color-card)",
+          }}
+        >
+          <MessageScrollerProvider
+            autoScroll
+            defaultScrollPosition="start"
+            scrollPreviousItemPeek={48}
+          >
+            <MessageScroller>
+              <MessageScrollerViewport>
+                <MessageScrollerContent className="gap-5 px-5 pb-12 pt-5">
+                  {transcriptDemo.map((message) => (
+                    <MessageScrollerItem
+                      key={message.id}
+                      messageId={message.id}
+                      scrollAnchor={message.role === "user"}
+                    >
+                      <div
+                        className={`chat-msg ${message.role} group flex w-full flex-col gap-2 ${message.role === "user" ? "is-user ml-auto max-w-[80%] justify-end" : "is-assistant max-w-[92%]"}`}
+                      >
+                        <div className="chat-role">{message.role === "user" ? "You" : "Understudy"}</div>
+                        <div className="flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground group-[.is-assistant]:text-foreground">
+                          {message.content}
+                        </div>
+                      </div>
+                    </MessageScrollerItem>
+                  ))}
+                </MessageScrollerContent>
+              </MessageScrollerViewport>
+              <ChatScrollControls anchors={transcriptAnchors} streaming={false} />
+            </MessageScroller>
+          </MessageScrollerProvider>
+        </div>
 
         {/* accent reference */}
         <Surface>

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2165,6 +2165,119 @@ select,
 [data-slot="message-scroller"][data-scrollable~="end"]::after {
   opacity: 1;
 }
+.chat-scroll-outline-trigger {
+  position: absolute;
+  z-index: 4;
+  top: 50%;
+  right: 7px;
+  display: flex;
+  width: 30px;
+  max-height: min(46%, 220px);
+  padding: 8px 5px;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  transform: translateY(-50%);
+  transition: border-color 140ms ease, background-color 140ms ease;
+}
+.chat-scroll-outline-trigger:hover,
+.chat-scroll-outline-trigger:focus-visible {
+  border-color: color-mix(in srgb, var(--mb-cyan) 14%, var(--border));
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  outline: none;
+}
+.chat-scroll-outline-tick {
+  display: block;
+  width: 13px;
+  height: 2px;
+  flex: 0 0 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-3) 32%, transparent);
+  transform-origin: right center;
+  transition: width 140ms ease, background-color 140ms ease, box-shadow 140ms ease;
+}
+.chat-scroll-outline-tick[data-visible="true"] {
+  width: 16px;
+  background: color-mix(in srgb, var(--text-2) 58%, transparent);
+}
+.chat-scroll-outline-tick[data-current="true"] {
+  width: 20px;
+  background: var(--mb-cyan);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--mb-cyan) 44%, transparent);
+}
+.chat-scroll-outline-card {
+  width: min(300px, calc(100vw - 64px));
+  max-height: min(60vh, 420px);
+  padding: 5px;
+  overflow: hidden;
+  border-color: color-mix(in srgb, var(--mb-cyan) 16%, var(--border));
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  color: var(--text);
+  box-shadow: 0 18px 54px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+.chat-scroll-outline-heading {
+  display: flex;
+  padding: 8px 9px 7px;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.chat-scroll-outline-list {
+  max-height: min(48vh, 340px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+.chat-scroll-outline-item {
+  display: grid;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 9px;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 7px;
+  align-items: center;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-2);
+  text-align: left;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+.chat-scroll-outline-item > span:first-child {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+}
+.chat-scroll-outline-item > span:last-child {
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-scroll-outline-item:hover,
+.chat-scroll-outline-item:focus-visible,
+.chat-scroll-outline-item[aria-current="location"] {
+  background: color-mix(in srgb, var(--mb-cyan) 8%, var(--surface-2));
+  color: var(--text);
+  outline: none;
+}
+.chat-scroll-outline-item[aria-current="location"] > span:first-child {
+  color: var(--mb-cyan);
+}
 [data-slot="message-scroller-button"].chat-scroll-tracker {
   z-index: 4;
   bottom: 10px;
@@ -2805,6 +2918,9 @@ select,
     animation: none;
   }
   [data-slot="message-scroller-button"].chat-scroll-tracker,
+  .chat-scroll-outline-trigger,
+  .chat-scroll-outline-tick,
+  .chat-scroll-outline-item,
   [data-slot="message-scroller"]::before,
   [data-slot="message-scroller"]::after {
     transition: none;

--- a/design-qa.md
+++ b/design-qa.md
@@ -84,3 +84,19 @@ The existing dark palette, cyan primary action, spacing, borders, typography, an
 No P0, P1, or P2 visual or interaction issues remain in this state.
 
 final result: passed
+
+## Message scroller reader position
+
+- Date: 2026-07-17
+- Reference: shadcn/ui Base Message Scroller, “Tracking the reader’s position”
+- Prototype: http://localhost:1426/design
+- Viewport: 1280 x 720
+- Compared state: transcript outline open at turn 1 of 4
+
+The right-edge trigger remains a quiet stack of small turn ticks, with the current turn in cyan. The outline floats beside the transcript without changing message layout or moving the composer, and follows the existing Understudy typography, spacing, borders, and dark palette. All four turns remain readable and directly selectable; no clipped labels, broken borders, or unintended horizontal overflow were observed.
+
+The rail is a native button with a descriptive turn-position label. Each outline item is a native button, the active turn exposes `aria-current="location"`, and selecting an item uses the scroller's own smooth `scrollToMessage` behavior. The existing “Turn X of Y / Latest” control remains available for returning to the live edge. Reduced-motion mode removes decorative transitions.
+
+One visibility subscription drives the rail and existing position control. The transcript retains `content-visibility: auto` and an intrinsic-size placeholder. Streaming transcript updates cannot rerender the controls unless turn anchors or streaming state change. The quiet rail renders at most 12 sampled ticks for long conversations while keeping the first, current, and final turns represented; the full outline mounts only while its hover or focus surface is open.
+
+final result: passed

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -15,6 +15,14 @@ const tauriConfigPath = new URL(
   import.meta.url,
 );
 const chatPath = new URL("../apps/homescreen/app/components/ChatPane.tsx", import.meta.url);
+const messageScrollerPath = new URL(
+  "../apps/homescreen/app/components/base-ui/message-scroller.tsx",
+  import.meta.url,
+);
+const chatScrollControlsPath = new URL(
+  "../apps/homescreen/app/components/ChatScrollControls.tsx",
+  import.meta.url,
+);
 const classifierLibraryPath = new URL(
   "../apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx",
   import.meta.url,
@@ -244,21 +252,30 @@ test("reading pace is quiet, optional, and safe across teacher replacement", asy
 });
 
 test("chat streaming batches paint work and only animates compositor-safe properties", async () => {
-  const [chat, css, batcher] = await Promise.all([
+  const [chat, css, batcher, messageScroller, scrollControls] = await Promise.all([
     readFile(chatPath, "utf8"),
     readFile(cssPath, "utf8"),
     readFile(streamBatcherPath, "utf8"),
+    readFile(messageScrollerPath, "utf8"),
+    readFile(chatScrollControlsPath, "utf8"),
   ]);
 
   assert.match(chat, /new ChatStreamBatcher\(applyAssistantPatch/);
   assert.match(chat, /streamBatcher\.current\?\.flush\(\)/);
   assert.match(chat, /requestAnimationFrame\(\(\) =>/);
-  assert.match(chat, /useMessageScrollerVisibility/);
+  assert.match(scrollControls, /const \{ scrollToMessage \} = useMessageScroller\(\)/);
+  assert.match(scrollControls, /useMessageScrollerVisibility/);
+  assert.match(scrollControls, /scrollToMessage\(anchor\.id,/);
+  assert.match(scrollControls, /maximumTicks = 12/);
+  assert.match(scrollControls, /sameTurnAnchors\(previous\.anchors, next\.anchors\)/);
   assert.match(chat, /defaultScrollPosition="last-anchor"/);
   assert.match(chat, /messageId=\{messageId\}/);
   assert.match(chat, /className=\{messageId === animatedMessageId \? "chat-message-enter" : undefined\}/);
+  assert.match(messageScroller, /\[content-visibility:auto\]/);
+  assert.match(messageScroller, /\[contain-intrinsic-size:auto_10rem\]/);
   assert.match(batcher, /this\.#scheduled = this\.#schedule\(\(\) =>/);
   assert.match(css, /@keyframes chat-message-enter\s*\{[\s\S]*?opacity:[\s\S]*?transform:/);
+  assert.match(css, /\.chat-scroll-outline-tick/);
   const animationRule = css.match(/@keyframes chat-message-enter\s*\{[\s\S]*?\n\}/)?.[0] ?? "";
   assert.doesNotMatch(animationRule, /height|margin|padding/);
   assert.match(css, /prefers-reduced-motion: reduce[\s\S]*?\.chat-message-enter/);


### PR DESCRIPTION
## Outcome

Adds a quiet reader-position rail to Desktop chat using the existing shadcn Base Message Scroller primitives. Readers can see the current anchored turn, open a compact conversation outline, jump directly to any turn, or return to the live edge.

## Streaming and performance

- keeps live-edge following, last-anchor restore, prior-context peek, and the existing Latest control
- uses one visibility subscription instead of adding another scroll listener
- isolates the controls from streaming transcript paint work with a memoized anchor contract
- retains `content-visibility: auto` and intrinsic-size placeholders for transcript rows
- caps the quiet rail at 12 sampled ticks while preserving the first, current, and final turns
- mounts the full outline only while its hover or focus surface is open
- disables decorative transitions for reduced-motion users

## Verification

- `npm run check` — 382 tests passed; 34 public skills valid; package smoke passed
- Desktop production build passed
- targeted Desktop UI-lineage suite — 20 passed
- `git diff --check` passed
- visual QA against the official shadcn reader-position example passed at 1280 x 720

Reference: https://ui.shadcn.com/docs/components/base/message-scroller#what-makes-a-great-streaming-chat-experience
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->