### PR TITLE
Add agent discovery pointers for OpenCode, Claude, and Codex #35

### DIFF
--- a/.claude/skills/capture-evidence
+++ b/.claude/skills/capture-evidence
@@ -1,0 +1,1 @@
+../../skills/capture-evidence

--- a/.claude/skills/check-routing-health
+++ b/.claude/skills/check-routing-health
@@ -1,0 +1,1 @@
+../../skills/check-routing-health

--- a/.claude/skills/compare-model-sweep
+++ b/.claude/skills/compare-model-sweep
@@ -1,0 +1,1 @@
+../../skills/compare-model-sweep

--- a/.claude/skills/compare-trajectories
+++ b/.claude/skills/compare-trajectories
@@ -1,0 +1,1 @@
+../../skills/compare-trajectories

--- a/.claude/skills/curate-trajectories
+++ b/.claude/skills/curate-trajectories
@@ -1,0 +1,1 @@
+../../skills/curate-trajectories

--- a/.claude/skills/design-simulated-environment
+++ b/.claude/skills/design-simulated-environment
@@ -1,0 +1,1 @@
+../../skills/design-simulated-environment

--- a/.claude/skills/distill-classifier
+++ b/.claude/skills/distill-classifier
@@ -1,0 +1,1 @@
+../../skills/distill-classifier

--- a/.claude/skills/ingest-traces
+++ b/.claude/skills/ingest-traces
@@ -1,0 +1,1 @@
+../../skills/ingest-traces

--- a/.claude/skills/inspect-billing-sources
+++ b/.claude/skills/inspect-billing-sources
@@ -1,0 +1,1 @@
+../../skills/inspect-billing-sources

--- a/.claude/skills/install-agent-adapter
+++ b/.claude/skills/install-agent-adapter
@@ -1,0 +1,1 @@
+../../skills/install-agent-adapter

--- a/.claude/skills/install-codex-plugin
+++ b/.claude/skills/install-codex-plugin
@@ -1,0 +1,1 @@
+../../skills/install-codex-plugin

--- a/.claude/skills/install-cursor-plugin
+++ b/.claude/skills/install-cursor-plugin
@@ -1,0 +1,1 @@
+../../skills/install-cursor-plugin

--- a/.claude/skills/install-opencode-plugin
+++ b/.claude/skills/install-opencode-plugin
@@ -1,0 +1,1 @@
+../../skills/install-opencode-plugin

--- a/.claude/skills/install-plugin
+++ b/.claude/skills/install-plugin
@@ -1,0 +1,1 @@
+../../skills/install-plugin

--- a/.claude/skills/ladder
+++ b/.claude/skills/ladder
@@ -1,0 +1,1 @@
+../../skills/ladder

--- a/.claude/skills/local-distillation-lab
+++ b/.claude/skills/local-distillation-lab
@@ -1,0 +1,1 @@
+../../skills/local-distillation-lab

--- a/.claude/skills/lower-anthropic-bill
+++ b/.claude/skills/lower-anthropic-bill
@@ -1,0 +1,1 @@
+../../skills/lower-anthropic-bill

--- a/.claude/skills/manage-local-models
+++ b/.claude/skills/manage-local-models
@@ -1,0 +1,1 @@
+../../skills/manage-local-models

--- a/.claude/skills/onboard
+++ b/.claude/skills/onboard
@@ -1,0 +1,1 @@
+../../skills/onboard

--- a/.claude/skills/optimize-agentic-workload
+++ b/.claude/skills/optimize-agentic-workload
@@ -1,0 +1,1 @@
+../../skills/optimize-agentic-workload

--- a/.claude/skills/optimize-local-model-compression
+++ b/.claude/skills/optimize-local-model-compression
@@ -1,0 +1,1 @@
+../../skills/optimize-local-model-compression

--- a/.claude/skills/optimize-workload
+++ b/.claude/skills/optimize-workload
@@ -1,0 +1,1 @@
+../../skills/optimize-workload

--- a/.claude/skills/plan-hosted-run
+++ b/.claude/skills/plan-hosted-run
@@ -1,0 +1,1 @@
+../../skills/plan-hosted-run

--- a/.claude/skills/prepare-verifier-handoff
+++ b/.claude/skills/prepare-verifier-handoff
@@ -1,0 +1,1 @@
+../../skills/prepare-verifier-handoff

--- a/.claude/skills/product-knowledge
+++ b/.claude/skills/product-knowledge
@@ -1,0 +1,1 @@
+../../skills/product-knowledge

--- a/.claude/skills/ramp-and-verify
+++ b/.claude/skills/ramp-and-verify
@@ -1,0 +1,1 @@
+../../skills/ramp-and-verify

--- a/.claude/skills/recursive-language-model
+++ b/.claude/skills/recursive-language-model
@@ -1,0 +1,1 @@
+../../skills/recursive-language-model

--- a/.claude/skills/run-local-model-lab
+++ b/.claude/skills/run-local-model-lab
@@ -1,0 +1,1 @@
+../../skills/run-local-model-lab

--- a/.claude/skills/share-savings
+++ b/.claude/skills/share-savings
@@ -1,0 +1,1 @@
+../../skills/share-savings

--- a/.claude/skills/simulate-before-launch
+++ b/.claude/skills/simulate-before-launch
@@ -1,0 +1,1 @@
+../../skills/simulate-before-launch

--- a/.claude/skills/understand-workload
+++ b/.claude/skills/understand-workload
@@ -1,0 +1,1 @@
+../../skills/understand-workload

--- a/.claude/skills/understudy
+++ b/.claude/skills/understudy
@@ -1,0 +1,1 @@
+../../skills/understudy

--- a/.claude/skills/use-understudy-gateway
+++ b/.claude/skills/use-understudy-gateway
@@ -1,0 +1,1 @@
+../../skills/use-understudy-gateway

--- a/.claude/skills/watch-logs
+++ b/.claude/skills/watch-logs
@@ -1,0 +1,1 @@
+../../skills/watch-logs

--- a/.codex/codex.md
+++ b/.codex/codex.md
@@ -1,0 +1,12 @@
+# Codex - Understudy skills
+
+Follow [`AGENTS.md`](../AGENTS.md).
+
+- Skill library: [`skills/`](../skills/)
+- Entrypoint / orchestrator: [`skills/understudy/SKILL.md`](../skills/understudy/SKILL.md)
+- Full index: [`skills/README.md`](../skills/README.md)
+
+These files only point at the shared skill tree. Do not copy or fork skill
+content here. For end-user Codex install, use
+[`install-agent-adapter`](../skills/install-agent-adapter/SKILL.md) (platform
+`codex`) or the local marketplace in [`.codex-plugin/`](../.codex-plugin/).

--- a/.codex/instructions.md
+++ b/.codex/instructions.md
@@ -1,0 +1,11 @@
+# Codex agent instructions
+
+When acting as an agent in this repository:
+
+1. Read and follow [`AGENTS.md`](../AGENTS.md).
+2. Load capability playbooks from [`skills/`](../skills/) as needed.
+3. Start with the orchestrator [`skills/understudy/SKILL.md`](../skills/understudy/SKILL.md);
+   use [`skills/README.md`](../skills/README.md) as the index.
+
+Do not maintain a per-skill catalog in this directory - the skill library is
+the source of truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,13 @@ workload, not to edit the library.
 
 The skill library lives in [`skills/`](skills/). Start with the orchestrator
 [`understudy`](skills/understudy/SKILL.md); the full index is
-[`skills/README.md`](skills/README.md). Claude Code discovers the same tree via
-the local marketplace (`.claude-plugin/`) - do not mirror skills under
-`.claude/skills/` in this repo.
+[`skills/README.md`](skills/README.md).
+
+Claude Code can discover the same tree two ways: the local marketplace plugin
+(`.claude-plugin/`), and native skill links under [`.claude/skills/`](.claude/skills/)
+that point back at `skills/` (not copies). Prefer the plugin install path in
+[`AGENTS.md`](AGENTS.md) for end users; the `.claude/skills/` links help agents
+opened on this repo without a plugin install.
 
 ## How to behave
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ before doing anything else:
 
 - **A user who wants to *use* Understudy** — improve an LLM app, cut cost, run a
   local model, pick a route. **Install the plugin first** (the
-  [`install-plugin`](skills/install-plugin/SKILL.md) skill), then run the
+  [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill), then run the
   [`onboard`](skills/onboard/SKILL.md) skill. The plugin's skills are what let
   you explain what Understudy is, why it matters, and actually solve their
   problem. Don't try to wing it from the source tree.
@@ -21,6 +21,14 @@ before doing anything else:
 
 When in doubt, assume the first. Most people here want help with their LLM
 workload, not to edit the library.
+
+## Skill Library Entry Point
+
+The skill library lives in [`skills/`](skills/). Start with the orchestrator
+[`understudy`](skills/understudy/SKILL.md); the full index is
+[`skills/README.md`](skills/README.md). Claude Code discovers the same tree via
+the local marketplace (`.claude-plugin/`) - do not mirror skills under
+`.claude/skills/` in this repo.
 
 ## How to behave
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": ["./skills"]
+  },
+  "instructions": [
+    "AGENTS.md",
+    "skills/README.md"
+  ]
+}


### PR DESCRIPTION
Closes #35

## Summary
- Add `opencode.json` so OpenCode scans `./skills` and loads `AGENTS.md` + `skills/README.md`
- Extend `CLAUDE.md` with a skill-library entry point (orchestrator + index)
- Add minimal `.codex/` pointer docs to the shared `skills/` tree
- Add `.claude/skills/` **symlinks** for the full `skills/` catalog so Claude Code can load playbooks natively without copying skill content

## Notes on `.claude/skills/`

Issue #35 asked for symlink/copy under `.claude/skills/` (or `.claude/commands/`).
This PR uses **symlinks** to every skill directory under `skills/` (34 links; skips `_resources`), not copies and not a partial hand-picked list.



## Implementation note: 
I used Cursor to assist with generating the initial implementation, but I manually reviewed every file, verified the changes, and made adjustments where needed before submitting this PR
