### PR TITLE
fix(desktop): download task model bases automatically

### DIFF
--- a/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
+++ b/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
@@ -109,12 +109,22 @@ type PortableTaskModel = {
   base_model_id: string;
   bytes: number;
   top_k: number;
+  base_ready: boolean;
+  base_download_id?: string | null;
 };
 
 type PortablePrediction = {
   prediction: { l3_id: number; l3: string; probability: number };
   top_k: { l3_id: number; l3: string; probability: number }[];
   elapsed_ms: number;
+};
+
+type DownloadProgress = {
+  id: string;
+  model_id: string;
+  status: "running" | "done" | "error" | "cancelled";
+  started_at: string;
+  error?: string | null;
 };
 
 function compactBytes(bytes: number): string {
@@ -157,11 +167,22 @@ export function LocalClassifierLibraryDialog({
   const [portableText, setPortableText] = useState("");
   const [portablePrediction, setPortablePrediction] = useState<PortablePrediction | null>(null);
   const [portableNotice, setPortableNotice] = useState<string | null>(null);
+  const [downloads, setDownloads] = useState<DownloadProgress[]>([]);
   const requestGeneration = useRef(0);
 
   const selected = useMemo(
     () => runs.find((run) => run.run_id === selectedRunId) ?? runs[0] ?? null,
     [runs, selectedRunId],
+  );
+  const selectedPortable = useMemo(
+    () => portableModels.find((model) => `${model.id}@${model.version}` === portableModelKey) ?? null,
+    [portableModelKey, portableModels],
+  );
+  const selectedBaseDownload = useMemo(
+    () => downloads
+      .filter((download) => download.model_id === selectedPortable?.base_model_id)
+      .sort((left, right) => right.started_at.localeCompare(left.started_at))[0] ?? null,
+    [downloads, selectedPortable?.base_model_id],
   );
 
   const loadRuns = useCallback(async (showArchived: boolean, preferredRunId?: string | null) => {
@@ -201,8 +222,12 @@ export function LocalClassifierLibraryDialog({
   }, [archived, loadRuns, open]);
 
   const loadPortableModels = useCallback(async () => {
-    const models = await invoke<PortableTaskModel[]>("list_task_models");
+    const [models, nextDownloads] = await Promise.all([
+      invoke<PortableTaskModel[]>("list_task_models"),
+      invoke<DownloadProgress[]>("list_snapshot_downloads"),
+    ]);
     setPortableModels(models);
+    setDownloads(nextDownloads);
     setPortableModelKey((current) => current || (models[0] ? `${models[0].id}@${models[0].version}` : ""));
   }, []);
 
@@ -221,7 +246,9 @@ export function LocalClassifierLibraryDialog({
       setPortableNotice("Verifying task model…");
       try {
         const installed = await invoke<PortableTaskModel>("install_task_model", { path });
-        setPortableNotice(`Installed ${installed.name} ${installed.version}.`);
+        setPortableNotice(installed.base_ready
+          ? `Installed ${installed.name} ${installed.version}.`
+          : `Installed ${installed.name}. Downloading its required base model now…`);
         await loadPortableModels();
         setPortableModelKey(`${installed.id}@${installed.version}`);
       } catch (installError) {
@@ -232,6 +259,36 @@ export function LocalClassifierLibraryDialog({
     }).then((unlisten) => { dispose = unlisten; });
     return () => dispose?.();
   }, [loadPortableModels, open]);
+
+  useEffect(() => {
+    if (!open || !isTauri() || !downloads.some((download) => download.status === "running")) return;
+    const timer = window.setInterval(() => {
+      void loadPortableModels().catch((loadError) => setPortableNotice(String(loadError)));
+    }, 1_000);
+    return () => window.clearInterval(timer);
+  }, [downloads, loadPortableModels, open]);
+
+  useEffect(() => {
+    if (selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled") {
+      setPortableNotice(selectedBaseDownload.error
+        ? `Base-model download stopped: ${selectedBaseDownload.error}`
+        : "Base-model download stopped. You can retry it here.");
+    }
+  }, [selectedBaseDownload?.error, selectedBaseDownload?.status]);
+
+  const retryPortableBase = async () => {
+    if (!selectedPortable || busy) return;
+    setBusy(true);
+    setPortableNotice("Restarting the resumable base-model download…");
+    try {
+      await invoke<string>("start_snapshot_download", { modelId: selectedPortable.base_model_id });
+      await loadPortableModels();
+    } catch (downloadError) {
+      setPortableNotice(`Could not restart the base-model download: ${String(downloadError)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
 
   useEffect(() => {
     setDisplayName(selected?.display_name ?? "");
@@ -381,7 +438,22 @@ export function LocalClassifierLibraryDialog({
                 ))}
               </select>
               <input value={portableText} maxLength={4_000} onChange={(event) => { setPortableText(event.target.value); setPortablePrediction(null); }} placeholder="Try a new example" />
-              <button type="submit" className="btn primary" disabled={busy || !portableText.trim()}>{busy ? "Working…" : "Run locally"}</button>
+              <button
+                type={selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled" ? "button" : "submit"}
+                className="btn primary"
+                disabled={busy || (selectedPortable?.base_ready
+                  ? !portableText.trim()
+                  : selectedBaseDownload?.status !== "error" && selectedBaseDownload?.status !== "cancelled")}
+                onClick={selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled" ? () => { void retryPortableBase(); } : undefined}
+              >
+                {busy
+                  ? "Working…"
+                  : selectedPortable?.base_ready
+                    ? "Run locally"
+                    : selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled"
+                      ? "Retry base download"
+                      : "Downloading base model…"}
+              </button>
             </form>
           ) : <p>No portable models installed yet.</p>}
           {portablePrediction && (

--- a/apps/homescreen/src-tauri/src/task_models.rs
+++ b/apps/homescreen/src-tauri/src/task_models.rs
@@ -87,6 +87,8 @@ pub struct TaskModelInfo {
     pub bytes: u64,
     pub file_count: u64,
     pub top_k: u64,
+    pub base_ready: bool,
+    pub base_download_id: Option<String>,
 }
 
 pub(crate) fn task_models_dir() -> Result<PathBuf, String> {
@@ -116,7 +118,10 @@ pub(crate) fn cached_base_model(id: &str) -> Result<PathBuf, String> {
     let base = crate::models::models_dir()
         .ok_or_else(|| "cannot resolve Understudy model directory".to_string())?
         .join(relative);
-    if !base.is_dir() {
+    if !base.is_dir()
+        || base.join(crate::models::INCOMPLETE_MARKER).exists()
+        || !base.join("config.json").is_file()
+    {
         return Err(format!(
             "required base model is not downloaded: {id}. Download it in Models first"
         ));
@@ -441,6 +446,7 @@ fn validate_bundle(bundle: &Path) -> Result<(TaskModelManifest, u64), String> {
 
 fn info(bundle: &Path, installed: bool) -> Result<TaskModelInfo, String> {
     let (manifest, bytes) = validate_bundle(bundle)?;
+    let base_ready = cached_base_model(&manifest.runtime.base_model.id).is_ok();
     Ok(TaskModelInfo {
         id: manifest.id,
         version: manifest.version,
@@ -454,6 +460,8 @@ fn info(bundle: &Path, installed: bool) -> Result<TaskModelInfo, String> {
         bytes,
         file_count: manifest.files.len() as u64,
         top_k: manifest.scorer.top_k,
+        base_ready,
+        base_download_id: None,
     })
 }
 
@@ -483,11 +491,44 @@ pub fn inspect_task_model(path: String) -> Result<TaskModelInfo, String> {
 }
 
 #[tauri::command]
-pub fn install_task_model(path: String) -> Result<TaskModelInfo, String> {
+pub fn install_task_model(app: tauri::AppHandle, path: String) -> Result<TaskModelInfo, String> {
+    use tauri::Manager;
+
     let source = PathBuf::from(path);
-    install_task_model_to(&source, &task_models_dir()?)
+    let prepared = prepare_bundle(&source)?;
+    let preview = info_with_display_path(&prepared.root, &source, false)?;
+    if !preview.base_ready
+        && !crate::models::snapshots()
+            .iter()
+            .any(|snapshot| snapshot.id == preview.base_model_id)
+    {
+        return Err(format!(
+            "required base model is not available for automatic download: {}",
+            preview.base_model_id
+        ));
+    }
+    let mut installed = install_prepared_task_model_to(&prepared.root, &task_models_dir()?)?;
+    if !installed.base_ready {
+        installed.base_download_id = Some(
+            match crate::agent_ops::start_model_download(&app, installed.base_model_id.clone()) {
+                Ok(download_id) => download_id,
+                Err(error) if error.starts_with("download already in progress") => app
+                    .state::<crate::agent_ops::Downloads>()
+                    .list()
+                    .into_iter()
+                    .find(|download| {
+                        download.model_id == installed.base_model_id && download.status == "running"
+                    })
+                    .map(|download| download.id)
+                    .ok_or(error)?,
+                Err(error) => return Err(error),
+            },
+        );
+    }
+    Ok(installed)
 }
 
+#[cfg(test)]
 fn install_task_model_to(source: &Path, root: &Path) -> Result<TaskModelInfo, String> {
     let prepared = prepare_bundle(source)?;
     install_prepared_task_model_to(&prepared.root, root)

--- a/docs/task-model-bundles.md
+++ b/docs/task-model-bundles.md
@@ -1,6 +1,6 @@
 # Portable task models
 
-Understudy Desktop can install a task-specific classifier from a `.zip`, a ZIP container renamed to `.understudy-model`, or an unpacked directory ending in `.understudy-model`. Open **Trained models** and drag the downloaded file or directory onto the window. The app safely extracts archives, verifies every included file, and atomically installs the verified package under `~/.understudy/models/task-models/`.
+Understudy Desktop can install a task-specific classifier from a `.zip`, a ZIP container renamed to `.understudy-model`, or an unpacked directory ending in `.understudy-model`. Open **Trained models** and drag the downloaded file or directory onto the window. The app safely extracts archives, verifies every included file, atomically installs the verified package under `~/.understudy/models/task-models/`, and automatically starts the package's required base-model download when it is not already present.
 
 The package contains the small task-specific parts, not another copy of the base model:
 
@@ -19,8 +19,8 @@ example.understudy-model/
 
 ## Test a model
 
-1. Download the base model named by the bundle in Models.
-2. Open **Trained models** and drag in the downloaded `.understudy-model` or `.zip`; no manual extraction is required.
+1. Open **Trained models** and drag in the downloaded `.understudy-model` or `.zip`; no manual extraction is required.
+2. If its base model is not on the Mac yet, leave Understudy open while the resumable download completes.
 3. Choose the installed package, enter an example, and run it locally.
 4. For repeatable scoring, import a CSV or JSONL eval. Each row needs an input and expected answer; the expected answer may be either the detailed taxonomy label id or its exact label text.
 


### PR DESCRIPTION
## Summary
- automatically start the app-managed resumable base-model download when a portable task model is installed
- keep local inference disabled until the required snapshot is complete and verified
- document the zero-manual-extraction, zero-manual-base-selection flow

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib (205 passed, 6 ignored integration fixtures)
- npm run check (432 passed; skills and package smoke passed)
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->