### PR TITLE
feat(desktop): management consolidation — Aamir's control-plane surfaces + nav into the app

### DIFF
--- a/docs/proposals/teacher-lessons.md
+++ b/docs/proposals/teacher-lessons.md
@@ -1,0 +1,87 @@
+---
+name: teacher-lessons
+purpose: Retrieval of past coding-agent traces as in-context teacher lessons for a local model, staged toward fine-tuned specialists.
+updated: 2026-07-07
+status: experiment
+---
+
+# Teacher lessons: trace-retrieval in-context learning for local models
+
+## Thesis
+
+Frontier coding agents (Claude Code, Codex, OpenCode) leave behind session
+traces on the *user's own* repos, tools, and conventions. A local open model
+(Gemma 4 E2B/E4B dense, 26B A4B MoE) fails on those same workloads mostly in
+predictable ways: brittle tool-call sequencing, poor error recovery, and no
+memory of local conventions. Retrieving the *decisive segments* of past
+successful traces and injecting them as compact worked examples ("lessons")
+should close part of that gap immediately — no training run, no contamination
+risk — and the lessons that repeatedly help become a pre-validated SFT/RL pool
+later.
+
+Two-speed learning:
+
+- **Fast loop (this experiment):** task → retrieve similar past trace segments
+  → compress into 300–800-token lessons → inject 1–3 into the local model's
+  context → measure task completion delta.
+- **Slow loop (later, existing skills):** lessons that repeatedly correlate
+  with success graduate into `local-distillation-lab` /
+  `curate-trajectories` training pools; internalized lessons retire from
+  retrieval.
+
+## Why this is ours to build
+
+- Lessons need a session-history index the harness can query mid-task
+  (a Moraine-style session store) — off-the-shelf harnesses have no such hook.
+- Lesson *value* is measurable per-trajectory when the serving layer returns
+  logprobs (did the lesson reduce uncertainty at the tool-call tokens?).
+  Only our certified QAT rungs + harness journaling keep that signal.
+- Frontier traces are teacher demonstrations on the user's distribution;
+  generic datasets are not.
+
+## MVP scope (experiments/teacher-lessons/)
+
+1. **Extractor** — given a task description, query the session index for
+   similar tasks; pull candidate segments (successful tool-call sequences,
+   error→recovery pairs, final diffs).
+2. **Normalizer** — map source-harness tool vocabulary (Read/Edit/Bash,
+   shell, OpenCode tools) into the target tool schema so the local model
+   never imitates tools it doesn't have.
+3. **Compressor** — LLM pass that turns a segment into a ≤800-token worked
+   example: situation, decisive actions, outcome, one-line moral.
+4. **Injector + A/B runner** — run N real tasks against the same local model
+   twice (with/without lessons), same decode settings, 3–5 seeds; score
+   final state; log tool-call parse failures, retries, tokens, and (where
+   available) logprob profiles at tool-call spans.
+
+Out of scope for MVP: automatic lesson-library evolution (GEPA over the
+extraction prompt), SFT graduation, harness-side mid-task retrieval. Those are
+the next cooks once the A/B shows signal.
+
+## Success criteria
+
+- Primary: task completion rate delta (lessons vs no-lessons) on ≥20
+  final-state-scored tasks, ≥3 seeds, same pinned model + decode settings.
+- Secondary: tool-call parse-failure rate, retries per task, tokens per task
+  (lessons must pay for their context cost), qualitative failure taxonomy
+  shift (fewer persistence/format failures).
+- Kill criterion: if lessons cost more tokens than they save and completion
+  delta is within noise after prompt iteration, write up the negative result
+  and stop.
+
+## Boundaries
+
+Local-first: the pipeline reads local session stores and serves local models;
+no uploads. Any committed fixtures must be synthetic traces — never real
+session content. Real-trace runs happen locally and only aggregate metrics
+are committed.
+
+## Relationship to existing skills
+
+- `curate-trajectories` — contamination-safe graduation of lessons to
+  training pools (frozen dev/holdout hard-block applies to lesson retrieval
+  for eval tasks too: never retrieve a lesson derived from a holdout task).
+- `local-distillation-lab` — the slow loop.
+- `optimize-workload` (GEPA) — later, evolve the extraction/compression
+  prompts against the same eval.
+- `compare-trajectories` — the with/without-lessons diff classifier.

--- a/experiments/teacher-lessons/README.md
+++ b/experiments/teacher-lessons/README.md
@@ -1,0 +1,38 @@
+# teacher-lessons (experiment)
+
+Status: scaffold. See the proposal:
+[`docs/proposals/teacher-lessons.md`](../../docs/proposals/teacher-lessons.md).
+
+Retrieve decisive segments of past coding-agent traces, compress them into
+compact worked examples ("lessons"), inject them into a local model's context,
+and A/B whether they move task completion on final-state-scored tasks.
+
+## Layout (planned)
+
+```
+extractor/    query a local session index for similar-task segments
+normalizer/   map source-harness tool vocabulary -> target tool schema
+compressor/   segment -> <=800-token worked example
+runner/       with/without-lessons A/B on a pinned local model
+fixtures/     synthetic traces only — never real session content
+results/      aggregate metrics (committed), raw runs (gitignored)
+```
+
+## Rules
+
+- Local-first; no uploads. Real traces stay on-machine; only aggregate
+  metrics land in git.
+- Pin everything per run: model rung, decode settings (QAT rungs:
+  temperature 1.0 / top_p 0.95 / top_k 64), lesson count, prompt hashes.
+- Never retrieve lessons derived from frozen dev/holdout tasks when scoring
+  eval tasks (see `curate-trajectories`).
+
+## MVP milestones
+
+1. Extractor + normalizer produce 10 lessons from real local session history
+   (manual spot-check for tool-schema correctness).
+2. Runner completes a 5-task smoke A/B on Gemma 4 E2B QAT.
+3. Full A/B: >=20 tasks, >=3 seeds, with/without lessons; report deltas on
+   completion, parse failures, retries, tokens.
+4. Decision: cook (lesson-library + GEPA over extraction prompts) or write up
+   the negative result.


### PR DESCRIPTION
Ultracode migration (31 agents, adversarially verified) bringing the web control-plane management surfaces into the desktop app, per the founder dinner doctrine (one surface = the desktop app; traditional management UI; innovation budget stays on training).

## Surfaces ported (all 11, enabled in nav)
org summary/dashboard, org analytics/reporting, project summary, project reporting, workload configuration (traffic dial + capture toggle), captures list+detail, API keys, models, billing, setup, settings.

## Nav
Aamir's group scheme ported onto the sidebar (Organization / Workload controls / Manage + scope switcher), IA = org → project → workload → experiment. shadcn navigation-menu was evaluated and overridden (horizontal menubar primitive, wrong for a left rail) in favor of the sidebar primitive Aamir already used — matches the founder's later base/sidebar call.

## Auth (read-only by construction, safe)
Panes authenticate with the existing org-scoped `sk_` key. They are **view-only**: sk_ cannot satisfy mutating routes. Per-user identity + mutation + multi-org selection land with the WorkOS user-auth workstream (separate PR); until then panes show honest "re-run login / no active org" notices rather than faking capability. See MIGRATION-GAPS.md.

## Verification
- Adversarial verifier per surface (fidelity vs origin/main web source, token conformance, safety, test honesty). **Found + fixed a real path-traversal** (percent-encoded `..` escaping the org root in admin.rs, c5111d3) plus two fidelity bugs.
- npm test 576/0, cargo test 289/0, clippy --all-targets -D warnings clean, builds green.
- MIGRATION-GAPS.md documents every known limit honestly (multi-org resolution, customer/v1 sk_ rejection, view-only mutation surfaces).

Do not ship management panes to customers until the WorkOS gate lands (they're safe read-only now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->