### PR TITLE
fix(desktop): remove Tauri from update copy

### DIFF
--- a/apps/homescreen/app/lib/runtime-repair.ts
+++ b/apps/homescreen/app/lib/runtime-repair.ts
@@ -149,7 +149,7 @@ export function promptForRepairFailure(prompt: RepairPrompt, error: unknown): Re
 }
 
 export function repairPromptMeta(prompt: RepairPrompt): string {
-  if (prompt.runtime === "desktop") return "Signed Tauri update";
+  if (prompt.runtime === "desktop") return "Signed update";
   if (prompt.runtime === "cli") return "Included with Understudy Desktop";
   return prompt.command;
 }

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -470,7 +470,8 @@ test("desktop has one shared managed-operation notice surface", async () => {
   assert.match(repair, /Install update/);
   assert.match(repair, /Automatic update stopped/);
   assert.match(repair, /The CLI is included with Understudy Desktop/);
-  assert.match(repair, /Signed Tauri update/);
+  assert.match(repair, /Signed update/);
+  assert.doesNotMatch(repair, /Tauri update/);
   assert.match(
     repair,
     /github\.com\/understudylabs\/understudy-agent-tools\/releases\/latest/,


### PR DESCRIPTION
## Summary

- Replace the update banner metadata `Signed Tauri update` with the product-facing `Signed update`.
- Add a regression assertion preventing the implementation-detail wording from returning.

## Why

The update prompt should communicate the user-facing trust property without exposing the Desktop framework.

## Validation

- `node --test tests/desktop-ui-lineage.test.mjs` — 20 passed
- `npx tsc --noEmit` in `apps/homescreen` — passed
- `git diff --check` — passed
