### PR TITLE
fix(release): ship fully stapled Desktop 0.3.32 DMG

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.28"
+    "version": "0.6.29"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.28"
+    "version": "0.6.29"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -214,7 +214,21 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           version="$(node -p "require('./apps/homescreen/package.json').version")"
+          app="$PWD/apps/homescreen/src-tauri/target/release/bundle/macos/Understudy.app"
           dmg="$PWD/apps/homescreen/src-tauri/target/release/bundle/dmg/Understudy_${version}_aarch64.dmg"
+          dmg_stage="$RUNNER_TEMP/understudy-dmg-stage"
+          mkdir "$dmg_stage"
+          ditto "$app" "$dmg_stage/Understudy.app"
+          ln -s /Applications "$dmg_stage/Applications"
+          xcrun stapler validate "$dmg_stage/Understudy.app"
+          rm -f "$dmg"
+          hdiutil create \
+            -volname Understudy \
+            -fs HFS+ \
+            -srcfolder "$dmg_stage" \
+            -ov \
+            -format UDZO \
+            "$dmg"
           xcrun notarytool submit "$dmg" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \
@@ -264,6 +278,21 @@ jobs:
             --context context:primary-signature \
             --verbose=2 \
             "$downloaded"
+          mounted_dmg="$RUNNER_TEMP/downloaded-dmg"
+          mkdir "$mounted_dmg"
+          detach_downloaded_dmg() {
+            hdiutil detach "$mounted_dmg" >/dev/null 2>&1 || true
+          }
+          trap detach_downloaded_dmg EXIT
+          hdiutil attach "$downloaded" \
+            -nobrowse \
+            -readonly \
+            -mountpoint "$mounted_dmg"
+          xcrun stapler validate "$mounted_dmg/Understudy.app"
+          codesign --verify --deep --strict --verbose=2 "$mounted_dmg/Understudy.app"
+          spctl --assess --type execute --verbose=2 "$mounted_dmg/Understudy.app"
+          detach_downloaded_dmg
+          trap - EXIT
 
       - name: Publish the verified release
         if: inputs.mode == 'release'

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.31",
+  "version": "0.3.32",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.31"
+version = "0.3.32"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -24,7 +24,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.28";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.29";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.31";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.32";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -120,9 +120,10 @@ cd ../..
 ```
 
 The build inherits `APPLE_SIGNING_IDENTITY` and `TAURI_SIGNING_PRIVATE_KEY`.
-Submit both the app and DMG to Apple. Staple the app before rebuilding and
-re-signing the updater archive so an offline update contains the notarization
-ticket; then generate the static `latest.json` contract:
+Submit both the app and DMG to Apple. Staple the app before rebuilding either
+distribution container so both an offline update and an app copied from the DMG
+contain the app notarization ticket; then generate the static `latest.json`
+contract:
 
 ```sh
 version="$(node -p "require('./apps/homescreen/package.json').version")"
@@ -145,6 +146,13 @@ bun run tauri signer sign \
 cd ../..
 npm run desktop:updater-manifest
 npm run desktop:release-check -- --stage signed
+dmg_stage="$(mktemp -d)"
+ditto "$app" "$dmg_stage/Understudy.app"
+ln -s /Applications "$dmg_stage/Applications"
+xcrun stapler validate "$dmg_stage/Understudy.app"
+rm -f "$dmg"
+hdiutil create -volname Understudy -fs HFS+ -srcfolder "$dmg_stage" \
+  -ov -format UDZO "$dmg"
 xcrun notarytool submit "$dmg" \
   --keychain-profile "$APPLE_NOTARY_KEYCHAIN_PROFILE" \
   --wait --output-format json
@@ -155,8 +163,9 @@ npm run desktop:release-check -- --stage notarized
 Create a draft release targeted at the exact commit and upload the stapled DMG,
 notarized updater archive, signature, and manifest. Download those assets into a
 new temporary directory and compare their hashes before publishing. Validate
-the downloaded DMG with `stapler` and `spctl`; the uploaded bytes, not the local
-paths, are the public product.
+the downloaded DMG with `stapler` and `spctl`, mount it, and separately validate
+the app ticket and signature inside it; the uploaded bytes, not the local paths,
+are the public product.
 
 ```sh
 tag="desktop-v${version}-mvp"
@@ -186,6 +195,12 @@ cmp "$updater_sig" "$download_dir/Understudy.app.tar.gz.sig"
 cmp "$updater_manifest" "$download_dir/latest.json"
 xcrun stapler validate "$downloaded"
 spctl --assess --type open --context context:primary-signature --verbose=2 "$downloaded"
+mounted_dmg="$(mktemp -d)"
+hdiutil attach "$downloaded" -nobrowse -readonly -mountpoint "$mounted_dmg"
+xcrun stapler validate "$mounted_dmg/Understudy.app"
+codesign --verify --deep --strict --verbose=2 "$mounted_dmg/Understudy.app"
+spctl --assess --type execute --verbose=2 "$mounted_dmg/Understudy.app"
+hdiutil detach "$mounted_dmg"
 gh release edit "$tag" --repo understudylabs/understudy-agent-tools \
   --draft=false --latest
 rm -rf "$updater_key_dir"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.28",
+      "version": "0.6.29",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.31";
+export const RUNTIME_VERSION = "0.3.32";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/desktop-release-workflow.test.mjs
+++ b/tests/desktop-release-workflow.test.mjs
@@ -67,11 +67,21 @@ test("Desktop release automation keeps every trust gate before publication", () 
   assert.match(workflow, /desktop:updater-manifest/);
   assert.match(workflow, /desktop:release-check -- --stage signed/);
   assert.match(workflow, /notarytool submit "\$dmg"/);
+  assert.match(workflow, /hdiutil create/);
+  assert.match(workflow, /-srcfolder "\$dmg_stage"/);
+  assert.match(workflow, /stapler validate "\$dmg_stage\/Understudy\.app"/);
+  assert.ok(
+    workflow.indexOf('stapler staple "$app"') <
+      workflow.indexOf('-srcfolder "$dmg_stage"'),
+  );
   assert.match(workflow, /desktop:release-check -- --stage notarized/);
   assert.match(workflow, /gh release create/);
   assert.match(workflow, /--draft/);
   assert.match(workflow, /gh release download/);
   assert.match(workflow, /xcrun stapler validate "\$downloaded"/);
+  assert.match(workflow, /xcrun stapler validate "\$mounted_dmg\/Understudy\.app"/);
+  assert.match(workflow, /codesign --verify --deep --strict/);
+  assert.match(workflow, /spctl --assess --type execute/);
   assert.match(workflow, /spctl --assess/);
   assert.ok(workflow.indexOf("gh release download") < workflow.indexOf("gh release edit"));
 });


### PR DESCRIPTION
## Summary

- rebuild the DMG from the already-notarized and stapled `Understudy.app`
- mount the downloaded public DMG and require the inner app to pass stapler, codesign, and Gatekeeper checks before publication
- document the exact offline trust boundary
- prepare Desktop 0.3.32 and CLI/adapters 0.6.29

## Root cause

The 0.3.31 workflow notarized and stapled the app after Tauri had already assembled the DMG. The DMG container itself was notarized, but an independent mount of the public artifact showed that the app copied from it did not contain the stapled ticket. The updater archive was unaffected because it was rebuilt after app stapling.

## Validation

- `npm run check` — 423 tests and 34 skills/package smoke checks pass
- `cargo test --manifest-path apps/homescreen/src-tauri/Cargo.toml` — 190 pass, 4 ignored
- `npm run desktop:release-check -- --stage source --allow-dirty --allow-unmerged`
- `cargo fmt --check --manifest-path apps/homescreen/src-tauri/Cargo.toml`
- `git diff --check`
- locally rebuilt an HFS+ DMG from the stapled 0.3.31 updater app; mounted inner app passes `xcrun stapler validate` and `codesign --verify --deep --strict`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->