### PR TITLE
fix(desktop): restore certified model downloads on clean Macs

### DIFF
--- a/apps/homescreen/src-tauri/knowledge/snapshots.json
+++ b/apps/homescreen/src-tauri/knowledge/snapshots.json
@@ -27,6 +27,20 @@
     "session_url": "https://models.understudylabs.com/session?model=gemma-4-e2b-it-mlx-vlm-4bit&ttl=21600"
   },
   {
+    "id": "gemma-4-e4b-it-qat-mlx-vlm-understudy",
+    "name": "Gemma 4 E4B IT QAT MLX 4-bit, Understudy",
+    "approx_gb": 5.6,
+    "loader": "mlx_vlm",
+    "default_rung": false,
+    "short_name": "understudy-balanced",
+    "certified": true,
+    "family": "gemma-4",
+    "tier": "e4b",
+    "quant": "qat-4bit-g32",
+    "notes": "First capability climb from the 2B default. Certified on the frozen text, image, tool, cancellation, restart, supervision, and compaction suite.",
+    "session_url": "https://models.understudylabs.com/session?model=gemma-4-e4b-it-qat-mlx-vlm-understudy&ttl=21600"
+  },
+  {
     "id": "gemma-4-e4b-it-mlx-vlm-4bit",
     "name": "Gemma 4 E4B IT MLX-VLM 4-bit",
     "approx_gb": 4.8,

--- a/apps/homescreen/src-tauri/src/metrics.rs
+++ b/apps/homescreen/src-tauri/src/metrics.rs
@@ -1,4 +1,6 @@
 use serde::Serialize;
+#[cfg(target_os = "macos")]
+use std::process::Command;
 use std::sync::Mutex;
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
@@ -17,11 +19,34 @@ pub struct Machine {
     pub memory_gb: u64,
 }
 
+fn total_memory_bytes(sys: &System) -> u64 {
+    let detected = sys.total_memory();
+    if detected > 0 {
+        return detected;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return Command::new("/usr/sbin/sysctl")
+            .args(["-n", "hw.memsize"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .unwrap_or(0);
+    }
+    #[cfg(not(target_os = "macos"))]
+    0
+}
+
 pub fn detect_machine() -> Machine {
     // A full sysinfo refresh also enumerates every process. Doing that twice in
     // Tauri setup delayed the event loop long enough for macOS to show a
     // beachball. Machine identity only needs CPU and memory facts.
-    let sys = resource_system();
+    let mut sys = resource_system();
+    // `new_with_specifics` may report zero total memory during early macOS
+    // app startup. Force one refresh before sizing the residency budget.
+    sys.refresh_memory();
     let chip = sys
         .cpus()
         .first()
@@ -30,7 +55,7 @@ pub fn detect_machine() -> Machine {
         .unwrap_or_else(|| "Apple Silicon".to_string());
     Machine {
         chip,
-        memory_gb: sys.total_memory() / (1024 * 1024 * 1024),
+        memory_gb: total_memory_bytes(&sys) / (1024 * 1024 * 1024),
     }
 }
 
@@ -71,5 +96,15 @@ impl MetricsReader {
             mem_total_gb: sys.total_memory() as f32 / gib,
             mem_used_gb: sys.used_memory() as f32 / gib,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_detection_never_reports_zero_memory() {
+        assert!(detect_machine().memory_gb > 0);
     }
 }

--- a/apps/homescreen/src-tauri/src/metrics.rs
+++ b/apps/homescreen/src-tauri/src/metrics.rs
@@ -26,14 +26,14 @@ fn total_memory_bytes(sys: &System) -> u64 {
     }
     #[cfg(target_os = "macos")]
     {
-        return Command::new("/usr/sbin/sysctl")
+        Command::new("/usr/sbin/sysctl")
             .args(["-n", "hw.memsize"])
             .output()
             .ok()
             .filter(|output| output.status.success())
             .and_then(|output| String::from_utf8(output.stdout).ok())
             .and_then(|value| value.trim().parse::<u64>().ok())
-            .unwrap_or(0);
+            .unwrap_or(0)
     }
     #[cfg(not(target_os = "macos"))]
     0

--- a/apps/homescreen/src-tauri/src/models.rs
+++ b/apps/homescreen/src-tauri/src/models.rs
@@ -463,6 +463,7 @@ mod tests {
             vec![
                 "gemma-4-e2b-it-qat-mlx-vlm-understudy",
                 "gemma-4-e2b-it-mlx-vlm-4bit",
+                "gemma-4-e4b-it-qat-mlx-vlm-understudy",
                 "gemma-4-e4b-it-mlx-vlm-4bit",
                 "gemma-4-12b-it-mlx-vlm-4bit",
                 "gemma-4-12b-it-mlx-vlm-bf16",
@@ -481,8 +482,8 @@ mod tests {
         );
         assert_eq!(
             rows.iter().filter(|r| r.certified == Some(true)).count(),
-            2,
-            "exactly the two understudy conversions are certified"
+            3,
+            "exactly the three understudy conversions are certified"
         );
         assert!(
             rows.iter().all(|r| r.session_url.is_some()),


### PR DESCRIPTION
## What this fixes

- makes the certified Gemma 4 E4B Understudy snapshot an embedded, pullable Desktop model
- refreshes macOS memory detection before residency sizing
- falls back to `hw.memsize` if startup-time sysinfo reports zero
- updates the bundled catalog invariant test from two to three certified conversions

## Customer impact

Fixes Derek’s clean-machine failures:
- `required base model is not available for automatic download` for the E4B task model
- bogus `0.0 GB safe residency` that also prevented `understudy-small` from loading

## Validation

- `cargo test --lib metrics::tests::machine_detection_never_reports_zero_memory`
- `cargo test --lib models::tests::bundled_snapshots_match_pullable_set`
- all 9 portable task-model ZIP/install tests
- full Rust lib suite (one unrelated timeout test flaked once and passed alone on retry)
- `npm run check` running/required before merge

The exact 5.6 GB E4B QAT base upload and clean-cache download test are being completed before the release is announced.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->