### PR TITLE
feat(desktop+cli): Explore Data — Phase B (tasks pane, empty states, scan-my-history)

### DIFF
--- a/apps/homescreen/app/components/explore/EmptyState.tsx
+++ b/apps/homescreen/app/components/explore/EmptyState.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+// Empty states for Explore Data — shown in place of the timeline field when
+// ClickHouse (Moraine) is unreachable or when it's up but holds no sessions
+// yet. Restrained mood-board styling: black field, ink-muted, rule borders,
+// mono type. Rendered by TimelinePane.
+
+import { useState } from "react";
+
+function CommandBlock({ cmd }: { cmd: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard?.writeText(cmd).then(
+          () => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          },
+          () => {},
+        );
+      }}
+      className="mono group flex w-full items-center justify-between gap-4 rounded-[8px] border border-rule bg-window/60 px-3 py-2 text-left text-[12px] text-ink transition-colors hover:border-ink-muted/50"
+      title="copy to clipboard"
+    >
+      <span className="select-text">
+        <span className="text-ink-muted/60">$ </span>
+        {cmd}
+      </span>
+      <span className="shrink-0 text-[10px] text-ink-muted/60 transition-colors group-hover:text-ink-muted">
+        {copied ? "copied" : "copy"}
+      </span>
+    </button>
+  );
+}
+
+export default function EmptyState({
+  variant,
+  detail,
+  onRetry,
+}: {
+  variant: "moraine-down" | "no-traces";
+  detail?: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center px-8">
+      <div className="w-full max-w-[440px]">
+        {variant === "moraine-down" ? (
+          <>
+            <div className="mono text-[13px] text-ink-bright">moraine isn&apos;t running</div>
+            <p className="mono mt-3 text-[11px] leading-relaxed text-ink-muted">
+              Explore Data reads your local agent traces from Moraine — a local, private trace
+              store. Nothing here leaves your machine.
+            </p>
+            <div className="mt-5 flex flex-col gap-2">
+              <div className="mono text-[10px] text-ink-muted/60">if moraine is installed</div>
+              <CommandBlock cmd="moraine up" />
+              <div className="mono mt-2 text-[10px] text-ink-muted/60">if not, install it first</div>
+              <CommandBlock cmd="uv tool install moraine-cli && moraine setup" />
+            </div>
+            {detail && (
+              <div className="mono mt-4 break-all text-[10px] text-ink-muted/40">{detail}</div>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="mono text-[13px] text-ink-bright">no traces yet</div>
+            <p className="mono mt-3 text-[11px] leading-relaxed text-ink-muted">
+              Moraine is running, but there&apos;s nothing in the trace store yet. Traces appear
+              here as you use coding agents — Claude Code, Codex, and friends — while Moraine
+              ingests. Do some work, then come back.
+            </p>
+          </>
+        )}
+        <button
+          onClick={onRetry}
+          className="mono mt-6 rounded-[8px] border border-rule px-3 py-1.5 text-[11px] text-ink-muted transition-colors hover:border-ink-muted/50 hover:text-ink-bright"
+        >
+          retry
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/explore/ExploreShell.tsx
+++ b/apps/homescreen/app/components/explore/ExploreShell.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 
 // Contract (see app/lib/exploreContract.ts, "Explore pane composition"):
 type TimelinePaneProps = { onOpenSession: (id: string) => void };
+type TasksPaneProps = { onOpenSession: (id: string) => void };
 type TranscriptPaneProps = { sessionId: string; onBack: () => void };
 
 const exploreLoading = () => (
@@ -25,6 +26,13 @@ const TimelinePane = dynamic<TimelinePaneProps>(
     }>,
   { ssr: false, loading: exploreLoading },
 );
+const TasksPane = dynamic<TasksPaneProps>(
+  () =>
+    import("./tasks/TasksPane") as Promise<{
+      default: ComponentType<TasksPaneProps>;
+    }>,
+  { ssr: false, loading: exploreLoading },
+);
 const TranscriptPane = dynamic<TranscriptPaneProps>(
   () =>
     import("./session/TranscriptPane") as Promise<{
@@ -33,11 +41,33 @@ const TranscriptPane = dynamic<TranscriptPaneProps>(
   { ssr: false, loading: exploreLoading },
 );
 
-type ExploreView = "timeline" | { session: string };
+type ListView = "timeline" | "tasks";
+type ExploreView = ListView | { session: string; from: ListView };
 
 export function ExploreShell() {
   const [view, setView] = useState<ExploreView>("timeline");
-  const sessionId = view === "timeline" ? null : view.session;
+  const sessionId = typeof view === "string" ? null : view.session;
+  // list view the breadcrumb returns to (and the sub-nav highlights)
+  const listView: ListView = typeof view === "string" ? view : view.from;
+
+  const navLink = (v: ListView) => (
+    <button
+      key={v}
+      type="button"
+      onClick={() => setView(v)}
+      aria-current={!sessionId && listView === v ? "page" : undefined}
+      style={{
+        background: "none",
+        border: "none",
+        padding: 0,
+        cursor: "pointer",
+        font: "inherit",
+        color: !sessionId && listView === v ? "var(--ink)" : "var(--ink-muted)",
+      }}
+    >
+      {v}
+    </button>
+  );
 
   return (
     <div
@@ -69,7 +99,7 @@ export function ExploreShell() {
           <>
             <button
               type="button"
-              onClick={() => setView("timeline")}
+              onClick={() => setView(listView)}
               style={{
                 background: "none",
                 border: "none",
@@ -79,7 +109,7 @@ export function ExploreShell() {
                 color: "var(--ink-muted)",
               }}
             >
-              explore / timeline
+              explore / {listView}
             </button>
             <span aria-hidden="true">/</span>
             <span style={{ color: "var(--ink)" }}>
@@ -87,17 +117,28 @@ export function ExploreShell() {
             </span>
           </>
         ) : (
-          <span>explore / timeline</span>
+          <>
+            <span>explore /</span>
+            {navLink("timeline")}
+            <span aria-hidden="true">·</span>
+            {navLink("tasks")}
+          </>
         )}
       </div>
       <div style={{ flex: 1, minHeight: 0, position: "relative", display: "flex", flexDirection: "column" }}>
         {sessionId ? (
           <TranscriptPane
             sessionId={sessionId}
-            onBack={() => setView("timeline")}
+            onBack={() => setView(listView)}
+          />
+        ) : listView === "tasks" ? (
+          <TasksPane
+            onOpenSession={(id: string) => setView({ session: id, from: "tasks" })}
           />
         ) : (
-          <TimelinePane onOpenSession={(id: string) => setView({ session: id })} />
+          <TimelinePane
+            onOpenSession={(id: string) => setView({ session: id, from: "timeline" })}
+          />
         )}
       </div>
     </div>

--- a/apps/homescreen/app/components/explore/ExploreShell.tsx
+++ b/apps/homescreen/app/components/explore/ExploreShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ComponentType } from "react";
+import { useEffect, useState, type ComponentType } from "react";
 import dynamic from "next/dynamic";
 
 // Contract (see app/lib/exploreContract.ts, "Explore pane composition"):
@@ -44,8 +44,40 @@ const TranscriptPane = dynamic<TranscriptPaneProps>(
 type ListView = "timeline" | "tasks";
 type ExploreView = ListView | { session: string; from: ListView };
 
+// Server-driven deep link (ui/focus with pane:"explore"): land on a list view
+// or directly on one session transcript. Queued through a module-level
+// pending slot so a focus that arrives while the pane is still mounting is
+// consumed by the shell's mount effect instead of being dropped.
+export type ExploreFocus = { view?: string; session?: string };
+let pendingFocus: ExploreFocus | null = null;
+
+export function requestExploreFocus(focus: ExploreFocus) {
+  pendingFocus = focus;
+  window.dispatchEvent(new CustomEvent<ExploreFocus>("explore-focus", { detail: focus }));
+}
+
+function focusToView(focus: ExploreFocus): ExploreView | null {
+  const from: ListView = focus.view === "tasks" ? "tasks" : "timeline";
+  if (focus.session) return { session: focus.session, from };
+  if (focus.view === "timeline" || focus.view === "tasks") return focus.view;
+  return null;
+}
+
 export function ExploreShell() {
   const [view, setView] = useState<ExploreView>("timeline");
+
+  useEffect(() => {
+    const apply = (focus: ExploreFocus | null) => {
+      pendingFocus = null;
+      const next = focus && focusToView(focus);
+      if (next) setView(next);
+    };
+    if (pendingFocus) apply(pendingFocus);
+    const onFocus = (e: Event) => apply((e as CustomEvent<ExploreFocus>).detail ?? null);
+    window.addEventListener("explore-focus", onFocus);
+    return () => window.removeEventListener("explore-focus", onFocus);
+  }, []);
+
   const sessionId = typeof view === "string" ? null : view.session;
   // list view the breadcrumb returns to (and the sub-nav highlights)
   const listView: ListView = typeof view === "string" ? view : view.from;

--- a/apps/homescreen/app/components/explore/tasks/TasksPane.tsx
+++ b/apps/homescreen/app/components/explore/tasks/TasksPane.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+// Tasks catalog — clusters as benchmark candidates (Stage-4 precursor).
+// Ported from the moraine-viewer /tasks TasksView; exemplar/session links
+// go through onOpenSession instead of <a href="/session/...">.
+
+import { useEffect, useState } from "react";
+import {
+  fetchBenchmarkDraft,
+  fetchTasks,
+  type BenchmarkDraft,
+  type TaskCluster,
+  type TaskEvalRow,
+  type TasksPayload,
+} from "../../../lib/exploreData";
+import { clusterColor, fmtTokens } from "../timeline/types";
+
+type TasksPaneProps = { onOpenSession: (id: string) => void };
+
+export default function TasksPane({ onOpenSession }: TasksPaneProps) {
+  const [data, setData] = useState<TasksPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchTasks()
+      .then((d) => alive && setData(d))
+      .catch((e) => alive && setError(String(e)));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (error) {
+    return <div className="mono text-xs text-ink-muted p-6">failed to load tasks — {error}</div>;
+  }
+  if (!data) {
+    return <div className="mono text-xs text-ink-muted p-6 breath">scanning clusters…</div>;
+  }
+
+  const totals = data.clusters.reduce(
+    (acc, c) => ({
+      interactive: acc.interactive + c.interactiveSessions,
+      tokens: acc.tokens + c.totalTokens,
+      commits: acc.commits + c.commits,
+    }),
+    { interactive: 0, tokens: 0, commits: 0 },
+  );
+
+  return (
+    <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+      <div className="px-6 py-8 max-w-6xl mx-auto w-full">
+        <header className="mb-8">
+          <h1 className="mono text-lg text-ink-bright tracking-wide">your tasks</h1>
+          <p className="text-sm text-ink-muted mt-1">
+            the recurring work in your traces — each of these is a personal benchmark waiting to
+            be built
+          </p>
+          <div className="mono text-xs text-ink-muted mt-3 flex gap-5">
+            <span>
+              <span className="text-ink">{totals.interactive}</span> interactive sessions
+            </span>
+            <span>
+              <span className="text-ink">{fmtTokens(totals.tokens)}</span> tokens
+            </span>
+            <span>
+              <span className="text-ink">{totals.commits}</span> commits
+            </span>
+          </div>
+        </header>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {data.clusters.map((c) => (
+            <ClusterCard key={c.id} c={c} onOpenSession={onOpenSession} />
+          ))}
+        </div>
+
+        {data.clusters.length === 0 && (
+          <p className="mono text-xs text-ink-muted">
+            no task clusters yet — the scan fills these in progressively
+          </p>
+        )}
+
+        {data.plumbing && data.plumbing.sessions > 0 && (
+          <p className="mono text-[11px] text-ink-muted/60 mt-8">
+            + {data.plumbing.sessions} sessions of {"'"}cli plumbing{"'"} — {data.plumbing.note}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ClusterCard({
+  c,
+  onOpenSession,
+}: {
+  c: TaskCluster;
+  onOpenSession: (id: string) => void;
+}) {
+  const color = clusterColor(c.id);
+  const [open, setOpen] = useState(false);
+  return (
+    <section className="border border-rule rounded-[12px] bg-card p-4 flex flex-col gap-3">
+      <header className="flex items-center gap-2">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+          style={{ background: color }}
+        />
+        <h2 className="mono text-sm text-ink-bright flex-1 truncate">{c.name}</h2>
+        <span className="mono text-xs text-ink-muted">
+          {c.sessions} sessions · {c.interactiveSessions} interactive
+        </span>
+      </header>
+
+      <div className="mono text-xs text-ink-muted flex gap-4 border-b border-rule pb-3">
+        <span>
+          <span className="text-ink">{fmtTokens(c.totalEvents)}</span> events
+        </span>
+        <span>
+          <span className="text-ink">{fmtTokens(c.totalTokens)}</span> tokens
+        </span>
+        <span>
+          <span className="text-ink">{c.commits}</span> commits
+        </span>
+      </div>
+
+      {c.topLanguages.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {c.topLanguages.map((l) => (
+            <span
+              key={l.lang}
+              className="mono text-[10px] px-1.5 py-0.5 rounded-[4px] border border-rule"
+              style={{ color }}
+            >
+              {l.lang} <span className="text-ink-muted">{l.files}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {c.topTools.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {c.topTools.map((t) => (
+            <span
+              key={t.tool}
+              className="mono text-[10px] px-1.5 py-0.5 rounded-full bg-hover text-ink-muted"
+            >
+              {t.tool} <span className="text-ink">{fmtTokens(t.uses)}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {c.topLabels.length > 0 && (
+        <ul className="mono text-[11px] text-ink-muted space-y-0.5">
+          {c.topLabels.map((l) => (
+            <li key={l.label} className="flex justify-between gap-3">
+              <span className="truncate">{l.label}</span>
+              <span className="text-ink shrink-0">{l.n}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {c.exemplars.length > 0 && (
+        <div className="border-t border-rule pt-3 space-y-2">
+          {c.exemplars.map((e) => (
+            <button
+              key={e.session_id}
+              type="button"
+              onClick={() => onOpenSession(e.session_id)}
+              className="block group w-full text-left bg-transparent border-none p-0 cursor-pointer"
+            >
+              <div className="mono text-[11px] text-ink group-hover:text-ink-bright transition-colors truncate">
+                {e.label ?? e.session_id}{" "}
+                <span className="text-ink-muted">· {fmtTokens(e.events)} events</span>
+              </div>
+              {e.summary && (
+                <div className="text-[11px] text-ink-muted truncate">{e.summary}</div>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <footer className="border-t border-rule pt-3 mt-auto">
+        {c.benchmark?.exists ? (
+          <>
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              className="mono text-[11px] border border-rule rounded-[8px] px-2.5 py-1 transition-colors hover:bg-hover"
+              style={{ color }}
+            >
+              {open ? "close benchmark draft ←" : "view benchmark draft →"}
+              <span className="text-ink-muted ml-2">
+                {c.benchmark.instances} instances · q {c.benchmark.meanQuality.toFixed(2)}
+                <EvalSummary evals={c.evals ?? []} legacy={c.eval} />
+              </span>
+            </button>
+            {open && (
+              <BenchmarkDrawer clusterName={c.name} color={color} onOpenSession={onOpenSession} />
+            )}
+          </>
+        ) : (
+          <button
+            type="button"
+            disabled
+            title="coming: turn these sessions into a verifiers environment"
+            className="mono text-[11px] text-ink-muted/60 border border-rule rounded-[8px] px-2.5 py-1 cursor-not-allowed"
+          >
+            → build benchmark (run scripts/benchmark.ts --cluster {c.id})
+          </button>
+        )}
+      </footer>
+    </section>
+  );
+}
+
+// measured plan-quality eval: amber below 0.5, ink to 0.75, promoted green above
+function evalColor(mean: number): string {
+  if (mean < 0.5) return "var(--warn, #f2b34c)";
+  if (mean <= 0.75) return "var(--ink, #e7e8ea)";
+  return "var(--state-promoted, #6ee7a0)";
+}
+
+// short display names for sweep candidate ids
+function shortModel(candidate: string): string {
+  if (candidate.startsWith("local:gemma-4-e2b")) return "gemma-e2b";
+  if (candidate.startsWith("gemma-4-31b")) return "gemma-31b";
+  if (candidate.startsWith("claude-opus")) return "opus";
+  if (candidate.startsWith("claude-haiku")) return "haiku";
+  if (candidate.startsWith("nemotron-3-super")) return "nemotron-super";
+  return candidate;
+}
+
+function isFrontier(candidate: string): boolean {
+  return candidate.startsWith("claude-") || candidate.startsWith("gpt-");
+}
+
+type LegacyEval = { candidate: string; mean: number; n: number; kind: string };
+
+// multi-model sweep summary: best open-weight + frontier side by side.
+function EvalSummary({ evals, legacy }: { evals: TaskEvalRow[]; legacy: LegacyEval | null }) {
+  if (evals.length === 0) {
+    // legacy single-eval fallback
+    if (!legacy) return null;
+    return (
+      <span className="mono" style={{ color: evalColor(legacy.mean) }}>
+        {" "}
+        · gemma plan-quality: {legacy.mean.toFixed(2)} (n={legacy.n})
+      </span>
+    );
+  }
+  const open = evals.filter((e) => !isFrontier(e.candidate));
+  const frontier = evals.filter((e) => isFrontier(e.candidate));
+  const bestOpen = open.length ? open.reduce((a, b) => (b.mean > a.mean ? b : a)) : null;
+  const bestFrontier = frontier.length
+    ? frontier.reduce((a, b) => (b.mean > a.mean ? b : a))
+    : null;
+  const judge = shortModel(evals[0].judge);
+  return (
+    <span className="mono">
+      {bestOpen && (
+        <span style={{ color: evalColor(bestOpen.mean) }}>
+          {" "}
+          · {shortModel(bestOpen.candidate)} {bestOpen.mean.toFixed(2)}
+        </span>
+      )}
+      {bestFrontier && (
+        <span style={{ color: evalColor(bestFrontier.mean) }}>
+          {" · "}
+          {shortModel(bestFrontier.candidate)} {bestFrontier.mean.toFixed(2)}
+        </span>
+      )}
+      <span className="text-ink-muted"> (judge: {judge})</span>
+    </span>
+  );
+}
+
+function qualityColor(q: number): string {
+  if (q > 0.66) return "var(--ok, #4ade80)";
+  if (q > 0.33) return "var(--warn, #fbbf24)";
+  return "var(--rule, #555)";
+}
+
+function BenchmarkDrawer({
+  clusterName,
+  color,
+  onOpenSession,
+}: {
+  clusterName: string;
+  color: string;
+  onOpenSession: (id: string) => void;
+}) {
+  const [draft, setDraft] = useState<BenchmarkDraft | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchBenchmarkDraft(clusterName)
+      .then((d) => {
+        if (!alive) return;
+        if (d) setDraft(d);
+        else setError("draft file missing");
+      })
+      .catch((e) => alive && setError(String(e)));
+    return () => {
+      alive = false;
+    };
+  }, [clusterName]);
+
+  if (error) return <div className="mono text-[11px] text-ink-muted mt-3">failed — {error}</div>;
+  if (!draft)
+    return <div className="mono text-[11px] text-ink-muted mt-3 breath">loading draft…</div>;
+
+  return (
+    <div className="mt-3 border-t border-rule pt-3 space-y-3">
+      <div className="mono text-[10px] text-ink-muted/70">
+        draft — holdout stays sealed; compile to verifiers env is the next stage
+      </div>
+      <div className="mono text-[11px] text-ink-muted flex gap-4">
+        <span>
+          train <span className="text-ink">{draft.counts.train}</span>
+        </span>
+        <span>
+          dev <span className="text-ink">{draft.counts.dev}</span>
+        </span>
+        <span>
+          holdout <span className="text-ink">{draft.counts.holdout}</span>
+        </span>
+        <span>
+          mean q <span style={{ color }}>{draft.mean_quality.toFixed(2)}</span>
+        </span>
+      </div>
+      <ul className="space-y-2">
+        {draft.instances.slice(0, 8).map((inst) => (
+          <li key={inst.instance_id} className="flex items-start gap-2">
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full mt-1.5 shrink-0"
+              style={{ background: qualityColor(inst.quality) }}
+              title={`quality ${inst.quality}`}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="mono text-[11px] text-ink truncate">
+                {inst.prompt.slice(0, 140)}
+              </div>
+              <div className="mono text-[10px] text-ink-muted flex gap-3">
+                <span>{inst.split}</span>
+                <span>{inst.reference.commits.length} commits</span>
+                <button
+                  type="button"
+                  onClick={() => onOpenSession(inst.session_id)}
+                  className="hover:text-ink-bright transition-colors bg-transparent border-none p-0 cursor-pointer mono text-[10px]"
+                  style={{ color }}
+                >
+                  session →
+                </button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/explore/timeline/TimelinePane.tsx
+++ b/apps/homescreen/app/components/explore/timeline/TimelinePane.tsx
@@ -10,15 +10,19 @@ import TimelineScene, { type LaneLayout } from "./TimelineScene";
 import TracePreview from "./TracePreview";
 import EmptyState from "../EmptyState";
 import {
+  cancelScan,
   fetchCommits,
   fetchCommitsDay,
   fetchExploreStatus,
   fetchHealth,
   fetchLanguages,
   fetchLive,
+  fetchScanStatus,
   fetchSessionDetail,
   fetchTimeline,
   searchTimeline,
+  startScan,
+  type ScanStatus,
   type SessionDetail,
 } from "@/app/lib/exploreData";
 import type { ExploreStatus } from "@/app/lib/exploreContract";
@@ -203,6 +207,9 @@ export default function TimelinePane({
 
   const [status, setStatus] = useState<ExploreStatus | null>(null);
   const [scanBannerDismissed, setScanBannerDismissed] = useState(false);
+  const [scan, setScan] = useState<ScanStatus | null>(null);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const prevScanRunning = useRef(false);
 
   // initial load; on failure (or an empty store) fetch explore_status so the
   // empty state can distinguish "moraine down" from "up but no traces yet"
@@ -226,6 +233,52 @@ export default function TimelinePane({
   useEffect(() => {
     loadTimeline();
   }, [loadTimeline]);
+
+  // scan pipeline status: poll every 5s (cheap local invoke) so an app- or
+  // CLI-started scan surfaces as a progress banner; when a run we watched
+  // finishes cleanly, reload the timeline so labels/clusters appear.
+  useEffect(() => {
+    let alive = true;
+    const tick = () => {
+      fetchScanStatus()
+        .then((s) => {
+          if (!alive) return;
+          if (prevScanRunning.current && !s.running && !s.error) {
+            loadTimeline();
+          }
+          prevScanRunning.current = s.running;
+          setScan(s);
+        })
+        .catch(() => {}); // browser dev / desktop hiccup: keep last state
+    };
+    tick();
+    const id = setInterval(tick, 5000);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, [loadTimeline]);
+
+  const onStartScan = useCallback(() => {
+    setScanError(null);
+    startScan()
+      .then(() => {
+        prevScanRunning.current = true;
+        setScan((prev) => ({
+          running: true,
+          stage: "scan",
+          error: null,
+          scannedSessions: prev?.scannedSessions ?? 0,
+        }));
+      })
+      .catch((e) => setScanError(String(e)));
+  }, []);
+
+  const onCancelScan = useCallback(() => {
+    cancelScan().catch(() => {});
+    prevScanRunning.current = false;
+    setScan((prev) => (prev ? { ...prev, running: false } : prev));
+  }, []);
 
   // commit layer (commits.sqlite via adapter; empty payload when absent)
   useEffect(() => {
@@ -791,10 +844,50 @@ export default function TimelinePane({
         )}
       </div>
 
-      {/* unlabeled-sessions banner (informational; never blocks the timeline) */}
-      {data && data.sessions.length > 0 && status && !status.hasScan && !scanBannerDismissed && (
+      {/* scan banner: progress while a pipeline runs (even when hasScan=true),
+          error with retry, or the unscanned call-to-action */}
+      {scan?.running ? (
+        <div className="mono flex items-center gap-3 border-b border-rule px-6 py-1.5 text-[10px] text-ink-muted">
+          <span>
+            scanning… stage {scan.stage ?? "…"} · {scan.scannedSessions} sessions labeled
+          </span>
+          <button
+            onClick={onCancelScan}
+            className="ml-auto text-ink-muted/60 transition-colors hover:text-ink-bright"
+            aria-label="cancel scan"
+          >
+            ×
+          </button>
+        </div>
+      ) : scanError || scan?.error ? (
+        <div className="mono flex items-center gap-3 border-b border-rule px-6 py-1.5 text-[10px]" style={{ color: "#f85149" }}>
+          <span>scan failed: {scanError ?? scan?.error}</span>
+          <button
+            onClick={onStartScan}
+            className="text-ink-muted transition-colors hover:text-ink-bright"
+          >
+            retry →
+          </button>
+          <button
+            onClick={() => {
+              setScanError(null);
+              setScan((prev) => (prev ? { ...prev, error: null } : prev));
+            }}
+            className="ml-auto text-ink-muted/60 transition-colors hover:text-ink-bright"
+            aria-label="dismiss scan banner"
+          >
+            ×
+          </button>
+        </div>
+      ) : data && data.sessions.length > 0 && status && !status.hasScan && !scanBannerDismissed ? (
         <div className="mono flex items-center gap-3 border-b border-rule px-6 py-1.5 text-[10px] text-ink-muted">
           <span>sessions unlabeled — run the scan pipeline to get task labels &amp; clusters</span>
+          <button
+            onClick={onStartScan}
+            className="text-ink-bright transition-colors hover:opacity-80"
+          >
+            scan my history →
+          </button>
           <button
             onClick={() => setScanBannerDismissed(true)}
             className="ml-auto text-ink-muted/60 transition-colors hover:text-ink-bright"
@@ -803,7 +896,7 @@ export default function TimelinePane({
             ×
           </button>
         </div>
-      )}
+      ) : null}
 
       {/* field */}
       <div className="relative flex-1 min-h-0 flex">

--- a/apps/homescreen/app/components/explore/timeline/TimelinePane.tsx
+++ b/apps/homescreen/app/components/explore/timeline/TimelinePane.tsx
@@ -8,9 +8,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import TimelineScene, { type LaneLayout } from "./TimelineScene";
 import TracePreview from "./TracePreview";
+import EmptyState from "../EmptyState";
 import {
   fetchCommits,
   fetchCommitsDay,
+  fetchExploreStatus,
   fetchHealth,
   fetchLanguages,
   fetchLive,
@@ -19,6 +21,7 @@ import {
   searchTimeline,
   type SessionDetail,
 } from "@/app/lib/exploreData";
+import type { ExploreStatus } from "@/app/lib/exploreContract";
 import {
   COST_RAMP,
   DAY,
@@ -145,6 +148,20 @@ function Chip({
 
 type HoverInfo = { point: TimelinePoint; clientX: number; clientY: number };
 
+// fixed-position tooltip placement: right of the cursor normally, flipped to
+// the left within FLIP_PX of the right window edge; clamped vertically
+const FLIP_PX = 280;
+function tooltipPos(clientX: number, clientY: number): React.CSSProperties {
+  const flip = typeof window !== "undefined" && clientX > window.innerWidth - FLIP_PX;
+  const maxTop = typeof window !== "undefined" ? window.innerHeight - 140 : Infinity;
+  return {
+    ...(flip
+      ? { right: window.innerWidth - clientX + 14 }
+      : { left: clientX + 14 }),
+    top: Math.max(8, Math.min(clientY + 14, maxTop)),
+  };
+}
+
 type CommitDay = { d: string; c: number };
 type DayCommit = { hash7: string; repo: string; subject: string; ts: number; sessions: string[] };
 
@@ -184,11 +201,31 @@ export default function TimelinePane({
   const viewRef = useRef(view);
   viewRef.current = view;
 
-  useEffect(() => {
+  const [status, setStatus] = useState<ExploreStatus | null>(null);
+  const [scanBannerDismissed, setScanBannerDismissed] = useState(false);
+
+  // initial load; on failure (or an empty store) fetch explore_status so the
+  // empty state can distinguish "moraine down" from "up but no traces yet"
+  const loadTimeline = useCallback(() => {
+    setError(null);
     fetchTimeline()
-      .then((d) => setData(d))
-      .catch((e) => setError(String(e)));
+      .then((d) => {
+        setData(d);
+        fetchExploreStatus()
+          .then(setStatus)
+          .catch(() => {});
+      })
+      .catch((e) => {
+        setError(String(e));
+        fetchExploreStatus()
+          .then(setStatus)
+          .catch(() => setStatus(null));
+      });
   }, []);
+
+  useEffect(() => {
+    loadTimeline();
+  }, [loadTimeline]);
 
   // commit layer (commits.sqlite via adapter; empty payload when absent)
   useEffect(() => {
@@ -754,6 +791,20 @@ export default function TimelinePane({
         )}
       </div>
 
+      {/* unlabeled-sessions banner (informational; never blocks the timeline) */}
+      {data && data.sessions.length > 0 && status && !status.hasScan && !scanBannerDismissed && (
+        <div className="mono flex items-center gap-3 border-b border-rule px-6 py-1.5 text-[10px] text-ink-muted">
+          <span>sessions unlabeled — run the scan pipeline to get task labels &amp; clusters</span>
+          <button
+            onClick={() => setScanBannerDismissed(true)}
+            className="ml-auto text-ink-muted/60 transition-colors hover:text-ink-bright"
+            aria-label="dismiss scan banner"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
       {/* field */}
       <div className="relative flex-1 min-h-0 flex">
         <div
@@ -809,10 +860,17 @@ export default function TimelinePane({
               reading the moraine…
             </div>
           )}
-          {error && (
-            <div className="mono flex h-full items-center justify-center text-xs text-[#f85149]">
-              couldn&apos;t reach clickhouse — {error}
-            </div>
+          {error &&
+            (status?.clickhouseUp ? (
+              // clickhouse is reachable but the query itself failed — surface it
+              <div className="mono flex h-full items-center justify-center text-xs text-[#f85149]">
+                couldn&apos;t read the timeline — {error}
+              </div>
+            ) : (
+              <EmptyState variant="moraine-down" detail={error} onRetry={loadTimeline} />
+            ))}
+          {data && data.sessions.length === 0 && (
+            <EmptyState variant="no-traces" onRetry={loadTimeline} />
           )}
 
           {/* selection ring */}
@@ -1008,8 +1066,7 @@ export default function TimelinePane({
           <div
             className="mono pointer-events-none fixed z-50 rounded-lg border border-rule px-3 py-2 text-[11px] leading-relaxed"
             style={{
-              left: commitHover.clientX + 14,
-              top: commitHover.clientY - 40,
+              ...tooltipPos(commitHover.clientX, commitHover.clientY - 54),
               background: "rgba(11,12,14,0.92)",
             }}
           >
@@ -1026,8 +1083,7 @@ export default function TimelinePane({
           <div
             className="mono pointer-events-none fixed z-50 max-w-xs rounded-lg border border-rule px-3 py-2 text-[11px] leading-relaxed"
             style={{
-              left: hover.clientX + 14,
-              top: hover.clientY + 14,
+              ...tooltipPos(hover.clientX, hover.clientY),
               background: "rgba(11,12,14,0.92)",
             }}
           >

--- a/apps/homescreen/app/lib/exploreData.ts
+++ b/apps/homescreen/app/lib/exploreData.ts
@@ -109,6 +109,37 @@ async function sq<T = Record<string, unknown>>(
   return JSON.parse(raw) as T[];
 }
 
+// ---------------------------------------------------------------------------
+// scan pipeline (the "scan my history" button) — desktop-only: the Rust side
+// spawns the bundled `understudy explore` CLI against the resident model.
+
+export type ScanStatus = {
+  running: boolean;
+  stage: string | null;
+  error: string | null;
+  scannedSessions: number;
+};
+
+function assertScanDesktop(): void {
+  if (!isDesktop()) throw new Error("scanning requires the desktop app");
+}
+
+export async function startScan(limit?: number): Promise<void> {
+  assertScanDesktop();
+  await invoke<string>("explore_scan_start", { limit: limit ?? null });
+}
+
+export async function fetchScanStatus(): Promise<ScanStatus> {
+  assertScanDesktop();
+  const raw = await invoke<string>("explore_scan_status");
+  return JSON.parse(raw) as ScanStatus;
+}
+
+export async function cancelScan(): Promise<void> {
+  assertScanDesktop();
+  await invoke("explore_scan_cancel");
+}
+
 function escCh(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }

--- a/apps/homescreen/app/lib/exploreData.ts
+++ b/apps/homescreen/app/lib/exploreData.ts
@@ -735,6 +735,325 @@ export async function fetchExploreStatus(): Promise<ExploreStatus> {
 }
 
 // ---------------------------------------------------------------------------
+// tasks catalog — clusters as benchmark candidates (ported from the
+// moraine-viewer /api/tasks route + benchmarkFile.ts, now fully client-side
+// over the invoke adapters). Every sqlite source degrades gracefully when
+// missing; ClickHouse failure → token totals stay 0.
+
+const PLUMBING_CLUSTER = "cli plumbing";
+
+// Eval files on disk are named <slug>__<candidate>.json and are NOT
+// enumerable through explore_read_json — so we probe the known sweep
+// candidates (scripts/evalrun.ts writes exactly these) and keep what exists.
+const KNOWN_EVAL_CANDIDATES = [
+  "local-gemma-4-e2b-qat-understudy",
+  "gemma-4-31b-it",
+  "glm-5-2",
+  "nemotron-3-super",
+  "claude-opus-4-8",
+];
+
+export interface TaskExemplar {
+  session_id: string;
+  label: string | null;
+  summary: string | null;
+  events: number;
+}
+
+export interface TaskEvalRow {
+  candidate: string;
+  mean: number;
+  n: number;
+  kind: string;
+  judge: string;
+}
+
+export interface TaskCluster {
+  id: number;
+  name: string;
+  sessions: number;
+  interactiveSessions: number;
+  totalEvents: number;
+  totalTokens: number;
+  commits: number;
+  topLanguages: Array<{ lang: string; files: number }>;
+  topTools: Array<{ tool: string; uses: number }>;
+  topLabels: Array<{ label: string; n: number }>;
+  exemplars: TaskExemplar[];
+  benchmark: { exists: boolean; instances: number; meanQuality: number } | null;
+  /** legacy single eval — the local-gemma entry, kept for back-compat */
+  eval: { candidate: string; mean: number; n: number; kind: string } | null;
+  /** all real measured evals (multi-model sweep) */
+  evals: TaskEvalRow[];
+}
+
+export interface TasksPayload {
+  clusters: TaskCluster[];
+  plumbing: { sessions: number; note: string } | null;
+}
+
+export interface BenchmarkInstance {
+  instance_id: string;
+  session_id: string;
+  split: "train" | "dev" | "holdout";
+  prompt: string;
+  context: {
+    project: string;
+    harness: string;
+    tools_used: string[];
+    label: string | null;
+    summary: string | null;
+  };
+  reference: {
+    final_assistant: string;
+    commits: string[];
+    events: number;
+  };
+  quality: number;
+}
+
+export interface BenchmarkDraft {
+  benchmark: string;
+  version: string;
+  created: string;
+  cluster: { id: number; name: string };
+  counts: { instances: number; train: number; dev: number; holdout: number; dropped: number };
+  mean_quality: number;
+  split_hash_seed: string;
+  instances: BenchmarkInstance[];
+}
+
+interface EvalFile {
+  benchmark: string;
+  candidate: string;
+  kind: string;
+  judge: string;
+  createdAt: string;
+  results: Array<{ instance_id: string; score: number; reason: string; candidate_chars: number }>;
+  mean: number;
+  n: number;
+}
+
+export function clusterSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+// explore_read_json invoke: ~/.understudy/explore/{benchmarks,evals}/<name>.json
+// (Rust sanitizes name to [A-Za-z0-9._-]; the "__" in eval names passes).
+async function readExploreJson<T>(kind: "benchmark" | "eval", name: string): Promise<T | null> {
+  assertDesktop();
+  if (!isDesktop() && DEV_FALLBACK) return null; // no browser path to the JSON dirs
+  try {
+    const raw = await invoke<string | null>("explore_read_json", { kind, name });
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchBenchmarkDraft(clusterName: string): Promise<BenchmarkDraft | null> {
+  return readExploreJson<BenchmarkDraft>("benchmark", clusterSlug(clusterName));
+}
+
+async function readClusterEvals(clusterName: string): Promise<EvalFile[]> {
+  const slug = clusterSlug(clusterName);
+  const reads = await Promise.all(
+    KNOWN_EVAL_CANDIDATES.map((cand) => readExploreJson<EvalFile>("eval", `${slug}__${cand}`)),
+  );
+  return reads.filter((e): e is EvalFile => e != null).sort((a, b) => b.mean - a.mean);
+}
+
+type TaskScanRow = {
+  session_id: string;
+  events: number;
+  label: string | null;
+  summary: string | null;
+  interactive: number;
+  cluster_id: number | null;
+  cluster_name: string | null;
+};
+
+export async function fetchTasks(): Promise<TasksPayload> {
+  // scan: session → cluster + label + events + interactivity
+  let scanRows: TaskScanRow[];
+  try {
+    scanRows = await sq<TaskScanRow>(
+      "scan",
+      `SELECT s.session_id, COALESCE(s.events, 0) AS events, s.label, s.summary,
+              COALESCE(s.interactive, 1) AS interactive,
+              m.cluster_id AS cluster_id, c.name AS cluster_name
+       FROM session_scan s
+       LEFT JOIN cluster_map m ON m.label = s.label
+       LEFT JOIN clusters c ON c.id = m.cluster_id`,
+    );
+  } catch {
+    // scan/cluster tables absent — no catalog yet
+    return { clusters: [], plumbing: null };
+  }
+  if (scanRows.length === 0) return { clusters: [], plumbing: null };
+
+  // commits: session → distinct commit hashes; langs/tools per session;
+  // token sums per session (UInt64 arrives as string; alias ≠ column names)
+  const commitMap = new Map<string, string[]>();
+  const langMap = new Map<string, Array<{ lang: string; files: number }>>();
+  const toolMap = new Map<string, Array<{ tool: string; uses: number }>>();
+  const tokenMap = new Map<string, number>();
+  await Promise.all([
+    (async () => {
+      try {
+        const rows = await sq<{ hash: string; session_id: string }>(
+          "commits",
+          `SELECT hash, session_id FROM commit_sessions`,
+        );
+        for (const r of rows) {
+          const list = commitMap.get(r.session_id);
+          if (list) list.push(r.hash);
+          else commitMap.set(r.session_id, [r.hash]);
+        }
+      } catch { /* commits.sqlite absent */ }
+    })(),
+    (async () => {
+      try {
+        const rows = await sq<{ session_id: string; lang: string; files: number }>(
+          "langs",
+          `SELECT session_id, lang, files FROM session_langs`,
+        );
+        for (const r of rows) {
+          const list = langMap.get(r.session_id) ?? [];
+          list.push({ lang: r.lang, files: Number(r.files) });
+          langMap.set(r.session_id, list);
+        }
+      } catch { /* langs.sqlite absent */ }
+    })(),
+    (async () => {
+      try {
+        const rows = await sq<{ session_id: string; tool: string; uses: number }>(
+          "langs",
+          `SELECT session_id, tool, uses FROM session_tools`,
+        );
+        for (const r of rows) {
+          const list = toolMap.get(r.session_id) ?? [];
+          list.push({ tool: r.tool, uses: Number(r.uses) });
+          toolMap.set(r.session_id, list);
+        }
+      } catch { /* session_tools absent */ }
+    })(),
+    (async () => {
+      try {
+        const rows = await ch<{ sid: string; tok: string }>(
+          `SELECT session_id AS sid,
+                  toString(sum(input_tokens) + sum(output_tokens) + sum(cache_read_tokens) + sum(cache_write_tokens)) AS tok
+           FROM events WHERE event_ts > '2026-01-01' GROUP BY session_id`,
+        );
+        for (const r of rows) tokenMap.set(r.sid, Number(r.tok));
+      } catch { /* ClickHouse down — token totals stay 0 */ }
+    })(),
+  ]);
+
+  // group by cluster; 'cli plumbing' is excluded from cards, kept as footnote
+  type Agg = { id: number; name: string; rows: TaskScanRow[] };
+  const byCluster = new Map<number, Agg>();
+  let plumbingSessions = 0;
+  for (const r of scanRows) {
+    if (r.cluster_id == null || !r.cluster_name) continue;
+    if (r.cluster_name === PLUMBING_CLUSTER) {
+      plumbingSessions++;
+      continue;
+    }
+    const agg =
+      byCluster.get(Number(r.cluster_id)) ??
+      { id: Number(r.cluster_id), name: r.cluster_name, rows: [] };
+    agg.rows.push(r);
+    byCluster.set(Number(r.cluster_id), agg);
+  }
+
+  const clusters: TaskCluster[] = await Promise.all(
+    [...byCluster.values()].map(async (agg) => {
+      const langs = new Map<string, number>();
+      const tools = new Map<string, number>();
+      const labels = new Map<string, number>();
+      let totalEvents = 0;
+      let totalTokens = 0;
+      let interactiveSessions = 0;
+      const commitHashes = new Set<string>();
+      for (const r of agg.rows) {
+        totalEvents += Number(r.events);
+        totalTokens += tokenMap.get(r.session_id) ?? 0;
+        if (Number(r.interactive)) interactiveSessions++;
+        if (r.label) labels.set(r.label, (labels.get(r.label) ?? 0) + 1);
+        for (const h of commitMap.get(r.session_id) ?? []) commitHashes.add(h);
+        for (const l of langMap.get(r.session_id) ?? [])
+          langs.set(l.lang, (langs.get(l.lang) ?? 0) + l.files);
+        for (const t of toolMap.get(r.session_id) ?? [])
+          tools.set(t.tool, (tools.get(t.tool) ?? 0) + t.uses);
+      }
+      const exemplars: TaskExemplar[] = agg.rows
+        .filter((r) => Number(r.interactive))
+        .sort((a, b) => Number(b.events) - Number(a.events))
+        .slice(0, 3)
+        .map((r) => ({
+          session_id: r.session_id,
+          label: r.label,
+          summary: r.summary ? r.summary.slice(0, 200) : null,
+          events: Number(r.events),
+        }));
+      const [draft, evalFiles] = await Promise.all([
+        fetchBenchmarkDraft(agg.name),
+        readClusterEvals(agg.name),
+      ]);
+      const legacy = evalFiles.find((e) => e.candidate.startsWith("local:")) ?? null;
+      return {
+        id: agg.id,
+        name: agg.name,
+        sessions: agg.rows.length,
+        interactiveSessions,
+        totalEvents,
+        totalTokens,
+        commits: commitHashes.size,
+        topLanguages: [...langs.entries()]
+          .map(([lang, files]) => ({ lang, files }))
+          .sort((a, b) => b.files - a.files || a.lang.localeCompare(b.lang))
+          .slice(0, 3),
+        topTools: [...tools.entries()]
+          .map(([tool, uses]) => ({ tool, uses }))
+          .sort((a, b) => b.uses - a.uses || a.tool.localeCompare(b.tool))
+          .slice(0, 5),
+        topLabels: [...labels.entries()]
+          .map(([label, n]) => ({ label, n }))
+          .sort((a, b) => b.n - a.n || a.label.localeCompare(b.label))
+          .slice(0, 5),
+        exemplars,
+        benchmark: draft
+          ? { exists: true, instances: draft.counts.instances, meanQuality: draft.mean_quality }
+          : null,
+        eval: legacy
+          ? { candidate: legacy.candidate, mean: legacy.mean, n: legacy.n, kind: legacy.kind }
+          : null,
+        evals: evalFiles.map((e) => ({
+          candidate: e.candidate,
+          mean: e.mean,
+          n: e.n,
+          kind: e.kind,
+          judge: e.judge,
+        })),
+      };
+    }),
+  );
+  clusters.sort(
+    (a, b) => b.interactiveSessions - a.interactiveSessions || b.sessions - a.sessions,
+  );
+
+  return {
+    clusters,
+    plumbing: {
+      sessions: plumbingSessions,
+      note: "non-interactive cli plumbing — excluded from benchmark candidacy",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // `model` values are sometimes JSON blobs or filesystem paths — normalize.
 
 export function normalizeModel(raw: string): string {

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -14,7 +14,7 @@ import { UsagePane } from "./components/UsagePane";
 import { DownloadQrButton } from "./components/DownloadQrButton";
 import { isTrainingPane, TrainingPane } from "./components/TrainingPane";
 import { RlmPane } from "./components/RlmPane";
-import { ExploreShell } from "./components/explore/ExploreShell";
+import { ExploreShell, requestExploreFocus } from "./components/explore/ExploreShell";
 import { RuntimeRepairPrompt } from "./components/RuntimeRepairPrompt";
 import { ModelDownloadNotice } from "./components/ModelDownloadNotice";
 import { useStatus } from "./lib/useStatus";
@@ -197,15 +197,26 @@ export default function Page() {
       "training-rl",
       "training-jobs",
     ];
-    const u = listen<{ pane?: string }>("server-focus", (e) => {
-      const requested = e.payload?.pane;
-      const p = (
-        requested === "marketplace" ? "models" :
-        requested && hidden.includes(requested) ? "status" :
-        requested
-      ) as PaneId;
-      if (p && (valid as string[]).includes(p)) setPane(p);
-    });
+    const u = listen<{ pane?: string; view?: string; session?: string }>(
+      "server-focus",
+      (e) => {
+        const requested = e.payload?.pane;
+        const p = (
+          requested === "marketplace" ? "models" :
+          requested && hidden.includes(requested) ? "status" :
+          requested
+        ) as PaneId;
+        if (p && (valid as string[]).includes(p)) setPane(p);
+        // Explore deep link: forward view/session to ExploreShell (queued if
+        // the pane is only mounting on this render).
+        if (p === "explore" && (e.payload?.view || e.payload?.session)) {
+          requestExploreFocus({
+            view: e.payload?.view,
+            session: e.payload?.session,
+          });
+        }
+      },
+    );
     return () => {
       u.then((f) => f());
     };

--- a/apps/homescreen/src-tauri/src/explore.rs
+++ b/apps/homescreen/src-tauri/src/explore.rs
@@ -38,9 +38,10 @@ fn is_read_only_clickhouse(sql: &str) -> bool {
 }
 
 /// Run a read-only query against the local Moraine ClickHouse and return the
-/// raw JSONEachRow response body.
-#[tauri::command]
-pub async fn explore_clickhouse_query(sql: String) -> Result<String, String> {
+/// raw JSONEachRow response body. Shared by the Tauri command and the local
+/// server (REST + MCP): allowlisted statement heads plus ClickHouse-side
+/// memory/thread/time caps.
+pub async fn run_clickhouse_query(sql: String) -> Result<String, String> {
     let sql = sql.trim().trim_end_matches(';').trim().to_string();
     if sql.is_empty() {
         return Err("empty query".into());
@@ -78,6 +79,11 @@ pub async fn explore_clickhouse_query(sql: String) -> Result<String, String> {
     Ok(body)
 }
 
+#[tauri::command]
+pub async fn explore_clickhouse_query(sql: String) -> Result<String, String> {
+    run_clickhouse_query(sql).await
+}
+
 fn sqlite_value_to_json(v: ValueRef<'_>) -> Value {
     match v {
         ValueRef::Null => Value::Null,
@@ -112,9 +118,9 @@ fn run_sqlite_query(path: PathBuf, sql: String, params: Vec<String>) -> Result<S
 }
 
 /// Read-only query over one of the explore side tables
-/// (~/.understudy/explore/{scan,commits,langs}.sqlite).
-#[tauri::command]
-pub async fn explore_sqlite_query(
+/// (~/.understudy/explore/{scan,commits,langs}.sqlite). Shared guarded
+/// helper: named-db allowlist, SELECT-only, read-only open, row cap.
+pub async fn query_sqlite(
     db: String,
     sql: String,
     params: Vec<String>,
@@ -134,9 +140,18 @@ pub async fn explore_sqlite_query(
         .map_err(|e| format!("sqlite task failed: {e}"))?
 }
 
-/// Read a benchmark or eval JSON artifact; `None` when the file is missing.
 #[tauri::command]
-pub async fn explore_read_json(kind: String, name: String) -> Result<Option<String>, String> {
+pub async fn explore_sqlite_query(
+    db: String,
+    sql: String,
+    params: Vec<String>,
+) -> Result<String, String> {
+    query_sqlite(db, sql, params).await
+}
+
+/// Read a benchmark or eval JSON artifact; `None` when the file is missing.
+/// Shared by the Tauri command and the local server.
+pub async fn read_artifact_json(kind: String, name: String) -> Result<Option<String>, String> {
     let dir = match kind.as_str() {
         "benchmark" => "benchmarks",
         "eval" => "evals",
@@ -155,6 +170,11 @@ pub async fn explore_read_json(kind: String, name: String) -> Result<Option<Stri
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(format!("read {}: {e}", path.display())),
     }
+}
+
+#[tauri::command]
+pub async fn explore_read_json(kind: String, name: String) -> Result<Option<String>, String> {
+    read_artifact_json(kind, name).await
 }
 
 // ---------------------------------------------------------------------------
@@ -273,14 +293,13 @@ fn run_scan_pipeline(shared: &Mutex<ScanJobInner>, llm_url: &str) -> Result<(), 
 /// Start the scan pipeline against the resident local model. Refuses when a
 /// pipeline is already running or no model is serving. Returns "started"
 /// immediately after the scan child spawns; the remaining stages chain in a
-/// background thread.
-#[tauri::command]
-pub async fn explore_scan_start(
+/// background thread. Shared by the Tauri command and the local server.
+pub fn scan_start(
+    job: &ScanJob,
+    residency: &crate::residency::Residency,
     limit: Option<u32>,
-    job: tauri::State<'_, ScanJob>,
-    residency: tauri::State<'_, crate::residency::Residency>,
 ) -> Result<String, String> {
-    let llm_url = resident_llm_url(&residency)?;
+    let llm_url = resident_llm_url(residency)?;
 
     let mut scan_args = vec!["--llm-url".to_string(), llm_url.clone()];
     if let Some(limit) = limit {
@@ -319,6 +338,15 @@ pub async fn explore_scan_start(
     Ok("started".into())
 }
 
+#[tauri::command]
+pub async fn explore_scan_start(
+    limit: Option<u32>,
+    job: tauri::State<'_, ScanJob>,
+    residency: tauri::State<'_, crate::residency::Residency>,
+) -> Result<String, String> {
+    scan_start(&job, &residency, limit)
+}
+
 fn scanned_sessions_count(path: &Path) -> i64 {
     if !path.exists() {
         return 0;
@@ -333,8 +361,7 @@ fn scanned_sessions_count(path: &Path) -> i64 {
 
 /// Progress snapshot for the scan pipeline:
 /// `{running, stage, error, scannedSessions}`.
-#[tauri::command]
-pub async fn explore_scan_status(job: tauri::State<'_, ScanJob>) -> Result<String, String> {
+pub async fn scan_status(job: &ScanJob) -> Result<String, String> {
     let (running, stage, error) = {
         let g = scan_locked(&job.0);
         (g.running, g.stage.clone(), g.error.clone())
@@ -352,9 +379,13 @@ pub async fn explore_scan_status(job: tauri::State<'_, ScanJob>) -> Result<Strin
     .to_string())
 }
 
-/// Cancel the in-flight scan pipeline (no-op when idle).
 #[tauri::command]
-pub async fn explore_scan_cancel(job: tauri::State<'_, ScanJob>) -> Result<(), String> {
+pub async fn explore_scan_status(job: tauri::State<'_, ScanJob>) -> Result<String, String> {
+    scan_status(&job).await
+}
+
+/// Cancel the in-flight scan pipeline (no-op when idle).
+pub fn scan_cancel(job: &ScanJob) -> Result<(), String> {
     let mut g = scan_locked(&job.0);
     if !g.running {
         return Ok(());
@@ -367,9 +398,14 @@ pub async fn explore_scan_cancel(job: tauri::State<'_, ScanJob>) -> Result<(), S
     Ok(())
 }
 
-/// Availability snapshot for the Explore pane: services + local artifacts.
 #[tauri::command]
-pub async fn explore_status() -> Result<String, String> {
+pub async fn explore_scan_cancel(job: tauri::State<'_, ScanJob>) -> Result<(), String> {
+    scan_cancel(&job)
+}
+
+/// Availability snapshot for the Explore pane: services + local artifacts.
+/// Shared by the Tauri command and the local server.
+pub async fn status_snapshot() -> Result<String, String> {
     let clickhouse_up = async {
         let client = match reqwest::Client::builder()
             .timeout(Duration::from_secs(2))
@@ -408,4 +444,9 @@ pub async fn explore_status() -> Result<String, String> {
         "hasLangs": dir.join("langs.sqlite").exists(),
     });
     Ok(status.to_string())
+}
+
+#[tauri::command]
+pub async fn explore_status() -> Result<String, String> {
+    status_snapshot().await
 }

--- a/apps/homescreen/src-tauri/src/explore.rs
+++ b/apps/homescreen/src-tauri/src/explore.rs
@@ -5,8 +5,10 @@
 //! (SQLite side tables + benchmark/eval JSON files).
 
 use std::net::{SocketAddr, TcpStream};
-use std::path::PathBuf;
-use std::time::Duration;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Stdio};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
 
 use rusqlite::{types::ValueRef, OpenFlags};
 use serde_json::{json, Map, Value};
@@ -153,6 +155,216 @@ pub async fn explore_read_json(kind: String, name: String) -> Result<Option<Stri
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(format!("read {}: {e}", path.display())),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Scan pipeline — the "scan my history" button runs the bundled
+// `understudy explore` CLI (scan → cluster → languages → commits) as a
+// managed child process against the app's resident local model.
+
+#[derive(Default)]
+struct ScanJobInner {
+    running: bool,
+    cancelled: bool,
+    stage: Option<String>,
+    error: Option<String>,
+    started_at: Option<Instant>,
+    child: Option<Child>,
+}
+
+/// Managed state for the single in-flight explore scan pipeline.
+#[derive(Default)]
+pub struct ScanJob(Arc<Mutex<ScanJobInner>>);
+
+fn scan_locked(m: &Mutex<ScanJobInner>) -> MutexGuard<'_, ScanJobInner> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Chat-completions URL of the app's resident local model server.
+/// Deterministically prefers the lowest warm port, mirroring
+/// `Residency::local_base_url`, but errors when nothing is serving instead
+/// of advertising the fresh-install default port.
+fn resident_llm_url(residency: &crate::residency::Residency) -> Result<String, String> {
+    let snapshot = residency.snapshot();
+    let port = snapshot
+        .slots
+        .iter()
+        .filter(|s| s.state == "running")
+        .filter_map(|s| s.port)
+        .min()
+        .ok_or_else(|| {
+            "no local model is serving — start a local model first (Models pane)".to_string()
+        })?;
+    Ok(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+}
+
+fn spawn_stage(stage: &str, extra: &[String]) -> Result<Child, String> {
+    let mut cmd = crate::bin::command("understudy");
+    cmd.arg("explore").arg(stage).args(extra);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    cmd.spawn()
+        .map_err(|e| format!("spawn `understudy explore {stage}`: {e}"))
+}
+
+/// Poll the current child to completion. Ok(true) = stage succeeded,
+/// Ok(false) = cancelled (child already reaped), Err = stage failed.
+fn wait_stage(shared: &Mutex<ScanJobInner>, stage: &str) -> Result<bool, String> {
+    loop {
+        std::thread::sleep(Duration::from_millis(400));
+        let mut g = scan_locked(shared);
+        if g.cancelled {
+            if let Some(child) = g.child.as_mut() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            g.child = None;
+            return Ok(false);
+        }
+        let Some(child) = g.child.as_mut() else {
+            return Ok(false);
+        };
+        match child.try_wait() {
+            Ok(None) => {}
+            Ok(Some(status)) => {
+                g.child = None;
+                if status.success() {
+                    return Ok(true);
+                }
+                return Err(format!("`understudy explore {stage}` exited with {status}"));
+            }
+            Err(e) => {
+                g.child = None;
+                return Err(format!("`understudy explore {stage}` wait failed: {e}"));
+            }
+        }
+    }
+}
+
+/// Runs after the scan child was spawned by `explore_scan_start`: wait for it,
+/// then chain the remaining stages sequentially.
+fn run_scan_pipeline(shared: &Mutex<ScanJobInner>, llm_url: &str) -> Result<(), String> {
+    if !wait_stage(shared, "scan")? {
+        return Ok(()); // cancelled
+    }
+    let stages: [(&str, Vec<String>); 3] = [
+        ("cluster", vec!["--llm-url".into(), llm_url.to_string()]),
+        ("languages", Vec::new()),
+        ("commits", Vec::new()),
+    ];
+    for (stage, extra) in stages {
+        {
+            let mut g = scan_locked(shared);
+            if g.cancelled {
+                return Ok(());
+            }
+            let child = spawn_stage(stage, &extra)?;
+            g.stage = Some(stage.to_string());
+            g.child = Some(child);
+        }
+        if !wait_stage(shared, stage)? {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+/// Start the scan pipeline against the resident local model. Refuses when a
+/// pipeline is already running or no model is serving. Returns "started"
+/// immediately after the scan child spawns; the remaining stages chain in a
+/// background thread.
+#[tauri::command]
+pub async fn explore_scan_start(
+    limit: Option<u32>,
+    job: tauri::State<'_, ScanJob>,
+    residency: tauri::State<'_, crate::residency::Residency>,
+) -> Result<String, String> {
+    let llm_url = resident_llm_url(&residency)?;
+
+    let mut scan_args = vec!["--llm-url".to_string(), llm_url.clone()];
+    if let Some(limit) = limit {
+        scan_args.push("--limit".into());
+        scan_args.push(limit.to_string());
+    }
+
+    {
+        let mut g = scan_locked(&job.0);
+        if g.running {
+            return Err("a scan is already running".into());
+        }
+        let child = spawn_stage("scan", &scan_args)?;
+        g.running = true;
+        g.cancelled = false;
+        g.error = None;
+        g.stage = Some("scan".into());
+        g.started_at = Some(Instant::now());
+        g.child = Some(child);
+    }
+
+    let shared = job.0.clone();
+    std::thread::spawn(move || {
+        let outcome = run_scan_pipeline(&shared, &llm_url);
+        let mut g = scan_locked(&shared);
+        g.running = false;
+        g.stage = None;
+        g.child = None;
+        if let Err(e) = outcome {
+            if !g.cancelled {
+                g.error = Some(e);
+            }
+        }
+    });
+
+    Ok("started".into())
+}
+
+fn scanned_sessions_count(path: &Path) -> i64 {
+    if !path.exists() {
+        return 0;
+    }
+    let Ok(conn) = rusqlite::Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+    else {
+        return 0;
+    };
+    conn.query_row("SELECT COUNT(*) FROM session_scan", [], |r| r.get(0))
+        .unwrap_or(0)
+}
+
+/// Progress snapshot for the scan pipeline:
+/// `{running, stage, error, scannedSessions}`.
+#[tauri::command]
+pub async fn explore_scan_status(job: tauri::State<'_, ScanJob>) -> Result<String, String> {
+    let (running, stage, error) = {
+        let g = scan_locked(&job.0);
+        (g.running, g.stage.clone(), g.error.clone())
+    };
+    let path = explore_dir()?.join("scan.sqlite");
+    let scanned = tauri::async_runtime::spawn_blocking(move || scanned_sessions_count(&path))
+        .await
+        .unwrap_or(0);
+    Ok(json!({
+        "running": running,
+        "stage": stage,
+        "error": error,
+        "scannedSessions": scanned,
+    })
+    .to_string())
+}
+
+/// Cancel the in-flight scan pipeline (no-op when idle).
+#[tauri::command]
+pub async fn explore_scan_cancel(job: tauri::State<'_, ScanJob>) -> Result<(), String> {
+    let mut g = scan_locked(&job.0);
+    if !g.running {
+        return Ok(());
+    }
+    g.cancelled = true;
+    g.error = None;
+    if let Some(child) = g.child.as_mut() {
+        let _ = child.kill();
+    }
+    Ok(())
 }
 
 /// Availability snapshot for the Explore pane: services + local artifacts.

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -123,6 +123,9 @@ pub fn run() {
             // download progress + the single-flight benchmark run gate.
             app.manage(agent_ops::Downloads::new());
             app.manage(agent_ops::BenchRuns::new());
+            // Single-flight explore scan pipeline (Explore pane's
+            // "scan my history" button).
+            app.manage(explore::ScanJob::default());
 
             // Paint the shell before process reconciliation or model re-warm.
             // This is background work, but starting it during the first frame
@@ -376,6 +379,9 @@ pub fn run() {
             explore::explore_sqlite_query,
             explore::explore_read_json,
             explore::explore_status,
+            explore::explore_scan_start,
+            explore::explore_scan_status,
+            explore::explore_scan_cancel,
             chat::chat_stream,
             restart_app,
         ])

--- a/apps/homescreen/src-tauri/src/server.rs
+++ b/apps/homescreen/src-tauri/src/server.rs
@@ -95,6 +95,18 @@ pub fn router(ctx: Ctx) -> Router {
         .route("/api/traces/search", get(traces_search))
         .route("/api/traces/:id", get(traces_open))
         .route("/api/ui/focus", post(ui_focus))
+        // Explore Data pane: read-only warehouse/artifact surfaces + scan job.
+        .route("/api/explore/status", get(explore_status))
+        .route("/api/explore/query", post(explore_query))
+        .route("/api/explore/sqlite", post(explore_sqlite))
+        .route("/api/explore/benchmark/:name", get(explore_benchmark))
+        .route("/api/explore/eval/:name", get(explore_eval))
+        .route(
+            "/api/explore/scan",
+            get(explore_scan_status)
+                .post(explore_scan_start)
+                .delete(explore_scan_cancel),
+        )
         // Stable versioned aliases for the CLI and third-party desktop agents.
         .route("/v1/capabilities", get(agent_capabilities))
         .route("/v1/status", get(status))
@@ -1192,10 +1204,14 @@ async fn traces_open(
 }
 
 /// Inbound: an agent asks the GUI to focus a pane / show something.
+/// `view`/`session` are Explore deep links: land on the timeline or tasks
+/// list, or directly on one session transcript.
 #[derive(serde::Deserialize)]
 struct FocusBody {
     pane: Option<String>,
     model: Option<String>,
+    view: Option<String>,
+    session: Option<String>,
 }
 async fn ui_focus(
     State(ctx): State<Ctx>,
@@ -1203,9 +1219,157 @@ async fn ui_focus(
     Json(b): Json<FocusBody>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     auth(&ctx, &h)?;
-    let _ = ctx
-        .app
-        .emit("server-focus", json!({ "pane": b.pane, "model": b.model }));
+    let _ = ctx.app.emit(
+        "server-focus",
+        json!({ "pane": b.pane, "model": b.model, "view": b.view, "session": b.session }),
+    );
+    Ok(Json(json!({ "ok": true })))
+}
+
+// ---------------- Explore Data (read-only + scan job) ----------------
+
+async fn explore_status(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Response, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let body = crate::explore::status_snapshot()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
+    Ok(json_string_response(body))
+}
+
+/// The explore helpers already serialize to JSON strings for the GUI; send
+/// them through as `application/json` without a re-parse round trip.
+fn json_string_response(body: String) -> Response {
+    let mut response = Response::new(Body::from(body));
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    response
+}
+
+#[derive(serde::Deserialize)]
+struct ExploreQueryBody {
+    sql: String,
+}
+
+async fn explore_query(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<ExploreQueryBody>,
+) -> Result<Response, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    // Guarded proxy: same allowlist + resource caps as the GUI invoke.
+    let body = crate::explore::run_clickhouse_query(b.sql)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    // JSONEachRow: newline-delimited JSON objects.
+    let mut response = Response::new(Body::from(body));
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson; charset=utf-8"),
+    );
+    Ok(response)
+}
+
+#[derive(serde::Deserialize)]
+struct ExploreSqliteBody {
+    db: String,
+    sql: String,
+    #[serde(default)]
+    params: Vec<String>,
+}
+
+async fn explore_sqlite(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Json(b): Json<ExploreSqliteBody>,
+) -> Result<Response, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let body = crate::explore::query_sqlite(b.db, b.sql, b.params)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    Ok(json_string_response(body))
+}
+
+async fn explore_read_json(
+    ctx: &Ctx,
+    h: &HeaderMap,
+    kind: &str,
+    name: String,
+) -> Result<Response, (StatusCode, String)> {
+    auth(ctx, h)?;
+    let body = crate::explore::read_artifact_json(kind.to_string(), name)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("{kind} artifact not found")))?;
+    Ok(json_string_response(body))
+}
+
+async fn explore_benchmark(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Path(name): Path<String>,
+) -> Result<Response, (StatusCode, String)> {
+    explore_read_json(&ctx, &h, "benchmark", name).await
+}
+
+async fn explore_eval(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    Path(name): Path<String>,
+) -> Result<Response, (StatusCode, String)> {
+    explore_read_json(&ctx, &h, "eval", name).await
+}
+
+#[derive(serde::Deserialize, Default)]
+struct ExploreScanBody {
+    limit: Option<u32>,
+}
+
+async fn explore_scan_start(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+    body: Option<Json<ExploreScanBody>>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let limit = body.map(|Json(b)| b.limit).unwrap_or(None);
+    let job = ctx.app.state::<crate::explore::ScanJob>();
+    let residency = ctx.app.state::<crate::residency::Residency>();
+    // Spawning the pipeline is quick (no waiting), but it does fork a child
+    // process — keep it off the axum workers like the other process work.
+    let status =
+        crate::explore::scan_start(&job, &residency, limit).map_err(|e| {
+            if e.contains("already running") {
+                (StatusCode::CONFLICT, e)
+            } else {
+                (StatusCode::BAD_REQUEST, e)
+            }
+        })?;
+    Ok(Json(json!({ "ok": true, "status": status })))
+}
+
+async fn explore_scan_status(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Response, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let job = ctx.app.state::<crate::explore::ScanJob>();
+    let body = crate::explore::scan_status(&job)
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
+    Ok(json_string_response(body))
+}
+
+async fn explore_scan_cancel(
+    State(ctx): State<Ctx>,
+    h: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    auth(&ctx, &h)?;
+    let job = ctx.app.state::<crate::explore::ScanJob>();
+    crate::explore::scan_cancel(&job).map_err(|e| (StatusCode::BAD_REQUEST, e))?;
     Ok(Json(json!({ "ok": true })))
 }
 
@@ -1492,12 +1656,36 @@ fn tools() -> Vec<Value> {
         ),
         (
             "ui_focus",
-            "Drive the GUI to a pane.",
+            "Drive the GUI to a pane. For the explore pane, optional view (timeline|tasks) and session (session id) deep-link to a list view or one transcript.",
             obj_schema(
                 json!({
                     "pane": { "type": "string" },
-                    "model": { "type": "string" }
+                    "model": { "type": "string" },
+                    "view": { "type": "string", "enum": ["timeline", "tasks"], "description": "Explore list view to land on." },
+                    "session": { "type": "string", "description": "Moraine session id to open in the explore transcript view." }
                 }),
+                &[],
+            ),
+        ),
+        // ----- Explore Data (local agent-trace warehouse) -----
+        (
+            "explore_status",
+            "Availability of the user's local agent-trace warehouse (Moraine ClickHouse + explore artifacts): services up, data dir, which side tables exist.",
+            empty_schema(),
+        ),
+        (
+            "explore_query",
+            "Query the user's local agent-trace warehouse (Moraine ClickHouse, read-only). SELECT/SHOW/DESCRIBE/WITH only; returns JSONEachRow text.",
+            obj_schema(
+                json!({ "sql": { "type": "string", "description": "Read-only SQL against the moraine database." } }),
+                &["sql"],
+            ),
+        ),
+        (
+            "explore_scan_start",
+            "Start the explore scan pipeline (scan, cluster, languages, commits) against the resident local model. Fails if already running or no local model is serving; poll with explore_status / GET /api/explore/scan.",
+            obj_schema(
+                json!({ "limit": { "type": "integer", "minimum": 1, "description": "Optional cap on sessions to scan." } }),
                 &[],
             ),
         ),
@@ -1753,9 +1941,30 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
         "ui_focus" => {
             let _ = app.emit(
                 "server-focus",
-                json!({ "pane": args.get("pane"), "model": args.get("model") }),
+                json!({
+                    "pane": args.get("pane"),
+                    "model": args.get("model"),
+                    "view": args.get("view"),
+                    "session": args.get("session"),
+                }),
             );
             json!({ "ok": true })
+        }
+        "explore_status" => {
+            let body = crate::explore::status_snapshot().await?;
+            serde_json::from_str(&body).map_err(|e| format!("explore status: {e}"))?
+        }
+        "explore_query" => {
+            let sql = required_str(args, "sql")?;
+            let rows = crate::explore::run_clickhouse_query(sql).await?;
+            json!({ "format": "JSONEachRow", "rows": rows })
+        }
+        "explore_scan_start" => {
+            let limit = args.get("limit").and_then(|v| v.as_u64()).map(|x| x as u32);
+            let job = app.state::<crate::explore::ScanJob>();
+            let residency = app.state::<crate::residency::Residency>();
+            let status = crate::explore::scan_start(&job, &residency, limit)?;
+            json!({ "ok": true, "status": status })
         }
         other => return Err(format!("unknown tool: {other}")),
     })

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@earendil-works/pi-ai": "0.80.6",
     "@earendil-works/pi-coding-agent": "0.80.6",
     "@inquirer/prompts": "^8.4.3",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "ai": "6.0.224",
     "commander": "^14.0.3",
     "kleur": "^4.1.5",
@@ -67,7 +68,6 @@
   "devDependencies": {
     "@types/json-schema": "7.0.15",
     "@types/node": "^24.3.0",
-    "@modelcontextprotocol/sdk": "1.29.0",
     "undici-types": "7.16.0",
     "typescript": "^5.7.3"
   },

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -23,7 +23,7 @@ import { Command } from "commander";
 const DEFAULT_LLM_URL = "http://127.0.0.1:8877/v1/chat/completions";
 const LLM_MODEL = "default_model";
 
-function exploreDir(): string {
+export function exploreDir(): string {
   const dir = process.env.UNDERSTUDY_EXPLORE_DIR ?? join(homedir(), ".understudy", "explore");
   mkdirSync(dir, { recursive: true });
   return dir;
@@ -31,11 +31,11 @@ function exploreDir(): string {
 
 // --- ClickHouse (read-only, per-query resource caps as URL params) -------------
 
-function clickhouseUrl(): string {
+export function clickhouseUrl(): string {
   return process.env.MORAINE_CLICKHOUSE_URL ?? "http://127.0.0.1:8123";
 }
 
-async function ch<T>(sql: string): Promise<T[]> {
+export async function ch<T>(sql: string): Promise<T[]> {
   const params =
     "database=moraine&default_format=JSONEachRow" +
     "&max_memory_usage=2000000000&max_threads=4&max_execution_time=30";
@@ -782,7 +782,7 @@ async function runLanguages(): Promise<void> {
 // status — store counts + ClickHouse reachability
 // =================================================================================
 
-function countIn(dbFile: string, sql: string): number | null {
+export function countIn(dbFile: string, sql: string): number | null {
   const path = join(exploreDir(), dbFile);
   if (!existsSync(path)) return null;
   try {
@@ -858,6 +858,29 @@ export function registerExploreCommand(program: Command): void {
     .description("Derive per-session language and tooling stats from file/shell tool events. Writes langs.sqlite.")
     .action(async () => {
       await runLanguages();
+    });
+
+  explore
+    .command("mcp")
+    .description(
+      "Run a stdio MCP server over the local Moraine ClickHouse + explore scan stores " +
+        "(drop-in for Moraine's MCP tool names, enriched with scan labels/clusters).",
+    )
+    .action(async () => {
+      const { runExploreMcpServer } = await import("../explore-mcp.js");
+      await runExploreMcpServer();
+    });
+
+  explore
+    .command("mcp-install")
+    .description(
+      "Register `understudy explore mcp` as the `understudy` MCP server in agent configs, " +
+        "replacing the `moraine` entry (Claude Code: ~/.claude.json). Backs up configs first.",
+    )
+    .option("--dry-run", "Print planned changes without writing.", false)
+    .action(async (opts: { dryRun: boolean }) => {
+      const { runExploreMcpInstall } = await import("../explore-mcp.js");
+      await runExploreMcpInstall({ dryRun: Boolean(opts.dryRun) });
     });
 
   explore

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -1,0 +1,869 @@
+// `understudy explore` — port of the Moraine viewer scan pipeline
+// (apps/moraine-viewer/scripts/{scan,cluster,commits,languages}.ts).
+//
+// Reads Moraine ClickHouse (read-only, capped per query) and writes
+// Understudy-owned SQLite stores under ~/.understudy/explore/
+// (override with UNDERSTUDY_EXPLORE_DIR):
+//   scan.sqlite    — session_scan, clusters, cluster_map
+//   commits.sqlite — commits, commit_sessions, commit_sessions_related
+//   langs.sqlite   — session_langs, session_tools
+//
+// The scan/cluster labeling model is any OpenAI-compatible chat-completions
+// endpoint — including the desktop app's resident model server — selected
+// with --llm-url (default http://127.0.0.1:8877/v1/chat/completions,
+// model name "default_model").
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Command } from "commander";
+
+const DEFAULT_LLM_URL = "http://127.0.0.1:8877/v1/chat/completions";
+const LLM_MODEL = "default_model";
+
+function exploreDir(): string {
+  const dir = process.env.UNDERSTUDY_EXPLORE_DIR ?? join(homedir(), ".understudy", "explore");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// --- ClickHouse (read-only, per-query resource caps as URL params) -------------
+
+function clickhouseUrl(): string {
+  return process.env.MORAINE_CLICKHOUSE_URL ?? "http://127.0.0.1:8123";
+}
+
+async function ch<T>(sql: string): Promise<T[]> {
+  const params =
+    "database=moraine&default_format=JSONEachRow" +
+    "&max_memory_usage=2000000000&max_threads=4&max_execution_time=30";
+  const res = await fetch(`${clickhouseUrl()}/?${params}`, {
+    method: "POST",
+    body: `${sql} FORMAT JSONEachRow`,
+  });
+  if (!res.ok) throw new Error(`clickhouse ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const text = await res.text();
+  return text.trim() ? text.trim().split("\n").map((l) => JSON.parse(l) as T) : [];
+}
+
+// --- LLM ------------------------------------------------------------------------
+
+async function llmJson(
+  llmUrl: string,
+  system: string,
+  user: string,
+  opts: { temperature: number; maxTokens: number },
+): Promise<string> {
+  const res = await fetch(llmUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: LLM_MODEL,
+      temperature: opts.temperature,
+      max_tokens: opts.maxTokens, // generous: reasoning eats the budget before the answer
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`llm ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const j = (await res.json()) as { choices?: { message?: { content?: string } }[] };
+  return j.choices?.[0]?.message?.content ?? "";
+}
+
+function extractJson(raw: string): string {
+  const m = raw.match(/\{[\s\S]*\}/);
+  if (!m) throw new Error(`no JSON in: ${raw.slice(0, 160)}`);
+  return m[0];
+}
+
+// =================================================================================
+// scan — label + summarize sessions
+// =================================================================================
+
+interface Sess {
+  session_id: string;
+  harness: string;
+  total_events: number;
+  origin_cwd: string;
+  mode: string;
+  user_messages: number;
+}
+
+function openScanDb(): DatabaseSync {
+  const db = new DatabaseSync(join(exploreDir(), "scan.sqlite"));
+  db.exec(`CREATE TABLE IF NOT EXISTS session_scan (
+    session_id TEXT PRIMARY KEY,
+    harness TEXT, events INTEGER,
+    label TEXT, summary TEXT,
+    digest TEXT, model TEXT, scanned_at TEXT DEFAULT (datetime('now'))
+  )`);
+  for (const col of ["interactive INTEGER DEFAULT 1", "user_messages INTEGER DEFAULT 0", "sub_events INTEGER DEFAULT 0"]) {
+    try { db.exec(`ALTER TABLE session_scan ADD COLUMN ${col}`); } catch { /* exists */ }
+  }
+  return db;
+}
+
+async function runScan(opts: { limit: number; concurrency: number; llmUrl: string }): Promise<void> {
+  const db = openScanDb();
+  const done = new Set(
+    (db.prepare("SELECT session_id FROM session_scan").all() as { session_id: string }[]).map((r) => r.session_id),
+  );
+
+  // commits shipped by a session are a strong signal of what the task actually was
+  const commitsBySession = new Map<string, string[]>();
+  try {
+    const cdb = new DatabaseSync(join(exploreDir(), "commits.sqlite"), { readOnly: true });
+    for (const r of cdb
+      .prepare("SELECT cs.session_id sid, c.subject subj FROM commit_sessions cs JOIN commits c ON c.hash = cs.hash")
+      .all() as { sid: string; subj: string }[]) {
+      if (!commitsBySession.has(r.sid)) commitsBySession.set(r.sid, []);
+      commitsBySession.get(r.sid)!.push(r.subj);
+    }
+    cdb.close();
+  } catch { /* commits.sqlite absent — digest just omits the line */ }
+
+  const sessions = (
+    await ch<Sess>(`
+      SELECT session_id, harness, toUInt32(total_events) AS total_events, origin_cwd, mode,
+        toUInt32(user_messages) AS user_messages
+      FROM mcp_open_sessions FINAL
+      WHERE total_events >= 5 AND first_event_time > toDateTime64('2001-01-01 00:00:00', 3)
+        AND mode != 'mcp_internal'
+        -- interactive work only: a human sent multiple messages, and it isn't a
+        -- giant machine-generated rollout stream
+        AND user_messages >= 1
+        AND total_events <= 3000
+      ORDER BY last_event_time DESC
+      LIMIT ${opts.limit}
+    `)
+  ).filter((s) => !done.has(s.session_id));
+
+  console.log(`${sessions.length} sessions to scan (${done.size} already done)`);
+
+  async function digestOf(s: Sess): Promise<string> {
+    const rows = await ch<{ event_type: string; name: string; t: string }>(`
+      SELECT event_type, name,
+        substring(multiIf(
+          length(text_content) > 0, text_content,
+          JSONExtractString(payload_json, 'text') != '', JSONExtractString(payload_json, 'text'),
+          JSON_VALUE(payload_json, '$.content[0].text') != '', JSON_VALUE(payload_json, '$.content[0].text'),
+          JSONExtractString(payload_json, 'input')
+        ), 1, 500) AS t
+      FROM mcp_open_events
+      WHERE session_id = '${s.session_id}' AND event_type IN ('user_input', 'assistant_response', 'tool_call')
+        -- subagent chatter skews labels toward what the subagents were told; main stream only
+        AND event_uid IN (
+          SELECT event_uid FROM events WHERE session_id = '${s.session_id}' AND is_substream = 0
+        )
+      ORDER BY event_order ASC, slot DESC, generation DESC
+      LIMIT 1 BY event_order
+      LIMIT 300
+    `);
+    const clean = (t: string) => t.replace(/\s+/g, " ").trim();
+    // all user inputs (capped), assistant messages sampled across the whole arc
+    const users = rows.filter((r) => r.event_type === "user_input" && r.t.trim()).slice(0, 8);
+    const assistants = rows.filter((r) => r.event_type === "assistant_response" && r.t.trim());
+    const pick = new Set<number>([0, Math.floor(assistants.length / 2), assistants.length - 1]);
+    const sampledAssistants = [...pick].filter((i) => i >= 0 && i < assistants.length).sort((a, b) => a - b);
+    const toolCounts = new Map<string, number>();
+    for (const r of rows) if (r.event_type === "tool_call" && r.name) toolCounts.set(r.name, (toolCounts.get(r.name) ?? 0) + 1);
+    const tools = [...toolCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8)
+      .map(([n, c]) => `${n}×${c}`).join(", ");
+    const proj = s.origin_cwd.split("/").filter(Boolean).slice(-2).join("/");
+    const commits = commitsBySession.get(s.session_id) ?? [];
+    return [
+      `harness: ${s.harness} · mode: ${s.mode} · events: ${s.total_events} · project: ${proj || "?"}`,
+      tools ? `tools: ${tools}` : "",
+      commits.length
+        ? `commits shipped (${commits.length}): ${commits.slice(0, 3).map((c) => c.slice(0, 80)).join(" | ")}`
+        : "",
+      ...users.map((u, i) => `user[${i}]: ${clean(u.t)}`),
+      ...sampledAssistants.map((i) => {
+        const pos = i === 0 ? "first" : i === assistants.length - 1 ? "last" : "mid";
+        return `assistant[${pos}]: ${clean(assistants[i].t).slice(0, 350)}`;
+      }),
+    ].filter(Boolean).join("\n");
+  }
+
+  async function labelOf(digest: string): Promise<{ label: string; summary: string }> {
+    const raw = await llmJson(
+      opts.llmUrl,
+      "You label coding-agent sessions by their PURPOSE — what the user was trying to accomplish, " +
+        "not how the session started. Agents always begin by reading/exploring the repo; that is never " +
+        "the task itself, so labels like \"repo exploration\" are wrong unless understanding the code was " +
+        "the user's entire goal. The last assistant message usually reveals the outcome — weight it heavily. " +
+        "Respond with ONLY a JSON object: " +
+        '{"label": "<2-4 word task type, lowercase, reusable across similar sessions (e.g. \\"fix failing tests\\", \\"data pipeline work\\", \\"ui prototyping\\", \\"model evaluation\\", \\"release management\\")>", "summary": "<1-2 sentence summary: what was accomplished and how it ended>"}',
+      digest,
+      { temperature: 0.2, maxTokens: 2000 },
+    );
+    const parsed = JSON.parse(extractJson(raw)) as { label?: string; summary?: string };
+    return {
+      label: (parsed.label ?? "unlabeled").toLowerCase().trim().slice(0, 60),
+      summary: (parsed.summary ?? "").trim().slice(0, 500),
+    };
+  }
+
+  const insert = db.prepare(
+    "INSERT OR REPLACE INTO session_scan (session_id, harness, events, label, summary, digest, model, interactive, user_messages, sub_events) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+  );
+
+  // slash-command invocations (/usage, /doctor, …) are CLI plumbing, not tasks —
+  // label them deterministically, skip the model, and mark non-interactive
+  function slashCommandOf(digest: string): string | null {
+    const userLines = digest.split("\n").filter((l) => /^user\[\d+\]:/.test(l));
+    if (!userLines.length) return null;
+    const meaningful = userLines.filter((l) => !l.includes("<local-command-caveat>"));
+    if (!meaningful.length || !meaningful.every((l) => l.includes("<command-name>"))) return null;
+    return meaningful[0].match(/<command-name>([^<]+)<\/command-name>/)?.[1]?.trim() ?? "/unknown";
+  }
+
+  async function subEventsOf(sessionId: string): Promise<number> {
+    const r = await ch<{ n: string }>(
+      `SELECT toString(countIf(is_substream = 1)) AS n FROM events WHERE session_id = '${sessionId}'`,
+    );
+    return Number(r[0]?.n ?? 0);
+  }
+
+  let ok = 0, failed = 0;
+  const t0 = Date.now();
+  const queue = [...sessions];
+  await Promise.all(
+    Array.from({ length: opts.concurrency }, async () => {
+      for (let s = queue.shift(); s; s = queue.shift()) {
+        try {
+          const [digest, subEvents] = await Promise.all([digestOf(s), subEventsOf(s.session_id)]);
+          const cmd = slashCommandOf(digest);
+          if (cmd) {
+            insert.run(s.session_id, s.harness, s.total_events, "cli command", `Slash-command invocation: ${cmd}`, digest, "deterministic", 0, s.user_messages, subEvents);
+            ok++;
+            continue;
+          }
+          const { label, summary } = await labelOf(digest);
+          insert.run(s.session_id, s.harness, s.total_events, label, summary, digest, LLM_MODEL, 1, s.user_messages, subEvents);
+          ok++;
+          if (ok % 20 === 0) {
+            const rate = ok / ((Date.now() - t0) / 1000);
+            console.log(`${ok}/${sessions.length} ok (${failed} failed) — ${rate.toFixed(2)}/s, eta ${Math.round((sessions.length - ok - failed) / rate / 60)}m`);
+          }
+        } catch (e) {
+          failed++;
+          console.error(`fail ${s.session_id.slice(0, 8)}: ${String(e).slice(0, 150)}`);
+        }
+      }
+    }),
+  );
+  console.log(`done: ${ok} ok, ${failed} failed in ${Math.round((Date.now() - t0) / 1000)}s`);
+  const top = db.prepare("SELECT label, COUNT(*) c FROM session_scan GROUP BY label ORDER BY c DESC LIMIT 15").all();
+  console.log("top labels:", JSON.stringify(top));
+  db.close();
+}
+
+// =================================================================================
+// cluster — consolidate free-form labels into canonical clusters
+// =================================================================================
+
+async function runCluster(opts: { llmUrl: string }): Promise<void> {
+  const db = openScanDb();
+  db.exec(`CREATE TABLE IF NOT EXISTS clusters (id INTEGER PRIMARY KEY, name TEXT UNIQUE)`);
+  db.exec(`CREATE TABLE IF NOT EXISTS cluster_map (label TEXT PRIMARY KEY, cluster_id INTEGER)`);
+
+  // deterministic plumbing labels get their own pinned cluster — never blended
+  // into real work clusters
+  const PINNED = ["cli command"];
+  const labels = (db
+    .prepare("SELECT label, COUNT(*) c FROM session_scan GROUP BY label ORDER BY c DESC")
+    .all() as { label: string; c: number }[]).filter((l) => !PINNED.includes(l.label));
+  if (!labels.length) {
+    console.log("no labels yet — run `understudy explore scan` first");
+    db.close();
+    return;
+  }
+  console.log(`${labels.length} distinct labels over ${labels.reduce((a, l) => a + l.c, 0)} sessions`);
+
+  // only repeated labels go to the model — 300+ singletons blow the token budget;
+  // singletons are assigned afterwards (batched LLM, then stemmed word overlap)
+  const repeated = labels.filter((l) => l.c >= 2);
+  const singletons = labels.filter((l) => l.c < 2);
+  console.log(`${repeated.length} repeated labels to the model, ${singletons.length} singletons assigned locally`);
+  const histogram = repeated.map((l) => `${l.label} (${l.c})`).join("\n");
+  const raw = await llmJson(
+    opts.llmUrl,
+    "You consolidate task labels from coding-agent sessions into canonical clusters. " +
+      "Given a label histogram, group ALL labels into 6-10 clusters of similar work. " +
+      'Respond with ONLY JSON: {"clusters": [{"name": "<2-3 word cluster name>", "labels": ["<every input label assigned here>"]}]}. ' +
+      "Every input label must appear in exactly one cluster.",
+    histogram,
+    { temperature: 0.2, maxTokens: 12000 }, // reasoning eats most of this before the JSON appears
+  );
+  const parsed = JSON.parse(extractJson(raw)) as { clusters: { name: string; labels: string[] }[] };
+
+  db.exec("DELETE FROM clusters");
+  db.exec("DELETE FROM cluster_map");
+  const insCluster = db.prepare("INSERT INTO clusters (id, name) VALUES (?, ?)");
+  const insMap = db.prepare("INSERT OR REPLACE INTO cluster_map (label, cluster_id) VALUES (?, ?)");
+  const assigned = new Set<string>();
+  parsed.clusters.forEach((c, i) => {
+    insCluster.run(i, c.name.toLowerCase().trim().slice(0, 40));
+    for (const l of c.labels) {
+      insMap.run(l.toLowerCase().trim(), i);
+      assigned.add(l.toLowerCase().trim());
+    }
+  });
+
+  // singletons + anything the model forgot: batched LLM assignment against the
+  // canonical cluster list; stemmed word overlap as fallback; last resort "other"
+  const STOP = new Set(["and", "the", "of", "for", "a", "an", "in", "on", "with", "to", "&"]);
+  const stem = (w: string) => w.replace(/(ing|ment|tion|s)$/, "");
+  const words = (s: string) =>
+    s.toLowerCase().split(/[^a-z]+/).filter((w) => w.length > 2 && !STOP.has(w)).map(stem);
+  const clusterNames = parsed.clusters.map((c) => c.name.toLowerCase().trim().slice(0, 40));
+  const clusterVocab = parsed.clusters.map((c) => {
+    const v = new Set<string>(words(c.name));
+    for (const l of c.labels) for (const w of words(l)) v.add(w);
+    return v;
+  });
+
+  async function assignBatch(batch: string[]): Promise<Map<string, number>> {
+    const out = new Map<string, number>();
+    let content: string;
+    try {
+      content = await llmJson(
+        opts.llmUrl,
+        `Assign each task label to the best-fitting cluster. Clusters (use the index): ` +
+          clusterNames.map((n, i) => `${i}=${n}`).join(", ") +
+          `. Respond ONLY with JSON: {"assignments": {"<label>": <cluster index>, ...}} covering every label.`,
+        batch.join("\n"),
+        { temperature: 0.1, maxTokens: 8000 },
+      );
+    } catch {
+      return out;
+    }
+    const mm = content.match(/\{[\s\S]*\}/);
+    if (!mm) return out;
+    try {
+      const a = (JSON.parse(mm[0]) as { assignments?: Record<string, number> }).assignments ?? {};
+      for (const [label, idx] of Object.entries(a)) {
+        if (Number.isInteger(idx) && idx >= 0 && idx < clusterNames.length) out.set(label.toLowerCase().trim(), idx);
+      }
+    } catch { /* fall through to overlap */ }
+    return out;
+  }
+
+  const otherId = parsed.clusters.length;
+  const missed = labels.filter((l) => !assigned.has(l.label));
+  let llmAssigned = 0, overlapAssigned = 0, toOther = 0;
+  const BATCH = 40;
+  for (let i = 0; i < missed.length; i += BATCH) {
+    const batch = missed.slice(i, i + BATCH);
+    const byLlm = await assignBatch(batch.map((l) => l.label));
+    for (const l of batch) {
+      const idx = byLlm.get(l.label);
+      if (idx !== undefined) { insMap.run(l.label, idx); llmAssigned++; continue; }
+      let best = -1, bestScore = 0;
+      clusterVocab.forEach((v, ci) => {
+        const score = words(l.label).filter((w) => v.has(w)).length;
+        if (score > bestScore) { bestScore = score; best = ci; }
+      });
+      if (best >= 0) { insMap.run(l.label, best); overlapAssigned++; }
+      else { insMap.run(l.label, otherId); toOther++; }
+    }
+    console.log(`assigned ${Math.min(i + BATCH, missed.length)}/${missed.length} stragglers`);
+  }
+  if (toOther) insCluster.run(otherId, "other");
+  console.log(`${llmAssigned} by LLM, ${overlapAssigned} by stemmed overlap, ${toOther} → "other"`);
+
+  // pinned plumbing cluster, after everything else
+  const pinnedId = otherId + 1;
+  insCluster.run(pinnedId, "cli plumbing");
+  for (const l of PINNED) insMap.run(l, pinnedId);
+
+  const report = db
+    .prepare(`
+      SELECT c.name, COUNT(s.session_id) sessions
+      FROM session_scan s
+      JOIN cluster_map m ON m.label = s.label
+      JOIN clusters c ON c.id = m.cluster_id
+      GROUP BY c.id ORDER BY sessions DESC
+    `)
+    .all();
+  console.log("clusters:", JSON.stringify(report, null, 1));
+  db.close();
+}
+
+// =================================================================================
+// commits — git-log harvest + session attribution
+// =================================================================================
+
+function git(dir: string, args: string[]): string | null {
+  try {
+    const p = spawnSync("git", ["-C", dir, ...args], { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+    if (p.status !== 0) return null;
+    return (p.stdout ?? "").trim();
+  } catch {
+    return null;
+  }
+}
+
+async function runCommits(): Promise<void> {
+  const MAX_REPOS = 100;
+
+  // --- 1. discover candidate dirs from ClickHouse -----------------------------
+  const dirs = new Set<string>();
+  for (const q of [
+    `SELECT DISTINCT worktree_root AS d FROM events WHERE worktree_root != '' AND event_ts > '2026-01-01'`,
+    `SELECT DISTINCT cwd AS d FROM events WHERE cwd != '' AND event_ts > '2026-01-01'`,
+  ]) {
+    try {
+      for (const r of await ch<{ d: string }>(q)) dirs.add(r.d);
+    } catch (e) {
+      console.error(`discovery query failed: ${String(e).slice(0, 200)}`);
+    }
+  }
+  console.log(`${dirs.size} candidate dirs from clickhouse`);
+
+  // normalize to git toplevels, dedupe, skip missing dirs
+  const repos = new Set<string>();
+  for (const d of dirs) {
+    if (repos.size >= MAX_REPOS) break;
+    if (!existsSync(d)) continue;
+    const top = git(d, ["rev-parse", "--show-toplevel"]);
+    if (top) repos.add(top);
+  }
+  console.log(`${repos.size} git repos (cap ${MAX_REPOS})`);
+
+  // --- 2. harvest commits -----------------------------------------------------
+  const db = new DatabaseSync(join(exploreDir(), "commits.sqlite"));
+  db.exec(`CREATE TABLE IF NOT EXISTS commits (
+    hash TEXT PRIMARY KEY,
+    repo TEXT,
+    ts INTEGER,
+    author_email TEXT,
+    subject TEXT
+  )`);
+  db.exec(`CREATE TABLE IF NOT EXISTS commit_sessions (
+    hash TEXT,
+    session_id TEXT,
+    PRIMARY KEY (hash, session_id)
+  )`);
+
+  // the user's identities: git config user.email across repos + fuzzy name match
+  const myEmails = new Set<string>();
+  const myNames = new Set<string>();
+  for (const repo of repos) {
+    const email = git(repo, ["config", "user.email"]);
+    if (email) myEmails.add(email.toLowerCase());
+    const name = git(repo, ["config", "user.name"]);
+    if (name) for (const part of name.toLowerCase().split(/\s+/)) if (part.length > 2) myNames.add(part);
+  }
+  console.log(`identities: ${[...myEmails].join(", ") || "(none)"}`);
+
+  type Commit = { hash: string; repo: string; ts: number; email: string; name: string; subject: string };
+  const all: Commit[] = [];
+  let reposScanned = 0;
+  for (const repo of repos) {
+    const out = git(repo, [
+      "log", "--all", "--no-merges", "--since=2026-01-01",
+      "--pretty=format:%H%x09%ct%x09%ae%x09%an%x09%s",
+    ]);
+    if (out === null) continue;
+    reposScanned++;
+    for (const line of out.split("\n")) {
+      if (!line.trim()) continue;
+      const [hash, ct, ae, an, ...rest] = line.split("\t");
+      if (!hash || !ct) continue;
+      all.push({ hash, repo, ts: Number(ct), email: (ae ?? "").toLowerCase(), name: an ?? "", subject: rest.join("\t") ?? "" });
+    }
+  }
+
+  // keep commits by the user (config emails ∪ fuzzy: author name shares a
+  // word with any configured user.name)
+  const mine = all.filter(
+    (c) => myEmails.has(c.email) || c.name.toLowerCase().split(/\s+/).some((w) => myNames.has(w)),
+  );
+  const insert = db.prepare(
+    "INSERT OR IGNORE INTO commits (hash, repo, ts, author_email, subject) VALUES (?, ?, ?, ?, ?)",
+  );
+  db.exec("BEGIN");
+  for (const c of mine) insert.run(c.hash, c.repo, c.ts, c.email, c.subject);
+  db.exec("COMMIT");
+
+  // --- 3. map commits → sessions -----------------------------------------------
+  // alias names differ from column names (ClickHouse alias-shadowing bug)
+  type ChSess = { sid: string; ocwd: string; start_s: string; end_s: string };
+  const sessions = await ch<ChSess>(`
+    SELECT session_id AS sid, origin_cwd AS ocwd,
+           toString(toUnixTimestamp(first_event_time)) AS start_s,
+           toString(toUnixTimestamp(last_event_time)) AS end_s
+    FROM mcp_open_sessions FINAL
+    WHERE first_event_time > '2001-01-01' AND origin_cwd != ''
+  `);
+  console.log(`${sessions.length} sessions from clickhouse`);
+
+  // each commit attributes to its single BEST session — most specific path match
+  // wins (exact cwd beats repo prefix), then smallest time distance to session
+  // end; all other window matches are kept as secondary "related" edges
+  db.exec(`CREATE TABLE IF NOT EXISTS commit_sessions_related (
+    hash TEXT, session_id TEXT, PRIMARY KEY (hash, session_id)
+  )`);
+  db.exec("DELETE FROM commit_sessions");
+  db.exec("DELETE FROM commit_sessions_related");
+  const insertMap = db.prepare("INSERT OR IGNORE INTO commit_sessions (hash, session_id) VALUES (?, ?)");
+  const insertRelated = db.prepare("INSERT OR IGNORE INTO commit_sessions_related (hash, session_id) VALUES (?, ?)");
+  const prefixed = (a: string, b: string) =>
+    a === b || b.startsWith(a.endsWith("/") ? a : a + "/") || a.startsWith(b.endsWith("/") ? b : b + "/");
+
+  // the same hash can be harvested from several worktrees — attribute it once,
+  // but let every worktree path it was seen in compete for the match
+  const reposByHash = new Map<string, Set<string>>();
+  for (const c of mine) {
+    if (!reposByHash.has(c.hash)) reposByHash.set(c.hash, new Set());
+    reposByHash.get(c.hash)!.add(c.repo);
+  }
+  const uniqMine = [...new Map(mine.map((c) => [c.hash, c])).values()];
+  db.exec("BEGIN");
+  for (const c of uniqMine) {
+    let best: ChSess | null = null;
+    let bestSpec = -1;
+    let bestDt = Infinity;
+    const related: ChSess[] = [];
+    const commitRepos = reposByHash.get(c.hash) ?? new Set([c.repo]);
+    for (const s of sessions) {
+      const start = Number(s.start_s);
+      const end = Number(s.end_s);
+      let spec = -1;
+      for (const repo of commitRepos) {
+        if (!prefixed(repo, s.ocwd)) continue;
+        // specificity: exact worktree match beats repo-prefix containment
+        const candidate = s.ocwd === repo ? 1e9 : Math.min(s.ocwd.length, repo.length);
+        if (candidate > spec) spec = candidate;
+      }
+      if (spec < 0) continue;
+      if (c.ts < start - 300 || c.ts > end + 1800) continue;
+      related.push(s);
+      const dt = Math.abs(c.ts - end);
+      if (spec > bestSpec || (spec === bestSpec && dt < bestDt)) {
+        best = s; bestSpec = spec; bestDt = dt;
+      }
+    }
+    if (best) {
+      insertMap.run(c.hash, best.sid);
+      for (const s of related) if (s.sid !== best.sid) insertRelated.run(c.hash, s.sid);
+    }
+  }
+  db.exec("COMMIT");
+
+  const total = (db.prepare("SELECT COUNT(*) c FROM commits").get() as { c: number }).c;
+  const mappedTotal = (db.prepare("SELECT COUNT(DISTINCT hash) c FROM commit_sessions").get() as { c: number }).c;
+  console.log(`repos scanned: ${reposScanned}`);
+  console.log(`commits found (mine, this run): ${mine.length} of ${all.length} total; db now ${total}`);
+  console.log(`mapped to sessions: ${mappedTotal}/${total} (${total ? ((100 * mappedTotal) / total).toFixed(1) : 0}%)`);
+  db.close();
+}
+
+// =================================================================================
+// languages — per-session language + tooling stats
+// =================================================================================
+
+const EXT_LANG: Record<string, string> = {
+  ts: "TypeScript", tsx: "TypeScript", mts: "TypeScript", cts: "TypeScript",
+  js: "JavaScript", jsx: "JavaScript", mjs: "JavaScript", cjs: "JavaScript",
+  py: "Python", pyi: "Python",
+  rs: "Rust",
+  go: "Go",
+  md: "Markdown", mdx: "Markdown",
+  json: "Config", jsonl: "Config", yaml: "Config", yml: "Config", toml: "Config", ini: "Config", env: "Config",
+  css: "CSS", scss: "CSS", sass: "CSS", less: "CSS",
+  html: "HTML", htm: "HTML",
+  sql: "SQL",
+  sh: "Shell", zsh: "Shell", bash: "Shell", fish: "Shell",
+  swift: "Swift",
+  c: "C/C++", cpp: "C/C++", cc: "C/C++", cxx: "C/C++", h: "C/C++", hpp: "C/C++", m: "C/C++", mm: "C/C++",
+  java: "Java", kt: "Kotlin",
+  rb: "Ruby",
+  php: "PHP",
+  lua: "Lua",
+  r: "R",
+  glsl: "GLSL", vert: "GLSL", frag: "GLSL", wgsl: "GLSL", metal: "GLSL",
+  proto: "Protobuf",
+  tf: "Terraform",
+  vue: "Vue", svelte: "Svelte",
+  ipynb: "Notebook",
+};
+
+function langOf(p: string): string | null {
+  const base = p.split("/").pop() ?? p;
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const ext = base.slice(dot + 1).toLowerCase();
+  return EXT_LANG[ext] ?? null;
+}
+
+const KNOWN_TOOLS = new Set([
+  "uv", "pip", "pip3", "python", "python3", "cargo", "rustc", "bun", "bunx",
+  "npm", "npx", "pnpm", "node", "pytest", "jest", "vitest", "go", "docker",
+  "kubectl", "git", "gh", "make", "brew", "sqlite3", "clickhouse",
+  "clickhouse-client", "curl",
+]);
+const TOOL_ALIAS: Record<string, string> = {
+  pip3: "pip", python3: "python", bunx: "bun", npx: "npm", "clickhouse-client": "clickhouse",
+};
+
+// leading command word(s) per shell segment; env-var prefixes stripped
+function toolWords(cmd: string): string[] {
+  const out: string[] = [];
+  for (const seg of cmd.split(/(?:&&|\|\||[;|\n])/)) {
+    const tokens = seg.trim().split(/\s+/);
+    let i = 0;
+    while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+    let word = tokens[i];
+    if (!word) continue;
+    word = word.split("/").pop()!.toLowerCase();
+    if (word.startsWith("mlx")) {
+      out.push("mlx"); // mlx_lm.generate, mlx-vlm, mlx_lm.server, …
+      continue;
+    }
+    if (KNOWN_TOOLS.has(word)) out.push(TOOL_ALIAS[word] ?? word);
+  }
+  return out;
+}
+
+async function runLanguages(): Promise<void> {
+  const SINCE = "2026-01-01";
+  const MAX_PATHS_PER_SESSION = 200;
+  const MAX_CMDS_PER_SESSION = 500;
+
+  // --- 1. file paths per session -----------------------------------------------
+  // Payload shapes vary by harness: Claude {"input":{"file_path"}}, opencode
+  // {"state":{"input":{"filePath"}}}, codex apply_patch {"input":"*** Update File: …"}.
+  type FileRow = {
+    session_id: string;
+    tool_name: string;
+    rrp: string;
+    a: string; // input.file_path
+    b: string; // input.filePath
+    c: string; // state.input.filePath
+    d: string; // top-level file_path
+    e: string; // top-level path
+    patch: string; // apply_patch's input string (truncated)
+  };
+  const fileRows = await ch<FileRow>(`
+    SELECT session_id, tool_name, repo_rel_path AS rrp,
+           JSONExtractString(payload_json,'input','file_path') AS a,
+           JSONExtractString(payload_json,'input','filePath') AS b,
+           JSONExtractString(payload_json,'state','input','filePath') AS c,
+           JSONExtractString(payload_json,'file_path') AS d,
+           JSONExtractString(payload_json,'path') AS e,
+           substring(JSONExtractString(payload_json,'input'), 1, 4000) AS patch
+    FROM events
+    WHERE tool_name IN ('Read','Edit','Write','read','edit','write','apply_patch')
+      AND is_substream = 0 AND event_ts > '${SINCE}'
+    ORDER BY event_ts
+    LIMIT ${MAX_PATHS_PER_SESSION} BY session_id
+  `);
+  console.log(`${fileRows.length} file-tool events`);
+
+  const PATCH_FILE_RE = /^\*\*\* (?:Update|Add|Delete) File: (.+)$/gm;
+  const sessionLangs = new Map<string, Map<string, number>>();
+  let classifiedPaths = 0;
+  for (const r of fileRows) {
+    const paths: string[] = [];
+    const direct = r.a || r.b || r.c || r.d || r.e || r.rrp;
+    if (direct) paths.push(direct);
+    if (r.tool_name === "apply_patch" && r.patch.startsWith("***")) {
+      for (const m of r.patch.matchAll(PATCH_FILE_RE)) paths.push(m[1].trim());
+    }
+    for (const p of paths) {
+      const lang = langOf(p);
+      if (!lang) continue;
+      classifiedPaths++;
+      let m = sessionLangs.get(r.session_id);
+      if (!m) sessionLangs.set(r.session_id, (m = new Map()));
+      m.set(lang, (m.get(lang) ?? 0) + 1);
+    }
+  }
+
+  // --- 2. command tooling per session --------------------------------------------
+  type CmdRow = {
+    session_id: string;
+    a: string; // input.command (Claude Bash)
+    b: string; // state.input.command (opencode bash)
+    c: string; // input as string (codex exec: js source calling exec_command)
+    d: string; // arguments json-string (codex exec_command)
+  };
+  const cmdRows = await ch<CmdRow>(`
+    SELECT session_id,
+           substring(JSONExtractString(payload_json,'input','command'), 1, 120) AS a,
+           substring(JSONExtractString(payload_json,'state','input','command'), 1, 120) AS b,
+           substring(JSONExtractString(payload_json,'input'), 1, 300) AS c,
+           substring(JSONExtractString(payload_json,'arguments'), 1, 300) AS d
+    FROM events
+    WHERE tool_name IN ('Bash','bash','exec','exec_command')
+      AND is_substream = 0 AND event_ts > '${SINCE}'
+    ORDER BY event_ts
+    LIMIT ${MAX_CMDS_PER_SESSION} BY session_id
+  `);
+  console.log(`${cmdRows.length} shell-tool events`);
+
+  const CMD_IN_JS_RE = /["']?cmd["']?\s*:\s*"((?:[^"\\]|\\.)*)"/;
+  function commandOf(r: CmdRow): string | null {
+    if (r.a) return r.a;
+    if (r.b) return r.b;
+    if (r.d) {
+      try {
+        const cmd = (JSON.parse(r.d) as { cmd?: string }).cmd;
+        if (cmd) return cmd.slice(0, 120);
+      } catch {
+        const m = r.d.match(CMD_IN_JS_RE);
+        if (m) return m[1].slice(0, 120);
+      }
+    }
+    if (r.c && !r.c.startsWith("***")) {
+      const m = r.c.match(CMD_IN_JS_RE);
+      if (m) {
+        try {
+          return (JSON.parse(`"${m[1]}"`) as string).slice(0, 120);
+        } catch {
+          return m[1].slice(0, 120);
+        }
+      }
+    }
+    return null;
+  }
+
+  const sessionTools = new Map<string, Map<string, number>>();
+  let parsedCmds = 0;
+  for (const r of cmdRows) {
+    const cmd = commandOf(r);
+    if (!cmd) continue;
+    parsedCmds++;
+    for (const tool of toolWords(cmd)) {
+      let m = sessionTools.get(r.session_id);
+      if (!m) sessionTools.set(r.session_id, (m = new Map()));
+      m.set(tool, (m.get(tool) ?? 0) + 1);
+    }
+  }
+
+  // --- 3. write langs.sqlite ------------------------------------------------------
+  const db = new DatabaseSync(join(exploreDir(), "langs.sqlite"));
+  db.exec(`CREATE TABLE IF NOT EXISTS session_langs (
+    session_id TEXT, lang TEXT, files INTEGER, PRIMARY KEY (session_id, lang)
+  )`);
+  db.exec(`CREATE TABLE IF NOT EXISTS session_tools (
+    session_id TEXT, tool TEXT, uses INTEGER, PRIMARY KEY (session_id, tool)
+  )`);
+  db.exec("DELETE FROM session_langs");
+  db.exec("DELETE FROM session_tools");
+
+  const insLang = db.prepare("INSERT OR REPLACE INTO session_langs (session_id, lang, files) VALUES (?, ?, ?)");
+  const insTool = db.prepare("INSERT OR REPLACE INTO session_tools (session_id, tool, uses) VALUES (?, ?, ?)");
+  db.exec("BEGIN");
+  for (const [sid, m] of sessionLangs) for (const [lang, files] of m) insLang.run(sid, lang, files);
+  for (const [sid, m] of sessionTools) for (const [tool, uses] of m) insTool.run(sid, tool, uses);
+  db.exec("COMMIT");
+
+  const topOf = (maps: Map<string, Map<string, number>>) => {
+    const agg = new Map<string, number>();
+    for (const m of maps.values()) for (const [k, v] of m) agg.set(k, (agg.get(k) ?? 0) + v);
+    return [...agg.entries()].sort((x, y) => y[1] - x[1]);
+  };
+  console.log(`sessions with language data: ${sessionLangs.size} (${classifiedPaths} classified paths)`);
+  console.log(`sessions with tooling data:  ${sessionTools.size} (${parsedCmds} parsed commands)`);
+  console.log("top languages:", topOf(sessionLangs).slice(0, 12).map(([k, v]) => `${k} ${v}`).join(", "));
+  console.log("top tools:    ", topOf(sessionTools).slice(0, 15).map(([k, v]) => `${k} ${v}`).join(", "));
+  db.close();
+}
+
+// =================================================================================
+// status — store counts + ClickHouse reachability
+// =================================================================================
+
+function countIn(dbFile: string, sql: string): number | null {
+  const path = join(exploreDir(), dbFile);
+  if (!existsSync(path)) return null;
+  try {
+    const db = new DatabaseSync(path, { readOnly: true });
+    const n = (db.prepare(sql).get() as { c: number } | undefined)?.c ?? 0;
+    db.close();
+    return n;
+  } catch {
+    return null;
+  }
+}
+
+async function runStatus(): Promise<void> {
+  const rows: [string, number | null][] = [
+    ["sessions scanned", countIn("scan.sqlite", "SELECT COUNT(*) c FROM session_scan")],
+    ["clusters", countIn("scan.sqlite", "SELECT COUNT(*) c FROM clusters")],
+    ["commits", countIn("commits.sqlite", "SELECT COUNT(*) c FROM commits")],
+    ["commits mapped", countIn("commits.sqlite", "SELECT COUNT(DISTINCT hash) c FROM commit_sessions")],
+    ["sessions with languages", countIn("langs.sqlite", "SELECT COUNT(DISTINCT session_id) c FROM session_langs")],
+    ["sessions with tooling", countIn("langs.sqlite", "SELECT COUNT(DISTINCT session_id) c FROM session_tools")],
+  ];
+  console.log(`explore dir: ${exploreDir()}`);
+  for (const [name, n] of rows) console.log(`${name}: ${n ?? "(no data)"}`);
+
+  let chOk = false;
+  try {
+    const r = await ch<{ one: number }>("SELECT 1 AS one");
+    chOk = r.length === 1;
+  } catch { /* unreachable */ }
+  console.log(`clickhouse (${clickhouseUrl()}): ${chOk ? "reachable" : "UNREACHABLE"}`);
+  if (!chOk) process.exitCode = 1;
+}
+
+// =================================================================================
+// registration
+// =================================================================================
+
+export function registerExploreCommand(program: Command): void {
+  const explore = program
+    .command("explore")
+    .description("Scan local Moraine trace history into task labels, clusters, commits, and language stats.");
+
+  explore
+    .command("scan")
+    .description(
+      "Label + summarize sessions from Moraine ClickHouse via an OpenAI-compatible LLM " +
+        "(including the desktop app's resident model). Writes scan.sqlite.",
+    )
+    .option("--limit <n>", "Max sessions to consider.", "500")
+    .option("--concurrency <n>", "Parallel labeling workers.", "2")
+    .option("--llm-url <url>", "OpenAI-compatible chat-completions endpoint.", DEFAULT_LLM_URL)
+    .action(async (opts: { limit: string; concurrency: string; llmUrl: string }) => {
+      await runScan({ limit: Number(opts.limit), concurrency: Number(opts.concurrency), llmUrl: opts.llmUrl });
+    });
+
+  explore
+    .command("cluster")
+    .description("Consolidate scan labels into canonical task clusters. Writes clusters + cluster_map.")
+    .option("--llm-url <url>", "OpenAI-compatible chat-completions endpoint.", DEFAULT_LLM_URL)
+    .action(async (opts: { llmUrl: string }) => {
+      await runCluster({ llmUrl: opts.llmUrl });
+    });
+
+  explore
+    .command("commits")
+    .description("Harvest your git commits from repos seen in traces and attribute them to sessions. Writes commits.sqlite.")
+    .action(async () => {
+      await runCommits();
+    });
+
+  explore
+    .command("languages")
+    .description("Derive per-session language and tooling stats from file/shell tool events. Writes langs.sqlite.")
+    .action(async () => {
+      await runLanguages();
+    });
+
+  explore
+    .command("status")
+    .description("Show explore store counts and ClickHouse reachability (exit 1 if unreachable).")
+    .action(async () => {
+      await runStatus();
+    });
+}

--- a/src/explore-mcp.ts
+++ b/src/explore-mcp.ts
@@ -1,0 +1,778 @@
+// `understudy explore mcp` — stdio MCP server that replaces Moraine's MCP for
+// coding agents: same tool names/shapes (search_sessions, open, list_sessions,
+// file_attention), reading local Moraine ClickHouse (read-only, capped) plus
+// the Understudy scan stores under ~/.understudy/explore/, with two
+// Understudy-native extras (explore_tasks, explore_status).
+//
+// All stdout is MCP protocol; diagnostics go to stderr only.
+
+import { existsSync } from "node:fs";
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { ch, clickhouseUrl, countIn, exploreDir } from "./commands/explore.js";
+
+// --- helpers ---------------------------------------------------------------------
+
+function sqlq(s: string): string {
+  // string literal escaping for ClickHouse
+  return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+const EVENT_TYPES = [
+  "user_input", "assistant_response", "reasoning", "tool_call",
+  "tool_response", "compaction", "system", "runtime",
+] as const;
+
+// same text-extraction fallback chain the explore scan digests use
+const TEXT_EXPR = `multiIf(
+  length(text_content) > 0, text_content,
+  JSONExtractString(payload_json, 'text') != '', JSONExtractString(payload_json, 'text'),
+  JSON_VALUE(payload_json, '$.content[0].text') != '', JSON_VALUE(payload_json, '$.content[0].text'),
+  JSONExtractString(payload_json, 'input'))`;
+
+function openScanDbRO(): DatabaseSync | null {
+  const path = join(exploreDir(), "scan.sqlite");
+  if (!existsSync(path)) return null;
+  try {
+    return new DatabaseSync(path, { readOnly: true });
+  } catch {
+    return null;
+  }
+}
+
+type ScanInfo = { label: string; summary: string; cluster: string | null };
+
+/** label/summary/cluster for a set of session ids; empty map when no scan store. */
+function scanInfoFor(sessionIds: string[]): Map<string, ScanInfo> {
+  const out = new Map<string, ScanInfo>();
+  const db = openScanDbRO();
+  if (!db || sessionIds.length === 0) {
+    db?.close();
+    return out;
+  }
+  try {
+    const hasClusters =
+      (db.prepare("SELECT COUNT(*) c FROM sqlite_master WHERE name IN ('clusters','cluster_map')").get() as { c: number }).c === 2;
+    const placeholders = sessionIds.map(() => "?").join(",");
+    const sql = hasClusters
+      ? `SELECT s.session_id sid, s.label, s.summary, c.name cluster
+         FROM session_scan s
+         LEFT JOIN cluster_map m ON m.label = s.label
+         LEFT JOIN clusters c ON c.id = m.cluster_id
+         WHERE s.session_id IN (${placeholders})`
+      : `SELECT session_id sid, label, summary, NULL cluster FROM session_scan WHERE session_id IN (${placeholders})`;
+    for (const r of db.prepare(sql).all(...sessionIds) as { sid: string; label: string; summary: string; cluster: string | null }[]) {
+      out.set(r.sid, { label: r.label, summary: r.summary, cluster: r.cluster ?? null });
+    }
+  } catch {
+    /* scan store present but unreadable — return what we have */
+  } finally {
+    db.close();
+  }
+  return out;
+}
+
+interface SessionMeta {
+  session_id: string;
+  harness: string;
+  source: string;
+  mode: string;
+  title: string;
+  total_turns: number;
+  total_events: number;
+  user_messages: number;
+  first_event_time: string;
+  last_event_time: string;
+  origin_cwd: string;
+}
+
+const SESSION_META_COLS = `session_id, harness, source, mode, title,
+  toUInt32(total_turns) AS total_turns, toUInt32(total_events) AS total_events,
+  toUInt32(user_messages) AS user_messages,
+  toString(first_event_time) AS first_event_time, toString(last_event_time) AS last_event_time,
+  origin_cwd`;
+
+async function sessionMetaFor(sessionIds: string[]): Promise<Map<string, SessionMeta>> {
+  const out = new Map<string, SessionMeta>();
+  if (!sessionIds.length) return out;
+  const inList = sessionIds.map((s) => `'${sqlq(s)}'`).join(",");
+  for (const r of await ch<SessionMeta>(
+    `SELECT ${SESSION_META_COLS} FROM mcp_open_sessions FINAL WHERE session_id IN (${inList})`,
+  )) {
+    out.set(r.session_id, r);
+  }
+  return out;
+}
+
+function enrich(meta: SessionMeta, scan: Map<string, ScanInfo>): Record<string, unknown> {
+  const s = scan.get(meta.session_id);
+  return {
+    id: `session:${meta.session_id}`,
+    session_id: meta.session_id,
+    harness: meta.harness,
+    source: meta.source,
+    mode: meta.mode,
+    title: meta.title || undefined,
+    total_turns: meta.total_turns,
+    total_events: meta.total_events,
+    user_messages: meta.user_messages,
+    first_event_time: meta.first_event_time,
+    last_event_time: meta.last_event_time,
+    origin_cwd: meta.origin_cwd || undefined,
+    ...(s ? { label: s.label, summary: s.summary, cluster: s.cluster ?? undefined } : {}),
+  };
+}
+
+// --- Moraine MCP proxy backend (bm25 search) ---------------------------------------
+
+type MoraineClient = import("@modelcontextprotocol/sdk/client/index.js").Client;
+let moraineClient: MoraineClient | null = null;
+let moraineClientCloser: (() => Promise<void>) | null = null;
+
+/** Lazily spawn `moraine run mcp` and connect as an MCP client. Reused across calls. */
+async function getMoraineClient(): Promise<MoraineClient> {
+  if (moraineClient) return moraineClient;
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+  const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
+  const transport = new StdioClientTransport({
+    command: "moraine",
+    args: ["run", "mcp"],
+    // child stderr must never leak into OUR stdout protocol stream
+    stderr: "ignore",
+  });
+  const client = new Client({ name: "understudy-explore-proxy", version: "1.0.0" });
+  await client.connect(transport);
+  moraineClient = client;
+  moraineClientCloser = async () => {
+    try { await client.close(); } catch { /* already gone */ }
+    moraineClient = null;
+    moraineClientCloser = null;
+  };
+  return client;
+}
+
+export async function closeMoraineClient(): Promise<void> {
+  await moraineClientCloser?.();
+}
+
+function extractSessionId(obj: unknown): string | null {
+  if (!obj || typeof obj !== "object") return null;
+  const r = obj as Record<string, unknown>;
+  for (const k of ["session_id", "sessionId", "id"]) {
+    const v = r[k];
+    if (typeof v === "string" && v.trim()) return v.replace(/^session:/, "");
+  }
+  return null;
+}
+
+/** First array of objects found in a parsed Moraine result (hits/sessions/results/root). */
+function findHitArray(v: unknown): Record<string, unknown>[] | null {
+  if (Array.isArray(v)) {
+    return v.every((x) => x && typeof x === "object") ? (v as Record<string, unknown>[]) : null;
+  }
+  if (v && typeof v === "object") {
+    for (const key of ["hits", "sessions", "results", "matches"]) {
+      const found = findHitArray((v as Record<string, unknown>)[key]);
+      if (found) return found;
+    }
+    for (const val of Object.values(v)) {
+      const found = findHitArray(val);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** Forward search_sessions verbatim to Moraine's MCP (its BM25 index); enrich hits with scan fields. */
+async function bm25Search(args: Record<string, unknown>): Promise<{ hits: Record<string, unknown>[]; raw?: string }> {
+  const client = await getMoraineClient();
+  const forward: Record<string, unknown> = {};
+  for (const k of ["query", "n_hits", "event_types", "harness", "source", "within_id"]) {
+    if (args[k] !== undefined) forward[k] = args[k];
+  }
+  const res = (await client.callTool({ name: "search_sessions", arguments: forward })) as {
+    content?: { type: string; text?: string }[];
+    isError?: boolean;
+  };
+  const text = (res.content ?? []).filter((c) => c.type === "text" && c.text).map((c) => c.text).join("\n");
+  if (res.isError) throw new Error(`moraine search_sessions failed: ${text.slice(0, 300)}`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Moraine 0.7.x returns prose with `(event:<base64-of-hex-uid>)` references:
+    // decode them, resolve to sessions via ClickHouse, and enrich those.
+    return { hits: await sessionsFromMoraineText(text), raw: text.slice(0, 6000) };
+  }
+  const hits = findHitArray(parsed) ?? [];
+  const ids = hits.map(extractSessionId).filter((s): s is string => Boolean(s));
+  const scan = scanInfoFor(ids);
+  for (const h of hits) {
+    const sid = extractSessionId(h);
+    const s = sid ? scan.get(sid) : undefined;
+    if (s) Object.assign(h, { label: s.label, summary: s.summary, cluster: s.cluster ?? undefined });
+  }
+  return { hits };
+}
+
+/** Resolve Moraine's text-form hits (event:<b64> refs) to enriched session records, order-preserving. */
+async function sessionsFromMoraineText(text: string): Promise<Record<string, unknown>[]> {
+  const uids: string[] = [];
+  for (const m of text.matchAll(/event:([A-Za-z0-9+/=_-]{16,})/g)) {
+    try {
+      const decoded = Buffer.from(m[1], "base64").toString("utf8");
+      if (/^[0-9a-f]{16,}$/.test(decoded) && !uids.includes(decoded)) uids.push(decoded);
+    } catch { /* not base64 — skip */ }
+  }
+  if (!uids.length) return [];
+  const inList = uids.map((u) => `'${sqlq(u)}'`).join(",");
+  const rows = await ch<{ event_uid: string; session_id: string }>(
+    `SELECT DISTINCT event_uid, session_id FROM mcp_open_events WHERE event_uid IN (${inList})`,
+  );
+  const sidByUid = new Map(rows.map((r) => [r.event_uid, r.session_id]));
+  const sids: string[] = [];
+  for (const u of uids) {
+    const sid = sidByUid.get(u);
+    if (sid && !sids.includes(sid)) sids.push(sid);
+  }
+  const meta = await sessionMetaFor(sids);
+  const scan = scanInfoFor(sids);
+  return sids.filter((s) => meta.has(s)).map((s) => enrich(meta.get(s)!, scan));
+}
+
+// --- tool implementations ----------------------------------------------------------
+
+async function keywordSearchSessions(args: Record<string, unknown>): Promise<{ hits: Record<string, unknown>[] }> {
+  const query = String(args.query ?? "").slice(0, 4096);
+  if (!query.trim()) throw new Error("query is required");
+  const nHits = Math.min(50, Math.max(1, Number(args.n_hits ?? 10)));
+  const harness = args.harness ? String(args.harness) : null;
+  const source = args.source ? String(args.source) : null;
+  const withinId = args.within_id ? String(args.within_id).replace(/^session:/, "") : null;
+  const eventTypes = Array.isArray(args.event_types)
+    ? (args.event_types as string[]).filter((t) => (EVENT_TYPES as readonly string[]).includes(t))
+    : [];
+
+  // (a) scan.sqlite label/summary matches — ranked first
+  const scanHits: { sid: string; via: string }[] = [];
+  const sdb = openScanDbRO();
+  if (sdb && !withinId) {
+    try {
+      const like = `%${query.replace(/[%_]/g, (c) => `\\${c}`)}%`;
+      const rows = sdb
+        .prepare(
+          `SELECT session_id sid, label, summary FROM session_scan
+           WHERE (label LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\')
+           ${harness ? "AND harness = ?" : ""}
+           ORDER BY scanned_at DESC LIMIT ?`,
+        )
+        .all(...(harness ? [like, like, harness, nHits] : [like, like, nHits])) as { sid: string }[];
+      for (const r of rows) scanHits.push({ sid: r.sid, via: "scan label/summary" });
+    } catch {
+      /* scan store unreadable — clickhouse leg still runs */
+    } finally {
+      sdb.close();
+    }
+  } else {
+    sdb?.close();
+  }
+
+  // (b) ClickHouse keyword scan over event text (positionCaseInsensitive, not BM25)
+  const where = [
+    `positionCaseInsensitive(txt, '${sqlq(query)}') > 0`,
+    eventTypes.length ? `event_type IN (${eventTypes.map((t) => `'${sqlq(t)}'`).join(",")})` : "",
+    withinId ? `session_id = '${sqlq(withinId)}'` : "",
+  ].filter(Boolean).join(" AND ");
+  type ChHit = { session_id: string; matches: string; snippet: string };
+  const chHits = await ch<ChHit>(`
+    SELECT session_id, toString(count()) AS matches, substring(any(txt), 1, 300) AS snippet
+    FROM (
+      SELECT session_id, event_type, substring(${TEXT_EXPR}, 1, 2000) AS txt
+      FROM mcp_open_events
+      LIMIT 1 BY event_uid
+    )
+    WHERE ${where}
+    GROUP BY session_id
+    ORDER BY count() DESC
+    LIMIT ${nHits * 3}
+  `);
+
+  const snippetBySid = new Map(chHits.map((h) => [h.session_id, h.snippet]));
+  const matchesBySid = new Map(chHits.map((h) => [h.session_id, Number(h.matches)]));
+  const orderedIds: string[] = [];
+  for (const h of scanHits) if (!orderedIds.includes(h.sid)) orderedIds.push(h.sid);
+  for (const h of chHits) if (!orderedIds.includes(h.session_id)) orderedIds.push(h.session_id);
+
+  const meta = await sessionMetaFor(orderedIds);
+  const scan = scanInfoFor(orderedIds);
+  const scanHitSet = new Set(scanHits.map((h) => h.sid));
+  const hits = orderedIds
+    .filter((sid) => {
+      const m = meta.get(sid);
+      return Boolean(m) && (!harness || m!.harness === harness) && (!source || m!.source === source);
+    })
+    .map((sid) => ({
+      ...enrich(meta.get(sid)!, scan),
+      matched_via: scanHitSet.has(sid) ? "scan label/summary" : "event text",
+      event_matches: matchesBySid.get(sid) ?? 0,
+      snippet: snippetBySid.get(sid)?.replace(/\s+/g, " ").trim() || undefined,
+    }))
+    .slice(0, nHits);
+
+  return { hits };
+}
+
+async function toolSearchSessions(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").slice(0, 4096);
+  if (!query.trim()) throw new Error("query is required");
+  const nHits = Math.min(50, Math.max(1, Number(args.n_hits ?? 10)));
+  const mode = ["bm25", "keyword", "both"].includes(String(args.mode)) ? String(args.mode) : "bm25";
+
+  let bm25Hits: Record<string, unknown>[] | null = null;
+  let bm25Raw: string | undefined;
+  let bm25Error: string | undefined;
+  if (mode === "bm25" || mode === "both") {
+    try {
+      const r = await bm25Search(args);
+      bm25Hits = r.hits;
+      bm25Raw = r.raw;
+    } catch (e) {
+      bm25Error = String(e instanceof Error ? e.message : e).slice(0, 300);
+    }
+  }
+
+  if (mode === "bm25") {
+    if (bm25Hits !== null) {
+      return { query, mode_used: "bm25", n_hits: bm25Hits.length, hits: bm25Hits, ...(bm25Raw ? { raw: bm25Raw } : {}) };
+    }
+    // moraine missing or call failed — keyword fallback
+    const kw = await keywordSearchSessions(args);
+    return {
+      query,
+      mode_used: "keyword",
+      fallback_reason: `bm25 backend unavailable: ${bm25Error ?? "unknown error"}`,
+      n_hits: kw.hits.length,
+      hits: kw.hits,
+    };
+  }
+
+  const kw = await keywordSearchSessions(args);
+  if (mode === "keyword") {
+    return { query, mode_used: "keyword", n_hits: kw.hits.length, hits: kw.hits };
+  }
+
+  // both: bm25 rank first, keyword-only additions after, deduped by session id
+  const merged: Record<string, unknown>[] = [];
+  const seen = new Set<string>();
+  for (const h of bm25Hits ?? []) {
+    const sid = extractSessionId(h);
+    if (sid) { if (seen.has(sid)) continue; seen.add(sid); }
+    merged.push(h);
+  }
+  for (const h of kw.hits) {
+    const sid = extractSessionId(h);
+    if (sid && seen.has(sid)) continue;
+    if (sid) seen.add(sid);
+    merged.push(h);
+  }
+  return {
+    query,
+    mode_used: bm25Hits !== null ? "both" : "keyword",
+    ...(bm25Error ? { bm25_error: bm25Error } : {}),
+    n_hits: Math.min(merged.length, nHits * 2),
+    hits: merged.slice(0, nHits * 2),
+  };
+}
+
+async function toolOpen(args: Record<string, unknown>): Promise<unknown> {
+  const rawId = String(args.id ?? "").trim();
+  if (!rawId) throw new Error("id is required");
+  if (/^(turn|event):/.test(rawId)) {
+    throw new Error(
+      `id form '${rawId.split(":")[0]}:' is not yet supported by understudy explore mcp v1 — ` +
+        "use a session id (bare or 'session:<id>'), then page events with the cursor parameter.",
+    );
+  }
+  const sessionId = rawId.replace(/^session:/, "");
+  const cursor = Math.max(0, Number(args.cursor ?? 0) || 0);
+  const limit = Math.min(200, Math.max(1, Number(args.limit ?? 50)));
+
+  const meta = await sessionMetaFor([sessionId]);
+  const m = meta.get(sessionId);
+  if (!m) throw new Error(`session not found: ${sessionId}`);
+
+  type Ev = {
+    event_order: number; turn_seq: number; event_time: string; actor_role: string;
+    event_type: string; name: string; t: string;
+  };
+  const events = await ch<Ev>(`
+    SELECT toUInt32(event_order) AS event_order, toUInt32(turn_seq) AS turn_seq,
+      toString(event_time) AS event_time, actor_role, event_type, name,
+      substring(${TEXT_EXPR}, 1, 700) AS t
+    FROM mcp_open_events
+    WHERE session_id = '${sqlq(sessionId)}' AND event_order >= ${cursor}
+    ORDER BY event_order ASC, slot DESC, generation DESC
+    LIMIT 1 BY event_order
+    LIMIT ${limit}
+  `);
+  const scan = scanInfoFor([sessionId]);
+  const last = events.at(-1);
+  return {
+    session: enrich(m, scan),
+    events: events.map((e) => ({
+      event_order: e.event_order,
+      turn: e.turn_seq,
+      time: e.event_time,
+      actor: e.actor_role,
+      type: e.event_type,
+      name: e.name || undefined,
+      text: e.t.replace(/\s+/g, " ").trim() || undefined,
+    })),
+    next_cursor: events.length === limit && last ? last.event_order + 1 : null,
+  };
+}
+
+async function toolListSessions(args: Record<string, unknown>): Promise<unknown> {
+  const start = String(args.start_datetime ?? "");
+  const end = String(args.end_datetime ?? "");
+  if (!start || !end) throw new Error("start_datetime and end_datetime are required (RFC3339)");
+  const limit = Math.min(25, Math.max(1, Number(args.limit ?? 20)));
+  const sort = args.sort === "asc" ? "ASC" : "DESC";
+  const offset = Math.max(0, Number(args.cursor ?? 0) || 0);
+  const filters = [
+    `last_event_time >= parseDateTime64BestEffort('${sqlq(start)}', 3)`,
+    `first_event_time <= parseDateTime64BestEffort('${sqlq(end)}', 3)`,
+    `first_event_time > toDateTime64('2001-01-01 00:00:00', 3)`,
+    args.harness ? `harness = '${sqlq(String(args.harness))}'` : "",
+    args.source ? `source = '${sqlq(String(args.source))}'` : "",
+    args.mode ? `mode = '${sqlq(String(args.mode))}'` : "",
+  ].filter(Boolean).join(" AND ");
+
+  // filter/sort in a subquery: SESSION_META_COLS aliases toString(last_event_time)
+  // AS last_event_time, and ClickHouse alias-shadowing would break the comparison
+  const rows = await ch<SessionMeta>(`
+    SELECT ${SESSION_META_COLS} FROM (
+      SELECT * FROM mcp_open_sessions FINAL
+      WHERE ${filters}
+      ORDER BY last_event_time ${sort}
+      LIMIT ${limit} OFFSET ${offset}
+    )
+    ORDER BY last_event_time ${sort} -- string sort; 'YYYY-MM-DD hh:mm:ss' is chronological
+  `);
+  const scan = scanInfoFor(rows.map((r) => r.session_id));
+  return {
+    sessions: rows.map((r) => enrich(r, scan)),
+    next_cursor: rows.length === limit ? String(offset + limit) : null,
+  };
+}
+
+const MUTATION_TOOLS = ["Edit", "Write", "edit", "write", "apply_patch", "NotebookEdit", "MultiEdit"];
+const FILE_TOOLS = ["Read", "Edit", "Write", "read", "edit", "write", "apply_patch", "NotebookEdit", "MultiEdit", "Grep", "grep"];
+
+async function toolFileAttention(args: Record<string, unknown>): Promise<unknown> {
+  const path = String(args.path ?? "").trim();
+  if (!path) throw new Error("path is required");
+  const limit = Math.min(100, Math.max(1, Number(args.limit ?? 25)));
+  const mutationsOnly = Boolean(args.mutations_only);
+  const toolFilter = args.tool ? String(args.tool) : null;
+  const tools = toolFilter ? [toolFilter] : mutationsOnly ? MUTATION_TOOLS : FILE_TOOLS;
+
+  // path extraction: same structured payload shapes as explore.ts languages logic
+  const pathExpr = `multiIf(
+    JSONExtractString(payload_json,'input','file_path') != '', JSONExtractString(payload_json,'input','file_path'),
+    JSONExtractString(payload_json,'input','filePath') != '', JSONExtractString(payload_json,'input','filePath'),
+    JSONExtractString(payload_json,'state','input','filePath') != '', JSONExtractString(payload_json,'state','input','filePath'),
+    JSONExtractString(payload_json,'file_path') != '', JSONExtractString(payload_json,'file_path'),
+    JSONExtractString(payload_json,'path') != '', JSONExtractString(payload_json,'path'),
+    repo_rel_path)`;
+  const filters = [
+    `tool_name IN (${tools.map((t) => `'${sqlq(t)}'`).join(",")})`,
+    `is_substream = 0`,
+    args.start_datetime
+      ? `event_ts >= parseDateTime64BestEffort('${sqlq(String(args.start_datetime))}', 3)`
+      : `event_ts > '2026-01-01'`,
+    args.end_datetime ? `event_ts <= parseDateTime64BestEffort('${sqlq(String(args.end_datetime))}', 3)` : "",
+    args.harness ? `harness = '${sqlq(String(args.harness))}'` : "",
+    args.source ? `source_name = '${sqlq(String(args.source))}'` : "",
+  ].filter(Boolean).join(" AND ");
+
+  type Row = { session_id: string; touches: string; tools: string[]; first: string; last: string; sample_path: string };
+  const rows = await ch<Row>(`
+    SELECT session_id, toString(count()) AS touches, groupUniqArray(tool_name) AS tools,
+      toString(min(event_ts)) AS first, toString(max(event_ts)) AS last,
+      any(p) AS sample_path
+    FROM (
+      SELECT session_id, tool_name, event_ts, ${pathExpr} AS p
+      FROM events
+      WHERE ${filters}
+    )
+    WHERE p != '' AND (endsWith(p, '${sqlq(path)}') OR positionCaseInsensitive(p, '${sqlq(path)}') > 0)
+    GROUP BY session_id
+    ORDER BY count() DESC
+    LIMIT ${limit}
+  `);
+  const scan = scanInfoFor(rows.map((r) => r.session_id));
+  const meta = await sessionMetaFor(rows.map((r) => r.session_id));
+  return {
+    path,
+    granularity: "sessions",
+    note: "sessions granularity only in v1; matches structured tool payload paths (apply_patch inline file lists are not parsed)",
+    sessions: rows.map((r) => ({
+      ...(meta.has(r.session_id) ? enrich(meta.get(r.session_id)!, scan) : { session_id: r.session_id }),
+      touches: Number(r.touches),
+      tools: r.tools,
+      first_touch: r.first,
+      last_touch: r.last,
+      sample_path: r.sample_path,
+    })),
+  };
+}
+
+function toolExploreTasks(): unknown {
+  const db = openScanDbRO();
+  if (!db) {
+    return { has_scan: false, hint: "No scan store yet — suggest running `understudy explore scan` (then `understudy explore cluster`)." };
+  }
+  try {
+    const scanned = (db.prepare("SELECT COUNT(*) c FROM session_scan").get() as { c: number }).c;
+    const hasClusters =
+      (db.prepare("SELECT COUNT(*) c FROM sqlite_master WHERE name IN ('clusters','cluster_map')").get() as { c: number }).c === 2;
+    if (!hasClusters) {
+      const top = db.prepare("SELECT label, COUNT(*) sessions FROM session_scan GROUP BY label ORDER BY sessions DESC LIMIT 20").all();
+      return { has_scan: true, sessions_scanned: scanned, clusters: null, top_labels: top, hint: "Run `understudy explore cluster` to build the cluster catalog." };
+    }
+    const clusters = db
+      .prepare(`
+        SELECT c.name, COUNT(s.session_id) sessions,
+          SUM(CASE WHEN s.label LIKE '%eval%' OR s.summary LIKE '%eval%'
+                 OR s.label LIKE '%benchmark%' OR s.summary LIKE '%benchmark%' THEN 1 ELSE 0 END) eval_or_benchmark_sessions,
+          GROUP_CONCAT(DISTINCT s.label) labels
+        FROM session_scan s
+        JOIN cluster_map m ON m.label = s.label
+        JOIN clusters c ON c.id = m.cluster_id
+        GROUP BY c.id ORDER BY sessions DESC
+      `)
+      .all() as { name: string; sessions: number; eval_or_benchmark_sessions: number; labels: string }[];
+    return {
+      has_scan: true,
+      sessions_scanned: scanned,
+      clusters: clusters.map((c) => ({
+        name: c.name,
+        sessions: c.sessions,
+        eval_or_benchmark_sessions: c.eval_or_benchmark_sessions,
+        sample_labels: c.labels.split(",").slice(0, 8),
+      })),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+async function toolExploreStatus(): Promise<unknown> {
+  let chOk = false;
+  try {
+    chOk = (await ch<{ one: number }>("SELECT 1 AS one")).length === 1;
+  } catch { /* unreachable */ }
+  const scanned = countIn("scan.sqlite", "SELECT COUNT(*) c FROM session_scan");
+  return {
+    explore_dir: exploreDir(),
+    clickhouse_url: clickhouseUrl(),
+    clickhouse_reachable: chOk,
+    has_scan: (scanned ?? 0) > 0,
+    sessions_scanned: scanned,
+    clusters: countIn("scan.sqlite", "SELECT COUNT(*) c FROM clusters"),
+    commits: countIn("commits.sqlite", "SELECT COUNT(*) c FROM commits"),
+    sessions_with_languages: countIn("langs.sqlite", "SELECT COUNT(DISTINCT session_id) c FROM session_langs"),
+    hint:
+      (scanned ?? 0) > 0
+        ? undefined
+        : "No scan data — suggest the user run `understudy explore scan` to enable label/summary/cluster enrichment.",
+  };
+}
+
+// --- MCP server -------------------------------------------------------------------
+
+const TOOLS = [
+  {
+    name: "search_sessions",
+    description:
+      "Search local coding-agent session history. mode: bm25 = Moraine's full-text index (default, " +
+      "proxied to `moraine run mcp`); keyword = substring scan over event text + Gemma scan " +
+      "labels/summaries (labels ranked first); both = merged, bm25 rank first. All modes enrich hits " +
+      "with Understudy scan label/summary/cluster where available; the result's mode_used reports any " +
+      "fallback (e.g. bm25 backend unavailable → keyword).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", maxLength: 4096, description: "Search terms." },
+        n_hits: { type: "integer", minimum: 1, maximum: 50, default: 10 },
+        mode: { type: "string", enum: ["bm25", "keyword", "both"], default: "bm25" },
+        event_types: { type: "array", items: { type: "string", enum: [...EVENT_TYPES] } },
+        harness: { type: "string", description: "e.g. codex, claude-code, opencode, cursor" },
+        source: { type: "string" },
+        within_id: { type: "string", description: "Restrict search to one session id." },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "open",
+    description:
+      "Open a session: metadata + scan label/summary/cluster + a page of events (text truncated). " +
+      "Accepts bare session ids or 'session:<id>'. 'turn:<n>' / 'event:<uid>' forms are not yet supported. " +
+      "Page with cursor (= next_cursor from the previous call).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Session id ('session:<id>' or bare)." },
+        cursor: { type: "integer", minimum: 0, description: "event_order to start from." },
+        limit: { type: "integer", minimum: 1, maximum: 200, default: 50 },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "list_sessions",
+    description:
+      "List sessions in a time window, newest first by default, enriched with scan labels. " +
+      "Cursor is an opaque offset string from next_cursor.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        start_datetime: { type: "string", description: "RFC3339 window start (required)." },
+        end_datetime: { type: "string", description: "RFC3339 window end (required)." },
+        harness: { type: "string" },
+        source: { type: "string" },
+        mode: { type: "string", description: "e.g. chat, tool_calling, web_search" },
+        limit: { type: "integer", minimum: 1, maximum: 25, default: 20 },
+        sort: { type: "string", enum: ["asc", "desc"], default: "desc" },
+        cursor: { type: "string" },
+      },
+      required: ["start_datetime", "end_datetime"],
+    },
+  },
+  {
+    name: "file_attention",
+    description:
+      "Which sessions touched a file path (suffix/substring match on structured tool-call payload paths). " +
+      "v1 supports sessions granularity only; apply_patch inline file lists are not parsed, so codex patch " +
+      "coverage is partial.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "File path or path tail, e.g. src/commands/explore.ts" },
+        granularity: { type: "string", enum: ["sessions", "events"], default: "sessions", description: "'events' falls back to sessions in v1." },
+        mutations_only: { type: "boolean", default: false, description: "Only Edit/Write/apply_patch-style tools." },
+        tool: { type: "string", description: "Restrict to one tool name." },
+        harness: { type: "string" },
+        source: { type: "string" },
+        start_datetime: { type: "string", description: "RFC3339; defaults to 2026-01-01." },
+        end_datetime: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 100, default: 25 },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "explore_tasks",
+    description:
+      "Understudy-native: the cluster catalog of what the user actually works on — clusters with session " +
+      "counts, sample labels, and how many sessions mention evals/benchmarks. Built from scan.sqlite; " +
+      "if empty, suggest `understudy explore scan`.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "explore_status",
+    description:
+      "Understudy-native: data availability — ClickHouse reachability, scan/cluster/commit/language store " +
+      "counts. If has_scan is false, suggest the user run `understudy explore scan`.",
+    inputSchema: { type: "object", properties: {} },
+  },
+] as const;
+
+export async function runExploreMcpServer(): Promise<void> {
+  const server = new Server(
+    { name: "understudy-explore", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS.map((t) => ({ ...t })) }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args = {} } = req.params;
+    try {
+      let result: unknown;
+      switch (name) {
+        case "search_sessions": result = await toolSearchSessions(args); break;
+        case "open": result = await toolOpen(args); break;
+        case "list_sessions": result = await toolListSessions(args); break;
+        case "file_attention": result = await toolFileAttention(args); break;
+        case "explore_tasks": result = toolExploreTasks(); break;
+        case "explore_status": result = await toolExploreStatus(); break;
+        default: throw new Error(`unknown tool: ${name}`);
+      }
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (e) {
+      return { content: [{ type: "text", text: String(e instanceof Error ? e.message : e) }], isError: true };
+    }
+  });
+
+  server.onclose = () => { void closeMoraineClient(); };
+  for (const sig of ["SIGINT", "SIGTERM"] as const) {
+    process.on(sig, () => { void closeMoraineClient().finally(() => process.exit(0)); });
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`understudy explore mcp: serving ${TOOLS.length} tools over stdio (clickhouse ${clickhouseUrl()})`);
+}
+
+// --- registration takeover ----------------------------------------------------------
+
+export async function runExploreMcpInstall(opts: { dryRun: boolean }): Promise<void> {
+  const configPath = join(homedir(), ".claude.json");
+  const serverEntry = { type: "stdio", command: "understudy", args: ["explore", "mcp"], env: {} };
+
+  if (!existsSync(configPath)) {
+    console.log(`claude-code: ${configPath} not found — nothing to install into.`);
+    return;
+  }
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+  } catch (e) {
+    console.error(`claude-code: could not parse ${configPath}: ${String(e).slice(0, 200)}`);
+    process.exitCode = 1;
+    return;
+  }
+  const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+  const hadMoraine = "moraine" in servers;
+  const changes: string[] = [];
+  if (hadMoraine) changes.push("remove mcpServers.moraine (replaced)");
+  changes.push(`set mcpServers.understudy = ${JSON.stringify(serverEntry)}`);
+
+  console.log(`claude-code (${configPath}):`);
+  for (const c of changes) console.log(`  - ${c}`);
+
+  if (opts.dryRun) {
+    console.log("dry run — no files written.");
+    return;
+  }
+
+  const backup = `${configPath}.bak-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  copyFileSync(configPath, backup);
+  delete servers.moraine;
+  servers.understudy = serverEntry;
+  config.mcpServers = servers;
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  console.log(`backup: ${backup}`);
+  console.log("done — restart Claude Code (or /mcp reconnect) to pick up the `understudy` server.");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { buildValueReport } from "./value-report.js";
 import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
 import { registerCapturesCommand } from "./commands/captures.js";
 import { registerEvalsCommand } from "./commands/evals.js";
+import { registerExploreCommand } from "./commands/explore.js";
 import { registerDaemonCommand } from "./commands/daemon.js";
 import { registerDesktopCommand } from "./commands/desktop.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
@@ -848,6 +849,7 @@ export function buildProgram(): Command {
   registerWorkloadsCommand(program);
   registerCapturesCommand(program);
   registerEvalsCommand(program);
+  registerExploreCommand(program);
   registerGatewayCommand(program);
   registerRoutesCommand(program);
   registerSetupCommand(program);

--- a/tests/explore-mcp.test.mjs
+++ b/tests/explore-mcp.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+
+const bin = resolve("dist/bin.js");
+
+function run(args, env = {}) {
+  return spawnSync("node", [bin, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, FORCE_COLOR: undefined, ...env },
+  });
+}
+
+// minimal JSON-RPC-over-stdio MCP client against `understudy explore mcp`
+function mcpSession(requests, { timeoutMs = 15000, env = {} } = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("node", [bin, "explore", "mcp"], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const expected = requests.filter((r) => r.id !== undefined).length;
+    const responses = new Map();
+    let buf = "";
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`mcp timeout; got ${responses.size}/${expected} responses`));
+    }, timeoutMs);
+    child.stdout.on("data", (d) => {
+      buf += d;
+      let nl;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        const msg = JSON.parse(line); // any non-JSON on stdout is a protocol violation → test fails
+        if (msg.id !== undefined) responses.set(msg.id, msg);
+        if (responses.size === expected) {
+          clearTimeout(timer);
+          child.kill();
+          resolvePromise(responses);
+        }
+      }
+    });
+    child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    for (const r of requests) child.stdin.write(JSON.stringify({ jsonrpc: "2.0", ...r }) + "\n");
+  });
+}
+
+const initialize = {
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "explore-mcp-test", version: "0.0.0" },
+  },
+};
+const initialized = { method: "notifications/initialized", params: {} };
+
+describe("explore mcp", () => {
+  it("help lists mcp and mcp-install", () => {
+    const res = run(["explore", "--help"]);
+    assert.equal(res.status, 0);
+    assert.match(res.stdout, /^  mcp /m);
+    assert.match(res.stdout, /^  mcp-install /m);
+  });
+
+  it("handshakes and lists the six tools over stdio", async () => {
+    const responses = await mcpSession([
+      initialize,
+      initialized,
+      { id: 2, method: "tools/list", params: {} },
+    ]);
+    const init = responses.get(1);
+    assert.equal(init.result.serverInfo.name, "understudy-explore");
+    const names = responses.get(2).result.tools.map((t) => t.name).sort();
+    assert.deepEqual(names, [
+      "explore_status",
+      "explore_tasks",
+      "file_attention",
+      "list_sessions",
+      "open",
+      "search_sessions",
+    ]);
+    const search = responses.get(2).result.tools.find((t) => t.name === "search_sessions");
+    assert.deepEqual(search.inputSchema.properties.mode.enum, ["bm25", "keyword", "both"]);
+  });
+
+  it("explore_status answers even with no scan data and unreachable clickhouse", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-explore-mcp-"));
+    try {
+      const responses = await mcpSession(
+        [initialize, initialized, { id: 2, method: "tools/call", params: { name: "explore_status", arguments: {} } }],
+        { env: { UNDERSTUDY_EXPLORE_DIR: dir, MORAINE_CLICKHOUSE_URL: "http://127.0.0.1:9" } },
+      );
+      const status = JSON.parse(responses.get(2).result.content[0].text);
+      assert.equal(status.clickhouse_reachable, false);
+      assert.equal(status.has_scan, false);
+      assert.match(status.hint, /understudy explore scan/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("mcp-install --dry-run plans the takeover without writing", () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-mcp-home-"));
+    try {
+      const configPath = join(home, ".claude.json");
+      const before = { mcpServers: { moraine: { type: "stdio", command: "moraine", args: ["run", "mcp"], env: {} } } };
+      writeFileSync(configPath, JSON.stringify(before, null, 2));
+      const res = run(["explore", "mcp-install", "--dry-run"], { HOME: home });
+      assert.equal(res.status, 0);
+      assert.match(res.stdout, /remove mcpServers\.moraine/);
+      assert.match(res.stdout, /mcpServers\.understudy/);
+      assert.match(res.stdout, /dry run/);
+      assert.deepEqual(JSON.parse(readFileSync(configPath, "utf8")), before); // untouched
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("mcp-install replaces moraine with understudy and leaves a backup", () => {
+    const home = mkdtempSync(join(tmpdir(), "understudy-mcp-home-"));
+    try {
+      const configPath = join(home, ".claude.json");
+      writeFileSync(
+        configPath,
+        JSON.stringify({ other: true, mcpServers: { moraine: { type: "stdio", command: "moraine", args: ["run", "mcp"] } } }),
+      );
+      const res = run(["explore", "mcp-install"], { HOME: home });
+      assert.equal(res.status, 0);
+      const after = JSON.parse(readFileSync(configPath, "utf8"));
+      assert.equal(after.mcpServers.moraine, undefined);
+      assert.deepEqual(after.mcpServers.understudy, {
+        type: "stdio",
+        command: "understudy",
+        args: ["explore", "mcp"],
+        env: {},
+      });
+      assert.equal(after.other, true);
+      const backups = readdirSync(home).filter((f) => f.startsWith(".claude.json.bak-"));
+      assert.equal(backups.length, 1);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/explore.test.mjs
+++ b/tests/explore.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+
+const cli = ["node", resolve("dist/bin.js")];
+
+function run(args, env = {}) {
+  return spawnSync(cli[0], [cli[1], ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: { ...process.env, FORCE_COLOR: undefined, ...env },
+  });
+}
+
+describe("explore command", () => {
+  it("lists all subcommands in help", () => {
+    const res = run(["explore", "--help"]);
+    assert.equal(res.status, 0);
+    for (const sub of ["scan", "cluster", "commits", "languages", "status"]) {
+      assert.match(res.stdout, new RegExp(`^  ${sub}`, "m"));
+    }
+  });
+
+  it("status reports empty stores and exits 1 when clickhouse is unreachable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-explore-"));
+    try {
+      const res = run(["explore", "status"], {
+        UNDERSTUDY_EXPLORE_DIR: dir,
+        MORAINE_CLICKHOUSE_URL: "http://127.0.0.1:9", // discard port — connection refused fast
+      });
+      assert.equal(res.status, 1);
+      assert.match(res.stdout, /sessions scanned: \(no data\)/);
+      assert.match(res.stdout, /UNREACHABLE/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

Stacked on #291. Completes the Explore Data env-viewer scope (leaderboard + anatomy cut per review — prototype-only) **and makes Understudy the only layer agents and users touch: Moraine becomes invisible infrastructure.**

### Surfaces
- **Tasks pane**: cluster catalog in the app — sessions/tokens/commits per task family, benchmark drafts with measured eval scores, exemplars opening transcripts; `explore / timeline · tasks` sub-nav
- **Empty states**: guided "moraine isn't running" (copyable install/start + retry), "no traces yet", dismissible unscanned banner; tooltip edge-flip
- **Scan my history**: one-click — Rust spawns the bundled CLI against the app's resident model, chains scan → cluster → languages → commits with live progress + cancel; fresh-user story is terminal-free

### Understudy as the only layer
- **`understudy explore` CLI**: scan/cluster/commits/languages/status (node:sqlite port, all query hardening preserved, per-query ClickHouse caps)
- **`understudy explore mcp`** (stdio, bundled, works without the app): drop-in Moraine-compatible tools — `search_sessions` with agent-controllable `mode` (**bm25 default**, proxied to a lazily-spawned `moraine run mcp` child backend; `keyword` = event text + Gemma labels/summaries; `both` = merged; `mode_used`/fallback surfaced), `open`, `list_sessions`, `file_attention` — every result enriched with scan labels/clusters — plus `explore_tasks` and `explore_status`
- **`understudy explore mcp-install`**: swaps the moraine MCP registration for understudy (timestamped backup, `--dry-run`)
- **App `:17790` agent surface**: `/api/explore/{status,query,sqlite,benchmark/:name,eval/:name}` + scan start/status/cancel, MCP tools (`explore_status/query/scan_start`), and `ui_focus` `view`/`session` deep-links (verified live: `{pane:"explore",view:"tasks"}` lands on the tasks catalog)

## Gates
repo build · 7/7 node --test (incl. live stdio handshake + BM25 round-trip through Moraine) · app tsc · static export · cargo check · server unit tests — all green. REST surface verified against a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)