### PR TITLE
fix(skills): make evidence and spend guidance outcome-first

### DIFF
--- a/docs/engagement-and-pacing.md
+++ b/docs/engagement-and-pacing.md
@@ -22,8 +22,25 @@ and what it costs, *before* running it. The user decides with that in hand.
   Starting it now."
 
 If you don't know the rate, measure a small sample first (a 3-task smoke), report
-the per-unit cost/time, then project the full run. Label projections as
-projections.
+the per-unit cost/time, then project the decision-sized run. Label projections
+as projections. The smoke estimates throughput and spend; it is not a reason to
+shrink the evidence plan or stop early.
+
+## 1a. Recommend the outcome-sized plan
+
+Optimize for resolving the developer's objective under their real constraints,
+not for minimizing spend in isolation. Present the recommended plan first with
+its expected outcome, wall-clock, spend envelope, and evidence it will produce.
+When useful, show a cheaper diagnostic and a faster or higher-confidence option
+beside it, but do not make the weakest option the default merely because it is
+cheap.
+
+One approval may cover a named, bounded batch or run plan. Do not interrupt for
+permission before every call inside that envelope. Before exceeding it, explain
+what the extra spend is expected to resolve and ask for the expansion. If the
+current evidence cannot answer the question, recommend more data, a stronger
+model, more compute, or a broader experiment plainly instead of hiding the
+tradeoff behind cautious prose.
 
 ## 2. Background the slow thing — first
 
@@ -108,4 +125,8 @@ If there's no profile yet, run [`onboard`](../skills/onboard/SKILL.md) first.
 - Going silent during a background run instead of doing analysis.
 - Doing the interactive interview *after* the download instead of during it.
 - Re-asking for information already in the profile or already on disk.
+- Treating the cheapest action as the recommendation without comparing expected
+  progress, time-to-answer, and confidence.
+- Stopping at a smoke test, weak model, or convenient cohort when the result
+  cannot answer the user's question.
 - Claiming a cost/latency/quality win without measured before/after evidence.

--- a/skills/README.md
+++ b/skills/README.md
@@ -232,11 +232,13 @@ shows headroom, no hosted RL until the local arms plateau.
 
 ## Public Safety
 
-Default to the cheapest path that still reaches an optimization outcome — not to
-zero spend (a skipped improvement has real opportunity cost). Get explicit
-approval before any upload, hosted run, or provider spend. Public examples
-should use synthetic fixtures, local `.understudy/` artifacts, public provider
-docs, or public open-source projects.
+Default to the path with the highest expected progress toward the stated
+objective under hard constraints, with spend, time, data scope, and expected
+evidence visible. Do not silently choose the weakest model, smallest cohort, or
+narrowest intervention because it is cheap. Get explicit approval before any
+upload, hosted run, or provider spend; one approval may cover a named bounded
+plan. Public examples should use synthetic fixtures, local `.understudy/`
+artifacts, public provider docs, or public open-source projects.
 
 Do not include customer names, domains, raw prompts, raw completions, traces,
 secrets, private notes, internal runbooks, or hosted-control details in public

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -112,7 +112,10 @@ enough provenance for another agent to repeat the step without guessing.
    An uncovered important stratum blocks a whole-workload conclusion; a failed
    read-then-write sentinel is a harness bug until proven otherwise. Keep a
    redacted local review packet with the coverage matrix, representative rows,
-   counterexamples, scorer rationale, and exact artifact/log refs.
+   counterexamples, scorer rationale, the data-sufficiency plan and stopping
+   evidence, and exact artifact/log refs. Treat pilot sizes as minimums, never
+   caps: when conclusions remain unstable or important strata are underfilled,
+   collect more rows instead of increasing confidence in the prose.
 5. Freeze splits.
    Write `splits.json` with train/dev/holdout names, sizes, source refs,
    deterministic split seed or frozen row ids, the per-stratum counts from the

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -15,14 +15,17 @@ for the workload, or when any core artifact is missing, stale, ambiguous, or
 untrusted.
 
 The OSS loop does not require registration, auth, provider keys, an Understudy
-account, or hosted gateway access. Do the smallest local pass that turns the
-workload into auditable artifacts.
+account, or hosted gateway access. Do a sufficient local pass that turns the
+workload into auditable artifacts and can answer the named decision.
 
 ## Safety Gates
 
-Default to the cheapest path that still reaches an optimization outcome — not to
-zero spend (a skipped improvement has real opportunity cost). Get the
-developer's explicit approval before any upload, hosted run, or provider spend.
+Default to the evidence plan most likely to resolve the decision under the
+developer's constraints, not the cheapest or smallest pass. Make cost, time,
+scope, and expected confidence visible; use
+[`../understudy/reference.md`](../understudy/reference.md) → Outcome-first spend
+posture. Get the developer's explicit approval before any upload, hosted run, or
+provider spend; one approval may cover a named bounded run plan.
 
 Follow the repo public boundary in
 [`../../docs/privacy-and-data-boundaries.md`](../../docs/privacy-and-data-boundaries.md).
@@ -181,7 +184,8 @@ claim savings in this worker. Its job is to make the next validation step
 possible.
 
 If any artifact cannot be created, write down the missing input, the attempted
-local command or inspection, and the next smallest action.
+local command or inspection, and the next action most likely to unblock the
+decision, with its cost and scope.
 
 ## Output Standard
 

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -105,11 +105,20 @@ enough provenance for another agent to repeat the step without guessing.
    forbidden-write avoidance, unnecessary calls/retries, schema validity, and
    recoverable errors as separate axes before collapsing to an overall score.
    If the metric or validator is unclear, stop and ask one concrete question.
-4. Freeze splits.
+4. Pass the evaluation evidence gates.
+   Build and confirm the coverage matrix, run harness-conformance sentinels,
+   and inspect actual scored rows before interpreting aggregate results. Follow
+   [`references/evaluation-evidence-gates.md`](references/evaluation-evidence-gates.md).
+   An uncovered important stratum blocks a whole-workload conclusion; a failed
+   read-then-write sentinel is a harness bug until proven otherwise. Keep a
+   redacted local review packet with the coverage matrix, representative rows,
+   counterexamples, scorer rationale, and exact artifact/log refs.
+5. Freeze splits.
    Write `splits.json` with train/dev/holdout names, sizes, source refs,
-   deterministic split seed or frozen row ids, and an explicit "no holdout
-   mutation" note.
-5. Rerun the incumbent baseline.
+   deterministic split seed or frozen row ids, the per-stratum counts from the
+   coverage matrix, uncovered strata, and an explicit "no holdout mutation"
+   note.
+6. Rerun the incumbent baseline.
    Use the frozen harness, metric, validator, and splits to rerun the current
    incumbent route. Write `baseline.json` with command, timestamp, split used,
    sample size, score, latency basis, cost basis if available, failures, and

--- a/skills/capture-evidence/reference.md
+++ b/skills/capture-evidence/reference.md
@@ -130,9 +130,9 @@ Turn the opportunity into a local dataset the harness can run against:
 ## Eval-harness discovery + build
 
 A baseline is only trustworthy if it runs against a real, repeatable eval. Reuse
-before you build, then build the smallest meaningful harness that scores the
-target behavior. Tie everything to the artifact contract so the next worker can
-trust it by hash.
+before you build, then build the simplest harness that completely scores the
+target behavior on a decision-sized cohort. Tie everything to the artifact
+contract so the next worker can trust it by hash.
 
 ### Discover existing tests/evals
 

--- a/skills/capture-evidence/reference.md
+++ b/skills/capture-evidence/reference.md
@@ -167,6 +167,12 @@ prior runs scored 0/12 (see `SKILL.md` → Required Checks step 3).
 - If no captured data exists, build a clearly-labeled **synthetic fixture** (see
   Acquire-fresh) and mark every synthetic result as such.
 
+Before calling the set representative, apply the coverage matrix, completed-run
+classification, hard-case minimums, qualitative row review, and claim-strength
+rules in
+[`references/evaluation-evidence-gates.md`](references/evaluation-evidence-gates.md).
+Random sampling alone does not establish coverage.
+
 ### Define metrics aligned to the objective
 
 Set the primary metric to the value lens and write it into `metric.json` with the

--- a/skills/capture-evidence/references/evaluation-evidence-gates.md
+++ b/skills/capture-evidence/references/evaluation-evidence-gates.md
@@ -20,14 +20,29 @@ Build a coverage matrix before sampling. The rows should include:
 Classify by the **completed execution** when input metadata does not reliably
 predict complexity. Do not call a sample representative merely because it was
 random. Confirm the matrix with the developer and ask whether important hard
-cases are missing. For a small pilot, aim for roughly 10 reviewable examples per
-important stratum when they exist; otherwise report the actual count and keep
-the uncertainty visible.
+cases are missing.
+
+Treat initial row counts as minimums, never caps. Size the evaluation for the
+decision risk, observed variance and failure rate, important-stratum coverage,
+and the smallest material difference the developer needs to detect. A small
+pilot validates plumbing and exposes new strata; it does not establish model
+parity or route readiness. When data is available locally, prefer using more of
+it over making a stronger assumption from a convenient subset. Include every
+available rare or high-consequence case when tractable.
 
 An uncovered important stratum blocks a whole-workload conclusion. Continue on
 the covered strata if useful, but scope every statement to them. Expand the
 capture, join executions back to local traces, or create a clearly labeled
 synthetic case before making a broader claim.
+
+Write a data-sufficiency plan before the full run. Continue adding rows when a
+material result changes across incremental batches, uncertainty remains wider
+than the decision tolerance, a stratum is underfilled, errors cluster, or review
+keeps discovering new failure classes. Stop only when the named decision is
+stable under another meaningful increment, important strata meet their planned
+precision or exhaustive-review rule, and the remaining uncertainty is explicit.
+If more data is unavailable, narrow or defer the conclusion rather than lowering
+the evidence bar silently.
 
 ## 2. Harness-conformance gate
 
@@ -51,16 +66,22 @@ harness and invalidate conclusions from affected runs before blaming the model.
 ## 3. Qualitative row-review gate
 
 Before interpreting recall, no-op rate, pass rate, or a surprising delta,
-inspect the smallest useful set of actual local rows. Each review row should
-show the redacted input or task id, expected outcome, candidate output or full
-trajectory, validator result, and scorer rationale.
+inspect actual local rows and expand the review as uncertainty or heterogeneity
+appears. Each review row should show the redacted input or task id, expected
+outcome, candidate output or full trajectory, validator result, and scorer
+rationale.
 
-At minimum inspect:
+The following are starting requirements, not a maximum:
 
 - one passing row;
 - one failing row for each failure class used in the conclusion;
 - one row behind every surprising or material aggregate delta;
 - one counterexample that could disprove the proposed headline.
+
+Then review additional random and stratified batches until the data-sufficiency
+stopping rule above passes. Review all failures when tractable; otherwise sample
+each failure class deeply enough to distinguish a systematic problem from an
+isolated row. A handful of attractive examples cannot support a broad claim.
 
 For free-text or semantic outputs, check whether different wording is
 equivalent before calling it a recall failure. For agentic runs, inspect the
@@ -82,7 +103,9 @@ Match the language to the evidence:
 
 A first optimization pass on a narrow cohort is a probe for headroom and
 overfitting. Do not widen the conclusion until a frozen candidate holds on a
-balanced sealed holdout.
+balanced sealed holdout sized for the decision. If the holdout is too small to
+separate practical parity from a material regression, collect more data before
+recommending a route change.
 
 ## 5. Review packet and presentation gate
 
@@ -90,8 +113,8 @@ Give the developer a spot-check path before recommending action. The local
 packet should contain:
 
 - the coverage matrix and uncovered strata;
-- 2–10 redacted examples per important stratum when available, including
-  failures and counterexamples;
+- a decision-sized stratified review set, including failures and
+  counterexamples, plus counts and links for the full evaluated cohort;
 - baseline and candidate outputs or trajectories side by side;
 - scorer rationale and failure classification;
 - exact run, task, artifact, and log references for deeper inspection.
@@ -99,4 +122,6 @@ packet should contain:
 Prefer a compact table and links to measured artifacts. Add a visualization
 only when it answers a named decision question better than the table; label the
 question and the source fields it uses. Decorative charts, animated mock runs,
-or projected candidate cells do not belong in an evidence report.
+or projected candidate cells do not belong in an evidence report. Pagination or
+summary pages may make a large packet usable, but must not reduce the underlying
+evaluation or hide its failures.

--- a/skills/capture-evidence/references/evaluation-evidence-gates.md
+++ b/skills/capture-evidence/references/evaluation-evidence-gates.md
@@ -1,0 +1,102 @@
+# Evaluation evidence gates
+
+Use these gates before turning an eval result into a workload-level conclusion,
+optimization run, model recommendation, or launch verdict. They apply to
+single-output and agentic workloads. Keep raw rows local and redact any review
+packet that leaves the working directory.
+
+## 1. Coverage gate
+
+Build a coverage matrix before sampling. The rows should include:
+
+- common task categories;
+- rare or high-consequence categories;
+- known failure modes and edge cases;
+- for agentic workloads, the read / transform / write / search / orchestrate /
+  notify / exec tool classes and the terminal outcomes they produce;
+- source count, captured count, split count, selection rule, and uncovered
+  categories for every stratum.
+
+Classify by the **completed execution** when input metadata does not reliably
+predict complexity. Do not call a sample representative merely because it was
+random. Confirm the matrix with the developer and ask whether important hard
+cases are missing. For a small pilot, aim for roughly 10 reviewable examples per
+important stratum when they exist; otherwise report the actual count and keep
+the uncertainty visible.
+
+An uncovered important stratum blocks a whole-workload conclusion. Continue on
+the covered strata if useful, but scope every statement to them. Expand the
+capture, join executions back to local traces, or create a clearly labeled
+synthetic case before making a broader claim.
+
+## 2. Harness-conformance gate
+
+Before a candidate matrix, run cheap synthetic sentinels through the exact
+driver, parser, tool registry, state reset, and validator:
+
+- a terminal direct-answer or no-op case;
+- a read-then-write case where the first assistant action is non-terminal;
+- a tool error followed by recovery, when recovery matters;
+- the existing oracle and reward-hacking sentinels for simulated environments.
+
+The read-then-write sentinel must execute the read, append its result, continue
+the loop, execute the write, and score the final state. Never classify an
+intermediate read/tool call as a no-op or missing write. Re-run parser and
+renderer conformance for every model family; a parser that works for one model
+is not evidence that the driver works for another.
+
+If a sentinel fails, the result is a harness bug until proven otherwise. Fix the
+harness and invalidate conclusions from affected runs before blaming the model.
+
+## 3. Qualitative row-review gate
+
+Before interpreting recall, no-op rate, pass rate, or a surprising delta,
+inspect the smallest useful set of actual local rows. Each review row should
+show the redacted input or task id, expected outcome, candidate output or full
+trajectory, validator result, and scorer rationale.
+
+At minimum inspect:
+
+- one passing row;
+- one failing row for each failure class used in the conclusion;
+- one row behind every surprising or material aggregate delta;
+- one counterexample that could disprove the proposed headline.
+
+For free-text or semantic outputs, check whether different wording is
+equivalent before calling it a recall failure. For agentic runs, inspect the
+full trajectory and final state, not only the first tool call or final string.
+Classify mismatches as model behavior, scorer/rubric error, harness/parser error,
+label error, or genuinely ambiguous. Correct the evidence and rerun when the
+failure is not the model's.
+
+## 4. Claim-strength gate
+
+Match the language to the evidence:
+
+- train/dev improvement is an optimization lead, not a win;
+- a small or unbalanced holdout is directional and names its counts;
+- an absent hard stratum limits the conclusion to represented categories;
+- projected price or latency is an estimate with its formula and assumptions;
+- model quality, per-row outcomes, and route readiness are measured or shown as
+  `not run` — never populated with plausible synthetic results.
+
+A first optimization pass on a narrow cohort is a probe for headroom and
+overfitting. Do not widen the conclusion until a frozen candidate holds on a
+balanced sealed holdout.
+
+## 5. Review packet and presentation gate
+
+Give the developer a spot-check path before recommending action. The local
+packet should contain:
+
+- the coverage matrix and uncovered strata;
+- 2–10 redacted examples per important stratum when available, including
+  failures and counterexamples;
+- baseline and candidate outputs or trajectories side by side;
+- scorer rationale and failure classification;
+- exact run, task, artifact, and log references for deeper inspection.
+
+Prefer a compact table and links to measured artifacts. Add a visualization
+only when it answers a named decision question better than the table; label the
+question and the source fields it uses. Decorative charts, animated mock runs,
+or projected candidate cells do not belong in an evidence report.

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -49,10 +49,14 @@ comparison.
 
    For remote Understudy candidates, run `understudy models list --json`;
    prefer managed-catalog ids unless BYO provider-direct behavior is required.
-3. **Run a smoke row first.** Each candidate must complete one row without
-   connection errors, empty responses, or bad model aliases. For local MLX, prefer
-   verified filesystem paths or Understudy snapshot aliases over arbitrary
-   Hugging Face ids.
+3. **Run conformance smoke first.** Each candidate must complete one row without
+   connection errors, empty responses, or bad model aliases. For agentic
+   workloads, also run a synthetic read-then-write sentinel through the exact
+   driver and parser: execute the read, append its result, continue, execute the
+   write, and score final state. Never score an intermediate tool call as a
+   no-op. For local MLX, prefer verified filesystem paths or Understudy snapshot
+   aliases over arbitrary Hugging Face ids. Apply the shared gates in
+   [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
 
 4. **Run the frozen matrix.** Call the same harness once per candidate with the
    same rows, split, tool-access mode, prompt, seed, and export path. Keep each
@@ -89,6 +93,12 @@ comparison.
    spend, and keep judge-scored quality as its own column — never silently
    blended with a programmatic metric.
 
+   Before explaining any aggregate delta, inspect the actual rows behind one
+   pass, each reported failure class, each surprising delta, and a counterexample
+   to the proposed conclusion. Distinguish model behavior from equivalent
+   free-text wording, scorer/rubric errors, labels, and harness/parser failures.
+   Scope conclusions to represented coverage strata.
+
 6. **Compute the frontier.** A candidate is dominated when another candidate has
    equal or better quality and equal or lower cost and latency, with no worse
    error rate or safety result. Write `pareto.json` with dominated reasons.
@@ -96,6 +106,10 @@ comparison.
 7. **Report the decision.** Write `report.md` with the top frontier candidates,
    the cheapest acceptable model at the agreed quality floor, and the next action:
    ship route, build retrieval/tooling, run GEPA, climb local model, or use remote.
+   Candidate quality cells must come from measured rows or say `not run`;
+   plausible projections are never substitutes. Include the coverage matrix and
+   a redacted row-review packet. Use a visualization only when it answers a
+   named decision question better than the results table.
 
 ## Harness Pattern
 
@@ -147,3 +161,5 @@ If the verdict supports changing production traffic, hand off to
 [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md): add the provider,
 set the route, and ramp staged traffic gated by the same production validator
 the sweep used.
+
+Detailed row-review packet guidance lives in [`reference.md`](reference.md).

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -57,6 +57,8 @@ comparison.
    no-op. For local MLX, prefer verified filesystem paths or Understudy snapshot
    aliases over arbitrary Hugging Face ids. Apply the shared gates in
    [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
+   The smoke row proves only that the harness runs; it provides no model-quality
+   evidence.
 
 4. **Run the frozen matrix.** Call the same harness once per candidate with the
    same rows, split, tool-access mode, prompt, seed, and export path. Keep each
@@ -108,8 +110,11 @@ comparison.
    ship route, build retrieval/tooling, run GEPA, climb local model, or use remote.
    Candidate quality cells must come from measured rows or say `not run`;
    plausible projections are never substitutes. Include the coverage matrix and
-   a redacted row-review packet. Use a visualization only when it answers a
-   named decision question better than the results table.
+   a redacted row-review packet. If the result is unstable across batches,
+   underpowered for the material difference, or still exposing new failure
+   classes, expand the frozen matrix before recommending a route. Use a
+   visualization only when it answers a named decision question better than the
+   results table.
 
 ## Harness Pattern
 

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 Use this worker when the question is not "can one model pass this eval?" but
 "which candidate sits on the useful frontier for this workload?" The skill runs
 one frozen harness across a candidate matrix, records each run, and emits a
-small Pareto report an agent can use for route decisions.
+decision-ready Pareto report an agent can use for route decisions.
 
 Prefer this after [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md),
 [`../optimize-agentic-workload/SKILL.md`](../optimize-agentic-workload/SKILL.md), or
@@ -27,6 +27,13 @@ submissions, uploads, or new model downloads. Local cached model runs are fine
 when the user has already approved the local harness. Never mix private traces or
 customer data into a public sweep report; use synthetic, anonymized, or local-only
 artifacts.
+
+Recommend a candidate matrix sized to resolve the objective, including a strong
+anchor when it could change the decision. Present expected spend and wall-clock
+before the run and follow
+[`../understudy/reference.md`](../understudy/reference.md) → Outcome-first spend
+posture. Do not omit the informative candidate merely to keep the first sweep
+cheap; one bounded approval may cover the whole named matrix.
 
 Do not claim a model is cheaper, faster, or better unless the sweep used the same
 rows, harness, metric, tool-access mode, prompt, seed, and state reset for every
@@ -106,7 +113,7 @@ comparison.
    error rate or safety result. Write `pareto.json` with dominated reasons.
 
 7. **Report the decision.** Write `report.md` with the top frontier candidates,
-   the cheapest acceptable model at the agreed quality floor, and the next action:
+   the best route for the agreed objective and constraints, and the next action:
    ship route, build retrieval/tooling, run GEPA, climb local model, or use remote.
    Candidate quality cells must come from measured rows or say `not run`;
    plausible projections are never substitutes. Include the coverage matrix and
@@ -153,10 +160,11 @@ When the sweep informs a real route decision, also write the report as a
   total cost, cost per unit of work the business counts (per deal, per ticket,
   per call — not per token), and the cost ratio vs the incumbent;
 - caching basis per row (see step 5) and any other comparability caveats;
-- where the residual failures cluster, as named patterns with the cheapest fix
-  per pattern (prompt line, decode/format fix, decomposition, route fallback);
+- where the residual failures cluster, as named patterns with the
+  highest-leverage supported fix per pattern (prompt line, decode/format fix,
+  decomposition, route fallback);
 - a staged recommendation: the drop-in safe swap, the parallel pilot, and the
-  cheap iteration, rather than one all-or-nothing verdict;
+  highest-information iteration, rather than one all-or-nothing verdict;
 - a scope line: what fraction of the workload's total LLM cost this step
   represents, and what's next if the approach extends;
 - one headline the finance owner can multiply by volume ("saves ~$X per

--- a/skills/compare-model-sweep/reference.md
+++ b/skills/compare-model-sweep/reference.md
@@ -14,7 +14,11 @@ working directory.
 
 Start with the rows required by the shared gate: one pass, one failure from each
 reported class, every surprising material delta, and a counterexample to the
-headline. Add up to 10 reviewable rows per important stratum when they exist.
+headline. These are starting requirements, not a review cap. Expand with random
+and stratified batches until the data-sufficiency stopping rule passes; review
+all rare or high-consequence failures when tractable.
 
 The packet is evidence for the summary, not a gallery. If a chart does not make
-a named route decision easier than the result table, omit it.
+a named route decision easier than the result table, omit it. Keep counts and
+links for the full evaluated cohort even when the human-facing packet is
+paginated or summarized.

--- a/skills/compare-model-sweep/reference.md
+++ b/skills/compare-model-sweep/reference.md
@@ -1,0 +1,20 @@
+# Compare model sweep — reference
+
+Deep detail for [`SKILL.md`](SKILL.md). The shared coverage, harness-conformance,
+qualitative row-review, claim-strength, and presentation rules live in
+[`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
+
+## Row-review packet
+
+Keep the packet local when it contains real workload data. For each selected
+row, record the task id, coverage stratum, baseline and candidate result refs,
+score and rationale, failure classification, and the artifact or log path that
+supports deeper inspection. Redact payload text in anything shared outside the
+working directory.
+
+Start with the rows required by the shared gate: one pass, one failure from each
+reported class, every surprising material delta, and a counterexample to the
+headline. Add up to 10 reviewable rows per important stratum when they exist.
+
+The packet is evidence for the summary, not a gallery. If a chart does not make
+a named route decision easier than the result table, omit it.

--- a/skills/compare-trajectories/SKILL.md
+++ b/skills/compare-trajectories/SKILL.md
@@ -122,12 +122,16 @@ behavioral verdict here, learnability cut there.
 
 A single run per model can mistake sampling noise for a behavioral gap. Before
 classifying gaps — and always before a candidate graduates toward live traffic
-— re-run the candidate on the same frozen rows N times (default 3): all repeats
+— re-run the candidate on the same frozen rows in incremental batches. Three
+repeats are a plumbing smoke, not a universal N; size the replay for the agreed
+instability tolerance and expand near the threshold. Then classify: all repeats
 match → stable; some → borderline; none → stochastic (exclude from gap
 classification and the warm-start yield). Above ~5% unstable, fix decoding
 (temperature, seed) or downgrade verdicts to directional-only. The dispositions
 feed the pre-ramp gate in [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md)
 (stable → serve, borderline → shadow, stochastic → incumbent fallback).
+Use the data-sufficiency stopping rule in
+[`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
 
 ## Token-logprob lens
 

--- a/skills/compare-trajectories/reference.md
+++ b/skills/compare-trajectories/reference.md
@@ -6,9 +6,11 @@ Loaded on demand from `SKILL.md`.
 
 The section in `SKILL.md` gives the rule; this is the working detail.
 
-1. **Choose N.** Default 3 full re-runs of the candidate on the same frozen
-   rows, same harness, same decoding settings. Raise N only when the per-run
-   cost is trivial; below N=3 the borderline bucket is meaningless.
+1. **Choose N adaptively.** Start with 3 full re-runs of the candidate on the
+   same frozen rows, harness, and decoding settings to validate mechanics. Add
+   meaningful batches until the instability estimate is stable within the
+   decision tolerance, especially near the serving threshold or when strata
+   differ. Cost informs the disclosed plan; it is not a reason to freeze N at 3.
 2. **Bucket per task** by comparing the scored outcome (and, for tool-call
    workloads, the tool-call sequence) across runs:
    - **all-repeats-match** — deterministic for this workload's purposes.

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -55,9 +55,11 @@ criteria (recall / precision / policy — not just cost/speed).
 
 ## Safety Gates
 
-- **Synthetic data only.** Seed the environment with invented entities and a small
-  hand-written fixture. Never embed customer transcripts, records, names, or IDs —
-  the simulated env is committable precisely because it contains none.
+- **Synthetic data only.** Seed the environment with invented entities. A small
+  hand-written fixture may validate the mechanics, but a workload claim needs a
+  scalable, decision-sized generated suite. Never embed customer transcripts,
+  records, names, or IDs — the simulated env is committable precisely because
+  it contains none.
 - **No live side effects.** Tools mutate in-memory state, never real systems.
 - Keep the captured customer traces local; use them only to *infer the shape* you
   simulate.
@@ -65,15 +67,17 @@ criteria (recall / precision / policy — not just cost/speed).
 ## Recipe
 
 1. **Seed synthetic state.** For the default env, use the built-in synthetic
-   inbox/ticket/project-board fixture. For a workload-specific env, use a few
-   records of each entity the workload touches
-   (deals, contacts, activities, a short transcript), small enough to read.
+   inbox/ticket/project-board fixture. For a workload-specific env, generate
+   enough records and tasks to cover common, rare, and high-consequence entity
+   and action combinations. Keep individual cases readable while scaling the
+   suite; follow the data-sufficiency rules in
+   [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
 2. **Implement the tools by intent, leniently.** Group the real tool catalog into
    read / transform / write classes (from understand-workload). For each class,
    return a plausible result from the seeded state. Be tolerant of arg/name
    variants (e.g. accept a tool called with or without an `mcp__…` prefix) so a
    candidate's reasonable-but-different call still gets a useful answer.
-3. **Define the gold + a validator.** Write the small set of correct outcomes the
+3. **Define the gold + a validator.** Write the complete correct outcomes each
    task implies (the observations/records a perfect run would write), each with the
    keys/values that must appear. Score the candidate's *final written state* vs gold
    → recall, precision, and any policy checks. The validator is the metric, not the

--- a/skills/distill-classifier/SKILL.md
+++ b/skills/distill-classifier/SKILL.md
@@ -100,7 +100,8 @@ command or handoff.
   confounds with prevention, corpus/training defaults, and the verdict
   thresholds.
 - [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) — the
-  cheaper no-weight rung; always first.
+  no-weight rung; use first when failure attribution says prompt or contract
+  repair can close the gap, otherwise proceed to the capacity-changing path.
 - [`../local-distillation-lab/SKILL.md`](../local-distillation-lab/SKILL.md) —
   local training arms and the weight-update proof discipline.
 - [`../curate-trajectories/SKILL.md`](../curate-trajectories/SKILL.md) — split

--- a/skills/local-distillation-lab/SKILL.md
+++ b/skills/local-distillation-lab/SKILL.md
@@ -94,7 +94,7 @@ on-policy state coverage (no exposure-bias gap). Arms O/P here train on teacher 
   curve, not the endpoint.
 - **Orchestration:** smoke budget must exceed arm guards; per-row try/except in data-gen (one
   router 500 shouldn't abort the build); retry serve calls; `caffeinate -i` + JSON checkpoints +
-  cheapest-arm-first for overnight runs.
+  highest-information-arm-first within the approved overnight envelope.
 
 ## Kernels (runnable, in `examples/`)
 

--- a/skills/local-distillation-lab/references/pedagogical-arm.md
+++ b/skills/local-distillation-lab/references/pedagogical-arm.md
@@ -55,7 +55,7 @@ If the workload is still not understood, route to
 [`understand-workload`](../../understand-workload/SKILL.md). If there is no
 resettable harness or metric, route to
 [`capture-evidence`](../../capture-evidence/SKILL.md). If prompt GEPA is the
-cheapest live-rollout intervention, route to
+highest-leverage live-rollout intervention for the named objective, route to
 [`optimize-workload`](../../optimize-workload/SKILL.md).
 
 ## Flow
@@ -66,8 +66,9 @@ cheapest live-rollout intervention, route to
    unexplained final-state edits, brittle chain-of-thought shortcuts, or
    impossible recovery from a corrupted prefix.
 
-2. **Prove local headroom first.** On a tiny train/dev slice, compare at least
-   three local conditions:
+2. **Prove local headroom first.** Use a small train/dev slice only to verify the
+   mechanics, then expand to a decision-sized cohort. Compare at least three
+   local conditions:
    - blind student: `x` only;
    - shortcut teacher: `x + c`, allowed to use the answer key directly;
    - pedagogical teacher: `x + c`, but required to output steps derivable from
@@ -119,7 +120,10 @@ cheapest live-rollout intervention, route to
 
 ## Local MLX rung order
 
-For Apple Silicon, prefer the smallest working local rung:
+For Apple Silicon, start with the rung most likely to resolve the named
+uncertainty. Lower-complexity rungs are useful when they can answer it quickly;
+skip directly to a weight update or hosted handoff when existing evidence shows
+that another local smoke will not change the decision:
 
 - **Prompt/template proof**: serve the local model and generate blind,
   shortcut, and pedagogical rollouts. This is the fastest proof of headroom.

--- a/skills/lower-anthropic-bill/SKILL.md
+++ b/skills/lower-anthropic-bill/SKILL.md
@@ -23,8 +23,10 @@ and route candidates. Do not edit code during the audit.
   paths, secrets, or private notes without explicit approval for that exact
   action.
 - No provider spend without a named surface, model, data class, row count, and
-  dollar cap. Token-counting, cache probes, OpenAI migration tests, and GEPA
-  reflection all need approval if they call a provider.
+  dollar envelope. Token-counting, cache probes, OpenAI migration tests, and
+  GEPA reflection all need approval if they call a provider. Recommend the
+  decision-sized test and explain its expected savings, time, and confidence;
+  one approval may cover the named bounded test matrix.
 - No silent source edits. Adding `cache_control`, changing model strings,
   rewriting prompts, or adding an OpenAI route is a follow-up change after the
   audit report is reviewed.
@@ -81,10 +83,15 @@ before estimating hotspots from bill data.
    later, do not invent a universal taxonomy: expose the candidate segments and
    let the developer drill into representative rows before labeling work as
    low-value or removable.
-7. **Pick candidate interventions.** Try the cheapest evidence path first:
-   cache fix, batch move, max-token/output tightening, older or cheaper
-   Anthropic model, local/open-weight candidate, OpenAI route, then GEPA prompt
-   repair. Route model comparisons to
+7. **Pick candidate interventions.** Start with the intervention offering the
+   largest expected addressable savings at sufficient quality and confidence.
+   Consider cache fixes, batch moves, max-token/output tightening, older or
+   cheaper Anthropic models, local/open-weight candidates, OpenAI routes, and
+   GEPA prompt repair in the order supported by the opportunity ledger—not a
+   fixed cheapest-first ladder. Prefer the lower-cost test only when alternatives
+   have comparable expected information value. Follow
+   [`../understudy/reference.md`](../understudy/reference.md) → Outcome-first
+   spend posture. Route model comparisons to
    [`../compare-model-sweep/SKILL.md`](../compare-model-sweep/SKILL.md) and GEPA
    to [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md).
 8. **Stop at the audit unless asked to implement.** If the developer chooses a

--- a/skills/lower-anthropic-bill/SKILL.md
+++ b/skills/lower-anthropic-bill/SKILL.md
@@ -74,8 +74,13 @@ before estimating hotspots from bill data.
    `cache_read_input_tokens`.
 6. **Rank the opportunity ledger.** Group findings by route and estimate
    addressable spend only from explicit volume, usage exports, or clearly labeled
-   synthetic assumptions. Include confidence: `high`, `medium`, `unknown`, or
-   `pending eval`.
+   synthetic assumptions. Rank by addressable spend × confidence × expected
+   implementation leverage so a small, easy tail item does not displace the
+   concentrated cost center. Include confidence: `high`, `medium`, `unknown`, or
+   `pending eval`. When value depends on who or what consumes an output now or
+   later, do not invent a universal taxonomy: expose the candidate segments and
+   let the developer drill into representative rows before labeling work as
+   low-value or removable.
 7. **Pick candidate interventions.** Try the cheapest evidence path first:
    cache fix, batch move, max-token/output tightening, older or cheaper
    Anthropic model, local/open-weight candidate, OpenAI route, then GEPA prompt

--- a/skills/manage-local-models/SKILL.md
+++ b/skills/manage-local-models/SKILL.md
@@ -15,10 +15,11 @@ enough to choose well. This skill is acquisition + curation + education; to scor
 a local model against a workload, use
 [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
 
-The habit this skill installs: **start with the smallest model that could work,
-cache it, prove the loop, and only step up when an eval says you must.** Small
-local models are free, private, and instant to iterate on; big quality lives one
-`understudy` route away when you actually need it.
+The habit this skill installs: **use a small verified model to prove the local
+loop, then choose the workload candidate from task fit, evidence, hardware, and
+time.** The bootstrap model is not a route recommendation. Skip directly to a
+stronger rung when a weak-model sequence would delay the answer; big quality
+lives one `understudy` route away when you need it.
 
 ## Safety Gates
 
@@ -60,11 +61,13 @@ or a second download of the same weights.
 1. **Inventory.** List installed runtimes and already-cached models, and report
    free disk. (`ollama list`; Hugging Face cache scan; MLX/LM Studio dirs — see
    [`reference.md`](reference.md).) Surface total disk used by weights.
-2. **Pick the smallest viable American model.** For onboarding on Apple Silicon,
-   be prescriptive: start with Understudy's verified
-   `google/gemma-4-e2b-it` MLX-VLM 4-bit snapshot, then climb only when the
-   head-to-head or eval says the rung is too weak. Match later goals and
-   hardware to a tier, biased small (full ladder + hardware rule-of-thumb in
+2. **Separate the bootstrap model from the workload candidate.** For onboarding
+   on Apple Silicon, be prescriptive: start with Understudy's verified
+   `google/gemma-4-e2b-it` MLX-VLM 4-bit snapshot as the fast product smoke. It
+   is not the default workload recommendation. Pick the workload model from task
+   fit, evidence, hardware, and time; skip directly to a stronger rung when a
+   small model is unlikely to answer the question. Match goals and hardware to a
+   tier (full ladder + hardware rule-of-thumb in
    [`reference.md`](reference.md) and
    [`../../docs/open-model-spotlight.md`](../../docs/open-model-spotlight.md)):
    - **Gemma 4** (Google) — verified E2B first; E4B/12B to climb; 26B-MoE / 31B

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -25,8 +25,9 @@ profile schema, interview bank, tooling-detection table — is in
 ## Safety Gates
 
 - **Download approval + size cap.** Name the exact model, quantization, and disk
-  size, and get a quick yes before pulling weights. Default to the *smallest*
-  American open model that gives a real win.
+  size, and get a quick yes before pulling weights. Default to the smallest
+  verified American open model that gives a real onboarding win, and label it
+  as a bootstrap model rather than a workload recommendation.
 - **Local-first, no upload.** Profiling, interview answers, and the model run
   entirely on the machine. The profile is local; it holds preferences and
   detected tooling — never secrets, keys, or customer data.

--- a/skills/optimize-agentic-workload/SKILL.md
+++ b/skills/optimize-agentic-workload/SKILL.md
@@ -43,11 +43,14 @@ shows the agent must *learn stateful behavior*.
 
 ## Safety Gates
 
-Default to the cheapest path that still reaches a decision — not to zero spend
-(a skipped improvement has real opportunity cost). Get the developer's explicit
-approval before any upload, hosted run, or provider spend, including every live
-tool call, live SaaS API call, credential change, production write, and every
-gateway eval run.
+Default to the path with the highest expected progress toward the multi-objective
+decision under hard constraints, not the cheapest rung. State the expected
+quality, latency, safety, time, and spend tradeoffs; follow
+[`../understudy/reference.md`](../understudy/reference.md) → Outcome-first spend
+posture. Get explicit approval before any upload, hosted run, provider spend,
+live SaaS API access, credential change, or production write. One approval may
+cover the named tool calls and gateway evals inside a bounded run plan; ask again
+before expanding it.
 
 Prefer local mocks, seeded fixtures, recorded schemas, and synthetic business
 data. Do not run live provider calls, tool calls, hosted jobs, model downloads,
@@ -146,11 +149,13 @@ single-output optimization does not need a tool environment.
    forbidden or missing writes, or non-termination. Single-turn /
    next-tool-call imitation scores are a *leading indicator only* — they cannot
    see result-propagation, recovery, or termination, which exist only inside
-   the running environment. Let the attribution pick the **cheapest rung that
-   closes the gap**, in order: output-contract repair (prefill / format /
-   parser / schema) → tool-access or endpoint-catalog repair → model A/B →
-   prompt / GEPA (automatic prompt evolution) → distillation → RL. Often the
-   gap is format or argument-fidelity, not planning, and a cheap rung wins.
+   the running environment. Let the attribution pick the **highest-leverage rung
+   likely to close the gap**: output-contract repair (prefill / format / parser /
+   schema), tool-access or endpoint-catalog repair, model A/B, prompt / GEPA
+   (automatic prompt evolution), distillation, or RL. Use the cheaper rung first
+   only when evidence says it can solve the attributed failure; skip directly to
+   a stronger model or broader intervention when weak iterations would only
+   delay the answer.
 
 7. **PRIMARY intervention — model A/B via the CLI.** This is the main move:
 

--- a/skills/optimize-agentic-workload/SKILL.md
+++ b/skills/optimize-agentic-workload/SKILL.md
@@ -128,13 +128,16 @@ single-output optimization does not need a tool environment.
    state and emits a request log.
 
 5. **Run the incumbent baseline before optimizing.** Execute the frozen harness
-   on train/dev or a small sanctioned sample, write per-task results, and bind
+   on the sanctioned train/dev set, write per-task results, and bind
    `harness_sha256`, `metric_sha256`, and `splits_sha256` into `baseline.json`.
    Confirm coverage across completed-execution strata, including rare or
    high-consequence tool paths, and inspect the actual trajectories behind at
    least one pass, each reported failure class, each surprising delta, and a
    counterexample to the proposed headline. Do not optimize until the baseline
-   is measured and those checks pass.
+   is measured and those checks pass. A smaller pilot may validate plumbing, but
+   it is not the baseline evidence. Expand the cohort whenever estimates remain
+   unstable, important strata are underfilled, or review discovers new failure
+   classes.
 
 6. **Attribute the multi-turn gap before intervening.** Read the rollouts, not
    just the final score, and tag where reward is lost: wrong tool/endpoint,

--- a/skills/optimize-agentic-workload/SKILL.md
+++ b/skills/optimize-agentic-workload/SKILL.md
@@ -105,6 +105,13 @@ single-output optimization does not need a tool environment.
    `.understudy/capture-evidence/` artifact contract — each reference documents
    the env → artifact bridge for its shape.
 
+   Before using model scores, pass the shared evaluation evidence gates in
+   [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
+   In particular, run a synthetic read-then-write trajectory through the exact
+   driver for every model family. The driver must append the read result,
+   continue the loop, execute the terminal write, and score final state; an
+   intermediate tool call is never a no-op verdict.
+
 3. **Define multi-objective success.** Quality is a per-criterion LLM-judge or
    final-state rubric that returns natural-language *why/what-to-change*
    feedback, not a bare score. Latency and cost come from the rollout records
@@ -123,7 +130,11 @@ single-output optimization does not need a tool environment.
 5. **Run the incumbent baseline before optimizing.** Execute the frozen harness
    on train/dev or a small sanctioned sample, write per-task results, and bind
    `harness_sha256`, `metric_sha256`, and `splits_sha256` into `baseline.json`.
-   Do not optimize until the baseline is measured.
+   Confirm coverage across completed-execution strata, including rare or
+   high-consequence tool paths, and inspect the actual trajectories behind at
+   least one pass, each reported failure class, each surprising delta, and a
+   counterexample to the proposed headline. Do not optimize until the baseline
+   is measured and those checks pass.
 
 6. **Attribute the multi-turn gap before intervening.** Read the rollouts, not
    just the final score, and tag where reward is lost: wrong tool/endpoint,

--- a/skills/optimize-agentic-workload/references/read-only-search.md
+++ b/skills/optimize-agentic-workload/references/read-only-search.md
@@ -200,9 +200,10 @@ The main lever is swapping the policy model with tools held fixed. Procedure:
 
 3. Read quality from the rubric and latency/cost from the `ToolEnv` rollout
    metadata. Tabulate quality vs latency vs cost across candidates.
-4. Pick the model you would ship under the `acceptable_regression` band: usually
-   the cheapest/fastest model whose quality stays within band, not the absolute
-   top-quality model.
+4. Pick the model you would ship for the named objective under the
+   `acceptable_regression` band. Compare expected quality, latency, spend, and
+   confidence explicitly; do not make the lowest-cost model the default when a
+   stronger or faster model would materially improve the outcome.
 5. Clear routes you are done with:
 
    ```sh
@@ -223,7 +224,7 @@ Inference defaults to Understudy after explicit approval via
 the developer prefers. Keep provider, model, budget, and data class in the local
 run artifact before any live call.
 
-## Secondary Intervention: GEPA the Cheap Model's Prompt
+## Secondary Intervention: GEPA a Promising Model's Prompt
 
 If a cheaper model wins latency/cost but trails on quality, optimize its prompt
 to close the gap while keeping the win. GEPA is train/dev-only and feeds on the
@@ -232,8 +233,9 @@ precondition. Hand the actual run to
 [`../../optimize-workload/SKILL.md`](../../optimize-workload/SKILL.md):
 
 - it refuses stale artifacts (hash check) and never touches holdout;
-- it climbs the cheapest-intervention ladder (prompt prefill/repair → context
-  trimming → route swap → GEPA);
+- it ranks interventions by expected progress toward the objective (prompt
+  prefill/repair, context trimming, route swap, or GEPA) and states their
+  cost/time tradeoffs;
 - it requires `claim.json` before any savings statement.
 
 For an agentic loop, useful prompt targets are: when to stop searching (turn

--- a/skills/optimize-agentic-workload/references/state-mutating-workflows.md
+++ b/skills/optimize-agentic-workload/references/state-mutating-workflows.md
@@ -359,8 +359,9 @@ Compare:
 - total token cost per task
 - API call count and retry count
 
-Pick the cheapest model that stays within the approved regression band and does
-not increase unsafe side effects. If both models fail the same invariant, the
+Pick the model with the best expected outcome under the approved regression,
+latency, spend, and safety constraints. Show the tradeoff rather than silently
+optimizing for the lowest price. If both models fail the same invariant, the
 next intervention is prompt/tool-description repair, not another blind model
 swap.
 
@@ -416,7 +417,7 @@ candidate prompt or patch as evidence, and restore external benchmark files
 before claiming a result. If you own the harness, add `--system-prompt-file` or
 an equivalent per-suite override.
 
-## Failure Modes And Cheapest Interventions
+## Failure Modes And Likely High-Leverage Interventions
 
 | Failure mode | Evidence | First intervention |
 | --- | --- | --- |

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -64,6 +64,13 @@ of optimizing.
 Confirm these before spending GEPA budget — full detail, model defaults, and
 validator kinds in [`reference.md`](reference.md):
 
+- **Evidence gates** — apply the coverage, harness-conformance, qualitative
+  row-review, and claim-strength gates in
+  [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
+  Do not optimize a narrow easy cohort as though it represents the workload.
+  Inspect the real rows behind the baseline headline and confirm important hard
+  strata have train/dev and sealed-holdout representation.
+
 - **Headroom** — `baseline.json` must show failing-but-promptable rows. No
   incumbent failures → nothing to optimize. A strong model fails them too →
   task beyond frontier; stop.
@@ -134,6 +141,10 @@ validator kinds in [`reference.md`](reference.md):
 7. Freeze the candidate before any holdout validation.
 8. Run holdout only once the candidate is frozen, and record score, failures,
    latency basis, cost basis, fallback route, demotion trigger, and caveats.
+   Inspect the actual rows behind material deltas before naming a win. A narrow
+   first pass that improves train/dev but regresses holdout is an overfitting
+   diagnosis, not evidence to iterate on the sealed rows; expand or rebalance a
+   new split contract and start a fresh experiment.
 
 The home of record for an optimization run is the **active experiment**
 directory (see the Experiment section of

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -69,7 +69,9 @@ validator kinds in [`reference.md`](reference.md):
   [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
   Do not optimize a narrow easy cohort as though it represents the workload.
   Inspect the real rows behind the baseline headline and confirm important hard
-  strata have train/dev and sealed-holdout representation.
+  strata have train/dev and sealed-holdout representation. Treat a small pilot
+  as a plumbing check only; if uncertainty, variance, or new failure classes
+  remain material, collect more data before optimizing or recommending a route.
 
 - **Headroom** — `baseline.json` must show failing-but-promptable rows. No
   incumbent failures → nothing to optimize. A strong model fails them too →

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -16,9 +16,12 @@ split-safe.
 
 ## Safety Gates
 
-Default to the cheapest path that still reaches an optimization outcome — not to
-zero spend (a skipped improvement has real opportunity cost). Get the
-developer's explicit approval before any upload, hosted run, or provider spend.
+Default to the intervention with the highest expected progress toward the
+objective under hard constraints, not the cheapest rung. State the expected
+quality gain, time, spend envelope, and evidence before execution; follow
+[`../understudy/reference.md`](../understudy/reference.md) → Outcome-first spend
+posture. Get explicit approval before any upload, hosted run, or provider spend;
+one approval may cover a named bounded optimization plan.
 
 Do not run live provider calls, hosted jobs, model downloads, uploads,
 benchmark submissions, or training without a named surface, capped spend or
@@ -100,14 +103,15 @@ validator kinds in [`reference.md`](reference.md):
 1. Inspect the required artifacts and confirm they describe the same workload.
 2. Re-state the metric, validator, split boundary, incumbent score, latency
    basis, cost basis if available, and failure taxonomy.
-3. Select the cheapest intervention that matches the observed failure mode:
+3. Select the highest-leverage intervention that matches the observed failure mode:
    prompt repair, parser/schema repair, context trimming, route change,
    candidate model comparison, or GEPA. When the complaint is cost (not
    quality) and inputs dominate the bill, check prompt-cache structure first —
    it's often the cheapest lever of all:
    [`references/prompt-cache-optimization.md`](references/prompt-cache-optimization.md).
-   Pick the cheapest *target* that matches
-   the failure too — see [`reference.md`](reference.md) → Optimization-Target
+   Prefer the lowest-cost *target* only among options expected to resolve the
+   failure; do not spend several weak iterations avoiding a stronger model or
+   broader experiment. See [`reference.md`](reference.md) → Optimization-Target
    Menu for the full list. For an agentic workload, treat latency
    and cost per rollout as first-class objectives alongside the rubric score —
    tool-call count, redundant calls, and wasted context are common, optimizable

--- a/skills/optimize-workload/reference.md
+++ b/skills/optimize-workload/reference.md
@@ -100,17 +100,20 @@ band, and the candidate route. A small live comparison only when replay can't
 answer the economic question (and only under the approval gate). Inference for
 evaluation follows the same Understudy-first default as optimization.
 
-**Optimize (cheapest intervention first).** Climb the evidence ladder: prompt
-prefill/repair → parser/schema repair → context trimming → route/candidate
-swap → GEPA. Confirm metric, incumbent route, split boundaries, sample size, and
-failure taxonomy first; run the smallest dry-run before any paid step; match the
-intervention to the *observed* failure class, not a guess.
+**Optimize (highest-leverage intervention first).** Consider prompt
+prefill/repair, parser/schema repair, context trimming, route/candidate swap, and
+GEPA according to the observed failure class. Confirm metric, incumbent route,
+split boundaries, sample size, and failure taxonomy first; use a dry-run to
+validate mechanics before any paid step, not to substitute for the full plan.
 
 ## Optimization-Target Menu
 
 The ladder above is *how* you change. This menu is *what* you change. Before
-spending budget, pick the **cheapest target that matches the observed failure
-mode** — changing a tool description is far cheaper than swapping the model.
+spending budget, pick the **target most likely to resolve the observed failure
+mode**. When multiple targets have comparable likelihood, prefer the cheaper and
+more reversible one; otherwise choose the stronger intervention and disclose the
+cost. Changing a tool description may be better than swapping the model when the
+failure is actually in tool guidance.
 State the chosen target and the failure mode it addresses in the run artifact:
 
 - **System prompt** — instructions, role, constraints applied to every call.
@@ -121,8 +124,9 @@ State the chosen target and the failure mode it addresses in the run artifact:
   bad-argument, or redundant-call failures in an agentic workload.
 - **Routing policy** — which model/route a request takes. For failures
   concentrated on a request class a different route handles better.
-- **Model choice** — the student model itself. Higher commitment; only after
-  cheaper targets stall and headroom remains.
+- **Model choice** — the student model itself. Use early when capacity or
+  capability evidence makes weaker prompt-only iterations unlikely to close the
+  gap.
 - **Context-window strategy** — what gets packed and trimmed. For truncation,
   lost-in-the-middle, or cost-from-bloat failures.
 - **Retrieval parameters** — top-k, chunking, reranking, query construction. For

--- a/skills/plan-hosted-run/SKILL.md
+++ b/skills/plan-hosted-run/SKILL.md
@@ -26,6 +26,13 @@ This skill estimates and recommends. It never provisions, rents, or spends —
 those are explicit, separate user actions. **Prices and features drift — verify
 on the provider's live pricing page before any spend.**
 
+Optimize the recommendation for reaching the workload objective, not for the
+lowest sticker price. Present the recommended outcome-sized plan first, then a
+cheaper diagnostic and a faster or higher-confidence option when useful. State
+what each buys in capability, confidence, and time-to-answer; follow
+[`../understudy/reference.md`](../understudy/reference.md) → Outcome-first spend
+posture.
+
 ## When to use
 
 - "How long will fine-tuning / SFT / an RL run take on my Mac vs a rented GPU?"
@@ -127,10 +134,12 @@ To *improve* a workload's hit rate rather than just price it, see
 ### Decide local vs cloud
 
 Present **local vs cloud side by side**: wall-clock and dollars for each, with
-the band and the dominant assumption. Recommend local when it's free and the
-wall-clock is tolerable; recommend cloud when local wall-clock is the blocker
-(typical for RL training and large-scale rollouts — the Understudy local-SFT /
-cloud-RL split). When the answer is cloud, continue to the routing below.
+the band and the dominant assumption. Recommend the route with the best expected
+progress under the real time, quality, and budget constraints—not local merely
+because its marginal dollar cost is zero. Cloud is often the correct answer when
+local wall-clock, capacity, or iteration speed blocks the objective (typical for
+RL training and large-scale rollouts — the Understudy local-SFT / cloud-RL
+split). When the answer is cloud, continue to the routing below.
 
 ## The routing decision
 

--- a/skills/prepare-verifier-handoff/SKILL.md
+++ b/skills/prepare-verifier-handoff/SKILL.md
@@ -53,9 +53,11 @@ Check these before doing anything else. Most agentic tool-use work stays local:
   trajectories? Go to
   [`../recursive-language-model/references/pedagogical-training.md`](../recursive-language-model/references/pedagogical-training.md)
   first; this handoff is only for work that still needs external or hosted
-  training. A cheaper local weight-update rung —
+  training. A local weight-update rung —
   [`../local-distillation-lab/SKILL.md`](../local-distillation-lab/SKILL.md) —
-  should also be ruled out first.
+  should be ruled out first when failure attribution says it could solve the
+  residual; do not require a weak local experiment when the evidence already
+  shows the missing capability needs hosted scale or a stronger trainer.
 - **Before** continuing, confirm RL would not be wasted spend: (a) attribute
   the multi-turn rollouts and confirm the residual is **cross-turn reasoning**,
   not format or argument-value (cheaper rungs fix those); (b) the reward is
@@ -81,6 +83,13 @@ private notes, provider keys, or secrets.
 Do not start hosted training, verifier execution, model downloads, or partner
 jobs from this repo. Require explicit approval, budget, data class, upload
 boundary, and fallback route before any future hosted action.
+
+Recommend a budget envelope sized for the learning question, with expected
+iterations, wall-clock, return-eval evidence, and the cheaper and accelerated
+alternatives visible. Do not shrink the proposed run until it is unlikely to
+answer the question merely to make the handoff look safer. Follow
+[`../understudy/reference.md`](../understudy/reference.md) → Outcome-first spend
+posture.
 
 Stages 1–2 are local-only engineering: synthetic state only, no live side
 effects, and the frozen dev/holdout rows never enter the RL train pool. Each

--- a/skills/product-knowledge/SKILL.md
+++ b/skills/product-knowledge/SKILL.md
@@ -7,7 +7,8 @@ description: Use when a user asks what Understudy is, how Understudy Desktop wor
 
 Explain Understudy as local-first infrastructure for improving LLM systems from real work:
 capture traces, run evals, compare model routes, optimize prompts or policies, and promote
-the cheapest route that meets the quality gate.
+the route that best meets the developer's objective across quality, reliability,
+latency, cost, and constraints.
 
 Use this skill for product explanations, onboarding copy, agent-facing help, and UI feature
 descriptions. Keep the answer concrete and tied to product surfaces the user can inspect.

--- a/skills/product-knowledge/reference.md
+++ b/skills/product-knowledge/reference.md
@@ -26,8 +26,8 @@ Understudy optimizes the complete production route, not only a model ID:
 3. Optimize the harness or prompt before escalating to training.
 4. Compare candidate models and suppliers against the incumbent or frontier route.
 5. Train only when the evidence supports it.
-6. Deploy the cheapest route that clears the quality gate, while retaining a control
-   slice and a fallback.
+6. Deploy the route that best satisfies the declared objective and constraints,
+   while retaining a control slice and a fallback.
 
 The route can include the prompt, tools, policy, model, compression, supplier,
 gateway, and deployment shape. Understudy should make the quality, latency, cost,

--- a/skills/ramp-and-verify/SKILL.md
+++ b/skills/ramp-and-verify/SKILL.md
@@ -56,9 +56,11 @@ node dist/bin.js status --json
    from [`../simulate-before-launch/SKILL.md`](../simulate-before-launch/SKILL.md)
    for the specific change being ramped (its contract axes — schema validity,
    tool-call validity — are the same ones step 3 verifies from captures).
-2. **Repeat-replay stability.** Re-run the candidate on the frozen rows N
-   times (default 3) and bucket each row: all-repeats-match / some / none
-   (the procedure lives in
+2. **Repeat-replay stability.** Re-run the candidate on the frozen rows in
+   incremental batches. Three repeats may serve as a plumbing smoke, but size N
+   for the agreed instability tolerance and increase it when results sit near
+   the threshold or vary across batches. Bucket each row: all-repeats-match /
+   some / none (the procedure lives in
    [`../compare-trajectories/SKILL.md`](../compare-trajectories/SKILL.md)).
    Rows that never repeat are stochastic pockets — assign each a disposition:
    **fallback** (route to incumbent), **shadow** (observe, don't serve), or
@@ -100,9 +102,11 @@ At each tier:
    error/status-code rate, latency distribution, schema/parse validity of
    outputs, and token/cost per call. The routed cohort must hold the lab
    quality bar on whatever the workload's validator can score from captures.
-4. **Spot-check determinism.** Re-run a small sample of routed rows against
-   the candidate; if repeats disagree materially more than the pre-ramp
-   measurement, stop the ramp and re-diagnose.
+4. **Check determinism on a decision-sized stratified set.** Re-run routed rows
+   against the candidate, expanding the set when variance, rare strata, or
+   failures remain uncertain. If repeats disagree materially more than the
+   pre-ramp measurement, stop the ramp and re-diagnose. Follow
+   [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
 5. **Advance or roll back.** Advance only when the tier window is clean.
    Rollback triggers — any one fires `understudy routes rollback` (or
    `routes clear`) immediately: error rate or schema-validity regression vs

--- a/skills/run-local-model-lab/SKILL.md
+++ b/skills/run-local-model-lab/SKILL.md
@@ -10,11 +10,12 @@ metadata:
 
 # Run Local Model Lab
 
-Run a local model against an existing Understudy workload/eval to see whether it
-is good enough before spending on hosted providers or routing remote traffic.
-Local inference is $0, private, and the only legal path under ZDR / SOC2 /
-local-only constraints — so it is the cheapest rung of the ladder. Same-family
-models (e.g. local Gemma 4 → remote Gemma 4 31B via the gateway) graduate cleanly.
+Run a local model against an existing Understudy workload/eval to determine the
+best route for the objective. Local inference is $0 and private, and it may be
+the only legal path under ZDR / SOC2 / local-only constraints, but do not use a
+weak local result to avoid an informative remote anchor when remote evaluation
+is allowed and could change the decision. Same-family models (e.g. local Gemma 4
+→ remote Gemma 4 31B via the gateway) graduate cleanly.
 
 **Apple Silicon + MLX only.** On Macs, MLX is the native local path — quantized
 open weights against unified memory at the best tokens/sec, no GPU drivers, no
@@ -81,10 +82,12 @@ GUI or stand up a second server against the same weights and memory budget.
    Silicon? This skill does not apply — local serving here is MLX-only.)
    See [`../../docs/background-ops.md`](../../docs/background-ops.md) for the
    background-launch and poll-readiness mechanics.
-2. **Pick a candidate tier** (candidate chooser + hardware-fit guidance in [`reference.md`](reference.md)):
-   choose the smallest model that is reasonable for the task, not the smallest
-   model available. If a ladder climb or prior local gap report already exists,
-   use it to decide
+2. **Pick a candidate tier** (candidate chooser + hardware-fit guidance in
+   [`reference.md`](reference.md)):
+   choose the model most likely to answer the route question within the hardware
+   and time available. If uncertainty is high, include a stronger anchor early
+   rather than serially exhausting weak rungs. If a ladder climb or prior local
+   gap report already exists, use it to decide
    whether to score the current rung, climb to a larger local model, or skip to
    hybrid/remote.
    - Tiny smoke — E2B / E4B class (fast, on-device; routing/triage/easy cases).
@@ -127,7 +130,8 @@ GUI or stand up a second server against the same weights and memory budget.
    blaming the model.
 4. **Compare against remote.** Score the local candidate vs the remote route
    (gateway / Lilac / frontier) on the objective:
-   - Local wins if it is *good enough* and cheaper / faster / private.
+   - Local wins if it best satisfies the agreed quality, cost, latency, and
+     privacy objective.
    - Remote wins if the quality gap blocks shipping, or local ops cost exceeds
      provider spend at the real volume.
    - Hybrid if local handles triage / extraction / routing and remote handles
@@ -142,6 +146,8 @@ GUI or stand up a second server against the same weights and memory budget.
 
 Make cost/availability/spec claims from fresh data (HF / official model cards /
 the gateway catalog), never from memory — label assumptions.
+Follow [`../understudy/reference.md`](../understudy/reference.md) → Outcome-first
+spend posture when choosing between a longer local run and a paid remote anchor.
 
 ## Output Standard
 

--- a/skills/simulate-before-launch/SKILL.md
+++ b/skills/simulate-before-launch/SKILL.md
@@ -62,6 +62,11 @@ better — this gate only judges a change, it never optimizes.
    environment from
    [`../design-simulated-environment/SKILL.md`](../design-simulated-environment/SKILL.md)
    (a recorded replay cannot host a different model's trajectory).
+4. **Evaluation evidence gates pass.** Apply
+   [`../capture-evidence/references/evaluation-evidence-gates.md`](../capture-evidence/references/evaluation-evidence-gates.md).
+   Important workload strata must be represented or explicitly excluded from
+   the verdict, agentic drivers must pass the read-then-write sentinel, and the
+   incumbent baseline must have a qualitative row review.
 
 ## The gate
 
@@ -101,6 +106,11 @@ better — this gate only judges a change, it never optimizes.
    (`understudy.launch_verdict.v1`, fields in [`reference.md`](reference.md))
    with both arms' rates, rollout counts, thresholds, and the artifact hash
    triple. Rows land as `understudy.eval_result.v1`.
+   Before issuing it, inspect the actual rollouts behind every material delta
+   and attach a redacted coverage/row-review packet. Quality and pass/fail cells
+   must be measured or say `not run`; never seed a launch report with projected
+   candidate outcomes. Add a visualization only if it answers a named launch
+   question better than the per-axis table.
 6. **Hand off.** `pass` → [`../ramp-and-verify/SKILL.md`](../ramp-and-verify/SKILL.md)
    with the verdict as pre-ramp gate 1. `block` → the failing axis is the
    work item; route to the owning skill

--- a/skills/understand-workload/SKILL.md
+++ b/skills/understand-workload/SKILL.md
@@ -144,7 +144,7 @@ When one environment-backed or tool-calling run failed and the question is
 separates environment evidence from model-visible evidence, reconstructs
 reads/writes before the first mutation, classifies the failure (retrieval,
 authority precedence, format, ID resolution, parser, harness), and recommends
-the cheapest fix before training.
+the highest-leverage fix supported by the failure evidence before training.
 
 ## References
 

--- a/skills/understand-workload/references/tool-trace-forensics.md
+++ b/skills/understand-workload/references/tool-trace-forensics.md
@@ -128,16 +128,20 @@ a structured norm.
 - `scorer_harness_issue` — the scorer assertion conflicts with visible task
   requirements or hides an impossible dependency.
 
-## Recommend the Cheapest Fix
+## Recommend the Highest-Leverage Fix
 
-Prefer read-only exploration policy, endpoint retrieval changes,
-authority-precedence prompt repair, ID-resolution rules, parser/schema repair,
-verifier changes, or route fallback before training. Training is appropriate
-only when the trace shows the model had the needed evidence and still failed a
-learnable decision repeatedly.
+Choose the intervention that addresses the measured failure with the highest
+expected progress toward the objective. Read-only exploration policy, endpoint
+retrieval changes, authority-precedence prompt repair, ID-resolution rules,
+parser/schema repair, verifier changes, or route fallback often beat training
+when the model never received usable evidence. Training is appropriate when the
+trace shows the model had the needed evidence and still failed a learnable
+decision repeatedly. State the expected cost, time, evidence, and confidence of
+the recommendation instead of making low spend the default objective.
 
-When the diagnosis is retrieval/planning, test a small prompt/policy repair
-before training:
+When the diagnosis is retrieval/planning, test a decision-sized prompt/policy
+repair before training. A small pilot may validate mechanics, but expand it
+until the result is stable enough for the named decision:
 
 ```text
 Read-only first.
@@ -179,7 +183,8 @@ verdict:
 - label: evidence
 
 ## Fix
-cheapest fix:
+recommended intervention:
+cost, time, and evidence:
 why not training yet:
 counterfactual result:
 remaining risk:

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -31,13 +31,15 @@ spend, or model downloads after explicit approval in the current thread.
    code path, profile the dataset/traces, and confirm the task meaning with the
    user.
 5. Capture or locate real traces.
-6. Build or improve a small, meaningful eval harness; rerun the incumbent
-   baseline.
+6. Build or improve a decision-sized, representative eval harness; rerun the
+   incumbent baseline.
 7. Run local optimization against eval failures.
 8. Compare candidate vs baseline on the objective.
-9. Recommend the most efficient route — harness, model, supplier, gateway/
-   inference-layer route, deployment approach.
-10. Implement the selected route safely (smallest viable change).
+9. Recommend the best route for the stated objective — harness, model, supplier,
+   gateway/inference-layer route, deployment approach — with cost and time
+   transparent.
+10. Implement the selected route safely with the smallest coherent change that
+    fully addresses the measured cause.
 11. Produce an Understudy Agent Improvement Report the developer can review.
 
 ## Frame every job
@@ -59,10 +61,11 @@ Keep these six separate and explicit — say them back before acting:
 - Measure before optimizing.
 - Optimize before routing.
 - Compare before deploying.
-- Ask before spending money or uploading data.
+- Recommend an outcome-sized plan with cost, time, data scope, and expected
+  evidence; ask before spending money or uploading data.
 
 Show partial findings early ("found 3 LLM call sites"; "app uses LiteLLM, so
-gateway insertion is low-risk"; "no evals — I'll build a small harness first";
+gateway insertion is low-risk"; "no evals — I'll build a decision-sized harness";
 "stated ZDR constraint blocks hosted upload unless approved").
 
 ## Engagement & pacing
@@ -259,12 +262,13 @@ harness/metric/split/baseline creates false progress.
 When the goal is "train an understudy" / "can a local model do this?", the
 orchestrator owns the ladder — sequence workers, don't reimplement them:
 
-1. **Smallest reasonable rung first.** Pick the smallest local model plausibly
-   reasonable for the task class (easy classification/extraction → Gemma 4 E2B
-   first; coding/structured generation → E2B feel-test then E4B/12B; tool-use →
-   E2B only if the tool surface can be bounded; long-context/high-recall →
-   expect hybrid or remote). Never start at the smallest model blindly, and
-   never evaluate `*-assistant` drafter checkpoints as standalone candidates.
+1. **Best-fit rung first.** Pick the local model most likely to answer the task
+   question within the available hardware and time (easy classification/
+   extraction → Gemma 4 E2B first; coding/structured generation → E2B feel-test
+   then E4B/12B; tool-use → E2B only if the tool surface can be bounded;
+   long-context/high-recall → start with a stronger local or remote anchor).
+   Never start at the smallest model blindly, and never evaluate `*-assistant`
+   drafter checkpoints as standalone candidates.
    Use [`../manage-local-models/SKILL.md`](../manage-local-models/SKILL.md) and
    [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
 2. **Optional frontier head-to-head** for calibration — use
@@ -292,11 +296,15 @@ orchestrator owns the ladder — sequence workers, don't reimplement them:
 
 ## Safety Gates
 
-Default to the cheapest path that still reaches an outcome — not to zero spend (a
-skipped improvement has real opportunity cost). Require explicit confirmation for
-any action that uploads data, spends money, changes credentials, deploys
-behavior, or alters a production route — unless the developer has configured
-unattended mode.
+Default to the path with the highest expected progress toward the stated
+objective under the developer's hard constraints. Make spend, wall-clock, data
+scope, expected evidence, and alternatives visible; do not silently choose the
+weakest model, smallest cohort, or narrowest intervention because it is cheap.
+Follow the outcome-first spend posture in [`reference.md`](reference.md). Require
+explicit confirmation for any action that uploads data, spends money, changes
+credentials, deploys behavior, or alters a production route — unless the
+developer has configured unattended mode. One confirmation may cover a named,
+bounded run plan; ask again before expanding its envelope.
 
 Do not ask the developer to register, authenticate, paste secrets, or configure
 provider keys before the local evidence loop has found a concrete need. When that

--- a/skills/understudy/reference.md
+++ b/skills/understudy/reference.md
@@ -37,6 +37,32 @@ Do not ask anything the repo answers. Surface what you found instead.
 A single change often moves several at once (e.g. a prompt that stops retries
 cuts both cost and latency) — measure all affected axes, not just the target.
 
+## Outcome-first spend posture
+
+Optimize for solving the named problem under hard constraints, not for the
+smallest bill or experiment by default. Spend and compute are decision axes;
+they become the primary objective only when the developer says so.
+
+For any paid or long-running path:
+
+1. Recommend the plan with the highest expected progress toward the objective.
+2. State its spend envelope, wall-clock, data boundary, evidence produced, and
+   confidence or decision it should unlock.
+3. When useful, show a cheaper diagnostic and a faster or higher-confidence
+   alternative, with the capability each option gives up or adds.
+4. Ask once for the named bounded plan. Continue within that approved envelope;
+   ask again only before expanding spend, data scope, production impact, or
+   another hard boundary.
+5. If the plan is inconclusive, say what more data, stronger model, extra
+   compute, or wider experiment is likely to resolve. Recommend that next step
+   when its expected value exceeds its cost.
+
+Stop only when the objective is met, another action is unlikely to change the
+decision, a hard constraint or approved envelope is reached, or the user chooses
+to stop. A cheap inconclusive run is evidence, not completion. Reuse prior
+evidence when it already answers the same question; outcome-first is not license
+for redundant spend.
+
 ## Constraints (detect, respect, gate)
 
 Detect from the repo and the developer: SOC 2, ZDR, local-only, data-retention
@@ -85,8 +111,9 @@ a current source is not a claim — it's a guess.
 
 ## Deploy and compare
 
-Keep the baseline reproducible. Apply the smallest viable change — prefer config
-or a workload route over editing hardcoded call sites. Register/route the improved
+Keep the baseline reproducible. Apply the smallest coherent change that fully
+addresses the measured cause — prefer config or a workload route over editing
+hardcoded call sites when either solves it. Register/route the improved
 behavior through the inference layer when appropriate (gateway route + traffic %),
 or write a local deployment artifact / `understudy.yaml` in local-only mode.
 Always include rollback steps, run comparison evals, show before/after metrics,
@@ -125,6 +152,10 @@ Produce this for every completed improvement attempt:
 - Make pricing/availability claims without current data.
 - Deploy production changes without approval.
 - Bury or omit regressions.
+- Default to the cheapest or smallest action without comparing expected
+  progress, time-to-answer, and confidence.
+- Treat an inconclusive smoke, weak candidate, or underpowered run as the end of
+  the job when more data or compute would likely resolve the question.
 
 ## Examples
 

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -288,9 +288,10 @@ Domain depth in [`reference.md`](reference.md):
   metadata; redact; skip upload in local-only / restricted (ZDR) modes; produce a
   trace inventory (defer call-site discovery to
   [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)).
-- **Deploy and compare** — reproducible baseline, smallest route/config change
-  via the workloads API (or a local `understudy.yaml`), rollback, comparison
-  evals, before/after metrics, surfaced regressions.
+- **Deploy and compare** — reproducible baseline, smallest coherent route/config
+  change that solves the measured cause via the workloads API (or a local
+  `understudy.yaml`), rollback, comparison evals, before/after metrics, surfaced
+  regressions.
 
 For route selection and the fresh-pricing rule, see
 [`../understudy/reference.md`](../understudy/reference.md); for measured claims,

--- a/skills/use-understudy-gateway/reference.md
+++ b/skills/use-understudy-gateway/reference.md
@@ -140,18 +140,20 @@ Write capture artifacts under a local path such as
 
 ## Workflow 2 — Deploy and compare
 
-Goal: ship the smallest viable improvement through the inference layer, prove it
-against the baseline, and make rollback and any regression obvious. Confirmation
-rules below apply to every upload, spend, credential, deploy, or route change.
+Goal: ship the smallest coherent improvement that fully addresses the measured
+cause through the inference layer, prove it against the baseline, and make
+rollback and any regression obvious. Confirmation rules below apply to every
+upload, spend, credential, deploy, or route change.
 
 1. **Keep the baseline reproducible.** Pin the incumbent route, the frozen eval
    split, and the captured baseline metrics before changing anything. Reuse the
    `capture-evidence` `baseline.json` contract so the comparison is hash-bound to
    the same harness, metric, and splits.
-2. **Apply the smallest viable change.** Prefer a config or route change over
-   editing hardcoded call sites: a model swap, a routed traffic split, a prompt
-   variant, or a parser fix is usually enough. Editing call sites directly is the
-   last resort and must be reversible.
+2. **Apply the smallest coherent change that solves the cause.** Prefer a config
+   or route change over editing hardcoded call sites when it is sufficient: a
+   model swap, routed traffic split, prompt variant, or parser fix may be enough.
+   Do not preserve an incomplete fix merely to minimize diff size. Editing call
+   sites directly is the last resort and must be reversible.
 3. **Register / route the improved behavior through the inference layer.** Use
    the workloads route API to send a bounded share of traffic to the improved
    model. The app keeps calling the normal gateway path; the control-plane route

--- a/tests/evaluation-evidence-gates.test.mjs
+++ b/tests/evaluation-evidence-gates.test.mjs
@@ -8,6 +8,10 @@ test("evaluation evidence standard covers coverage, conformance, rows, and claim
   const standard = read("skills/capture-evidence/references/evaluation-evidence-gates.md");
 
   assert.match(standard, /completed execution/i);
+  assert.match(standard, /minimums, never caps/i);
+  assert.match(standard, /prefer using more of\s+it/i);
+  assert.match(standard, /data-sufficiency plan/i);
+  assert.match(standard, /stable under another meaningful increment/i);
   assert.match(standard, /uncovered important stratum blocks a whole-workload conclusion/i);
   assert.match(standard, /read-then-write/i);
   assert.match(standard, /intermediate read\/tool call as a no-op/i);
@@ -15,6 +19,7 @@ test("evaluation evidence standard covers coverage, conformance, rows, and claim
   assert.match(standard, /scorer\/rubric error, harness\/parser error/i);
   assert.match(standard, /not run/i);
   assert.match(standard, /Decorative charts/i);
+  assert.doesNotMatch(standard, /2[–-]10|up to 10|roughly 10/i);
 });
 
 test("decision skills enforce the shared evaluation evidence gates", () => {

--- a/tests/evaluation-evidence-gates.test.mjs
+++ b/tests/evaluation-evidence-gates.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path) => readFileSync(path, "utf8");
+
+test("evaluation evidence standard covers coverage, conformance, rows, and claims", () => {
+  const standard = read("skills/capture-evidence/references/evaluation-evidence-gates.md");
+
+  assert.match(standard, /completed execution/i);
+  assert.match(standard, /uncovered important stratum blocks a whole-workload conclusion/i);
+  assert.match(standard, /read-then-write/i);
+  assert.match(standard, /intermediate read\/tool call as a no-op/i);
+  assert.match(standard, /one counterexample/i);
+  assert.match(standard, /scorer\/rubric error, harness\/parser error/i);
+  assert.match(standard, /not run/i);
+  assert.match(standard, /Decorative charts/i);
+});
+
+test("decision skills enforce the shared evaluation evidence gates", () => {
+  for (const path of [
+    "skills/capture-evidence/SKILL.md",
+    "skills/optimize-agentic-workload/SKILL.md",
+    "skills/compare-model-sweep/SKILL.md",
+    "skills/optimize-workload/SKILL.md",
+    "skills/simulate-before-launch/SKILL.md",
+  ]) {
+    assert.match(
+      read(path),
+      /evaluation-evidence-gates\.md/,
+      `${path} must link to the shared gate`,
+    );
+  }
+});
+
+test("cost audits prioritize concentration and keep value classification human-guided", () => {
+  const skill = read("skills/lower-anthropic-bill/SKILL.md");
+
+  assert.match(skill, /addressable spend × confidence × expected\s+implementation leverage/);
+  assert.match(skill, /let the developer drill into representative rows/i);
+});

--- a/tests/outcome-first-spend-posture.test.mjs
+++ b/tests/outcome-first-spend-posture.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path) => readFileSync(path, "utf8");
+
+test("orchestrator defines an outcome-first and transparent spend posture", () => {
+  const reference = read("skills/understudy/reference.md");
+
+  assert.match(reference, /highest expected progress toward the objective/i);
+  assert.match(reference, /spend envelope, wall-clock, data boundary/i);
+  assert.match(reference, /Ask once for the named bounded plan/i);
+  assert.match(reference, /A cheap inconclusive run is evidence, not completion/i);
+  assert.match(reference, /outcome-first is not license\s+for redundant spend/i);
+});
+
+test("core decision skills apply outcome-first spend guidance", () => {
+  for (const path of [
+    "skills/capture-evidence/SKILL.md",
+    "skills/optimize-workload/SKILL.md",
+    "skills/optimize-agentic-workload/SKILL.md",
+    "skills/compare-model-sweep/SKILL.md",
+    "skills/lower-anthropic-bill/SKILL.md",
+    "skills/run-local-model-lab/SKILL.md",
+    "skills/plan-hosted-run/SKILL.md",
+    "skills/prepare-verifier-handoff/SKILL.md",
+  ]) {
+    assert.match(
+      read(path),
+      /Outcome-first\s+spend\s+posture/i,
+      `${path} must link to the shared posture`,
+    );
+  }
+});
+
+test("decision guidance rejects minimum-spend defaults and fixed smoke conclusions", () => {
+  const corpus = [
+    "skills/understudy/SKILL.md",
+    "skills/capture-evidence/SKILL.md",
+    "skills/optimize-workload/SKILL.md",
+    "skills/optimize-agentic-workload/SKILL.md",
+    "skills/compare-model-sweep/SKILL.md",
+    "skills/compare-trajectories/SKILL.md",
+    "skills/run-local-model-lab/SKILL.md",
+    "skills/design-simulated-environment/SKILL.md",
+    "skills/understand-workload/references/tool-trace-forensics.md",
+    "skills/optimize-agentic-workload/references/read-only-search.md",
+    "skills/optimize-agentic-workload/references/state-mutating-workflows.md",
+    "skills/local-distillation-lab/references/pedagogical-arm.md",
+  ]
+    .map(read)
+    .join("\n");
+
+  assert.doesNotMatch(corpus, /default to the cheapest path/i);
+  assert.doesNotMatch(corpus, /cheapest acceptable model/i);
+  assert.doesNotMatch(corpus, /small set of correct outcomes/i);
+  assert.doesNotMatch(corpus, /recommend the cheapest fix/i);
+  assert.doesNotMatch(corpus, /pick the cheapest model/i);
+  assert.doesNotMatch(corpus, /prefer the smallest working local rung/i);
+  assert.doesNotMatch(corpus, /tiny train\/dev slice/i);
+  assert.match(corpus, /Three\s+repeats are a plumbing smoke, not a universal N/i);
+  assert.match(corpus, /include a stronger anchor early/i);
+});


### PR DESCRIPTION
## Summary

Turns recent workflow feedback into shared evidence gates across capture, optimization, model comparison, launch simulation, and spend decisions. The changes stay generic and public-safe: no customer identity, private payloads, transcript excerpts, or private artifact paths are included.

This revision removes two related failure modes:

- Fixed small-sample guidance. Pilots validate plumbing only; evaluation expands until the named decision is stable, important strata meet planned precision or exhaustive-review rules, and remaining uncertainty is explicit.
- Minimum-spend defaults. Skills recommend the outcome-sized plan first, disclose spend, time, data scope, evidence, and confidence, and use stronger models, more data, or more compute when they are likely to resolve the question.

Privacy, upload, credential, production-mutation, and hard spend-envelope gates remain intact. One approval may cover a named bounded plan; expanding that envelope still requires approval.

## Punchlist

| Area | Desired state | Action | Status |
| --- | --- | --- | --- |
| Data sufficiency | More data is the default response to unstable, heterogeneous, or underpowered evidence | Treat row targets as minimums, never caps; size for decision risk and material difference; expand in meaningful batches until stopping criteria pass | Implemented |
| Smoke tests | Tiny samples prove mechanics, not product quality or completion | Relabel 3-task, 3-repeat, and small-slice runs as plumbing smokes; require adaptive expansion before claims | Implemented |
| Spend posture | Optimize for solving the named problem under hard constraints, not minimizing spend in isolation | Add a shared outcome-first doctrine; recommend the outcome-sized plan first and disclose spend envelope, wall-clock, data boundary, evidence, and confidence | Implemented |
| Approval pacing | Users understand and control spend without approving every call | Allow one explicit approval for a named bounded batch; ask again only before expanding spend, data scope, production impact, or another hard boundary | Implemented |
| Model and compute escalation | Weak candidates do not become the default merely because they are cheap or local | Include a strong anchor early when informative; skip directly to stronger models, hosted runs, training, or broader experiments when prior evidence shows another weak smoke will not change the decision | Implemented |
| Intervention selection | Skills fix the measured cause with the highest expected leverage | Replace cheapest-fix and cheapest-intervention ladders with expected-progress ranking across prompt, context, route, model, training, and harness changes | Implemented |
| Transparency | The user sees capability and tradeoffs before execution | State expected outcome, cost, time, evidence, confidence, and what cheaper or faster alternatives give up or add | Implemented |
| Stop conditions | Cheap inconclusive work is evidence, not completion | Stop only when the objective is met, another action is unlikely to change the decision, a hard boundary is reached, or the user stops | Implemented |
| Metric interpretation | Aggregate claims are grounded in actual rows and counterexamples | Require expanding row review for passes, every claimed failure class, surprising deltas, and disconfirming examples; separate model failures from scorer, harness, label, and free-text-equivalence problems | Implemented |
| Coverage | Common and rare or high-consequence paths are represented, with complexity classified from completed execution when needed | Add a coverage matrix, require exhaustive rare/high-consequence review when tractable, and block whole-workload claims when important strata are uncovered | Implemented in skills; automation roadmapped in #281 |
| Agentic harnesses | Multi-turn read-to-write behavior reaches terminal state before scoring | Add per-model-family conformance sentinels and make intermediate tool-call no-op verdicts invalid | Implemented |
| Optimization rigor | Small development gains do not become launch claims and sealed holdout regressions are treated as overfitting | Make small pilots plumbing-only, calibrate claims by split, and require more data or a fresh balanced split contract when evidence is unstable | Implemented |
| Reviewability | Developers can inspect decision-sized evidence and drill into the full cohort | Require a redacted local review packet with stratified batches, scorer rationale, full-cohort counts, and run, task, artifact, and log references | Implemented in skills; automatic packet generation roadmapped in #281 |
| Decision surfaces | Candidate outcomes are real and visuals answer a concrete decision | Require measured values or not run; prohibit plausible synthetic quality cells and decorative or mock-run visuals | Implemented |
| Cost prioritization | Work starts at concentrated, addressable spend with high-confidence leverage | Rank by addressable spend times confidence times implementation leverage | Implemented |
| Value segmentation | Value and consumption labels remain human-guided and inspectable | Expose candidate segments and representative rows instead of imposing a universal low-value taxonomy | Implemented in skill; durable tags roadmapped in #281 |

## Outcome-first stopping rule

Continue when a material result changes across batches, uncertainty exceeds the decision tolerance, a stratum is underfilled, errors cluster, review discovers new failure classes, or a stronger model or wider experiment is likely to change the decision. Stop only when the decision remains stable under another meaningful increment, important strata meet planned precision or exhaustive-review rules, and residual uncertainty is explicit. If more evidence is unavailable, narrow or defer the conclusion.

Outcome-first is not permission for redundant spend: reuse prior evidence when it already answers the same question.

## Roadmap

Closes the skills-level gaps now. Durable execution-derived cohort discovery, incremental expansion, stability reporting, rare-case accumulation, human tags, and generated local review packets need CLI and artifact work, tracked in #281.

## Validation

- npm run check - passed (404 tests, 0 failures; 34 public skills validated; package dry-run passed)
- git diff --check - passed
- Added regression tests that reject fixed evidence caps, cheapest-first defaults, tiny-slice conclusions, and specialist references that override the shared outcome-first posture
