### PR TITLE
Desktop: design language v2.0 alignment + WorkOS AuthKit user sign-in

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -168,6 +168,11 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          # Baked into the binary via option_env! (src-tauri/src/auth.rs).
+          # A public OAuth client id, not a secret — repo vars keep it out
+          # of the OSS source while shipped builds sign in out of the box.
+          UNDERSTUDY_WORKOS_CLIENT_ID: ${{ vars.UNDERSTUDY_WORKOS_CLIENT_ID }}
+          UNDERSTUDY_AUTHKIT_DOMAIN: ${{ vars.UNDERSTUDY_AUTHKIT_DOMAIN }}
         run: bun run tauri build --bundles app,dmg
 
       - name: Notarize and staple the app

--- a/apps/homescreen/app/components/AccountPane.tsx
+++ b/apps/homescreen/app/components/AccountPane.tsx
@@ -114,6 +114,73 @@ export function AccountPane({
     }
   };
 
+  // WorkOS AuthKit user session (PKCE via system browser). Parallel to the
+  // sk_ org key: identity for management surfaces, not a replacement.
+  const [userSession, setUserSession] = useState<Any | null>(null);
+  const [userBusy, setUserBusy] = useState(false);
+  const refreshUserSession = () => {
+    invoke<Any>("auth_session_status").then(setUserSession).catch(() => {});
+  };
+  useEffect(refreshUserSession, []);
+  const userSignIn = async () => {
+    setUserBusy(true);
+    setErr(null);
+    try {
+      await invoke("auth_login");
+      refreshUserSession();
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setUserBusy(false);
+    }
+  };
+  const userSignOut = async () => {
+    setUserBusy(true);
+    try {
+      await invoke("auth_logout");
+      refreshUserSession();
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setUserBusy(false);
+    }
+  };
+
+  const userAuthCard = (
+    <div className="card">
+      <div className="card-row">
+        <div>
+          <div className="card-title">User sign-in</div>
+          {userSession?.signed_in ? (
+            <div className="svc-desc">
+              signed in as {String(userSession.email ?? userSession.user_id ?? "")}
+              {userSession.org_id ? ` · ${String(userSession.org_id)}` : ""}
+            </div>
+          ) : (
+            <div className="svc-desc">
+              {userSession?.configured === false
+                ? "Not configured — set UNDERSTUDY_WORKOS_CLIENT_ID and UNDERSTUDY_AUTHKIT_DOMAIN (or ~/.understudy/desktop-auth.json)."
+                : "Sign in with your Understudy account to manage routing, captures, and keys as yourself."}
+            </div>
+          )}
+        </div>
+        {userSession?.signed_in ? (
+          <button className="btn" disabled={userBusy} onClick={userSignOut}>
+            Sign out
+          </button>
+        ) : (
+          <button
+            className="btn primary"
+            disabled={userBusy || userSession?.configured === false}
+            onClick={userSignIn}
+          >
+            {userBusy ? "Waiting for browser…" : "Sign in with browser"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
   const signInCard = (
     <div className="card account-sign-in-card">
       <div className="card-title" style={{ marginBottom: 4 }}>Sign in / create account</div>
@@ -142,6 +209,7 @@ export function AccountPane({
       <div className="pane-body">
         {err && <div className="card err">{err}</div>}
         {!signedIn && prioritizeSignIn ? signInCard : null}
+        {userAuthCard}
 
         <div className="card">
           <div className="card-title" style={{ marginBottom: 4 }}>App icon</div>

--- a/apps/homescreen/app/components/OrgSummaryPane.tsx
+++ b/apps/homescreen/app/components/OrgSummaryPane.tsx
@@ -155,7 +155,7 @@ function SummaryView({
           {partialErrors.join("; ")} — their workloads are omitted below.
         </Notice>
       )}
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <MetricCard
           label="7-day spend"
           value={metrics.totalSpendUsd === null ? "—" : formatUSD(metrics.totalSpendUsd)}
@@ -248,8 +248,8 @@ function MetricCard({
 
 function Notice({ title, children }: { title: string; children: ReactNode }): ReactNode {
   return (
-    <div className="border border-[var(--color-stamp)]/50 bg-[var(--color-stamp)]/5 p-4 text-sm leading-6">
-      <p className="font-medium text-[var(--color-stamp)]">{title}</p>
+    <div className="border border-[var(--color-warn)]/50 bg-[var(--color-warn)]/5 p-4 text-sm leading-6">
+      <p className="font-medium text-[var(--color-warn)]">{title}</p>
       <div className="mt-1 text-muted-foreground">{children}</div>
     </div>
   );
@@ -373,7 +373,7 @@ function SpendTrend({ rows }: { rows: ReportingSeriesPoint[] }): ReactNode {
         {points.map(([day, cost]) => (
           <div key={day} className="flex h-full min-w-0 flex-1 items-end">
             <div
-              className="w-full rounded-t-sm bg-[var(--color-stamp)]"
+              className="w-full rounded-t-sm bg-[var(--model-mint)]"
               style={{
                 height: `${maximum > 0 ? Math.max((cost / maximum) * 100, 4) : 4}%`,
               }}
@@ -407,7 +407,7 @@ function MiniMetric({ label, value }: { label: string; value: string }): ReactNo
 function SummarySkeleton(): ReactNode {
   return (
     <div className="grid animate-pulse gap-4" aria-label="Loading organization summary">
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {[0, 1, 2, 3].map((index) => (
           <div key={index} className="h-28 rounded-xl border border-border bg-muted/30" />
         ))}

--- a/apps/homescreen/app/components/ProjectReportingPane.tsx
+++ b/apps/homescreen/app/components/ProjectReportingPane.tsx
@@ -171,47 +171,11 @@ export function ProjectReportingPane({ scope }: { scope: Scope }) {
         <div className="card">
           <div className="projrep-card-head">
             <div>
-              <div className="card-title">Workload status</div>
+              <div className="card-title">Workloads</div>
               <p className="projrep-card-sub">
-                Observed traffic over the last {STATUS_WINDOW}. Refreshes
-                every 60s while this window is visible.
-              </p>
-            </div>
-            <UpdatedStamp at={statusFetchedAt} />
-          </div>
-          {status === null ? (
-            <LoadingRows />
-          ) : status.ok ? (
-            status.data.workloads.length === 0 ? (
-              <EmptyState>
-                No workloads yet. Send a request through the gateway and it
-                will show up here within a minute.
-              </EmptyState>
-            ) : (
-              <div className="projrep-status-grid">
-                {status.data.workloads.map((entry) => (
-                  <WorkloadStatusCard key={entry.workload_id} entry={entry} />
-                ))}
-              </div>
-            )
-          ) : (
-            <FetchError
-              what="workload status"
-              error={status.error}
-              requestId={status.request_id}
-              onRetry={() => void refreshStatus()}
-            />
-          )}
-        </div>
-
-        <div className="card">
-          <div className="projrep-card-head">
-            <div>
-              <div className="card-title">Usage</div>
-              <p className="projrep-card-sub">
-                Requests, cost, and cache reads per workload over the last{" "}
-                {usageWindow}. Refreshes every 5 minutes while this window is
-                visible.
+                Requests, cost, cache reads, errors, and traffic allocation
+                per workload over the last {usageWindow}. Refreshes every 5
+                minutes while this window is visible.
               </p>
             </div>
             <div className="projrep-card-actions">
@@ -239,7 +203,10 @@ export function ProjectReportingPane({ scope }: { scope: Scope }) {
               usage.data.byWorkload.length === 0 ? (
                 <EmptyState>No usage in this window yet.</EmptyState>
               ) : (
-                <UsageSection data={usage.data} />
+                <UsageSection
+                  data={usage.data}
+                  statusEntries={status?.ok ? status.data.workloads : []}
+                />
               )
             ) : (
               <FetchError
@@ -347,82 +314,7 @@ function FetchError({
   );
 }
 
-// ---- workload status cards ----
-
-function StatusPill({
-  status,
-}: {
-  status: WorkloadStatusEntry["status"];
-}): ReactNode {
-  return (
-    <span className={`projrep-status-pill ${status}`}>
-      <span aria-hidden="true" className="dot" />
-      {status}
-    </span>
-  );
-}
-
-function WorkloadStatusCard({
-  entry,
-}: {
-  entry: WorkloadStatusEntry;
-}): ReactNode {
-  return (
-    <div className="projrep-workload-card">
-      <div className="projrep-workload-head">
-        <span className="projrep-workload-name">{entry.display_name}</span>
-        <StatusPill status={entry.status} />
-      </div>
-
-      <dl className="projrep-ministats">
-        <MiniStat
-          label="requests"
-          value={entry.requests.toLocaleString("en-US")}
-        />
-        <MiniStat label="error rate" value={formatShare(entry.error_rate)} />
-        <MiniStat
-          label="declared route"
-          value={
-            entry.declared.routed === "none"
-              ? "none"
-              : `${entry.declared.routed} @ ${entry.declared.split_pct}%`
-          }
-        />
-      </dl>
-
-      <RouteShares shares={entry.route_shares} />
-      <ServedModels entry={entry} />
-
-      {entry.last_error_at ? (
-        <div className="projrep-last-error">
-          <span className="muted">
-            last error {formatTimestamp(entry.last_error_at)}
-          </span>
-          {entry.example_request_ids.slice(0, 3).map((id) => (
-            <span key={id} className="projrep-request-id">
-              <code>{id}</code> <CopyId value={id} />
-            </span>
-          ))}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function MiniStat({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}): ReactNode {
-  return (
-    <div className="projrep-ministat">
-      <dt>{label}</dt>
-      <dd>{value}</dd>
-    </div>
-  );
-}
+// ---- usage table (single combined view) ----
 
 /**
  * Observed route outcome shares — canonical vocabulary only
@@ -434,63 +326,57 @@ const ROUTE_SEGMENTS = [
   { key: "fallback", className: "seg-fallback" },
 ] as const;
 
-function RouteShares({
+/** Compact allocation cell: share bar + the nonzero segments as text. */
+function AllocationCell({
   shares,
 }: {
   shares: WorkloadStatusEntry["route_shares"];
 }): ReactNode {
+  const nonzero = ROUTE_SEGMENTS.filter(({ key }) => shares[key] > 0);
   return (
-    <div className="projrep-route-shares">
-      <span className="projrep-label">route shares</span>
-      <div className="projrep-share-bar">
-        {ROUTE_SEGMENTS.map(({ key, className }) =>
-          shares[key] > 0 ? (
-            <div
-              key={key}
-              className={className}
-              style={{ width: `${shares[key] * 100}%` }}
-            />
-          ) : null,
-        )}
-      </div>
-      <div className="projrep-share-legend">
-        {ROUTE_SEGMENTS.map(({ key, className }) => (
-          <span key={key}>
-            <span aria-hidden="true" className={`legend-dot ${className}`} />
-            {key} {formatShare(shares[key])}
-          </span>
+    <div className="projrep-alloc">
+      <div
+        className="projrep-share-bar"
+        title={ROUTE_SEGMENTS.map(
+          ({ key }) => `${key} ${formatShare(shares[key])}`,
+        ).join(" · ")}
+      >
+        {nonzero.map(({ key, className }) => (
+          <div
+            key={key}
+            className={className}
+            style={{ width: `${shares[key] * 100}%` }}
+          />
         ))}
       </div>
+      <span className="projrep-alloc-label">
+        {nonzero.length === 0
+          ? "no traffic"
+          : nonzero
+              .map(({ key }) => `${key} ${formatShare(shares[key])}`)
+              .join(" · ")}
+      </span>
     </div>
   );
 }
 
-function ServedModels({ entry }: { entry: WorkloadStatusEntry }): ReactNode {
-  return (
-    <div className="projrep-served-models">
-      <span className="projrep-label">served models</span>
-      {entry.served_models.length === 0 ? (
-        <span className="muted">no traffic in window</span>
-      ) : (
-        entry.served_models.map((served) => (
-          <div key={served.model} className="projrep-served-row">
-            <code>{served.model}</code>
-            <span className="muted">
-              {served.provider_label} · {formatShare(served.share)}
-            </span>
-          </div>
-        ))
-      )}
-    </div>
-  );
-}
-
-// ---- usage section ----
-
-function UsageSection({ data }: { data: UsageSummaryData }): ReactNode {
+function UsageSection({
+  data,
+  statusEntries,
+}: {
+  data: UsageSummaryData;
+  statusEntries: WorkloadStatusEntry[];
+}): ReactNode {
   const daily = dailySeries(data.byDay);
   const rows = [...data.byWorkload].sort((a, b) => b.requests - a.requests);
   const totals = totalsFrom(rows);
+  // Status entries key by workload id/display name; usage rows carry both.
+  const statusFor = (row: (typeof rows)[number]) =>
+    statusEntries.find(
+      (entry) =>
+        entry.workload_id === row.workload_id ||
+        entry.display_name === row.workload,
+    ) ?? null;
   const maxRequests = Math.max(1, ...daily.map((d) => d.requests));
   return (
     <>
@@ -521,22 +407,35 @@ function UsageSection({ data }: { data: UsageSummaryData }): ReactNode {
             <th className="num">requests</th>
             <th className="num">cost</th>
             <th className="num">cache read</th>
+            <th className="num">error rate</th>
+            <th>allocation</th>
           </tr>
         </thead>
         <tbody>
-          {rows.map((group) => (
-            <tr key={group.workload_id ?? group.workload ?? "unattributed"}>
-              <td>{group.workload ?? group.workload_id ?? "unattributed"}</td>
-              <td className="num">{formatTokens(group.requests)}</td>
-              <td className="num">{formatUSD(group.customer_cost_usd)}</td>
-              <td className="num">{formatShare(group.cache_read_pct)}</td>
-            </tr>
-          ))}
+          {rows.map((group) => {
+            const live = statusFor(group);
+            return (
+              <tr key={group.workload_id ?? group.workload ?? "unattributed"}>
+                <td>{group.workload ?? group.workload_id ?? "unattributed"}</td>
+                <td className="num">{formatTokens(group.requests)}</td>
+                <td className="num">{formatUSD(group.customer_cost_usd)}</td>
+                <td className="num">{formatShare(group.cache_read_pct)}</td>
+                <td className="num">
+                  {live ? formatShare(live.error_rate) : "—"}
+                </td>
+                <td>
+                  {live ? <AllocationCell shares={live.route_shares} /> : "—"}
+                </td>
+              </tr>
+            );
+          })}
           <tr className="totals">
             <td>all workloads</td>
             <td className="num">{formatTokens(totals.requests)}</td>
             <td className="num">{formatUSD(totals.costUsd)}</td>
             <td className="num">{formatShare(cacheReadShare(totals))}</td>
+            <td className="num">—</td>
+            <td>—</td>
           </tr>
         </tbody>
       </table>

--- a/apps/homescreen/app/components/ReportingPane.tsx
+++ b/apps/homescreen/app/components/ReportingPane.tsx
@@ -58,11 +58,11 @@ const ALL = "__all__";
 // Canonical model colors from the app's globals.css (design system v2.0)
 // stand in for the web's --color-chart-1..5.
 const PALETTE = [
-  "var(--model-clay)",
   "var(--model-mint)",
-  "var(--model-amber)",
   "var(--model-violet)",
+  "var(--model-amber)",
   "var(--model-cyan)",
+  "var(--model-clay)",
 ] as const;
 
 export function ReportingPane() {

--- a/apps/homescreen/app/components/SetupPane.tsx
+++ b/apps/homescreen/app/components/SetupPane.tsx
@@ -516,7 +516,7 @@ function StepCard({
       <div className="card-row" style={{ alignItems: "flex-start" }}>
         <div>
           <div className="card-title flex items-center gap-3">
-            <span className="flex size-5 shrink-0 items-center justify-center border border-[var(--c-stamp)]/60 text-[0.68rem] text-[var(--c-stamp)]">
+            <span className="flex size-5 shrink-0 items-center justify-center border border-[var(--model-mint)]/60 text-[0.68rem] text-[var(--model-mint)]">
               {step}
             </span>
             {title}
@@ -549,7 +549,7 @@ function PathOption({
       onClick={onSelect}
       className={`grid min-w-0 content-start gap-1 rounded-md border p-4 text-left transition-colors ${
         selected
-          ? "border-[var(--c-stamp)] bg-[var(--c-stamp)]/5"
+          ? "border-[var(--model-mint)] bg-[var(--model-mint)]/5"
           : "border-[var(--border)] hover:border-[var(--c-ink-muted)]"
       }`}
     >

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { PlusIcon } from "lucide-react";
 import { TooltipProvider } from "@/app/components/base-ui/tooltip";
 import { NAV_ITEMS, paneToNavId, type NavGroupId, type Scope } from "../lib/nav";
@@ -47,7 +49,7 @@ const AccountIcon = () => (
 );
 
 const GROUP_LABELS: Record<NavGroupId, string> = {
-  organization: "Organization",
+  organization: "Capture",
   workload: "Workload",
   training: "Training",
   sessions: "Chats",
@@ -101,8 +103,26 @@ export function Sidebar({
 }) {
   const activeNavId = paneToNavId(active, activeSessionId, activeThreadId);
 
+  // Bottom-left identity: prefer a real org name when the gateway exposes
+  // one; fall back to a shortened org id ("org_01KT…81YX"), then "Account".
+  const [orgLabel, setOrgLabel] = useState<string | null>(null);
+  useEffect(() => {
+    if (!isTauri()) return;
+    invoke<{ org_name?: string | null; org_id?: string | null }>("account_status")
+      .then((s) => {
+        if (s?.org_name) setOrgLabel(s.org_name);
+        else if (s?.org_id) {
+          const id = s.org_id;
+          setOrgLabel(id.length > 14 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id);
+        }
+      })
+      .catch(() => {});
+  }, [connected]);
+
   const itemsFor = (group: NavGroupId) =>
-    NAV_ITEMS.filter((item) => item.group === group).map((item) => (
+    NAV_ITEMS.filter(
+      (item) => item.group === group && (!item.requiresWorkload || scope.workloadId),
+    ).map((item) => (
       <NavItem
         key={item.id}
         label={item.label}
@@ -129,12 +149,6 @@ export function Sidebar({
         <NavGroup group="organization" label={GROUP_LABELS.organization}>
           {itemsFor("organization")}
         </NavGroup>
-
-        {scope.workloadId && (
-          <NavGroup group="workload" label={GROUP_LABELS.workload}>
-            {itemsFor("workload")}
-          </NavGroup>
-        )}
 
         <NavGroup group="training" label={GROUP_LABELS.training}>
           {itemsFor("training")}
@@ -178,7 +192,7 @@ export function Sidebar({
         >
           <AccountIcon />
           <span className="nav-account-copy">
-            <span>Account</span>
+            <span>{orgLabel ?? "Account"}</span>
             <span className="nav-account-status">
               <span className={"dot" + (connected ? " running" : "")} />
               {connected ? "Connected" : "Disconnected"}

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -104,7 +104,7 @@ export function Sidebar({
   const activeNavId = paneToNavId(active, activeSessionId, activeThreadId);
 
   // Bottom-left identity: prefer a real org name when the gateway exposes
-  // one; fall back to a shortened org id ("org_01KT…81YX"), then "Account".
+  // one; fall back to a shortened org id ("org_ABCD…WXYZ"), then "Account".
   const [orgLabel, setOrgLabel] = useState<string | null>(null);
   useEffect(() => {
     if (!isTauri()) return;

--- a/apps/homescreen/app/components/WorkloadConfigPane.tsx
+++ b/apps/homescreen/app/components/WorkloadConfigPane.tsx
@@ -395,7 +395,7 @@ function RouteEditor({
         </Button>
       </div>
       {error ? (
-        <p role="alert" className="mt-3 text-sm text-[var(--color-stamp)]">
+        <p role="alert" className="mt-3 text-sm text-[var(--color-bad)]">
           {error}
         </p>
       ) : null}
@@ -457,7 +457,7 @@ function CaptureCard({
           onClick={() => void toggle()}
           className={`inline-flex h-7 w-16 items-center border border-[var(--color-rule)] p-1 text-[0.62rem] font-medium uppercase tracking-[0.12em] transition-colors disabled:opacity-50 ${
             enabled
-              ? "justify-end bg-[color-mix(in_srgb,var(--color-card)_80%,var(--color-stamp)_20%)] text-[var(--color-ink)]"
+              ? "justify-end bg-[color-mix(in_srgb,var(--color-card)_72%,var(--model-mint)_28%)] text-[var(--color-ink)]"
               : "justify-start bg-[var(--color-card)] text-[var(--color-ink-muted)]"
           }`}
         >
@@ -465,7 +465,7 @@ function CaptureCard({
         </button>
       </div>
       {error ? (
-        <p role="alert" className="mt-3 text-sm text-[var(--color-stamp)]">
+        <p role="alert" className="mt-3 text-sm text-[var(--color-bad)]">
           {error}
         </p>
       ) : null}

--- a/apps/homescreen/app/components/sidebar/TrainingThreadList.tsx
+++ b/apps/homescreen/app/components/sidebar/TrainingThreadList.tsx
@@ -24,10 +24,19 @@ export function TrainingThreadList({
   onSelectThread: (threadId: string) => void;
   onArchiveThread: (threadId: string) => Promise<boolean>;
 }) {
-  if (trainingThreads.length === 0) return null;
+  // "Active" threads whose run stopped updating are abandoned/killed jobs —
+  // hide them rather than showing a forever-"In progress" row. (They remain
+  // dismissible from the Training overview; unparseable timestamps stay shown.)
+  const STALE_ACTIVE_MS = 2 * 60 * 60 * 1000;
+  const visibleThreads = trainingThreads.filter((thread) => {
+    if (thread.status !== "active") return true;
+    const updated = Date.parse(thread.updated_at);
+    return Number.isNaN(updated) || Date.now() - updated < STALE_ACTIVE_MS;
+  });
+  if (visibleThreads.length === 0) return null;
   return (
     <nav className="chat-nav-list training-thread-list" aria-label="Training threads">
-      {trainingThreads.map((thread) => {
+      {visibleThreads.map((thread) => {
         const glyph = trainingThreadStatusGlyph(thread.status);
         const isActive = active === "chat" && activeThreadId === thread.thread_id;
         return (

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -32,8 +32,8 @@
   --color-input: var(--c-card);
   /* The reviewed Train desktop uses cyan for model focus and activity. */
   --color-ring: color-mix(in srgb, #67e8f9 55%, rgba(255,255,255,0.25));
-  --color-primary: var(--c-stamp);
-  --color-primary-foreground: var(--c-paper);
+  --color-primary: var(--model-mint);
+  --color-primary-foreground: #0a0a0a;
   --color-secondary: var(--c-hover);
   --color-secondary-foreground: var(--c-ink);
   --color-accent: var(--c-hover);
@@ -86,14 +86,19 @@
     --text: var(--c-ink);
     --text-2: var(--c-ink-muted);
     --text-3: var(--c-ink-muted);
-    --accent: var(--c-stamp);
-    --accent-press: var(--c-stamp);
+    /* mint is the primary operational accent (design.md: "identifies the
+       active action"); clay stamp is reserved for identity/vendor use */
+    --accent: var(--model-mint);
+    --accent-press: color-mix(in srgb, var(--model-mint) 82%, black);
+    --accent-ink: #0a0a0a; /* ink placed ON mint/cyan/amber fills */
     --running: var(--c-ok);
     --loading: var(--c-warn);
     --stopped: var(--c-ink-muted);
     --error: var(--c-bad);
-    --ai: var(--c-stamp);
-    --user: var(--c-stamp);
+    --success: var(--c-ok);
+    --danger: var(--c-bad);
+    --ai: var(--model-mint);
+    --user: var(--model-mint);
     --tool-bg: var(--c-card);
     --r-card: 10px;
     --r-control: 8px;
@@ -175,6 +180,9 @@ select,
 .shell {
   display: grid;
   grid-template-columns: 1fr;
+  /* clamp the single row to the viewport so .content's own
+     overflow-y:auto engages (auto rows grow past 100vh and body clips) */
+  grid-template-rows: minmax(0, 1fr);
   height: 100vh;
 }
 .shell.rail-open {
@@ -828,7 +836,7 @@ select,
   align-items: center;
   gap: 8px;
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-ink);
   border: none;
   border-radius: var(--r-pill);
   padding: 9px 18px;
@@ -837,7 +845,7 @@ select,
   cursor: pointer;
   transition: background 0.12s;
 }
-.connect-btn:hover { background: #2a97ff; }
+.connect-btn:hover { background: color-mix(in srgb, var(--accent) 86%, white); }
 .connect-btn:active { background: var(--accent-press); }
 .connect-btn.connected {
   background: var(--surface-2);
@@ -1026,10 +1034,10 @@ select,
 .btn.primary {
   background: var(--accent);
   border-color: transparent;
-  color: #fff;
+  color: var(--accent-ink);
   font-weight: 600;
 }
-.btn.primary:hover { background: #2a97ff; }
+.btn.primary:hover { background: color-mix(in srgb, var(--accent) 86%, white); }
 .btn:disabled {
   opacity: 0.55;
   cursor: default;
@@ -1171,11 +1179,11 @@ select,
 }
 .flow-node.gateway .flow-node-icon {
   background: color-mix(in srgb, var(--accent) 28%, var(--surface-2));
-  color: #fff;
+  color: var(--text);
 }
 .flow-node.live .flow-node-icon {
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-ink);
   box-shadow: 0 0 22px color-mix(in srgb, var(--accent) 28%, transparent);
 }
 .flow-provider-mark {
@@ -1222,7 +1230,7 @@ select,
   position: relative;
   z-index: 1;
   height: 2px;
-  background: linear-gradient(90deg, var(--border), color-mix(in srgb, var(--accent) 45%, transparent), var(--border));
+  background: linear-gradient(90deg, var(--border), color-mix(in srgb, var(--model-cyan) 45%, transparent), var(--border));
 }
 .gateway-to-provider {
   opacity: 0;
@@ -1249,8 +1257,8 @@ select,
   width: 14px;
   height: 14px;
   border-radius: 4px;
-  background: color-mix(in srgb, var(--accent) 78%, white);
-  box-shadow: 0 0 18px color-mix(in srgb, var(--accent) 42%, transparent);
+  background: var(--model-cyan);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--model-cyan) 42%, transparent);
   animation: packet-run 2.4s linear infinite;
 }
 @keyframes packet-run {
@@ -1592,7 +1600,7 @@ select,
 }
 .test-stat.ok strong { color: var(--success); }
 .test-stat.error strong { color: var(--danger); }
-.test-stat.running strong { color: var(--accent); }
+.test-stat.running strong { color: var(--model-amber); }
 .test-stat.skipped strong { color: var(--loading); }
 .test-results-list {
   display: grid;
@@ -1640,7 +1648,7 @@ select,
 }
 .test-status.passed { background: var(--success); }
 .test-status.failed { background: var(--danger); }
-.test-status.running { background: var(--accent); }
+.test-status.running { background: var(--model-amber); }
 .test-status.skipped { background: var(--loading); }
 .test-detail-grid {
   display: grid;
@@ -1669,7 +1677,7 @@ select,
   line-height: 1.45;
 }
 .rollout-live {
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-color: color-mix(in srgb, var(--model-amber) 34%, var(--border));
 }
 .score-pill {
   min-width: 64px;
@@ -1693,7 +1701,7 @@ select,
   display: block;
   height: 100%;
   border-radius: inherit;
-  background: var(--accent);
+  background: var(--model-amber);
   transition: width 220ms ease;
 }
 .rollout-grid {
@@ -1742,7 +1750,7 @@ select,
 .rollout-row:hover {
   background: var(--hover);
 }
-.rollout-row.running strong { color: var(--accent); }
+.rollout-row.running strong { color: var(--model-amber); }
 .rollout-row.ok strong { color: var(--success); }
 .rollout-row.error strong { color: var(--danger); }
 .rollout-row.skipped strong { color: var(--loading); }
@@ -1828,7 +1836,7 @@ select,
   stroke: var(--border);
   stroke-width: 1.4;
 }
-.rlm-link.running { stroke: var(--accent); }
+.rlm-link.running { stroke: var(--model-violet); }
 .rlm-link.done { stroke: var(--success); }
 .rlm-link.error { stroke: var(--danger); }
 .rlm-node {
@@ -1851,9 +1859,9 @@ select,
   background: var(--hover);
 }
 .rlm-node.active {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  border-color: color-mix(in srgb, var(--model-violet) 45%, var(--border));
 }
-.rlm-node.running { border-color: color-mix(in srgb, var(--accent) 55%, var(--border)); }
+.rlm-node.running { border-color: color-mix(in srgb, var(--model-violet) 55%, var(--border)); }
 .rlm-node.done { border-color: color-mix(in srgb, var(--success) 45%, var(--border)); }
 .rlm-node.error { border-color: color-mix(in srgb, var(--danger) 50%, var(--border)); }
 .rlm-node.planned { border-style: dashed; }
@@ -1865,7 +1873,7 @@ select,
   background: var(--text-3);
 }
 .rlm-node-dot.running {
-  background: var(--accent);
+  background: var(--model-violet);
   animation: rlm-pulse 1.1s ease-in-out infinite;
 }
 .rlm-node-dot.done { background: var(--success); }
@@ -5982,10 +5990,10 @@ select,
 
 /* ---------- GEPA optimization pane ---------- */
 .gepa-root {
-  /* Chart mark colors. Best/front pair validated for CVD separation and
-     3:1 contrast on the dark desktop surface (dataviz six checks). */
-  --gepa-best: var(--c-stamp);
-  --gepa-front: #3987e5;
+  /* Chart mark colors on the v2.0 grammar: mint = best candidate,
+     violet = frontier/search set. Mint vs violet vs muted separates for CVD. */
+  --gepa-best: var(--model-mint);
+  --gepa-front: var(--model-violet);
   --gepa-other: var(--c-ink-muted);
 }
 .gepa-demo-pill {
@@ -7881,7 +7889,7 @@ select,
   background: var(--model-amber);
 }
 .workload-health-dot.failing {
-  background: var(--model-clay);
+  background: var(--c-bad);
 }
 
 /* ---------- Organization Analytics (reporting pane) ----------
@@ -7938,8 +7946,8 @@ select,
 }
 .reporting-metric-tabs button:hover { color: var(--text); }
 .reporting-metric-tabs button.active {
-  background: var(--model-clay);
-  color: #fff;
+  background: var(--model-mint);
+  color: var(--accent-ink);
 }
 .reporting-refresh {
   display: inline-flex;
@@ -8220,7 +8228,7 @@ select,
 .mgmt-trend-bar {
   width: 100%;
   border-radius: 2px 2px 0 0;
-  background: var(--model-clay);
+  background: var(--model-mint);
 }
 .mgmt-trend-labels {
   display: flex;
@@ -8259,7 +8267,7 @@ select,
 .mgmt-credit-warning {
   font-size: 11.5px;
   font-weight: 550;
-  color: var(--model-clay);
+  color: var(--c-warn);
   margin: 0;
 }
 .mgmt-empty {
@@ -8270,8 +8278,8 @@ select,
   color: var(--c-ink-muted);
 }
 .mgmt-notice {
-  border-color: color-mix(in srgb, var(--model-clay) 40%, transparent);
-  background: color-mix(in srgb, var(--model-clay) 5%, transparent);
+  border-color: color-mix(in srgb, var(--c-warn) 40%, transparent);
+  background: color-mix(in srgb, var(--c-warn) 5%, transparent);
 }
 .mgmt-notice-label {
   display: flex;
@@ -8281,13 +8289,13 @@ select,
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  color: var(--model-clay);
+  color: var(--c-warn);
   margin-bottom: 8px;
 }
 .mgmt-notice-dot {
   width: 6px;
   height: 6px;
-  background: var(--model-clay);
+  background: var(--c-warn);
 }
 .mgmt-notice-body {
   font-size: 13px;
@@ -8315,7 +8323,7 @@ select,
 }
 .mgmt-form-error {
   font-size: 12.5px;
-  color: var(--model-clay);
+  color: var(--c-bad);
   margin: 0;
 }
 .mgmt-code {
@@ -8324,8 +8332,8 @@ select,
 }
 /* ---------- Reporting (project Analytics) pane ---------- */
 /* Port of the web reporting page, restyled to the app's tokens: the
-   route-shares "understudy" segment and the daily bars use --c-stamp
-   (the web page's --color-stamp), status colors use --c-ok/--c-bad. */
+   route-shares "understudy" segment and the daily bars use --model-mint
+   (v2.0 operational accent), status colors use --c-ok/--c-bad. */
 .projrep-card-head {
   display: flex;
   align-items: flex-start;
@@ -8384,8 +8392,8 @@ select,
   50% { opacity: 1; }
 }
 .projrep-error {
-  border: 1px solid color-mix(in srgb, var(--c-stamp) 40%, transparent);
-  background: color-mix(in srgb, var(--c-stamp) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--c-bad) 40%, transparent);
+  background: color-mix(in srgb, var(--c-bad) 6%, transparent);
   border-radius: var(--r-control);
   display: grid;
   gap: 8px;
@@ -8495,6 +8503,21 @@ select,
   text-transform: uppercase;
 }
 .projrep-route-shares { display: grid; gap: 6px; }
+/* compact allocation cell inside the combined workloads table */
+.projrep-alloc {
+  display: grid;
+  gap: 4px;
+  min-width: 150px;
+}
+.projrep-alloc .projrep-share-bar {
+  height: 5px;
+}
+.projrep-alloc-label {
+  color: var(--c-ink-muted);
+  font-family: var(--mono);
+  font-size: 10px;
+  white-space: nowrap;
+}
 .projrep-share-bar {
   background: var(--c-hover);
   border-radius: 2px;
@@ -8504,7 +8527,7 @@ select,
   width: 100%;
 }
 .seg-primary { background: color-mix(in srgb, var(--c-ink-muted) 40%, transparent); }
-.seg-understudy { background: var(--c-stamp); }
+.seg-understudy { background: var(--model-mint); }
 .seg-fallback { background: var(--c-bad); }
 .projrep-share-legend {
   color: var(--c-ink-muted);
@@ -8579,7 +8602,7 @@ select,
   min-width: 0;
 }
 .projrep-chart-bar {
-  background: var(--c-stamp);
+  background: var(--model-mint);
   border-radius: 2px 2px 0 0;
   min-height: 1px;
 }
@@ -8873,7 +8896,7 @@ select,
   margin-top: 14px;
 }
 .billing-chart rect {
-  fill: var(--c-stamp);
+  fill: var(--model-mint);
   opacity: 0.85;
 }
 .billing-chart rect:hover { opacity: 1; }
@@ -8944,10 +8967,10 @@ select,
   color: var(--text);
 }
 .settings-danger-card {
-  border-color: color-mix(in srgb, var(--c-stamp) 40%, transparent);
+  border-color: color-mix(in srgb, var(--c-bad) 40%, transparent);
 }
 .settings-danger-text {
-  color: var(--c-stamp);
+  color: var(--c-bad);
   font-size: 12px;
   margin-top: 8px;
 }
@@ -8956,9 +8979,9 @@ select,
   margin-top: 0;
 }
 .settings-danger-btn {
-  border-color: color-mix(in srgb, var(--c-stamp) 50%, transparent);
-  color: var(--c-stamp);
+  border-color: color-mix(in srgb, var(--c-bad) 50%, transparent);
+  color: var(--c-bad);
 }
 .settings-danger-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--c-stamp) 10%, transparent);
+  background: color-mix(in srgb, var(--c-bad) 10%, transparent);
 }

--- a/apps/homescreen/app/lib/nav.ts
+++ b/apps/homescreen/app/lib/nav.ts
@@ -2,16 +2,13 @@ import type { LucideIcon } from "lucide-react";
 import {
   BarChart3,
   Beaker,
-  FolderKanban,
   Boxes,
   CreditCard,
   Compass,
   FlaskConical,
-  HardDrive,
   Inbox,
   KeyRound,
   LayoutDashboard,
-  ScrollText,
   Settings2,
   UserCog,
   Wrench,
@@ -45,32 +42,31 @@ export const NAV_ITEMS: NavItemDef[] = [
   // Organization
   { id: "org-summary", group: "organization", label: "Summary", icon: LayoutDashboard, pane: "org-summary" },
   { id: "org-analytics", group: "organization", label: "Analytics", icon: BarChart3, pane: "reporting" },
-  // The web's project Summary (`/p/[project_slug]`, ActiveView "summary");
-  // the desktop scopes by the sidebar Project selector instead of a slug URL.
-  { id: "org-project", group: "organization", label: "Project", icon: FolderKanban, pane: "project-summary" },
-  // The web's project-scoped Analytics (`/p/[project_slug]` reporting view).
-  { id: "org-project-analytics", group: "organization", label: "Project Analytics", icon: BarChart3, pane: "project-reporting" },
-  // Workload (conditional on scope.workloadId)
+  // The web's project Summary is folded into org Summary on desktop — the
+  // panes were near-duplicates (same metrics/trend/workload cards). The
+  // project-summary pane itself remains reachable by pane id.
+  // The web's project-scoped Analytics (`/p/[project_slug]` reporting view),
+  // presented as the per-workload breakdown.
+  { id: "org-project-analytics", group: "organization", label: "Workloads", icon: BarChart3, pane: "project-reporting" },
+  // Former Workload group, folded into Capture (still gated on a selected workload).
   {
     id: "workload-config",
-    group: "workload",
+    group: "organization",
     label: "Configuration",
     icon: Settings2,
     pane: "workload-config",
     requiresWorkload: true,
   },
-  { id: "workload-captures", group: "workload", label: "Captures", icon: Inbox, pane: "captures", requiresWorkload: true },
+  { id: "workload-captures", group: "organization", label: "Captures", icon: Inbox, pane: "captures", requiresWorkload: true },
   // Training
   { id: "training-overview", group: "training", label: "Overview", icon: FlaskConical, pane: "training-jobs" },
   // Chats (Explore is an ordinary row; New chat is rendered separately)
   { id: "chats-explore", group: "sessions", label: "Explore Data", icon: Compass, pane: "explore" },
   // Manage
   // "Models" is Aamir's catalog surface (web /models). The desktop-native
-  // local model library keeps its own row so it stays reachable from nav.
+  // local model library pane still exists but is reachable only via deep-link.
   { id: "manage-models", group: "manage", label: "Models", icon: Boxes, pane: "model-catalog" },
-  { id: "manage-local-models", group: "manage", label: "Local models", icon: HardDrive, pane: "models" },
   { id: "manage-api-keys", group: "manage", label: "API keys", icon: KeyRound, pane: "api-keys" },
-  { id: "manage-traces", group: "manage", label: "Traces", icon: ScrollText, pane: "traces" },
   { id: "manage-lab", group: "manage", label: "Lab", icon: Beaker, pane: "rlm" },
   // Web: footer Account (/settings) + project settings (/p/:slug/settings).
   { id: "manage-settings", group: "manage", label: "Settings", icon: UserCog, pane: "settings" },

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -35,8 +35,8 @@ import type { ChatSessionRequest, ChatSessionSummary } from "./lib/chat-history"
 import type { TrainingThreadRequest, TrainingThreadSummary } from "./lib/training-threads.mjs";
 
 export default function Page() {
-  const [pane, setPane] = useState<PaneId>("chat");
-  const [railOpen, setRailOpen] = useState(false);
+  const [pane, setPane] = useState<PaneId>("org-summary");
+  const [railOpen, setRailOpen] = useState(true);
   const [scope, setScope] = useState<Scope>({ projectId: null, workloadId: null });
   const [chatResetToken, setChatResetToken] = useState(0);
   const [chatHistory, setChatHistory] = useState<ChatSessionSummary[]>([]);

--- a/apps/homescreen/src-tauri/src/auth.rs
+++ b/apps/homescreen/src-tauri/src/auth.rs
@@ -53,23 +53,39 @@ fn non_empty_env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|v| !v.trim().is_empty())
 }
 
-/// env > ~/.understudy/desktop-auth.json. `None` = not configured yet.
+/// env > ~/.understudy/desktop-auth.json > compile-time default.
+/// `None` = not configured yet.
+///
+/// The compile-time default is injected by release CI via
+/// `UNDERSTUDY_WORKOS_CLIENT_ID` / `UNDERSTUDY_AUTHKIT_DOMAIN` at build
+/// time, so the OSS source carries no environment-specific values while
+/// shipped binaries work out of the box. (A public OAuth client id is not
+/// a secret — PKCE is the protection — keeping it out of the repo is about
+/// rotation flexibility, not confidentiality.)
 pub fn client_config() -> Option<AuthClientConfig> {
+    const BAKED_CLIENT_ID: Option<&str> = option_env!("UNDERSTUDY_WORKOS_CLIENT_ID");
+    const BAKED_AUTHKIT_DOMAIN: Option<&str> = option_env!("UNDERSTUDY_AUTHKIT_DOMAIN");
     let from_file = config_file_path()
         .and_then(|p| std::fs::read_to_string(p).ok())
         .and_then(|s| serde_json::from_str::<Value>(&s).ok());
-    let get = |env: &str, key: &str| {
-        non_empty_env(env).or_else(|| {
-            from_file
-                .as_ref()
-                .and_then(|v| v.get(key))
-                .and_then(|v| v.as_str())
-                .map(str::to_string)
-        })
+    let get = |env: &str, key: &str, baked: Option<&str>| {
+        non_empty_env(env)
+            .or_else(|| {
+                from_file
+                    .as_ref()
+                    .and_then(|v| v.get(key))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .or_else(|| baked.map(str::to_string))
     };
     Some(AuthClientConfig {
-        client_id: get("UNDERSTUDY_WORKOS_CLIENT_ID", "client_id")?,
-        authkit_domain: get("UNDERSTUDY_AUTHKIT_DOMAIN", "authkit_domain")?,
+        client_id: get("UNDERSTUDY_WORKOS_CLIENT_ID", "client_id", BAKED_CLIENT_ID)?,
+        authkit_domain: get(
+            "UNDERSTUDY_AUTHKIT_DOMAIN",
+            "authkit_domain",
+            BAKED_AUTHKIT_DOMAIN,
+        )?,
     })
 }
 

--- a/apps/homescreen/src-tauri/src/auth.rs
+++ b/apps/homescreen/src-tauri/src/auth.rs
@@ -1,0 +1,654 @@
+//! WorkOS AuthKit user authentication for the desktop (docs/proposals/desktop-user-auth.md).
+//!
+//! Public-client OAuth 2.0 Authorization Code + PKCE:
+//!   system browser -> AuthKit -> loopback (127.0.0.1:<ephemeral>) redirect ->
+//!   direct code exchange at WorkOS /user_management/authenticate (no secret).
+//!
+//! Storage split:
+//!   - access + refresh tokens -> macOS Keychain (`security` CLI),
+//!     service `com.understudy.desktop`, account = gateway URL
+//!   - non-secret session metadata -> ~/.understudy/session.json
+//!
+//! The `sk_` credentials store (`creds.rs`) is untouched; a user can hold
+//! both. `management_auth` is the single seam loaders use to pick a Bearer.
+//!
+//! Config-agnostic by design: the WorkOS client id / AuthKit domain come from
+//! env (`UNDERSTUDY_WORKOS_CLIENT_ID`, `UNDERSTUDY_AUTHKIT_DOMAIN`) or
+//! ~/.understudy/desktop-auth.json — nothing is baked in, so the flow is
+//! testable up to the browser hop before the dashboard client exists.
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, TcpListener};
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const KEYCHAIN_SERVICE: &str = "com.understudy.desktop";
+const WORKOS_AUTH_BASE: &str = "https://api.workos.com/user_management";
+const LOGIN_TIMEOUT: Duration = Duration::from_secs(120);
+
+// ---------- configuration (nothing baked in) ----------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthClientConfig {
+    pub client_id: String,
+    /// AuthKit hosted domain, e.g. `https://auth.understudylabs.com`.
+    pub authkit_domain: String,
+}
+
+fn config_file_path() -> Option<PathBuf> {
+    dirs_home().map(|h| h.join(".understudy").join("desktop-auth.json"))
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.trim().is_empty())
+}
+
+/// env > ~/.understudy/desktop-auth.json. `None` = not configured yet.
+pub fn client_config() -> Option<AuthClientConfig> {
+    let from_file = config_file_path()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok());
+    let get = |env: &str, key: &str| {
+        non_empty_env(env).or_else(|| {
+            from_file
+                .as_ref()
+                .and_then(|v| v.get(key))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+    };
+    Some(AuthClientConfig {
+        client_id: get("UNDERSTUDY_WORKOS_CLIENT_ID", "client_id")?,
+        authkit_domain: get("UNDERSTUDY_AUTHKIT_DOMAIN", "authkit_domain")?,
+    })
+}
+
+// ---------- session metadata (non-secret, survives without Keychain) ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMeta {
+    pub user_id: String,
+    pub org_id: Option<String>,
+    pub email: Option<String>,
+    pub name: Option<String>,
+    /// Unix seconds when the access token expires (refresh after this).
+    pub access_token_expires_at: u64,
+    pub gateway_url: String,
+}
+
+fn session_file_path() -> Result<PathBuf> {
+    Ok(dirs_home()
+        .context("no HOME")?
+        .join(".understudy")
+        .join("session.json"))
+}
+
+pub fn read_session() -> Option<SessionMeta> {
+    let path = session_file_path().ok()?;
+    serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
+}
+
+fn write_session(meta: &SessionMeta) -> Result<()> {
+    let path = session_file_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // write-new-then-swap so a crash never leaves a torn file
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_vec_pretty(meta)?)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn clear_session() {
+    if let Ok(path) = session_file_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+// ---------- Keychain (secrets) ----------
+
+fn keychain_account() -> String {
+    crate::creds::resolve()
+        .map(|c| c.gateway_url)
+        .unwrap_or_else(|| crate::creds::DEFAULT_GATEWAY_URL.to_string())
+}
+
+fn keychain_set(kind: &str, secret: &str) -> Result<()> {
+    let account = format!("{}#{kind}", keychain_account());
+    // -U updates in place; stdin is not supported by add-generic-password's
+    // -w, so pass via arg. Acceptable: `security` is Apple-signed and the
+    // value never enters shell history (no shell involved).
+    let out = Command::new("security")
+        .args([
+            "add-generic-password",
+            "-U",
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-a",
+            &account,
+            "-w",
+            secret,
+        ])
+        .output()
+        .context("run security add-generic-password")?;
+    if !out.status.success() {
+        bail!(
+            "keychain write failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn keychain_get(kind: &str) -> Option<String> {
+    let account = format!("{}#{kind}", keychain_account());
+    let out = Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-a",
+            &account,
+            "-w",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let s = s.trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+fn keychain_delete(kind: &str) {
+    let account = format!("{}#{kind}", keychain_account());
+    let _ = Command::new("security")
+        .args([
+            "delete-generic-password",
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-a",
+            &account,
+        ])
+        .output();
+}
+
+// ---------- PKCE ----------
+
+fn random_urlsafe(bytes: usize) -> String {
+    // getrandom via std: fill from /dev/urandom-backed OS RNG. std has no
+    // public RNG; use the `sha2` of process entropy sources would be weak —
+    // read the OS RNG directly instead.
+    let mut buf = vec![0u8; bytes];
+    getrandom_fill(&mut buf);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(buf)
+}
+
+fn getrandom_fill(buf: &mut [u8]) {
+    use std::fs::File;
+    let mut f = File::open("/dev/urandom").expect("open /dev/urandom");
+    f.read_exact(buf).expect("read /dev/urandom");
+}
+
+struct Pkce {
+    verifier: String,
+    challenge: String,
+}
+
+fn pkce_pair() -> Pkce {
+    let verifier = random_urlsafe(48); // 64 chars, within RFC 7636's 43..128
+    let digest = Sha256::digest(verifier.as_bytes());
+    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+    Pkce {
+        verifier,
+        challenge,
+    }
+}
+
+// ---------- loopback listener ----------
+
+/// One-shot loopback HTTP listener: accepts exactly one GET, validates
+/// `state`, replies with a close-this-tab page, and returns the `code`.
+fn await_callback(listener: TcpListener, expected_state: &str) -> Result<String> {
+    listener
+        .set_nonblocking(false)
+        .context("listener blocking mode")?;
+    let deadline = SystemTime::now() + LOGIN_TIMEOUT;
+    // SO_TIMEOUT via accept loop: TcpListener has no accept timeout, so use
+    // a short socket read timeout per connection and re-check the deadline.
+    loop {
+        if SystemTime::now() > deadline {
+            bail!("sign-in timed out after {}s", LOGIN_TIMEOUT.as_secs());
+        }
+        listener.set_nonblocking(true).ok();
+        match listener.accept() {
+            Ok((mut stream, _addr)) => {
+                stream.set_nonblocking(false).ok();
+                stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                let mut buf = [0u8; 4096];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let first_line = req.lines().next().unwrap_or_default();
+                // GET /callback?code=...&state=... HTTP/1.1
+                let query = first_line
+                    .split_whitespace()
+                    .nth(1)
+                    .and_then(|path| path.split_once('?'))
+                    .map(|(_, q)| q)
+                    .unwrap_or_default();
+                let mut code = None;
+                let mut state = None;
+                for pair in query.split('&') {
+                    match pair.split_once('=') {
+                        Some(("code", v)) => code = Some(url_decode(v)),
+                        Some(("state", v)) => state = Some(url_decode(v)),
+                        _ => {}
+                    }
+                }
+                let ok = state.as_deref() == Some(expected_state) && code.is_some();
+                let body = if ok {
+                    "<html><body style=\"font-family:sans-serif;padding:40px\">\
+                     <h2>Signed in to Understudy</h2><p>You can close this tab.</p></body></html>"
+                } else {
+                    "<html><body style=\"font-family:sans-serif;padding:40px\">\
+                     <h2>Sign-in failed</h2><p>State mismatch or missing code. Return to the app and retry.</p></body></html>"
+                };
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.flush();
+                if !ok {
+                    bail!("authorization callback state mismatch");
+                }
+                return Ok(code.expect("checked above"));
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(120));
+            }
+            Err(e) => return Err(anyhow!("loopback accept failed: {e}")),
+        }
+    }
+}
+
+fn url_decode(s: &str) -> String {
+    let mut out = Vec::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("");
+                if let Ok(v) = u8::from_str_radix(hex, 16) {
+                    out.push(v);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() * 3);
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+// ---------- token exchange / refresh ----------
+
+#[derive(Debug)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    user: Value,
+    organization_id: Option<String>,
+}
+
+async fn workos_authenticate(body: Value) -> Result<TokenResponse> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{WORKOS_AUTH_BASE}/authenticate"))
+        .json(&body)
+        .send()
+        .await
+        .context("reach WorkOS authenticate endpoint")?;
+    let status = resp.status();
+    let payload: Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    if !status.is_success() {
+        let msg = payload
+            .get("message")
+            .or_else(|| payload.get("error_description"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("authentication failed");
+        bail!("WorkOS: {msg} (HTTP {status})");
+    }
+    Ok(TokenResponse {
+        access_token: payload
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .context("no access_token in response")?
+            .to_string(),
+        refresh_token: payload
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        user: payload.get("user").cloned().unwrap_or(json!({})),
+        organization_id: payload
+            .get("organization_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+    })
+}
+
+/// Decode the JWT payload (no signature check — the server verifies; we only
+/// read expiry + org for local bookkeeping).
+fn jwt_claims(token: &str) -> Value {
+    token
+        .split('.')
+        .nth(1)
+        .and_then(|p| {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(p)
+                .ok()
+        })
+        .and_then(|b| serde_json::from_slice(&b).ok())
+        .unwrap_or(json!({}))
+}
+
+fn store_tokens(tokens: &TokenResponse) -> Result<SessionMeta> {
+    let claims = jwt_claims(&tokens.access_token);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let meta = SessionMeta {
+        user_id: claims
+            .get("sub")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        org_id: claims
+            .get("org_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .or_else(|| tokens.organization_id.clone()),
+        email: tokens
+            .user
+            .get("email")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        name: {
+            let first = tokens.user.get("first_name").and_then(|v| v.as_str());
+            let last = tokens.user.get("last_name").and_then(|v| v.as_str());
+            match (first, last) {
+                (Some(f), Some(l)) => Some(format!("{f} {l}")),
+                (Some(f), None) => Some(f.to_string()),
+                (None, Some(l)) => Some(l.to_string()),
+                _ => None,
+            }
+        },
+        access_token_expires_at: claims
+            .get("exp")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(now + 300),
+        gateway_url: keychain_account(),
+    };
+    // Rotation safety: write the NEW refresh token before discarding the old
+    // one (keychain_set -U overwrites atomically; keep a one-generation
+    // backup under a distinct kind first).
+    if let Some(refresh) = &tokens.refresh_token {
+        if let Some(prev) = keychain_get("refresh") {
+            let _ = keychain_set("refresh.bak", &prev);
+        }
+        keychain_set("refresh", refresh)?;
+    }
+    keychain_set("access", &tokens.access_token)?;
+    write_session(&meta)?;
+    Ok(meta)
+}
+
+// ---------- the flows ----------
+
+/// Interactive sign-in: PKCE + system browser + loopback. Blocking on the
+/// browser round-trip; call from an async command so the UI stays live.
+pub async fn user_login() -> Result<SessionMeta> {
+    let config = client_config().context(
+        "WorkOS desktop client is not configured. Set UNDERSTUDY_WORKOS_CLIENT_ID and \
+         UNDERSTUDY_AUTHKIT_DOMAIN (or ~/.understudy/desktop-auth.json).",
+    )?;
+    let pkce = pkce_pair();
+    let state = random_urlsafe(24);
+
+    // Loopback bound to 127.0.0.1 ONLY, ephemeral port.
+    let listener =
+        TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).context("bind loopback listener")?;
+    let port = listener.local_addr()?.port();
+    let redirect_uri = format!("http://127.0.0.1:{port}/callback");
+
+    let authorize_url = format!(
+        "{}/authorize?client_id={}&response_type=code&code_challenge={}&code_challenge_method=S256&redirect_uri={}&state={}&provider=authkit",
+        config.authkit_domain.trim_end_matches('/'),
+        url_encode(&config.client_id),
+        url_encode(&pkce.challenge),
+        url_encode(&redirect_uri),
+        url_encode(&state),
+    );
+
+    tauri_plugin_opener::open_url(&authorize_url, None::<&str>)
+        .context("open system browser")?;
+
+    // The blocking accept loop runs on a worker thread so we don't pin the
+    // async runtime.
+    let code = tokio::task::spawn_blocking(move || await_callback(listener, &state))
+        .await
+        .context("join loopback task")??;
+
+    let tokens = workos_authenticate(json!({
+        "client_id": config.client_id,
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": pkce.verifier,
+    }))
+    .await?;
+    store_tokens(&tokens)
+}
+
+/// Refresh the access token via the rotated refresh token. Returns the new
+/// session, or an error that should surface as "re-login required".
+pub async fn refresh_session() -> Result<SessionMeta> {
+    let config = client_config().context("WorkOS desktop client not configured")?;
+    let refresh = keychain_get("refresh")
+        .or_else(|| keychain_get("refresh.bak"))
+        .context("no refresh token stored — sign in first")?;
+    let tokens = workos_authenticate(json!({
+        "client_id": config.client_id,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+    }))
+    .await?;
+    store_tokens(&tokens)
+}
+
+pub fn user_logout() {
+    keychain_delete("access");
+    keychain_delete("refresh");
+    keychain_delete("refresh.bak");
+    clear_session();
+}
+
+// ---------- the TokenProvider seam ----------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthLevel {
+    /// Mutating management calls: MUST carry a user identity.
+    User,
+    /// Read-only owner surfaces: prefer the user token, tolerate `sk_`.
+    OwnerRead,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthContext {
+    pub bearer: String,
+    pub org_id: Option<String>,
+    /// `Some` only for a WorkOS user token.
+    pub user_id: Option<String>,
+    pub email: Option<String>,
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// The single seam: which Bearer goes on a management call.
+pub async fn management_auth(level: AuthLevel) -> Result<AuthContext> {
+    // 1. A live user session wins at either level.
+    if let Some(meta) = read_session() {
+        // refresh 30s before expiry
+        let meta = if meta.access_token_expires_at <= now_secs() + 30 {
+            match refresh_session().await {
+                Ok(m) => m,
+                Err(e) if level == AuthLevel::User => {
+                    return Err(anyhow!("re-login required: {e}"))
+                }
+                Err(_) => meta, // OwnerRead: fall through to sk_ below
+            }
+        } else {
+            meta
+        };
+        if let Some(access) = keychain_get("access") {
+            if meta.access_token_expires_at > now_secs() {
+                return Ok(AuthContext {
+                    bearer: access,
+                    org_id: meta.org_id.clone(),
+                    user_id: Some(meta.user_id.clone()),
+                    email: meta.email.clone(),
+                });
+            }
+        }
+        if level == AuthLevel::User {
+            bail!("re-login required: stored session has no usable access token");
+        }
+    } else if level == AuthLevel::User {
+        bail!("sign in required: this action needs an attributable user identity");
+    }
+    // 2. OwnerRead falls back to the org sk_ key.
+    let creds = crate::creds::resolve().context("not signed in and no sk_ credentials")?;
+    Ok(AuthContext {
+        bearer: creds.api_key,
+        org_id: creds.org_id,
+        user_id: None,
+        email: None,
+    })
+}
+
+// ---------- Tauri commands ----------
+
+#[tauri::command]
+pub async fn auth_login() -> Result<Value, String> {
+    user_login()
+        .await
+        .map(|meta| json!({ "ok": true, "session": meta }))
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn auth_logout() -> Value {
+    user_logout();
+    json!({ "ok": true })
+}
+
+#[tauri::command]
+pub fn auth_session_status() -> Value {
+    let configured = client_config().is_some();
+    match read_session() {
+        Some(meta) => json!({
+            "ok": true,
+            "configured": configured,
+            "signed_in": true,
+            "user_id": meta.user_id,
+            "org_id": meta.org_id,
+            "email": meta.email,
+            "name": meta.name,
+            "access_token_expires_at": meta.access_token_expires_at,
+        }),
+        None => json!({
+            "ok": true,
+            "configured": configured,
+            "signed_in": false,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_challenge_is_s256_of_verifier() {
+        let p = pkce_pair();
+        let digest = Sha256::digest(p.verifier.as_bytes());
+        let expect = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+        assert_eq!(p.challenge, expect);
+        assert!(p.verifier.len() >= 43 && p.verifier.len() <= 128);
+    }
+
+    #[test]
+    fn url_decode_handles_percent_and_plus() {
+        assert_eq!(url_decode("a%2Fb+c"), "a/b c");
+        assert_eq!(url_decode("plain"), "plain");
+    }
+
+    #[test]
+    fn url_encode_roundtrip() {
+        let s = "http://127.0.0.1:53211/callback";
+        assert_eq!(url_decode(&url_encode(s)), s);
+    }
+
+    #[test]
+    fn jwt_claims_reads_unverified_payload() {
+        // header.payload.sig with payload {"sub":"user_1","org_id":"org_1","exp":99}
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"sub":"user_1","org_id":"org_1","exp":99}"#);
+        let token = format!("e30.{payload}.sig");
+        let claims = jwt_claims(&token);
+        assert_eq!(claims["sub"], "user_1");
+        assert_eq!(claims["org_id"], "org_1");
+        assert_eq!(claims["exp"], 99);
+    }
+}

--- a/apps/homescreen/src-tauri/src/auth.rs
+++ b/apps/homescreen/src-tauri/src/auth.rs
@@ -452,9 +452,15 @@ pub async fn user_login() -> Result<SessionMeta> {
     let pkce = pkce_pair();
     let state = random_urlsafe(24);
 
-    // Loopback bound to 127.0.0.1 ONLY, ephemeral port.
-    let listener =
-        TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).context("bind loopback listener")?;
+    // Loopback bound to 127.0.0.1 ONLY. WorkOS wildcards cover subdomains,
+    // not ports, so the redirect URIs are registered on a fixed port list
+    // (see the "Understudy Desktop" application in the WorkOS dashboard);
+    // try them in order in case one is taken.
+    const LOOPBACK_PORTS: [u16; 3] = [17871, 17872, 17873];
+    let listener = LOOPBACK_PORTS
+        .iter()
+        .find_map(|p| TcpListener::bind((Ipv4Addr::LOCALHOST, *p)).ok())
+        .context("all registered loopback ports (17871-17873) are in use")?;
     let port = listener.local_addr()?.port();
     let redirect_uri = format!("http://127.0.0.1:{port}/callback");
 

--- a/apps/homescreen/src-tauri/src/captures.rs
+++ b/apps/homescreen/src-tauri/src/captures.rs
@@ -96,16 +96,23 @@ struct Auth {
     gateway_url: String,
 }
 
-fn resolve_auth() -> Result<Auth, String> {
-    let creds = crate::creds::resolve()
-        .ok_or("Not signed in. Run `understudy login` (or open Account) first.")?;
-    let org_id = creds.org_id.clone().ok_or(
-        "No active organization in ~/.understudy/credentials.json — sign in again to scope one.",
+/// Captures are owner-read surfaces: prefer the WorkOS user token (unlocks
+/// the customer/v1 workload-scoped + detail routes), fall back to the org
+/// `sk_` key (admin/v1 project aggregate only).
+async fn resolve_auth() -> Result<Auth, String> {
+    let gateway_url = crate::creds::resolve()
+        .map(|c| c.gateway_url)
+        .unwrap_or_else(|| crate::creds::DEFAULT_GATEWAY_URL.to_string());
+    let ctx = crate::auth::management_auth(crate::auth::AuthLevel::OwnerRead)
+        .await
+        .map_err(|e| format!("Not signed in ({e}). Open Account to sign in."))?;
+    let org_id = ctx.org_id.ok_or(
+        "No active organization — sign in again to scope one.",
     )?;
     Ok(Auth {
-        api_key: creds.api_key,
+        api_key: ctx.bearer,
         org_id,
-        gateway_url: creds.gateway_url,
+        gateway_url,
     })
 }
 
@@ -146,7 +153,7 @@ pub async fn captures_list(
     cursor: Option<String>,
     limit: Option<u32>,
 ) -> Result<Value, String> {
-    let auth = resolve_auth()?;
+    let auth = resolve_auth().await?;
     let url = list_url(
         &auth.gateway_url,
         &auth.org_id,
@@ -165,7 +172,7 @@ pub async fn capture_get(
     request_id: String,
     workload_id: Option<String>,
 ) -> Result<Value, String> {
-    let auth = resolve_auth()?;
+    let auth = resolve_auth().await?;
     let url = detail_url(
         &auth.gateway_url,
         &auth.org_id,

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod aa;
 mod account;
+mod auth;
 mod admin;
 mod agent_card;
 mod agent_ops;
@@ -297,6 +298,9 @@ pub fn run() {
             moraine::moraine_start,
             commands::stop_moraine,
             commands::account_status,
+            auth::auth_login,
+            auth::auth_logout,
+            auth::auth_session_status,
             commands::account_platforms,
             commands::account_keys,
             commands::account_captures,


### PR DESCRIPTION
## Design v2.0 alignment (`95bea87`)

- **De-orange the operational layer**: `--accent`/`--ai`/`--user`/primary/ring/selection move from the clay stamp to **mint** (design.md: mint is the primary operational accent; dark ink on mint fills). Kills two fossil `#2a97ff` hovers. Clay survives only as vendor identity.
- **Model-color grammar**: cyan = capture-flow packets/lanes (trace flow), violet = RLM tree + GEPA marks (search/lineage), amber = rollout/test family (data-taking). Series palettes lead with mint.
- **Bug fixes en route**: `--success`/`--danger` were referenced but never defined (silent no-op); `.shell` never clamped its grid row so pane scrolling was dead (`grid-template-rows: minmax(0,1fr)`).
- **Nav cleanup**: Organization→Capture; Project folded into Summary (near-duplicate panes); Project Analytics→Workloads with a single combined table (requests/cost/cache/**error rate**/**allocation**); Workload group merged into Capture; Local models + Traces rows cut; default pane = Summary; sidebar open by default; org identity bottom-left; abandoned "active" training threads (>2h stale) hidden.

## WorkOS AuthKit user sign-in (`22100e9`, `ccccebf`)

Client side of `docs/proposals/desktop-user-auth.md`:

- `src-tauri/src/auth.rs`: public-client **Authorization Code + PKCE** via the system browser and a single-use `127.0.0.1` loopback listener (state-checked, 2-min timeout); direct code exchange at WorkOS `/user_management/authenticate` (no secret). Tokens in the macOS Keychain (rotation-safe refresh), session metadata in `~/.understudy/session.json`. Loopback binds a fixed registered port list (17871–17873) — WorkOS redirect wildcards are subdomain-only.
- **TokenProvider seam** `management_auth(User | OwnerRead)`: `User` never silently downgrades to `sk_`; `OwnerRead` prefers the user JWT, tolerates `sk_`.
- Captures loaders ride `OwnerRead`: signed-in users regain the `customer/v1` workload-scoped + detail routes (401ing for legacy keys since the WorkOS migration); `sk_`-only keeps the `admin/v1` aggregate.
- Account pane: "Sign in with browser" / signed-in-as / sign-out. `sk_` email-code flow and `credentials.json` untouched (parallel store).

**Verified live end-to-end**: sign-in from the app → AuthKit (Understudy Desktop application, `client_01KY333PN55JP0CAZ01QV97WRY`, redirect URIs registered) → loopback → session stored.

Remaining (platform, tracked in the proposal): `requireUser` on mutating `/admin/v1/*` — the real ship gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->