### PR TITLE
ci: mirror desktop DMGs to R2

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -310,6 +310,30 @@ jobs:
           echo "### Understudy Desktop ${version}" >> "$GITHUB_STEP_SUMMARY"
           echo "Published https://github.com/${GITHUB_REPOSITORY}/releases/tag/${tag}" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Mirror the published DMG to Cloudflare R2
+        if: inputs.mode == 'release'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: 5cca5c86ba359c3dddb773e57e6cd991
+        run: |
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+            echo "The desktop-release environment is missing CLOUDFLARE_API_TOKEN." >&2
+            exit 1
+          fi
+          version="$(node -p "require('./apps/homescreen/package.json').version")"
+          filename="Understudy_${version}_aarch64.dmg"
+          dmg="$PWD/apps/homescreen/src-tauri/target/release/bundle/dmg/$filename"
+          key="desktop/releases/${version}/${filename}"
+          pointer="$RUNNER_TEMP/understudy-desktop-latest.json"
+          npx --yes wrangler@4.95.0 r2 object put "understudy-model-snapshots/$key" \
+            --remote --file "$dmg" --content-type application/x-apple-diskimage
+          jq -n --arg version "$version" --arg key "$key" --arg filename "$filename" \
+            '{version: $version, key: $key, filename: $filename}' > "$pointer"
+          npx --yes wrangler@4.95.0 r2 object put \
+            "understudy-model-snapshots/desktop/releases/latest.json" \
+            --remote --file "$pointer" --content-type application/json
+          echo "Mirrored ${filename} to R2 and advanced desktop/releases/latest.json." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Remove temporary signing material
         if: always()
         run: |

--- a/tests/desktop-release-workflow.test.mjs
+++ b/tests/desktop-release-workflow.test.mjs
@@ -56,7 +56,7 @@ test("Desktop release automation keeps every trust gate before publication", () 
   assert.doesNotMatch(workflow, /cargo test/);
   assert.match(workflow, /notarytool history/);
   assert.match(workflow, /jq -e '\.history \| type == "array"'/);
-  assert.equal([...workflow.matchAll(/if: inputs\.mode == 'release'/g)].length, 9);
+  assert.equal([...workflow.matchAll(/if: inputs\.mode == 'release'/g)].length, 10);
   assert.match(workflow, /notarytool submit "\$app_zip"/);
   assert.match(workflow, /stapler staple "\$app"/);
   assert.match(
@@ -92,4 +92,10 @@ test("Desktop release automation keeps every trust gate before publication", () 
   assert.match(workflow, /spctl --assess --type execute/);
   assert.match(workflow, /spctl --assess/);
   assert.ok(workflow.indexOf("gh release download") < workflow.indexOf("gh release edit"));
+  assert.match(workflow, /Mirror the published DMG to Cloudflare R2/);
+  assert.match(workflow, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
+  assert.ok(
+    workflow.indexOf("gh release edit") <
+      workflow.indexOf("Mirror the published DMG to Cloudflare R2"),
+  );
 });


### PR DESCRIPTION
Publishes the verified versioned macOS DMG to R2 and advances desktop/releases/latest.json after GitHub publishes the release.

Validation: workflow YAML parsed. The desktop-release environment now has CLOUDFLARE_API_TOKEN; the workflow fails closed if it is missing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->