### PR TITLE
desktop: add portable task model bundles

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -1472,6 +1472,9 @@ export function ChatPane({
     let unlisten: (() => void) | null = null;
     void getCurrentWebview()
       .onDragDropEvent((event) => {
+        // The trained-model dialog owns portable model packages while open;
+        // do not also compile them as generic dropped workloads.
+        if (classifierLibraryOpen) return;
         if (event.payload.type === "enter" || event.payload.type === "over") {
           dispatchDrop({ type: "drag_enter" });
           return;
@@ -1568,7 +1571,7 @@ export function ChatPane({
       disposed = true;
       unlisten?.();
     };
-  }, []);
+  }, [classifierLibraryOpen]);
 
   const hydrateSavedMessages = async (
     saved: PersistedChatSession,

--- a/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
+++ b/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke, isTauri } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
   ArchiveIcon,
@@ -100,6 +101,22 @@ type PredictionExport = {
   output_path: string;
 };
 
+type PortableTaskModel = {
+  id: string;
+  version: string;
+  name: string;
+  publisher: string;
+  base_model_id: string;
+  bytes: number;
+  top_k: number;
+};
+
+type PortablePrediction = {
+  prediction: { l3_id: number; l3: string; probability: number };
+  top_k: { l3_id: number; l3: string; probability: number }[];
+  elapsed_ms: number;
+};
+
 function compactBytes(bytes: number): string {
   if (bytes < 1024 ** 2) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
   if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(0)} MB`;
@@ -135,6 +152,11 @@ export function LocalClassifierLibraryDialog({
   const [predictionText, setPredictionText] = useState("");
   const [prediction, setPrediction] = useState<ClassificationPrediction | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [portableModels, setPortableModels] = useState<PortableTaskModel[]>([]);
+  const [portableModelKey, setPortableModelKey] = useState("");
+  const [portableText, setPortableText] = useState("");
+  const [portablePrediction, setPortablePrediction] = useState<PortablePrediction | null>(null);
+  const [portableNotice, setPortableNotice] = useState<string | null>(null);
   const requestGeneration = useRef(0);
 
   const selected = useMemo(
@@ -178,6 +200,36 @@ export function LocalClassifierLibraryDialog({
     void loadRuns(archived);
   }, [archived, loadRuns, open]);
 
+  const loadPortableModels = useCallback(async () => {
+    const models = await invoke<PortableTaskModel[]>("list_task_models");
+    setPortableModels(models);
+    setPortableModelKey((current) => current || (models[0] ? `${models[0].id}@${models[0].version}` : ""));
+  }, []);
+
+  useEffect(() => {
+    if (!open || !isTauri()) return;
+    void loadPortableModels().catch((loadError) => setPortableNotice(String(loadError)));
+    let dispose: (() => void) | undefined;
+    getCurrentWindow().onDragDropEvent(async (event) => {
+      if (event.payload.type !== "drop") return;
+      const path = event.payload.paths.find((candidate) => candidate.endsWith(".understudy-model"));
+      if (!path) return;
+      setBusy(true);
+      setPortableNotice("Verifying task model…");
+      try {
+        const installed = await invoke<PortableTaskModel>("install_task_model", { path });
+        setPortableNotice(`Installed ${installed.name} ${installed.version}.`);
+        await loadPortableModels();
+        setPortableModelKey(`${installed.id}@${installed.version}`);
+      } catch (installError) {
+        setPortableNotice(`Package rejected: ${String(installError)}`);
+      } finally {
+        setBusy(false);
+      }
+    }).then((unlisten) => { dispose = unlisten; });
+    return () => dispose?.();
+  }, [loadPortableModels, open]);
+
   useEffect(() => {
     setDisplayName(selected?.display_name ?? "");
     setRenameOpen(false);
@@ -218,6 +270,28 @@ export function LocalClassifierLibraryDialog({
       setPrediction(result);
     } catch (predictionError) {
       setError(String(predictionError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const predictPortable = async () => {
+    const model = portableModels.find((candidate) => `${candidate.id}@${candidate.version}` === portableModelKey);
+    if (!model || !portableText.trim() || busy) return;
+    setBusy(true);
+    setPortablePrediction(null);
+    setPortableNotice(null);
+    try {
+      const [result] = await invoke<PortablePrediction[]>("run_task_model", {
+        request: {
+          model_id: model.id,
+          version: model.version,
+          rows: [{ task_id: "library-preview", text: portableText.trim() }],
+        },
+      });
+      setPortablePrediction(result);
+    } catch (predictionError) {
+      setPortableNotice(String(predictionError));
     } finally {
       setBusy(false);
     }
@@ -288,6 +362,33 @@ export function LocalClassifierLibraryDialog({
           <button type="button" aria-pressed={!archived} onClick={() => setArchived(false)}>Active</button>
           <button type="button" aria-pressed={archived} onClick={() => setArchived(true)}>Archived</button>
         </div>
+
+        <section className="classifier-library-portable">
+          <div>
+            <strong>Portable task models</strong>
+            <span>Drop a <code>.understudy-model</code> onto this window to verify and install it.</span>
+          </div>
+          {portableModels.length ? (
+            <form onSubmit={(event) => { event.preventDefault(); void predictPortable(); }}>
+              <select value={portableModelKey} onChange={(event) => { setPortableModelKey(event.target.value); setPortablePrediction(null); }}>
+                {portableModels.map((model) => (
+                  <option key={`${model.id}@${model.version}`} value={`${model.id}@${model.version}`}>
+                    {model.name} · {model.version}
+                  </option>
+                ))}
+              </select>
+              <input value={portableText} maxLength={4_000} onChange={(event) => { setPortableText(event.target.value); setPortablePrediction(null); }} placeholder="Try a new example" />
+              <button type="submit" className="btn primary" disabled={busy || !portableText.trim()}>{busy ? "Working…" : "Run locally"}</button>
+            </form>
+          ) : <p>No portable models installed yet.</p>}
+          {portablePrediction && (
+            <output>
+              <strong>{portablePrediction.prediction.l3}</strong>
+              <span>{(portablePrediction.prediction.probability * 100).toFixed(1)}% · {portablePrediction.elapsed_ms} ms</span>
+            </output>
+          )}
+          {portableNotice && <p role="status">{portableNotice}</p>}
+        </section>
 
         <div className="classifier-library-body">
           <nav className="classifier-library-list" aria-label={archived ? "Archived trained models" : "Active trained models"}>

--- a/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
+++ b/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
@@ -212,7 +212,10 @@ export function LocalClassifierLibraryDialog({
     let dispose: (() => void) | undefined;
     getCurrentWindow().onDragDropEvent(async (event) => {
       if (event.payload.type !== "drop") return;
-      const path = event.payload.paths.find((candidate) => candidate.endsWith(".understudy-model"));
+      const path = event.payload.paths.find((candidate) => {
+        const lower = candidate.toLowerCase();
+        return lower.endsWith(".understudy-model") || lower.endsWith(".zip");
+      });
       if (!path) return;
       setBusy(true);
       setPortableNotice("Verifying task model…");
@@ -366,7 +369,7 @@ export function LocalClassifierLibraryDialog({
         <section className="classifier-library-portable">
           <div>
             <strong>Portable task models</strong>
-            <span>Drop a <code>.understudy-model</code> onto this window to verify and install it.</span>
+            <span>Drop a <code>.understudy-model</code> or <code>.zip</code> onto this window to verify and install it.</span>
           </div>
           {portableModels.length ? (
             <form onSubmit={(event) => { event.preventDefault(); void predictPortable(); }}>

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -5868,6 +5868,32 @@ select,
   color: var(--mb-cyan);
 }
 
+.classifier-library-portable {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--mb-mint) 24%, var(--border));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--mb-mint) 4%, var(--surface));
+}
+.classifier-library-portable > div { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.classifier-library-portable > div strong { color: var(--text); font-size: 12px; }
+.classifier-library-portable > div span,
+.classifier-library-portable > p { margin: 0; color: var(--text-3); font: 9px/1.4 var(--mono); }
+.classifier-library-portable form { display: grid; grid-template-columns: minmax(150px, .8fr) minmax(220px, 1.4fr) auto; gap: 7px; }
+.classifier-library-portable select,
+.classifier-library-portable input {
+  min-width: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 7px;
+  padding: 7px 9px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 11px;
+}
+.classifier-library-portable output { display: flex; justify-content: space-between; gap: 12px; color: var(--mb-mint); font-size: 11px; }
+.classifier-library-portable output span { color: var(--text-3); font: 9px/1.3 var(--mono); }
+
 .classifier-library-body {
   display: grid;
   grid-template-columns: minmax(190px, 0.72fr) minmax(0, 1.55fr);

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.34",
+  "version": "0.3.35",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4756,6 +4756,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "tokio-util",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -5917,6 +5918,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.34"
+version = "0.3.35"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -41,6 +41,9 @@ calamine = "0.36"
 # Bounded, quote-aware decoding for dropped CSV/TSV datasets. File format
 # selects only the parser; route and training backend remain user decisions.
 csv = "1"
+# Portable `.understudy-model` files are ZIP containers. Keep only the
+# deflate reader; bundles never execute archive contents.
+zip = { version = "2.4.2", default-features = false, features = ["deflate"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-updater = "2.10.1"

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.34"
+version = "0.3.35"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/runtime/task_model_runner.py
+++ b/apps/homescreen/src-tauri/runtime/task_model_runner.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Fixed local runner for verified `.understudy-model` classifier bundles."""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import mlx.core as mx
+from mlx_vlm import load
+
+
+def truncated(ids, max_length):
+    if len(ids) <= max_length:
+        return ids
+    tail = min(96, max_length // 4)
+    return ids[: max_length - tail] + ids[-tail:]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--base-model", required=True)
+    args = parser.parse_args()
+
+    bundle = Path(args.bundle)
+    manifest = json.loads((bundle / "manifest.json").read_text())
+    taxonomy = json.loads((bundle / manifest["scorer"]["taxonomy_path"]).read_text())
+    runtime = manifest["runtime"]
+    model, processor = load(
+        args.base_model,
+        adapter_path=str(bundle / runtime["adapter_path"]),
+        lazy=True,
+        strict=False,
+    )
+    tokenizer = getattr(processor, "tokenizer", processor)
+    head = mx.load(str(bundle / runtime["classifier_head_path"]))
+    weight = head["classifier.weight"].astype(mx.float32)
+    bias = head["classifier.bias"].astype(mx.float32)
+    l3_to_l1 = head["l3_to_l1"].tolist()
+    l3_to_l2 = head["l3_to_l2"].tolist()
+    paths = {int(row["l3_id"]): row for row in taxonomy["paths"]}
+    max_length = int(manifest["input"]["max_length"])
+    prompt_template = manifest["input"].get(
+        "prompt_template", "Classify this feedback into the learned issue taxonomy.\n\n{text}"
+    )
+    if prompt_template.count("{text}") != 1:
+        raise ValueError("input.prompt_template must contain exactly one {text} placeholder")
+    top_k = int(manifest["scorer"]["top_k"])
+
+    for line in __import__("sys").stdin:
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        started = time.perf_counter()
+        messages = [{"role": "user", "content": prompt_template.replace("{text}", row["text"])}]
+        rendered = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        ids = tokenizer.encode(rendered, add_special_tokens=False)
+        ids = truncated(ids, max_length)
+        hidden = model.language_model.model(mx.array([ids]))
+        last = hidden[:, -1, :].astype(mx.float32)
+        logits = last @ weight.T + bias
+        probabilities = mx.softmax(logits, axis=-1)[0]
+        ranked = mx.argsort(probabilities)[::-1][:top_k].tolist()
+        choices = []
+        for l3_id in ranked:
+            path = paths[int(l3_id)]
+            choices.append({
+                "l1_id": int(l3_to_l1[l3_id]),
+                "l1": path["l1"],
+                "l2_id": int(l3_to_l2[l3_id]),
+                "l2": path["l2"],
+                "l3_id": int(l3_id),
+                "l3": path["l3"],
+                "probability": float(probabilities[l3_id]),
+            })
+        print(json.dumps({
+            "task_id": row.get("task_id"),
+            "prediction": choices[0],
+            "top_k": choices,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        }), flush=True)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/apps/homescreen/src-tauri/src/bin.rs
+++ b/apps/homescreen/src-tauri/src/bin.rs
@@ -247,6 +247,19 @@ pub fn mlx_server() -> String {
     }
     resolve("mlx_vlm.server")
 }
+pub fn mlx_python() -> Result<String, String> {
+    let server = mlx_server();
+    let launcher = std::fs::read_to_string(&server)
+        .map_err(|err| format!("cannot inspect MLX-VLM runtime at {server}: {err}"))?;
+    let first = launcher.lines().next().unwrap_or_default().trim();
+    let python = first
+        .strip_prefix("#!")
+        .ok_or_else(|| format!("MLX-VLM launcher has no Python shebang: {server}"))?;
+    if !Path::new(python).is_file() {
+        return Err(format!("MLX-VLM Python runtime is missing: {python}"));
+    }
+    Ok(python.to_string())
+}
 pub fn understudy() -> String {
     resolve("understudy")
 }

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.34";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.35";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -29,6 +29,8 @@ mod sidecar;
 mod supervision_export;
 mod supervision_review;
 mod supervision_tiebreaker;
+mod task_model_runtime;
+mod task_models;
 mod tool_proof;
 mod workload_drop;
 
@@ -320,6 +322,11 @@ pub fn run() {
             custom_evals::delete_custom_eval,
             custom_evals::run_custom_eval,
             custom_evals::run_custom_eval_live,
+            task_model_runtime::run_task_model,
+            task_model_runtime::run_task_model_eval,
+            task_models::inspect_task_model,
+            task_models::install_task_model,
+            task_models::list_task_models,
             commands::sidekick_runs,
             commands::sidekick_metrics,
             commands::set_sidekick_run_feedback,

--- a/apps/homescreen/src-tauri/src/task_model_runtime.rs
+++ b/apps/homescreen/src-tauri/src/task_model_runtime.rs
@@ -1,0 +1,254 @@
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::process::{Command, Stdio};
+use tauri::{AppHandle, Manager};
+
+const RUNNER: &str = include_str!("../runtime/task_model_runner.py");
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaskModelInput {
+    pub task_id: Option<String>,
+    pub text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaxonomyChoice {
+    pub l1_id: i64,
+    pub l1: String,
+    pub l2_id: i64,
+    pub l2: String,
+    pub l3_id: i64,
+    pub l3: String,
+    pub probability: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaskModelPrediction {
+    pub task_id: Option<String>,
+    pub prediction: TaxonomyChoice,
+    pub top_k: Vec<TaxonomyChoice>,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Deserialize)]
+pub struct RunTaskModelRequest {
+    pub model_id: String,
+    pub version: String,
+    pub rows: Vec<TaskModelInput>,
+}
+
+fn run_blocking(request: RunTaskModelRequest) -> Result<Vec<TaskModelPrediction>, String> {
+    if request.rows.is_empty() {
+        return Err("at least one row is required".to_string());
+    }
+    if request.rows.len() > 100_000 {
+        return Err("a task-model run is limited to 100,000 rows".to_string());
+    }
+    if request.rows.iter().any(|row| row.text.trim().is_empty()) {
+        return Err("task-model inputs cannot be empty".to_string());
+    }
+    let (bundle, manifest) =
+        crate::task_models::installed_task_model(&request.model_id, &request.version)?;
+    let base = crate::task_models::cached_base_model(&manifest.runtime.base_model.id)?;
+    let python = crate::bin::mlx_python()?;
+    let runner_path = std::env::temp_dir().join(format!(
+        "understudy-task-model-runner-{}-{}.py",
+        std::process::id(),
+        chrono::Utc::now().timestamp_millis()
+    ));
+    std::fs::write(&runner_path, RUNNER)
+        .map_err(|err| format!("cannot prepare task-model runner: {err}"))?;
+    let mut child = Command::new(python)
+        .arg(&runner_path)
+        .arg("--bundle")
+        .arg(&bundle)
+        .arg("--base-model")
+        .arg(&base)
+        .env("PATH", crate::bin::runtime_path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| format!("cannot start task-model runtime: {err}"))?;
+    let input_result = (|| {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or("task-model runtime has no stdin")?;
+        for row in &request.rows {
+            serde_json::to_writer(&mut stdin, row)
+                .map_err(|err| format!("cannot encode task-model input: {err}"))?;
+            stdin
+                .write_all(b"\n")
+                .map_err(|err| format!("cannot write task-model input: {err}"))?;
+        }
+        Ok::<(), String>(())
+    })();
+    if let Err(err) = input_result {
+        let _ = child.kill();
+        let _ = std::fs::remove_file(&runner_path);
+        return Err(err);
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|err| format!("cannot wait for task-model runtime: {err}"));
+    let _ = std::fs::remove_file(&runner_path);
+    let output = output?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "task-model runtime exited with {}: {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|err| format!("task-model runtime returned invalid UTF-8: {err}"))?;
+    let predictions = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<TaskModelPrediction>(line)
+                .map_err(|err| format!("invalid task-model output: {err}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if predictions.len() != request.rows.len() {
+        return Err(format!(
+            "task-model runtime returned {} predictions for {} rows",
+            predictions.len(),
+            request.rows.len()
+        ));
+    }
+    Ok(predictions)
+}
+
+#[tauri::command]
+pub async fn run_task_model(
+    request: RunTaskModelRequest,
+) -> Result<Vec<TaskModelPrediction>, String> {
+    tauri::async_runtime::spawn_blocking(move || run_blocking(request))
+        .await
+        .map_err(|err| format!("task-model worker failed: {err}"))?
+}
+
+#[derive(Deserialize)]
+pub struct RunTaskModelEvalRequest {
+    pub eval_id: String,
+    pub model_id: String,
+    pub version: String,
+    pub max_examples: Option<u32>,
+}
+
+#[derive(Serialize)]
+pub struct TaskModelEvalRun {
+    pub run_id: String,
+    pub eval_id: String,
+    pub model: String,
+    pub rows: u64,
+    pub right: u64,
+    pub accuracy: f64,
+    pub elapsed_ms: u64,
+}
+
+#[tauri::command]
+pub async fn run_task_model_eval(
+    app: AppHandle,
+    request: RunTaskModelEvalRequest,
+) -> Result<TaskModelEvalRun, String> {
+    let db = app.state::<crate::db::Db>();
+    let eval = db
+        .get_custom_eval(&request.eval_id)
+        .map_err(|err| err.to_string())?
+        .ok_or_else(|| format!("unknown custom eval: {}", request.eval_id))?;
+    let mut examples = db
+        .list_custom_eval_examples(&request.eval_id)
+        .map_err(|err| err.to_string())?;
+    if let Some(max) = request.max_examples {
+        examples.truncate(max.max(1) as usize);
+    }
+    let rows = examples
+        .iter()
+        .map(|row| TaskModelInput {
+            task_id: Some(row.task_id.clone()),
+            text: row.prompt.clone(),
+        })
+        .collect::<Vec<_>>();
+    let model = format!("{}@{}", request.model_id, request.version);
+    let started = std::time::Instant::now();
+    let predictions = tauri::async_runtime::spawn_blocking({
+        let model_id = request.model_id.clone();
+        let version = request.version.clone();
+        move || {
+            run_blocking(RunTaskModelRequest {
+                model_id,
+                version,
+                rows,
+            })
+        }
+    })
+    .await
+    .map_err(|err| format!("task-model worker failed: {err}"))??;
+    let run_id = format!(
+        "task-model-{}-{}",
+        request.eval_id,
+        chrono::Utc::now().timestamp_millis()
+    );
+    let mut right = 0u64;
+    for (example, prediction) in examples.iter().zip(&predictions) {
+        let expected = example.expected.trim();
+        let hit = expected == prediction.prediction.l3_id.to_string()
+            || expected.eq_ignore_ascii_case(prediction.prediction.l3.trim());
+        right += u64::from(hit);
+        db.record_fusion_benchmark(&crate::db::FusionBenchmarkInput {
+            run_id: run_id.clone(),
+            capture_run_id: None,
+            runtime_backend: "local".to_string(),
+            task_id: example.task_id.clone(),
+            mode: crate::custom_evals::CUSTOM_EVAL_MODE.to_string(),
+            model: model.clone(),
+            elapsed_ms: Some(prediction.elapsed_ms),
+            prompt_tokens: None,
+            completion_tokens: None,
+            sidekick_runs: 0,
+            sidekick_tool_calls: 0,
+            gateway_used: false,
+            compacted: false,
+            context_tokens_before: None,
+            local_mem_gb: None,
+            score: Some(if hit { 1.0 } else { 0.0 }),
+            status: "ok".to_string(),
+            notes: Some(format!(
+                "task-model:{}; expected={}; predicted={}; top_k={}",
+                eval.eval_id,
+                expected,
+                prediction.prediction.l3_id,
+                prediction
+                    .top_k
+                    .iter()
+                    .map(|choice| choice.l3_id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            )),
+            cost_usd: None,
+            cost_basis: None,
+            split: Some("none".to_string()),
+            harness_sha256: eval.harness_sha256.clone(),
+            split_sha256: None,
+        })
+        .map_err(|err| err.to_string())?;
+    }
+    let count = predictions.len() as u64;
+    Ok(TaskModelEvalRun {
+        run_id,
+        eval_id: request.eval_id,
+        model,
+        rows: count,
+        right,
+        accuracy: if count == 0 {
+            0.0
+        } else {
+            right as f64 / count as f64
+        },
+        elapsed_ms: started.elapsed().as_millis() as u64,
+    })
+}

--- a/apps/homescreen/src-tauri/src/task_model_runtime.rs
+++ b/apps/homescreen/src-tauri/src/task_model_runtime.rs
@@ -51,15 +51,10 @@ fn run_blocking(request: RunTaskModelRequest) -> Result<Vec<TaskModelPrediction>
         crate::task_models::installed_task_model(&request.model_id, &request.version)?;
     let base = crate::task_models::cached_base_model(&manifest.runtime.base_model.id)?;
     let python = crate::bin::mlx_python()?;
-    let runner_path = std::env::temp_dir().join(format!(
-        "understudy-task-model-runner-{}-{}.py",
-        std::process::id(),
-        chrono::Utc::now().timestamp_millis()
-    ));
-    std::fs::write(&runner_path, RUNNER)
-        .map_err(|err| format!("cannot prepare task-model runner: {err}"))?;
+    let row_count = request.rows.len();
     let mut child = Command::new(python)
-        .arg(&runner_path)
+        .arg("-c")
+        .arg(RUNNER)
         .arg("--bundle")
         .arg(&bundle)
         .arg("--base-model")
@@ -70,30 +65,31 @@ fn run_blocking(request: RunTaskModelRequest) -> Result<Vec<TaskModelPrediction>
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|err| format!("cannot start task-model runtime: {err}"))?;
-    let input_result = (|| {
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or("task-model runtime has no stdin")?;
-        for row in &request.rows {
-            serde_json::to_writer(&mut stdin, row)
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or("task-model runtime has no stdin")?;
+    let writer = std::thread::spawn(move || {
+        for row in request.rows {
+            serde_json::to_writer(&mut stdin, &row)
                 .map_err(|err| format!("cannot encode task-model input: {err}"))?;
             stdin
                 .write_all(b"\n")
                 .map_err(|err| format!("cannot write task-model input: {err}"))?;
         }
         Ok::<(), String>(())
-    })();
-    if let Err(err) = input_result {
-        let _ = child.kill();
-        let _ = std::fs::remove_file(&runner_path);
-        return Err(err);
-    }
+    });
+    // Drain stdout and stderr while the writer feeds stdin. Reading only after
+    // every input row is written can deadlock once the child's stdout pipe is
+    // full and the child stops consuming stdin.
     let output = child
         .wait_with_output()
         .map_err(|err| format!("cannot wait for task-model runtime: {err}"));
-    let _ = std::fs::remove_file(&runner_path);
+    let input_result = writer
+        .join()
+        .map_err(|_| "task-model input writer panicked".to_string())?;
     let output = output?;
+    input_result?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!(
@@ -112,11 +108,11 @@ fn run_blocking(request: RunTaskModelRequest) -> Result<Vec<TaskModelPrediction>
                 .map_err(|err| format!("invalid task-model output: {err}"))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    if predictions.len() != request.rows.len() {
+    if predictions.len() != row_count {
         return Err(format!(
             "task-model runtime returned {} predictions for {} rows",
             predictions.len(),
-            request.rows.len()
+            row_count
         ));
     }
     Ok(predictions)

--- a/apps/homescreen/src-tauri/src/task_models.rs
+++ b/apps/homescreen/src-tauri/src/task_models.rs
@@ -342,7 +342,7 @@ pub fn install_task_model(path: String) -> Result<TaskModelInfo, String> {
 }
 
 fn install_task_model_to(source: &Path, root: &Path) -> Result<TaskModelInfo, String> {
-    let (manifest, _) = validate_bundle(&source)?;
+    let (manifest, _) = validate_bundle(source)?;
     fs::create_dir_all(root).map_err(|err| err.to_string())?;
     let target = root
         .join(&manifest.id)

--- a/apps/homescreen/src-tauri/src/task_models.rs
+++ b/apps/homescreen/src-tauri/src/task_models.rs
@@ -1,0 +1,608 @@
+//! Portable task-model bundles.
+//!
+//! A `.understudy-model` is a directory package. It carries only the
+//! task-specific weights and contract; large certified base snapshots remain
+//! in the normal Understudy model cache and are referenced by id.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+pub const TASK_MODEL_SCHEMA: &str = "understudy.task_model.v1";
+pub const TASK_MODEL_RUNTIME: &str = "mlx_vlm_classifier_v1";
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct BundleFile {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct BaseModelRef {
+    pub id: String,
+    pub loader: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RuntimeContract {
+    pub kind: String,
+    pub base_model: BaseModelRef,
+    pub adapter_path: String,
+    pub adapter_config_path: String,
+    pub classifier_head_path: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct InputContract {
+    pub text_columns: Vec<String>,
+    #[serde(default)]
+    pub expected_label_columns: Vec<String>,
+    pub max_length: u64,
+    #[serde(default)]
+    pub prompt_template: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ScorerContract {
+    pub kind: String,
+    pub taxonomy_path: String,
+    #[serde(default = "default_top_k")]
+    pub top_k: u64,
+}
+
+fn default_top_k() -> u64 {
+    3
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TaskModelManifest {
+    pub schema_version: String,
+    pub id: String,
+    pub version: String,
+    pub name: String,
+    pub publisher: String,
+    pub runtime: RuntimeContract,
+    pub input: InputContract,
+    pub scorer: ScorerContract,
+    pub files: Vec<BundleFile>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct TaskModelInfo {
+    pub id: String,
+    pub version: String,
+    pub name: String,
+    pub publisher: String,
+    pub runtime: String,
+    pub base_model_id: String,
+    pub path: String,
+    pub installed: bool,
+    pub verified: bool,
+    pub bytes: u64,
+    pub file_count: u64,
+    pub top_k: u64,
+}
+
+pub(crate) fn task_models_dir() -> Result<PathBuf, String> {
+    crate::models::models_dir()
+        .map(|root| root.join("task-models"))
+        .ok_or_else(|| "cannot resolve Understudy model directory".to_string())
+}
+
+pub(crate) fn installed_task_model(
+    id: &str,
+    version: &str,
+) -> Result<(PathBuf, TaskModelManifest), String> {
+    validate_slug(id, "model id")?;
+    validate_slug(version, "model version")?;
+    let bundle = task_models_dir()?
+        .join(id)
+        .join(format!("{version}.understudy-model"));
+    let (manifest, _) = validate_bundle(&bundle)?;
+    if manifest.id != id || manifest.version != version {
+        return Err("installed task-model identity does not match its path".to_string());
+    }
+    Ok((bundle, manifest))
+}
+
+pub(crate) fn cached_base_model(id: &str) -> Result<PathBuf, String> {
+    let relative = relative_bundle_path(id)?;
+    let base = crate::models::models_dir()
+        .ok_or_else(|| "cannot resolve Understudy model directory".to_string())?
+        .join(relative);
+    if !base.is_dir() {
+        return Err(format!(
+            "required base model is not downloaded: {id}. Download it in Models first"
+        ));
+    }
+    Ok(base)
+}
+
+fn validate_slug(value: &str, field: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > 120
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(format!("invalid {field}: {value:?}"));
+    }
+    Ok(())
+}
+
+fn relative_bundle_path(value: &str) -> Result<PathBuf, String> {
+    let path = Path::new(value);
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Err(format!("bundle path must be relative: {value}"));
+    }
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(format!("unsafe bundle path: {value}"));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn sha256_file(path: &Path) -> Result<(String, u64), String> {
+    let metadata = fs::symlink_metadata(path).map_err(|err| err.to_string())?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(format!(
+            "bundle member must be a regular file: {}",
+            path.display()
+        ));
+    }
+    let mut file = fs::File::open(path).map_err(|err| err.to_string())?;
+    let mut hasher = Sha256::new();
+    let mut bytes = 0u64;
+    let mut buffer = [0u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|err| err.to_string())?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        bytes += read as u64;
+    }
+    Ok((format!("{:x}", hasher.finalize()), bytes))
+}
+
+fn checked_bundle_member(bundle: &Path, relative: &Path) -> Result<PathBuf, String> {
+    let mut current = bundle.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(part) = component else {
+            return Err(format!("unsafe bundle path: {}", relative.display()));
+        };
+        current.push(part);
+        let metadata = fs::symlink_metadata(&current).map_err(|err| err.to_string())?;
+        if metadata.file_type().is_symlink() {
+            return Err(format!(
+                "bundle paths cannot traverse symlinks: {}",
+                relative.display()
+            ));
+        }
+    }
+    Ok(current)
+}
+
+fn load_manifest(bundle: &Path) -> Result<TaskModelManifest, String> {
+    if bundle.extension().and_then(|value| value.to_str()) != Some("understudy-model") {
+        return Err("task model must be a directory ending in .understudy-model".to_string());
+    }
+    let metadata = fs::symlink_metadata(bundle).map_err(|err| err.to_string())?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err("task model package must be a real directory, not a symlink".to_string());
+    }
+    let bytes = fs::read(bundle.join("manifest.json")).map_err(|err| {
+        format!(
+            "cannot read {}: {err}",
+            bundle.join("manifest.json").display()
+        )
+    })?;
+    serde_json::from_slice(&bytes).map_err(|err| format!("invalid manifest.json: {err}"))
+}
+
+fn validate_bundle(bundle: &Path) -> Result<(TaskModelManifest, u64), String> {
+    let manifest = load_manifest(bundle)?;
+    if manifest.schema_version != TASK_MODEL_SCHEMA {
+        return Err(format!(
+            "unsupported task-model schema: {}",
+            manifest.schema_version
+        ));
+    }
+    validate_slug(&manifest.id, "model id")?;
+    validate_slug(&manifest.version, "model version")?;
+    if manifest.name.trim().is_empty() || manifest.publisher.trim().is_empty() {
+        return Err("model name and publisher are required".to_string());
+    }
+    if manifest.runtime.kind != TASK_MODEL_RUNTIME {
+        return Err(format!(
+            "unsupported task-model runtime: {}",
+            manifest.runtime.kind
+        ));
+    }
+    if manifest.runtime.base_model.id.trim().is_empty()
+        || manifest.runtime.base_model.loader != "mlx_vlm"
+    {
+        return Err("runtime must reference an MLX-VLM base model".to_string());
+    }
+    if manifest.input.text_columns.is_empty() || manifest.input.max_length == 0 {
+        return Err("input contract needs text columns and a positive max_length".to_string());
+    }
+    if manifest
+        .input
+        .prompt_template
+        .as_ref()
+        .is_some_and(|template| template.matches("{text}").count() != 1)
+    {
+        return Err(
+            "input.prompt_template must contain exactly one {text} placeholder".to_string(),
+        );
+    }
+    if manifest.scorer.kind != "hierarchical_taxonomy_v1"
+        || manifest.scorer.top_k == 0
+        || manifest.scorer.top_k > 20
+    {
+        return Err("unsupported scorer contract".to_string());
+    }
+    if manifest.files.is_empty() {
+        return Err("manifest has no files".to_string());
+    }
+
+    let required = [
+        manifest.runtime.adapter_config_path.as_str(),
+        manifest.runtime.classifier_head_path.as_str(),
+        manifest.scorer.taxonomy_path.as_str(),
+    ];
+    for path in required {
+        if !manifest.files.iter().any(|entry| entry.path == path) {
+            return Err(format!("required file is not hash-committed: {path}"));
+        }
+    }
+    let adapter_root = relative_bundle_path(&manifest.runtime.adapter_path)?;
+    if !manifest.files.iter().any(|entry| {
+        relative_bundle_path(&entry.path)
+            .ok()
+            .is_some_and(|path| path.starts_with(&adapter_root))
+    }) {
+        return Err("adapter_path contains no hash-committed files".to_string());
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut total = 0u64;
+    for entry in &manifest.files {
+        if !seen.insert(entry.path.as_str()) {
+            return Err(format!("duplicate bundle file: {}", entry.path));
+        }
+        let relative = relative_bundle_path(&entry.path)?;
+        let member = checked_bundle_member(bundle, &relative)?;
+        let (digest, bytes) = sha256_file(&member)?;
+        if bytes != entry.bytes {
+            return Err(format!("size mismatch for {}", entry.path));
+        }
+        if digest != entry.sha256.to_ascii_lowercase() {
+            return Err(format!("SHA-256 mismatch for {}", entry.path));
+        }
+        total = total
+            .checked_add(bytes)
+            .ok_or_else(|| "bundle size overflow".to_string())?;
+    }
+
+    let taxonomy_path = checked_bundle_member(
+        bundle,
+        &relative_bundle_path(&manifest.scorer.taxonomy_path)?,
+    )?;
+    let taxonomy: serde_json::Value =
+        serde_json::from_slice(&fs::read(&taxonomy_path).map_err(|err| err.to_string())?)
+            .map_err(|err| format!("invalid taxonomy JSON: {err}"))?;
+    if !taxonomy.is_object() {
+        return Err("taxonomy must be a JSON object".to_string());
+    }
+    Ok((manifest, total))
+}
+
+fn info(bundle: &Path, installed: bool) -> Result<TaskModelInfo, String> {
+    let (manifest, bytes) = validate_bundle(bundle)?;
+    Ok(TaskModelInfo {
+        id: manifest.id,
+        version: manifest.version,
+        name: manifest.name,
+        publisher: manifest.publisher,
+        runtime: manifest.runtime.kind,
+        base_model_id: manifest.runtime.base_model.id,
+        path: bundle.to_string_lossy().into_owned(),
+        installed,
+        verified: true,
+        bytes,
+        file_count: manifest.files.len() as u64,
+        top_k: manifest.scorer.top_k,
+    })
+}
+
+fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), String> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+    }
+    fs::copy(source, destination).map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn inspect_task_model(path: String) -> Result<TaskModelInfo, String> {
+    info(Path::new(&path), false)
+}
+
+#[tauri::command]
+pub fn install_task_model(path: String) -> Result<TaskModelInfo, String> {
+    let source = PathBuf::from(path);
+    install_task_model_to(&source, &task_models_dir()?)
+}
+
+fn install_task_model_to(source: &Path, root: &Path) -> Result<TaskModelInfo, String> {
+    let (manifest, _) = validate_bundle(&source)?;
+    fs::create_dir_all(root).map_err(|err| err.to_string())?;
+    let target = root
+        .join(&manifest.id)
+        .join(format!("{}.understudy-model", manifest.version));
+    if target.exists() {
+        let (installed_manifest, _) = validate_bundle(&target)?;
+        if installed_manifest == manifest {
+            return info(&target, true);
+        }
+        return Err(format!(
+            "{} {} is already installed with different contents",
+            manifest.id, manifest.version
+        ));
+    }
+    let nonce = chrono::Utc::now().timestamp_millis();
+    let staging = root.join(format!(
+        ".installing-{}-{nonce}.understudy-model",
+        manifest.id
+    ));
+    fs::create_dir_all(&staging).map_err(|err| err.to_string())?;
+    let install_result = (|| {
+        copy_regular_file(
+            &source.join("manifest.json"),
+            &staging.join("manifest.json"),
+        )?;
+        for entry in &manifest.files {
+            let relative = relative_bundle_path(&entry.path)?;
+            copy_regular_file(&source.join(&relative), &staging.join(&relative))?;
+        }
+        // Re-verify the copied bytes before making the install visible.
+        validate_bundle(&staging)?;
+        fs::create_dir_all(target.parent().unwrap()).map_err(|err| err.to_string())?;
+        fs::rename(&staging, &target).map_err(|err| err.to_string())?;
+        Ok::<(), String>(())
+    })();
+    if let Err(err) = install_result {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err);
+    }
+    info(&target, true)
+}
+
+#[tauri::command]
+pub fn list_task_models() -> Result<Vec<TaskModelInfo>, String> {
+    let root = task_models_dir()?;
+    let mut models = vec![];
+    let Ok(ids) = fs::read_dir(root) else {
+        return Ok(models);
+    };
+    for id in ids.flatten() {
+        if id.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let Ok(versions) = fs::read_dir(id.path()) else {
+            continue;
+        };
+        for version in versions.flatten() {
+            if let Ok(row) = info(&version.path(), true) {
+                models.push(row);
+            }
+        }
+    }
+    models.sort_by(|left, right| (&left.id, &left.version).cmp(&(&right.id, &right.version)));
+    Ok(models)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_NONCE: AtomicU64 = AtomicU64::new(0);
+
+    fn test_dir(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "understudy-task-model-{name}-{nonce}-{}.understudy-model",
+            TEST_NONCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn fixture() -> PathBuf {
+        let root = test_dir("valid");
+        let members = [
+            ("model/adapter/adapter_config.json", b"{}".as_slice()),
+            (
+                "model/adapter/adapter_model.safetensors",
+                b"adapter".as_slice(),
+            ),
+            ("model/classifier-head.safetensors", b"head".as_slice()),
+            ("taxonomy.json", br#"{"paths":[]}"#.as_slice()),
+        ];
+        let mut files = vec![];
+        for (relative, content) in members {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, content).unwrap();
+            let (digest, bytes) = sha256_file(&path).unwrap();
+            files.push(BundleFile {
+                path: relative.to_string(),
+                sha256: digest,
+                bytes,
+            });
+        }
+        let manifest = TaskModelManifest {
+            schema_version: TASK_MODEL_SCHEMA.to_string(),
+            id: "fixture-classifier".to_string(),
+            version: "1.0.0".to_string(),
+            name: "Fixture classifier".to_string(),
+            publisher: "Understudy Labs".to_string(),
+            runtime: RuntimeContract {
+                kind: TASK_MODEL_RUNTIME.to_string(),
+                base_model: BaseModelRef {
+                    id: "gemma-fixture".to_string(),
+                    loader: "mlx_vlm".to_string(),
+                },
+                adapter_path: "model/adapter".to_string(),
+                adapter_config_path: "model/adapter/adapter_config.json".to_string(),
+                classifier_head_path: "model/classifier-head.safetensors".to_string(),
+            },
+            input: InputContract {
+                text_columns: vec!["text".to_string()],
+                expected_label_columns: vec!["expected_l3".to_string()],
+                max_length: 512,
+                prompt_template: Some("Classify this feedback.\n\n{text}".to_string()),
+            },
+            scorer: ScorerContract {
+                kind: "hierarchical_taxonomy_v1".to_string(),
+                taxonomy_path: "taxonomy.json".to_string(),
+                top_k: 3,
+            },
+            files,
+        };
+        fs::write(
+            root.join("manifest.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        root
+    }
+
+    #[test]
+    fn valid_bundle_is_verified() {
+        let root = fixture();
+        let row = info(&root, false).unwrap();
+        assert!(row.verified);
+        assert_eq!(row.id, "fixture-classifier");
+        assert_eq!(row.top_k, 3);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn modified_member_is_rejected() {
+        let root = fixture();
+        fs::write(root.join("taxonomy.json"), "{}").unwrap();
+        let error = validate_bundle(&root).unwrap_err();
+        assert!(error.contains("mismatch"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn unsafe_relative_paths_are_rejected() {
+        assert!(relative_bundle_path("../secret").is_err());
+        assert!(relative_bundle_path("/tmp/secret").is_err());
+        assert!(relative_bundle_path("model/head.safetensors").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bundle_member_ancestor_symlink_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let root = fixture();
+        let external = std::env::temp_dir().join(format!(
+            "understudy-task-model-external-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&external).unwrap();
+        fs::copy(
+            root.join("model/classifier-head.safetensors"),
+            external.join("classifier-head.safetensors"),
+        )
+        .unwrap();
+        fs::remove_file(root.join("model/classifier-head.safetensors")).unwrap();
+        fs::remove_dir(root.join("model/adapter")).unwrap_err();
+        symlink(&external, root.join("model/head-link")).unwrap();
+        let manifest_path = root.join("manifest.json");
+        let mut manifest = load_manifest(&root).unwrap();
+        let entry = manifest
+            .files
+            .iter_mut()
+            .find(|entry| entry.path == "model/classifier-head.safetensors")
+            .unwrap();
+        entry.path = "model/head-link/classifier-head.safetensors".to_string();
+        manifest.runtime.classifier_head_path = entry.path.clone();
+        fs::write(manifest_path, serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+        let error = validate_bundle(&root).unwrap_err();
+        assert!(error.contains("symlink"));
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(external).unwrap();
+    }
+
+    #[test]
+    fn install_is_verified_and_idempotent() {
+        let source = fixture();
+        let install_root = std::env::temp_dir().join(format!(
+            "understudy-task-model-installs-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let first = install_task_model_to(&source, &install_root).unwrap();
+        let second = install_task_model_to(&source, &install_root).unwrap();
+        assert!(first.installed);
+        assert_eq!(first.path, second.path);
+        assert!(Path::new(&first.path).join("manifest.json").exists());
+        fs::remove_dir_all(source).unwrap();
+        fs::remove_dir_all(install_root).unwrap();
+    }
+
+    #[test]
+    fn install_rejects_same_version_with_different_hashes() {
+        let source = fixture();
+        let install_root = std::env::temp_dir().join(format!(
+            "understudy-task-model-conflict-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        install_task_model_to(&source, &install_root).unwrap();
+        let taxonomy = source.join("taxonomy.json");
+        fs::write(&taxonomy, br#"{"paths":[1]}"#).unwrap();
+        let (digest, bytes) = sha256_file(&taxonomy).unwrap();
+        let mut manifest = load_manifest(&source).unwrap();
+        let entry = manifest
+            .files
+            .iter_mut()
+            .find(|entry| entry.path == "taxonomy.json")
+            .unwrap();
+        entry.sha256 = digest;
+        entry.bytes = bytes;
+        fs::write(
+            source.join("manifest.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        let error = install_task_model_to(&source, &install_root).unwrap_err();
+        assert!(error.contains("different contents"));
+        fs::remove_dir_all(source).unwrap();
+        fs::remove_dir_all(install_root).unwrap();
+    }
+}

--- a/apps/homescreen/src-tauri/src/task_models.rs
+++ b/apps/homescreen/src-tauri/src/task_models.rs
@@ -314,8 +314,7 @@ fn prepare_bundle(source: &Path) -> Result<PreparedBundle, String> {
         for child in fs::read_dir(&payload).map_err(|err| err.to_string())? {
             let child = child.map_err(|err| err.to_string())?.path();
             if child.is_dir()
-                && child.extension().and_then(|value| value.to_str())
-                    == Some("understudy-model")
+                && child.extension().and_then(|value| value.to_str()) == Some("understudy-model")
                 && child.join("manifest.json").is_file()
             {
                 roots.push(child);
@@ -670,7 +669,9 @@ mod tests {
             archive
                 .start_file(format!("{prefix}{relative}"), options)
                 .unwrap();
-            archive.write_all(&fs::read(source.join(relative)).unwrap()).unwrap();
+            archive
+                .write_all(&fs::read(source.join(relative)).unwrap())
+                .unwrap();
         }
         archive.finish().unwrap();
         path
@@ -726,7 +727,10 @@ mod tests {
                 .as_nanos()
         ));
         let inspected = prepare_bundle(&archive).unwrap();
-        assert_eq!(validate_bundle(&inspected.root).unwrap().0.id, "fixture-classifier");
+        assert_eq!(
+            validate_bundle(&inspected.root).unwrap().0.id,
+            "fixture-classifier"
+        );
         drop(inspected);
         let installed = install_task_model_to(&archive, &install_root).unwrap();
         assert!(installed.installed);

--- a/apps/homescreen/src-tauri/src/task_models.rs
+++ b/apps/homescreen/src-tauri/src/task_models.rs
@@ -10,6 +10,9 @@ use std::fs;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
+const MAX_ARCHIVE_FILES: usize = 10_000;
+const MAX_ARCHIVE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
 pub const TASK_MODEL_SCHEMA: &str = "understudy.task_model.v1";
 pub const TASK_MODEL_RUNTIME: &str = "mlx_vlm_classifier_v1";
 
@@ -205,6 +208,139 @@ fn load_manifest(bundle: &Path) -> Result<TaskModelManifest, String> {
     serde_json::from_slice(&bytes).map_err(|err| format!("invalid manifest.json: {err}"))
 }
 
+#[derive(Debug)]
+struct PreparedBundle {
+    root: PathBuf,
+    cleanup: Option<PathBuf>,
+}
+
+impl Drop for PreparedBundle {
+    fn drop(&mut self) {
+        if let Some(path) = &self.cleanup {
+            let _ = fs::remove_dir_all(path);
+        }
+    }
+}
+
+fn prepare_bundle(source: &Path) -> Result<PreparedBundle, String> {
+    let metadata = fs::symlink_metadata(source).map_err(|err| err.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Err("task model package cannot be a symlink".to_string());
+    }
+    if metadata.is_dir() {
+        return Ok(PreparedBundle {
+            root: source.to_path_buf(),
+            cleanup: None,
+        });
+    }
+    let extension = source
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    if !metadata.is_file()
+        || !(extension.eq_ignore_ascii_case("zip")
+            || extension.eq_ignore_ascii_case("understudy-model"))
+    {
+        return Err(
+            "task model must be a .zip, a ZIP-backed .understudy-model file, or a .understudy-model directory"
+                .to_string(),
+        );
+    }
+
+    let file = fs::File::open(source).map_err(|err| err.to_string())?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|err| format!("task model is not a readable ZIP archive: {err}"))?;
+    if archive.len() > MAX_ARCHIVE_FILES {
+        return Err(format!(
+            "task-model archive contains too many entries ({} > {MAX_ARCHIVE_FILES})",
+            archive.len()
+        ));
+    }
+    let temp = std::env::temp_dir().join(format!(
+        "understudy-task-model-{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_micros()
+    ));
+    let payload = temp.join("payload.understudy-model");
+    fs::create_dir_all(&payload).map_err(|err| err.to_string())?;
+    let extraction_result = (|| {
+        let mut seen = std::collections::HashSet::new();
+        let mut total = 0u64;
+        for index in 0..archive.len() {
+            let mut entry = archive
+                .by_index(index)
+                .map_err(|err| format!("cannot read task-model archive entry: {err}"))?;
+            let relative = entry
+                .enclosed_name()
+                .ok_or_else(|| format!("unsafe archive path: {}", entry.name()))?
+                .to_path_buf();
+            if relative.as_os_str().is_empty() || !seen.insert(relative.clone()) {
+                return Err(format!(
+                    "duplicate or empty archive path: {}",
+                    relative.display()
+                ));
+            }
+            if entry
+                .unix_mode()
+                .is_some_and(|mode| mode & 0o170000 == 0o120000)
+            {
+                return Err(format!(
+                    "task-model archives cannot contain symlinks: {}",
+                    relative.display()
+                ));
+            }
+            total = total
+                .checked_add(entry.size())
+                .ok_or_else(|| "task-model archive size overflow".to_string())?;
+            if total > MAX_ARCHIVE_BYTES {
+                return Err("task-model archive expands beyond 4 GiB".to_string());
+            }
+            let destination = payload.join(&relative);
+            if entry.is_dir() {
+                fs::create_dir_all(&destination).map_err(|err| err.to_string())?;
+                continue;
+            }
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+            }
+            let mut output = fs::File::create(&destination).map_err(|err| err.to_string())?;
+            std::io::copy(&mut entry, &mut output).map_err(|err| err.to_string())?;
+        }
+
+        let mut roots = Vec::new();
+        if payload.join("manifest.json").is_file() {
+            roots.push(payload.clone());
+        }
+        for child in fs::read_dir(&payload).map_err(|err| err.to_string())? {
+            let child = child.map_err(|err| err.to_string())?.path();
+            if child.is_dir()
+                && child.extension().and_then(|value| value.to_str())
+                    == Some("understudy-model")
+                && child.join("manifest.json").is_file()
+            {
+                roots.push(child);
+            }
+        }
+        if roots.len() != 1 {
+            return Err(format!(
+                "task-model archive must contain exactly one package root; found {}",
+                roots.len()
+            ));
+        }
+        Ok::<PathBuf, String>(roots.remove(0))
+    })();
+    match extraction_result {
+        Ok(root) => Ok(PreparedBundle {
+            root,
+            cleanup: Some(temp),
+        }),
+        Err(err) => {
+            let _ = fs::remove_dir_all(&temp);
+            Err(err)
+        }
+    }
+}
+
 fn validate_bundle(bundle: &Path) -> Result<(TaskModelManifest, u64), String> {
     let manifest = load_manifest(bundle)?;
     if manifest.schema_version != TASK_MODEL_SCHEMA {
@@ -322,6 +458,16 @@ fn info(bundle: &Path, installed: bool) -> Result<TaskModelInfo, String> {
     })
 }
 
+fn info_with_display_path(
+    bundle: &Path,
+    display_path: &Path,
+    installed: bool,
+) -> Result<TaskModelInfo, String> {
+    let mut model = info(bundle, installed)?;
+    model.path = display_path.to_string_lossy().into_owned();
+    Ok(model)
+}
+
 fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), String> {
     if let Some(parent) = destination.parent() {
         fs::create_dir_all(parent).map_err(|err| err.to_string())?;
@@ -332,7 +478,9 @@ fn copy_regular_file(source: &Path, destination: &Path) -> Result<(), String> {
 
 #[tauri::command]
 pub fn inspect_task_model(path: String) -> Result<TaskModelInfo, String> {
-    info(Path::new(&path), false)
+    let source = PathBuf::from(path);
+    let prepared = prepare_bundle(&source)?;
+    info_with_display_path(&prepared.root, &source, false)
 }
 
 #[tauri::command]
@@ -342,6 +490,11 @@ pub fn install_task_model(path: String) -> Result<TaskModelInfo, String> {
 }
 
 fn install_task_model_to(source: &Path, root: &Path) -> Result<TaskModelInfo, String> {
+    let prepared = prepare_bundle(source)?;
+    install_prepared_task_model_to(&prepared.root, root)
+}
+
+fn install_prepared_task_model_to(source: &Path, root: &Path) -> Result<TaskModelInfo, String> {
     let (manifest, _) = validate_bundle(source)?;
     fs::create_dir_all(root).map_err(|err| err.to_string())?;
     let target = root
@@ -412,6 +565,7 @@ pub fn list_task_models() -> Result<Vec<TaskModelInfo>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -490,6 +644,38 @@ mod tests {
         root
     }
 
+    fn archive_fixture(source: &Path, extension: &str, nested: bool) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "understudy-task-model-archive-{}-{}.{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            TEST_NONCE.fetch_add(1, Ordering::Relaxed),
+            extension
+        ));
+        let file = fs::File::create(&path).unwrap();
+        let mut archive = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        let manifest = load_manifest(source).unwrap();
+        let prefix = if nested {
+            "fixture.understudy-model/"
+        } else {
+            ""
+        };
+        for relative in std::iter::once("manifest.json".to_string())
+            .chain(manifest.files.iter().map(|entry| entry.path.clone()))
+        {
+            archive
+                .start_file(format!("{prefix}{relative}"), options)
+                .unwrap();
+            archive.write_all(&fs::read(source.join(relative)).unwrap()).unwrap();
+        }
+        archive.finish().unwrap();
+        path
+    }
+
     #[test]
     fn valid_bundle_is_verified() {
         let root = fixture();
@@ -507,6 +693,67 @@ mod tests {
         let error = validate_bundle(&root).unwrap_err();
         assert!(error.contains("mismatch"));
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn zip_archive_installs_without_manual_extraction() {
+        let source = fixture();
+        let archive = archive_fixture(&source, "zip", true);
+        let install_root = std::env::temp_dir().join(format!(
+            "understudy-task-model-zip-installs-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let installed = install_task_model_to(&archive, &install_root).unwrap();
+        assert!(installed.installed);
+        assert_eq!(installed.id, "fixture-classifier");
+        fs::remove_dir_all(source).unwrap();
+        fs::remove_file(archive).unwrap();
+        fs::remove_dir_all(install_root).unwrap();
+    }
+
+    #[test]
+    fn renamed_zip_understudy_model_file_installs() {
+        let source = fixture();
+        let archive = archive_fixture(&source, "understudy-model", false);
+        let install_root = std::env::temp_dir().join(format!(
+            "understudy-task-model-renamed-installs-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let inspected = prepare_bundle(&archive).unwrap();
+        assert_eq!(validate_bundle(&inspected.root).unwrap().0.id, "fixture-classifier");
+        drop(inspected);
+        let installed = install_task_model_to(&archive, &install_root).unwrap();
+        assert!(installed.installed);
+        fs::remove_dir_all(source).unwrap();
+        fs::remove_file(archive).unwrap();
+        fs::remove_dir_all(install_root).unwrap();
+    }
+
+    #[test]
+    fn archive_path_traversal_is_rejected() {
+        let path = std::env::temp_dir().join(format!(
+            "understudy-task-model-unsafe-{}.zip",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let file = fs::File::create(&path).unwrap();
+        let mut archive = zip::ZipWriter::new(file);
+        archive
+            .start_file("../manifest.json", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        archive.write_all(b"{}").unwrap();
+        archive.finish().unwrap();
+        let error = prepare_bundle(&path).unwrap_err();
+        assert!(error.contains("unsafe archive path"));
+        fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/docs/task-model-bundles.md
+++ b/docs/task-model-bundles.md
@@ -1,0 +1,27 @@
+# Portable task models
+
+Understudy Desktop can install a task-specific classifier packaged as a directory whose name ends in `.understudy-model`. Open **Trained models** and drag the package onto the window. The app verifies every included file before atomically installing it under `~/.understudy/models/task-models/`.
+
+The package contains the small task-specific parts, not another copy of the base model:
+
+```text
+example.understudy-model/
+├── manifest.json
+├── taxonomy.json
+└── model/
+    ├── adapter/
+    │   ├── adapter_config.json
+    │   └── adapters.safetensors
+    └── classifier-head.safetensors
+```
+
+`manifest.json` uses `understudy.task_model.v1`. It identifies the required MLX-VLM base model, the adapter and classifier head, accepted input columns, the prompt used during training, the taxonomy scorer, and a SHA-256 plus byte count for every member. Paths must be relative and symlinks are rejected.
+
+## Test a model
+
+1. Download the base model named by the bundle in Models.
+2. Open **Trained models** and drag in the `.understudy-model` package.
+3. Choose the installed package, enter an example, and run it locally.
+4. For repeatable scoring, import a CSV or JSONL eval. Each row needs an input and expected answer; the expected answer may be either the detailed taxonomy label id or its exact label text.
+
+The runner loads the local base, applies the adapter and classifier head, returns the top choices, and stores each right or wrong answer in the normal evaluation results. Model packages are data artifacts; they do not carry executable Python or shell code.

--- a/docs/task-model-bundles.md
+++ b/docs/task-model-bundles.md
@@ -1,6 +1,6 @@
 # Portable task models
 
-Understudy Desktop can install a task-specific classifier packaged as a directory whose name ends in `.understudy-model`. Open **Trained models** and drag the package onto the window. The app verifies every included file before atomically installing it under `~/.understudy/models/task-models/`.
+Understudy Desktop can install a task-specific classifier from a `.zip`, a ZIP container renamed to `.understudy-model`, or an unpacked directory ending in `.understudy-model`. Open **Trained models** and drag the downloaded file or directory onto the window. The app safely extracts archives, verifies every included file, and atomically installs the verified package under `~/.understudy/models/task-models/`.
 
 The package contains the small task-specific parts, not another copy of the base model:
 
@@ -20,7 +20,7 @@ example.understudy-model/
 ## Test a model
 
 1. Download the base model named by the bundle in Models.
-2. Open **Trained models** and drag in the `.understudy-model` package.
+2. Open **Trained models** and drag in the downloaded `.understudy-model` or `.zip`; no manual extraction is required.
 3. Choose the installed package, enter an example, and run it locally.
 4. For repeatable scoring, import a CSV or JSONL eval. Each row needs an input and expected answer; the expected answer may be either the detailed taxonomy label id or its exact label text.
 

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.34";
+export const RUNTIME_VERSION = "0.3.35";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -774,6 +774,11 @@ test("trained-model library is restart-safe and stays separate from chat models"
   assert.match(library, /"list_local_classification_runs"/);
   assert.match(library, /"update_local_classification_run"/);
   assert.match(library, /"predict_local_classification"/);
+  assert.match(library, /"list_task_models"/);
+  assert.match(library, /"install_task_model"/);
+  assert.match(library, /"run_task_model"/);
+  assert.match(library, /\.understudy-model/);
+  assert.match(chat, /if \(classifierLibraryOpen\) return/);
   assert.match(library, /revealItemInDir/);
   assert.match(library, /They never appear in the chat-model picker/);
   assert.match(library, /Correct answers/);
@@ -784,6 +789,8 @@ test("trained-model library is restart-safe and stays separate from chat models"
   assert.match(css, /\.classifier-library-dialog/);
   assert.match(tauri, /workload_drop::list_local_classification_runs/);
   assert.match(tauri, /workload_drop::update_local_classification_run/);
+  assert.match(tauri, /task_models::install_task_model/);
+  assert.match(tauri, /task_model_runtime::run_task_model/);
 });
 
 test("desktop model downloads are app-owned, pausable, and resumable", async () => {


### PR DESCRIPTION
## What changed

- adds a verified `.understudy-model` package contract with atomic local installation
- adds a fixed MLX-VLM adapter and taxonomy-classifier runtime
- integrates portable models into the existing Trained models library for drag-and-drop installation and local prediction previews
- advances the Desktop and runtime contract to v0.3.35

## Why

This lets partners run their own task-specific adapter and classifier weights locally without copying a base model or sending their data to an API. It reuses the current classifier library instead of adding another product surface.

## Safety

- verifies every packaged file by SHA-256 and byte count
- permits only relative paths and rejects traversal, absolute paths, and symlinks
- detects same-version packages with conflicting contents
- installs atomically after complete verification
- packages contain no executable code; inference uses the fixed runner shipped with the app

## Validation

- `cargo test --lib`: 202 passed, 6 environment-only tests ignored
- `cargo check`
- frontend production build
- release and UI tests: 24 passed
- real E4B package smoke test returned the expected exact label locally
- v0.3.35 app and DMG generated locally; updater signing remained fail-closed without the CI signing secret

## Review note

This PR does not include customer model weights. Those remain outside the public repository.
