### PR TITLE
fix(release): sign rebuilt Desktop DMG

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -211,6 +211,7 @@ jobs:
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           version="$(node -p "require('./apps/homescreen/package.json').version")"
@@ -229,6 +230,7 @@ jobs:
             -ov \
             -format UDZO \
             "$dmg"
+          codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "$dmg"
           xcrun notarytool submit "$dmg" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -153,6 +153,7 @@ xcrun stapler validate "$dmg_stage/Understudy.app"
 rm -f "$dmg"
 hdiutil create -volname Understudy -fs HFS+ -srcfolder "$dmg_stage" \
   -ov -format UDZO "$dmg"
+codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "$dmg"
 xcrun notarytool submit "$dmg" \
   --keychain-profile "$APPLE_NOTARY_KEYCHAIN_PROFILE" \
   --wait --output-format json

--- a/tests/desktop-release-workflow.test.mjs
+++ b/tests/desktop-release-workflow.test.mjs
@@ -69,6 +69,14 @@ test("Desktop release automation keeps every trust gate before publication", () 
   assert.match(workflow, /notarytool submit "\$dmg"/);
   assert.match(workflow, /hdiutil create/);
   assert.match(workflow, /-srcfolder "\$dmg_stage"/);
+  assert.match(
+    workflow,
+    /codesign --force --sign "\$APPLE_SIGNING_IDENTITY" --timestamp "\$dmg"/,
+  );
+  assert.match(
+    workflow,
+    /- name: Notarize and staple the DMG[\s\S]*?APPLE_SIGNING_IDENTITY: \$\{\{ secrets\.APPLE_SIGNING_IDENTITY \}\}[\s\S]*?codesign --force/,
+  );
   assert.match(workflow, /stapler validate "\$dmg_stage\/Understudy\.app"/);
   assert.ok(
     workflow.indexOf('stapler staple "$app"') <


### PR DESCRIPTION
## Summary

- sign the rebuilt DMG with the imported Developer ID identity before Apple notarization
- document the required signing order
- lock the signing command and step-scoped secret wiring into the release workflow test

## Failure evidence

Release run 29763568644 failed closed before publication. Apple accepted and stapled the rebuilt DMG, but the final local release gate rejected it with `source=no usable signature`. Rebuilding the container after app stapling removed the Tauri-produced DMG signature.

## Validation

- `node --test tests/desktop-release-workflow.test.mjs`
- `npm run desktop:release-check -- --stage source --allow-dirty --allow-unmerged`
- `git diff --check`
- locally signed a rebuilt HFS+ DMG with the same Developer ID Application identity and timestamp; `codesign --verify` reports valid on disk and satisfies its designated requirement

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->