### PR TITLE
Fix Desktop release build type narrowing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,17 @@ jobs:
       - name: Node checks
         run: npm run check
 
+      - name: Setup Bun 1.3.14
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Desktop web build
+        working-directory: apps/homescreen
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
   rust:
     runs-on: macos-latest
     defaults:

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -2415,7 +2415,9 @@ export function ChatPane({
                       </> : (
                         <div className="remote-training-state" role="status" aria-live="polite">
                           <strong>{environmentArchitectProgress ? "Understudy is checking the training plan" : `Preparing ${trainingUseCaseLabel(trainingRecipe.detected_use_case)}`}</strong>
-                          <small>{environmentArchitectProgress?.message ?? (environmentArchitect
+                          <small>{(environmentArchitectProgress?.type === "phase"
+                            ? environmentArchitectProgress.message
+                            : environmentArchitectProgress?.text) ?? (environmentArchitect
                             ? "The verifier draft is ready, but this task still needs an executable portable recipe. No upload or spend has started."
                             : "Profiling and splitting locally. No upload or spend has started.")}</small>
                         </div>


### PR DESCRIPTION
## Summary
- narrow streamed dataset-analysis events before reading their phase message
- compile the exported Desktop web app in CI so release-only TypeScript failures fail on PRs

## Evidence
- `bun install --frozen-lockfile && bun run build` in `apps/homescreen` passes
- `node --test tests/remote-training-desktop.test.mjs` passes
- fixes Desktop Release run 29785373270, which failed before signing and spent no provider/training budget

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->