### PR TITLE
feat(desktop): add customer production monitor

### DIFF
--- a/apps/homescreen/app/components/MonitorPane.tsx
+++ b/apps/homescreen/app/components/MonitorPane.tsx
@@ -14,6 +14,7 @@ import {
   cacheReusePercent,
   displayModelName,
   monitoringState,
+  snapshotForSelection,
   topModelRows,
 } from "../lib/monitoring.mjs";
 
@@ -249,16 +250,17 @@ export function MonitorPane({ onOpenAccount }: { onOpenAccount: () => void }) {
     return () => globalThis.clearInterval(timer);
   }, [loadSnapshot, projectId, window]);
 
-  const state = useMemo(() => monitoringState(snapshot?.health), [snapshot]);
+  const visibleSnapshot = snapshotForSelection(snapshot, projectId, window);
+  const state = useMemo(() => monitoringState(visibleSnapshot?.health), [visibleSnapshot]);
   const workloads = useMemo(
-    () => buildWorkloadRows(snapshot?.routing.workloads, snapshot?.health.providers),
-    [snapshot],
+    () => buildWorkloadRows(visibleSnapshot?.routing.workloads, visibleSnapshot?.health.providers),
+    [visibleSnapshot],
   );
   const models = useMemo(
-    () => topModelRows(snapshot?.usage_by_model?.rows ?? [], 6),
-    [snapshot],
+    () => topModelRows(visibleSnapshot?.usage_by_model?.rows ?? [], 6),
+    [visibleSnapshot],
   );
-  const reuse = cacheReusePercent(snapshot?.billing?.summary);
+  const reuse = cacheReusePercent(visibleSnapshot?.billing?.summary);
   const maxModelCost = Math.max(0, ...models.map((model) => model.cost_usd));
   const selectedProject = projects.find((project) => project.id === projectId);
 
@@ -324,13 +326,13 @@ export function MonitorPane({ onOpenAccount }: { onOpenAccount: () => void }) {
         </div>
       </header>
 
-      {loading && !snapshot ? (
+      {loading && !visibleSnapshot ? (
         <div className="monitor-loading" aria-live="polite">
           <span className="monitor-loading-ring" aria-hidden="true" />
           <strong>Checking production traffic…</strong>
           <span>Routing and health first; spend follows independently.</span>
         </div>
-      ) : error && !snapshot ? (
+      ) : error && !visibleSnapshot ? (
         <div className="monitor-blocked" role="alert">
           <AlertTriangleIcon aria-hidden="true" size={20} />
           <div>
@@ -341,7 +343,7 @@ export function MonitorPane({ onOpenAccount }: { onOpenAccount: () => void }) {
             <button type="button" onClick={onOpenAccount}>Sign in</button>
           )}
         </div>
-      ) : snapshot ? (
+      ) : visibleSnapshot ? (
         <>
           <section className={`monitor-verdict ${state.tone}`} aria-live="polite">
             <div className="monitor-verdict-icon">
@@ -356,11 +358,11 @@ export function MonitorPane({ onOpenAccount }: { onOpenAccount: () => void }) {
               <h2>{state.label}</h2>
               <p>{state.detail}</p>
             </div>
-            <time dateTime={snapshot.fetched_at}>Updated {relativeTime(snapshot.fetched_at)}</time>
+            <time dateTime={visibleSnapshot.fetched_at}>Updated {relativeTime(visibleSnapshot.fetched_at)}</time>
           </section>
 
           {error && <div className="monitor-stale" role="status">Showing the last local snapshot. {error}</div>}
-          {snapshot.warnings.length > 0 && (
+          {visibleSnapshot.warnings.length > 0 && (
             <div className="monitor-warning" role="status">
               Traffic health is current. Some spend context is unavailable.
             </div>
@@ -369,12 +371,12 @@ export function MonitorPane({ onOpenAccount }: { onOpenAccount: () => void }) {
           <section className="monitor-metrics" aria-label="Production summary">
             <article>
               <span>Requests</span>
-              <strong>{count.format(snapshot.health.total_requests)}</strong>
+              <strong>{count.format(visibleSnapshot.health.total_requests)}</strong>
               <small>Selected project</small>
             </article>
             <article>
               <span>Estimated spend</span>
-              <strong>{snapshot.billing ? money.format(snapshot.billing.summary.estimated_cost_usd) : "—"}</strong>
+              <strong>{visibleSnapshot.billing ? money.format(visibleSnapshot.billing.summary.estimated_cost_usd) : "—"}</strong>
               <small>All org projects</small>
             </article>
             <article className={state.errors > 0 ? "attention" : ""}>

--- a/apps/homescreen/app/components/MonitorPane.tsx
+++ b/apps/homescreen/app/components/MonitorPane.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  ClipboardCheckIcon,
+  CopyIcon,
+  RefreshCwIcon,
+} from "lucide-react";
+import {
+  buildWorkloadRows,
+  cacheReusePercent,
+  displayModelName,
+  monitoringState,
+  topModelRows,
+} from "../lib/monitoring.mjs";
+
+type ReportingProject = {
+  id: string;
+  slug: string;
+  name: string;
+  created_at: string;
+};
+
+type ReportingProjectsResponse = {
+  org_id: string;
+  projects: ReportingProject[];
+};
+
+type RoutingStatusEntry = {
+  workload_id: string;
+  display_name: string;
+  environment: string | null;
+  route_mode: "primary" | "understudy" | "passthrough";
+  active_traffic_pct: number;
+  provider_label: string | null;
+  model: string | null;
+  updated_at: string;
+};
+
+type ProviderHealthEntry = {
+  provider: string;
+  workload: string;
+  model: string;
+  request_count: number;
+  error_5xx_count: number;
+  error_5xx_rate: number;
+  timeout_count: number;
+  fallback_count: number;
+  last_failing_at: string | null;
+  example_request_ids: string[];
+};
+
+type TokenBreakdown = {
+  input_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  output_tokens: number;
+  reasoning_output_tokens: number;
+  total_tokens: number;
+};
+
+type MonitoringSnapshot = {
+  project_id: string;
+  window: string;
+  fetched_at: string;
+  source: string;
+  routing: {
+    project_id: string;
+    workloads: RoutingStatusEntry[];
+    workload_count: number;
+    generated_at: string;
+  };
+  health: {
+    project_id: string;
+    window: string;
+    window_start: string;
+    window_end: string;
+    total_requests: number;
+    total_errors: number;
+    providers: ProviderHealthEntry[];
+    generated_at: string;
+  };
+  billing: {
+    summary: {
+      org_id: string;
+      from: string;
+      to: string;
+      tokens: TokenBreakdown;
+      metered_requests: number;
+      priced_events: number;
+      estimated_cost_usd: number;
+      blended_price_per_mtok: number;
+    };
+  } | null;
+  usage_by_model: {
+    rows: Array<{
+      provider: string;
+      served_model: string;
+      requests: number;
+      tokens: TokenBreakdown;
+      cost_usd: number;
+    }>;
+  } | null;
+  warnings: string[];
+};
+
+const WINDOWS = [
+  ["30m", "30 min"],
+  ["1h", "1 hour"],
+  ["6h", "6 hours"],
+  ["12h", "12 hours"],
+  ["24h", "24 hours"],
+] as const;
+const CACHE_PREFIX = "understudy.monitor.snapshot.v1";
+const PROJECT_KEY = "understudy.monitor.project.v1";
+const WINDOW_KEY = "understudy.monitor.window.v1";
+
+const count = new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 });
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function cacheKey(projectId: string, window: string) {
+  return `${CACHE_PREFIX}.${projectId}.${window}`;
+}
+
+function readCachedSnapshot(projectId: string, window: string): MonitoringSnapshot | null {
+  try {
+    const raw = localStorage.getItem(cacheKey(projectId, window));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as MonitoringSnapshot;
+    return parsed.project_id === projectId && parsed.window === window ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function relativeTime(value: string) {
+  const elapsed = Math.max(0, Date.now() - new Date(value).getTime());
+  if (elapsed < 60_000) return "just now";
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+}
+
+function routeLabel(mode: string, percent: number) {
+  if (mode === "passthrough") return "Direct";
+  if (percent >= 100) return "Understudy · all traffic";
+  return `Understudy · ${percent}%`;
+}
+
+export function MonitorPane({ onOpenAccount }: { onOpenAccount: () => void }) {
+  const [projects, setProjects] = useState<ReportingProject[]>([]);
+  const [projectId, setProjectId] = useState("");
+  const [window, setWindow] = useState("12h");
+  const [snapshot, setSnapshot] = useState<MonitoringSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const requestSequence = useRef(0);
+
+  const loadSnapshot = useCallback(async (
+    nextProjectId: string,
+    nextWindow: string,
+    options: { preferCache?: boolean; background?: boolean } = {},
+  ) => {
+    if (!nextProjectId || !isTauri()) return;
+    const sequence = ++requestSequence.current;
+    const cached = options.preferCache ? readCachedSnapshot(nextProjectId, nextWindow) : null;
+    if (cached) {
+      setSnapshot(cached);
+      setLoading(false);
+    }
+    if (options.background) setRefreshing(true);
+    else if (!cached) setLoading(true);
+    setError(null);
+    try {
+      const next = await invoke<MonitoringSnapshot>("reporting_snapshot", {
+        projectId: nextProjectId,
+        window: nextWindow,
+      });
+      if (sequence !== requestSequence.current) return;
+      setSnapshot(next);
+      localStorage.setItem(cacheKey(nextProjectId, nextWindow), JSON.stringify(next));
+    } catch (nextError) {
+      if (sequence !== requestSequence.current) return;
+      setError(String(nextError));
+    } finally {
+      if (sequence === requestSequence.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isTauri()) {
+      setLoading(false);
+      setError("Production monitoring is available in the installed Desktop app.");
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await invoke<ReportingProjectsResponse>("reporting_projects");
+        if (cancelled) return;
+        setProjects(response.projects);
+        const storedProject = localStorage.getItem(PROJECT_KEY);
+        const selected = response.projects.find((project) => project.id === storedProject)
+          ?? response.projects[0];
+        const storedWindow = localStorage.getItem(WINDOW_KEY);
+        const selectedWindow = WINDOWS.some(([value]) => value === storedWindow)
+          ? storedWindow!
+          : "12h";
+        setWindow(selectedWindow);
+        if (!selected) {
+          setLoading(false);
+          setError("No projects are available for this organization yet.");
+          return;
+        }
+        setProjectId(selected.id);
+        await loadSnapshot(selected.id, selectedWindow, { preferCache: true });
+      } catch (nextError) {
+        if (!cancelled) {
+          setLoading(false);
+          setError(String(nextError));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadSnapshot]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const timer = globalThis.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        void loadSnapshot(projectId, window, { background: true });
+      }
+    }, 60_000);
+    return () => globalThis.clearInterval(timer);
+  }, [loadSnapshot, projectId, window]);
+
+  const state = useMemo(() => monitoringState(snapshot?.health), [snapshot]);
+  const workloads = useMemo(
+    () => buildWorkloadRows(snapshot?.routing.workloads, snapshot?.health.providers),
+    [snapshot],
+  );
+  const models = useMemo(
+    () => topModelRows(snapshot?.usage_by_model?.rows ?? [], 6),
+    [snapshot],
+  );
+  const reuse = cacheReusePercent(snapshot?.billing?.summary);
+  const maxModelCost = Math.max(0, ...models.map((model) => model.cost_usd));
+  const selectedProject = projects.find((project) => project.id === projectId);
+
+  const copyRequestId = async (requestId: string) => {
+    await navigator.clipboard.writeText(requestId);
+    setCopied(requestId);
+    globalThis.setTimeout(() => setCopied((current) => current === requestId ? null : current), 1800);
+  };
+
+  return (
+    <section className="monitor-pane settle" aria-labelledby="monitor-title">
+      <header className="monitor-topbar">
+        <div>
+          <span className="monitor-kicker">Production monitor</span>
+          <h1 id="monitor-title">{selectedProject?.name ?? "Your traffic"}</h1>
+          <p>Customer-safe aggregates only. Prompts and responses never load here.</p>
+        </div>
+        <div className="monitor-controls">
+          {projects.length > 1 && (
+            <label>
+              <span className="sr-only">Project</span>
+              <select
+                value={projectId}
+                onChange={(event) => {
+                  const next = event.target.value;
+                  setProjectId(next);
+                  localStorage.setItem(PROJECT_KEY, next);
+                  void loadSnapshot(next, window, { preferCache: true });
+                }}
+              >
+                {projects.map((project) => (
+                  <option key={project.id} value={project.id}>{project.name}</option>
+                ))}
+              </select>
+            </label>
+          )}
+          <label>
+            <span className="sr-only">Time window</span>
+            <select
+              value={window}
+              onChange={(event) => {
+                const next = event.target.value;
+                setWindow(next);
+                localStorage.setItem(WINDOW_KEY, next);
+                void loadSnapshot(projectId, next, { preferCache: true });
+              }}
+            >
+              {WINDOWS.map(([value, label]) => (
+                <option key={value} value={value}>Last {label}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="monitor-refresh"
+            aria-label="Refresh production monitor"
+            disabled={!projectId || refreshing}
+            onClick={() => void loadSnapshot(projectId, window, { background: true })}
+          >
+            <RefreshCwIcon aria-hidden="true" size={15} className={refreshing ? "spinning" : ""} />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      {loading && !snapshot ? (
+        <div className="monitor-loading" aria-live="polite">
+          <span className="monitor-loading-ring" aria-hidden="true" />
+          <strong>Checking production traffic…</strong>
+          <span>Routing and health first; spend follows independently.</span>
+        </div>
+      ) : error && !snapshot ? (
+        <div className="monitor-blocked" role="alert">
+          <AlertTriangleIcon aria-hidden="true" size={20} />
+          <div>
+            <strong>Monitoring could not open</strong>
+            <p>{error}</p>
+          </div>
+          {error.toLowerCase().includes("sign in") && (
+            <button type="button" onClick={onOpenAccount}>Sign in</button>
+          )}
+        </div>
+      ) : snapshot ? (
+        <>
+          <section className={`monitor-verdict ${state.tone}`} aria-live="polite">
+            <div className="monitor-verdict-icon">
+              {state.tone === "healthy" ? (
+                <CheckCircle2Icon aria-hidden="true" size={25} strokeWidth={1.6} />
+              ) : (
+                <AlertTriangleIcon aria-hidden="true" size={25} strokeWidth={1.6} />
+              )}
+            </div>
+            <div>
+              <span>Right now</span>
+              <h2>{state.label}</h2>
+              <p>{state.detail}</p>
+            </div>
+            <time dateTime={snapshot.fetched_at}>Updated {relativeTime(snapshot.fetched_at)}</time>
+          </section>
+
+          {error && <div className="monitor-stale" role="status">Showing the last local snapshot. {error}</div>}
+          {snapshot.warnings.length > 0 && (
+            <div className="monitor-warning" role="status">
+              Traffic health is current. Some spend context is unavailable.
+            </div>
+          )}
+
+          <section className="monitor-metrics" aria-label="Production summary">
+            <article>
+              <span>Requests</span>
+              <strong>{count.format(snapshot.health.total_requests)}</strong>
+              <small>Selected project</small>
+            </article>
+            <article>
+              <span>Estimated spend</span>
+              <strong>{snapshot.billing ? money.format(snapshot.billing.summary.estimated_cost_usd) : "—"}</strong>
+              <small>All org projects</small>
+            </article>
+            <article className={state.errors > 0 ? "attention" : ""}>
+              <span>Provider failures</span>
+              <strong>{count.format(state.errors)}</strong>
+              <small>{state.timeouts} timeouts · {state.fallbacks} fallbacks</small>
+            </article>
+            <article>
+              <span>Input reused</span>
+              <strong>{reuse === null ? "—" : `${reuse.toFixed(1)}%`}</strong>
+              <small>Org-wide prompt cache</small>
+            </article>
+          </section>
+
+          <div className="monitor-grid">
+            <section className="monitor-panel monitor-workloads">
+              <header>
+                <div>
+                  <span className="monitor-kicker">Traffic by workload</span>
+                  <h2>What is live</h2>
+                </div>
+                <span>{workloads.length} workloads</span>
+              </header>
+              <div className="monitor-workload-list">
+                {workloads.length === 0 ? (
+                  <p className="monitor-empty">No workloads are configured yet.</p>
+                ) : workloads.map((workload) => {
+                  const hasProblem = workload.errors > 0 || workload.timeouts > 0;
+                  const hasFallback = workload.fallbacks > 0;
+                  return (
+                    <article key={workload.workloadId} className={hasProblem ? "attention" : hasFallback ? "watch" : ""}>
+                      <div className="monitor-workload-main">
+                        <span className="monitor-health-dot" aria-hidden="true" />
+                        <div>
+                          <strong>{workload.name}</strong>
+                          <small>{routeLabel(workload.routeMode, workload.trafficPercent)}{workload.model ? ` · ${displayModelName(workload.model)}` : ""}</small>
+                        </div>
+                      </div>
+                      <div className="monitor-workload-count">
+                        <strong>{count.format(workload.requests)}</strong>
+                        <span>requests</span>
+                      </div>
+                      <div className="monitor-workload-state">
+                        {hasProblem
+                          ? `${workload.errors} errors · ${workload.timeouts} timeouts`
+                          : hasFallback
+                            ? `${workload.fallbacks} fallbacks`
+                            : workload.requests > 0 ? "Healthy" : "No traffic"}
+                      </div>
+                      {workload.requestIds.length > 0 && (
+                        <div className="monitor-request-ids">
+                          <span>Affected requests</span>
+                          {workload.requestIds.map((requestId) => (
+                            <button key={requestId} type="button" onClick={() => void copyRequestId(requestId)}>
+                              <code>{requestId}</code>
+                              {copied === requestId
+                                ? <ClipboardCheckIcon aria-hidden="true" size={12} />
+                                : <CopyIcon aria-hidden="true" size={12} />}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="monitor-panel monitor-models">
+              <header>
+                <div>
+                  <span className="monitor-kicker">Spend-weighted</span>
+                  <h2>Models used</h2>
+                </div>
+                <span>Org-wide</span>
+              </header>
+              {models.length === 0 ? (
+                <p className="monitor-empty">Model spend is not available for this window.</p>
+              ) : (
+                <div className="monitor-model-list">
+                  {models.map((model) => (
+                    <article key={`${model.provider}:${model.served_model}`}>
+                      <div>
+                        <strong>{displayModelName(model.served_model)}</strong>
+                        <span>{count.format(model.requests)} requests</span>
+                      </div>
+                      <b>{money.format(model.cost_usd)}</b>
+                      <i aria-hidden="true"><span style={{ width: `${maxModelCost > 0 ? (model.cost_usd / maxModelCost) * 100 : 0}%` }} /></i>
+                    </article>
+                  ))}
+                </div>
+              )}
+              <footer>
+                Ranked by spend so the highest-leverage traffic is always first.
+              </footer>
+            </section>
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import {
+  ActivityIcon,
   ArchiveIcon,
   ArchiveRestoreIcon,
   ArrowLeftIcon,
@@ -24,6 +25,7 @@ export type PaneId =
   | "capture"
   | "account"
   | "usage"
+  | "monitor"
   | "traces"
   | "rlm"
   | "training-evals"
@@ -217,6 +219,13 @@ export function Sidebar({
       </Dialog>
 
       <div className="nav-spacer" />
+      <button
+        className={"nav-monitor" + (active === "monitor" ? " active" : "")}
+        onClick={() => onSelect("monitor")}
+      >
+        <ActivityIcon className="nav-icon" aria-hidden="true" size={16} strokeWidth={1.7} />
+        <span>Monitor</span>
+      </button>
       <button
         className={"nav-account" + (active === "account" ? " active" : "")}
         onClick={() => onSelect("account")}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -590,6 +590,31 @@ select,
   flex: 1;
 }
 
+.nav-monitor {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: calc(100% - 4px);
+  min-height: 36px;
+  margin: 0 2px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--r-control);
+  background: transparent;
+  color: var(--text-2);
+  font-size: 12px;
+  text-align: left;
+}
+.nav-monitor:hover,
+.nav-monitor.active {
+  border-color: var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+}
+.nav-monitor.active .nav-icon {
+  color: var(--mb-cyan);
+}
+
 .nav-account {
   display: flex;
   align-items: center;
@@ -6072,6 +6097,276 @@ select,
   overflow-wrap: anywhere;
 }
 .experiment-notice.error { border-color: color-mix(in srgb, var(--error) 45%, var(--border)); color: var(--error); }
+
+/* ---------- Customer production monitor ---------- */
+.monitor-pane {
+  width: min(1180px, 100%);
+  min-height: 100%;
+  margin: 0 auto;
+  padding-bottom: 24px;
+}
+.monitor-topbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+.monitor-topbar h1 {
+  margin: 5px 0 3px;
+  font-size: clamp(22px, 3vw, 31px);
+  font-weight: 550;
+  letter-spacing: -0.035em;
+}
+.monitor-topbar p {
+  margin: 0;
+  color: var(--text-3);
+  font-size: 11px;
+}
+.monitor-kicker {
+  color: var(--mb-cyan);
+  font: 9px/1.2 var(--mono);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+.monitor-controls {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.monitor-controls select,
+.monitor-refresh {
+  height: 34px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text-2);
+  font-size: 11px;
+}
+.monitor-controls select {
+  max-width: 190px;
+  padding: 0 28px 0 10px;
+}
+.monitor-refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 11px;
+}
+.monitor-refresh:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--mb-cyan) 34%, var(--border));
+  color: var(--text);
+}
+.monitor-refresh:disabled { opacity: 0.5; }
+.monitor-refresh .spinning { animation: monitor-spin 900ms linear infinite; }
+@keyframes monitor-spin { to { transform: rotate(360deg); } }
+
+.monitor-loading,
+.monitor-blocked {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  min-height: 420px;
+  color: var(--text-2);
+}
+.monitor-loading {
+  flex-direction: column;
+}
+.monitor-loading strong { color: var(--text); font-size: 14px; font-weight: 500; }
+.monitor-loading > span:last-child { color: var(--text-3); font-size: 11px; }
+.monitor-loading-ring {
+  width: 34px;
+  height: 34px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 18%, transparent);
+  border-top-color: var(--mb-cyan);
+  border-radius: 50%;
+  animation: monitor-spin 1s linear infinite;
+}
+.monitor-blocked {
+  min-height: 280px;
+}
+.monitor-blocked > svg { color: var(--c-warn); }
+.monitor-blocked strong { color: var(--text); font-weight: 550; }
+.monitor-blocked p { max-width: 560px; margin: 5px 0 0; font-size: 11px; line-height: 1.5; }
+.monitor-blocked button {
+  min-height: 34px;
+  border: 1px solid color-mix(in srgb, var(--mb-cyan) 40%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mb-cyan) 12%, transparent);
+  padding: 0 12px;
+  color: var(--text);
+}
+
+.monitor-verdict {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  min-height: 92px;
+  border: 1px solid color-mix(in srgb, var(--c-ok) 26%, var(--border));
+  border-radius: 13px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--c-ok) 7%, transparent), transparent 48%);
+  padding: 15px 18px;
+}
+.monitor-verdict.attention {
+  border-color: color-mix(in srgb, var(--error) 38%, var(--border));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--error) 7%, transparent), transparent 48%);
+}
+.monitor-verdict.watch,
+.monitor-verdict.quiet {
+  border-color: color-mix(in srgb, var(--c-warn) 30%, var(--border));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--c-warn) 6%, transparent), transparent 48%);
+}
+.monitor-verdict-icon {
+  display: grid;
+  width: 45px;
+  height: 45px;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--c-ok) 11%, transparent);
+  color: var(--c-ok);
+}
+.monitor-verdict.attention .monitor-verdict-icon { background: color-mix(in srgb, var(--error) 11%, transparent); color: var(--error); }
+.monitor-verdict.watch .monitor-verdict-icon,
+.monitor-verdict.quiet .monitor-verdict-icon { background: color-mix(in srgb, var(--c-warn) 10%, transparent); color: var(--c-warn); }
+.monitor-verdict span,
+.monitor-verdict time {
+  color: var(--text-3);
+  font: 9px/1.2 var(--mono);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.monitor-verdict h2 { margin: 4px 0 2px; font-size: 19px; font-weight: 550; letter-spacing: -0.025em; }
+.monitor-verdict p { margin: 0; color: var(--text-2); font-size: 11px; }
+.monitor-verdict time { align-self: start; padding-top: 3px; }
+.monitor-stale,
+.monitor-warning {
+  margin-top: 8px;
+  border: 1px solid color-mix(in srgb, var(--c-warn) 26%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--c-warn) 5%, transparent);
+  padding: 8px 10px;
+  color: color-mix(in srgb, var(--c-warn) 68%, var(--text));
+  font-size: 10px;
+}
+
+.monitor-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.monitor-metrics article {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+  padding: 13px 15px;
+  border-right: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+}
+.monitor-metrics article:last-child { border-right: 0; }
+.monitor-metrics article.attention { background: color-mix(in srgb, var(--error) 5%, var(--surface)); }
+.monitor-metrics span,
+.monitor-metrics small { overflow: hidden; color: var(--text-3); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.monitor-metrics span { font-family: var(--mono); letter-spacing: 0.04em; text-transform: uppercase; }
+.monitor-metrics strong { font: 500 22px/1.05 var(--mono); font-variant-numeric: tabular-nums; }
+
+.monitor-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.75fr);
+  gap: 12px;
+  margin-top: 12px;
+}
+.monitor-panel {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 86%, transparent);
+  overflow: hidden;
+}
+.monitor-panel > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 58px;
+  border-bottom: 1px solid var(--border);
+  padding: 11px 14px;
+}
+.monitor-panel > header h2 { margin: 4px 0 0; font-size: 14px; font-weight: 550; }
+.monitor-panel > header > span { color: var(--text-3); font: 9px/1.2 var(--mono); }
+.monitor-empty { margin: 0; padding: 26px 15px; color: var(--text-3); font-size: 11px; }
+
+.monitor-workload-list { display: grid; max-height: 340px; overflow-y: auto; }
+.monitor-workload-list > article {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 82px 120px;
+  align-items: center;
+  gap: 12px;
+  min-height: 60px;
+  border-bottom: 1px solid var(--border);
+  padding: 9px 13px;
+}
+.monitor-workload-list > article:last-child { border-bottom: 0; }
+.monitor-workload-main { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.monitor-workload-main > div { display: grid; min-width: 0; gap: 4px; }
+.monitor-workload-main strong,
+.monitor-workload-main small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.monitor-workload-main strong { font-size: 11px; font-weight: 550; }
+.monitor-workload-main small { color: var(--text-3); font: 8px/1.2 var(--mono); }
+.monitor-health-dot { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--c-ok); box-shadow: 0 0 8px color-mix(in srgb, var(--c-ok) 46%, transparent); }
+.monitor-workload-list > article.attention .monitor-health-dot { background: var(--error); box-shadow: 0 0 8px color-mix(in srgb, var(--error) 50%, transparent); }
+.monitor-workload-list > article.watch .monitor-health-dot { background: var(--c-warn); box-shadow: 0 0 8px color-mix(in srgb, var(--c-warn) 50%, transparent); }
+.monitor-workload-count { display: grid; gap: 3px; text-align: right; }
+.monitor-workload-count strong { font: 500 12px/1.2 var(--mono); }
+.monitor-workload-count span,
+.monitor-workload-state { color: var(--text-3); font: 8px/1.2 var(--mono); }
+.monitor-workload-state { text-align: right; }
+.monitor-workload-list > article.attention .monitor-workload-state { color: var(--error); }
+.monitor-workload-list > article.watch .monitor-workload-state { color: var(--c-warn); }
+.monitor-request-ids {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin: -1px 0 2px 17px;
+}
+.monitor-request-ids > span { margin-right: 3px; color: var(--text-3); font: 8px/1.2 var(--mono); text-transform: uppercase; }
+.monitor-request-ids button { display: inline-flex; align-items: center; gap: 5px; max-width: 180px; border: 1px solid var(--border); border-radius: 999px; background: var(--bg); padding: 4px 7px; color: var(--text-3); }
+.monitor-request-ids button:hover { border-color: color-mix(in srgb, var(--mb-cyan) 30%, var(--border)); color: var(--text); }
+.monitor-request-ids code { overflow: hidden; font: 8px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+
+.monitor-model-list { display: grid; padding: 5px 13px 9px; }
+.monitor-model-list article { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 5px 10px; padding: 9px 0; border-bottom: 1px solid var(--border); }
+.monitor-model-list article:last-child { border-bottom: 0; }
+.monitor-model-list article > div { display: grid; min-width: 0; gap: 3px; }
+.monitor-model-list strong { overflow: hidden; font: 500 9px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.monitor-model-list article span { color: var(--text-3); font: 8px/1.2 var(--mono); }
+.monitor-model-list b { font: 500 10px/1.2 var(--mono); }
+.monitor-model-list i { grid-column: 1 / -1; display: block; height: 2px; overflow: hidden; border-radius: 99px; background: var(--border); }
+.monitor-model-list i span { display: block; height: 100%; border-radius: inherit; background: var(--mb-cyan); }
+.monitor-models footer { border-top: 1px solid var(--border); padding: 9px 13px; color: var(--text-3); font-size: 9px; line-height: 1.4; }
+
+@media (prefers-reduced-motion: reduce) {
+  .monitor-refresh .spinning,
+  .monitor-loading-ring { animation-duration: 2.5s; }
+}
+
+@media (max-width: 900px) {
+  .monitor-topbar { align-items: flex-start; flex-direction: column; }
+  .monitor-controls { width: 100%; }
+  .monitor-controls label { flex: 1; }
+  .monitor-controls select { width: 100%; max-width: none; }
+  .monitor-metrics { grid-template-columns: 1fr 1fr; }
+  .monitor-metrics article:nth-child(2) { border-right: 0; }
+  .monitor-metrics article:nth-child(-n+2) { border-bottom: 1px solid var(--border); }
+  .monitor-grid { grid-template-columns: 1fr; }
+  .monitor-workload-list { max-height: none; }
+}
 
 @media (max-width: 900px) {
   .content:has(.supervision-review),

--- a/apps/homescreen/app/lib/monitoring.d.mts
+++ b/apps/homescreen/app/lib/monitoring.d.mts
@@ -1,0 +1,65 @@
+export type RoutingEntryLike = {
+  workload_id: string;
+  display_name?: string;
+  environment?: string | null;
+  route_mode: string;
+  active_traffic_pct?: number;
+  provider_label?: string | null;
+  model?: string | null;
+};
+
+export type HealthEntryLike = {
+  workload: string;
+  provider?: string;
+  model?: string;
+  request_count?: number;
+  error_5xx_count?: number;
+  timeout_count?: number;
+  fallback_count?: number;
+  example_request_ids?: string[];
+};
+
+export type WorkloadMonitorRow = {
+  workloadId: string;
+  name: string;
+  environment: string | null;
+  routeMode: string;
+  trafficPercent: number;
+  provider: string | null;
+  model: string | null;
+  requests: number;
+  errors: number;
+  timeouts: number;
+  fallbacks: number;
+  requestIds: string[];
+};
+
+export function buildWorkloadRows(
+  routingEntries?: RoutingEntryLike[],
+  healthEntries?: HealthEntryLike[],
+): WorkloadMonitorRow[];
+
+export function monitoringState(health?: {
+  total_requests?: number;
+  total_errors?: number;
+  providers?: HealthEntryLike[];
+}): {
+  tone: "attention" | "watch" | "quiet" | "healthy";
+  label: string;
+  detail: string;
+  errors: number;
+  timeouts: number;
+  fallbacks: number;
+};
+
+export function cacheReusePercent(summary?: {
+  tokens?: {
+    input_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+} | null): number | null;
+
+export function topModelRows<T extends { cost_usd?: number }>(rows?: T[], limit?: number): T[];
+
+export function displayModelName(value?: unknown): string;

--- a/apps/homescreen/app/lib/monitoring.d.mts
+++ b/apps/homescreen/app/lib/monitoring.d.mts
@@ -63,3 +63,9 @@ export function cacheReusePercent(summary?: {
 export function topModelRows<T extends { cost_usd?: number }>(rows?: T[], limit?: number): T[];
 
 export function displayModelName(value?: unknown): string;
+
+export function snapshotForSelection<T extends { project_id?: string; window?: string }>(
+  snapshot: T | null | undefined,
+  projectId: string,
+  window: string,
+): T | null;

--- a/apps/homescreen/app/lib/monitoring.mjs
+++ b/apps/homescreen/app/lib/monitoring.mjs
@@ -1,0 +1,131 @@
+export function buildWorkloadRows(routingEntries = [], healthEntries = []) {
+  const rows = new Map();
+
+  for (const route of routingEntries) {
+    rows.set(route.workload_id, {
+      workloadId: route.workload_id,
+      name: route.display_name || route.workload_id,
+      environment: route.environment ?? null,
+      routeMode: route.route_mode,
+      trafficPercent: Number(route.active_traffic_pct ?? 0),
+      provider: route.provider_label ?? null,
+      model: route.model ?? null,
+      requests: 0,
+      errors: 0,
+      timeouts: 0,
+      fallbacks: 0,
+      requestIds: [],
+    });
+  }
+
+  for (const health of healthEntries) {
+    const existing = rows.get(health.workload) ?? {
+      workloadId: health.workload,
+      name: health.workload,
+      environment: null,
+      routeMode: "unknown",
+      trafficPercent: 0,
+      provider: null,
+      model: null,
+      requests: 0,
+      errors: 0,
+      timeouts: 0,
+      fallbacks: 0,
+      requestIds: [],
+    };
+    existing.requests += Number(health.request_count ?? 0);
+    existing.errors += Number(health.error_5xx_count ?? 0);
+    existing.timeouts += Number(health.timeout_count ?? 0);
+    existing.fallbacks += Number(health.fallback_count ?? 0);
+    existing.provider ||= health.provider || null;
+    existing.model ||= health.model || null;
+    existing.requestIds = [...new Set([
+      ...existing.requestIds,
+      ...(health.example_request_ids ?? []),
+    ])].slice(0, 5);
+    rows.set(health.workload, existing);
+  }
+
+  return [...rows.values()].sort((left, right) => {
+    if (right.requests !== left.requests) return right.requests - left.requests;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function monitoringState(health) {
+  const requests = Number(health?.total_requests ?? 0);
+  const errors = Number(health?.total_errors ?? 0);
+  const timeouts = (health?.providers ?? []).reduce(
+    (sum, provider) => sum + Number(provider.timeout_count ?? 0),
+    0,
+  );
+  const fallbacks = (health?.providers ?? []).reduce(
+    (sum, provider) => sum + Number(provider.fallback_count ?? 0),
+    0,
+  );
+
+  if (errors > 0 || timeouts > 0) {
+    return {
+      tone: "attention",
+      label: "Needs attention",
+      detail: `${errors} errors · ${timeouts} timeouts`,
+      errors,
+      timeouts,
+      fallbacks,
+    };
+  }
+  if (fallbacks > 0) {
+    return {
+      tone: "watch",
+      label: "Healthy with fallbacks",
+      detail: `${fallbacks} requests used a fallback`,
+      errors,
+      timeouts,
+      fallbacks,
+    };
+  }
+  if (requests === 0) {
+    return {
+      tone: "quiet",
+      label: "No traffic yet",
+      detail: "No requests in this window",
+      errors,
+      timeouts,
+      fallbacks,
+    };
+  }
+  return {
+    tone: "healthy",
+    label: "Everything is green",
+    detail: "No provider errors, timeouts, or fallbacks",
+    errors,
+    timeouts,
+    fallbacks,
+  };
+}
+
+export function cacheReusePercent(summary) {
+  const tokens = summary?.tokens;
+  if (!tokens) return null;
+  const cached = Number(tokens.cache_read_input_tokens ?? 0);
+  const totalInput =
+    Number(tokens.input_tokens ?? 0) +
+    cached +
+    Number(tokens.cache_creation_input_tokens ?? 0);
+  if (totalInput <= 0) return null;
+  return Math.max(0, Math.min(100, (cached / totalInput) * 100));
+}
+
+export function topModelRows(rows = [], limit = 6) {
+  return [...rows]
+    .sort((left, right) => Number(right.cost_usd ?? 0) - Number(left.cost_usd ?? 0))
+    .slice(0, limit);
+}
+
+export function displayModelName(value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "Unknown model";
+  const path = raw.split("?")[0].replace(/\/+$/, "");
+  const segments = path.split(/[/:]/).filter(Boolean);
+  return segments.at(-1) || raw;
+}

--- a/apps/homescreen/app/lib/monitoring.mjs
+++ b/apps/homescreen/app/lib/monitoring.mjs
@@ -129,3 +129,10 @@ export function displayModelName(value) {
   const segments = path.split(/[/:]/).filter(Boolean);
   return segments.at(-1) || raw;
 }
+
+export function snapshotForSelection(snapshot, projectId, window) {
+  if (!snapshot) return null;
+  return snapshot.project_id === projectId && snapshot.window === window
+    ? snapshot
+    : null;
+}

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -11,6 +11,7 @@ import { ChatPane } from "./components/ChatPane";
 import { TracesPane } from "./components/TracesPane";
 import { AccountPane } from "./components/AccountPane";
 import { UsagePane } from "./components/UsagePane";
+import { MonitorPane } from "./components/MonitorPane";
 import { DownloadQrButton } from "./components/DownloadQrButton";
 import { isTrainingPane, TrainingPane } from "./components/TrainingPane";
 import { RlmPane } from "./components/RlmPane";
@@ -181,6 +182,7 @@ export default function Page() {
       "chat",
       "models",
       "account",
+      "monitor",
       "rlm",
     ];
     const hidden = [
@@ -304,6 +306,7 @@ export default function Page() {
           />
         )}
         {pane === "usage" && <UsagePane status={status} />}
+        {pane === "monitor" && <MonitorPane onOpenAccount={() => setPane("account")} />}
         {pane === "traces" && <TracesPane />}
       </main>
     </div>

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod mcp;
 mod metrics;
 mod models;
 mod moraine;
+mod reporting;
 mod residency;
 mod rlm;
 mod route_policy;
@@ -282,6 +283,8 @@ pub fn run() {
             commands::account_login_send,
             commands::account_login_code,
             commands::account_logout,
+            reporting::reporting_projects,
+            reporting::reporting_snapshot,
             commands::knowledge_dossiers,
             gepa::gepa_demo_run,
             gepa::gepa_load_run,

--- a/apps/homescreen/src-tauri/src/reporting.rs
+++ b/apps/homescreen/src-tauri/src/reporting.rs
@@ -1,0 +1,366 @@
+use chrono::{Duration as ChronoDuration, SecondsFormat, Utc};
+use reqwest::{Client, StatusCode};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use std::time::Duration;
+
+const MAX_PROJECT_PAGES: usize = 5;
+const PROJECT_PAGE_SIZE: usize = 100;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportingProject {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectPage {
+    projects: Vec<ReportingProject>,
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReportingProjectsResponse {
+    pub org_id: String,
+    pub projects: Vec<ReportingProject>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingStatusEntry {
+    pub workload_id: String,
+    pub display_name: String,
+    pub environment: Option<String>,
+    pub route_mode: String,
+    pub active_traffic_pct: u8,
+    pub provider_label: Option<String>,
+    pub model: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingStatusResponse {
+    pub project_id: String,
+    pub workloads: Vec<RoutingStatusEntry>,
+    pub workload_count: u64,
+    pub generated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderHealthEntry {
+    pub provider: String,
+    pub workload: String,
+    pub model: String,
+    pub request_count: u64,
+    pub error_5xx_count: u64,
+    pub error_5xx_rate: f64,
+    pub timeout_count: u64,
+    pub fallback_count: u64,
+    pub last_failing_at: Option<String>,
+    pub example_request_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderHealthResponse {
+    pub project_id: String,
+    pub window: String,
+    pub window_start: String,
+    pub window_end: String,
+    pub total_requests: u64,
+    pub total_errors: u64,
+    pub providers: Vec<ProviderHealthEntry>,
+    pub generated_at: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TokenBreakdown {
+    pub input_tokens: f64,
+    pub cache_read_input_tokens: f64,
+    pub cache_creation_input_tokens: f64,
+    pub output_tokens: f64,
+    pub reasoning_output_tokens: f64,
+    pub total_tokens: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillingSummary {
+    pub org_id: String,
+    pub from: String,
+    pub to: String,
+    pub tokens: TokenBreakdown,
+    pub metered_requests: f64,
+    pub priced_events: f64,
+    pub estimated_cost_usd: f64,
+    pub blended_price_per_mtok: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillingSummaryResponse {
+    pub summary: BillingSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageByModelRow {
+    pub provider: String,
+    pub served_model: String,
+    pub requests: f64,
+    pub tokens: TokenBreakdown,
+    pub cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageByModelResponse {
+    pub rows: Vec<UsageByModelRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MonitoringSnapshot {
+    pub project_id: String,
+    pub window: String,
+    pub fetched_at: String,
+    pub source: &'static str,
+    pub routing: RoutingStatusResponse,
+    pub health: ProviderHealthResponse,
+    pub billing: Option<BillingSummaryResponse>,
+    pub usage_by_model: Option<UsageByModelResponse>,
+    pub warnings: Vec<String>,
+}
+
+fn client() -> Result<Client, String> {
+    Client::builder()
+        .timeout(Duration::from_secs(20))
+        .user_agent("Understudy-Desktop/reporting")
+        .build()
+        .map_err(|_| "Could not prepare the monitoring connection.".to_string())
+}
+
+fn credentials() -> Result<crate::creds::ResolvedCredentials, String> {
+    let resolved = crate::creds::resolve()
+        .ok_or_else(|| "Sign in to Understudy to monitor production traffic.".to_string())?;
+    if resolved.org_id.is_none() {
+        return Err(
+            "Desktop could not choose an organization. Sign in again with the organization you want to monitor."
+                .to_string(),
+        );
+    }
+    Ok(resolved)
+}
+
+fn safe_path_id(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty()
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    {
+        return Err(format!("Invalid {label}."));
+    }
+    Ok(())
+}
+
+fn window_minutes(window: &str) -> Option<i64> {
+    match window {
+        "30m" => Some(30),
+        "1h" => Some(60),
+        "6h" => Some(6 * 60),
+        "12h" => Some(12 * 60),
+        "24h" => Some(24 * 60),
+        _ => None,
+    }
+}
+
+fn api_error(label: &str, status: StatusCode, body: &Value) -> String {
+    let message = body
+        .get("message")
+        .and_then(Value::as_str)
+        .filter(|message| !message.trim().is_empty())
+        .unwrap_or("The service could not complete this request.");
+    let request_id = body
+        .get("request_id")
+        .and_then(Value::as_str)
+        .filter(|request_id| !request_id.trim().is_empty());
+    match request_id {
+        Some(request_id) => format!(
+            "{label} failed ({}): {message} Request ID: {request_id}",
+            status.as_u16()
+        ),
+        None => format!("{label} failed ({}): {message}", status.as_u16()),
+    }
+}
+
+async fn get_json<T: DeserializeOwned>(
+    client: &Client,
+    api_key: &str,
+    url: &str,
+    query: &[(&str, String)],
+    label: &str,
+) -> Result<T, String> {
+    let response = client
+        .get(url)
+        .bearer_auth(api_key)
+        .query(query)
+        .send()
+        .await
+        .map_err(|error| {
+            if error.is_timeout() {
+                format!("{label} timed out. Try refreshing in a moment.")
+            } else {
+                format!("{label} could not reach Understudy.")
+            }
+        })?;
+    let status = response.status();
+    let body = response
+        .json::<Value>()
+        .await
+        .map_err(|_| format!("{label} returned an unreadable response."))?;
+    if !status.is_success() {
+        return Err(api_error(label, status, &body));
+    }
+    serde_json::from_value(body).map_err(|_| format!("{label} returned an unexpected response."))
+}
+
+#[tauri::command]
+pub async fn reporting_projects() -> Result<ReportingProjectsResponse, String> {
+    let resolved = credentials()?;
+    let org_id = resolved.org_id.clone().expect("checked above");
+    safe_path_id(&org_id, "organization")?;
+    let client = client()?;
+    let base = resolved.gateway_url.trim_end_matches('/');
+    let url = format!("{base}/admin/v1/orgs/{org_id}/projects");
+    let mut projects = Vec::new();
+    let mut cursor: Option<String> = None;
+
+    for _ in 0..MAX_PROJECT_PAGES {
+        let mut query = vec![("limit", PROJECT_PAGE_SIZE.to_string())];
+        if let Some(value) = cursor.as_ref() {
+            query.push(("cursor", value.clone()));
+        }
+        let page: ProjectPage =
+            get_json(&client, &resolved.api_key, &url, &query, "Projects").await?;
+        projects.extend(page.projects);
+        cursor = page.cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    Ok(ReportingProjectsResponse { org_id, projects })
+}
+
+#[tauri::command]
+pub async fn reporting_snapshot(
+    project_id: String,
+    window: Option<String>,
+) -> Result<MonitoringSnapshot, String> {
+    safe_path_id(&project_id, "project")?;
+    let window = window.unwrap_or_else(|| "12h".to_string());
+    let minutes = window_minutes(&window)
+        .ok_or_else(|| "Choose a monitoring window between 30 minutes and 24 hours.".to_string())?;
+    let resolved = credentials()?;
+    let org_id = resolved.org_id.clone().expect("checked above");
+    safe_path_id(&org_id, "organization")?;
+
+    let now = Utc::now();
+    let from =
+        (now - ChronoDuration::minutes(minutes)).to_rfc3339_opts(SecondsFormat::Millis, true);
+    let to = now.to_rfc3339_opts(SecondsFormat::Millis, true);
+    let fetched_at = to.clone();
+    let base = resolved.gateway_url.trim_end_matches('/');
+    let project_base = format!("{base}/admin/v1/orgs/{org_id}/projects/{project_id}");
+    let billing_base = format!("{base}/admin/v1/orgs/{org_id}/billing");
+    let routing_url = format!("{project_base}/routing-status");
+    let health_url = format!("{project_base}/provider-health");
+    let billing_url = format!("{billing_base}/summary");
+    let models_url = format!("{billing_base}/usage-by-model");
+    let client = client()?;
+    let empty: Vec<(&str, String)> = Vec::new();
+    let health_query = vec![("window", window.clone())];
+    let billing_query = vec![("from", from), ("to", to)];
+
+    let routing_future = get_json::<RoutingStatusResponse>(
+        &client,
+        &resolved.api_key,
+        &routing_url,
+        &empty,
+        "Routing status",
+    );
+    let health_future = get_json::<ProviderHealthResponse>(
+        &client,
+        &resolved.api_key,
+        &health_url,
+        &health_query,
+        "Traffic health",
+    );
+    let billing_future = get_json::<BillingSummaryResponse>(
+        &client,
+        &resolved.api_key,
+        &billing_url,
+        &billing_query,
+        "Spend summary",
+    );
+    let models_future = get_json::<UsageByModelResponse>(
+        &client,
+        &resolved.api_key,
+        &models_url,
+        &billing_query,
+        "Model usage",
+    );
+    let (routing, health, billing, usage_by_model) =
+        tokio::join!(routing_future, health_future, billing_future, models_future);
+    let routing = routing?;
+    let health = health?;
+    let mut warnings = Vec::new();
+    let billing = billing.map_err(|error| warnings.push(error)).ok();
+    let usage_by_model = usage_by_model.map_err(|error| warnings.push(error)).ok();
+
+    Ok(MonitoringSnapshot {
+        project_id,
+        window,
+        fetched_at,
+        source: "understudy-admin-api",
+        routing,
+        health,
+        billing,
+        usage_by_model,
+        warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn monitoring_windows_are_bounded_and_explicit() {
+        assert_eq!(window_minutes("30m"), Some(30));
+        assert_eq!(window_minutes("12h"), Some(720));
+        assert_eq!(window_minutes("24h"), Some(1_440));
+        assert_eq!(window_minutes("25h"), None);
+        assert_eq!(window_minutes("all"), None);
+    }
+
+    #[test]
+    fn path_ids_reject_path_or_query_injection() {
+        assert!(safe_path_id("proj_01ABC", "project").is_ok());
+        assert!(safe_path_id("proj-one", "project").is_ok());
+        assert!(safe_path_id("../other", "project").is_err());
+        assert!(safe_path_id("proj?window=24h", "project").is_err());
+    }
+
+    #[test]
+    fn api_errors_preserve_request_id_without_response_payloads() {
+        let error = api_error(
+            "Traffic health",
+            StatusCode::BAD_GATEWAY,
+            &json!({
+                "message": "Could not load provider health.",
+                "request_id": "req_safe_123",
+                "secret": "must-not-appear"
+            }),
+        );
+        assert!(error.contains("req_safe_123"));
+        assert!(error.contains("Could not load provider health."));
+        assert!(!error.contains("must-not-appear"));
+    }
+}

--- a/tests/monitoring.test.mjs
+++ b/tests/monitoring.test.mjs
@@ -5,6 +5,7 @@ import {
   cacheReusePercent,
   displayModelName,
   monitoringState,
+  snapshotForSelection,
   topModelRows,
 } from "../apps/homescreen/app/lib/monitoring.mjs";
 
@@ -100,4 +101,11 @@ test("model labels hide provider routing namespaces", () => {
   assert.equal(displayModelName("accounts/vendor/models/glm-5p2"), "glm-5p2");
   assert.equal(displayModelName("zai-org/glm-5.2"), "glm-5.2");
   assert.equal(displayModelName("gemma-4-12b-it"), "gemma-4-12b-it");
+});
+
+test("monitor snapshots render only for the selected project and window", () => {
+  const snapshot = { project_id: "project-a", window: "12h", health: "green" };
+  assert.equal(snapshotForSelection(snapshot, "project-a", "12h"), snapshot);
+  assert.equal(snapshotForSelection(snapshot, "project-b", "12h"), null);
+  assert.equal(snapshotForSelection(snapshot, "project-a", "24h"), null);
 });

--- a/tests/monitoring.test.mjs
+++ b/tests/monitoring.test.mjs
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildWorkloadRows,
+  cacheReusePercent,
+  displayModelName,
+  monitoringState,
+  topModelRows,
+} from "../apps/homescreen/app/lib/monitoring.mjs";
+
+test("workload monitor joins aggregate health to routes and sorts by volume", () => {
+  const rows = buildWorkloadRows(
+    [
+      {
+        workload_id: "workload-a",
+        display_name: "Conversation updater",
+        route_mode: "primary",
+        active_traffic_pct: 100,
+        provider_label: "managed",
+        model: "model-a",
+      },
+      {
+        workload_id: "workload-b",
+        display_name: "Next steps",
+        route_mode: "understudy",
+        active_traffic_pct: 30,
+      },
+    ],
+    [
+      {
+        workload: "workload-b",
+        provider: "managed",
+        model: "model-b",
+        request_count: 80,
+        error_5xx_count: 1,
+        timeout_count: 1,
+        fallback_count: 2,
+        example_request_ids: ["req-1", "req-1", "req-2"],
+      },
+      {
+        workload: "workload-a",
+        request_count: 20,
+        error_5xx_count: 0,
+        timeout_count: 0,
+        fallback_count: 0,
+      },
+    ],
+  );
+
+  assert.equal(rows[0].name, "Next steps");
+  assert.equal(rows[0].requests, 80);
+  assert.equal(rows[0].provider, "managed");
+  assert.deepEqual(rows[0].requestIds, ["req-1", "req-2"]);
+  assert.equal(rows[1].trafficPercent, 100);
+});
+
+test("monitoring state only claims green when the exact health checks are clear", () => {
+  assert.equal(
+    monitoringState({ total_requests: 100, total_errors: 0, providers: [] }).label,
+    "Everything is green",
+  );
+  assert.equal(
+    monitoringState({
+      total_requests: 100,
+      total_errors: 0,
+      providers: [{ workload: "a", fallback_count: 2 }],
+    }).tone,
+    "watch",
+  );
+  assert.equal(
+    monitoringState({ total_requests: 0, total_errors: 0, providers: [] }).tone,
+    "quiet",
+  );
+});
+
+test("cache reuse is based on all input-side token classes", () => {
+  assert.equal(
+    cacheReusePercent({
+      tokens: {
+        input_tokens: 20,
+        cache_read_input_tokens: 70,
+        cache_creation_input_tokens: 10,
+      },
+    }),
+    70,
+  );
+  assert.equal(cacheReusePercent({ tokens: {} }), null);
+});
+
+test("top models are spend-weighted", () => {
+  const rows = topModelRows([
+    { served_model: "small", cost_usd: 1 },
+    { served_model: "large", cost_usd: 20 },
+    { served_model: "medium", cost_usd: 5 },
+  ], 2);
+  assert.deepEqual(rows.map((row) => row.served_model), ["large", "medium"]);
+});
+
+test("model labels hide provider routing namespaces", () => {
+  assert.equal(displayModelName("accounts/vendor/models/glm-5p2"), "glm-5p2");
+  assert.equal(displayModelName("zai-org/glm-5.2"), "glm-5.2");
+  assert.equal(displayModelName("gemma-4-12b-it"), "gemma-4-12b-it");
+});


### PR DESCRIPTION
## Outcome

Adds an organization-scoped production monitor to Desktop so signed-in customers can answer whether traffic is live and healthy without opening an internal Grafana dashboard.

## Product behavior

- shows a quiet `Everything is green` verdict only when exact provider error, timeout, and fallback checks are clear
- breaks traffic down by workload with routing state, model name, request volume, and copyable affected request IDs
- ranks model use by estimated spend and reports org-wide prompt-cache reuse
- scopes routing and health to the selected project; labels org-wide billing metrics explicitly
- restores an aggregate-only local snapshot immediately, refreshes every 60 seconds while visible, and preserves stale context through transient failures
- never downloads prompts or responses, never stores credentials in the frontend, and removes provider namespaces from model labels

## Architecture

The native Rust bridge reads the existing Understudy CLI credentials and calls the authenticated Admin APIs directly. Routing and traffic health are required; billing context is optional so spend outages cannot hide production health. No platform or ClickHouse credentials are added to Desktop.

## Verification

- `npm run check` — 387 tests passed, public skills and package smoke passed
- Desktop `npm run build` — production export passed
- `cargo test --lib` — 181 passed, 4 real-environment tests ignored
- native macOS debug bundle — authenticated visual QA passed
- live production API contract check — projects, routing, health, billing summary, and model usage returned expected shapes
- `git diff --check` and focused privacy/secret scan passed

## Follow-up

Production-traffic parity evaluation remains a separate slice: select or ask the agent to find edge cases, freeze a cohort, compare incumbent and candidate models, and monitor parity over time. This PR does not imply that comparison evidence exists yet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->