### PR TITLE
feat(desktop): Explore Data — Phase A (Moraine timeline + transcript in the app)

### DIFF
--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -26,6 +26,7 @@ export type PaneId =
   | "usage"
   | "traces"
   | "rlm"
+  | "explore"
   | "training-evals"
   | "training-optimization"
   | "training-datasets"
@@ -74,9 +75,81 @@ export function Sidebar({
   const [showArchived, setShowArchived] = useState(false);
   const [archiveAllOpen, setArchiveAllOpen] = useState(false);
   const visibleSessions = showArchived ? archivedSessions : sessions;
+  const inExplore = active === "explore";
+
+  const sectionStyle = (selected: boolean): React.CSSProperties => ({
+    flex: 1,
+    padding: "4px 0",
+    border: "none",
+    borderRadius: 5,
+    cursor: "pointer",
+    fontFamily: "var(--mono)",
+    fontSize: 10.5,
+    letterSpacing: "0.05em",
+    background: selected ? "var(--hover)" : "transparent",
+    color: selected ? "var(--c-ink)" : "var(--c-ink-muted)",
+  });
+
+  const sectionSwitcher = (
+    <div
+      role="tablist"
+      aria-label="Section"
+      style={{
+        display: "flex",
+        gap: 2,
+        margin: "0 8px 8px",
+        padding: 2,
+        borderRadius: 7,
+        border: "1px solid var(--c-rule)",
+        background: "var(--c-window)",
+      }}
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={!inExplore}
+        style={sectionStyle(!inExplore)}
+        onClick={() => onSelect("chat")}
+      >
+        Chat
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={inExplore}
+        style={sectionStyle(inExplore)}
+        onClick={() => onSelect("explore")}
+      >
+        Explore Data
+      </button>
+    </div>
+  );
+
+  if (inExplore) {
+    return (
+      <aside className="sidebar">
+        {sectionSwitcher}
+        <div className="nav-spacer" />
+        <button
+          className={"nav-account" + ((active as PaneId) === "account" ? " active" : "")}
+          onClick={() => onSelect("account")}
+        >
+          <AccountIcon />
+          <span className="nav-account-copy">
+            <span>Account</span>
+            <span className="nav-account-status">
+              <span className={"dot" + (connected ? " running" : "")} />
+              {connected ? "Connected" : "Disconnected"}
+            </span>
+          </span>
+        </button>
+      </aside>
+    );
+  }
 
   return (
     <aside className="sidebar">
+      {sectionSwitcher}
       <div className="chat-nav-heading">
         <div className="nav-section">{showArchived ? "Archived" : "Chats"}</div>
         <button

--- a/apps/homescreen/app/components/explore/ExploreShell.tsx
+++ b/apps/homescreen/app/components/explore/ExploreShell.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, type ComponentType } from "react";
+import dynamic from "next/dynamic";
+
+// Contract (see app/lib/exploreContract.ts, "Explore pane composition"):
+type TimelinePaneProps = { onOpenSession: (id: string) => void };
+type TranscriptPaneProps = { sessionId: string; onBack: () => void };
+
+const exploreLoading = () => (
+  <div
+    className="explore-loading mono"
+    style={{ padding: 16, color: "var(--ink-muted)", fontSize: 12 }}
+  >
+    loading explore…
+  </div>
+);
+
+// The timeline and session panes render WebGL scenes; the app is a static
+// export (output: "export"), so they are loaded client-only.
+const TimelinePane = dynamic<TimelinePaneProps>(
+  () =>
+    import("./timeline/TimelinePane") as Promise<{
+      default: ComponentType<TimelinePaneProps>;
+    }>,
+  { ssr: false, loading: exploreLoading },
+);
+const TranscriptPane = dynamic<TranscriptPaneProps>(
+  () =>
+    import("./session/TranscriptPane") as Promise<{
+      default: ComponentType<TranscriptPaneProps>;
+    }>,
+  { ssr: false, loading: exploreLoading },
+);
+
+type ExploreView = "timeline" | { session: string };
+
+export function ExploreShell() {
+  const [view, setView] = useState<ExploreView>("timeline");
+  const sessionId = view === "timeline" ? null : view.session;
+
+  return (
+    <div
+      className="explore-shell mono"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        minHeight: 0,
+        background: "var(--field, #000)",
+      }}
+    >
+      <div
+        className="explore-subheader"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flex: "none",
+          padding: "6px 12px",
+          borderBottom: "1px solid var(--rule)",
+          fontFamily: "var(--mono)",
+          fontSize: 11,
+          letterSpacing: "0.04em",
+          color: "var(--ink-muted)",
+        }}
+      >
+        {sessionId ? (
+          <>
+            <button
+              type="button"
+              onClick={() => setView("timeline")}
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                font: "inherit",
+                color: "var(--ink-muted)",
+              }}
+            >
+              explore / timeline
+            </button>
+            <span aria-hidden="true">/</span>
+            <span style={{ color: "var(--ink)" }}>
+              session {sessionId.slice(0, 8)}
+            </span>
+          </>
+        ) : (
+          <span>explore / timeline</span>
+        )}
+      </div>
+      <div style={{ flex: 1, minHeight: 0, position: "relative", display: "flex", flexDirection: "column" }}>
+        {sessionId ? (
+          <TranscriptPane
+            sessionId={sessionId}
+            onBack={() => setView("timeline")}
+          />
+        ) : (
+          <TimelinePane onOpenSession={(id: string) => setView({ session: id })} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/explore/session/TranscriptPane.tsx
+++ b/apps/homescreen/app/components/explore/session/TranscriptPane.tsx
@@ -1,0 +1,649 @@
+"use client";
+
+// Full lossless transcript view — ported from the moraine-viewer prototype's
+// TranscriptClient. Every event type renders verbatim; long bodies and
+// reasoning collapse; substream (subagent) runs nest one level under a
+// labeled group header; pagination via event_order cursor; live tail polling.
+//
+// Desktop adaptations: data flows through fetchTranscript (Tauri invoke);
+// a back button (props.onBack) replaces nav links; scrolling/follow-mode is
+// computed against the pane's own scroll container instead of window (the
+// pane lives inside the shell's overflow container, not a scrolling page).
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { fetchTranscript } from "@/app/lib/exploreData";
+import type { SessionMeta, TranscriptEvent, TranscriptPage } from "./types";
+
+const LONG_TEXT = 2000;
+const TOOL_PREVIEW_LINES = 3;
+const GROUP_AUTOCOLLAPSE = 30;
+
+// live tailing
+const LIVE_WINDOW_MS = 3 * 60 * 1000; // < 3 min since last event => live
+const LIVE_POLL_MS = 5_000;
+const IDLE_POLL_MS = 30_000; // keep a slow pulse so a sleeping session can wake
+const FRESH_FADE_MS = 2_500;
+const FOLLOW_SLACK_PX = 160; // "near bottom" threshold
+
+// ---------- helpers ----------
+
+function fmtInt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function parseChTime(t: string): number {
+  return Date.parse(t.replace(" ", "T") + "Z");
+}
+
+function fmtDuration(first: string, last: string): string {
+  const ms = parseChTime(last) - parseChTime(first);
+  if (!Number.isFinite(ms) || ms <= 0) return "—";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+  return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
+}
+
+function eventAccent(t: string): string {
+  switch (t) {
+    case "user_input": return "var(--model-clay)";
+    case "tool_call":
+    case "tool_response": return "var(--model-mint)";
+    case "reasoning": return "var(--model-violet)";
+    case "compaction": return "var(--model-amber)";
+    case "assistant_response": return "var(--ink)";
+    default: return "var(--ink-muted)";
+  }
+}
+
+function firstLines(text: string, n: number): { head: string; more: boolean } {
+  const lines = text.split("\n");
+  if (lines.length <= n && text.length <= LONG_TEXT) return { head: text, more: false };
+  return { head: lines.slice(0, n).join("\n").slice(0, LONG_TEXT), more: true };
+}
+
+// ---------- collapsible long text ----------
+
+function LongText({ text, truncated }: { text: string; truncated: boolean }) {
+  const [open, setOpen] = useState(false);
+  const long = text.length > LONG_TEXT;
+  const shown = open || !long ? text : text.slice(0, LONG_TEXT);
+  return (
+    <div>
+      <pre className="mono" style={{ whiteSpace: "pre-wrap", wordBreak: "break-word", margin: 0, fontSize: 12, lineHeight: 1.55 }}>
+        {shown}
+        {!open && long ? "…" : ""}
+      </pre>
+      {long && (
+        <button onClick={() => setOpen(!open)} style={btnStyle}>
+          {open ? "collapse" : `show all ${fmtInt(text.length)} chars`}
+        </button>
+      )}
+      {truncated && (
+        <span className="mono" style={{ fontSize: 10, color: "var(--model-amber)", marginLeft: 8 }}>
+          truncated at 20,000 chars
+        </span>
+      )}
+    </div>
+  );
+}
+
+const btnStyle: React.CSSProperties = {
+  background: "none",
+  border: "1px solid var(--rule)",
+  borderRadius: 4,
+  color: "var(--ink-muted)",
+  fontSize: 10,
+  fontFamily: "var(--font-mono)",
+  padding: "2px 8px",
+  marginTop: 6,
+  cursor: "pointer",
+};
+
+// ---------- single event card ----------
+
+function EventCard({
+  ev,
+  highlighted,
+  nested,
+  fresh = false,
+}: {
+  ev: TranscriptEvent;
+  highlighted: boolean;
+  nested: boolean;
+  fresh?: boolean;
+}) {
+  const collapsedByDefault =
+    ev.event_type === "reasoning" ||
+    ev.event_type === "tool_call" ||
+    ev.event_type === "tool_response" ||
+    ev.event_type === "system" ||
+    ev.event_type === "runtime" ||
+    ev.event_type === "unknown";
+  const [open, setOpen] = useState(!collapsedByDefault);
+  const [showRaw, setShowRaw] = useState(false);
+  const accent = eventAccent(ev.event_type);
+  const dim = ev.event_type === "system" || ev.event_type === "runtime" || ev.event_type === "unknown";
+  const isTool = ev.event_type === "tool_call" || ev.event_type === "tool_response";
+  const preview = useMemo(() => firstLines(ev.text, TOOL_PREVIEW_LINES), [ev.text]);
+
+  const label = isTool
+    ? `${ev.event_type === "tool_call" ? "→" : "←"} ${ev.name || "tool"}`
+    : ev.event_type;
+
+  return (
+    <div
+      id={`event-${ev.event_order}`}
+      style={{
+        borderLeft: `2px solid ${ev.event_type === "user_input" ? "var(--model-clay)" : "transparent"}`,
+        background: highlighted
+          ? "rgba(242,179,76,0.10)"
+          : isTool
+            ? "rgba(158,219,211,0.04)"
+            : ev.event_type === "reasoning"
+              ? "rgba(167,139,250,0.04)"
+              : "transparent",
+        borderRadius: 4,
+        padding: nested ? "6px 10px 6px 8px" : "8px 12px 8px 10px",
+        opacity: dim ? 0.55 : 1,
+        margin: "2px 0",
+        animation: fresh ? "live-fresh 2s var(--ease)" : undefined,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+        <span className="mono" style={{ fontSize: 10, color: "var(--ink-muted)", minWidth: 42 }}>
+          #{ev.event_order}
+        </span>
+        <span className="mono" style={{ fontSize: 11, color: accent, fontWeight: 600 }}>
+          {ev.event_type === "compaction" ? "◆ compaction" : label}
+        </span>
+        {ev.call_id && (
+          <span className="mono" style={{ fontSize: 10, color: "var(--ink-muted)" }}>
+            {ev.call_id.slice(0, 12)}
+          </span>
+        )}
+        <span className="mono" style={{ fontSize: 10, color: "var(--ink-muted)" }}>
+          {ev.event_time.slice(11, 19)}
+        </span>
+        {ev.tokens > 0 && (
+          <span className="mono" style={{ fontSize: 10, color: "var(--ink-muted)" }}>
+            {fmtInt(ev.tokens)} tok
+          </span>
+        )}
+        <span style={{ flex: 1 }} />
+        {collapsedByDefault && (ev.text || ev.payload_json) && (
+          <button onClick={() => setOpen(!open)} style={{ ...btnStyle, marginTop: 0 }}>
+            {open ? "collapse" : "expand"}
+          </button>
+        )}
+        {ev.payload_json && (
+          <button
+            onClick={() => setShowRaw(!showRaw)}
+            style={{ ...btnStyle, marginTop: 0, color: showRaw ? "var(--model-amber)" : "var(--ink-muted)" }}
+          >
+            raw
+          </button>
+        )}
+      </div>
+
+      {ev.text && (
+        <div style={{ marginTop: 4, color: ev.event_type === "reasoning" ? "var(--model-violet)" : dim ? "var(--ink-muted)" : "var(--ink)" }}>
+          {open ? (
+            <LongText text={ev.text} truncated={ev.text_truncated === 1} />
+          ) : (
+            <pre className="mono" style={{ whiteSpace: "pre-wrap", wordBreak: "break-word", margin: 0, fontSize: 12, lineHeight: 1.55, color: "var(--ink-muted)" }}>
+              {preview.head}
+              {(preview.more || ev.text.length > preview.head.length) && " …"}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {showRaw && (
+        <div style={{ marginTop: 6 }}>
+          <pre
+            className="mono"
+            style={{
+              margin: 0,
+              fontSize: 11,
+              lineHeight: 1.5,
+              maxHeight: 320,
+              overflow: "auto",
+              background: "rgba(255,255,255,0.03)",
+              border: "1px solid var(--rule)",
+              borderRadius: 4,
+              padding: 8,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+              color: "var(--ink-muted)",
+            }}
+          >
+            {ev.payload_json}
+          </pre>
+          {ev.payload_truncated === 1 && (
+            <span className="mono" style={{ fontSize: 10, color: "var(--model-amber)" }}>
+              payload truncated at 20,000 chars
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------- substream group ----------
+
+function SubstreamGroup({
+  runId,
+  label,
+  events,
+  highlightOrder,
+  freshOrders,
+}: {
+  runId: string;
+  label: string;
+  events: TranscriptEvent[];
+  highlightOrder: number | null;
+  freshOrders: ReadonlySet<number>;
+}) {
+  const containsHighlight = highlightOrder !== null && events.some((e) => e.event_order === highlightOrder);
+  const [open, setOpen] = useState(events.length <= GROUP_AUTOCOLLAPSE || containsHighlight);
+  return (
+    <div style={{ margin: "6px 0 6px 0" }}>
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          ...btnStyle,
+          marginTop: 0,
+          display: "block",
+          width: "100%",
+          textAlign: "left",
+          borderColor: "rgba(167,139,250,0.35)",
+          color: "var(--model-violet)",
+          padding: "5px 10px",
+        }}
+      >
+        {open ? "▾" : "▸"} subagent: {label || "unlabeled"} · run {runId.slice(0, 8)}… · {events.length} events
+      </button>
+      {open && (
+        <div style={{ marginLeft: 18, borderLeft: "2px solid rgba(167,139,250,0.35)", paddingLeft: 8 }}>
+          {events.map((e) => (
+            <EventCard key={e.event_order} ev={e} nested highlighted={e.event_order === highlightOrder} fresh={freshOrders.has(e.event_order)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------- stream assembly ----------
+
+type StreamItem =
+  | { kind: "event"; ev: TranscriptEvent }
+  | { kind: "turn"; turn: number }
+  | { kind: "group"; runId: string; label: string; events: TranscriptEvent[] };
+
+function buildStream(events: TranscriptEvent[]): StreamItem[] {
+  const items: StreamItem[] = [];
+  let lastTurn = -1;
+  let i = 0;
+  while (i < events.length) {
+    const ev = events[i];
+    if (ev.turn_seq !== lastTurn) {
+      items.push({ kind: "turn", turn: ev.turn_seq });
+      lastTurn = ev.turn_seq;
+    }
+    if (ev.is_substream === 1 && ev.agent_run_id) {
+      // consecutive events of the same agent_run_id group together
+      const group: TranscriptEvent[] = [];
+      const run = ev.agent_run_id;
+      while (i < events.length && events[i].is_substream === 1 && events[i].agent_run_id === run) {
+        group.push(events[i]);
+        i++;
+      }
+      items.push({ kind: "group", runId: run, label: group.find((g) => g.agent_label)?.agent_label ?? "", events: group });
+    } else {
+      items.push({ kind: "event", ev });
+      i++;
+    }
+  }
+  return items;
+}
+
+// ---------- chips ----------
+
+function Chip({ children, color }: { children: React.ReactNode; color?: string }) {
+  return (
+    <span
+      className="mono"
+      style={{
+        fontSize: 10,
+        border: "1px solid var(--rule)",
+        borderRadius: 999,
+        padding: "2px 10px",
+        color: color ?? "var(--ink-muted)",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+// ---------- main pane ----------
+
+export default function TranscriptPane({
+  sessionId,
+  onBack,
+  initialEvent = null,
+}: {
+  sessionId: string;
+  onBack: () => void;
+  initialEvent?: number | null;
+}) {
+  const [session, setSession] = useState<SessionMeta | null>(null);
+  const [events, setEvents] = useState<TranscriptEvent[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrolledRef = useRef(false);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  // live tailing state
+  const [lastEventMs, setLastEventMs] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const [freshOrders, setFreshOrders] = useState<ReadonlySet<number>>(new Set());
+  const [following, setFollowing] = useState(true);
+  const eventsRef = useRef<TranscriptEvent[]>([]);
+  const followingRef = useRef(true);
+  const appendedRef = useRef(false);
+  const pollBusyRef = useRef(false);
+
+  useEffect(() => {
+    eventsRef.current = events;
+  }, [events]);
+
+  const nearBottom = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return true;
+    return el.scrollTop + el.clientHeight >= el.scrollHeight - FOLLOW_SLACK_PX;
+  }, []);
+
+  const loadPage = useCallback(
+    async (cursor: number) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const page: TranscriptPage = await fetchTranscript(sessionId, cursor, 500);
+        setSession(page.session);
+        setEvents((prev) => (cursor === 0 ? page.events : [...prev, ...page.events]));
+        setNextCursor(page.nextCursor);
+        if (page.lastEventAgoS != null) setLastEventMs(Date.now() - page.lastEventAgoS * 1000);
+        else if (page.lastEventTime) setLastEventMs(parseChTime(page.lastEventTime));
+        setNow(Date.now());
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [sessionId],
+  );
+
+  useEffect(() => {
+    // reset when the pane is pointed at another session
+    scrolledRef.current = false;
+    setSession(null);
+    setEvents([]);
+    setNextCursor(null);
+    setLastEventMs(null);
+    setFreshOrders(new Set());
+    void loadPage(0);
+  }, [loadPage]);
+
+  // ---- live tail polling ----
+  const isLive = lastEventMs !== null && now - lastEventMs < LIVE_WINDOW_MS;
+
+  const poll = useCallback(async () => {
+    // don't burn ClickHouse queries in background windows
+    if (document.visibilityState !== "visible") return;
+    if (pollBusyRef.current) return;
+    pollBusyRef.current = true;
+    try {
+      const loaded = eventsRef.current;
+      const cursor = loaded.length ? loaded[loaded.length - 1].event_order : 0;
+      const page: TranscriptPage = await fetchTranscript(sessionId, cursor, 500);
+      setSession(page.session);
+      setNextCursor(page.nextCursor);
+      if (page.lastEventAgoS != null) setLastEventMs(Date.now() - page.lastEventAgoS * 1000);
+      else if (page.lastEventTime) setLastEventMs(parseChTime(page.lastEventTime));
+      setNow(Date.now());
+      const have = new Set(loaded.map((e) => e.event_order));
+      const fresh = page.events.filter((e) => !have.has(e.event_order));
+      if (fresh.length) {
+        appendedRef.current = true;
+        // snapshot "near bottom" BEFORE the new events render (the scroll
+        // listener alone goes stale when content grows under a user who
+        // never scrolled)
+        followingRef.current = nearBottom();
+        setFollowing(followingRef.current);
+        setEvents((prev) => {
+          const seen = new Set(prev.map((e) => e.event_order));
+          return [...prev, ...fresh.filter((e) => !seen.has(e.event_order))];
+        });
+        const orders = fresh.map((e) => e.event_order);
+        setFreshOrders((prev) => new Set([...prev, ...orders]));
+        window.setTimeout(() => {
+          setFreshOrders((prev) => {
+            const next = new Set(prev);
+            for (const o of orders) next.delete(o);
+            return next;
+          });
+        }, FRESH_FADE_MS);
+      }
+    } catch {
+      // transient poll failures are silent; next tick retries
+    } finally {
+      pollBusyRef.current = false;
+    }
+  }, [sessionId, nearBottom]);
+
+  useEffect(() => {
+    // 5s cadence while live, 30s idle heartbeat so a woken session flips back
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+      void poll();
+    }, isLive ? LIVE_POLL_MS : IDLE_POLL_MS);
+    const onVis = () => {
+      if (document.visibilityState === "visible") void poll();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, [isLive, poll]);
+
+  // ---- follow mode (against the pane's own scroll container) ----
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const nb = nearBottom();
+      followingRef.current = nb;
+      setFollowing(nb);
+    };
+    onScroll();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [nearBottom]);
+
+  useEffect(() => {
+    if (!appendedRef.current) return;
+    appendedRef.current = false;
+    const el = scrollerRef.current;
+    if (followingRef.current && el) {
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    }
+  }, [events]);
+
+  const jumpToLive = useCallback(() => {
+    followingRef.current = true;
+    setFollowing(true);
+    const el = scrollerRef.current;
+    if (el) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }, []);
+
+  const idleMinutes = lastEventMs !== null ? Math.max(1, Math.floor((now - lastEventMs) / 60_000)) : null;
+
+  // deep link: scroll to and highlight ?event=<event_order> once it exists
+  useEffect(() => {
+    if (initialEvent === null || scrolledRef.current) return;
+    const el = document.getElementById(`event-${initialEvent}`);
+    if (el) {
+      el.scrollIntoView({ block: "center" });
+      scrolledRef.current = true;
+    } else if (nextCursor !== null && !loading && events.length > 0 && events[events.length - 1].event_order < initialEvent) {
+      void loadPage(nextCursor);
+    }
+  }, [initialEvent, events, nextCursor, loading, loadPage]);
+
+  const stream = useMemo(() => buildStream(events), [events]);
+
+  return (
+    <div
+      ref={scrollerRef}
+      style={{ position: "relative", flex: 1, minHeight: 0, overflowY: "auto" }}
+    >
+      <div style={{ maxWidth: 960, margin: "0 auto", padding: "24px 20px 80px" }}>
+        <style>{`@keyframes live-fresh { from { background-color: rgba(110,231,160,0.08); } to { background-color: transparent; } }`}</style>
+        {/* header */}
+        <header style={{ borderBottom: "1px solid var(--rule)", paddingBottom: 16, marginBottom: 16 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
+            <button
+              onClick={onBack}
+              className="mono"
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                fontSize: 11,
+                color: "var(--model-mint)",
+                cursor: "pointer",
+              }}
+            >
+              ← timeline
+            </button>
+            <h1 className="mono" style={{ fontSize: 15, margin: 0, color: "var(--ink-bright)" }}>
+              {session?.title || "untitled session"}
+            </h1>
+            {isLive ? (
+              <span className="mono breath" style={{ fontSize: 11, color: "#6ee7a0" }}>● live</span>
+            ) : idleMinutes !== null ? (
+              <span className="mono" style={{ fontSize: 11, color: "var(--ink-muted)" }}>
+                idle · last event {idleMinutes}m ago
+              </span>
+            ) : null}
+          </div>
+          <div className="mono" style={{ fontSize: 10, color: "var(--ink-muted)", marginTop: 4, wordBreak: "break-all" }}>
+            {sessionId}
+          </div>
+          {session && (
+            <>
+              <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 10 }}>
+                <Chip color="var(--model-clay)">{session.harness || "unknown harness"}</Chip>
+                <Chip>{session.mode}</Chip>
+                {session.models.map((m) => (
+                  <Chip key={m} color="var(--model-mint)">{m}</Chip>
+                ))}
+              </div>
+              <div className="mono" style={{ fontSize: 11, color: "var(--ink-muted)", marginTop: 10 }}>
+                {fmtInt(session.turns)} turns · {fmtInt(session.events)} events · {fmtInt(session.totalTokens)} tokens ·{" "}
+                {fmtDuration(session.firstEventTime, session.lastEventTime)}
+              </div>
+            </>
+          )}
+        </header>
+
+        {error && (
+          <div className="mono" style={{ color: "var(--model-amber)", fontSize: 12, padding: 12, border: "1px solid var(--rule)", borderRadius: 6 }}>
+            {error}
+          </div>
+        )}
+
+        {/* stream */}
+        {stream.map((item, idx) => {
+          if (item.kind === "turn") {
+            return (
+              <div key={`t-${item.turn}-${idx}`} style={{ display: "flex", alignItems: "center", gap: 10, margin: "18px 0 6px" }}>
+                <span className="mono" style={{ fontSize: 10, color: "var(--ink-muted)" }}>T{item.turn}</span>
+                <div style={{ flex: 1, borderTop: "1px solid var(--rule)" }} />
+              </div>
+            );
+          }
+          if (item.kind === "group") {
+            return (
+              <SubstreamGroup
+                key={`g-${item.runId}-${item.events[0].event_order}`}
+                runId={item.runId}
+                label={item.label}
+                events={item.events}
+                highlightOrder={initialEvent}
+                freshOrders={freshOrders}
+              />
+            );
+          }
+          return (
+            <EventCard
+              key={item.ev.event_order}
+              ev={item.ev}
+              nested={false}
+              highlighted={item.ev.event_order === initialEvent}
+              fresh={freshOrders.has(item.ev.event_order)}
+            />
+          );
+        })}
+
+        {/* follow-mode pill */}
+        {isLive && !following && (
+          <button
+            onClick={jumpToLive}
+            className="mono"
+            style={{
+              position: "fixed",
+              bottom: 24,
+              right: 24,
+              zIndex: 20,
+              background: "var(--paper, #111)",
+              border: "1px solid rgba(110,231,160,0.4)",
+              borderRadius: 999,
+              color: "#6ee7a0",
+              fontSize: 11,
+              padding: "6px 14px",
+              cursor: "pointer",
+              boxShadow: "0 2px 12px rgba(0,0,0,0.35)",
+            }}
+          >
+            ↓ following off — jump to live
+          </button>
+        )}
+
+        {/* pagination */}
+        <div style={{ marginTop: 20, display: "flex", alignItems: "center", gap: 12 }}>
+          {session && (
+            <span className="mono" style={{ fontSize: 11, color: "var(--ink-muted)" }}>
+              showing {fmtInt(events.length)} of {fmtInt(session.events)}
+            </span>
+          )}
+          {loading && (
+            <span className="mono" style={{ fontSize: 11, color: "var(--ink-muted)" }}>loading…</span>
+          )}
+          {nextCursor !== null && !loading && (
+            <button onClick={() => void loadPage(nextCursor)} style={{ ...btnStyle, marginTop: 0, padding: "6px 16px", fontSize: 11 }}>
+              load more
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/explore/session/types.ts
+++ b/apps/homescreen/app/components/explore/session/types.ts
@@ -1,0 +1,40 @@
+export interface TranscriptEvent {
+  event_order: number;
+  turn_seq: number;
+  event_time: string;
+  actor_role: string;
+  event_type: string;
+  name: string;
+  call_id: string;
+  text: string;
+  text_truncated: number;
+  payload_json: string;
+  payload_truncated: number;
+  tokens: number;
+  is_substream: number;
+  agent_label: string;
+  agent_run_id: string;
+}
+
+export interface SessionMeta {
+  id: string;
+  title: string;
+  harness: string;
+  mode: string;
+  turns: number;
+  events: number;
+  firstEventTime: string;
+  lastEventTime: string;
+  models: string[];
+  totalTokens: number;
+}
+
+export interface TranscriptPage {
+  session: SessionMeta;
+  events: TranscriptEvent[];
+  latestOrder: number;
+  lastEventTime: string;
+  lastEventAgoS?: number; // server-computed — avoids client tz parsing of ClickHouse local-time strings
+  nextCursor: number | null;
+  error?: string;
+}

--- a/apps/homescreen/app/components/explore/timeline/TimelinePane.tsx
+++ b/apps/homescreen/app/components/explore/timeline/TimelinePane.tsx
@@ -1,0 +1,1214 @@
+"use client";
+
+// Timeline pane — the whole agent history as a temporal field of traces.
+// Ported from the moraine-viewer prototype's TimelineClient; data flows
+// through app/lib/exploreData.ts (Tauri invoke) instead of /api routes, and
+// "open session" calls props.onOpenSession instead of navigating.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import TimelineScene, { type LaneLayout } from "./TimelineScene";
+import TracePreview from "./TracePreview";
+import {
+  fetchCommits,
+  fetchCommitsDay,
+  fetchHealth,
+  fetchLanguages,
+  fetchLive,
+  fetchSessionDetail,
+  fetchTimeline,
+  searchTimeline,
+  type SessionDetail,
+} from "@/app/lib/exploreData";
+import {
+  COST_RAMP,
+  DAY,
+  FALLBACK_COLOR,
+  HARNESS_COLORS,
+  LANE_ORDER,
+  clusterColor,
+  fmtTokens,
+  harnessColor,
+  hashJitter,
+  langColor,
+  type ColorMode,
+  type SearchPayload,
+  type SearchResult,
+  type TimelinePayload,
+  type TimelinePoint,
+  type TimelineSession,
+  type ViewState,
+} from "./types";
+
+const MIN_PX_PER_DAY = 1.5;
+const MIN_LANE_FRACTION = 0.05; // lanes under 5% of all sessions start collapsed
+const MAX_PX_PER_DAY = 900;
+const AXIS_H = 36; // px reserved for the date axis
+const STRIP_H = 28; // px commit strip above the axis
+const COMMIT_COLOR = "110, 231, 160"; // --state-promoted #6ee7a0 rgb
+const COMMIT_STEPS = [0.18, 0.35, 0.6, 0.9]; // heatmap opacities by quantile
+
+function fmtDate(unix: number): string {
+  return new Date(unix * 1000).toISOString().slice(0, 10);
+}
+function fmtDateTime(unix: number): string {
+  return new Date(unix * 1000).toISOString().slice(0, 16).replace("T", " ");
+}
+function fmtAgo(s: number): string {
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  return `${Math.round(s / 3600)}h`;
+}
+
+type Tick = { x: number; label: string; major: boolean };
+
+// adaptive mono date axis: months → weeks → days by px/day
+function computeTicks(view: ViewState, day0: number, width: number): Tick[] {
+  const ticks: Tick[] = [];
+  const dayAt = (px: number) => (px - view.offsetPx) / view.pxPerDay;
+  const firstDay = Math.floor(dayAt(0));
+  const lastDay = Math.ceil(dayAt(width));
+  const p = view.pxPerDay;
+
+  if (p >= 24) {
+    for (let d = firstDay; d <= lastDay; d++) {
+      const t = new Date((day0 + d * DAY) * 1000);
+      const dom = t.getUTCDate();
+      ticks.push({
+        x: view.offsetPx + d * p,
+        label:
+          dom === 1
+            ? t.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" })
+            : String(dom).padStart(2, "0"),
+        major: dom === 1,
+      });
+    }
+  } else if (p >= 5) {
+    for (let d = firstDay; d <= lastDay; d++) {
+      const t = new Date((day0 + d * DAY) * 1000);
+      if (t.getUTCDate() === 1) {
+        ticks.push({
+          x: view.offsetPx + d * p,
+          label: t.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" }),
+          major: true,
+        });
+      } else if (t.getUTCDay() === 1) {
+        ticks.push({ x: view.offsetPx + d * p, label: String(t.getUTCDate()), major: false });
+      }
+    }
+  } else {
+    for (let d = firstDay; d <= lastDay; d++) {
+      const t = new Date((day0 + d * DAY) * 1000);
+      if (t.getUTCDate() === 1) {
+        ticks.push({
+          x: view.offsetPx + d * p,
+          label: t.toLocaleDateString("en-US", { month: "short", year: "2-digit", timeZone: "UTC" }),
+          major: true,
+        });
+      }
+    }
+  }
+  return ticks.filter((t) => t.x >= -60 && t.x <= width + 60);
+}
+
+function Chip({
+  label,
+  color,
+  active,
+  onClick,
+}: {
+  label: string;
+  color?: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="mono text-[11px] px-2.5 py-1 rounded-full border transition-colors"
+      style={{
+        borderColor: active ? (color ?? "var(--ink-muted)") : "var(--rule)",
+        color: active ? "var(--ink-bright)" : "var(--ink-muted)",
+        background: active && color ? `${color}1a` : "transparent",
+        transitionTimingFunction: "var(--ease)",
+      }}
+    >
+      {color && (
+        <span
+          className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle"
+          style={{ background: color, opacity: active ? 1 : 0.4 }}
+        />
+      )}
+      {label}
+    </button>
+  );
+}
+
+type HoverInfo = { point: TimelinePoint; clientX: number; clientY: number };
+
+type CommitDay = { d: string; c: number };
+type DayCommit = { hash7: string; repo: string; subject: string; ts: number; sessions: string[] };
+
+export default function TimelinePane({
+  onOpenSession,
+}: {
+  onOpenSession: (id: string) => void;
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [data, setData] = useState<TimelinePayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [size, setSize] = useState({ width: 1200, height: 700 });
+  const [view, setView] = useState<ViewState>({ offsetPx: 40, pxPerDay: 12 });
+  const [hover, setHover] = useState<HoverInfo | null>(null);
+  const [selected, setSelected] = useState<TimelineSession | null>(null);
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [hiddenHarness, setHiddenHarness] = useState<Set<string>>(new Set());
+  const [colorMode, setColorMode] = useState<ColorMode>("harness");
+  const [hiddenClusters, setHiddenClusters] = useState<Set<number>>(new Set());
+  const [hiddenLangs, setHiddenLangs] = useState<Set<string>>(new Set());
+  const [showPlumbing, setShowPlumbing] = useState(false);
+  const [langCounts, setLangCounts] = useState<Array<{ lang: string; sessions: number }>>([]);
+
+  const [query, setQuery] = useState("");
+  const [search, setSearch] = useState<SearchPayload | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  const [liveIds, setLiveIds] = useState<Set<string>>(new Set());
+  const [health, setHealth] = useState<{ lastEventAgoS: number; ingesting: boolean } | null>(null);
+
+  const [commitDays, setCommitDays] = useState<CommitDay[]>([]);
+  const [commitHover, setCommitHover] = useState<{ d: string; c: number; clientX: number; clientY: number } | null>(null);
+  const [commitPopover, setCommitPopover] = useState<{ d: string; x: number; commits: DayCommit[] | null } | null>(null);
+
+  const dragRef = useRef<{ x: number; offset: number; moved: boolean } | null>(null);
+  const cancelAnimRef = useRef<() => void>(() => {});
+  const viewRef = useRef(view);
+  viewRef.current = view;
+
+  useEffect(() => {
+    fetchTimeline()
+      .then((d) => setData(d))
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  // commit layer (commits.sqlite via adapter; empty payload when absent)
+  useEffect(() => {
+    fetchCommits()
+      .then((d) => setCommitDays(d.days ?? []))
+      .catch(() => {});
+  }, []);
+
+  // language layer (langs.sqlite via adapter; empty payload when absent)
+  useEffect(() => {
+    fetchLanguages()
+      .then((d) => setLangCounts(d.langs ?? []))
+      .catch(() => {});
+  }, []);
+
+  // live "now" marker + ingest health: one shared 30s poll timer.
+  // keep the Set's identity stable when membership hasn't changed — the scene's
+  // applied-ref buffer rewrite keys on identity
+  useEffect(() => {
+    const tick = () => {
+      fetchLive()
+        .then((d) => {
+          setLiveIds((prev) =>
+            prev.size === d.ids.length && d.ids.every((id) => prev.has(id)) ? prev : new Set(d.ids),
+          );
+        })
+        .catch(() => {});
+      fetchHealth()
+        .then((d) => setHealth(d))
+        .catch(() => {});
+    };
+    tick();
+    const t = setInterval(tick, 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  // cost mode thresholds: quantiles over nonzero token totals (log-heat ramp)
+  const costThresholds = useMemo(() => {
+    const toks = (data?.sessions ?? [])
+      .map((s) => s.tokens)
+      .filter((t) => t > 0)
+      .sort((a, b) => a - b);
+    if (!toks.length) return [0, 0, 0];
+    const q = (p: number) => toks[Math.min(toks.length - 1, Math.floor(p * toks.length))];
+    return [q(0.25), q(0.5), q(0.75)];
+  }, [data]);
+
+  // harnesses: canonical order first, then any strays from the data
+  const allHarnesses = useMemo(() => {
+    const seen = new Set(data?.meta.harnesses ?? []);
+    const out = LANE_ORDER.filter((h) => seen.has(h));
+    for (const h of seen) if (!out.includes(h)) out.push(h);
+    return out;
+  }, [data]);
+
+  const harnessCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of data?.sessions ?? []) {
+      if (!showPlumbing && s.cluster === "cli plumbing") continue;
+      counts.set(s.harness, (counts.get(s.harness) ?? 0) + 1);
+    }
+    return counts;
+  }, [data, showPlumbing]);
+
+  const plumbingCount = useMemo(
+    () => (data?.sessions ?? []).filter((s) => s.cluster === "cli plumbing").length,
+    [data],
+  );
+
+  // clusters present in the data (task color mode chips), by descending count
+  const clusters = useMemo(() => {
+    const map = new Map<number, { id: number; name: string; count: number }>();
+    for (const s of data?.sessions ?? []) {
+      if (s.clusterId == null) continue;
+      const e = map.get(s.clusterId) ?? { id: s.clusterId, name: s.cluster ?? `cluster ${s.clusterId}`, count: 0 };
+      e.count++;
+      map.set(s.clusterId, e);
+    }
+    return [...map.values()].sort((a, b) => b.count - a.count);
+  }, [data]);
+
+  // plumbing (CodexBar /usage probes etc.) starts hidden in task mode so the
+  // real work distribution reads; its chip stays one click away
+  const autoHidPlumbing = useRef(false);
+  useEffect(() => {
+    if (autoHidPlumbing.current) return;
+    const plumbing = clusters.find((c) => c.name === "cli plumbing");
+    if (!plumbing) return;
+    autoHidPlumbing.current = true;
+    setHiddenClusters((prev) => new Set([...prev, plumbing.id]));
+  }, [clusters]);
+
+  // sparse lanes start hidden so the field isn't mostly empty rows; the chips
+  // still show them (with counts) and one click brings the lane back
+  const autoHidden = useRef(false);
+  useEffect(() => {
+    if (autoHidden.current || !data) return;
+    autoHidden.current = true;
+    const realSessions = data.sessions.filter((s) => s.cluster !== "cli plumbing").length;
+    const minSessions = (realSessions || 1) * MIN_LANE_FRACTION;
+    const sparse = allHarnesses.filter((h) => (harnessCounts.get(h) ?? 0) < minSessions);
+    if (sparse.length) setHiddenHarness(new Set(sparse));
+  }, [data, allHarnesses, harnessCounts]);
+
+  // only visible harnesses get a lane row — hiding collapses the row entirely
+  const lanesList = useMemo(
+    () => allHarnesses.filter((h) => !hiddenHarness.has(h)),
+    [allHarnesses, hiddenHarness],
+  );
+
+  const day0 = useMemo(() => {
+    if (!data || data.sessions.length === 0) return 0;
+    const min = Math.min(...data.sessions.map((s) => s.start));
+    return Math.floor(min / DAY) * DAY;
+  }, [data]);
+
+  const points = useMemo<TimelinePoint[]>(() => {
+    if (!data) return [];
+    const laneIdx = new Map(lanesList.map((h, i) => [h, i]));
+    return data.sessions.map((s) => {
+      const mid = (s.start + s.end) / 2;
+      return {
+        s,
+        day: (mid - day0) / DAY,
+        dayStart: (s.start - day0) / DAY,
+        dayEnd: (s.end - day0) / DAY,
+        lane: laneIdx.get(s.harness) ?? lanesList.length - 1,
+        jitter: hashJitter(s.id, 7),
+        size: 2.4 + 2.1 * Math.log1p(s.events) * 0.45, // ∝ log(total_events)
+      };
+    });
+  }, [data, lanesList, day0]);
+
+  const numDays = useMemo(
+    () => (points.length ? Math.max(...points.map((p) => p.dayEnd)) + 1 : 1),
+    [points],
+  );
+
+  // fit the whole range (first load + reset button)
+  const fitAll = useCallback(() => {
+    if (!points.length || !wrapRef.current) return;
+    const w = wrapRef.current.clientWidth;
+    const p = Math.min(MAX_PX_PER_DAY, Math.max(MIN_PX_PER_DAY, (w - 160) / Math.max(numDays, 1)));
+    setView({ offsetPx: 120, pxPerDay: p });
+  }, [points.length, numDays]);
+
+  useEffect(() => {
+    fitAll();
+  }, [fitAll]);
+
+  const fitView = useMemo(() => {
+    const w = size.width;
+    return {
+      offsetPx: 120,
+      pxPerDay: Math.min(MAX_PX_PER_DAY, Math.max(MIN_PX_PER_DAY, (w - 160) / Math.max(numDays, 1))),
+    };
+  }, [size.width, numDays]);
+  const isFit =
+    Math.abs(view.pxPerDay - fitView.pxPerDay) < 0.01 && Math.abs(view.offsetPx - fitView.offsetPx) < 1;
+
+  // resize observer
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => setSize({ width: el.clientWidth, height: el.clientHeight }));
+    ro.observe(el);
+    setSize({ width: el.clientWidth, height: el.clientHeight });
+    return () => ro.disconnect();
+  }, []);
+
+  // wheel zoom around cursor (non-passive so we can preventDefault)
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      cancelAnimRef.current();
+      const rect = el.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const v = viewRef.current;
+      if (e.ctrlKey || Math.abs(e.deltaY) >= Math.abs(e.deltaX)) {
+        const factor = Math.exp(-e.deltaY * 0.0016);
+        const p = Math.min(MAX_PX_PER_DAY, Math.max(MIN_PX_PER_DAY, v.pxPerDay * factor));
+        const dayAtCursor = (cx - v.offsetPx) / v.pxPerDay;
+        setView({ pxPerDay: p, offsetPx: cx - dayAtCursor * p });
+      } else {
+        setView({ ...v, offsetPx: v.offsetPx - e.deltaX });
+      }
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
+  // debounced search
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setSearch(null);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    const t = setTimeout(() => {
+      searchTimeline(q)
+        .then((d) => {
+          setSearch(d);
+          setSearching(false);
+        })
+        .catch(() => setSearching(false));
+    }, 250);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const matches = useMemo(() => (search ? new Set(search.ids) : null), [search]);
+
+  // lane pixel layout (shared between shader uniforms, labels, and picking)
+  const laneLayout = useMemo<LaneLayout>(() => {
+    const top = 12;
+    const usable = Math.max(1, size.height - AXIS_H - STRIP_H - top - 8);
+    const gap = usable / Math.max(1, lanesList.length);
+    return { top, gap, jitterAmp: gap * 0.3 };
+  }, [size.height, lanesList.length]);
+
+  const laneY = useCallback(
+    (lane: number, jitter = 0) =>
+      laneLayout.top + (lane + 0.5) * laneLayout.gap + jitter * laneLayout.jitterAmp,
+    [laneLayout],
+  );
+  const dayX = useCallback((day: number) => view.offsetPx + day * view.pxPerDay, [view]);
+
+  // shared visibility: harness hiding always, cluster hiding in task mode,
+  // language hiding in language mode
+  const isVisible = useCallback(
+    (p: TimelinePoint) =>
+      (showPlumbing || p.s.cluster !== "cli plumbing") &&
+      !hiddenHarness.has(p.s.harness) &&
+      !(colorMode === "task" && p.s.clusterId != null && hiddenClusters.has(p.s.clusterId)) &&
+      !(colorMode === "language" && p.s.lang != null && hiddenLangs.has(p.s.lang)),
+    [showPlumbing, hiddenHarness, colorMode, hiddenClusters, hiddenLangs],
+  );
+
+  // nearest visible point in screen space (Points raycast thresholds are awkward)
+  const nearest = useCallback(
+    (clientX: number, clientY: number): TimelinePoint | null => {
+      const el = wrapRef.current;
+      if (!el) return null;
+      const rect = el.getBoundingClientRect();
+      const px = clientX - rect.left;
+      const py = clientY - rect.top;
+      let best: TimelinePoint | null = null;
+      let bestDist = 11;
+      for (const p of points) {
+        if (!isVisible(p)) continue;
+        const d = Math.hypot(dayX(p.day) - px, laneY(p.lane, p.jitter) - py);
+        if (d < bestDist) {
+          bestDist = d;
+          best = p;
+        }
+      }
+      return best;
+    },
+    [points, isVisible, dayX, laneY],
+  );
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    cancelAnimRef.current();
+    dragRef.current = { x: e.clientX, offset: viewRef.current.offsetPx, moved: false };
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+  }, []);
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (dragRef.current) {
+        const dx = e.clientX - dragRef.current.x;
+        if (Math.abs(dx) > 3) dragRef.current.moved = true;
+        setView({ ...viewRef.current, offsetPx: dragRef.current.offset + dx });
+        setHover(null);
+        return;
+      }
+      const p = nearest(e.clientX, e.clientY);
+      setHover(p ? { point: p, clientX: e.clientX, clientY: e.clientY } : null);
+    },
+    [nearest],
+  );
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      const wasDrag = dragRef.current?.moved;
+      dragRef.current = null;
+      if (wasDrag) return;
+      const p = nearest(e.clientX, e.clientY);
+      if (p) flyToPointRef.current(p);
+      else setSelected(null);
+    },
+    [nearest],
+  );
+  // defined below (needs animateTo); called through a ref to keep handler order simple
+  const flyToPointRef = useRef<(p: TimelinePoint) => void>(() => {});
+  const onPointerLeave = useCallback(() => {
+    dragRef.current = null;
+    setHover(null);
+  }, []);
+
+  // detail fetch on select
+  useEffect(() => {
+    if (!selected) {
+      setDetail(null);
+      return;
+    }
+    let stale = false;
+    setDetail(null);
+    fetchSessionDetail(selected.id)
+      .then((d) => {
+        if (!stale) setDetail(d);
+      })
+      .catch(() => {});
+    return () => {
+      stale = true;
+    };
+  }, [selected]);
+
+  // animated camera move: zoom in log-space, converge the screen-center day
+  const animRef = useRef<number | null>(null);
+  const cancelAnim = useCallback(() => {
+    if (animRef.current !== null) cancelAnimationFrame(animRef.current);
+    animRef.current = null;
+  }, []);
+  cancelAnimRef.current = cancelAnim;
+  useEffect(() => cancelAnim, [cancelAnim]);
+
+  const animateTo = useCallback(
+    (target: ViewState) => {
+      cancelAnim();
+      const from = viewRef.current;
+      const w = size.width;
+      const centerFrom = (w / 2 - from.offsetPx) / from.pxPerDay;
+      const centerTo = (w / 2 - target.offsetPx) / target.pxPerDay;
+      const t0 = performance.now();
+      const dur = 600;
+      const ease = (t: number) => 1 - Math.pow(1 - t, 3);
+      const step = (now: number) => {
+        const k = ease(Math.min(1, (now - t0) / dur));
+        const px = from.pxPerDay * Math.pow(target.pxPerDay / from.pxPerDay, k);
+        const center = centerFrom + (centerTo - centerFrom) * k;
+        setView({ pxPerDay: px, offsetPx: w / 2 - center * px });
+        if (k < 1) animRef.current = requestAnimationFrame(step);
+        else animRef.current = null;
+      };
+      animRef.current = requestAnimationFrame(step);
+    },
+    [cancelAnim, size.width],
+  );
+
+  // zoom onto a session's dot + select it (dot clicks and search results)
+  const flyToPoint = useCallback(
+    (p: TimelinePoint) => {
+      const pxPerDay = Math.min(MAX_PX_PER_DAY, Math.max(viewRef.current.pxPerDay, 48));
+      animateTo({ pxPerDay, offsetPx: size.width / 2 - p.day * pxPerDay });
+      setSelected(p.s);
+    },
+    [animateTo, size.width],
+  );
+
+  flyToPointRef.current = flyToPoint;
+
+  const flyTo = useCallback(
+    (r: SearchResult) => {
+      const p = points.find((pt) => pt.s.id === r.id);
+      if (p) flyToPoint(p);
+    },
+    [points, flyToPoint],
+  );
+
+  const toggleHarness = useCallback((h: string) => {
+    setHiddenHarness((prev) => {
+      const next = new Set(prev);
+      if (next.has(h)) next.delete(h);
+      else next.add(h);
+      return next;
+    });
+  }, []);
+
+  const toggleCluster = useCallback((id: number) => {
+    setHiddenClusters((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleLang = useCallback((lang: string) => {
+    setHiddenLangs((prev) => {
+      const next = new Set(prev);
+      if (next.has(lang)) next.delete(lang);
+      else next.add(lang);
+      return next;
+    });
+  }, []);
+
+  const ticks = useMemo(
+    () => (points.length ? computeTicks(view, day0, size.width) : []),
+    [points.length, view, day0, size.width],
+  );
+
+  const visibleCount = useMemo(() => points.filter(isVisible).length, [points, isVisible]);
+
+  // commit strip cells: same x mapping as everything else (day since day0)
+  const commitCells = useMemo(() => {
+    if (!commitDays.length || !day0) return [];
+    return commitDays.map((r) => ({
+      ...r,
+      day: (Date.parse(`${r.d}T00:00:00Z`) / 1000 - day0) / DAY,
+    }));
+  }, [commitDays, day0]);
+
+  // GitHub-heatmap semantics: 4 intensity steps by count quantiles (nonzero days)
+  const commitOpacity = useMemo(() => {
+    const counts = commitDays.map((r) => r.c).sort((a, b) => a - b);
+    if (!counts.length) return () => 0;
+    const q = (p: number) => counts[Math.min(counts.length - 1, Math.floor(p * counts.length))];
+    const t = [q(0.25), q(0.5), q(0.75)];
+    return (c: number) =>
+      c <= 0 ? 0 : c <= t[0] ? COMMIT_STEPS[0] : c <= t[1] ? COMMIT_STEPS[1] : c <= t[2] ? COMMIT_STEPS[2] : COMMIT_STEPS[3];
+  }, [commitDays]);
+
+  const openCommitDay = useCallback((d: string, x: number) => {
+    setCommitPopover((prev) => (prev?.d === d ? null : { d, x, commits: null }));
+  }, []);
+  useEffect(() => {
+    if (!commitPopover || commitPopover.commits !== null) return;
+    let stale = false;
+    fetchCommitsDay(commitPopover.d)
+      .then((d) => {
+        if (!stale) setCommitPopover((prev) => (prev?.d === commitPopover.d ? { ...prev, commits: d.commits ?? [] } : prev));
+      })
+      .catch(() => {});
+    return () => {
+      stale = true;
+    };
+  }, [commitPopover]);
+
+  // clicking a commit with mapped sessions flies to its trace
+  const flyToSession = useCallback(
+    (ids: string[]) => {
+      for (const id of ids) {
+        const p = points.find((pt) => pt.s.id === id);
+        if (p) {
+          flyToPointRef.current(p);
+          return;
+        }
+      }
+    },
+    [points],
+  );
+
+  const selectedPoint = selected ? points.find((p) => p.s.id === selected.id) : null;
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {/* filter chips */}
+      <div className="flex flex-wrap items-center gap-2 px-6 py-3 border-b border-rule">
+        {/* color-mode segmented control */}
+        <span className="mono text-[11px] text-ink-muted">color:</span>
+        <div className="mono flex items-center rounded-full border border-rule text-[11px] mr-2">
+          {(["harness", "task", "language", "cost"] as const).map((m) => (
+            <button
+              key={m}
+              onClick={() => setColorMode(m)}
+              className="px-2.5 py-1 rounded-full transition-colors"
+              style={{
+                color: colorMode === m ? "var(--ink-bright)" : "var(--ink-muted)",
+                background: colorMode === m ? "var(--hover, rgba(255,255,255,0.06))" : "transparent",
+                transitionTimingFunction: "var(--ease)",
+              }}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+        {colorMode === "harness" ? (
+          <>
+            <span className="mono text-[11px] text-ink-muted mr-1">harness</span>
+            {allHarnesses.map((h) => (
+              <Chip
+                key={h}
+                label={`${h} · ${harnessCounts.get(h) ?? 0}`}
+                color={HARNESS_COLORS[h] ?? FALLBACK_COLOR}
+                active={!hiddenHarness.has(h)}
+                onClick={() => toggleHarness(h)}
+              />
+            ))}
+          </>
+        ) : colorMode === "task" ? (
+          <>
+            <span className="mono text-[11px] text-ink-muted mr-1">task</span>
+            {clusters.length === 0 && (
+              <span className="mono text-[11px] text-ink-muted/60">no clusters yet</span>
+            )}
+            {clusters.map((c) => (
+              <Chip
+                key={c.id}
+                label={`${c.name} · ${c.count}`}
+                color={clusterColor(c.id)}
+                active={!hiddenClusters.has(c.id)}
+                onClick={() => toggleCluster(c.id)}
+              />
+            ))}
+          </>
+        ) : colorMode === "cost" ? (
+          <>
+            {/* no chips in cost mode — a tiny sequential legend instead */}
+            <span className="mono text-[11px] text-ink-muted mr-1">tokens</span>
+            <span className="mono flex items-center gap-1 text-[10px] text-ink-muted">
+              low
+              {COST_RAMP.map((c) => (
+                <span key={c} className="inline-block h-1.5 w-4 rounded-[2px]" style={{ background: c }} />
+              ))}
+              high
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="mono text-[11px] text-ink-muted mr-1">language</span>
+            {langCounts.length === 0 && (
+              <span className="mono text-[11px] text-ink-muted/60">no language data yet</span>
+            )}
+            {langCounts.map((l) => (
+              <Chip
+                key={l.lang}
+                label={`${l.lang} · ${l.sessions}`}
+                color={langColor(l.lang)}
+                active={!hiddenLangs.has(l.lang)}
+                onClick={() => toggleLang(l.lang)}
+              />
+            ))}
+          </>
+        )}
+        <span className="ml-auto flex items-center gap-3">
+          {plumbingCount > 0 && (
+            <button
+              onClick={() => setShowPlumbing((v) => !v)}
+              className="mono text-[10px] px-2 py-0.5 rounded-full border transition-colors"
+              style={{
+                borderColor: showPlumbing ? "var(--ink-muted)" : "var(--rule)",
+                color: showPlumbing ? "var(--ink)" : "rgba(155,157,163,0.5)",
+              }}
+              title="CodexBar /usage probe sessions — hidden by default in every mode"
+            >
+              plumbing · {plumbingCount}
+            </button>
+          )}
+          <span className="mono text-[11px] text-ink-muted">
+            {visibleCount}/{data?.meta.count ?? "…"} sessions
+            {liveIds.size > 0 && <span style={{ color: "#6ee7a0" }}> · {liveIds.size} live</span>}
+          </span>
+        </span>
+        {health && (
+          <span
+            className="mono text-[10px]"
+            style={{ color: health.ingesting ? "var(--ink-muted)" : "#f85149" }}
+          >
+            {health.ingesting ? "ingest current" : "ingest stale"} · last event {fmtAgo(health.lastEventAgoS)} ago
+          </span>
+        )}
+      </div>
+
+      {/* field */}
+      <div className="relative flex-1 min-h-0 flex">
+        <div
+          ref={wrapRef}
+          className="relative flex-1 min-w-0 cursor-grab active:cursor-grabbing overflow-hidden"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerLeave={onPointerLeave}
+        >
+          {/* faint lane rules + thin mono lane labels */}
+          {points.length > 0 &&
+            lanesList.map((h, i) => (
+              <div key={h}>
+                <div
+                  className="pointer-events-none absolute left-0 right-0 h-px"
+                  style={{ top: laneY(i), background: "rgba(255,255,255,0.05)" }}
+                />
+                <div
+                  className="mono pointer-events-none absolute left-3 -translate-y-1/2 text-[10px] tracking-wide"
+                  style={{
+                    top: laneY(i),
+                    color: hiddenHarness.has(h)
+                      ? "rgba(155,157,163,0.3)"
+                      : (HARNESS_COLORS[h] ?? FALLBACK_COLOR),
+                    opacity: 0.75,
+                  }}
+                >
+                  {h}
+                </div>
+              </div>
+            ))}
+
+          {points.length > 0 && (
+            <TimelineScene
+              points={points}
+              view={view}
+              width={size.width}
+              height={size.height}
+              lanes={laneLayout}
+              matches={matches}
+              hiddenHarness={hiddenHarness}
+              colorMode={colorMode}
+              hiddenClusters={hiddenClusters}
+              hiddenLangs={hiddenLangs}
+              liveIds={liveIds}
+              costThresholds={costThresholds}
+              showPlumbing={showPlumbing}
+            />
+          )}
+          {!data && !error && (
+            <div className="mono breath flex h-full items-center justify-center text-xs text-ink-muted">
+              reading the moraine…
+            </div>
+          )}
+          {error && (
+            <div className="mono flex h-full items-center justify-center text-xs text-[#f85149]">
+              couldn&apos;t reach clickhouse — {error}
+            </div>
+          )}
+
+          {/* selection ring */}
+          {selectedPoint && isVisible(selectedPoint) && (
+            <div
+              className="pointer-events-none absolute breath rounded-full border"
+              style={{
+                left: dayX(selectedPoint.day) - 9,
+                top: laneY(selectedPoint.lane, selectedPoint.jitter) - 9,
+                width: 18,
+                height: 18,
+                borderColor: harnessColor(selectedPoint.s.harness),
+              }}
+            />
+          )}
+
+          {/* reset view */}
+          {!isFit && (
+            <button
+              onClick={fitAll}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="mono absolute right-4 top-3 z-20 rounded-[8px] border border-rule bg-window/90 px-3 py-1.5 text-[11px] text-ink-muted backdrop-blur transition-colors hover:bg-hover hover:text-ink-bright"
+            >
+              ⤢ reset view
+            </button>
+          )}
+
+          {/* search overlay */}
+          <div className="absolute left-4 top-3 z-20 w-[300px]" onPointerDown={(e) => e.stopPropagation()}>
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="search your history…"
+              spellCheck={false}
+              className="mono w-full rounded-[8px] border border-rule bg-window/90 px-3 py-1.5 text-[12px] text-ink placeholder:text-ink-muted/60 outline-none focus:border-ink-muted/50 backdrop-blur"
+            />
+            {search && (
+              <div className="mono mt-1.5 text-[10px] text-ink-muted">
+                {searching ? "searching…" : `${search.count} match${search.count === 1 ? "" : "es"}`}
+              </div>
+            )}
+            {search && search.results.length > 0 && (
+              <div className="mt-1.5 max-h-[42vh] overflow-y-auto rounded-[8px] border border-rule bg-window/90 backdrop-blur">
+                {search.results.map((r) => {
+                  const s = points.find((p) => p.s.id === r.id)?.s;
+                  return (
+                    <button
+                      key={r.id}
+                      onClick={() => flyTo(r)}
+                      className="block w-full border-b border-rule px-3 py-2 text-left last:border-b-0 hover:bg-hover transition-colors"
+                    >
+                      <div className="mono flex items-center gap-2 text-[10px]">
+                        <span
+                          className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{ background: s ? harnessColor(s.harness) : FALLBACK_COLOR }}
+                        />
+                        <span className="truncate text-ink-bright">
+                          {s?.title || r.id.slice(0, 18)}
+                        </span>
+                        {s && <span className="ml-auto shrink-0 text-ink-muted">{fmtDate(s.start)}</span>}
+                      </div>
+                      <div className="mono mt-0.5 truncate text-[10px] text-ink-muted">{r.snippet}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* commit strip — a bottom row above the date axis, same x mapping */}
+          {commitCells.length > 0 && (
+            <div
+              className="absolute left-0 right-0 z-10 overflow-hidden"
+              style={{
+                bottom: AXIS_H,
+                height: STRIP_H,
+                borderTop: "1px solid rgba(255,255,255,0.06)",
+                background: "rgba(11,12,14,0.4)",
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              onPointerMove={(e) => e.stopPropagation()}
+              onPointerUp={(e) => e.stopPropagation()}
+              onPointerLeave={() => setCommitHover(null)}
+            >
+              {commitCells.map((cell) => {
+                const x = view.offsetPx + cell.day * view.pxPerDay;
+                if (x < -view.pxPerDay || x > size.width + view.pxPerDay) return null;
+                const w = Math.max(2, view.pxPerDay - (view.pxPerDay >= 4 ? 1 : 0));
+                return (
+                  <div
+                    key={cell.d}
+                    className="absolute cursor-pointer"
+                    style={{
+                      left: x,
+                      top: 7,
+                      width: w,
+                      height: STRIP_H - 13,
+                      borderRadius: 1,
+                      background: `rgba(${COMMIT_COLOR}, ${commitOpacity(cell.c)})`,
+                    }}
+                    onPointerMove={(e) => {
+                      e.stopPropagation();
+                      setCommitHover({ d: cell.d, c: cell.c, clientX: e.clientX, clientY: e.clientY });
+                    }}
+                    onPointerLeave={() => setCommitHover(null)}
+                    onClick={() => openCommitDay(cell.d, x)}
+                  />
+                );
+              })}
+              <div className="mono pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[9px] tracking-wide text-ink-muted/70">
+                commits
+              </div>
+            </div>
+          )}
+
+          {/* commit day popover */}
+          {commitPopover && (
+            <div
+              className="mono absolute z-30 w-[380px] max-h-[40vh] overflow-y-auto rounded-[8px] border border-rule bg-window/95 backdrop-blur text-[10px]"
+              style={{
+                bottom: AXIS_H + STRIP_H + 6,
+                left: Math.max(8, Math.min(commitPopover.x - 100, size.width - 396)),
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between border-b border-rule px-3 py-2 text-ink-muted">
+                <span>
+                  {commitPopover.d} · {commitPopover.commits ? `${commitPopover.commits.length} commits` : "loading…"}
+                </span>
+                <button
+                  onClick={() => setCommitPopover(null)}
+                  className="text-ink-muted hover:text-ink-bright transition-colors"
+                  aria-label="close commits"
+                >
+                  ×
+                </button>
+              </div>
+              {commitPopover.commits?.map((c) => {
+                const hasTrace = c.sessions.length > 0;
+                return (
+                  <button
+                    key={c.hash7}
+                    disabled={!hasTrace}
+                    onClick={() => {
+                      if (!hasTrace) return;
+                      flyToSession(c.sessions);
+                      setCommitPopover(null);
+                    }}
+                    className={`block w-full border-b border-rule px-3 py-1.5 text-left last:border-b-0 transition-colors ${
+                      hasTrace ? "hover:bg-hover cursor-pointer" : "cursor-default"
+                    }`}
+                  >
+                    <span className="text-ink-muted/70">{c.hash7}</span>{" "}
+                    <span style={{ color: "#6ee7a0", opacity: 0.8 }}>{c.repo}</span>{" "}
+                    <span className="text-ink">{c.subject}</span>
+                    {hasTrace && <span className="text-ink-muted"> · in trace</span>}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {/* date axis */}
+          <div className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-9 border-t border-rule bg-field/70">
+            {ticks.map((t, i) => (
+              <div key={i} className="absolute bottom-0 h-9" style={{ left: t.x }}>
+                <div
+                  className="absolute bottom-5 h-2 w-px"
+                  style={{ background: t.major ? "rgba(255,255,255,0.4)" : "rgba(255,255,255,0.15)" }}
+                />
+                <div
+                  className={`mono absolute bottom-1 -translate-x-1/2 whitespace-nowrap text-[10px] ${
+                    t.major ? "text-ink" : "text-ink-muted"
+                  }`}
+                >
+                  {t.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* hint */}
+          <div
+            className="mono pointer-events-none absolute left-4 z-10 text-[10px] text-ink-muted/70"
+            style={{ bottom: AXIS_H + (commitCells.length ? STRIP_H : 0) + 12 }}
+          >
+            drag to pan · wheel to zoom time · hover points · click for detail
+          </div>
+        </div>
+
+        {/* commit cell tooltip */}
+        {commitHover && (
+          <div
+            className="mono pointer-events-none fixed z-50 rounded-lg border border-rule px-3 py-2 text-[11px] leading-relaxed"
+            style={{
+              left: commitHover.clientX + 14,
+              top: commitHover.clientY - 40,
+              background: "rgba(11,12,14,0.92)",
+            }}
+          >
+            <span className="text-ink-bright">{commitHover.d}</span>
+            <span className="text-ink-muted">
+              {" · "}
+              {commitHover.c} commit{commitHover.c === 1 ? "" : "s"}
+            </span>
+          </div>
+        )}
+
+        {/* hover tooltip */}
+        {hover && (
+          <div
+            className="mono pointer-events-none fixed z-50 max-w-xs rounded-lg border border-rule px-3 py-2 text-[11px] leading-relaxed"
+            style={{
+              left: hover.clientX + 14,
+              top: hover.clientY + 14,
+              background: "rgba(11,12,14,0.92)",
+            }}
+          >
+            <div className="truncate text-ink-bright">
+              {hover.point.s.title || hover.point.s.id.slice(0, 18)}
+            </div>
+            <div className="text-ink-muted">
+              <span style={{ color: harnessColor(hover.point.s.harness) }}>{hover.point.s.harness}</span>
+              {" · "}
+              {fmtDate(hover.point.s.start)}
+            </div>
+            <div className="text-ink-muted">
+              {hover.point.s.events.toLocaleString()} events · {hover.point.s.turns} turns
+              {hover.point.s.tokens > 0 && <> · {fmtTokens(hover.point.s.tokens)} tok</>}
+              {hover.point.s.lang && (
+                <>
+                  {" · "}
+                  <span style={{ color: langColor(hover.point.s.lang) }}>{hover.point.s.lang}</span>
+                </>
+              )}
+            </div>
+            {hover.point.s.label && (
+              <div style={{ color: clusterColor(hover.point.s.clusterId) }}>
+                {hover.point.s.label}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* side panel */}
+        {selected && (
+          <aside className="w-[340px] shrink-0 border-l border-rule overflow-y-auto p-5 bg-window">
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="text-sm text-ink-bright leading-snug">
+                {selected.title || "untitled session"}
+              </h2>
+              <button
+                onClick={() => setSelected(null)}
+                className="mono text-xs text-ink-muted hover:text-ink-bright transition-colors"
+                aria-label="close panel"
+              >
+                ×
+              </button>
+            </div>
+            <div className="mono text-[11px] text-ink-muted mt-1 break-all">{selected.id}</div>
+
+            <dl className="mono text-[11px] mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
+              <dt className="text-ink-muted">harness</dt>
+              <dd style={{ color: harnessColor(selected.harness) }}>{selected.harness}</dd>
+              <dt className="text-ink-muted">mode</dt>
+              <dd>{selected.mode}</dd>
+              <dt className="text-ink-muted">turns</dt>
+              <dd>{selected.turns}</dd>
+              <dt className="text-ink-muted">events</dt>
+              <dd>{selected.events.toLocaleString()}</dd>
+              {selected.tokens > 0 && (
+                <>
+                  <dt className="text-ink-muted">tokens</dt>
+                  <dd>{fmtTokens(selected.tokens)}</dd>
+                </>
+              )}
+              {detail && (
+                <>
+                  <dt className="text-ink-muted">tool calls</dt>
+                  <dd>{detail.tool_calls}</dd>
+                </>
+              )}
+              <dt className="text-ink-muted">span</dt>
+              <dd>
+                {fmtDateTime(selected.start)} → {fmtDateTime(selected.end)}
+              </dd>
+              {detail?.origin_cwd && (
+                <>
+                  <dt className="text-ink-muted">cwd</dt>
+                  <dd className="break-all">{detail.origin_cwd}</dd>
+                </>
+              )}
+            </dl>
+
+            {/* language + tooling stack (langs.sqlite; absent = block hidden) */}
+            {detail?.langs && detail.langs.length > 0 && (
+              <div className="mt-5">
+                <div className="mono text-[11px] text-ink-muted mb-1.5">stack</div>
+                {(() => {
+                  const total = detail.langs!.reduce((a, l) => a + l.files, 0) || 1;
+                  return (
+                    <>
+                      <div className="flex h-1.5 w-full overflow-hidden rounded-full">
+                        {detail.langs!.map((l) => (
+                          <div
+                            key={l.lang}
+                            style={{
+                              width: `${(100 * l.files) / total}%`,
+                              background: langColor(l.lang),
+                              opacity: 0.85,
+                            }}
+                          />
+                        ))}
+                      </div>
+                      <div className="mono mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-[10px]">
+                        {detail.langs!.map((l) => (
+                          <div key={l.lang} className="flex items-center gap-1.5">
+                            <span
+                              className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                              style={{ background: langColor(l.lang) }}
+                            />
+                            <span className="text-ink">{l.lang}</span>
+                            <span className="ml-auto text-ink-muted">{l.files}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  );
+                })()}
+                {detail.tools && detail.tools.length > 0 && (
+                  <div className="mt-2.5 flex flex-wrap gap-1.5">
+                    {detail.tools.map((t) => (
+                      <span
+                        key={t.tool}
+                        className="mono rounded-full border border-rule px-2 py-0.5 text-[10px] text-ink-muted"
+                      >
+                        {t.tool} <span className="text-ink-muted/60">×{t.uses}</span>
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="mt-5">
+              <div className="mono text-[11px] text-ink-muted mb-1.5">summary</div>
+              {detail === null ? (
+                <div className="mono text-[11px] text-ink-muted breath">loading…</div>
+              ) : detail.session_summary ? (
+                <p className="text-[13px] leading-relaxed text-ink whitespace-pre-wrap">
+                  {detail.session_summary}
+                </p>
+              ) : (
+                <div className="mono text-[11px] text-ink-muted">no summary projected</div>
+              )}
+            </div>
+
+            {(detail?.label || selected.label || detail?.scan_summary) && (
+              <div className="mt-5">
+                <div className="mono text-[11px] text-ink-muted mb-1.5">scanned by gemma</div>
+                {(detail?.label || selected.label) && (
+                  <span
+                    className="mono inline-block text-[11px] px-2.5 py-1 rounded-full border mb-2"
+                    style={{
+                      borderColor: clusterColor(detail?.clusterId ?? selected.clusterId),
+                      color: "var(--ink-bright)",
+                      background: `${clusterColor(detail?.clusterId ?? selected.clusterId)}1a`,
+                    }}
+                  >
+                    {detail?.label ?? selected.label}
+                  </span>
+                )}
+                {detail?.scan_summary && (
+                  <p className="text-[13px] leading-relaxed text-ink whitespace-pre-wrap">
+                    {detail.scan_summary}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="mt-5">
+              <div className="mono text-[11px] text-ink-muted mb-1.5">trace</div>
+              <TracePreview sessionId={selected.id} />
+            </div>
+
+            <div className="mt-5 flex gap-4">
+              <button
+                onClick={() => onOpenSession(selected.id)}
+                className="mono text-[11px] text-ink-bright underline decoration-rule underline-offset-4 hover:text-ink transition-colors cursor-pointer bg-transparent border-0 p-0"
+              >
+                full transcript →
+              </button>
+            </div>
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/explore/timeline/TimelineScene.tsx
+++ b/apps/homescreen/app/components/explore/timeline/TimelineScene.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+import {
+  FALLBACK_COLOR,
+  HARNESS_COLORS,
+  clusterColor,
+  costColor,
+  langColor,
+  type ColorMode,
+  type TimelinePoint,
+  type ViewState,
+} from "./types";
+
+// Geometry lives in (day, lane) space; the vertex shaders map straight to NDC
+// from the pan/zoom view state — no camera matrices, so pan/zoom is just a
+// uniform update. Bright core + halo, additive, like /map's point field.
+
+export interface LaneLayout {
+  top: number; // px of first lane's top edge
+  gap: number; // px per lane
+  jitterAmp: number; // px amplitude of per-session jitter
+}
+
+interface SceneProps {
+  points: TimelinePoint[];
+  view: ViewState;
+  width: number;
+  height: number;
+  lanes: LaneLayout;
+  matches: Set<string> | null; // null = no active search
+  hiddenHarness: Set<string>;
+  colorMode: ColorMode; // harness vs task-cluster vs language colors
+  hiddenClusters: Set<number>; // task-mode visibility (clusterId)
+  hiddenLangs: Set<string>; // language-mode visibility (dominant lang; "" = no data)
+  liveIds: Set<string>; // sessions active in the last 120s — breathing pulse
+  costThresholds: number[]; // [q25, q50, q75] over nonzero tokens (cost mode)
+  showPlumbing: boolean; // CodexBar probe sessions — hidden in ALL modes by default
+}
+
+const PROJECT = /* glsl */ `
+  uniform float uOffsetPx;
+  uniform float uPxPerDay;
+  uniform float uWidth;
+  uniform float uHeight;
+  uniform float uLaneTop;
+  uniform float uLaneGap;
+  uniform float uJitterAmp;
+
+  vec2 toPx(float day, float lane, float jitter) {
+    float x = uOffsetPx + day * uPxPerDay;
+    float y = uLaneTop + (lane + 0.5) * uLaneGap + jitter * uJitterAmp;
+    return vec2(x, y);
+  }
+  vec4 toClip(vec2 px) {
+    return vec4(px.x / uWidth * 2.0 - 1.0, 1.0 - px.y / uHeight * 2.0, 0.0, 1.0);
+  }
+`;
+
+const POINT_VERT = /* glsl */ `
+  attribute float aDay;
+  attribute float aLane;
+  attribute float aJitter;
+  attribute float aSize;
+  attribute vec3 aColor;
+  attribute float aMatch;
+  attribute float aVisible;
+  attribute float aLive;
+  uniform float uDpr;
+  uniform float uTime; // seconds — drives the live breathing pulse
+  uniform float uSearch; // 0 = no search, 1 = search active (animated)
+  uniform float uSizeScale; // grows with time-zoom so dots stay findable
+  varying vec3 vColor;
+  varying float vAlpha;
+  ${PROJECT}
+  void main() {
+    vColor = aColor;
+    // non-matches sink to ~0.12 opacity while a search is live
+    float searchDim = mix(1.0, mix(0.12, 1.0, aMatch), uSearch);
+    // live sessions breathe: 5.2s period, eased sine (breath = activity)
+    float breath = 0.5 - 0.5 * cos(uTime * ${(2 * Math.PI / 5.2).toFixed(6)});
+    breath = breath * breath * (3.0 - 2.0 * breath); // smoothstep ease
+    vAlpha = aVisible * searchDim * mix(1.0, 0.72 + 0.5 * breath, aLive);
+    gl_Position = toClip(toPx(aDay, aLane, aJitter));
+    if (aVisible < 0.5) gl_Position = vec4(2.0, 2.0, 2.0, 1.0); // cull offscreen
+    float boost = 1.0 + 0.4 * aMatch * uSearch; // matches enlarge slightly
+    boost *= 1.0 + 0.45 * breath * aLive; // live pulse also swells the dot
+    gl_PointSize = clamp(aSize * boost * uSizeScale, 1.5, 64.0) * uDpr;
+  }
+`;
+
+const POINT_FRAG = /* glsl */ `
+  varying vec3 vColor;
+  varying float vAlpha;
+  void main() {
+    float d = length(gl_PointCoord - 0.5);
+    if (d > 0.5) discard;
+    float core = smoothstep(0.22, 0.0, d);
+    float halo = smoothstep(0.5, 0.08, d) * 0.35;
+    gl_FragColor = vec4(vColor, (core + halo) * 0.95 * vAlpha);
+  }
+`;
+
+const TAIL_VERT = /* glsl */ `
+  attribute float aDay;
+  attribute float aLane;
+  attribute float aJitter;
+  attribute vec3 aColor;
+  attribute float aMatch;
+  attribute float aVisible;
+  uniform float uSearch;
+  varying vec3 vColor;
+  varying float vAlpha;
+  ${PROJECT}
+  void main() {
+    vColor = aColor;
+    float searchDim = mix(1.0, mix(0.12, 1.0, aMatch), uSearch);
+    vAlpha = aVisible * searchDim;
+    gl_Position = toClip(toPx(aDay, aLane, aJitter));
+    if (aVisible < 0.5) gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+  }
+`;
+
+const TAIL_FRAG = /* glsl */ `
+  varying vec3 vColor;
+  varying float vAlpha;
+  void main() {
+    gl_FragColor = vec4(vColor, 0.16 * vAlpha); // faint duration tail
+  }
+`;
+
+// sessions longer than this get a start→end tail
+const TAIL_MIN_S = 30 * 60;
+
+function makeUniforms() {
+  return {
+    uOffsetPx: { value: 0 },
+    uPxPerDay: { value: 12 },
+    uWidth: { value: 1200 },
+    uHeight: { value: 700 },
+    uLaneTop: { value: 0 },
+    uLaneGap: { value: 100 },
+    uJitterAmp: { value: 28 },
+    uSearch: { value: 0 },
+    uSizeScale: { value: 1 },
+    uTime: { value: 0 },
+    uDpr: { value: 1 },
+  };
+}
+
+// Prop updates don't reliably cross the r3f Canvas root bridge here (the inner
+// tree kept rendering with mount-time values), so Field reads everything mutable
+// through a ref each frame instead of depending on re-renders.
+function Field({ points, propsRef }: { points: TimelinePoint[]; propsRef: React.RefObject<SceneProps> }) {
+  const pointMat = useRef<THREE.ShaderMaterial>(null);
+  const tailMat = useRef<THREE.ShaderMaterial>(null);
+  const searchRef = useRef(0);
+  const appliedRef = useRef<{
+    matches: Set<string> | null;
+    hidden: Set<string> | null;
+    colorMode: ColorMode | null;
+    hiddenClusters: Set<number> | null;
+    hiddenLangs: Set<string> | null;
+    live: Set<string> | null;
+    costThresholds: number[] | null;
+    showPlumbing: boolean | null;
+    buf: object | null; // which buffer set the write landed on — rebuilt buffers start all-invisible
+  }>({ matches: null, hidden: null, colorMode: null, hiddenClusters: null, hiddenLangs: null, live: null, costThresholds: null, showPlumbing: null, buf: null });
+
+  // static per-point buffers (rebuilt only when the dataset changes)
+  const pointBuf = useMemo(() => {
+    const n = points.length;
+    const day = new Float32Array(n);
+    const lane = new Float32Array(n);
+    const jitter = new Float32Array(n);
+    const size = new Float32Array(n);
+    const color = new Float32Array(n * 3);
+    const c = new THREE.Color();
+    points.forEach((p, i) => {
+      day[i] = p.day;
+      lane[i] = p.lane;
+      jitter[i] = p.jitter;
+      size[i] = p.size;
+      c.set(HARNESS_COLORS[p.s.harness] ?? FALLBACK_COLOR);
+      color[i * 3] = c.r;
+      color[i * 3 + 1] = c.g;
+      color[i * 3 + 2] = c.b;
+    });
+    return { day, lane, jitter, size, color, match: new Float32Array(n), visible: new Float32Array(n), live: new Float32Array(n) };
+  }, [points]);
+
+  // tail segments: 2 verts per long session
+  const tailBuf = useMemo(() => {
+    const long = points.filter((p) => p.s.end - p.s.start >= TAIL_MIN_S);
+    const n = long.length * 2;
+    const day = new Float32Array(n);
+    const lane = new Float32Array(n);
+    const jitter = new Float32Array(n);
+    const color = new Float32Array(n * 3);
+    const c = new THREE.Color();
+    long.forEach((p, i) => {
+      c.set(HARNESS_COLORS[p.s.harness] ?? FALLBACK_COLOR);
+      for (const k of [0, 1]) {
+        const v = i * 2 + k;
+        day[v] = k === 0 ? p.dayStart : p.dayEnd;
+        lane[v] = p.lane;
+        jitter[v] = p.jitter;
+        color[v * 3] = c.r;
+        color[v * 3 + 1] = c.g;
+        color[v * 3 + 2] = c.b;
+      }
+    });
+    return { sessions: long, day, lane, jitter, color, match: new Float32Array(n), visible: new Float32Array(n) };
+  }, [points]);
+
+  const pointGeom = useMemo(() => {
+    const g = new THREE.BufferGeometry();
+    const b = pointBuf;
+    g.setAttribute("position", new THREE.BufferAttribute(new Float32Array(points.length * 3), 3));
+    g.setAttribute("aDay", new THREE.BufferAttribute(b.day, 1));
+    g.setAttribute("aLane", new THREE.BufferAttribute(b.lane, 1));
+    g.setAttribute("aJitter", new THREE.BufferAttribute(b.jitter, 1));
+    g.setAttribute("aSize", new THREE.BufferAttribute(b.size, 1));
+    g.setAttribute("aColor", new THREE.BufferAttribute(b.color, 3));
+    g.setAttribute("aMatch", new THREE.BufferAttribute(b.match, 1));
+    g.setAttribute("aVisible", new THREE.BufferAttribute(b.visible, 1));
+    g.setAttribute("aLive", new THREE.BufferAttribute(b.live, 1));
+    return g;
+  }, [pointBuf, points.length]);
+
+  const tailGeom = useMemo(() => {
+    const g = new THREE.BufferGeometry();
+    const b = tailBuf;
+    const n = b.day.length;
+    g.setAttribute("position", new THREE.BufferAttribute(new Float32Array(n * 3), 3));
+    g.setAttribute("aDay", new THREE.BufferAttribute(b.day, 1));
+    g.setAttribute("aLane", new THREE.BufferAttribute(b.lane, 1));
+    g.setAttribute("aJitter", new THREE.BufferAttribute(b.jitter, 1));
+    g.setAttribute("aColor", new THREE.BufferAttribute(b.color, 3));
+    g.setAttribute("aMatch", new THREE.BufferAttribute(b.match, 1));
+    g.setAttribute("aVisible", new THREE.BufferAttribute(b.visible, 1));
+    return g;
+  }, [tailBuf]);
+
+  useEffect(
+    () => () => {
+      pointGeom.dispose();
+      tailGeom.dispose();
+    },
+    [pointGeom, tailGeom],
+  );
+
+  const pointUniforms = useMemo(makeUniforms, []);
+  const tailUniforms = useMemo(makeUniforms, []);
+
+  useFrame((state, delta) => {
+    const { view, width, height, lanes, matches, hiddenHarness, colorMode, hiddenClusters, hiddenLangs, liveIds, costThresholds, showPlumbing } =
+      propsRef.current;
+
+    // match/visibility/color rewrites only when the sets (or the buffer set —
+    // rebuilt attributes start zeroed) change identity
+    const applied = appliedRef.current;
+    if (
+      applied.matches !== matches ||
+      applied.hidden !== hiddenHarness ||
+      applied.colorMode !== colorMode ||
+      applied.hiddenClusters !== hiddenClusters ||
+      applied.hiddenLangs !== hiddenLangs ||
+      applied.live !== liveIds ||
+      applied.costThresholds !== costThresholds ||
+      applied.showPlumbing !== showPlumbing ||
+      applied.buf !== pointBuf
+    ) {
+      applied.matches = matches;
+      applied.hidden = hiddenHarness;
+      applied.colorMode = colorMode;
+      applied.hiddenClusters = hiddenClusters;
+      applied.hiddenLangs = hiddenLangs;
+      applied.live = liveIds;
+      applied.costThresholds = costThresholds;
+      applied.showPlumbing = showPlumbing;
+      applied.buf = pointBuf;
+
+      const c = new THREE.Color();
+      const colorOf = (p: TimelinePoint) =>
+        colorMode === "task"
+          ? clusterColor(p.s.clusterId)
+          : colorMode === "language"
+            ? langColor(p.s.lang)
+            : colorMode === "cost"
+              ? costColor(p.s.tokens, costThresholds)
+              : (HARNESS_COLORS[p.s.harness] ?? FALLBACK_COLOR);
+      // harness hiding always collapses the lane; task mode additionally hides
+      // points whose cluster chip is toggled off; language mode likewise by lang
+      // (cost mode: harness hiding only)
+      const visibleOf = (p: TimelinePoint) =>
+        (!showPlumbing && p.s.cluster === "cli plumbing") ||
+        hiddenHarness.has(p.s.harness) ||
+        (colorMode === "task" && p.s.clusterId != null && hiddenClusters.has(p.s.clusterId)) ||
+        (colorMode === "language" && p.s.lang != null && hiddenLangs.has(p.s.lang))
+          ? 0
+          : 1;
+
+      points.forEach((p, i) => {
+        pointBuf.match[i] = matches?.has(p.s.id) ? 1 : 0;
+        pointBuf.visible[i] = visibleOf(p);
+        pointBuf.live[i] = liveIds.has(p.s.id) ? 1 : 0;
+        c.set(colorOf(p));
+        pointBuf.color[i * 3] = c.r;
+        pointBuf.color[i * 3 + 1] = c.g;
+        pointBuf.color[i * 3 + 2] = c.b;
+      });
+      (pointGeom.getAttribute("aMatch") as THREE.BufferAttribute).needsUpdate = true;
+      (pointGeom.getAttribute("aVisible") as THREE.BufferAttribute).needsUpdate = true;
+      (pointGeom.getAttribute("aColor") as THREE.BufferAttribute).needsUpdate = true;
+      (pointGeom.getAttribute("aLive") as THREE.BufferAttribute).needsUpdate = true;
+
+      tailBuf.sessions.forEach((p, i) => {
+        const m = matches?.has(p.s.id) ? 1 : 0;
+        const v = visibleOf(p);
+        c.set(colorOf(p));
+        for (const k of [0, 1]) {
+          const vi = i * 2 + k;
+          tailBuf.match[vi] = m;
+          tailBuf.visible[vi] = v;
+          tailBuf.color[vi * 3] = c.r;
+          tailBuf.color[vi * 3 + 1] = c.g;
+          tailBuf.color[vi * 3 + 2] = c.b;
+        }
+      });
+      (tailGeom.getAttribute("aMatch") as THREE.BufferAttribute).needsUpdate = true;
+      (tailGeom.getAttribute("aVisible") as THREE.BufferAttribute).needsUpdate = true;
+      (tailGeom.getAttribute("aColor") as THREE.BufferAttribute).needsUpdate = true;
+    }
+
+    // ease the search dim in/out (motion carries meaning, nothing louder)
+    const target = matches ? 1 : 0;
+    const k = 1 - Math.exp(-delta * 9);
+    searchRef.current += (target - searchRef.current) * k;
+
+    // this three build clones uniforms at ShaderMaterial construction, so the
+    // memoized objects we passed as props are dead ends — mutate the live
+    // copies on the materials themselves
+    const liveUniforms = [pointMat.current?.uniforms, tailMat.current?.uniforms].filter(
+      (u): u is typeof pointUniforms => !!u,
+    );
+    for (const u of liveUniforms) {
+      u.uOffsetPx.value = view.offsetPx;
+      u.uPxPerDay.value = view.pxPerDay;
+      u.uWidth.value = Math.max(1, width);
+      u.uHeight.value = Math.max(1, height);
+      u.uLaneTop.value = lanes.top;
+      u.uLaneGap.value = lanes.gap;
+      u.uJitterAmp.value = lanes.jitterAmp;
+      u.uSearch.value = searchRef.current;
+      if (u.uTime) u.uTime.value = state.clock.elapsedTime;
+      // ~1x at the fitted overview (~14 px/day), up to 4x at day-level zoom
+      u.uSizeScale.value = Math.min(4, Math.max(0.8, Math.pow(view.pxPerDay / 14, 0.45)));
+    }
+    if (pointMat.current) pointMat.current.uniforms.uDpr.value = state.gl.getPixelRatio();
+  });
+
+  return (
+    <>
+      <lineSegments geometry={tailGeom} frustumCulled={false}>
+        <shaderMaterial
+          ref={tailMat}
+          vertexShader={TAIL_VERT}
+          fragmentShader={TAIL_FRAG}
+          uniforms={tailUniforms}
+          transparent
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </lineSegments>
+      <points geometry={pointGeom} frustumCulled={false}>
+        <shaderMaterial
+          ref={pointMat}
+          vertexShader={POINT_VERT}
+          fragmentShader={POINT_FRAG}
+          uniforms={pointUniforms}
+          transparent
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </points>
+    </>
+  );
+}
+
+export default function TimelineScene(props: SceneProps) {
+  const propsRef = useRef<SceneProps>(props);
+  propsRef.current = props;
+  return (
+    <Canvas
+      orthographic
+      camera={{ position: [0, 0, 100], zoom: 1, near: 0.1, far: 1000 }}
+      gl={{ antialias: true, alpha: true }}
+      style={{ background: "transparent" }}
+    >
+      <Field points={props.points} propsRef={propsRef} />
+    </Canvas>
+  );
+}

--- a/apps/homescreen/app/components/explore/timeline/TracePreview.tsx
+++ b/apps/homescreen/app/components/explore/timeline/TracePreview.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchTracePreview, type TracePreviewEvent } from "@/app/lib/exploreData";
+
+// Compact trace preview for the timeline side panel: a color-railed event list.
+// Data comes through the exploreData adapter (fetchTracePreview — the ported
+// anatomy event query). The full transcript lives in the session pane.
+
+const TYPE_COLORS: Record<string, string> = {
+  user_input: "var(--model-clay)",
+  assistant_response: "var(--model-house)",
+  reasoning: "var(--model-violet)",
+  tool_call: "var(--model-mint)",
+  tool_response: "var(--model-mint)",
+  system: "var(--ink-muted)",
+  runtime: "var(--ink-muted)",
+  compaction: "var(--model-amber)",
+};
+
+const MAX_EVENTS = 40;
+const SNIPPET = 110;
+
+export default function TracePreview({ sessionId }: { sessionId: string }) {
+  const [events, setEvents] = useState<TracePreviewEvent[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let stale = false;
+    setEvents(null);
+    setFailed(false);
+    fetchTracePreview(sessionId)
+      .then((rows) => {
+        if (!stale) setEvents(rows);
+      })
+      .catch(() => {
+        if (!stale) setFailed(true);
+      });
+    return () => {
+      stale = true;
+    };
+  }, [sessionId]);
+
+  if (failed) return <div className="mono text-[11px] text-ink-muted">trace unavailable</div>;
+  if (events === null)
+    return <div className="mono breath text-[11px] text-ink-muted">reading trace…</div>;
+  if (events.length === 0)
+    return <div className="mono text-[11px] text-ink-muted">no events projected</div>;
+
+  // plumbing events (system/runtime/unknown with no text) drown the story — skip them
+  const meaningful = events.filter(
+    (e) =>
+      !(
+        ["system", "runtime", "unknown"].includes(e.event_type) &&
+        !(e.preview || "").trim()
+      ),
+  );
+  const shown = meaningful.slice(0, MAX_EVENTS);
+  let lastTurn = -1;
+
+  return (
+    <div className="max-h-[38vh] overflow-y-auto rounded-[8px] border border-rule bg-window/60">
+      {shown.map((e) => {
+        const turnBreak = e.turn_seq !== lastTurn;
+        lastTurn = e.turn_seq;
+        const color = TYPE_COLORS[e.event_type] ?? "var(--ink-muted)";
+        const text = (e.preview || "").replace(/\s+/g, " ").trim();
+        return (
+          <div key={e.event_order}>
+            {turnBreak && (
+              <div className="mono border-b border-rule/60 px-2.5 pt-2 pb-0.5 text-[9px] tracking-widest text-ink-muted/70">
+                T{e.turn_seq}
+              </div>
+            )}
+            <div className="flex gap-2 px-2.5 py-1">
+              <span
+                className="mt-[5px] block h-[calc(100%-6px)] w-[2px] shrink-0 self-stretch rounded-full"
+                style={{ background: color, opacity: 0.8 }}
+              />
+              <div className="min-w-0">
+                <span className="mono text-[10px]" style={{ color }}>
+                  {e.event_type === "tool_call" || e.event_type === "tool_response"
+                    ? `${e.event_type === "tool_call" ? "→" : "←"} ${e.name || "tool"}`
+                    : e.event_type}
+                </span>
+                {text && (
+                  <p className="truncate text-[11px] leading-snug text-ink-muted">
+                    {text.slice(0, SNIPPET)}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      {meaningful.length > shown.length && (
+        <div className="mono border-t border-rule px-2.5 py-1.5 text-[10px] text-ink-muted">
+          +{meaningful.length - shown.length} more events — open the full transcript for the rest
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/explore/timeline/types.ts
+++ b/apps/homescreen/app/components/explore/timeline/types.ts
@@ -1,0 +1,174 @@
+// /timeline — the whole agent history as a temporal field of traces.
+
+export type TimelineSession = {
+  id: string;
+  harness: string;
+  mode: string;
+  title: string;
+  events: number;
+  turns: number;
+  start: number; // unix seconds
+  end: number; // unix seconds
+  // Stage-2 scan (sqlite) — present once the scan has reached this session
+  label?: string;
+  cluster?: string;
+  clusterId?: number;
+  // language layer (langs.sqlite) — dominant language by file count
+  lang?: string;
+  // bulk token total (input+output+cache r/w) from events; 0 = none recorded
+  tokens: number;
+};
+
+export type TimelinePayload = {
+  sessions: TimelineSession[];
+  meta: { count: number; harnesses: string[] };
+};
+
+export type SessionDetail = {
+  session_id: string;
+  title: string;
+  harness: string;
+  mode: string;
+  total_turns: number;
+  total_events: number;
+  tool_calls: number;
+  session_summary: string;
+  origin_cwd: string;
+  start: number;
+  end: number;
+  // Stage-2 scan (sqlite)
+  label?: string;
+  scan_summary?: string;
+  cluster?: string;
+  clusterId?: number;
+  // language layer (langs.sqlite)
+  langs?: Array<{ lang: string; files: number }>;
+  tools?: Array<{ tool: string; uses: number }>;
+};
+
+export type ColorMode = "harness" | "task" | "language" | "cost";
+
+// cost color mode — sequential heat ramp over token-count quantiles
+// (dim ink → amber → stamp → near-white)
+export const COST_RAMP = ["#4b4d52", "#f2b34c", "#d7623e", "#f2f2f0"];
+
+// thresholds = client-side quantiles [q25, q50, q75] over nonzero tokens
+export function costColor(tokens: number, thresholds: number[]): string {
+  if (tokens <= 0 || thresholds.length < 3) return COST_RAMP[0];
+  if (tokens <= thresholds[0]) return COST_RAMP[0];
+  if (tokens <= thresholds[1]) return COST_RAMP[1];
+  if (tokens <= thresholds[2]) return COST_RAMP[2];
+  return COST_RAMP[3];
+}
+
+// compact mono token count: 823 · 4.2k · 1.2M · 3.1B
+export function fmtTokens(t: number): string {
+  if (t < 1000) return String(t);
+  if (t < 1e6) return `${(t / 1e3).toFixed(t < 1e4 ? 1 : 0)}k`;
+  if (t < 1e9) return `${(t / 1e6).toFixed(t < 1e7 ? 1 : 0)}M`;
+  return `${(t / 1e9).toFixed(1)}B`;
+}
+
+// cluster palette — cycled by clusterId in task color mode
+export const CLUSTER_PALETTE = [
+  "#d97757", // --model-clay
+  "#9edbd3", // --model-mint
+  "#f2b34c", // --model-amber
+  "#a78bfa", // --model-violet
+  "#67e8f9", // --model-cyan
+  "#6ee7a0", // --state-promoted
+  "#f2f2f0",
+  "#d7623e", // --stamp
+];
+// unscanned sessions in task mode: neutral dim ink
+export const UNSCANNED_COLOR = "#4b4d52";
+
+export function clusterColor(clusterId: number | undefined): string {
+  if (clusterId == null) return UNSCANNED_COLOR;
+  return CLUSTER_PALETTE[((clusterId % CLUSTER_PALETTE.length) + CLUSTER_PALETTE.length) % CLUSTER_PALETTE.length];
+}
+
+// language color mode: fixed assignments for the big languages, cycle for the
+// rest, dim ink for sessions with no file-tool data
+export const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: "#67e8f9", // cyan
+  Python: "#f2b34c", // amber
+  Rust: "#d97757", // clay
+  JavaScript: "#f2f2f0",
+  Markdown: "#9b9da3", // ink-muted
+  Config: "#a78bfa", // violet
+  Shell: "#9edbd3", // mint
+};
+export const LANGUAGE_CYCLE = ["#6ee7a0", "#d7623e", "#e7e8ea", "#c9a2f5", "#7dd3fc"];
+export const NO_LANG_COLOR = "#4b4d52";
+
+export function langColor(lang: string | undefined): string {
+  if (!lang) return NO_LANG_COLOR;
+  const fixed = LANGUAGE_COLORS[lang];
+  if (fixed) return fixed;
+  let h = 0;
+  for (let i = 0; i < lang.length; i++) h = (Math.imul(h, 31) + lang.charCodeAt(i)) >>> 0;
+  return LANGUAGE_CYCLE[h % LANGUAGE_CYCLE.length];
+}
+
+export type SearchResult = { id: string; field: string; snippet: string };
+
+export type SearchPayload = {
+  q: string;
+  count: number;
+  ids: string[];
+  results: SearchResult[];
+};
+
+// x axis world unit = 1 day since day0. Same grammar as /river.
+export type ViewState = {
+  offsetPx: number; // screen px of day 0
+  pxPerDay: number;
+};
+
+export const DAY = 86400;
+
+// harness → model-color map (same assignment as /river)
+export const HARNESS_COLORS: Record<string, string> = {
+  codex: "#67e8f9", // cyan
+  "claude-code": "#d97757", // clay
+  opencode: "#f2b34c", // amber
+  cursor: "#a78bfa", // violet
+  "pi-coding-agent": "#9edbd3", // mint
+  hermes: "#e7e8ea", // ink
+};
+export const FALLBACK_COLOR = "#9b9da3";
+
+export function harnessColor(h: string): string {
+  return HARNESS_COLORS[h] ?? FALLBACK_COLOR;
+}
+
+// canonical lane order, top → bottom
+export const LANE_ORDER = [
+  "codex",
+  "claude-code",
+  "opencode",
+  "cursor",
+  "pi-coding-agent",
+  "hermes",
+];
+
+// one prepared point per session, ready for the GPU + picking
+export type TimelinePoint = {
+  s: TimelineSession;
+  day: number; // session midpoint, in days since day0
+  dayStart: number;
+  dayEnd: number;
+  lane: number; // lane index
+  jitter: number; // deterministic, [-1, 1]
+  size: number; // base px, ∝ log(total_events)
+};
+
+// deterministic jitter from session_id — stable across reloads (same trick as /api/map)
+export function hashJitter(id: string, salt: number): number {
+  let h = 2166136261 ^ salt;
+  for (let i = 0; i < id.length; i++) {
+    h = Math.imul(h ^ id.charCodeAt(i), 16777619);
+  }
+  return ((h >>> 0) / 4294967295) * 2 - 1;
+}

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -6985,3 +6985,42 @@ select,
   .experiment-run-card,
   .experiment-result-card { min-height: 440px; }
 }
+
+/* ----------------------------------------------------------------------------
+ * Explore Data — WebGL viewer palette (timeline + session transcript scenes).
+ * Additive only. NOTE: --hover already exists above (alias of --c-hover,
+ * same #1c1e25 value) and is intentionally NOT redefined here.
+ * -------------------------------------------------------------------------- */
+:root {
+  --field: #000000;
+  --rule: rgba(255, 255, 255, 0.08);
+  --ink: #e7e8ea;
+  --ink-bright: #f2f2f0;
+  --ink-muted: #9b9da3;
+  --card: #141519;
+  --window: #0b0c0e;
+  --stamp: #d7623e;
+  --model-house: #ffffff;
+  --model-clay: #d97757;
+  --model-mint: #9edbd3;
+  --model-amber: #f2b34c;
+  --model-violet: #a78bfa;
+  --model-cyan: #67e8f9;
+  --state-promoted: #6ee7a0;
+}
+
+@keyframes breath {
+  0% { opacity: 0.55; }
+  50% { opacity: 1; }
+  100% { opacity: 0.55; }
+}
+.breath {
+  animation: breath 5.2s cubic-bezier(0.2, 0.7, 0.2, 1) infinite;
+}
+
+/* No existing `.mono` utility in this sheet; components use var(--mono) /
+ * var(--font-mono) inline. Provide the class the explore panes expect. */
+.mono {
+  font-family: var(--font-mono, "IBM Plex Mono", monospace);
+}
+/* end Explore Data viewer palette */

--- a/apps/homescreen/app/lib/exploreContract.ts
+++ b/apps/homescreen/app/lib/exploreContract.ts
@@ -1,0 +1,136 @@
+// Explore Data — the contract between the Rust invoke commands (src-tauri/src/
+// explore.rs) and the frontend adapter (app/lib/exploreData.ts). Both sides
+// implement exactly these shapes. Ported from the moraine-viewer prototype's
+// API routes (which cannot ship: the desktop frontend is a static export).
+
+// ---- invoke command names (Rust side registers these) ----
+// explore_clickhouse_query { sql: string } -> string (raw JSONEachRow lines)
+//   Guardrails in Rust: SELECT/SHOW/DESCRIBE/WITH only; db=moraine;
+//   max_memory_usage=2e9, max_threads=4, max_execution_time=30.
+// explore_sqlite_query { db: "scan"|"commits"|"langs", sql: string, params: string[] }
+//   -> string (JSON array of row objects). Read-only handles over
+//   ~/.understudy/explore/<db>.sqlite; returns "[]" when the file is missing.
+// explore_read_json { kind: "benchmark"|"eval", name: string } -> string|null
+//   Reads ~/.understudy/explore/{benchmarks,evals}/<name>.json (name is
+//   sanitized to [a-z0-9-_.]); null when missing.
+// explore_status {} -> string (JSON: { moraineUp: boolean, clickhouseUp: boolean,
+//   dataDir: string, hasScan: boolean, hasCommits: boolean, hasLangs: boolean })
+
+// ---- frontend adapter surface (exploreData.ts implements over invoke) ----
+export interface TimelineSessionRow {
+  id: string;
+  harness: string;
+  mode: string;
+  title: string;
+  events: number;
+  turns: number;
+  start: number; // unix seconds
+  end: number;
+  tokens: number;
+  label?: string;
+  cluster?: string;
+  clusterId?: number;
+  lang?: string;
+}
+
+export interface TimelinePayload {
+  sessions: TimelineSessionRow[];
+  meta: { count: number; harnesses: string[] };
+}
+
+export interface SessionDetailPayload {
+  // superset of TimelineSessionRow fields for one session
+  session_summary?: string;
+  origin_cwd?: string;
+  scan_summary?: string;
+  langs?: Array<{ lang: string; files: number }>;
+  tools?: Array<{ tool: string; uses: number }>;
+  tool_calls?: number;
+}
+
+export interface SearchPayload {
+  q: string;
+  count: number;
+  ids: string[];
+  results: Array<{ id: string; field: string; snippet: string }>;
+}
+
+export interface CommitsPayload {
+  days: Array<{ d: string; c: number }>;
+  total: number;
+  mapped: number;
+}
+
+export interface DayCommit {
+  hash7: string;
+  repo: string;
+  subject: string;
+  ts: number;
+  sessions: string[];
+}
+
+export interface TranscriptEventRow {
+  event_order: number;
+  turn_seq: number;
+  event_time: string;
+  actor_role: string;
+  event_type: string;
+  name: string;
+  call_id: string;
+  text: string;
+  text_truncated: number;
+  payload_json: string;
+  payload_truncated: number;
+  tokens: number;
+  is_substream: number;
+  agent_label: string;
+  agent_run_id: string;
+}
+
+export interface TranscriptPage {
+  session: {
+    id: string;
+    title: string;
+    harness: string;
+    mode: string;
+    turns: number;
+    events: number;
+    firstEventTime: string;
+    lastEventTime: string;
+    models: string[];
+    totalTokens: number;
+  };
+  events: TranscriptEventRow[];
+  latestOrder: number;
+  lastEventTime: string;
+  lastEventAgoS?: number;
+  nextCursor: number | null;
+}
+
+export interface ExploreStatus {
+  moraineUp: boolean;
+  clickhouseUp: boolean;
+  dataDir: string;
+  hasScan: boolean;
+  hasCommits: boolean;
+  hasLangs: boolean;
+}
+
+// Adapter functions (implemented in exploreData.ts):
+//   fetchTimeline(): Promise<TimelinePayload>
+//   fetchSessionDetail(id): Promise<SessionDetailPayload | null>
+//   searchTimeline(q): Promise<SearchPayload>
+//   fetchLive(): Promise<{ now: number; ids: string[] }>
+//   fetchHealth(): Promise<{ lastEventAgoS: number; ingesting: boolean }>
+//   fetchCommits(): Promise<CommitsPayload>
+//   fetchCommitsDay(day): Promise<{ commits: DayCommit[] }>
+//   fetchLanguages(): Promise<{ langs: Array<{ lang: string; sessions: number }> }>
+//   fetchTranscript(id, cursor?, limit?): Promise<TranscriptPage>
+//   fetchExploreStatus(): Promise<ExploreStatus>
+
+// ---- Explore pane composition (shell side) ----
+// ExploreShell renders an internal sub-nav: "timeline" | "session:<id>".
+// TimelinePane (components/explore/timeline/TimelinePane.tsx):
+//   props { onOpenSession: (id: string) => void }
+// TranscriptPane (components/explore/session/TranscriptPane.tsx):
+//   props { sessionId: string; onBack: () => void }

--- a/apps/homescreen/app/lib/exploreData.ts
+++ b/apps/homescreen/app/lib/exploreData.ts
@@ -1,0 +1,738 @@
+"use client";
+
+// Explore Data adapter — implements the frontend surface declared in
+// app/lib/exploreContract.ts over the Tauri invoke commands
+// (src-tauri/src/explore.rs). Ported from the moraine-viewer prototype's
+// route handlers (app/api/timeline/*, app/api/session, app/api/anatomy/session),
+// which carry the hard-won ClickHouse fixes:
+//   - alias-shadowing avoidance (unix-time aliases differ from column names)
+//   - `LIMIT 1 BY event_order` dedup over slot/generation DESC on mcp_open_events
+//     (no FINAL on mcp_open_events — projection tables dedup this way)
+//   - payload-json multiIf text fallback chain
+//   - sentinel-date filters (first_event_time > '2001-01-01')
+//   - server-computed "ago" via ClickHouse now() (event clocks can run ahead)
+
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  CommitsPayload,
+  DayCommit,
+  ExploreStatus,
+  SearchPayload,
+  TimelinePayload,
+  TimelineSessionRow,
+  TranscriptEventRow,
+  TranscriptPage,
+} from "./exploreContract";
+
+// Full detail for one session (superset of TimelineSessionRow — the
+// SessionDetailPayload shape of the contract, concretely).
+export interface SessionDetail {
+  session_id: string;
+  title: string;
+  harness: string;
+  mode: string;
+  total_turns: number;
+  total_events: number;
+  tool_calls: number;
+  session_summary: string;
+  origin_cwd: string;
+  start: number;
+  end: number;
+  label?: string;
+  scan_summary?: string;
+  cluster?: string;
+  clusterId?: number;
+  langs?: Array<{ lang: string; files: number }>;
+  tools?: Array<{ tool: string; uses: number }>;
+}
+
+export interface TracePreviewEvent {
+  event_order: number;
+  turn_seq: number;
+  event_type: string;
+  name: string;
+  preview: string;
+}
+
+// ---------------------------------------------------------------------------
+// invoke plumbing
+
+// Browser-only dev fallback (NEXT_PUBLIC_EXPLORE_DEV=1): talk straight to
+// local ClickHouse so the pane can be visually verified under `next dev`
+// without booting a second app instance against shared desktop state.
+// SQLite layers have no browser path and degrade to empty. Never on in prod.
+const DEV_FALLBACK =
+  process.env.NEXT_PUBLIC_EXPLORE_DEV === "1" && process.env.NODE_ENV !== "production";
+
+function isDesktop(): boolean {
+  if (typeof window === "undefined") return false;
+  const w = window as unknown as Record<string, unknown>;
+  // Tauri v2 always injects __TAURI_INTERNALS__; __TAURI__ only exists with
+  // withGlobalTauri. Under plain `next dev` neither is present.
+  return w.__TAURI_INTERNALS__ !== undefined || w.__TAURI__ !== undefined;
+}
+
+function assertDesktop(): void {
+  if (!isDesktop() && !DEV_FALLBACK) {
+    throw new Error("explore requires the desktop app");
+  }
+}
+
+// ClickHouse read (JSONEachRow lines → row objects)
+async function ch<T = Record<string, unknown>>(sql: string): Promise<T[]> {
+  assertDesktop();
+  let raw: string;
+  if (!isDesktop() && DEV_FALLBACK) {
+    const res = await fetch(
+      "/ch-proxy?database=moraine&default_format=JSONEachRow&max_memory_usage=2000000000&max_threads=4&max_execution_time=30",
+      { method: "POST", body: `${sql.trim().replace(/;+\s*$/, "")} FORMAT JSONEachRow` },
+    );
+    if (!res.ok) throw new Error(`clickhouse ${res.status}`);
+    raw = await res.text();
+  } else {
+    raw = await invoke<string>("explore_clickhouse_query", { sql });
+  }
+  const text = raw.trim();
+  if (!text) return [];
+  return text.split("\n").map((line) => JSON.parse(line) as T);
+}
+
+// SQLite read over ~/.understudy/explore/<db>.sqlite (missing file → [])
+async function sq<T = Record<string, unknown>>(
+  db: "scan" | "commits" | "langs",
+  sql: string,
+  params: string[] = [],
+): Promise<T[]> {
+  assertDesktop();
+  if (!isDesktop() && DEV_FALLBACK) return []; // no browser path to sqlite
+  const raw = await invoke<string>("explore_sqlite_query", { db, sql, params });
+  return JSON.parse(raw) as T[];
+}
+
+function escCh(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+// ---------------------------------------------------------------------------
+// scan / langs side tables (ported from scan-db.ts / langs-db.ts)
+
+type ScanRow = {
+  session_id: string;
+  label: string | null;
+  summary: string | null;
+  clusterId: number | null;
+  cluster: string | null;
+};
+
+async function readScanMap(): Promise<Map<string, ScanRow>> {
+  const map = new Map<string, ScanRow>();
+  let rows: Array<Record<string, unknown>>;
+  try {
+    rows = await sq(
+      "scan",
+      `SELECT s.session_id, s.label, s.summary,
+              m.cluster_id AS cluster_id, c.name AS cluster_name
+       FROM session_scan s
+       LEFT JOIN cluster_map m ON m.label = s.label
+       LEFT JOIN clusters c ON c.id = m.cluster_id`,
+    );
+  } catch {
+    // cluster tables absent (the scan fills in progressively) — raw labels only
+    try {
+      rows = await sq("scan", `SELECT session_id, label, summary FROM session_scan`);
+    } catch {
+      return map;
+    }
+  }
+  for (const r of rows) {
+    map.set(String(r.session_id), {
+      session_id: String(r.session_id),
+      label: (r.label as string | null) ?? null,
+      summary: (r.summary as string | null) ?? null,
+      clusterId: r.cluster_id == null ? null : Number(r.cluster_id),
+      cluster: (r.cluster_name as string | null) ?? null,
+    });
+  }
+  return map;
+}
+
+// session_id → dominant language (highest file count; ORDER BY keeps ties stable)
+async function readDominantLangMap(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    const rows = await sq<{ session_id: string; lang: string }>(
+      "langs",
+      `SELECT session_id, lang FROM session_langs ORDER BY files DESC, lang ASC`,
+    );
+    for (const r of rows) {
+      if (!map.has(String(r.session_id))) map.set(String(r.session_id), String(r.lang));
+    }
+  } catch {
+    // langs.sqlite unreadable — language layer simply absent
+  }
+  return map;
+}
+
+async function readSessionLangs(sessionId: string, limit = 6) {
+  try {
+    return await sq<{ lang: string; files: number }>(
+      "langs",
+      `SELECT lang, files FROM session_langs WHERE session_id = ?
+       ORDER BY files DESC, lang ASC LIMIT ?`,
+      [sessionId, String(limit)],
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function readSessionTools(sessionId: string, limit = 8) {
+  try {
+    return await sq<{ tool: string; uses: number }>(
+      "langs",
+      `SELECT tool, uses FROM session_tools WHERE session_id = ?
+       ORDER BY uses DESC, tool ASC LIMIT ?`,
+      [sessionId, String(limit)],
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function searchScan(
+  q: string,
+): Promise<Array<{ session_id: string; label: string | null; summary: string | null }>> {
+  const pat = `%${q.replace(/[\\%_]/g, (m) => `\\${m}`)}%`;
+  try {
+    return await sq(
+      "scan",
+      `SELECT session_id, label, summary FROM session_scan
+       WHERE label LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\'`,
+      [pat, pat],
+    );
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// fetchTimeline — session list + scan labels/clusters + dominant lang + tokens
+
+interface ChSessionRow {
+  session_id: string;
+  harness: string;
+  mode: string;
+  title: string;
+  total_events: number;
+  total_turns: number;
+  start_s: string;
+  end_s: string;
+}
+
+export async function fetchTimeline(): Promise<TimelinePayload> {
+  const [rows, tokenRows, scanMap, langMap] = await Promise.all([
+    // alias-shadowing gotcha: unix-time aliases (start_s/end_s) must DIFFER
+    // from the column names or WHERE filters on those names break
+    ch<ChSessionRow>(
+      `SELECT session_id, harness, mode, title,
+              toUInt32(total_events) AS total_events,
+              toUInt32(total_turns) AS total_turns,
+              toString(toUnixTimestamp(first_event_time)) AS start_s,
+              toString(toUnixTimestamp(last_event_time)) AS end_s
+       FROM mcp_open_sessions FINAL
+       WHERE first_event_time > '2001-01-01'`,
+    ),
+    // bulk token totals (cost color mode) — UInt64 sums arrive as strings
+    ch<{ sid: string; tok: string }>(
+      `SELECT session_id AS sid,
+              toString(sum(input_tokens) + sum(output_tokens) + sum(cache_read_tokens) + sum(cache_write_tokens)) AS tok
+       FROM events WHERE event_ts > '2026-01-01' GROUP BY session_id`,
+    ),
+    readScanMap(),
+    readDominantLangMap(),
+  ]);
+  const tokenMap = new Map(tokenRows.map((r) => [r.sid, Number(r.tok)]));
+
+  const sessions: TimelineSessionRow[] = rows.map((r) => {
+    const scan = scanMap.get(r.session_id);
+    const lang = langMap.get(r.session_id);
+    return {
+      id: r.session_id,
+      harness: r.harness || "unknown",
+      mode: r.mode || "unknown",
+      title: r.title,
+      events: r.total_events,
+      turns: r.total_turns,
+      start: Number(r.start_s),
+      end: Number(r.end_s),
+      tokens: tokenMap.get(r.session_id) ?? 0,
+      ...(scan?.label ? { label: scan.label } : {}),
+      ...(scan?.cluster ? { cluster: scan.cluster } : {}),
+      ...(scan?.clusterId != null ? { clusterId: scan.clusterId } : {}),
+      ...(lang ? { lang } : {}),
+    };
+  });
+
+  const harnesses = [...new Set(sessions.map((s) => s.harness))].sort();
+  return { sessions, meta: { count: sessions.length, harnesses } };
+}
+
+// ---------------------------------------------------------------------------
+// fetchSessionDetail — one session incl. summary + scan + langs/tools
+
+export async function fetchSessionDetail(id: string): Promise<SessionDetail | null> {
+  const rows = await ch<{
+    session_id: string;
+    title: string;
+    harness: string;
+    mode: string;
+    total_turns: number;
+    total_events: number;
+    tool_calls: number;
+    session_summary: string;
+    origin_cwd: string;
+    start_s: string;
+    end_s: string;
+  }>(
+    `SELECT session_id, title, harness, mode,
+            toUInt32(total_turns) AS total_turns,
+            toUInt32(total_events) AS total_events,
+            toUInt32(tool_calls) AS tool_calls,
+            session_summary, origin_cwd,
+            toString(toUnixTimestamp(first_event_time)) AS start_s,
+            toString(toUnixTimestamp(last_event_time)) AS end_s
+     FROM mcp_open_sessions FINAL
+     WHERE session_id = '${escCh(id)}'
+     LIMIT 1`,
+  );
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  const [scanMap, langs, tools] = await Promise.all([
+    readScanMap(),
+    readSessionLangs(r.session_id, 6),
+    readSessionTools(r.session_id, 8),
+  ]);
+  const scan = scanMap.get(r.session_id);
+  return {
+    ...(langs.length ? { langs } : {}),
+    ...(tools.length ? { tools } : {}),
+    ...(scan?.label ? { label: scan.label } : {}),
+    ...(scan?.summary ? { scan_summary: scan.summary } : {}),
+    ...(scan?.cluster ? { cluster: scan.cluster } : {}),
+    ...(scan?.clusterId != null ? { clusterId: scan.clusterId } : {}),
+    session_id: r.session_id,
+    title: r.title,
+    harness: r.harness,
+    mode: r.mode,
+    total_turns: r.total_turns,
+    total_events: r.total_events,
+    tool_calls: r.tool_calls,
+    session_summary: r.session_summary,
+    origin_cwd: r.origin_cwd,
+    start: Number(r.start_s),
+    end: Number(r.end_s),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// searchTimeline — ClickHouse ILIKE over title/summary/cwd/slug + scan union
+
+const SNIPPET_LEN = 140;
+
+interface SearchRow {
+  session_id: string;
+  title: string;
+  session_summary: string;
+  origin_cwd: string;
+  session_slug: string;
+}
+
+function snippetFor(row: SearchRow, q: string): { field: string; snippet: string } {
+  const lower = q.toLowerCase();
+  const fields: Array<[string, string]> = [
+    ["title", row.title],
+    ["session_summary", row.session_summary],
+    ["origin_cwd", row.origin_cwd],
+    ["session_slug", row.session_slug],
+  ];
+  for (const [field, value] of fields) {
+    const idx = value.toLowerCase().indexOf(lower);
+    if (idx < 0) continue;
+    // center a ~140-char window on the first hit
+    const from = Math.max(0, idx - Math.floor((SNIPPET_LEN - q.length) / 2));
+    let snip = value.slice(from, from + SNIPPET_LEN).replace(/\s+/g, " ").trim();
+    if (from > 0) snip = `…${snip}`;
+    if (from + SNIPPET_LEN < value.length) snip = `${snip}…`;
+    return { field, snippet: snip };
+  }
+  return { field: "title", snippet: (row.title || row.session_id).slice(0, SNIPPET_LEN) };
+}
+
+export async function searchTimeline(q: string): Promise<SearchPayload> {
+  const query = q.trim();
+  if (!query) return { q: "", count: 0, ids: [], results: [] };
+
+  // escape for a single-quoted ILIKE pattern
+  const escaped = escCh(query).replace(/%/g, "\\%").replace(/_/g, "\\_");
+  const pat = `'%${escaped}%'`;
+
+  const [rows, scanHits] = await Promise.all([
+    ch<SearchRow>(
+      `SELECT session_id, title,
+              substring(session_summary, 1, 4000) AS session_summary,
+              origin_cwd, session_slug
+       FROM mcp_open_sessions FINAL
+       WHERE first_event_time > '2001-01-01'
+         AND (title ILIKE ${pat}
+           OR session_summary ILIKE ${pat}
+           OR origin_cwd ILIKE ${pat}
+           OR session_slug ILIKE ${pat})`,
+    ),
+    searchScan(query),
+  ]);
+
+  const chIds = new Set(rows.map((r) => r.session_id));
+  const ids = rows.map((r) => r.session_id);
+  const results = rows.slice(0, 40).map((r) => ({ id: r.session_id, ...snippetFor(r, query) }));
+
+  const lower = query.toLowerCase();
+  for (const hit of scanHits) {
+    if (chIds.has(hit.session_id)) continue;
+    ids.push(hit.session_id);
+    if (results.length >= 40) continue;
+    const labelHit = (hit.label ?? "").toLowerCase().includes(lower);
+    const src = labelHit ? (hit.label ?? "") : (hit.summary ?? "");
+    results.push({
+      id: hit.session_id,
+      field: labelHit ? "label" : "scan",
+      snippet: src.replace(/\s+/g, " ").trim().slice(0, SNIPPET_LEN),
+    });
+  }
+
+  return { q: query, count: ids.length, ids, results };
+}
+
+// ---------------------------------------------------------------------------
+// fetchLive / fetchHealth — server-computed ago via ClickHouse now()
+
+export async function fetchLive(): Promise<{ now: number; ids: string[] }> {
+  // Query window is 150s; the 120s cut happens here against ClickHouse's own
+  // now() (event clocks can run ahead of the server, so ahead counts as live).
+  // Aliases (sid/last_s) must differ from column names — see alias gotcha.
+  const [rows, nowRows] = await Promise.all([
+    ch<{ sid: string; last_s: string }>(
+      `SELECT session_id AS sid,
+              toString(toUnixTimestamp(last_event_time)) AS last_s
+       FROM mcp_open_sessions FINAL
+       WHERE last_event_time > now() - INTERVAL 150 SECOND`,
+    ),
+    ch<{ n: string }>(`SELECT toString(toUnixTimestamp(now())) AS n`),
+  ]);
+  const now = Number(nowRows[0]?.n ?? Math.floor(Date.now() / 1000));
+  const ids = rows.filter((r) => now - Number(r.last_s) <= 120).map((r) => r.sid);
+  return { now, ids };
+}
+
+export async function fetchHealth(): Promise<{ lastEventAgoS: number; ingesting: boolean }> {
+  // max() over an empty day comes back as unix 0 — treat as stale; clamp
+  // negative ages (event clocks ahead of server) to 0
+  const rows = await ch<{ m: string; n: string }>(
+    `SELECT toString(toUnixTimestamp(max(event_ts))) AS m,
+            toString(toUnixTimestamp(now())) AS n
+     FROM events WHERE event_ts > now() - INTERVAL 1 DAY`,
+  );
+  const m = Number(rows[0]?.m ?? 0);
+  const now = Number(rows[0]?.n ?? Math.floor(Date.now() / 1000));
+  const lastEventAgoS = m > 0 ? Math.max(0, now - m) : 86400;
+  return { lastEventAgoS, ingesting: lastEventAgoS < 300 };
+}
+
+// ---------------------------------------------------------------------------
+// commits layer (commits.sqlite)
+
+export async function fetchCommits(): Promise<CommitsPayload> {
+  try {
+    const [days, totals, mappedRows] = await Promise.all([
+      sq<{ d: string; c: number }>(
+        "commits",
+        `SELECT date(ts, 'unixepoch') AS d, COUNT(*) AS c
+         FROM commits GROUP BY d ORDER BY d ASC`,
+      ),
+      sq<{ c: number }>("commits", `SELECT COUNT(*) AS c FROM commits`),
+      sq<{ c: number }>("commits", `SELECT COUNT(DISTINCT hash) AS c FROM commit_sessions`),
+    ]);
+    return {
+      days: days.map((r) => ({ d: String(r.d), c: Number(r.c) })),
+      total: Number(totals[0]?.c ?? 0),
+      mapped: Number(mappedRows[0]?.c ?? 0),
+    };
+  } catch {
+    return { days: [], total: 0, mapped: 0 };
+  }
+}
+
+export async function fetchCommitsDay(day: string): Promise<{ commits: DayCommit[] }> {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return { commits: [] };
+  const start = Math.floor(Date.parse(`${day}T00:00:00Z`) / 1000);
+  const end = start + 86400;
+  try {
+    // \x1f (unit separator) as the GROUP_CONCAT joiner — session ids never
+    // contain it, unlike ',' which would also survive in some slugs
+    const rows = await sq<{ hash: string; repo: string; subject: string; ts: number; sess: string }>(
+      "commits",
+      `SELECT c.hash, c.repo, c.subject, c.ts,
+              COALESCE(GROUP_CONCAT(cs.session_id, '\x1f'), '') AS sess
+       FROM commits c
+       LEFT JOIN commit_sessions cs ON cs.hash = c.hash
+       WHERE c.ts >= ? AND c.ts < ?
+       GROUP BY c.hash
+       ORDER BY c.ts ASC`,
+      [String(start), String(end)],
+    );
+    return {
+      commits: rows.map((r) => ({
+        hash7: r.hash.slice(0, 7),
+        repo: r.repo.split("/").filter(Boolean).pop() ?? r.repo,
+        subject: r.subject,
+        ts: Number(r.ts),
+        sessions: r.sess ? r.sess.split("\x1f") : [],
+      })),
+    };
+  } catch {
+    return { commits: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// languages chips (dominant-language session counts)
+
+export async function fetchLanguages(): Promise<{
+  langs: Array<{ lang: string; sessions: number }>;
+}> {
+  const counts = new Map<string, number>();
+  for (const lang of (await readDominantLangMap()).values()) {
+    counts.set(lang, (counts.get(lang) ?? 0) + 1);
+  }
+  const langs = [...counts.entries()]
+    .map(([lang, sessions]) => ({ lang, sessions }))
+    .sort((a, b) => b.sessions - a.sessions || a.lang.localeCompare(b.lang));
+  return { langs };
+}
+
+// ---------------------------------------------------------------------------
+// fetchTranscript — full lossless transcript page (ported from /api/session)
+
+const DEFAULT_LIMIT = 500;
+const MAX_LIMIT = 1000;
+const TEXT_CAP = 20000;
+
+// The established payload fallback: text_content, then payload_json
+// .text / .content[0].text / .input / .output.
+const FULL_TEXT_EXPR = `multiIf(
+  length(text_content) > 0, text_content,
+  JSONExtractString(payload_json, 'text') != '', JSONExtractString(payload_json, 'text'),
+  JSON_VALUE(payload_json, '$.content[0].text') != '', JSON_VALUE(payload_json, '$.content[0].text'),
+  JSONExtractString(payload_json, 'input') != '', JSONExtractString(payload_json, 'input'),
+  JSONExtractString(payload_json, 'output')
+)`;
+
+interface RawTranscriptEvent extends TranscriptEventRow {
+  event_uid: string;
+}
+
+export async function fetchTranscript(
+  id: string,
+  cursor = 0,
+  limit = DEFAULT_LIMIT,
+): Promise<TranscriptPage> {
+  if (!/^[A-Za-z0-9_-]{8,64}$/.test(id)) throw new Error("bad session id");
+  const cur = Math.max(0, Math.floor(cursor) || 0);
+  const lim = Math.min(MAX_LIMIT, Math.max(1, Math.floor(limit) || DEFAULT_LIMIT));
+
+  const [sessions, rawEvents, models, tokenTotals, latestRows] = await Promise.all([
+    ch<{
+      session_id: string;
+      title: string;
+      harness: string;
+      mode: string;
+      total_turns: number;
+      total_events: number;
+      first_event_time: string;
+      last_event_time: string;
+    }>(`
+      SELECT
+        session_id, title, harness, mode,
+        toUInt32(total_turns) AS total_turns,
+        toUInt32(total_events) AS total_events,
+        toString(first_event_time) AS first_event_time,
+        toString(last_event_time) AS last_event_time
+      FROM mcp_open_sessions FINAL
+      WHERE session_id = '${id}'
+      ORDER BY generation DESC
+      LIMIT 1
+    `),
+    ch<RawTranscriptEvent>(`
+      SELECT
+        toUInt32(event_order) AS event_order,
+        toUInt32(turn_seq) AS turn_seq,
+        toString(event_time) AS event_time,
+        actor_role, event_type, name, call_id,
+        event_uid,
+        substring(${FULL_TEXT_EXPR}, 1, ${TEXT_CAP}) AS text,
+        toUInt8(length(${FULL_TEXT_EXPR}) > ${TEXT_CAP}) AS text_truncated,
+        substring(payload_json, 1, ${TEXT_CAP}) AS payload_json,
+        toUInt8(length(payload_json) > ${TEXT_CAP}) AS payload_truncated,
+        toUInt32(arraySum(mapValues(token_usage_buckets))) AS tokens
+      FROM mcp_open_events
+      WHERE session_id = '${id}' AND event_order > ${cur}
+      ORDER BY event_order ASC, slot DESC, generation DESC
+      LIMIT 1 BY event_order
+      LIMIT ${lim}
+    `),
+    ch<{ model: string }>(`
+      SELECT DISTINCT model
+      FROM events
+      WHERE session_id = '${id}' AND model != ''
+      LIMIT 12
+    `),
+    ch<{ total_tokens: string }>(`
+      SELECT toString(sum(arraySum(mapValues(token_usage_buckets)))) AS total_tokens
+      FROM (
+        SELECT token_usage_buckets
+        FROM mcp_open_events
+        WHERE session_id = '${id}'
+        ORDER BY event_order ASC, slot DESC, generation DESC
+        LIMIT 1 BY event_order
+      )
+    `),
+    // Cheap tail probe for live tailing: max event_order + last event time
+    // currently in the projection.
+    ch<{ latest_order: number; last_time: string; ago_s: string }>(`
+      SELECT
+        toUInt32(max(event_order)) AS latest_order,
+        toString(max(event_time)) AS last_time,
+        toInt64(now() - max(event_time)) AS ago_s
+      FROM mcp_open_events
+      WHERE session_id = '${id}'
+    `),
+  ]);
+
+  if (!sessions.length) throw new Error("session not found");
+
+  // Bulk substream join keyed by event_uid (alias outputs so they don't
+  // shadow the filter columns).
+  const uids = [
+    ...new Set(rawEvents.map((e) => e.event_uid).filter((u) => /^[a-f0-9]{16,64}$/.test(u))),
+  ];
+  const subMap = new Map<string, { uid: string; sub: number; label: string; run: string }>();
+  if (uids.length) {
+    const rows = await ch<{ uid: string; sub: number; label: string; run: string }>(`
+      SELECT
+        event_uid AS uid,
+        toUInt8(max(is_substream)) AS sub,
+        anyLast(agent_label) AS label,
+        anyLast(agent_run_id) AS run
+      FROM events
+      WHERE session_id = '${id}'
+        AND event_uid IN (${uids.map((u) => `'${u}'`).join(",")})
+      GROUP BY event_uid
+    `);
+    for (const r of rows) subMap.set(r.uid, r);
+  }
+
+  const events: TranscriptEventRow[] = rawEvents.map(({ event_uid, ...e }) => {
+    const s = subMap.get(event_uid);
+    return {
+      ...e,
+      is_substream: s?.sub ?? 0,
+      agent_label: s?.label ?? "",
+      agent_run_id: s?.run ?? "",
+    };
+  });
+
+  const s = sessions[0];
+  return {
+    session: {
+      id: s.session_id,
+      title: s.title,
+      harness: s.harness,
+      mode: s.mode,
+      turns: s.total_turns,
+      events: s.total_events,
+      firstEventTime: s.first_event_time,
+      lastEventTime: s.last_event_time,
+      models: [...new Set(models.map((m) => normalizeModel(m.model)))],
+      totalTokens: Number(tokenTotals[0]?.total_tokens ?? 0),
+    },
+    events,
+    latestOrder: latestRows[0]?.latest_order ?? 0,
+    lastEventTime: latestRows[0]?.last_time ?? s.last_event_time,
+    lastEventAgoS: Math.max(0, Number(latestRows[0]?.ago_s ?? 86400)),
+    nextCursor: events.length === lim ? events[events.length - 1].event_order : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// fetchTracePreview — compact event list for the timeline side panel.
+// Ported from /api/anatomy/session's event query (deduped, 1200-char preview)
+// but capped at 400 rows instead of 2000: the preview shows ≤40 meaningful
+// events, and the full trace lives one click away in the transcript pane.
+
+const PREVIEW_MAX_EVENTS = 400;
+
+export async function fetchTracePreview(id: string): Promise<TracePreviewEvent[]> {
+  if (!/^[A-Za-z0-9_-]{8,64}$/.test(id)) throw new Error("bad session id");
+  return ch<TracePreviewEvent>(`
+    SELECT
+      toUInt32(event_order) AS event_order,
+      toUInt32(turn_seq) AS turn_seq,
+      event_type, name,
+      substring(
+        multiIf(
+          length(text_content) > 0, text_content,
+          JSONExtractString(payload_json, 'text') != '', JSONExtractString(payload_json, 'text'),
+          JSON_VALUE(payload_json, '$.content[0].text') != '', JSON_VALUE(payload_json, '$.content[0].text'),
+          JSONExtractString(payload_json, 'input') != '', JSONExtractString(payload_json, 'input'),
+          JSONExtractString(payload_json, 'output')
+        ), 1, 1200
+      ) AS preview
+    FROM mcp_open_events
+    WHERE session_id = '${id}'
+    ORDER BY event_order ASC, slot DESC, generation DESC
+    LIMIT 1 BY event_order
+    LIMIT ${PREVIEW_MAX_EVENTS}
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// status
+
+export async function fetchExploreStatus(): Promise<ExploreStatus> {
+  assertDesktop();
+  if (!isDesktop() && DEV_FALLBACK) {
+    let clickhouseUp = false;
+    try {
+      clickhouseUp = (await (await fetch("/ch-proxy?query=SELECT%201")).text()).trim() === "1";
+    } catch { /* down */ }
+    return { moraineUp: clickhouseUp, clickhouseUp, dataDir: "(dev fallback)", hasScan: false, hasCommits: false, hasLangs: false };
+  }
+  const raw = await invoke<string>("explore_status");
+  return JSON.parse(raw) as ExploreStatus;
+}
+
+// ---------------------------------------------------------------------------
+// `model` values are sometimes JSON blobs or filesystem paths — normalize.
+
+export function normalizeModel(raw: string): string {
+  if (!raw) return "unknown";
+  if (raw.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, string>;
+      return parsed.modelid ?? parsed.model ?? raw;
+    } catch {
+      return raw;
+    }
+  }
+  if (raw.includes("/")) return raw.split("/").filter(Boolean).pop() ?? raw;
+  return raw;
+}

--- a/apps/homescreen/app/lib/exploreData.ts
+++ b/apps/homescreen/app/lib/exploreData.ts
@@ -260,7 +260,9 @@ export async function fetchTimeline(): Promise<TimelinePayload> {
       id: r.session_id,
       harness: r.harness || "unknown",
       mode: r.mode || "unknown",
-      title: r.title,
+      // Moraine only gets titles from opencode/cursor; the Gemma scan labeled
+      // everything else — a far better name than "untitled session"
+      title: r.title || scan?.label || "",
       events: r.total_events,
       turns: r.total_turns,
       start: Number(r.start_s),
@@ -321,7 +323,7 @@ export async function fetchSessionDetail(id: string): Promise<SessionDetail | nu
     ...(scan?.cluster ? { cluster: scan.cluster } : {}),
     ...(scan?.clusterId != null ? { clusterId: scan.clusterId } : {}),
     session_id: r.session_id,
-    title: r.title,
+    title: r.title || scan?.label || "",
     harness: r.harness,
     mode: r.mode,
     total_turns: r.total_turns,
@@ -651,10 +653,22 @@ export async function fetchTranscript(
   });
 
   const s = sessions[0];
+  // Moraine titles only exist for opencode/cursor — fall back to the scan label
+  let title = s.title;
+  if (!title) {
+    try {
+      const scan = await sq<{ label: string }>(
+        "scan",
+        "SELECT label FROM session_scan WHERE session_id = ? LIMIT 1",
+        [id],
+      );
+      title = scan[0]?.label ?? "";
+    } catch { /* scan store absent */ }
+  }
   return {
     session: {
       id: s.session_id,
-      title: s.title,
+      title,
       harness: s.harness,
       mode: s.mode,
       turns: s.total_turns,

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -14,6 +14,7 @@ import { UsagePane } from "./components/UsagePane";
 import { DownloadQrButton } from "./components/DownloadQrButton";
 import { isTrainingPane, TrainingPane } from "./components/TrainingPane";
 import { RlmPane } from "./components/RlmPane";
+import { ExploreShell } from "./components/explore/ExploreShell";
 import { RuntimeRepairPrompt } from "./components/RuntimeRepairPrompt";
 import { ModelDownloadNotice } from "./components/ModelDownloadNotice";
 import { useStatus } from "./lib/useStatus";
@@ -182,6 +183,7 @@ export default function Page() {
       "models",
       "account",
       "rlm",
+      "explore",
     ];
     const hidden = [
       "capture",
@@ -296,6 +298,7 @@ export default function Page() {
         {pane === "models" && <ModelsPane />}
         {pane === "capture" && <CapturePane />}
         {pane === "rlm" && <RlmPane />}
+        {pane === "explore" && <ExploreShell />}
         {isTrainingPane(pane) && <TrainingPane section={pane} />}
         {pane === "account" && (
           <AccountPane

--- a/apps/homescreen/bun.lock
+++ b/apps/homescreen/bun.lock
@@ -6,6 +6,8 @@
       "name": "app",
       "dependencies": {
         "@radix-ui/react-use-controllable-state": "^1.2.3",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "@rive-app/react-webgl2": "^4.29.3",
         "@shadcn/react": "0.2.1",
         "@streamdown/cjk": "^1.0.3",
@@ -31,6 +33,7 @@
         "remark-gfm": "^4.0.1",
         "streamdown": "^2.5.0",
         "tailwind-merge": "^3.6.0",
+        "three": "^0.185.1",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.1",
@@ -39,6 +42,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/three": "^0.185.1",
         "tailwindcss": "^4.3.1",
         "typescript": "~5.8.3",
       },
@@ -55,9 +59,13 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
+    "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
@@ -133,7 +141,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.17", "", {}, "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="],
+
     "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
+
+    "@monogrid/gainmap-js": ["@monogrid/gainmap-js@3.4.0", "", { "dependencies": { "promise-worker-transferable": "^1.0.4" }, "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg=="],
 
     "@next/env": ["@next/env@15.5.19", "", {}, "sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw=="],
 
@@ -273,6 +285,10 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.2", "", {}, "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA=="],
 
+    "@react-three/drei": ["@react-three/drei@10.7.7", "", { "dependencies": { "@babel/runtime": "^7.26.0", "@mediapipe/tasks-vision": "0.10.17", "@monogrid/gainmap-js": "^3.0.6", "@use-gesture/react": "^10.3.1", "camera-controls": "^3.1.0", "cross-env": "^7.0.3", "detect-gpu": "^5.0.56", "glsl-noise": "^0.0.0", "hls.js": "^1.5.17", "maath": "^0.10.8", "meshline": "^3.3.1", "stats-gl": "^2.2.8", "stats.js": "^0.17.0", "suspend-react": "^0.1.3", "three-mesh-bvh": "^0.8.3", "three-stdlib": "^2.35.6", "troika-three-text": "^0.52.4", "tunnel-rat": "^0.1.2", "use-sync-external-store": "^1.4.0", "utility-types": "^3.11.0", "zustand": "^5.0.1" }, "peerDependencies": { "@react-three/fiber": "^9.0.0", "react": "^19", "react-dom": "^19", "three": ">=0.159" }, "optionalPeers": ["react-dom"] }, "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ=="],
+
+    "@react-three/fiber": ["@react-three/fiber@9.6.1", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^2.0.0", "react-use-measure": "^2.1.7", "scheduler": "^0.27.0", "suspend-react": "^0.1.3", "use-sync-external-store": "^1.4.0", "zustand": "^5.0.3" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": ">=19 <19.3", "react-dom": ">=19 <19.3", "react-native": ">=0.78", "three": ">=0.156" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg=="],
+
     "@rive-app/react-webgl2": ["@rive-app/react-webgl2@4.29.3", "", { "dependencies": { "@rive-app/webgl2": "2.38.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0" } }, "sha512-NotopuJ2FEM/th6t3kTN9aZB35xKeyqW68UXBy2ybPirysbLqn2yrGTP7IXoouG0MmRiGqFm+Ufbhk7LrkTc7g=="],
 
     "@rive-app/webgl2": ["@rive-app/webgl2@2.38.3", "", {}, "sha512-/bbhfV8fel3yPuOWBnqRlNjVa0j4B0Rm4t5VAQqIvNRHJrz9jzQ/gJx93X6IpQovgD57Gb+Jnwp6WPHFgX3eGA=="],
@@ -365,6 +381,8 @@
 
     "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
@@ -429,6 +447,8 @@
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
+    "@types/draco3d": ["@types/draco3d@1.4.10", "", {}, "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -445,19 +465,33 @@
 
     "@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
 
+    "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
+
     "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-reconciler": ["@types/react-reconciler@0.28.9", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="],
+
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.185.1", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
+    "@use-gesture/core": ["@use-gesture/core@10.3.1", "", {}, "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="],
+
+    "@use-gesture/react": ["@use-gesture/react@10.3.1", "", { "dependencies": { "@use-gesture/core": "10.3.1" }, "peerDependencies": { "react": ">= 16.8.0" } }, "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
@@ -473,7 +507,15 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "camera-controls": ["camera-controls@3.1.2", "", { "peerDependencies": { "three": ">=0.126.1" } }, "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
 
@@ -506,6 +548,10 @@
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -593,6 +639,8 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
+    "detect-gpu": ["detect-gpu@5.0.70", "", { "dependencies": { "webgl-constants": "^1.1.1" } }, "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
@@ -602,6 +650,8 @@
     "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 
     "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+
+    "draco3d": ["draco3d@1.5.7", "", {}, "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -619,6 +669,8 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "framer-motion": ["framer-motion@12.42.0", "", { "dependencies": { "motion-dom": "^12.42.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA=="],
@@ -628,6 +680,8 @@
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
+    "glsl-noise": ["glsl-noise@0.0.0", "", {}, "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -661,11 +715,17 @@
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
+    "hls.js": ["hls.js@1.6.16", "", {}, "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
@@ -685,6 +745,12 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "its-fine": ["its-fine@2.0.0", "", { "dependencies": { "@types/react-reconciler": "^0.28.9" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
@@ -694,6 +760,8 @@
     "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -726,6 +794,8 @@
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lucide-react": ["lucide-react@1.22.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg=="],
+
+    "maath": ["maath@0.10.8", "", { "peerDependencies": { "@types/three": ">=0.134.0", "three": ">=0.134.0" } }, "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -770,6 +840,10 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+
+    "meshline": ["meshline@3.3.1", "", { "peerDependencies": { "three": ">=0.137" } }, "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ=="],
+
+    "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -867,6 +941,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
@@ -876,6 +952,10 @@
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "potpack": ["potpack@1.0.2", "", {}, "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="],
+
+    "promise-worker-transferable": ["promise-worker-transferable@1.0.4", "", { "dependencies": { "is-promise": "^2.1.0", "lie": "^3.0.2" } }, "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
 
@@ -894,6 +974,8 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -927,6 +1009,8 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
@@ -945,11 +1029,19 @@
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stats-gl": ["stats-gl@2.4.2", "", { "dependencies": { "@types/three": "*", "three": "^0.170.0" } }, "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ=="],
+
+    "stats.js": ["stats.js@0.17.0", "", {}, "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw=="],
 
     "streamdown": ["streamdown@2.5.0", "", { "dependencies": { "clsx": "^2.1.1", "hast-util-to-jsx-runtime": "^2.3.6", "html-url-attributes": "^3.0.1", "marked": "^17.0.1", "mermaid": "^11.12.2", "rehype-harden": "^1.1.8", "rehype-raw": "^7.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remend": "1.3.0", "tailwind-merge": "^3.4.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA=="],
 
@@ -967,21 +1059,37 @@
 
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
+    "suspend-react": ["suspend-react@0.1.3", "", { "peerDependencies": { "react": ">=17.0" } }, "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="],
+
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
+
+    "three-mesh-bvh": ["three-mesh-bvh@0.8.3", "", { "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg=="],
+
+    "three-stdlib": ["three-stdlib@2.36.1", "", { "dependencies": { "@types/draco3d": "^1.4.0", "@types/offscreencanvas": "^2019.6.4", "@types/webxr": "^0.5.2", "draco3d": "^1.4.1", "fflate": "^0.6.9", "potpack": "^1.0.1" }, "peerDependencies": { "three": ">=0.128.0" } }, "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg=="],
+
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "troika-three-text": ["troika-three-text@0.52.4", "", { "dependencies": { "bidi-js": "^1.0.2", "troika-three-utils": "^0.52.4", "troika-worker-utils": "^0.52.0", "webgl-sdf-generator": "1.1.1" }, "peerDependencies": { "three": ">=0.125.0" } }, "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg=="],
+
+    "troika-three-utils": ["troika-three-utils@0.52.4", "", { "peerDependencies": { "three": ">=0.125.0" } }, "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A=="],
+
+    "troika-worker-utils": ["troika-worker-utils@0.52.0", "", {}, "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
@@ -1007,6 +1115,10 @@
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
+
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
@@ -1016,6 +1128,12 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "webgl-constants": ["webgl-constants@1.1.1", "", {}, "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="],
+
+    "webgl-sdf-generator": ["webgl-sdf-generator@1.1.1", "", {}, "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
@@ -1028,6 +1146,8 @@
     "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -1058,6 +1178,12 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "postcss/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "stats-gl/three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
+
+    "three-stdlib/fflate": ["fflate@0.6.11", "", {}, "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg=="],
+
+    "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 

--- a/apps/homescreen/next.config.mjs
+++ b/apps/homescreen/next.config.mjs
@@ -14,6 +14,12 @@ const nextConfig = {
   reactStrictMode: true,
   // The in-app shell already has native chrome; hide Next's dev-mode badge.
   devIndicators: false,
+  // Dev-only ClickHouse proxy for the Explore pane's browser fallback
+  // (NEXT_PUBLIC_EXPLORE_DEV=1). Rewrites are ignored by `output: "export"`
+  // production builds — the shipped app talks to ClickHouse via Rust invoke.
+  async rewrites() {
+    return [{ source: "/ch-proxy", destination: "http://127.0.0.1:8123/" }];
+  },
 };
 
 export default nextConfig;

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@radix-ui/react-use-controllable-state": "^1.2.3",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@rive-app/react-webgl2": "^4.29.3",
     "@shadcn/react": "0.2.1",
     "@streamdown/cjk": "^1.0.3",
@@ -34,7 +36,8 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "streamdown": "^2.5.0",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "three": "^0.185.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.1",
@@ -43,6 +46,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/three": "^0.185.1",
     "tailwindcss": "^4.3.1",
     "typescript": "~5.8.3"
   }

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev -p 1420",
     "build": "next build",
     "start": "next start -p 1420",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "dev:explore": "next dev -p 14300",
+    "tauri:dev:explore": "UNDERSTUDY_SERVER_PORT=17791 tauri dev --config src-tauri/tauri.dev-explore.conf.json"
   },
   "dependencies": {
     "@radix-ui/react-use-controllable-state": "^1.2.3",

--- a/apps/homescreen/src-tauri/src/explore.rs
+++ b/apps/homescreen/src-tauri/src/explore.rs
@@ -1,0 +1,199 @@
+//! Explore Data pane — Rust data layer.
+//!
+//! Contract: app/lib/exploreContract.ts. Four read-only commands over the
+//! local Moraine ClickHouse instance and the ~/.understudy/explore artifacts
+//! (SQLite side tables + benchmark/eval JSON files).
+
+use std::net::{SocketAddr, TcpStream};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rusqlite::{types::ValueRef, OpenFlags};
+use serde_json::{json, Map, Value};
+
+const CLICKHOUSE_BASE: &str = "http://127.0.0.1:8123";
+const MONITOR_ADDR: &str = "127.0.0.1:8080";
+const SQLITE_ROW_CAP: usize = 10_000;
+
+fn explore_dir() -> Result<PathBuf, String> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| "could not resolve home directory".to_string())?;
+    Ok(home.join(".understudy").join("explore"))
+}
+
+fn is_read_only_clickhouse(sql: &str) -> bool {
+    let head = sql.trim_start().to_ascii_uppercase();
+    ["SELECT", "SHOW", "DESCRIBE", "DESC", "WITH"]
+        .iter()
+        .any(|kw| {
+            head.starts_with(kw)
+                && head[kw.len()..]
+                    .chars()
+                    .next()
+                    .map_or(true, |c| !c.is_ascii_alphanumeric() && c != '_')
+        })
+}
+
+/// Run a read-only query against the local Moraine ClickHouse and return the
+/// raw JSONEachRow response body.
+#[tauri::command]
+pub async fn explore_clickhouse_query(sql: String) -> Result<String, String> {
+    let sql = sql.trim().trim_end_matches(';').trim().to_string();
+    if sql.is_empty() {
+        return Err("empty query".into());
+    }
+    if !is_read_only_clickhouse(&sql) {
+        return Err("only SELECT/SHOW/DESCRIBE/WITH queries are allowed".into());
+    }
+
+    let url = format!(
+        "{CLICKHOUSE_BASE}/?database=moraine&default_format=JSONEachRow\
+         &max_memory_usage=2000000000&max_threads=4&max_execution_time=30"
+    );
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(35))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+    let resp = client
+        .post(&url)
+        .body(format!("{sql} FORMAT JSONEachRow"))
+        .send()
+        .await
+        .map_err(|e| format!("clickhouse request failed: {e}"))?;
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("clickhouse response read failed: {e}"))?;
+    if !status.is_success() {
+        let mut msg = body;
+        if msg.len() > 2000 {
+            msg.truncate(2000);
+        }
+        return Err(format!("clickhouse error ({status}): {msg}"));
+    }
+    Ok(body)
+}
+
+fn sqlite_value_to_json(v: ValueRef<'_>) -> Value {
+    match v {
+        ValueRef::Null => Value::Null,
+        ValueRef::Integer(i) => json!(i),
+        ValueRef::Real(f) => json!(f),
+        ValueRef::Text(t) => Value::String(String::from_utf8_lossy(t).into_owned()),
+        ValueRef::Blob(_) => Value::Null,
+    }
+}
+
+fn run_sqlite_query(path: PathBuf, sql: String, params: Vec<String>) -> Result<String, String> {
+    let conn = rusqlite::Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("open {}: {e}", path.display()))?;
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("prepare: {e}"))?;
+    let columns: Vec<String> = stmt.column_names().iter().map(|c| c.to_string()).collect();
+    let mut rows = stmt
+        .query(rusqlite::params_from_iter(params.iter()))
+        .map_err(|e| format!("query: {e}"))?;
+    let mut out: Vec<Value> = Vec::new();
+    while let Some(row) = rows.next().map_err(|e| format!("row: {e}"))? {
+        let mut obj = Map::with_capacity(columns.len());
+        for (i, name) in columns.iter().enumerate() {
+            let v = row.get_ref(i).map_err(|e| format!("column {name}: {e}"))?;
+            obj.insert(name.clone(), sqlite_value_to_json(v));
+        }
+        out.push(Value::Object(obj));
+        if out.len() >= SQLITE_ROW_CAP {
+            break;
+        }
+    }
+    serde_json::to_string(&out).map_err(|e| format!("serialize: {e}"))
+}
+
+/// Read-only query over one of the explore side tables
+/// (~/.understudy/explore/{scan,commits,langs}.sqlite).
+#[tauri::command]
+pub async fn explore_sqlite_query(
+    db: String,
+    sql: String,
+    params: Vec<String>,
+) -> Result<String, String> {
+    if !matches!(db.as_str(), "scan" | "commits" | "langs") {
+        return Err(format!("unknown explore db: {db}"));
+    }
+    if !sql.trim_start().to_ascii_uppercase().starts_with("SELECT") {
+        return Err("only SELECT queries are allowed".into());
+    }
+    let path = explore_dir()?.join(format!("{db}.sqlite"));
+    if !path.exists() {
+        return Ok("[]".into());
+    }
+    tauri::async_runtime::spawn_blocking(move || run_sqlite_query(path, sql, params))
+        .await
+        .map_err(|e| format!("sqlite task failed: {e}"))?
+}
+
+/// Read a benchmark or eval JSON artifact; `None` when the file is missing.
+#[tauri::command]
+pub async fn explore_read_json(kind: String, name: String) -> Result<Option<String>, String> {
+    let dir = match kind.as_str() {
+        "benchmark" => "benchmarks",
+        "eval" => "evals",
+        _ => return Err(format!("unknown explore json kind: {kind}")),
+    };
+    let name: String = name
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        .collect();
+    if name.is_empty() || name.chars().all(|c| c == '.') {
+        return Err("invalid artifact name".into());
+    }
+    let path = explore_dir()?.join(dir).join(format!("{name}.json"));
+    match tokio::fs::read_to_string(&path).await {
+        Ok(text) => Ok(Some(text)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("read {}: {e}", path.display())),
+    }
+}
+
+/// Availability snapshot for the Explore pane: services + local artifacts.
+#[tauri::command]
+pub async fn explore_status() -> Result<String, String> {
+    let clickhouse_up = async {
+        let client = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        match client.get(format!("{CLICKHOUSE_BASE}/ping")).send().await {
+            Ok(resp) if resp.status().is_success() => resp
+                .text()
+                .await
+                .map(|t| t.trim() == "Ok.")
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+    .await;
+
+    // Moraine's monitor port, same probe moraine.rs uses (skip the slower
+    // binary resolution — the pane only cares whether the service is up).
+    let moraine_up = tauri::async_runtime::spawn_blocking(|| {
+        let addr: SocketAddr = MONITOR_ADDR.parse().unwrap();
+        TcpStream::connect_timeout(&addr, Duration::from_millis(400)).is_ok()
+    })
+    .await
+    .unwrap_or(false);
+
+    let dir = explore_dir()?;
+    let status = json!({
+        "moraineUp": moraine_up,
+        "clickhouseUp": clickhouse_up,
+        "dataDir": dir.to_string_lossy(),
+        "hasScan": dir.join("scan.sqlite").exists(),
+        "hasCommits": dir.join("commits.sqlite").exists(),
+        "hasLangs": dir.join("langs.sqlite").exists(),
+    });
+    Ok(status.to_string())
+}

--- a/apps/homescreen/src-tauri/src/explore.rs
+++ b/apps/homescreen/src-tauri/src/explore.rs
@@ -31,7 +31,7 @@ fn is_read_only_clickhouse(sql: &str) -> bool {
                 && head[kw.len()..]
                     .chars()
                     .next()
-                    .map_or(true, |c| !c.is_ascii_alphanumeric() && c != '_')
+                    .is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_')
         })
 }
 

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod conversation_sidecar;
 mod creds;
 mod custom_evals;
 mod db;
+mod explore;
 mod gepa;
 mod knowledge;
 mod mcp;
@@ -371,6 +372,10 @@ pub fn run() {
             rlm::rlm_demo_catalog,
             rlm::rlm_plan,
             rlm::run_rlm_live,
+            explore::explore_clickhouse_query,
+            explore::explore_sqlite_query,
+            explore::explore_read_json,
+            explore::explore_status,
             chat::chat_stream,
             restart_app,
         ])

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -178,9 +178,10 @@ pub fn start(app: AppHandle) {
             }
         }
     };
-    let port = db
-        .setting_get(PORT_KEY)
+    let port = std::env::var("UNDERSTUDY_SERVER_PORT")
+        .ok()
         .and_then(|p| p.parse().ok())
+        .or_else(|| db.setting_get(PORT_KEY).and_then(|p| p.parse().ok()))
         .unwrap_or(DEFAULT_PORT);
 
     let ctx = Ctx { app, token };
@@ -1819,9 +1820,10 @@ fn is_legacy_token(token: &str) -> bool {
 pub fn info(app: &AppHandle) -> Option<(String, String)> {
     let db = app.try_state::<crate::db::Db>()?;
     let token = db.setting_get(TOKEN_KEY)?;
-    let port = db
-        .setting_get(PORT_KEY)
+    let port = std::env::var("UNDERSTUDY_SERVER_PORT")
+        .ok()
         .and_then(|p| p.parse().ok())
+        .or_else(|| db.setting_get(PORT_KEY).and_then(|p| p.parse().ok()))
         .unwrap_or(DEFAULT_PORT);
     Some((format!("http://127.0.0.1:{port}"), token))
 }

--- a/apps/homescreen/src-tauri/tauri.dev-explore.conf.json
+++ b/apps/homescreen/src-tauri/tauri.dev-explore.conf.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Understudy Dev (explore 0.3.32)",
+  "identifier": "com.homescreen.dev.explore",
+  "build": {
+    "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev:explore",
+    "devUrl": "http://localhost:14300"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Understudy Dev \u2014 explore-data-phase-a (0.3.32)",
+        "width": 1180,
+        "height": 820,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 17,
+          "y": 24
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

New top-level section in the desktop app: **Chat | Explore Data** — local Moraine traces as the hero data-exploration use case, per `docs/moraine-viewer-roadmap.md` (Phase A of `docs/desktop-integration-plan.md` on the prototype branch).

- **Rail switcher + `explore` pane** with internal sub-nav (timeline / session), deep-linkable via `server-focus` / `POST /api/ui/focus {"pane":"explore"}`
- **Timeline** (WebGL, ported from the moraine-viewer prototype): sessions as shader points in harness lanes over time, 4 color modes (harness/task/language/cost), search-with-dim + fly-to, live-session pulse, ingest health, commit heat strip, CodexBar-probe quarantine, side panel with Gemma scan labels/summaries + trace preview
- **Full lossless transcript**: every event verbatim, subagent runs as collapsible groups, raw payload toggle, cursor pagination, live tail for active sessions
- **All data via Rust** (static export has no Node): `explore.rs` invoke commands — read-only capped ClickHouse proxy (SELECT-only, 2GB/4thr/30s), read-only rusqlite over `~/.understudy/explore/`, status probe. Zero new crates.
- **Session titles**: Moraine only titles opencode/cursor sessions; panel/tooltip/transcript fall back to Gemma scan labels
- **Parallel dev instances**: `bun run tauri:dev:explore` boots an isolated copy (:14300/:17791, own identifier → own app-data DB, branch-named window) via `UNDERSTUDY_SERVER_PORT` env override + config overlay

## Gates
- `bunx tsc --noEmit` clean · `next build` (static export) green · `cargo check` green
- Verified in the real WKWebView app against live Moraine (timeline, panel, transcript, live tail, plumbing quarantine, commit strip)

## Notes
- Explore requires the scan sqlite files at `~/.understudy/explore/` (generated by the prototype branch's scripts; Phase B moves generation into the bundled CLI) and local Moraine/ClickHouse; degrades gracefully when absent (labels/commits simply missing). Moraine-not-installed guided empty state is the known Phase A follow-up.
- Rail stays collapsed on boot by design for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->