### PR TITLE
fix(desktop): preserve remote training and frontier evidence

### DIFF
--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -136,6 +136,11 @@ type FrontierComparison = {
     accuracy: number;
     macro_f1: number;
     latency_ms_p50: number;
+    latency_samples: {
+      requested: number;
+      completed: number;
+      failures: string[];
+    };
     failure_count: number;
     weakest_classes: {
       label: string;
@@ -681,29 +686,36 @@ export function LocalTrainingPanel({
         </div>
       )}
       {frontierComparison && frontierComparison.heldout.weakest_classes[0] && state.result.heldout.weakest_classes[0] && (
-        <EvaluationRadar
-          accuracy={state.result.heldout.accuracy}
-          macroF1={state.result.heldout.macro_f1}
-          baselineAccuracy={state.result.linear_baseline.accuracy}
-          baselineMacroF1={state.result.linear_baseline.macro_f1}
-          weakestClass={state.result.heldout.weakest_classes[0]}
-          latencyMs={state.result.heldout.latency_ms_p50}
-          modelSizeBytes={state.result.model.size_bytes}
-          failureCount={state.result.heldout.failure_count}
-          rowCount={state.result.heldout.row_count}
-          completedRuns={1}
-          requiredRuns={2}
-          frontier={{
-            name: "GLM 5.2",
-            accuracy: frontierComparison.heldout.accuracy,
-            macroF1: frontierComparison.heldout.macro_f1,
-            weakestClass: frontierComparison.heldout.weakest_classes[0],
-            latencyMs: frontierComparison.heldout.latency_ms_p50,
-            failureCount: frontierComparison.heldout.failure_count,
-            rowCount: frontierComparison.row_count,
-            costUsd: frontierComparison.spend.attributed_cost_usd,
-          }}
-        />
+        <>
+          <EvaluationRadar
+            accuracy={state.result.heldout.accuracy}
+            macroF1={state.result.heldout.macro_f1}
+            baselineAccuracy={state.result.linear_baseline.accuracy}
+            baselineMacroF1={state.result.linear_baseline.macro_f1}
+            weakestClass={state.result.heldout.weakest_classes[0]}
+            latencyMs={state.result.heldout.latency_ms_p50}
+            modelSizeBytes={state.result.model.size_bytes}
+            failureCount={state.result.heldout.failure_count}
+            rowCount={state.result.heldout.row_count}
+            completedRuns={1}
+            requiredRuns={2}
+            frontier={{
+              name: "GLM 5.2",
+              accuracy: frontierComparison.heldout.accuracy,
+              macroF1: frontierComparison.heldout.macro_f1,
+              weakestClass: frontierComparison.heldout.weakest_classes[0],
+              latencyMs: frontierComparison.heldout.latency_ms_p50,
+              failureCount: frontierComparison.heldout.failure_count,
+              rowCount: frontierComparison.row_count,
+              costUsd: frontierComparison.spend.attributed_cost_usd,
+            }}
+          />
+          {frontierComparison.heldout.latency_samples.completed < frontierComparison.heldout.latency_samples.requested && (
+            <small>
+              Frontier quality scored on the full held-out set. Latency median uses {frontierComparison.heldout.latency_samples.completed} of {frontierComparison.heldout.latency_samples.requested} responses because some auxiliary probes returned no completion.
+            </small>
+          )}
+        </>
       )}
       <div className="local-training-failures">
         <strong>Notable failures</strong>

--- a/apps/homescreen/src-tauri/src/remote_training.rs
+++ b/apps/homescreen/src-tauri/src/remote_training.rs
@@ -8,7 +8,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tauri::ipc::Channel;
-use tokio_util::io::ReaderStream;
 
 const DATASET_SCHEMA: &str = "understudy.capture_import.classification_dataset.v2";
 const PLAN_SCHEMA: &str = "understudy.remote_training.plan.v2";
@@ -894,13 +893,23 @@ async fn upload_artifact(artifact: &RemoteArtifact, intent: &Value) -> Result<()
         .and_then(|value| Url::parse(value).ok())
         .filter(|url| url.scheme() == "https")
         .ok_or_else(|| "The training service returned an unsafe upload URL.".to_string())?;
-    let file = tokio::fs::File::open(&artifact.path)
+    // Vercel Blob's signed PUT endpoint can acknowledge a chunked reqwest
+    // stream while persisting an empty object. The control plane caps remote
+    // artifacts, so send one fixed-size body to make the signed byte-length
+    // assertion unambiguous.
+    let body = tokio::fs::read(&artifact.path)
         .await
         .map_err(|_| format!("The {} artifact is unavailable.", artifact.artifact_role))?;
+    if body.len() as u64 != artifact.size_bytes {
+        return Err(format!(
+            "The {} artifact changed before upload.",
+            artifact.artifact_role
+        ));
+    }
     let mut request = client()?
         .put(url)
         .header("content-length", artifact.size_bytes)
-        .body(reqwest::Body::wrap_stream(ReaderStream::new(file)));
+        .body(body);
     if let Some(headers) = intent.get("required_headers").and_then(Value::as_object) {
         for (name, value) in headers {
             let header_name = reqwest::header::HeaderName::from_bytes(name.as_bytes())

--- a/src/local-classifier/frontier.ts
+++ b/src/local-classifier/frontier.ts
@@ -68,6 +68,11 @@ export type FrontierClassificationResult = {
     accuracy: number;
     macro_f1: number;
     latency_ms_p50: number;
+    latency_samples: {
+      requested: number;
+      completed: number;
+      failures: string[];
+    };
     per_class: Array<{
       label: string;
       precision: number;
@@ -676,19 +681,25 @@ export async function compareClassifierWithFrontier(
     });
     const latencyMs: number[] = [];
     const latencyResults: GatewayChunkResult[] = [];
+    const latencyFailures: string[] = [];
     for (let index = 0; index < latencySamples.length; index += 1) {
       const started = performance.now();
-      const result = await callGateway(
-        [latencySamples[index]!],
-        verified.labels,
-        modelId,
-        LATENCY_MAX_COMPLETION_TOKENS,
-        fetchImpl,
-        auth,
-        options.signal,
-      );
-      latencyMs.push(performance.now() - started);
-      latencyResults.push(result);
+      try {
+        const result = await callGateway(
+          [latencySamples[index]!],
+          verified.labels,
+          modelId,
+          LATENCY_MAX_COMPLETION_TOKENS,
+          fetchImpl,
+          auth,
+          options.signal,
+        );
+        latencyMs.push(performance.now() - started);
+        latencyResults.push(result);
+      } catch (error) {
+        if (options.signal?.aborted) throw error;
+        latencyFailures.push(error instanceof Error ? error.message.slice(0, 240) : String(error).slice(0, 240));
+      }
       options.onEvent?.({
         type: "phase",
         phase: "measuring",
@@ -724,12 +735,19 @@ export async function compareClassifierWithFrontier(
         destination: "Understudy managed GLM 5.2 on Fireworks",
         retention_expectation: "Fireworks-published zero data retention; Understudy comparison evidence excludes holdout text",
       },
-      heldout: computeHeldout(
-        verified.rows,
-        chunkResults.flatMap((chunk) => chunk.predictions),
-        verified.labels,
-        median(latencyMs),
-      ),
+      heldout: {
+        ...computeHeldout(
+          verified.rows,
+          chunkResults.flatMap((chunk) => chunk.predictions),
+          verified.labels,
+          median(latencyMs),
+        ),
+        latency_samples: {
+          requested: latencySamples.length,
+          completed: latencyResults.length,
+          failures: latencyFailures,
+        },
+      },
       usage: {
         prompt_tokens: promptTokens,
         completion_tokens: completionTokens,

--- a/tests/local-classifier-frontier.test.mjs
+++ b/tests/local-classifier-frontier.test.mjs
@@ -78,7 +78,7 @@ function fixture() {
   return { root, rows, holdoutPath, runManifestPath };
 }
 
-function frontierFetch({ servedModel = "glm-5.2", spamLabel = "ham" } = {}) {
+function frontierFetch({ servedModel = "glm-5.2", spamLabel = "ham", emptyResponseAt } = {}) {
   const requests = [];
   const fetchImpl = async (_url, init) => {
     const request = JSON.parse(init.body);
@@ -88,7 +88,7 @@ function frontierFetch({ servedModel = "glm-5.2", spamLabel = "ham" } = {}) {
       example_id: example.example_id,
       label: example.example_id === "example-spam" ? spamLabel : "ham",
     }));
-    const content = `\`\`\`json\n${JSON.stringify({ predictions })}\n\`\`\``;
+    const content = emptyResponseAt === requests.length ? "" : `\`\`\`json\n${JSON.stringify({ predictions })}\n\`\`\``;
     const split = Math.ceil(content.length / 2);
     const stream = [
       { model: servedModel, choices: [{ delta: { content: content.slice(0, split) } }] },
@@ -195,6 +195,7 @@ describe("frontier classification comparison", () => {
     assert.equal(result.row_count, 2);
     assert.equal(result.heldout.accuracy, 0.5);
     assert.equal(result.heldout.failure_count, 1);
+    assert.deepEqual(result.heldout.latency_samples, { requested: 2, completed: 2, failures: [] });
     assert.equal(result.heldout.failures.length, 1);
     assert.equal(result.data_boundary.training_examples_uploaded, false);
     assert.equal(result.data_boundary.holdout_examples_uploaded, true);
@@ -215,6 +216,28 @@ describe("frontier classification comparison", () => {
     assert.ok(events.some((event) => event.phase === "measuring"));
     assert.ok(existsSync(result.artifact_path));
     assert.deepEqual(JSON.parse(readFileSync(result.artifact_path, "utf8")), result);
+  });
+
+  it("keeps completed quality evidence when an auxiliary latency sample is empty", async () => {
+    const data = fixture();
+    const { fetchImpl, requests } = frontierFetch({ emptyResponseAt: 2 });
+    const result = await compareClassifierWithFrontier({
+      runManifestPath: data.runManifestPath,
+      confirmRemote: true,
+      confirmSpend: true,
+      budgetUsd: 1,
+      auth: fakeAuth,
+      fetchImpl,
+      concurrency: 1,
+    });
+
+    assert.equal(result.heldout.accuracy, 0.5);
+    assert.equal(requests.length, 3);
+    assert.deepEqual(result.heldout.latency_samples, {
+      requested: 2,
+      completed: 1,
+      failures: ["frontier model returned no classifications"],
+    });
   });
 
   it("scores a valid predicted category that has no correct answers in the holdout", async () => {


### PR DESCRIPTION
## Summary

Fix two failure modes discovered during the first managed remote-training run:

- upload signed Vercel Blob artifacts with a fixed-size request body, after checking the approved local file length, so the persisted object cannot silently become zero bytes
- preserve completed frontier quality results when an auxiliary latency sample returns an empty completion, and report the latency sample as partial instead of failing the entire comparison

## Live evidence

The managed run reached the workflow and failed closed before Fireworks training began: the held-out artifact was expected to contain 87,001 bytes but Vercel Blob reported 0 bytes. Spend remained $0 and cleanup completed.

Separately, the full 777-example quality comparison succeeded before an empty response in the third of five latency samples erased the completed result. This change retains the quality evidence while making the degraded latency measurement explicit.

## Validation

- `npm run check`
- `node --test tests/local-classifier-frontier.test.mjs tests/remote-training-desktop.test.mjs`
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml remote_training::tests`
- `git diff --check`

## Rollout

This is the reliability prerequisite for the separate remote-training UX and recipe-detection work in #280. It does not itself broaden training beyond the existing classification flow.

[![Review by Devin](https://img.shields.io/badge/Review%20by-Devin-6B50FF?logo=devin&logoColor=white)](https://app.devin.ai/sessions/7aa4d17c145b40c3958351add5e87522)