### PR TITLE
release: Desktop 0.3.39 / CLI 0.6.36

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "understudy-skills",
   "metadata": {
     "description": "Understudy skills for improving LLM apps with local-first evidence, evals, optimization, local models, and routing.",
-    "version": "0.6.35"
+    "version": "0.6.36"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for improving LLM apps with Understudy — trace, evaluate, optimize, compare, deploy.",
-    "version": "0.6.35"
+    "version": "0.6.36"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces — reduce cost/latency, raise quality/reliability, capture traces, build evals, run local optimization (GEPA), compare models/providers, and route through Understudy.",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy",
   "description": "Improve LLM apps and agents from real traces: capture evidence, build evals, optimize prompts/routes, compare models, run local models, and hand off to Understudy.",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "author": {
     "name": "Understudy Labs"
   },

--- a/.devin/adapter.json
+++ b/.devin/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-devin-adapter",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "skills": "./skills",
   "discovery": "AGENTS.md rule injection + knowledge notes"
 }

--- a/.hermes/adapter.json
+++ b/.hermes/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-hermes-adapter",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "skills": "./skills",
   "register": "skills.external_dirs in ~/.hermes/config.yaml"
 }

--- a/.opencode/adapter.json
+++ b/.opencode/adapter.json
@@ -1,6 +1,6 @@
 {
   "name": "understudy-opencode-adapter",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "skills": "./skills",
   "commands": "./commands"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Added
 
+- **See and manage your whole Understudy account from the app.** Desktop/runtime
+  0.3.39 and CLI 0.6.36 bring the management control plane into Understudy
+  Desktop: without leaving the app you can see your organization and project at
+  a glance, read analytics and reporting on usage, cost, and errors, inspect
+  each workload's configuration and its live traffic dial, browse captures,
+  list your API keys and models, and reach billing, setup, and settings. This
+  first release is view-oriented — it surfaces what your account is doing today
+  in one place, ahead of in-app editing — and it sits alongside the on-your-own-
+  data training work described below, which carries forward unchanged.
 - **Train on your own data, end to end.** Desktop/runtime 0.3.38 and CLI
   0.6.35 let you drop a spreadsheet (`.xlsx` workbooks now work, alongside CSV
   and other tables) onto Understudy Desktop and go all the way to a trained

--- a/apps/homescreen/package.json
+++ b/apps/homescreen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "understudy-desktop",
   "private": true,
-  "version": "0.3.38",
+  "version": "0.3.39",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build",

--- a/apps/homescreen/src-tauri/Cargo.lock
+++ b/apps/homescreen/src-tauri/Cargo.lock
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "understudy"
-version = "0.3.38"
+version = "0.3.39"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/homescreen/src-tauri/Cargo.toml
+++ b/apps/homescreen/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "understudy"
-version = "0.3.38"
+version = "0.3.39"
 description = "Understudy Desktop"
 authors = ["Understudy Labs"]
 edition = "2021"

--- a/apps/homescreen/src-tauri/src/bootstrap.rs
+++ b/apps/homescreen/src-tauri/src/bootstrap.rs
@@ -24,7 +24,7 @@ pub struct ToolStatus {
     pub detail: String,
 }
 
-const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.35";
+const MIN_UNDERSTUDY_CLI_VERSION: &str = "0.6.36";
 
 #[derive(Serialize, Clone)]
 pub struct BootstrapStatus {

--- a/apps/homescreen/src-tauri/src/conversation_runtime.rs
+++ b/apps/homescreen/src-tauri/src/conversation_runtime.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 pub(crate) const EVENT_SCHEMA: &str = "understudy-conversation-runtime-event-v1";
-pub(crate) const RUNTIME_VERSION: &str = "0.3.38";
+pub(crate) const RUNTIME_VERSION: &str = "0.3.39";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/apps/homescreen/src-tauri/tauri.conf.json
+++ b/apps/homescreen/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Understudy",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "identifier": "com.homescreen.app",
   "build": {
     "beforeDevCommand": "node ../../scripts/build-desktop-cli.mjs && bun run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@understudylabs/understudy-agent-tools",
-      "version": "0.6.35",
+      "version": "0.6.36",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understudylabs/understudy-agent-tools",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "description": "Public Understudy agent tools CLI and skill library.",
   "type": "module",
   "bin": {

--- a/src/runtime/conversation/contract.ts
+++ b/src/runtime/conversation/contract.ts
@@ -8,7 +8,7 @@ export const CONFORMANCE_SCHEMA =
 export const RUNTIME_ID = "understudy-conversation-sidecar";
 export const VERCEL_RUNTIME_ID = "vercel-ai-sdk";
 export const PI_RUNTIME_ID = "pi-agent-session";
-export const RUNTIME_VERSION = "0.3.38";
+export const RUNTIME_VERSION = "0.3.39";
 
 export function piNodeSupported(version = process.versions.node): boolean {
   const [major, minor] = version.split(".").map(Number);


### PR DESCRIPTION
Release commit for **Understudy Desktop 0.3.39 / CLI 0.6.36** (lockstep bump from 0.3.38 / 0.6.35).

## What's in it
- Bumps all 17 canonical version sources (desktop package/tauri/Cargo, RUNTIME_VERSION in Rust + TS conversation runtime, CLI package + adapter manifests, Desktop minimum-CLI floor) via `scripts/desktop-release-plan.mjs --apply`. `--verify` reports `errors: []` and all compatibility flags aligned.
- User-facing CHANGELOG entry for the **management control plane** now surfaced in Understudy Desktop: org/project summary, analytics & reporting, workload configuration + live traffic dial, captures, API keys, models, billing, setup, settings — view-oriented in this release. On-your-own-data training work carries forward unchanged.

## Verification (local)
- `npm run build` + `npm run typecheck` clean
- `desktop:release-check --allow-dirty --allow-unmerged`: `ok desktop 0.3.39 source release check`
- `npm test`: 575/576 pass — the sole failure is the known `installer.test.mjs` /tmp-symlink worktree artifact
- `apps/homescreen` `bun run build` clean; `cargo test` 297 passed; `cargo clippy --all-targets -D warnings` clean

Release itself ships via the **Desktop Release** workflow (validate → release) after this merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->