### PR TITLE
feat(desktop): make dropped task models active

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.33"
+    "version": "0.6.34"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.33"
+    "version": "0.6.34"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -1950,11 +1950,22 @@ export function ChatPane({
         setErr(`${activeTaskModel.name} accepts text only.`);
         return;
       }
-      const installed = await invoke<ActiveTaskModel[]>("list_task_models")
-        .then((models) => models.find((model) => model.id === activeTaskModel.id && model.version === activeTaskModel.version))
-        .catch(() => undefined);
-      if (!installed?.base_ready) {
-        if (installed) setActiveTaskModel(installed);
+      let installed: ActiveTaskModel | undefined;
+      try {
+        const models = await invoke<ActiveTaskModel[]>("list_task_models");
+        installed = models.find((model) => model.id === activeTaskModel.id && model.version === activeTaskModel.version);
+      } catch (cause) {
+        setErr(`Could not check ${activeTaskModel.name}. ${String(cause)}`);
+        return;
+      }
+      if (!installed) {
+        setActiveTaskModel(null);
+        window.localStorage.removeItem(ACTIVE_TASK_MODEL_KEY);
+        setErr(`${activeTaskModel.name} is no longer installed. Drop the model file here to install it again.`);
+        return;
+      }
+      if (!installed.base_ready) {
+        setActiveTaskModel(installed);
         setNotice(`${activeTaskModel.name} is absorbed. Its base model is still downloading.`);
         return;
       }

--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { Channel, invoke, isTauri } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
   MessageScroller,
   MessageScrollerContent,
@@ -388,6 +389,26 @@ type ModelChoice =
 
 type AnthropicModel = { id: string; label: string; detail: string };
 type AnthropicStatus = { present: boolean; source: string | null };
+type ActiveTaskModel = {
+  id: string;
+  version: string;
+  name: string;
+  base_ready: boolean;
+  top_k: number;
+};
+type TaskModelPrediction = {
+  prediction: { l3_id: number; l3: string; probability: number };
+  top_k: Array<{ l3_id: number; l3: string; probability: number }>;
+  elapsed_ms: number;
+};
+type TaskModelFileRun = {
+  rows: number;
+  labeled_rows: number;
+  right: number;
+  accuracy?: number | null;
+  elapsed_ms: number;
+  output_path: string;
+};
 
 const CLOUD_MODEL: ModelChoice = {
   id: "cloud:glm-5.2",
@@ -400,7 +421,9 @@ const CLOUD_MODEL: ModelChoice = {
 
 const PERSONA_WHITE: PersonaColor = { red: 255, green: 255, blue: 255 };
 const PERSONA_CYAN: PersonaColor = { red: 103, green: 232, blue: 249 };
+const PERSONA_TASK: PersonaColor = { red: 244, green: 114, blue: 182 };
 const PERSONA_ERROR: PersonaColor = { red: 248, green: 113, blue: 113 };
+const ACTIVE_TASK_MODEL_KEY = "understudy.active-task-model.v1";
 
 function compactBytes(bytes: number): string {
   if (bytes < 1_024) return `${bytes} B`;
@@ -1087,6 +1110,8 @@ export function ChatPane({
   const [remoteTrainingView, setRemoteTrainingView] = useState(false);
   const [trainingHaloVisual, setTrainingHaloVisual] = useState<TrainingHaloVisual | null>(null);
   const [classifierLibraryOpen, setClassifierLibraryOpen] = useState(false);
+  const [activeTaskModel, setActiveTaskModel] = useState<ActiveTaskModel | null>(null);
+  const [taskModelFileRun, setTaskModelFileRun] = useState<TaskModelFileRun | null>(null);
   const [pacingMessageIndex, setPacingMessageIndex] = useState<number | null>(null);
   const [pacedRevealed, setPacedRevealed] = useState<number | null>(null);
   const [animatedMessageId, setAnimatedMessageId] = useState<string | null>(null);
@@ -1110,6 +1135,25 @@ export function ChatPane({
   }, [dropPhase, localTrainingActive, onTrainingChange]);
 
   useEffect(() => () => onTrainingChange?.(false), [onTrainingChange]);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(ACTIVE_TASK_MODEL_KEY);
+    if (!stored) return;
+    let identity: { id?: string; version?: string };
+    try {
+      identity = JSON.parse(stored) as { id?: string; version?: string };
+    } catch {
+      window.localStorage.removeItem(ACTIVE_TASK_MODEL_KEY);
+      return;
+    }
+    invoke<ActiveTaskModel[]>("list_task_models")
+      .then((models) => {
+        const match = models.find((model) => model.id === identity.id && model.version === identity.version);
+        if (match) setActiveTaskModel(match);
+        else window.localStorage.removeItem(ACTIVE_TASK_MODEL_KEY);
+      })
+      .catch(() => undefined);
+  }, []);
 
   const applyAssistantPatch = (patch: ChatStreamPatch) => {
     setMessages((current) => {
@@ -1553,16 +1597,29 @@ export function ChatPane({
       try {
         if (inspectFirst) await invoke("inspect_task_model", { path });
         const installed = await invoke<{
+          id: string;
           name: string;
           version: string;
           base_ready: boolean;
+          top_k: number;
         }>("install_task_model", { path });
         if (disposed) return;
+        const taskModel = {
+          id: installed.id,
+          name: installed.name,
+          version: installed.version,
+          base_ready: installed.base_ready,
+          top_k: installed.top_k,
+        };
+        setActiveTaskModel(taskModel);
+        window.localStorage.setItem(ACTIVE_TASK_MODEL_KEY, JSON.stringify({
+          id: installed.id,
+          version: installed.version,
+        }));
         setNotice(installed.base_ready
-          ? `Installed ${installed.name} ${installed.version}.`
-          : `Installed ${installed.name} ${installed.version}. Downloading its required base model now…`);
+          ? `${installed.name} is active.`
+          : `${installed.name} is active. Downloading its required base model now…`);
         dispatchDrop({ type: "reset" });
-        setClassifierLibraryOpen(true);
       } catch (error) {
         if (disposed) return;
         if (inspectFirst) {
@@ -1575,6 +1632,34 @@ export function ChatPane({
         setErr(`Model package rejected: ${String(error)}`);
       } finally {
         if (!handedOffToWorkload) dropInFlight.current = false;
+      }
+    };
+    const scoreDroppedFile = async (path: string) => {
+      if (!activeTaskModel || dropInFlight.current) return;
+      dropInFlight.current = true;
+      setErr(null);
+      setTaskModelFileRun(null);
+      setNotice(`Scoring test data with ${activeTaskModel.name}…`);
+      try {
+        const result = await invoke<TaskModelFileRun>("run_task_model_file", {
+          request: {
+            model_id: activeTaskModel.id,
+            version: activeTaskModel.version,
+            path,
+          },
+        });
+        if (disposed) return;
+        setTaskModelFileRun(result);
+        setNotice(result.accuracy == null
+          ? `Scored ${result.rows.toLocaleString()} rows for human review.`
+          : `${result.right.toLocaleString()} of ${result.labeled_rows.toLocaleString()} labeled rows matched.`);
+        dispatchDrop({ type: "reset" });
+      } catch (error) {
+        if (disposed) return;
+        dispatchDrop({ type: "failed" });
+        setErr(`Test data could not be scored: ${String(error)}`);
+      } finally {
+        dropInFlight.current = false;
       }
     };
     void getCurrentWebview()
@@ -1612,6 +1697,10 @@ export function ChatPane({
           void installDroppedModel(path, true);
           return;
         }
+        if (activeTaskModel && /\.(?:csv|tsv|jsonl|ndjson)$/.test(lowerPath)) {
+          void scoreDroppedFile(path);
+          return;
+        }
         compileDroppedPath(path);
       })
       .then((stop) => {
@@ -1625,7 +1714,7 @@ export function ChatPane({
       disposed = true;
       unlisten?.();
     };
-  }, [classifierLibraryOpen]);
+  }, [activeTaskModel, classifierLibraryOpen]);
 
   const hydrateSavedMessages = async (
     saved: PersistedChatSession,
@@ -1855,11 +1944,68 @@ export function ChatPane({
       });
   }, [csvInspection, datasetProfileConfirmed, droppedWorkload, environmentArchitect, environmentArchitectRetry, gatewaySignedIn, selectedChoice, trainingRecipe]);
 
+  const runActiveTaskModel = async (clean: string, files: FileUIPart[]) => {
+    if (activeTaskModel) {
+      if (!clean || files.length > 0) {
+        setErr(`${activeTaskModel.name} accepts text only.`);
+        return;
+      }
+      const installed = await invoke<ActiveTaskModel[]>("list_task_models")
+        .then((models) => models.find((model) => model.id === activeTaskModel.id && model.version === activeTaskModel.version))
+        .catch(() => undefined);
+      if (!installed?.base_ready) {
+        if (installed) setActiveTaskModel(installed);
+        setNotice(`${activeTaskModel.name} is absorbed. Its base model is still downloading.`);
+        return;
+      }
+      setActiveTaskModel(installed);
+      setInput("");
+      const toSend: Msg[] = [
+        ...messages,
+        { role: "user", content: clean, model: installed.name },
+      ];
+      setAnimatedMessageId(`${sessionId}:message:${messages.length}`);
+      setMessages([...toSend, { role: "assistant", content: "", model: installed.name }]);
+      setStreaming(true);
+      setAssistantSpeaking(false);
+      try {
+        const [result] = await invoke<TaskModelPrediction[]>("run_task_model", {
+          request: {
+            model_id: installed.id,
+            version: installed.version,
+            rows: [{ task_id: `${sessionId}:${messages.length}`, text: clean }],
+          },
+        });
+        if (!result) throw new Error("The classifier returned no prediction.");
+        const top = result.top_k.slice(0, 3);
+        const detail = top.map((choice, index) =>
+          `${index + 1}. ${choice.l3} — ${(choice.probability * 100).toFixed(1)}%`
+        ).join("\n");
+        setMessages([...toSend, {
+          role: "assistant",
+          model: installed.name,
+          content: `**${result.prediction.l3}**\n\n${detail}\n\nRan locally in ${result.elapsed_ms} ms.`,
+        }]);
+      } catch (error) {
+        setErr(String(error));
+        setMessages(toSend);
+      } finally {
+        setStreaming(false);
+        setAssistantSpeaking(false);
+      }
+    }
+  };
+
   const send = async (text: string, files: FileUIPart[] = []) => {
     const clean = text.trim();
     if ((!clean && files.length === 0) || streaming) return;
     setErr(null);
     setNotice(null);
+
+    if (activeTaskModel) {
+      await runActiveTaskModel(clean, files);
+      return;
+    }
 
     const choice = selectedChoice;
     if (choice.route === "cloud") {
@@ -2164,6 +2310,8 @@ export function ChatPane({
     ? PERSONA_ERROR
     : dropHovering || dropRunning || localTrainingActive || classificationDataset
       ? PERSONA_CYAN
+      : activeTaskModel
+        ? PERSONA_TASK
       : PERSONA_WHITE;
   const selectedTargetColumn = csvInspection?.columns.find((column) => column.name === mappingLabelColumn) ?? null;
   const selectedTargetBlockReason = !mappingLabelColumn || !selectedTargetColumn
@@ -2226,6 +2374,7 @@ export function ChatPane({
         "chat ai-chat" +
         (messages.length > 0 ? " has-messages" : "") +
         (dropRunning || droppedWorkload ? " has-workload" : "") +
+        (activeTaskModel ? " task-model-active" : "") +
         (dropPhase === "preparing_dataset" || classificationDataset || localTrainingActive || remoteTrainingView ? " is-training-flow" : "") +
         (streaming ? " is-streaming" : "")
       }
@@ -2270,7 +2419,35 @@ export function ChatPane({
             <span>{dropStatus.detail}</span>
           </div>
         )}
+        {activeTaskModel && !dropStatus && (
+          <button
+            type="button"
+            className="active-task-model-badge"
+            onClick={() => setClassifierLibraryOpen(true)}
+            title="Open trained models"
+          >
+            <span />
+            <strong>{activeTaskModel.name}</strong>
+            <small>{activeTaskModel.base_ready ? "absorbed" : "absorbing…"}</small>
+          </button>
+        )}
       </div>
+      {activeTaskModel && (
+        <section className={"active-task-dropzone" + (dropHovering ? " is-hovering" : "")} aria-label="Test the active classifier">
+          <div>
+            <strong>Drop test data to score</strong>
+            <span>CSV or JSONL · expected labels optional · review stays local</span>
+          </div>
+          {taskModelFileRun && (
+            <button type="button" onClick={() => void revealItemInDir(taskModelFileRun.output_path)}>
+              {taskModelFileRun.accuracy == null
+                ? `${taskModelFileRun.rows.toLocaleString()} predictions`
+                : `${(taskModelFileRun.accuracy * 100).toFixed(1)}% matched`}
+              <small>Open review CSV</small>
+            </button>
+          )}
+        </section>
+      )}
       <MessageScrollerProvider
         key={`${sessionId}:${classificationDataset ? "training" : droppedWorkload ? "workload" : "chat"}`}
         autoScroll={!droppedWorkload}
@@ -2665,7 +2842,10 @@ export function ChatPane({
               <ModelPicker
                 choices={choices}
                 selected={selectedChoice}
+                activeTaskModel={activeTaskModel}
                 onSelect={(id) => {
+                  setActiveTaskModel(null);
+                  window.localStorage.removeItem(ACTIVE_TASK_MODEL_KEY);
                   selectedModelUserOwned.current = true;
                   setSelectedModel(id);
                 }}
@@ -2676,7 +2856,7 @@ export function ChatPane({
                 }
                 onThinkingToggle={setThinking}
               />
-              <ModelCardDrawer
+              {!activeTaskModel && <ModelCardDrawer
                 modelId={selectedChoice.route === "local" ? selectedChoice.modelId : selectedChoice.id}
                 label={selectedChoice.label}
                 route={selectedChoice.route}
@@ -2686,12 +2866,12 @@ export function ChatPane({
                   loading: selectedChoice.route === "local" ? selectedChoice.loading : false,
                   thinking: selectedChoice.route === "local" ? selectedChoice.thinking : false,
                 }}
-              />
+              />}
               <PromptInputBody className="composer-row-body">
                 <PromptInputTextarea
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
-                  placeholder="Ask Understudy..."
+                  placeholder={activeTaskModel ? `Classify with ${activeTaskModel.name}…` : "Ask Understudy..."}
                   disabled={streaming}
                 />
               </PromptInputBody>
@@ -2713,6 +2893,7 @@ export function ChatPane({
 function ModelPicker({
   choices,
   selected,
+  activeTaskModel,
   onSelect,
   onConnectAnthropic,
   thinkingDisabled,
@@ -2721,6 +2902,7 @@ function ModelPicker({
 }: {
   choices: ModelChoice[];
   selected: ModelChoice;
+  activeTaskModel: ActiveTaskModel | null;
   onSelect: (id: string) => void;
   onConnectAnthropic: () => void;
   thinkingDisabled: boolean;
@@ -2735,15 +2917,25 @@ function ModelPicker({
         <button
           type="button"
           className="ai-model-trigger"
-          title={`${selected.label} · ${selected.route}`}
+          title={activeTaskModel ? `${activeTaskModel.name} · task model` : `${selected.label} · ${selected.route}`}
         >
-          <span>{selected.label}</span>
+          <span>{activeTaskModel?.name ?? selected.label}</span>
         </button>
       </ModelSelectorTrigger>
       <ModelSelectorContent>
         <ModelSelectorInput placeholder="Search models..." />
         <ModelSelectorList>
           <ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
+          {activeTaskModel && (
+            <ModelSelectorGroup heading="Active task model">
+              <ModelSelectorItem value={`task:${activeTaskModel.id}@${activeTaskModel.version}`}>
+                <ModelSelectorName>{activeTaskModel.name}</ModelSelectorName>
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  {activeTaskModel.base_ready ? "Runs locally" : "Downloading base model"}
+                </span>
+              </ModelSelectorItem>
+            </ModelSelectorGroup>
+          )}
           <ModelSelectorGroup heading="Serving">
             {choices
               .filter((choice) => choice.route === "local")

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -2377,6 +2377,11 @@ select,
   border-color: color-mix(in srgb, var(--mb-cyan) 72%, transparent);
   animation-duration: 1.05s;
 }
+.task-model-active .persona-stage::before {
+  border-color: color-mix(in srgb, #f472b6 34%, transparent);
+  box-shadow: 0 0 34px color-mix(in srgb, #f472b6 12%, transparent);
+  opacity: 1;
+}
 .persona-halo {
   position: relative;
   z-index: 1;
@@ -2392,6 +2397,50 @@ select,
     height 260ms cubic-bezier(0.2, 0.7, 0.2, 1),
     opacity 300ms cubic-bezier(0.2, 0.7, 0.2, 1),
     transform 300ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.task-model-active .persona-halo {
+  --pc-tint: #f472b6;
+}
+.active-task-model-badge {
+  position: absolute;
+  z-index: 3;
+  bottom: clamp(6px, 2vh, 20px);
+  left: 50%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  max-width: min(420px, calc(100% - 32px));
+  padding: 7px 11px;
+  border: 1px solid color-mix(in srgb, #f472b6 25%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-1) 86%, transparent);
+  color: var(--text-2);
+  font-size: 11px;
+  transform: translateX(-50%);
+  backdrop-filter: blur(14px);
+}
+.active-task-model-badge:hover {
+  border-color: color-mix(in srgb, #f472b6 48%, var(--border));
+  color: var(--text);
+}
+.active-task-model-badge > span {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 6px;
+  border-radius: 50%;
+  background: #f472b6;
+  box-shadow: 0 0 9px color-mix(in srgb, #f472b6 70%, transparent);
+}
+.active-task-model-badge strong {
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.active-task-model-badge small {
+  color: #f9a8d4;
+  font-family: var(--mono);
+  white-space: nowrap;
 }
 .sidekick-persona-orbit {
   grid-area: 1 / 1;
@@ -2584,6 +2633,61 @@ select,
 .ai-chat.has-messages .persona-stamp {
   width: 34px;
   height: 34px;
+}
+.ai-chat.has-messages .active-task-model-badge {
+  top: 50%;
+  bottom: auto;
+  left: calc(50% + 32px);
+  max-width: min(320px, calc(100vw - 160px));
+  padding: 5px 9px;
+  transform: translateY(-50%);
+}
+.active-task-dropzone {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 4px 8px;
+  padding: 10px 13px;
+  border: 1px dashed color-mix(in srgb, #f472b6 34%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, #f472b6 4%, var(--surface-1));
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+.active-task-dropzone.is-hovering {
+  border-color: #f472b6;
+  background: color-mix(in srgb, #f472b6 10%, var(--surface-1));
+  transform: scale(1.006);
+}
+.active-task-dropzone > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.active-task-dropzone strong {
+  color: var(--text-2);
+  font-size: 12px;
+  font-weight: 620;
+}
+.active-task-dropzone span,
+.active-task-dropzone small {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+.active-task-dropzone > button {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 1px;
+  padding: 6px 9px;
+  border: 1px solid color-mix(in srgb, #f472b6 22%, var(--border));
+  border-radius: 9px;
+  color: #f9a8d4;
+  font-size: 11px;
+  text-align: right;
+}
+.active-task-dropzone > button:hover {
+  border-color: color-mix(in srgb, #f472b6 52%, var(--border));
 }
 .ai-chat.has-messages.is-streaming .persona-stage {
   height: 36px;

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.36",
+  "version": "0.3.37",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.36"
+version = "0.3.37"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.36"
+version = "0.3.37"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -24,7 +24,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.33";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.34";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.36";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.37";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -323,6 +323,7 @@ pub fn run() {
             custom_evals::run_custom_eval,
             custom_evals::run_custom_eval_live,
             task_model_runtime::run_task_model,
+            task_model_runtime::run_task_model_file,
             task_model_runtime::run_task_model_eval,
             task_models::inspect_task_model,
             task_models::install_task_model,

--- a/apps/homescreen/src-tauri/src/task_model_runtime.rs
+++ b/apps/homescreen/src-tauri/src/task_model_runtime.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tauri::{AppHandle, Manager};
 
@@ -128,6 +131,251 @@ pub async fn run_task_model(
 }
 
 #[derive(Deserialize)]
+pub struct RunTaskModelFileRequest {
+    pub model_id: String,
+    pub version: String,
+    pub path: String,
+}
+
+#[derive(Serialize)]
+pub struct TaskModelFileRun {
+    pub rows: u64,
+    pub labeled_rows: u64,
+    pub right: u64,
+    pub accuracy: Option<f64>,
+    pub elapsed_ms: u64,
+    pub output_path: String,
+}
+
+#[derive(Clone, Debug)]
+struct ReviewRow {
+    task_id: String,
+    text: String,
+    expected: Option<String>,
+}
+
+fn field<'a>(value: &'a Value, names: &[&str]) -> Option<&'a str> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(Value::as_str))
+}
+
+fn read_review_rows(path: &Path) -> Result<Vec<ReviewRow>, String> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if matches!(extension.as_str(), "jsonl" | "ndjson") {
+        let content =
+            fs::read_to_string(path).map_err(|err| format!("cannot read test data: {err}"))?;
+        let mut rows = vec![];
+        for (index, line) in content.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_str(line)
+                .map_err(|err| format!("invalid JSON on line {}: {err}", index + 1))?;
+            let text = field(
+                &value,
+                &[
+                    "text", "input", "prompt", "review", "feedback", "comment", "content",
+                    "message",
+                ],
+            )
+            .ok_or_else(|| format!("line {} has no text or input field", index + 1))?;
+            let task_id = field(&value, &["task_id", "id", "row_id"])
+                .map(str::to_string)
+                .unwrap_or_else(|| (index + 1).to_string());
+            let expected = field(
+                &value,
+                &["expected", "label", "l3", "l3_label", "category", "target"],
+            )
+            .map(str::to_string);
+            rows.push(ReviewRow {
+                task_id,
+                text: text.to_string(),
+                expected,
+            });
+        }
+        return Ok(rows);
+    }
+    if !matches!(extension.as_str(), "csv" | "tsv") {
+        return Err("test data must be CSV, TSV, JSONL, or NDJSON".to_string());
+    }
+    let delimiter = if extension == "tsv" { b'\t' } else { b',' };
+    let mut reader = csv::ReaderBuilder::new()
+        .delimiter(delimiter)
+        .from_path(path)
+        .map_err(|err| format!("cannot read test data: {err}"))?;
+    let headers = reader
+        .headers()
+        .map_err(|err| format!("cannot read headers: {err}"))?
+        .clone();
+    let find = |names: &[&str]| {
+        headers.iter().position(|header| {
+            names
+                .iter()
+                .any(|name| header.trim().eq_ignore_ascii_case(name))
+        })
+    };
+    let text_index = find(&[
+        "text",
+        "input",
+        "prompt",
+        "review",
+        "customer_feedback",
+        "feedback",
+        "comment",
+        "content",
+        "body",
+        "message",
+    ])
+    .or_else(|| (!headers.is_empty()).then_some(0))
+    .ok_or_else(|| "test data has no columns".to_string())?;
+    let expected_index = find(&["expected", "label", "l3", "l3_label", "category", "target"]);
+    let id_index = find(&["task_id", "id", "row_id"]);
+    let mut rows = vec![];
+    for (index, record) in reader.records().enumerate() {
+        let record = record.map_err(|err| format!("invalid row {}: {err}", index + 2))?;
+        let text = record.get(text_index).unwrap_or("").trim();
+        if text.is_empty() {
+            return Err(format!("row {} has no text", index + 2));
+        }
+        let task_id = id_index
+            .and_then(|column| record.get(column))
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| (index + 1).to_string());
+        let expected = expected_index
+            .and_then(|column| record.get(column))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        rows.push(ReviewRow {
+            task_id,
+            text: text.to_string(),
+            expected,
+        });
+    }
+    Ok(rows)
+}
+
+fn run_file_blocking(
+    request: RunTaskModelFileRequest,
+    output_root: PathBuf,
+) -> Result<TaskModelFileRun, String> {
+    let source = fs::canonicalize(request.path.trim())
+        .map_err(|err| format!("cannot open test data: {err}"))?;
+    if !source.is_file() {
+        return Err("test data must be one file".to_string());
+    }
+    let rows = read_review_rows(&source)?;
+    if rows.is_empty() {
+        return Err("test data has no rows".to_string());
+    }
+    if rows.len() > 100_000 {
+        return Err("a task-model file run is limited to 100,000 rows".to_string());
+    }
+    let started = std::time::Instant::now();
+    let predictions = run_blocking(RunTaskModelRequest {
+        model_id: request.model_id.clone(),
+        version: request.version.clone(),
+        rows: rows
+            .iter()
+            .map(|row| TaskModelInput {
+                task_id: Some(row.task_id.clone()),
+                text: row.text.clone(),
+            })
+            .collect(),
+    })?;
+    fs::create_dir_all(&output_root)
+        .map_err(|err| format!("cannot create review folder: {err}"))?;
+    let output = output_root.join(format!(
+        "{}-review-{}.csv",
+        request
+            .model_id
+            .replace(|character: char| !character.is_ascii_alphanumeric(), "-"),
+        chrono::Utc::now().timestamp_millis()
+    ));
+    let mut writer = csv::Writer::from_path(&output)
+        .map_err(|err| format!("cannot create review CSV: {err}"))?;
+    writer
+        .write_record([
+            "task_id",
+            "input",
+            "expected",
+            "predicted",
+            "correct",
+            "confidence",
+            "choice_1",
+            "choice_2",
+            "choice_3",
+            "elapsed_ms",
+        ])
+        .map_err(|err| err.to_string())?;
+    let mut labeled = 0u64;
+    let mut right = 0u64;
+    for (row, prediction) in rows.iter().zip(&predictions) {
+        let hit = row.expected.as_ref().map(|expected| {
+            expected == &prediction.prediction.l3_id.to_string()
+                || expected.eq_ignore_ascii_case(prediction.prediction.l3.trim())
+        });
+        if let Some(hit) = hit {
+            labeled += 1;
+            right += u64::from(hit);
+        }
+        let choices = (0..3)
+            .map(|index| {
+                prediction
+                    .top_k
+                    .get(index)
+                    .map(|choice| format!("{} ({:.1}%)", choice.l3, choice.probability * 100.0))
+                    .unwrap_or_default()
+            })
+            .collect::<Vec<_>>();
+        writer
+            .write_record([
+                row.task_id.as_str(),
+                row.text.as_str(),
+                row.expected.as_deref().unwrap_or(""),
+                prediction.prediction.l3.as_str(),
+                hit.map(|value| value.to_string()).as_deref().unwrap_or(""),
+                &format!("{:.6}", prediction.prediction.probability),
+                &choices[0],
+                &choices[1],
+                &choices[2],
+                &prediction.elapsed_ms.to_string(),
+            ])
+            .map_err(|err| err.to_string())?;
+    }
+    writer.flush().map_err(|err| err.to_string())?;
+    Ok(TaskModelFileRun {
+        rows: predictions.len() as u64,
+        labeled_rows: labeled,
+        right,
+        accuracy: (labeled > 0).then_some(right as f64 / labeled as f64),
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        output_path: output.to_string_lossy().into_owned(),
+    })
+}
+
+#[tauri::command]
+pub async fn run_task_model_file(
+    app: AppHandle,
+    request: RunTaskModelFileRequest,
+) -> Result<TaskModelFileRun, String> {
+    let output_root = app
+        .path()
+        .app_data_dir()
+        .map_err(|err| err.to_string())?
+        .join("task-model-reviews");
+    tauri::async_runtime::spawn_blocking(move || run_file_blocking(request, output_root))
+        .await
+        .map_err(|err| format!("task-model file worker failed: {err}"))?
+}
+
+#[derive(Deserialize)]
 pub struct RunTaskModelEvalRequest {
     pub eval_id: String,
     pub model_id: String,
@@ -247,4 +495,54 @@ pub async fn run_task_model_eval(
         },
         elapsed_ms: started.elapsed().as_millis() as u64,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_path(name: &str) -> PathBuf {
+        let (stem, extension) = name.rsplit_once('.').unwrap();
+        std::env::temp_dir().join(format!(
+            "understudy-task-review-{stem}-{}-{}.{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default(),
+            extension,
+        ))
+    }
+
+    #[test]
+    fn reads_labeled_csv_for_human_review() {
+        let path = test_path("reviews.csv");
+        fs::write(
+            &path,
+            "id,customer_feedback,label\nrow-1,The delivery was late,Delivery timing\n",
+        )
+        .unwrap();
+        let rows = read_review_rows(&path).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].task_id, "row-1");
+        assert_eq!(rows[0].text, "The delivery was late");
+        assert_eq!(rows[0].expected.as_deref(), Some("Delivery timing"));
+    }
+
+    #[test]
+    fn reads_unlabeled_jsonl_for_prediction_review() {
+        let path = test_path("reviews.jsonl");
+        fs::write(&path, "{\"row_id\":\"r2\",\"review\":\"Great shopper\"}\n").unwrap();
+        let rows = read_review_rows(&path).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].task_id, "r2");
+        assert_eq!(rows[0].text, "Great shopper");
+        assert_eq!(rows[0].expected, None);
+    }
+
+    #[test]
+    fn rejects_files_without_review_text() {
+        let path = test_path("missing-text.jsonl");
+        fs::write(&path, "{\"label\":\"Delivery timing\"}\n").unwrap();
+        assert!(read_review_rows(&path)
+            .unwrap_err()
+            .contains("no text or input field"));
+    }
 }

--- a/apps/homescreen/src-tauri/src/task_model_runtime.rs
+++ b/apps/homescreen/src-tauri/src/task_model_runtime.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::borrow::Cow;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -7,6 +8,14 @@ use std::process::{Command, Stdio};
 use tauri::{AppHandle, Manager};
 
 const RUNNER: &str = include_str!("../runtime/task_model_runner.py");
+
+fn spreadsheet_safe(value: &str) -> Cow<'_, str> {
+    if value.starts_with(['=', '+', '-', '@']) {
+        Cow::Owned(format!("'{value}"))
+    } else {
+        Cow::Borrowed(value)
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TaskModelInput {
@@ -336,15 +345,15 @@ fn run_file_blocking(
             .collect::<Vec<_>>();
         writer
             .write_record([
-                row.task_id.as_str(),
-                row.text.as_str(),
-                row.expected.as_deref().unwrap_or(""),
-                prediction.prediction.l3.as_str(),
+                spreadsheet_safe(row.task_id.as_str()).as_ref(),
+                spreadsheet_safe(row.text.as_str()).as_ref(),
+                spreadsheet_safe(row.expected.as_deref().unwrap_or("")).as_ref(),
+                spreadsheet_safe(prediction.prediction.l3.as_str()).as_ref(),
                 hit.map(|value| value.to_string()).as_deref().unwrap_or(""),
                 &format!("{:.6}", prediction.prediction.probability),
-                &choices[0],
-                &choices[1],
-                &choices[2],
+                spreadsheet_safe(&choices[0]).as_ref(),
+                spreadsheet_safe(&choices[1]).as_ref(),
+                spreadsheet_safe(&choices[2]).as_ref(),
                 &prediction.elapsed_ms.to_string(),
             ])
             .map_err(|err| err.to_string())?;
@@ -544,5 +553,15 @@ mod tests {
         assert!(read_review_rows(&path)
             .unwrap_err()
             .contains("no text or input field"));
+    }
+
+    #[test]
+    fn neutralizes_spreadsheet_formulas_in_review_fields() {
+        assert_eq!(
+            spreadsheet_safe("=HYPERLINK(\"https://example.com\")"),
+            "'=HYPERLINK(\"https://example.com\")"
+        );
+        assert_eq!(spreadsheet_safe("+SUM(1,1)"), "'+SUM(1,1)");
+        assert_eq!(spreadsheet_safe("ordinary feedback"), "ordinary feedback");
     }
 }

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.33",
+      "version": "0.6.34",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.36";
+export const RUNTIME_VERSION = "0.3.37";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -777,6 +777,13 @@ test("trained-model library is restart-safe and stays separate from chat models"
   assert.match(library, /"list_task_models"/);
   assert.match(library, /"install_task_model"/);
   assert.match(library, /"run_task_model"/);
+  assert.match(chat, /ACTIVE_TASK_MODEL_KEY/);
+  assert.match(chat, /setActiveTaskModel\(taskModel\)/);
+  assert.match(chat, /"run_task_model_file"/);
+  assert.match(chat, /Drop test data to score/);
+  assert.match(chat, /Open review CSV/);
+  assert.match(css, /\.active-task-model-badge/);
+  assert.match(css, /\.active-task-dropzone/);
   assert.match(library, /\.understudy-model/);
   assert.match(chat, /if \(classifierLibraryOpen\) return/);
   assert.match(library, /revealItemInDir/);


### PR DESCRIPTION
## What changed
- make a dropped `.understudy-model` the persistent active task model without opening the Trained Models dialog
- recolor the Understudy avatar and show the absorbed model identity
- route the main composer through the active local classifier with top-three predictions
- add a CSV/TSV/JSONL/NDJSON test-data dropzone
- export a local review CSV with expected labels, predictions, correct/incorrect, confidence, and top-three choices

## Verification
- `npm run check` (432 tests)
- `cargo test --lib` (208 passed, 6 ignored)
- `cargo clippy --all-targets -- -D warnings`
- Desktop production web build
- native parser tests for labeled CSV, unlabeled JSONL, and malformed inputs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->