### PR TITLE
chore(release): prepare Desktop 0.3.31

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.27"
+    "version": "0.6.28"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.27"
+    "version": "0.6.28"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/apps/homescreen/app/components/RemoteTrainingPanel.tsx
+++ b/apps/homescreen/app/components/RemoteTrainingPanel.tsx
@@ -101,6 +101,30 @@ type RemoteResult = {
   output_model?: string;
   endpoint?: string;
   spend_usd: number;
+  estimated_spend_usd?: number;
+  reserved_spend_usd?: number;
+  reconciled_spend_usd?: number | null;
+  provider_error?: {
+    phase: "training" | "deployment" | "adapter" | "evaluation";
+    resource_id: string;
+    resource: string;
+    status: string;
+    code?: string;
+    message?: string;
+  };
+  terminal_error?: {
+    phase: "queued" | "upload" | "training" | "deployment" | "adapter" | "evaluation" | "cleanup";
+    code: string;
+    message: string;
+  };
+  cleanup_attempts?: Array<{
+    resource_kind: "training_job" | "adapter" | "deployment" | "model" | "datasets" | "uploads";
+    resource_id: string;
+    attempts: number;
+    outcome: "removed_or_absent" | "pending";
+    error?: string;
+  }>;
+  cleanup_pending?: Array<"training_job" | "adapter" | "deployment" | "model" | "datasets" | "uploads">;
   metrics: HumanMetric[];
   failures: { input_summary: string; expected: string; actual: string }[];
 };
@@ -493,13 +517,31 @@ export function RemoteTrainingPanel(props: Props) {
         : result.outcome === "cancelled"
           ? { eyebrow: "Stopped safely", title: "Remote training was cancelled" }
           : { eyebrow: "Run ended", title: "Remote training did not complete" };
+    const diagnostic = result.provider_error
+      ? {
+          title: `${result.provider_error.phase} failed · ${result.provider_error.code ?? result.provider_error.status}`,
+          message: result.provider_error.message ?? result.terminal_error?.message ?? "The provider stopped this resource.",
+        }
+      : result.terminal_error
+        ? { title: `${result.terminal_error.phase} failed · ${result.terminal_error.code}`, message: result.terminal_error.message }
+        : result.outcome === "failed"
+          ? { title: "No detailed diagnostic", message: "This run predates detailed failure receipts. New runs preserve the provider error here and on this Mac." }
+          : null;
+    const hasSpendBreakdown = result.estimated_spend_usd !== undefined
+      || result.reserved_spend_usd !== undefined
+      || result.reconciled_spend_usd !== undefined;
+    const hasCleanupDetails = (result.cleanup_attempts?.length ?? 0) > 0 || (result.cleanup_pending?.length ?? 0) > 0;
     return (
       <div className={`remote-training-result ${result.outcome}`}>
-        <div><span>{terminalCopy.eyebrow}</span><strong>{terminalCopy.title}</strong><small>Reported training cost: ${result.spend_usd.toFixed(2)}</small></div>
+        <div><span>{terminalCopy.eyebrow}</span><strong>{terminalCopy.title}</strong><small>{result.reconciled_spend_usd != null ? "Provider spend" : "Budget accounted"}: ${result.spend_usd.toFixed(2)}</small></div>
+        {diagnostic && <p className="remote-training-diagnostic"><strong>{diagnostic.title}</strong><small>{diagnostic.message}</small></p>}
         {primaryMetric && <div className="remote-training-metrics"><article><span>{primaryMetric.label}</span><strong>{primaryMetric.display_value}</strong></article></div>}
-        {(secondaryMetrics.length > 0 || result.failures.length > 0 || result.output_model) && (
+        {(secondaryMetrics.length > 0 || result.failures.length > 0 || result.output_model || result.provider_error || hasSpendBreakdown || hasCleanupDetails) && (
           <details className="remote-training-details">
             <summary>Run details</summary>
+            {hasSpendBreakdown && <small>Estimate ${result.estimated_spend_usd?.toFixed(2) ?? "—"} · reserve ${result.reserved_spend_usd?.toFixed(2) ?? "—"} · reconciled {result.reconciled_spend_usd == null ? "pending" : `$${result.reconciled_spend_usd.toFixed(2)}`}</small>}
+            {result.provider_error && <small>Provider {result.provider_error.status} · {result.provider_error.resource_id}</small>}
+            {hasCleanupDetails && <small>{result.cleanup_pending?.length ? `Cleanup pending: ${result.cleanup_pending.join(", ")}` : "Cleanup complete"}</small>}
             {secondaryMetrics.length > 0 && <div className="remote-training-metrics">{secondaryMetrics.map((metric) => <article key={metric.id}><span>{metric.label}</span><strong>{metric.display_value}</strong><small>{metric.explanation}</small></article>)}</div>}
             {result.failures.length > 0 && <div className="remote-training-failures"><strong>Where it still fails</strong>{result.failures.slice(0, 3).map((failure, index) => <p key={index}>{failure.expected} expected · {failure.actual} returned · {failure.input_summary}</p>)}</div>}
             {result.output_model && <div className="remote-training-endpoint"><span>Private trained model</span><code>{result.output_model}</code>{result.endpoint && <small>Serving is active through the authenticated Understudy endpoint.</small>}</div>}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -3843,6 +3843,18 @@ select,
 .remote-training-state.failed small {
   color: var(--warning) !important;
 }
+.remote-training-diagnostic {
+  display: grid;
+  gap: 3px;
+  margin: 0;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, var(--warning) 28%, var(--border));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--warning) 4%, transparent);
+}
+.remote-training-diagnostic strong {
+  font-size: 11px;
+}
 .remote-training-result.promoted {
   border-color: color-mix(in srgb, var(--success) 42%, var(--border));
 }

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.30",
+  "version": "0.3.31",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.30"
+version = "0.3.31"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.30"
+version = "0.3.31"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -24,7 +24,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.27";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.28";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.30";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.31";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/remote_training.rs
+++ b/apps/homescreen/src-tauri/src/remote_training.rs
@@ -2688,6 +2688,20 @@ pub async fn remote_training_poll(run_manifest_path: String) -> Result<Value, St
         None,
     )
     .await?;
+    if matches!(
+        status.get("workflow_status").and_then(Value::as_str),
+        Some("completed" | "failed" | "cancelled")
+    ) {
+        if let Some(result) = status.get("result") {
+            let result_path = PathBuf::from(&run.run_manifest_path)
+                .parent()
+                .ok_or_else(|| {
+                    "The remote training run has no private result directory.".to_string()
+                })?
+                .join("result.json");
+            replace_private_json(&result_path, result)?;
+        }
+    }
     Ok(json!({
         "schema_version": "understudy.remote_training.poll.v1",
         "run_id": run.run_id,

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.27",
+      "version": "0.6.28",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.30";
+export const RUNTIME_VERSION = "0.3.31";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/remote-training-desktop.test.mjs
+++ b/tests/remote-training-desktop.test.mjs
@@ -71,6 +71,13 @@ test("remote training uses live capabilities with explicit upload and spend cons
   assert.doesNotMatch(panel, /Approve & run/);
   assert.doesNotMatch(panel, /<summary>Details<\/summary>/);
   assert.match(panel, /<summary>Run details<\/summary>/);
+  assert.match(panel, /provider_error/);
+  assert.match(panel, /terminal_error/);
+  assert.match(panel, /Provider spend/);
+  assert.match(panel, /Budget accounted/);
+  assert.match(panel, /This run predates detailed failure receipts/);
+  assert.match(native, /join\("result\.json"\)/);
+  assert.match(native, /Some\("completed" \| "failed" \| "cancelled"\)/);
   assert.match(panel, /private splits · endpoint auto-deletes/);
   assert.doesNotMatch(panel, /type="checkbox"/);
   assert.match(panel, /Where it still fails/);


### PR DESCRIPTION
## Summary

- bump Desktop and bundled runtime from 0.3.30 to 0.3.31
- bump the CLI and all adapter compatibility manifests from 0.6.27 to 0.6.28
- render provider and terminal failure diagnostics returned by the hosted correctness API
- distinguish provider spend from budget-accounted reserve and keep the breakdown in Run details
- persist every terminal remote-training result privately beside run.json for local investigation

## Validation

- npm run desktop:release-plan -- --verify
- npm run check (423 tests, 34 public skills, package smoke)
- npm run desktop:release-check -- --stage source --allow-dirty --allow-unmerged
- bun install --frozen-lockfile && bun run build
- cargo test (190 passed, 4 ignored real-data fixtures)
- cargo fmt --check
- git diff --check

After merge, the production workflow will independently require green gates and rust checks for the exact main commit before signing, notarizing, stapling, round-trip validating, and publishing.