### PR TITLE
fix(desktop): make portable model installation automatic

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.32"
+    "version": "0.6.33"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.32"
+    "version": "0.6.33"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -1470,6 +1470,111 @@ export function ChatPane({
     if (!isTauri()) return;
     let disposed = false;
     let unlisten: (() => void) | null = null;
+    const compileDroppedPath = (path: string) => {
+      if (dropInFlight.current) {
+        setNotice("The current dropped workload is still being compiled locally.");
+        return;
+      }
+      dropInFlight.current = true;
+      dispatchDrop({ type: "drop_received" });
+      const requestGeneration = dropRequestGeneration.current + 1;
+      dropRequestGeneration.current = requestGeneration;
+      setDroppedWorkload(null);
+      setCsvInspection(null);
+      setMappingInputColumns([]);
+      setMappingLabelColumn("");
+      setMappingGroupColumn("");
+      setClassificationDataset(null);
+      setErr(null);
+      setNotice(null);
+      const channel = new Channel<WorkloadDropEvent>();
+      channel.onmessage = (message) => {
+        if (disposed || dropRequestGeneration.current !== requestGeneration) return;
+        dispatchDrop({
+          type: message.type === "validating" ? "validation_started" : "compilation_started",
+        });
+      };
+      void invoke<DroppedWorkload>("compile_dropped_workload", {
+        path,
+        onEvent: channel,
+      })
+        .then(async (result) => {
+          if (disposed || dropRequestGeneration.current !== requestGeneration) return;
+          setDroppedWorkload(result);
+          const inspectTable = shouldInspectDroppedTable(result);
+          const inspectStructured = shouldInspectStructuredDataset(result);
+          if (inspectStructured) {
+            dispatchDrop({ type: "inspection_started" });
+            try {
+              await inspectTrainingRecipe(result, requestGeneration);
+            } catch (error) {
+              if (!inspectTable) throw error;
+              await inspectCsvWorkload(result, requestGeneration);
+            }
+          } else if (inspectTable) {
+            dispatchDrop({ type: "inspection_started" });
+            try {
+              await inspectCsvWorkload(result, requestGeneration);
+            } catch (error) {
+              const extensionless = !result.source_name.includes(".");
+              if (!extensionless) throw error;
+              dispatchDrop({ type: "succeeded" });
+              setNotice("Workload draft created locally; this extensionless file is not a supported table.");
+            }
+          } else {
+            dispatchDrop({ type: "succeeded" });
+            setNotice(
+              result.truncated
+                ? "Workload draft created at the safety limit; no file contents were read."
+                : "Workload draft created locally; no file contents were read.",
+            );
+          }
+        })
+        .catch((error) => {
+          if (!disposed && dropRequestGeneration.current === requestGeneration) {
+            dispatchDrop({ type: "failed" });
+            setErr(String(error));
+          }
+        })
+        .finally(() => {
+          if (dropRequestGeneration.current !== requestGeneration) return;
+          dropInFlight.current = false;
+        });
+    };
+    const installDroppedModel = async (path: string, inspectFirst: boolean) => {
+      if (dropInFlight.current) {
+        setNotice("The current dropped file is still being processed locally.");
+        return;
+      }
+      dropInFlight.current = true;
+      let handedOffToWorkload = false;
+      setErr(null);
+      setNotice(inspectFirst ? "Checking ZIP for a portable task model…" : "Verifying portable task model…");
+      try {
+        if (inspectFirst) await invoke("inspect_task_model", { path });
+        const installed = await invoke<{
+          name: string;
+          version: string;
+          base_ready: boolean;
+        }>("install_task_model", { path });
+        if (disposed) return;
+        setNotice(installed.base_ready
+          ? `Installed ${installed.name} ${installed.version}.`
+          : `Installed ${installed.name} ${installed.version}. Downloading its required base model now…`);
+        setClassifierLibraryOpen(true);
+      } catch (error) {
+        if (disposed) return;
+        if (inspectFirst) {
+          dropInFlight.current = false;
+          handedOffToWorkload = true;
+          compileDroppedPath(path);
+          return;
+        }
+        setErr(`Model package rejected: ${String(error)}`);
+      } finally {
+        if (!handedOffToWorkload) dropInFlight.current = false;
+      }
+    };
     void getCurrentWebview()
       .onDragDropEvent((event) => {
         // The trained-model dialog owns portable model packages while open;
@@ -1495,70 +1600,17 @@ export function ChatPane({
           setErr("Drop one file or folder at a time so each Workload Card has a clear source.");
           return;
         }
-        dropInFlight.current = true;
-        const requestGeneration = dropRequestGeneration.current + 1;
-        dropRequestGeneration.current = requestGeneration;
-        setDroppedWorkload(null);
-        setCsvInspection(null);
-        setMappingInputColumns([]);
-        setMappingLabelColumn("");
-        setMappingGroupColumn("");
-        setClassificationDataset(null);
-        setErr(null);
-        setNotice(null);
-        const channel = new Channel<WorkloadDropEvent>();
-        channel.onmessage = (message) => {
-          if (disposed || dropRequestGeneration.current !== requestGeneration) return;
-          dispatchDrop({
-            type: message.type === "validating" ? "validation_started" : "compilation_started",
-          });
-        };
-        void invoke<DroppedWorkload>("compile_dropped_workload", {
-          path: paths[0],
-          onEvent: channel,
-        })
-          .then(async (result) => {
-            if (disposed || dropRequestGeneration.current !== requestGeneration) return;
-            setDroppedWorkload(result);
-            const inspectTable = shouldInspectDroppedTable(result);
-            const inspectStructured = shouldInspectStructuredDataset(result);
-            if (inspectStructured) {
-              dispatchDrop({ type: "inspection_started" });
-              try {
-                await inspectTrainingRecipe(result, requestGeneration);
-              } catch (error) {
-                if (!inspectTable) throw error;
-                await inspectCsvWorkload(result, requestGeneration);
-              }
-            } else if (inspectTable) {
-              dispatchDrop({ type: "inspection_started" });
-              try {
-                await inspectCsvWorkload(result, requestGeneration);
-              } catch (error) {
-                const extensionless = !result.source_name.includes(".");
-                if (!extensionless) throw error;
-                dispatchDrop({ type: "succeeded" });
-                setNotice("Workload draft created locally; this extensionless file is not a supported table.");
-              }
-            } else {
-              dispatchDrop({ type: "succeeded" });
-              setNotice(
-                result.truncated
-                  ? "Workload draft created at the safety limit; no file contents were read."
-                  : "Workload draft created locally; no file contents were read.",
-              );
-            }
-          })
-          .catch((error) => {
-            if (!disposed && dropRequestGeneration.current === requestGeneration) {
-              dispatchDrop({ type: "failed" });
-              setErr(String(error));
-            }
-          })
-          .finally(() => {
-            if (dropRequestGeneration.current !== requestGeneration) return;
-            dropInFlight.current = false;
-          });
+        const path = paths[0];
+        const lowerPath = path.toLowerCase();
+        if (lowerPath.endsWith(".understudy-model")) {
+          void installDroppedModel(path, false);
+          return;
+        }
+        if (lowerPath.endsWith(".zip")) {
+          void installDroppedModel(path, true);
+          return;
+        }
+        compileDroppedPath(path);
       })
       .then((stop) => {
         if (disposed) stop();

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -1561,6 +1561,7 @@ export function ChatPane({
         setNotice(installed.base_ready
           ? `Installed ${installed.name} ${installed.version}.`
           : `Installed ${installed.name} ${installed.version}. Downloading its required base model now…`);
+        dispatchDrop({ type: "reset" });
         setClassifierLibraryOpen(true);
       } catch (error) {
         if (disposed) return;
@@ -1570,6 +1571,7 @@ export function ChatPane({
           compileDroppedPath(path);
           return;
         }
+        dispatchDrop({ type: "failed" });
         setErr(`Model package rejected: ${String(error)}`);
       } finally {
         if (!handedOffToWorkload) dropInFlight.current = false;

--- a/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
+++ b/apps/homescreen/app/components/LocalClassifierLibraryDialog.tsx
@@ -151,6 +151,7 @@ export function LocalClassifierLibraryDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const [view, setView] = useState<"models" | "runs">("models");
   const [archived, setArchived] = useState(false);
   const [runs, setRuns] = useState<LocalClassifierRun[]>([]);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
@@ -415,47 +416,53 @@ export function LocalClassifierLibraryDialog({
       <DialogContent className="classifier-library-dialog">
         <DialogHeader className="classifier-library-header">
           <DialogTitle>Trained models</DialogTitle>
-          <DialogDescription>Local task models saved on this Mac. They never appear in the chat-model picker.</DialogDescription>
+          <DialogDescription>Install and run a trained classifier on this Mac.</DialogDescription>
         </DialogHeader>
 
         <div className="classifier-library-tabs" aria-label="Trained model views">
-          <button type="button" aria-pressed={!archived} onClick={() => setArchived(false)}>Active</button>
-          <button type="button" aria-pressed={archived} onClick={() => setArchived(true)}>Archived</button>
+          <button type="button" aria-pressed={view === "models"} onClick={() => setView("models")}>Installed models</button>
+          <button type="button" aria-pressed={view === "runs"} onClick={() => setView("runs")}>Previous runs</button>
         </div>
 
-        <section className="classifier-library-portable">
+        {view === "models" && <section className="classifier-library-portable">
           <div>
-            <strong>Portable task models</strong>
-            <span>Drop a <code>.understudy-model</code> or <code>.zip</code> onto this window to verify and install it.</span>
+            <strong>Local classifier</strong>
+            <span>Drop a model file anywhere in Understudy to install it.</span>
           </div>
           {portableModels.length ? (
             <form onSubmit={(event) => { event.preventDefault(); void predictPortable(); }}>
-              <select value={portableModelKey} onChange={(event) => { setPortableModelKey(event.target.value); setPortablePrediction(null); }}>
-                {portableModels.map((model) => (
-                  <option key={`${model.id}@${model.version}`} value={`${model.id}@${model.version}`}>
-                    {model.name} · {model.version}
-                  </option>
-                ))}
-              </select>
-              <input value={portableText} maxLength={4_000} onChange={(event) => { setPortableText(event.target.value); setPortablePrediction(null); }} placeholder="Try a new example" />
+              <label>
+                <span>Model</span>
+                <select value={portableModelKey} onChange={(event) => { setPortableModelKey(event.target.value); setPortablePrediction(null); }}>
+                  {portableModels.map((model) => (
+                    <option key={`${model.id}@${model.version}`} value={`${model.id}@${model.version}`}>
+                      {model.name} · {model.version}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="classifier-library-example">
+                <span>Try an example</span>
+                <input value={portableText} maxLength={4_000} onChange={(event) => { setPortableText(event.target.value); setPortablePrediction(null); }} placeholder="Paste customer feedback" />
+              </label>
               <button
-                type={selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled" ? "button" : "submit"}
-                className="btn primary"
-                disabled={busy || (selectedPortable?.base_ready
-                  ? !portableText.trim()
-                  : selectedBaseDownload?.status !== "error" && selectedBaseDownload?.status !== "cancelled")}
-                onClick={selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled" ? () => { void retryPortableBase(); } : undefined}
-              >
-                {busy
-                  ? "Working…"
-                  : selectedPortable?.base_ready
-                    ? "Run locally"
-                    : selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled"
-                      ? "Retry base download"
-                      : "Downloading base model…"}
-              </button>
+                  type={selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled" ? "button" : "submit"}
+                  className="btn primary"
+                  disabled={busy || (selectedPortable?.base_ready
+                    ? !portableText.trim()
+                    : selectedBaseDownload?.status !== "error" && selectedBaseDownload?.status !== "cancelled")}
+                  onClick={selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled" ? () => { void retryPortableBase(); } : undefined}
+                >
+                  {busy
+                    ? "Working…"
+                    : selectedPortable?.base_ready
+                      ? "Run locally"
+                      : selectedBaseDownload?.status === "error" || selectedBaseDownload?.status === "cancelled"
+                        ? "Retry download"
+                        : "Downloading base…"}
+                </button>
             </form>
-          ) : <p>No portable models installed yet.</p>}
+          ) : <div className="classifier-library-model-empty"><strong>Drop a model file to get started</strong><span>Understudy verifies it and downloads the matching base automatically.</span></div>}
           {portablePrediction && (
             <output>
               <strong>{portablePrediction.prediction.l3}</strong>
@@ -463,9 +470,14 @@ export function LocalClassifierLibraryDialog({
             </output>
           )}
           {portableNotice && <p role="status">{portableNotice}</p>}
-        </section>
+        </section>}
 
-        <div className="classifier-library-body">
+        {view === "runs" && <>
+          <div className="classifier-library-run-tabs" aria-label="Previous run status">
+            <button type="button" aria-pressed={!archived} onClick={() => setArchived(false)}>Active</button>
+            <button type="button" aria-pressed={archived} onClick={() => setArchived(true)}>Archived</button>
+          </div>
+          <div className="classifier-library-body">
           <nav className="classifier-library-list" aria-label={archived ? "Archived trained models" : "Active trained models"}>
             {loading ? (
               <div className="classifier-library-empty">Reading local runs…</div>
@@ -611,7 +623,8 @@ export function LocalClassifierLibraryDialog({
               </div>
             )}
           </section>
-        </div>
+          </div>
+        </>}
       </DialogContent>
     </Dialog>
   );

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -5845,7 +5845,8 @@ select,
   line-height: 1.45;
 }
 
-.classifier-library-tabs {
+.classifier-library-tabs,
+.classifier-library-run-tabs {
   display: flex;
   width: fit-content;
   padding: 2px;
@@ -5854,7 +5855,8 @@ select,
   background: color-mix(in srgb, var(--surface) 72%, transparent);
 }
 
-.classifier-library-tabs button {
+.classifier-library-tabs button,
+.classifier-library-run-tabs button {
   border: 0;
   border-radius: 6px;
   padding: 6px 11px;
@@ -5863,36 +5865,53 @@ select,
   font-size: 11px;
 }
 
-.classifier-library-tabs button[aria-pressed="true"] {
+.classifier-library-tabs button[aria-pressed="true"],
+.classifier-library-run-tabs button[aria-pressed="true"] {
   background: color-mix(in srgb, var(--mb-cyan) 12%, var(--surface));
   color: var(--mb-cyan);
 }
 
 .classifier-library-portable {
   display: grid;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: 16px;
+  padding: 18px;
   border: 1px solid color-mix(in srgb, var(--mb-mint) 24%, var(--border));
   border-radius: 10px;
   background: color-mix(in srgb, var(--mb-mint) 4%, var(--surface));
 }
 .classifier-library-portable > div { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
-.classifier-library-portable > div strong { color: var(--text); font-size: 12px; }
+.classifier-library-portable > div strong { color: var(--text); font-size: 14px; }
 .classifier-library-portable > div span,
 .classifier-library-portable > p { margin: 0; color: var(--text-3); font: 9px/1.4 var(--mono); }
-.classifier-library-portable form { display: grid; grid-template-columns: minmax(150px, .8fr) minmax(220px, 1.4fr) auto; gap: 7px; }
+.classifier-library-portable form { display: grid; grid-template-columns: minmax(190px, .85fr) minmax(260px, 1.35fr) auto; align-items: end; gap: 9px; }
+.classifier-library-portable label { display: grid; gap: 6px; min-width: 0; }
+.classifier-library-portable label > span { color: var(--text-2); font: 10px/1.3 var(--mono); }
 .classifier-library-portable select,
 .classifier-library-portable input {
   min-width: 0;
   border: 1px solid var(--border-strong);
   border-radius: 7px;
-  padding: 7px 9px;
+  height: 38px;
+  padding: 0 10px;
   background: var(--bg);
   color: var(--text);
   font-size: 11px;
 }
 .classifier-library-portable output { display: flex; justify-content: space-between; gap: 12px; color: var(--mb-mint); font-size: 11px; }
 .classifier-library-portable output span { color: var(--text-3); font: 9px/1.3 var(--mono); }
+.classifier-library-model-empty {
+  display: grid !important;
+  justify-content: start !important;
+  gap: 5px !important;
+  padding: 24px;
+  border: 1px dashed var(--border-strong);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--surface) 65%, transparent);
+}
+.classifier-library-model-empty strong { font-size: 13px !important; }
+.classifier-library-model-empty span { color: var(--text-3); font-size: 11px; }
+
+.classifier-library-run-tabs { margin-top: -2px; }
 
 .classifier-library-body {
   display: grid;
@@ -6156,6 +6175,8 @@ select,
 }
 
 @media (max-width: 720px) {
+  .classifier-library-portable > div { align-items: flex-start; flex-direction: column; }
+  .classifier-library-portable form { grid-template-columns: 1fr; }
   .classifier-library-body { grid-template-columns: 1fr; overflow-y: auto; }
   .classifier-library-list { max-height: 160px; border-right: 0; border-bottom: 1px solid var(--border); }
   .classifier-library-detail { overflow: visible; }

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.35",
+  "version": "0.3.36",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.35"
+version = "0.3.36"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.35"
+version = "0.3.36"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -24,7 +24,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.32";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.33";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.35";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.36";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/design-qa.md
+++ b/design-qa.md
@@ -53,6 +53,21 @@ A separate crop was not needed: the sidebar is legible at full resolution in the
 
 final result: passed
 
+## Trained-model installer focus
+
+- Date: 2026-07-20
+- Source: `/var/folders/p8/bn77j4_d6676ws9hw78lqrgh0000gn/T/codex-clipboard-f3da513b-b932-4f9a-84c7-d393eda2caba.png`
+- Native implementation: `/var/folders/p8/bn77j4_d6676ws9hw78lqrgh0000gn/T/orca-computer-use/539923fa-266d-4abd-a7b9-bcbb340e4184-screenshot.png`
+- Viewport: 1180 x 820 logical pixels at 2x native scale
+
+The default view now contains only the customer task: choose an installed classifier, paste customer feedback, and run locally. Model installation guidance remains visible, but implementation details and historical training runs no longer compete with the primary action. The former Active and Archived controls live under a secondary Previous runs view, where their scope is clear.
+
+The native pass confirmed both views are keyboard-accessible and functional. The installed-model screen fits without clipping or internal scrolling, uses the existing dark surfaces and cyan focus language, and keeps the primary action aligned with its input. Previous runs still exposes the full list, selection details, Active and Archived controls, and run actions without changing their behavior.
+
+No actionable P0, P1, or P2 visual or interaction issues remain for this scoped simplification.
+
+final result: passed
+
 ## Local classifier training progress
 
 - Source visual truth: Fable training flow at `http://localhost:1423/cedar/flows/training`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.32",
+      "version": "0.6.33",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.35";
+export const RUNTIME_VERSION = "0.3.36";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -780,11 +780,13 @@ test("trained-model library is restart-safe and stays separate from chat models"
   assert.match(library, /\.understudy-model/);
   assert.match(chat, /if \(classifierLibraryOpen\) return/);
   assert.match(library, /revealItemInDir/);
-  assert.match(library, /They never appear in the chat-model picker/);
+  assert.match(library, /Install and run a trained classifier on this Mac/);
+  assert.match(library, /Installed models/);
+  assert.match(library, /Previous runs/);
   assert.match(library, /Correct answers/);
   assert.match(library, /Separate test examples/);
   assert.match(library, /Archived/);
-  assert.match(library, /source rows will not be copied|Local task models saved on this Mac/);
+  assert.match(library, /Understudy verifies it and downloads the matching base automatically/);
   assert.doesNotMatch(library, /training examples|raw rows|source payload/i);
   assert.match(css, /\.classifier-library-dialog/);
   assert.match(tauri, /workload_drop::list_local_classification_runs/);


### PR DESCRIPTION
## What changed
- intercept `.understudy-model` drops before generic workload/chat handling
- inspect every `.zip` as a possible portable model before falling back to ordinary workload behavior
- install verified adapters natively, start the required base-model download, and open Trained Models status
- surface invalid model packages as package errors instead of sending filenames to an LLM
- simplify Trained Models around the customer workflow: select model, paste feedback, run locally
- move historical training runs and Active/Archived controls behind a secondary Previous runs view

## Verification
- native Tauri visual and interaction pass at 1180×820
- `bun run build` in `apps/homescreen`
- `npm test` (432/432 passing)
- design QA passed with no P0/P1/P2 findings

## User-visible bug
Dropping a model anywhere outside the hidden Trained Models dialog created a workload/chat attachment. The chat model then attempted to interpret the filename as a snapshot model ID and failed.