### PR TITLE
fix(release-check): built-CLI runtime assertion skips source stage without dist

### DIFF
--- a/scripts/desktop-release-check.mjs
+++ b/scripts/desktop-release-check.mjs
@@ -348,15 +348,22 @@ export async function inspectDesktopRelease({
   const versionState = inspectDesktopVersions(root);
   const errors = [...versionState.errors];
   let builtCliRuntime = null;
-  try {
-    builtCliRuntime = builtCliRuntimeVersion(root);
-    const runtimeError = builtCliRuntimeVersionError(
-      builtCliRuntime,
-      versionState.versions.rust_runtime,
-    );
-    if (runtimeError) errors.push(runtimeError);
-  } catch (error) {
-    errors.push(`built CLI runtime-version check failed: ${error.message}`);
+  // The built-CLI runtime assertion needs dist/bin.js. It is mandatory in the
+  // signed/notarized stages (the bundle is built by then). In the source stage
+  // — which validates pristine checked-in sources on a fresh CI checkout —
+  // dist/ may not be built yet, so enforce only when it already exists.
+  const builtCliPresent = existsSync(join(root, "dist", "bin.js"));
+  if (stage !== "source" || builtCliPresent) {
+    try {
+      builtCliRuntime = builtCliRuntimeVersion(root);
+      const runtimeError = builtCliRuntimeVersionError(
+        builtCliRuntime,
+        versionState.versions.rust_runtime,
+      );
+      if (runtimeError) errors.push(runtimeError);
+    } catch (error) {
+      errors.push(`built CLI runtime-version check failed: ${error.message}`);
+    }
   }
   let head = null;
   let originMain = null;


### PR DESCRIPTION
Unblocks the Desktop Release validate job for 0.3.38.

The built-CLI runtime-version guard (added this cycle to prevent CLI/app runtime skew shipping) ran in every stage. But `--stage source` runs on a fresh CI checkout before `dist/` is built, so the release workflow's 'Validate the exact release source' step failed with 'built CLI is missing'.

Fix: enforce the assertion in signed/notarized stages (where the bundle is built and skew matters) and in source only when `dist/bin.js` already exists (local dev). Verified: source-stage-without-dist passes, signed-stage-without-dist still hard-blocks, tests 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->