### PR TITLE
Add local trace benchmark foundry

### DIFF
--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -53,6 +53,12 @@ Build this only after [`../understand-workload/SKILL.md`](../understand-workload
 has produced the workload's purpose, tool catalog, inputs/outputs, and the success
 criteria (recall / precision / policy — not just cost/speed).
 
+When production traces are the source, first run the generic foundry in
+[`../ingest-traces/SKILL.md`](../ingest-traces/SKILL.md). Its machine proposal,
+source DAG, and human review become the evidence-backed starting point for this
+simulation. Customer names and workload-specific assumptions must never enter
+the generic compiler or viewer.
+
 ## Safety Gates
 
 - **Synthetic data only.** Seed the environment with invented entities. A small
@@ -202,6 +208,9 @@ live-effect, reward, hash, and parser gates pass.
 
 ## References
 
+- [`references/trace-to-benchmark-foundry.md`](references/trace-to-benchmark-foundry.md) — machine-first trace compilation, review, promotion, and diminishing returns.
+- [`references/automationbench-adaptation.md`](references/automationbench-adaptation.md) — reuse canonical stateful-benchmark patterns without losing trace provenance.
+- [`references/resumable-environment-goal.md`](references/resumable-environment-goal.md) — automate trace batches with deterministic resumption and approval gates.
 - [`references/cookbook-traces-to-env.md`](references/cookbook-traces-to-env.md) — the stage-by-stage recipe from captured traces/tests to a runnable verifiers env (gold policies, tool-stub strategies, contract rubric, playbook-as-argument, validator gates).
 - [`examples/event-categorizer/`](examples/event-categorizer/README.md) — complete synthetic scaffold: env module, tasks, swappable playbooks, capture converter, and an offline `smoke.py` verified against `verifiers==0.2.0`.
 - [`../understand-workload/SKILL.md`](../understand-workload/SKILL.md) — produces the shape this simulates.

--- a/skills/design-simulated-environment/references/automationbench-adaptation.md
+++ b/skills/design-simulated-environment/references/automationbench-adaptation.md
@@ -1,0 +1,23 @@
+# AutomationBench and reference-environment adaptation
+
+AutomationBench is a useful public control for business-tool state mutation.
+Reuse seeded deterministic state, tools that execute rather than replay,
+final-state and preservation grading, scripted oracle, adversarial sentinels,
+task/harness/rubric separation, and a frozen return-eval.
+
+Trace-derived environments additionally require versioned envelope/SSE
+normalization, message/tool fingerprints, source-history DAGs, evidence ledgers,
+capability fit and inheritance, machine proposals with human final judgment,
+task-to-source provenance, freshness, privacy, contradiction, and diminishing-
+return gates.
+
+Do not copy a canonical environment blindly. Audit its current schemas,
+runtime, task objects, trace representation, parser/renderer seam, rubric API,
+and dependency pin before adapting it. Record the audited Verifiers release or
+commit in benchmark artifacts.
+
+For replay, every model receives the same approved system, messages, tools, and
+state. Context-rot experiments hold task and reward fixed while varying minimal
+context, authentic history, longer history, distractors, errors/conflicts, and
+practical saturation. Score outcome, preservation, forbidden effects, failures,
+retries, context size, cost, and latency.

--- a/skills/design-simulated-environment/references/resumable-environment-goal.md
+++ b/skills/design-simulated-environment/references/resumable-environment-goal.md
@@ -1,0 +1,29 @@
+# Resumable environment-generation goal
+
+An autonomous coding agent can grind through trace batches when deterministic
+state makes the work resumable without chat history.
+
+Persist a machine-readable goal state and append-only event log beneath
+`.understudy/benchmarks/<run>/`. Each event records input hashes, attempted
+action, outputs, validation, blockers, and next action.
+
+The goal owns these work packages:
+
+1. discover fresh local captures and update the immutable ledger;
+2. normalize envelopes and assemble executions;
+3. reconstruct and validate source DAGs;
+4. compile or extend capability/world semantics;
+5. generate tasks, contracts, reset, tools, and sentinels;
+6. build the benchmark and local viewer;
+7. import final human judgments and rerun regressions;
+8. stop at diminishing returns or a genuine evidence/privacy blocker;
+9. prepare, but do not execute, multi-model replay plans.
+
+Deterministic code owns hashes, DAG validation, schemas, split assignment,
+review application, regressions, and promotion. The LLM owns proposals and
+classification. The user adjudicates close calls and final promotion.
+
+Provider calls, uploads, untrusted generated-code execution, hosted evaluation,
+and training remain separate explicit approval gates. The terminal condition is
+a locally executable environment with passing oracle/sentinels/regressions, or a
+specific external blocker recorded in goal state.

--- a/skills/design-simulated-environment/references/trace-to-benchmark-foundry.md
+++ b/skills/design-simulated-environment/references/trace-to-benchmark-foundry.md
@@ -1,0 +1,55 @@
+# Trace-to-benchmark foundry
+
+Turn local traces into stateful, human-adjudicated tasks without making the
+incumbent trajectory the oracle.
+
+Keep two graphs separate: the source-history DAG owns grouping, retries,
+branches, mutations, errors, and provenance; every fresh model evaluation owns
+a new native Verifiers trace through the approved task, tools, runtime, and
+rubric. Never splice the historical future into a fresh rollout.
+
+## Machine-first compiler loop
+
+1. discover unprocessed local objects and update an immutable ledger;
+2. normalize envelopes and reconstruct source DAGs;
+3. choose the earliest defensible candidate boundary;
+4. label claims `observed`, `inferred`, or `specified` with confidence;
+5. fit against a capability catalog and inherit matching approved semantics;
+6. propose novel state, tools, transitions, outcome and preservation contracts,
+   forbidden effects, and sentinels;
+7. classify as `new_instance`, `environment_extension`, `task_variant`,
+   `new_capability`, `contradiction`, or `blocked`;
+8. run deterministic schema, split, DAG, sentinel, and regression gates;
+9. send close calls, contradictions, and novel semantics to human judgment.
+
+The machine makes its strongest proposal immediately but never approves its own
+inferred or specified claims. Human decisions are `accept`, `restrict`,
+`needs_more`, and `reject`, persisted with time, evidence hashes, restrictions,
+and decision hash.
+
+## Artifacts and viewer
+
+Keep captures, normalized rows, DAG, tasks, benchmark, lazy per-capture viewer
+data, and exported reviews below `.understudy/`. The viewer shows task/source
+hashes, vertical lineage, selected round, parsed/raw request and response,
+machine world/outcome proposals, claim classes, sentinels, split, contamination
+warnings, and final review actions.
+
+Promotion requires deterministic reset, stateful tools rather than historical
+lookup tables, independent final-state contracts, intended/no-op/wrong/
+destructive sentinels, regression of prior tasks, split validation, and human
+final judgment. Exact incumbent replay is a regression, never the only success
+definition.
+
+Freeze construction, fit, and held-out splits before model comparison. Related
+traces stay together when leakage is plausible. Held-out traces never author
+semantics.
+
+After initial construction, process batches of ten. Move to maintenance only
+after two consecutive batches have at least 90% clean reuse, fewer than 5% new
+semantic rules, no unresolved high-impact contradictions, and passing prior
+regressions.
+
+Once rewards are trustworthy, baseline first, run train/dev-only GEPA, select
+on validation, evaluate once on sealed held-out, then consider context policy,
+SFT, RLM, or RL. GEPA cannot repair false tool semantics or leaked rewards.

--- a/skills/ingest-traces/SKILL.md
+++ b/skills/ingest-traces/SKILL.md
@@ -15,8 +15,15 @@ harness can be attached and run. Many workloads arrive the other way around:
 the traces already exist — in an object-store bucket, a provider log export,
 or an Understudy gateway capture export — and the job is to get them into
 local evidence artifacts without leaking anything. This worker does that
-transformation: source → deterministic classification → frozen slices →
-redacted manifests, all on the local machine.
+transformation: local source → normalized captures → source-history DAG →
+machine-proposed benchmark → human judgment, all on the local machine.
+
+## OSS filesystem boundary
+
+This public skill starts with files already present in `.understudy/captures/`
+or another explicitly supplied local directory. It never invokes a privileged
+administrative surface, changes tenant membership, or embeds a vendor-specific
+downloader. Acquisition is a separate producer; this skill owns processing.
 
 ## Safety Gates
 
@@ -91,6 +98,27 @@ bulk semantic-triage playbook in
 
 ## Flow
 
+For multi-turn tool workloads, start the deterministic foundry with:
+
+```sh
+understudy traces build-benchmark \
+  --source .understudy/captures \
+  --output .understudy/benchmarks/latest \
+  --max-age-days 3
+```
+
+This fails closed when no capture falls inside the requested freshness window.
+It writes normalized captures, a source DAG, machine-proposed tasks and outcome
+contracts, a canonical benchmark manifest, and a local Design Language v2
+viewer. The viewer defaults to parsed JSON, retains an explicit Raw view, and
+loads individual private captures lazily from disk.
+
+The machine should make its strongest supported proposal immediately. Human
+review supplies final judgment and focuses on close calls; it does not manually
+author every environment. Captured incumbent behavior is evidence, never the
+sole oracle, and outcome contracts grade semantic final state rather than exact
+trajectory reproduction.
+
 1. **Classify deterministically.** Bucket every trace into workload groups by
    content-based rules, never hand-picking: match on stable markers in the
    request (a system-prompt heading, a template name, an endpoint). Record the
@@ -133,6 +161,10 @@ skill for this workload.
 
 ## References
 
+- [`references/trace-envelopes.md`](references/trace-envelopes.md) — local
+  versioned-envelope decoding, SSE, raw preservation, and freshness.
+- [`references/source-history-dag.md`](references/source-history-dag.md) —
+  fingerprints, retries, branches, folds, mutations, and validation.
 - [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) — owns the
   metric/validator/baseline contract the frozen slices feed.
 - [`references/profile-captures.md`](references/profile-captures.md) —

--- a/skills/ingest-traces/references/source-history-dag.md
+++ b/skills/ingest-traces/references/source-history-dag.md
@@ -1,0 +1,33 @@
+# Source-history DAG contract
+
+The longest captured request is a candidate tip, not proof of perfect history.
+Reconstruct executions from stable fingerprints and time evidence before deriving tasks.
+
+Hash every message and ordered block; tool calls by stable ID, name, and arguments;
+tool results by call/result ID, status, content, and error shape; ordered message
+prefixes; and the raw source representation. Semantic normalization may bridge
+encoding differences, but raw hashes must expose changed content.
+
+Every non-root invocation receives one defensible relation:
+
+- `prefix_append`: the full parent history is preserved and events append;
+- `folded_continuation`: prior events were intentionally summarized, with a
+  ledger of contributing fingerprints;
+- `retry`: the same model boundary was attempted again after an error, timeout,
+  empty response, or invalid call;
+- `branch`: a shared prefix produced a different continuation;
+- `same_depth_mutation`: history length stayed fixed but prior content changed;
+- `destructive_mutation`: earlier history disappeared or was rewritten without
+  defensible fold evidence.
+
+Do not call every mutation a retry. Persistence, redaction, summarization,
+concurrency, framework memory, and runtime behavior can all rewrite context.
+
+Failed calls and responses are first-class evidence. Link retries only when
+boundary and tool identity support it. Deduplicate cumulative results by stable
+IDs plus content hashes, never similar text.
+
+Fail closed when parentage is ambiguous, results match multiple calls,
+timestamps contradict an edge, a fold lacks contributing fingerprints, or a
+source pointer/hash cannot reproduce a node. Historical source DAGs never
+replace the native trace created by a fresh candidate rollout.

--- a/skills/ingest-traces/references/trace-envelopes.md
+++ b/skills/ingest-traces/references/trace-envelopes.md
@@ -1,0 +1,22 @@
+# Local trace-envelope normalization
+
+The public boundary is `.understudy/captures/`. Acquisition, credentials,
+tenant selection, and privileged administration are outside this skill.
+
+Preserve the original local record while normalizing request ID; `ts` or
+`created_at`; `workload_id` or legacy `placement_id`; requested and upstream
+model separately; customer request; upstream request; and `response_body` or
+legacy `customer_response_body`.
+
+Bodies may be objects or bounded layers of JSON-encoded strings. Streamed SSE
+must be parsed event-by-event and reassembled without discarding ordering,
+event types, tool-call deltas, stop reasons, or original representation.
+
+Each normalized row retains system, ordered messages, tools, settings, response
+messages/calls, aliases and warnings, source pointer/hash, and raw request and
+response representations. Unknown schema versions are unsupported until
+inspected; never silently coerce them.
+
+Use `--max-age-days` when the benchmark represents current behavior. Missing or
+invalid timestamps are excluded, and an empty fresh window fails rather than
+falling back to stale captures.

--- a/src/commands/traces.ts
+++ b/src/commands/traces.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { join, resolve } from "node:path";
+import { compileTraceFoundry } from "../trace-foundry.js";
+
+export function registerTracesCommand(program: Command): void {
+  const traces = program.command("traces").description("Compile local trace captures into benchmark environments");
+  traces.command("build-benchmark")
+    .description("Build a source DAG, machine-proposed benchmark, and local review viewer")
+    .option("--source <path>", "Local capture directory", ".understudy/captures")
+    .option("--output <path>", "Private output directory", ".understudy/benchmarks/latest")
+    .option("--max-age-days <days>", "Fail closed on stale captures", "3")
+    .action((options: { source: string; output: string; maxAgeDays: string }) => {
+      const result = compileTraceFoundry(resolve(options.source), resolve(options.output), Number(options.maxAgeDays));
+      console.log(JSON.stringify(result, null, 2));
+      console.error(`viewer: ${join(result.output_dir, "viewer", "index.html")}`);
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { planRouteDecision } from "./route-decision.js";
 import { buildValueReport } from "./value-report.js";
 import { type AgentPlatformAdapter, agentPlatformAdapters, findAgentPlatformAdapter } from "./agent-platforms.js";
 import { registerCapturesCommand } from "./commands/captures.js";
+import { registerTracesCommand } from "./commands/traces.js";
 import { registerEvalsCommand } from "./commands/evals.js";
 import { registerExploreCommand } from "./commands/explore.js";
 import { registerDaemonCommand } from "./commands/daemon.js";
@@ -848,6 +849,7 @@ export function buildProgram(): Command {
   registerProjectsCommand(program);
   registerWorkloadsCommand(program);
   registerCapturesCommand(program);
+  registerTracesCommand(program);
   registerEvalsCommand(program);
   registerExploreCommand(program);
   registerGatewayCommand(program);

--- a/src/trace-foundry.ts
+++ b/src/trace-foundry.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+type J = null | boolean | number | string | J[] | { [key: string]: J };
+type Obj = Record<string, any>;
+
+export type FoundryResult = {
+  schema_version: "understudy.trace_foundry.v1";
+  source: string;
+  output_dir: string;
+  freshness: { max_age_days: number; cutoff_utc: string; newest_capture_utc: string };
+  counts: { source_files: number; captures: number; tasks: number; edges: number; stale_filtered: number };
+  artifacts: Record<string, string>;
+  privacy: { local_only: true; contains_customer_payloads: true; upload_performed: false; provider_called: false };
+};
+
+const mutationPrefixes = ["add-", "apply-", "archive-", "cancel-", "create-", "delete-", "draft-", "mark-", "move-", "notify-", "promote-", "reassign-", "remove-", "save-", "send-", "set-", "share-", "update-", "write-"];
+const hash = (value: unknown) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
+const asObject = (value: unknown): Obj => value !== null && typeof value === "object" && !Array.isArray(value) ? value as Obj : {};
+const jsonish = (value: unknown): unknown => {
+  let current = value;
+  for (let i = 0; i < 3 && typeof current === "string"; i += 1) {
+    const text = current.trim();
+    if (!text.startsWith("{") && !text.startsWith("[")) break;
+    try { current = JSON.parse(text); } catch { break; }
+  }
+  return current;
+};
+const contentText = (content: unknown): string => typeof content === "string" ? content : Array.isArray(content) ? content.map((b) => asObject(b).text ?? "").join("") : "";
+const iso = (value: unknown): string => {
+  const date = new Date(String(value ?? ""));
+  if (Number.isNaN(date.valueOf())) throw new Error(`Capture has no valid timestamp: ${String(value)}`);
+  return date.toISOString();
+};
+
+function sourceFiles(root: string): string[] {
+  if (!existsSync(root)) throw new Error(`Capture source does not exist: ${root}`);
+  if (statSync(root).isFile()) return [root];
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.isFile() && [".json", ".jsonl", ".ndjson"].some((ext) => entry.name.endsWith(ext)) ? [path] : [];
+  }).sort();
+}
+
+function envelopes(path: string): Obj[] {
+  const text = readFileSync(path, "utf8");
+  if (path.endsWith(".json")) {
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) return parsed.map(asObject);
+    const object = asObject(parsed);
+    const rows = object.captures ?? object.data;
+    return Array.isArray(rows) ? rows.map(asObject) : [object];
+  }
+  return text.split(/\r?\n/).filter(Boolean).map((line) => asObject(JSON.parse(line)));
+}
+
+function responseProjection(raw: unknown): Obj {
+  if (typeof raw === "string" && raw.includes("data:")) {
+    const events = raw.split(/\r?\n/).filter((line) => line.startsWith("data:") && !line.includes("[DONE]")).flatMap((line) => {
+      try { return [asObject(JSON.parse(line.slice(5).trim()))]; } catch { return []; }
+    });
+    const toolCalls: Obj[] = [];
+    for (const event of events) {
+      const block = asObject(event.content_block);
+      if (block.type === "tool_use") toolCalls.push({ id: block.id, name: block.name, arguments: block.input ?? {} });
+      for (const choice of Array.isArray(event.choices) ? event.choices : []) {
+        for (const call of asObject(choice).delta?.tool_calls ?? []) toolCalls.push(asObject(call));
+      }
+    }
+    return { encoding: "sse", events, tool_calls: toolCalls, stop_reason: events.at(-1)?.delta?.stop_reason ?? null };
+  }
+  const parsed = jsonish(raw);
+  const object = asObject(parsed);
+  const calls: Obj[] = [];
+  for (const block of Array.isArray(object.content) ? object.content : []) {
+    const b = asObject(block);
+    if (b.type === "tool_use") calls.push({ id: b.id, name: b.name, arguments: b.input ?? {} });
+  }
+  for (const call of Array.isArray(object.tool_calls) ? object.tool_calls : []) calls.push(asObject(call));
+  return { encoding: "json", body: parsed as J, tool_calls: calls, stop_reason: object.stop_reason ?? object.stopReason ?? null };
+}
+
+function normalize(envelope: Obj, pointer: string): Obj {
+  const version = Number(envelope.schema_version ?? 4);
+  if (![2, 3, 4].includes(version)) throw new Error(`Unsupported capture schema_version ${version}`);
+  const requestRaw = envelope.customer_request_body ?? envelope.request_body ?? envelope.request;
+  const responseRaw = envelope.response_body ?? envelope.customer_response_body ?? envelope.response;
+  const request = asObject(jsonish(requestRaw));
+  const messages = Array.isArray(request.messages) ? request.messages.map(asObject) : [];
+  const tools = Array.isArray(request.tools) ? request.tools.map(asObject) : [];
+  const capturedAt = iso(envelope.ts ?? envelope.created_at ?? envelope.uploaded);
+  const captureId = String(envelope.request_id ?? envelope.id ?? hash(envelope).slice(0, 24));
+  return {
+    schema_version: "understudy.normalized_capture.v1", capture_id: captureId, captured_at: capturedAt,
+    source: { pointer, sha256: hash(envelope) },
+    scope: { org_id: envelope.workos_org_id ?? envelope.org_id ?? null, project_id: envelope.project_id ?? null, workload_id: envelope.workload_id ?? envelope.placement_id ?? null, workload_name: envelope.workload_name ?? null },
+    routing: { provider: envelope.provider ?? null, requested_model: envelope.requested_model ?? request.model ?? null, upstream_model: envelope.upstream_model ?? null },
+    transport: { endpoint: envelope.endpoint ?? null, status_code: envelope.status_code ?? null, latency_ms: envelope.latency_ms ?? null },
+    request: { system: request.system ?? null, messages, tools, settings: Object.fromEntries(Object.entries(request).filter(([k]) => !["system", "messages", "tools"].includes(k))) },
+    response: responseProjection(responseRaw), raw: { request: requestRaw ?? null, response: responseRaw ?? null },
+    fingerprints: { group: hash({ system: request.system ?? null, first_user: messages.find((m) => m.role === "user") ?? null }), messages: messages.map(hash), sequence: hash(messages) },
+  };
+}
+
+function commonPrefix(a: string[], b: string[]): number { let n = 0; while (n < a.length && n < b.length && a[n] === b[n]) n += 1; return n; }
+function buildDag(rows: Obj[]): Obj {
+  const groups = new Map<string, Obj[]>();
+  for (const row of rows) groups.set(row.fingerprints.group, [...(groups.get(row.fingerprints.group) ?? []), row]);
+  const nodes: Obj[] = [], edges: Obj[] = [], groupRows: Obj[] = [];
+  for (const [groupId, captures] of groups) {
+    captures.sort((a, b) => a.captured_at.localeCompare(b.captured_at));
+    const roots: string[] = [];
+    captures.forEach((capture, index) => {
+      nodes.push({ id: capture.capture_id, execution_group: groupId, captured_at: capture.captured_at, message_count: capture.request.messages.length, has_error: Number(capture.transport.status_code ?? 200) >= 400, source: capture.source });
+      if (index === 0) { roots.push(capture.capture_id); return; }
+      const prior = captures.slice(0, index);
+      const candidates = prior.map((parent) => ({ parent, prefix: commonPrefix(parent.fingerprints.messages, capture.fingerprints.messages) })).sort((a, b) => b.prefix - a.prefix || b.parent.captured_at.localeCompare(a.parent.captured_at));
+      const best = candidates[0];
+      if (!best) { roots.push(capture.capture_id); return; }
+      const p = best.parent.fingerprints.messages as string[], c = capture.fingerprints.messages as string[];
+      const type = p.length === c.length && best.prefix === p.length ? "retry" : best.prefix === p.length ? "prefix_append" : best.prefix > 0 ? "branch" : "destructive_mutation";
+      edges.push({ from: best.parent.capture_id, to: capture.capture_id, type, execution_group: groupId, confidence: type === "destructive_mutation" ? "low" : "deterministic", evidence: { common_prefix_messages: best.prefix } });
+    });
+    groupRows.push({ id: groupId, capture_count: captures.length, edge_count: Math.max(0, captures.length - 1), roots });
+  }
+  return { schema_version: "understudy.source_dag.v1", valid: true, nodes, edges, groups: groupRows };
+}
+
+function toolEvents(captures: Obj[]): Obj[] {
+  const events: Obj[] = [];
+  for (const capture of captures) {
+    for (const message of capture.request.messages) for (const blockValue of Array.isArray(message.content) ? message.content : []) {
+      const block = asObject(blockValue);
+      if (["tool_use", "tool_call"].includes(block.type)) events.push({ kind: "call", id: block.id, name: block.name, arguments: block.input ?? block.arguments ?? {} });
+      if (["tool_result", "tool_response"].includes(block.type)) events.push({ kind: "result", id: block.tool_use_id ?? block.id, status: block.is_error ? "error" : "ok", content: block.content });
+    }
+    for (const callValue of capture.response.tool_calls ?? []) { const call = asObject(callValue), fn = asObject(call.function); events.push({ kind: "call", id: call.id, name: call.name ?? fn.name, arguments: call.arguments ?? fn.arguments ?? {} }); }
+  }
+  return [...new Map(events.map((event) => [hash(event), event])).values()];
+}
+
+function tasksFrom(dag: Obj, rows: Obj[]): Obj[] {
+  const byId = new Map(rows.map((row) => [row.capture_id, row]));
+  return dag.groups.map((group: Obj) => {
+    const nodes = dag.nodes.filter((node: Obj) => node.execution_group === group.id).sort((a: Obj, b: Obj) => a.captured_at.localeCompare(b.captured_at));
+    const captures = nodes.map((node: Obj) => byId.get(node.id)).filter(Boolean) as Obj[];
+    const root = captures[0], first = root.request.messages.find((m: Obj) => m.role === "user") ?? {};
+    const events = toolEvents(captures), calls = events.filter((e) => e.kind === "call" && e.name), mutations = calls.filter((e) => mutationPrefixes.some((prefix) => String(e.name).toLowerCase().startsWith(prefix)));
+    const required = mutations.map((call) => ({ type: "state_effect", tool: call.name, observed_arguments: call.arguments, matching: "semantic_outcome_not_exact_trajectory", confidence: "medium" }));
+    const confidence = required.length > 0 && !events.some((e) => e.status === "error") ? "high" : calls.length > 0 ? "medium" : "low";
+    const bucket = Number.parseInt(hash(group.id).slice(0, 8), 16) % 100;
+    return { schema_version: "understudy.benchmark_task.v1", task_id: `task-${group.id.slice(0, 16)}`, execution_group: group.id, title: contentText(first.content).trim().slice(0, 160) || `Trace group ${group.id.slice(0, 8)}`, status: confidence === "high" ? "machine_proposed" : "needs_review", split: bucket < 70 ? "construction" : bucket < 90 ? "fit" : "heldout", candidate_boundary: root.capture_id, machine_confidence: confidence, close_call: confidence !== "high", tool_surface: [...new Set(calls.map((e) => e.name))].sort(), source: { node_ids: nodes.map((n: Obj) => n.id), edges: dag.edges.filter((e: Obj) => e.execution_group === group.id), captures: nodes.map((n: Obj) => ({ capture_id: n.id, ...n.source })) }, world_model: { status: "machine_proposed", initial_state: { source: "observed_tool_results", materialized: false }, transitions: required }, outcome_contract: { status: "machine_proposed", required, preserved: [], forbidden: [], grading: "final_state_and_obligations" }, claims: [...calls.map((c) => ({ kind: "observed", claim: `tool ${c.name} was called`, source_call_id: c.id })), ...mutations.map((c) => ({ kind: "inferred", claim: `${c.name} appears to mutate state`, confidence: "medium" }))], sentinels: [], review: { decision: "pending_final_judgment" } };
+  });
+}
+
+const viewerHtml = (payload: Obj) => `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Understudy · benchmark orchard</title><style>@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap');:root{--ink:#e7e8ea;--bright:#f2f2f0;--dim:#9b9da3;--line:rgba(255,255,255,.09);--hover:#1c1e25;--mint:#9edbd3;--violet:#a78bfa;--cyan:#67e8f9;--good:#6ee7a0;--bad:#f85149;--mono:'IBM Plex Mono',monospace;--sans:'IBM Plex Sans',sans-serif}*{box-sizing:border-box}body{margin:0;background:#000;color:var(--ink);font:13px var(--sans);overflow:hidden}header{height:56px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:20px;padding:0 18px}header b,label,nav button{font:500 10px var(--mono);letter-spacing:.15em;text-transform:uppercase}.brand{color:var(--bright)}.brand:before{content:'';display:inline-block;width:7px;height:7px;border:1px solid var(--mint);border-radius:50%;margin-right:10px}.meta{color:var(--dim);flex:1}.grid{height:calc(100vh - 56px);display:grid;grid-template-columns:260px minmax(340px,.82fr) minmax(460px,1.18fr)}aside,section{min-width:0;border-right:1px solid var(--line);display:flex;flex-direction:column}.head{height:54px;border-bottom:1px solid var(--line);padding:0 14px;display:flex;align-items:center;justify-content:space-between;color:var(--dim)}.scroll{overflow:auto;min-height:0}.tasks{padding:7px}.task{width:100%;display:grid;grid-template-columns:30px 1fr;gap:8px;text-align:left;border:0;border-bottom:1px solid var(--line);background:none;color:var(--ink);padding:11px 8px;cursor:pointer}.task:hover,.task.on{background:var(--hover)}.num,.sub{font:10px var(--mono);color:var(--dim)}.title{font-size:12px;line-height:1.45}.lineage{position:relative;padding:26px 20px}.lineage:before{content:'';position:absolute;left:40px;top:26px;bottom:30px;width:1px;background:linear-gradient(var(--violet),var(--cyan),transparent)}.node{position:relative;padding-left:40px;margin-bottom:9px}.node:before{content:'';position:absolute;left:14px;top:15px;width:11px;height:11px;border:1px solid var(--violet);border-radius:50%;background:#000;z-index:2}.node.on:before{background:var(--cyan);border-color:var(--cyan);box-shadow:0 0 16px #67e8f966}.node button{width:100%;text-align:left;border:1px solid var(--line);border-radius:8px;background:none;color:var(--ink);padding:10px;cursor:pointer}.node.on button{border-color:#67e8f977;background:#67e8f90b}.edge{display:block;margin-top:6px;color:var(--violet);font:9px var(--mono);text-transform:uppercase;letter-spacing:.08em}.inspect-head{padding:13px 17px 0;border-bottom:1px solid var(--line)}.eyebrow{color:var(--mint);font:10px var(--mono);text-transform:uppercase;letter-spacing:.12em}h1{font:400 18px/1.35 var(--mono);margin:8px 0 12px;color:var(--bright)}nav{display:flex;gap:18px}nav button{border:0;border-bottom:1px solid transparent;background:none;color:var(--dim);padding:9px 0;cursor:pointer}nav button.on{color:var(--bright);border-color:var(--mint)}.body{padding:20px 20px 95px}.lede{font-size:14px;line-height:1.6;color:var(--bright)}.facts{display:grid;grid-template-columns:repeat(3,1fr);border:1px solid var(--line);border-radius:8px;margin:18px 0}.fact{padding:12px;border-right:1px solid var(--line)}.fact:last-child{border:0}.fact b{display:block;margin-top:5px;font:13px var(--mono)}details{border-top:1px solid var(--line)}summary{padding:12px 0;cursor:pointer;font:500 10px var(--mono);text-transform:uppercase;letter-spacing:.1em;color:var(--dim)}pre{white-space:pre-wrap;word-break:break-word;max-height:50vh;overflow:auto;background:#08090b;border:1px solid var(--line);border-radius:8px;padding:13px;font:11px/1.55 var(--mono)}.mode{display:flex;justify-content:flex-end;gap:5px}.mode button,.review button,header button{border:1px solid var(--line);border-radius:8px;background:none;color:var(--ink);padding:7px 9px;cursor:pointer}.mode button.on{background:var(--hover)}.review{position:sticky;bottom:0;margin-top:auto;padding:12px 16px;border-top:1px solid var(--line);background:#0e0f12ee;display:flex;justify-content:flex-end;gap:6px}.review .accept{color:var(--good);border-color:var(--good)}@media(max-width:850px){.grid{grid-template-columns:220px 300px 1fr}}</style></head><body><header><b class="brand">benchmark orchard</b><span class="meta" id="meta"></span><button onclick="exportReviews()">Export reviews</button></header><main class="grid"><aside><div class="head"><label>Task inbox</label><span id="tc"></span></div><div class="tasks scroll" id="tasks"></div></aside><section><div class="head"><label>Source lineage</label><span id="nc"></span></div><div class="lineage scroll" id="dag"></div></section><section><div class="inspect-head"><div class="eyebrow" id="eye"></div><h1 id="title"></h1><nav id="tabs"></nav></div><div class="body scroll" id="body"></div><div class="review"><button class="accept" onclick="judge('accept')">Accept</button><button onclick="judge('restrict')">Restrict</button><button onclick="judge('needs_more')">Needs more</button><button onclick="judge('reject')">Reject</button></div></section></main><script>const D=${JSON.stringify(payload).replaceAll("</", "<\\/")};let task=D.tasks[0],node=task.candidate_boundary,tab='task',mode='parsed';const cache={},reviews=JSON.parse(localStorage.getItem('understudy-reviews')||'{}'),e=s=>String(s??'').replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;'}[c])),p=x=>e(JSON.stringify(x,null,2));async function load(){if(!cache[node])cache[node]=await fetch(D.captures[node].path).then(r=>r.json())}function render(){document.querySelector('#meta').textContent=D.tasks.length+' tasks · '+D.nodes.length+' captures · local evidence';document.querySelector('#tc').textContent=D.tasks.length+' tasks';document.querySelector('#tasks').innerHTML=D.tasks.map((t,i)=>'<button class="task '+(t.task_id===task.task_id?'on':'')+'" onclick="pickTask(\''+t.task_id+'\')"><span class="num">'+String(i+1).padStart(2,'0')+'</span><span><span class="title">'+e(t.title)+'</span><br><span class="sub">'+e(t.split)+' · '+e(reviews[t.task_id]?.decision||t.status)+'</span></span></button>').join('');const ids=new Set(task.source.node_ids),ns=D.nodes.filter(n=>ids.has(n.id)).sort((a,b)=>a.captured_at.localeCompare(b.captured_at));document.querySelector('#nc').textContent=ns.length+' rounds';document.querySelector('#dag').innerHTML=ns.map((n,i)=>{const x=task.source.edges.find(x=>x.to===n.id);return '<div class="node '+(n.id===node?'on':'')+'"><button onclick="pickNode(\''+n.id+'\')"><span class="sub">round '+String(i+1).padStart(2,'0')+' · '+n.id.slice(0,8)+'</span><br>'+n.message_count+' messages<span class="edge">'+e(x?.type||'root boundary')+'</span></button></div>'}).join('');document.querySelector('#eye').textContent=task.task_id+' · '+task.machine_confidence+' confidence';document.querySelector('#title').textContent=task.title;document.querySelector('#tabs').innerHTML=['task','request','response','contract'].map(x=>'<button class="'+(tab===x?'on':'')+'" onclick="setTab(\''+x+'\')">'+x+'</button>').join('');const c=cache[node]||{};if(tab==='task')document.querySelector('#body').innerHTML='<p class="lede">The machine assembled this task from '+task.source.node_ids.length+' captured rounds and proposed a stateful verifier. Human judgment controls final promotion.</p><div class="facts"><div class="fact"><label>Confidence</label><b>'+task.machine_confidence+'</b></div><div class="fact"><label>Split</label><b>'+task.split+'</b></div><div class="fact"><label>Tools</label><b>'+task.tool_surface.length+'</b></div></div><details open><summary>Machine claims</summary><pre>'+p(task.claims)+'</pre></details>';else if(tab==='contract')document.querySelector('#body').innerHTML='<p class="lede">Grade the resulting state—not an exact historical trajectory.</p><details open><summary>Outcome contract</summary><pre>'+p(task.outcome_contract)+'</pre></details><details><summary>World model</summary><pre>'+p(task.world_model)+'</pre></details>';else{const value=c[tab]||{},raw=c.raw?.[tab],rawText=typeof raw==='string'?raw:JSON.stringify(raw??value,null,2);document.querySelector('#body').innerHTML='<div class="mode"><button class="'+(mode==='parsed'?'on':'')+'" onclick="setMode(\'parsed\')">Parsed JSON</button><button class="'+(mode==='raw'?'on':'')+'" onclick="setMode(\'raw\')">Raw</button></div>'+(mode==='raw'?'<p class="sub">'+(raw!=null?'preserved source representation':'canonical serialization · original unavailable')+'</p><pre>'+e(rawText)+'</pre>':Object.entries(value).map(([k,v])=>'<details open><summary>'+e(k)+'</summary><pre>'+p(v)+'</pre></details>').join(''))}}async function pickTask(id){task=D.tasks.find(t=>t.task_id===id);node=task.candidate_boundary;tab='task';await load();render()}async function pickNode(id){node=id;tab='request';mode='parsed';await load();render()}function setTab(x){tab=x;mode='parsed';render()}function setMode(x){mode=x;render()}function judge(x){reviews[task.task_id]={decision:x,reviewed_at:new Date().toISOString()};localStorage.setItem('understudy-reviews',JSON.stringify(reviews));render()}function exportReviews(){const s=Object.entries(reviews).map(([task_id,r])=>JSON.stringify({task_id,...r})).join('\n');const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([s+'\n'],{type:'application/x-ndjson'}));a.download='benchmark-reviews.jsonl';a.click()}load().then(render)</script></body></html>`;
+
+function writeJson(path: string, value: unknown): void { mkdirSync(resolve(path, ".."), { recursive: true }); writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 }); }
+function writeJsonl(path: string, rows: Obj[]): void { mkdirSync(resolve(path, ".."), { recursive: true }); writeFileSync(path, rows.map((row) => JSON.stringify(row)).join("\n") + "\n", { mode: 0o600 }); }
+
+export function compileTraceFoundry(sourceInput: string, outputInput: string, maxAgeDays = 3, now = new Date()): FoundryResult {
+  if (!Number.isInteger(maxAgeDays) || maxAgeDays <= 0) throw new Error("--max-age-days must be a positive integer");
+  const source = resolve(sourceInput), output = resolve(outputInput), files = sourceFiles(source), cutoff = new Date(now.valueOf() - maxAgeDays * 86_400_000);
+  const all = files.flatMap((file) => envelopes(file).map((row, index) => normalize(row, `${relative(source, file) || file}#L${index + 1}`)));
+  const rows = all.filter((row) => new Date(row.captured_at) >= cutoff);
+  if (rows.length === 0) throw new Error(`No captures satisfy --max-age-days ${maxAgeDays}; cutoff ${cutoff.toISOString()}. Refusing to compile a stale benchmark.`);
+  const dag = buildDag(rows), tasks = tasksFrom(dag, rows), viewer = join(output, "viewer"), capturesDir = join(viewer, "data", "captures");
+  mkdirSync(capturesDir, { recursive: true });
+  const captureIndex: Obj = {};
+  for (const row of rows) { const path = join(capturesDir, `${row.capture_id}.json`); writeJson(path, row); captureIndex[row.capture_id] = { path: `data/captures/${row.capture_id}.json`, source: row.source }; }
+  writeJsonl(join(output, "normalized-captures.jsonl"), rows); writeJson(join(output, "source-dag.json"), dag); writeJsonl(join(output, "tasks.jsonl"), tasks);
+  writeJson(join(output, "benchmark.json"), { schema_version: "understudy.benchmark.v1", status: "machine_compiled_review_pending", executable: false, promotion_blockers: ["human_final_judgment", "sentinel_tests"], tasks: tasks.map((task) => ({ task_id: task.task_id, split: task.split, status: task.status })) });
+  writeFileSync(join(viewer, "index.html"), viewerHtml({ tasks, nodes: dag.nodes, captures: captureIndex }), { mode: 0o600 });
+  const result: FoundryResult = { schema_version: "understudy.trace_foundry.v1", source, output_dir: output, freshness: { max_age_days: maxAgeDays, cutoff_utc: cutoff.toISOString(), newest_capture_utc: rows.map((row) => row.captured_at).sort().at(-1) }, counts: { source_files: files.length, captures: rows.length, tasks: tasks.length, edges: dag.edges.length, stale_filtered: all.length - rows.length }, artifacts: { normalized: join(output, "normalized-captures.jsonl"), dag: join(output, "source-dag.json"), tasks: join(output, "tasks.jsonl"), benchmark: join(output, "benchmark.json"), viewer: join(viewer, "index.html") }, privacy: { local_only: true, contains_customer_payloads: true, upload_performed: false, provider_called: false } };
+  writeJson(join(output, "manifest.json"), result); return result;
+}

--- a/src/trace-foundry.ts
+++ b/src/trace-foundry.ts
@@ -10,7 +10,7 @@ export type FoundryResult = {
   source: string;
   output_dir: string;
   freshness: { max_age_days: number; cutoff_utc: string; newest_capture_utc: string };
-  counts: { source_files: number; captures: number; tasks: number; edges: number; stale_filtered: number };
+  counts: { source_files: number; captures: number; tasks: number; edges: number; stale_filtered: number; invalid_timestamp_filtered: number };
   artifacts: Record<string, string>;
   privacy: { local_only: true; contains_customer_payloads: true; upload_performed: false; provider_called: false };
 };
@@ -28,9 +28,9 @@ const jsonish = (value: unknown): unknown => {
   return current;
 };
 const contentText = (content: unknown): string => typeof content === "string" ? content : Array.isArray(content) ? content.map((b) => asObject(b).text ?? "").join("") : "";
-const iso = (value: unknown): string => {
+const iso = (value: unknown): string | null => {
   const date = new Date(String(value ?? ""));
-  if (Number.isNaN(date.valueOf())) throw new Error(`Capture has no valid timestamp: ${String(value)}`);
+  if (Number.isNaN(date.valueOf())) return null;
   return date.toISOString();
 };
 
@@ -57,9 +57,14 @@ function envelopes(path: string): Obj[] {
 }
 
 function responseProjection(raw: unknown): Obj {
-  if (typeof raw === "string" && raw.includes("data:")) {
-    const events = raw.split(/\r?\n/).filter((line) => line.startsWith("data:") && !line.includes("[DONE]")).flatMap((line) => {
-      try { return [asObject(JSON.parse(line.slice(5).trim()))]; } catch { return []; }
+  let isJson = false;
+  if (typeof raw === "string") {
+    try { JSON.parse(raw.trim()); isJson = true; } catch { /* non-JSON transport */ }
+  }
+  const lines = typeof raw === "string" ? raw.split(/\r?\n/) : [];
+  if (!isJson && lines.some((line) => line.trimStart().startsWith("data:"))) {
+    const events = lines.filter((line) => line.trimStart().startsWith("data:") && !line.includes("[DONE]")).flatMap((line) => {
+      try { return [asObject(JSON.parse(line.trimStart().slice(5).trim()))]; } catch { return []; }
     });
     const toolCalls: Obj[] = [];
     for (const event of events) {
@@ -82,7 +87,7 @@ function responseProjection(raw: unknown): Obj {
   return { encoding: "json", body: parsed as J, tool_calls: calls, stop_reason: object.stop_reason ?? object.stopReason ?? null };
 }
 
-function normalize(envelope: Obj, pointer: string): Obj {
+function normalize(envelope: Obj, pointer: string): Obj | null {
   const version = Number(envelope.schema_version ?? 4);
   if (![2, 3, 4].includes(version)) throw new Error(`Unsupported capture schema_version ${version}`);
   const requestRaw = envelope.customer_request_body ?? envelope.request_body ?? envelope.request;
@@ -91,6 +96,7 @@ function normalize(envelope: Obj, pointer: string): Obj {
   const messages = Array.isArray(request.messages) ? request.messages.map(asObject) : [];
   const tools = Array.isArray(request.tools) ? request.tools.map(asObject) : [];
   const capturedAt = iso(envelope.ts ?? envelope.created_at ?? envelope.uploaded);
+  if (capturedAt === null) return null;
   const captureId = String(envelope.request_id ?? envelope.id ?? hash(envelope).slice(0, 24));
   return {
     schema_version: "understudy.normalized_capture.v1", capture_id: captureId, captured_at: capturedAt,
@@ -163,16 +169,27 @@ function writeJsonl(path: string, rows: Obj[]): void { mkdirSync(resolve(path, "
 export function compileTraceFoundry(sourceInput: string, outputInput: string, maxAgeDays = 3, now = new Date()): FoundryResult {
   if (!Number.isInteger(maxAgeDays) || maxAgeDays <= 0) throw new Error("--max-age-days must be a positive integer");
   const source = resolve(sourceInput), output = resolve(outputInput), files = sourceFiles(source), cutoff = new Date(now.valueOf() - maxAgeDays * 86_400_000);
-  const all = files.flatMap((file) => envelopes(file).map((row, index) => normalize(row, `${relative(source, file) || file}#L${index + 1}`)));
+  const all: Obj[] = [];
+  let invalidTimestampFiltered = 0;
+  for (const file of files) for (const [index, envelope] of envelopes(file).entries()) {
+    const row = normalize(envelope, `${relative(source, file) || file}#L${index + 1}`);
+    if (row === null) invalidTimestampFiltered += 1;
+    else all.push(row);
+  }
   const rows = all.filter((row) => new Date(row.captured_at) >= cutoff);
   if (rows.length === 0) throw new Error(`No captures satisfy --max-age-days ${maxAgeDays}; cutoff ${cutoff.toISOString()}. Refusing to compile a stale benchmark.`);
   const dag = buildDag(rows), tasks = tasksFrom(dag, rows), viewer = join(output, "viewer"), capturesDir = join(viewer, "data", "captures");
   mkdirSync(capturesDir, { recursive: true });
   const captureIndex: Obj = {};
-  for (const row of rows) { const path = join(capturesDir, `${row.capture_id}.json`); writeJson(path, row); captureIndex[row.capture_id] = { path: `data/captures/${row.capture_id}.json`, source: row.source }; }
+  for (const row of rows) {
+    const fileId = hash({ capture_id: row.capture_id, source_sha256: row.source.sha256 }).slice(0, 40);
+    const path = join(capturesDir, `${fileId}.json`);
+    writeJson(path, row);
+    captureIndex[row.capture_id] = { path: `data/captures/${fileId}.json`, source: row.source };
+  }
   writeJsonl(join(output, "normalized-captures.jsonl"), rows); writeJson(join(output, "source-dag.json"), dag); writeJsonl(join(output, "tasks.jsonl"), tasks);
   writeJson(join(output, "benchmark.json"), { schema_version: "understudy.benchmark.v1", status: "machine_compiled_review_pending", executable: false, promotion_blockers: ["human_final_judgment", "sentinel_tests"], tasks: tasks.map((task) => ({ task_id: task.task_id, split: task.split, status: task.status })) });
   writeFileSync(join(viewer, "index.html"), viewerHtml({ tasks, nodes: dag.nodes, captures: captureIndex }), { mode: 0o600 });
-  const result: FoundryResult = { schema_version: "understudy.trace_foundry.v1", source, output_dir: output, freshness: { max_age_days: maxAgeDays, cutoff_utc: cutoff.toISOString(), newest_capture_utc: rows.map((row) => row.captured_at).sort().at(-1) }, counts: { source_files: files.length, captures: rows.length, tasks: tasks.length, edges: dag.edges.length, stale_filtered: all.length - rows.length }, artifacts: { normalized: join(output, "normalized-captures.jsonl"), dag: join(output, "source-dag.json"), tasks: join(output, "tasks.jsonl"), benchmark: join(output, "benchmark.json"), viewer: join(viewer, "index.html") }, privacy: { local_only: true, contains_customer_payloads: true, upload_performed: false, provider_called: false } };
+  const result: FoundryResult = { schema_version: "understudy.trace_foundry.v1", source, output_dir: output, freshness: { max_age_days: maxAgeDays, cutoff_utc: cutoff.toISOString(), newest_capture_utc: rows.map((row) => row.captured_at).sort().at(-1) }, counts: { source_files: files.length, captures: rows.length, tasks: tasks.length, edges: dag.edges.length, stale_filtered: all.length - rows.length, invalid_timestamp_filtered: invalidTimestampFiltered }, artifacts: { normalized: join(output, "normalized-captures.jsonl"), dag: join(output, "source-dag.json"), tasks: join(output, "tasks.jsonl"), benchmark: join(output, "benchmark.json"), viewer: join(viewer, "index.html") }, privacy: { local_only: true, contains_customer_payloads: true, upload_performed: false, provider_called: false } };
   writeJson(join(output, "manifest.json"), result); return result;
 }

--- a/tests/trace-foundry.test.mjs
+++ b/tests/trace-foundry.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -16,18 +16,31 @@ test("builds a fresh generic DAG, benchmark, lazy viewer, and raw/parsed inspect
   const source = join(root, ".understudy", "captures"), output = join(root, ".understudy", "benchmarks", "latest");
   mkdirSync(source, { recursive: true });
   const rows = [
-    capture("round-1", "2026-07-20T12:00:00Z", [{ role: "user", content: "Set synthetic record 7 active" }], { content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }], stop_reason: "tool_use" }),
+    capture("round-1", "2026-07-20T12:00:00Z", [{ role: "user", content: "Set synthetic record 7 active" }], { content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }], note: "data:image/png;base64,not-sse", stop_reason: "tool_use" }),
     capture("round-2", "2026-07-20T12:00:01Z", [{ role: "user", content: "Set synthetic record 7 active" }, { role: "assistant", content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }] }, { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: "{\"ok\":true}" }] }], { content: [{ type: "text", text: "Done" }], stop_reason: "end_turn" }),
     capture("stale", "2026-07-01T12:00:00Z", [{ role: "user", content: "Old task" }], { content: [{ type: "text", text: "Old" }], stop_reason: "end_turn" }),
+    capture("missing-time", undefined, [{ role: "user", content: "Malformed timestamp" }], {}),
   ];
   writeFileSync(join(source, "captures.jsonl"), rows.map((row) => JSON.stringify(row)).join("\n") + "\n");
   const result = compileTraceFoundry(source, output, 3, new Date("2026-07-21T12:00:00Z"));
-  assert.equal(result.counts.captures, 2); assert.equal(result.counts.stale_filtered, 1); assert.equal(result.counts.tasks, 1);
+  assert.equal(result.counts.captures, 2); assert.equal(result.counts.stale_filtered, 1); assert.equal(result.counts.invalid_timestamp_filtered, 1); assert.equal(result.counts.tasks, 1);
   const tasks = readFileSync(join(output, "tasks.jsonl"), "utf8");
   assert.match(tasks, /semantic_outcome_not_exact_trajectory/); assert.doesNotMatch(tasks, /Example Customer/);
   const viewer = readFileSync(join(output, "viewer", "index.html"), "utf8");
-  assert.match(viewer, /benchmark orchard/); assert.match(viewer, /Parsed JSON/); assert.match(viewer, />Raw</); assert.match(viewer, /data\/captures\/round-1.json/);
-  assert.ok(readFileSync(join(output, "viewer", "data", "captures", "round-1.json"), "utf8").includes("raw"));
+  assert.match(viewer, /benchmark orchard/); assert.match(viewer, /Parsed JSON/); assert.match(viewer, />Raw</); assert.doesNotMatch(viewer, /data\/captures\/round-1.json/);
+  const captures = readdirSync(join(output, "viewer", "data", "captures"));
+  assert.ok(captures.every((name) => /^[a-f0-9]{40}\.json$/.test(name)));
+  const first = captures.map((name) => JSON.parse(readFileSync(join(output, "viewer", "data", "captures", name), "utf8"))).find((row) => row.capture_id === "round-1");
+  assert.equal(first.response.encoding, "json"); assert.equal(first.response.body.note, "data:image/png;base64,not-sse"); assert.ok(first.raw);
+});
+
+test("does not derive viewer paths from capture-controlled request IDs", () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-foundry-path-"));
+  const source = join(root, ".understudy", "captures"), output = join(root, ".understudy", "benchmarks", "latest"); mkdirSync(source, { recursive: true });
+  writeFileSync(join(source, "one.json"), JSON.stringify(capture("../../escaped", "2026-07-20T00:00:00Z", [{ role: "user", content: "Safe path" }], {})));
+  compileTraceFoundry(source, output, 3, new Date("2026-07-21T00:00:00Z"));
+  const files = readdirSync(join(output, "viewer", "data", "captures"));
+  assert.equal(files.length, 1); assert.match(files[0], /^[a-f0-9]{40}\.json$/); assert.equal(existsSync(join(output, "viewer", "escaped.json")), false);
 });
 
 test("fails closed when no trace is within the requested window", () => {

--- a/tests/trace-foundry.test.mjs
+++ b/tests/trace-foundry.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { compileTraceFoundry } from "../dist/trace-foundry.js";
+
+const capture = (id, ts, messages, response) => ({
+  schema_version: 4, request_id: id, ts, workload_name: "synthetic-automation",
+  customer_request_body: JSON.stringify({ system: "Operate a synthetic project board.", messages, tools: [{ name: "update-record", input_schema: { type: "object" } }] }),
+  response_body: JSON.stringify(response), status_code: 200,
+});
+
+test("builds a fresh generic DAG, benchmark, lazy viewer, and raw/parsed inspector", () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-foundry-"));
+  const source = join(root, ".understudy", "captures"), output = join(root, ".understudy", "benchmarks", "latest");
+  mkdirSync(source, { recursive: true });
+  const rows = [
+    capture("round-1", "2026-07-20T12:00:00Z", [{ role: "user", content: "Set synthetic record 7 active" }], { content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }], stop_reason: "tool_use" }),
+    capture("round-2", "2026-07-20T12:00:01Z", [{ role: "user", content: "Set synthetic record 7 active" }, { role: "assistant", content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }] }, { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: "{\"ok\":true}" }] }], { content: [{ type: "text", text: "Done" }], stop_reason: "end_turn" }),
+    capture("stale", "2026-07-01T12:00:00Z", [{ role: "user", content: "Old task" }], { content: [{ type: "text", text: "Old" }], stop_reason: "end_turn" }),
+  ];
+  writeFileSync(join(source, "captures.jsonl"), rows.map((row) => JSON.stringify(row)).join("\n") + "\n");
+  const result = compileTraceFoundry(source, output, 3, new Date("2026-07-21T12:00:00Z"));
+  assert.equal(result.counts.captures, 2); assert.equal(result.counts.stale_filtered, 1); assert.equal(result.counts.tasks, 1);
+  const tasks = readFileSync(join(output, "tasks.jsonl"), "utf8");
+  assert.match(tasks, /semantic_outcome_not_exact_trajectory/); assert.doesNotMatch(tasks, /Example Customer/);
+  const viewer = readFileSync(join(output, "viewer", "index.html"), "utf8");
+  assert.match(viewer, /benchmark orchard/); assert.match(viewer, /Parsed JSON/); assert.match(viewer, />Raw</); assert.match(viewer, /data\/captures\/round-1.json/);
+  assert.ok(readFileSync(join(output, "viewer", "data", "captures", "round-1.json"), "utf8").includes("raw"));
+});
+
+test("fails closed when no trace is within the requested window", () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-foundry-stale-"));
+  const source = join(root, ".understudy", "captures"); mkdirSync(source, { recursive: true });
+  writeFileSync(join(source, "one.json"), JSON.stringify(capture("old", "2026-07-01T00:00:00Z", [{ role: "user", content: "Old" }], {})));
+  assert.throws(() => compileTraceFoundry(source, join(root, ".understudy", "out"), 3, new Date("2026-07-21T00:00:00Z")), /Refusing to compile a stale benchmark/);
+});


### PR DESCRIPTION
## What changed

- add `understudy traces build-benchmark` for local `.understudy/captures`
- normalize v2-v4 JSON/JSONL envelopes while preserving raw request/response forms
- enforce a fail-closed freshness window, defaulting to three days
- reconstruct source-history DAGs across retries, prefixes, branches, and destructive mutations
- machine-propose task, world-model, and semantic final-state contracts
- generate private benchmark artifacts and a lazy-loading local review viewer
- apply Understudy Design Language v2 with an Orchard-style lineage field
- provide parsed JSON and explicit Raw request/response views
- expand the existing ingestion and simulated-environment skills with the research contracts for DAGs, AutomationBench adaptation, diminishing returns, GEPA placement, and resumable environment-generation goals

## Why

Trace-derived verifier environments need a public, local-first compiler between raw capture exports and workload-specific Verifiers packages. The compiler must preserve provenance and errors, avoid treating the longest capture as perfect history, and avoid scoring exact incumbent trajectory reproduction as task success.

## Developer impact

Developers can place authorized trace exports under `.understudy/captures/` and run:

```sh
understudy traces build-benchmark \
  --source .understudy/captures \
  --output .understudy/benchmarks/latest \
  --max-age-days 3
```

The output remains local and review-gated. Acquisition, provider calls, uploads, hosted evaluation, and training remain outside this command.

## Validation

- `npm run build`
- `npm run typecheck`
- `node --test tests/trace-foundry.test.mjs`
- `npm run skills:validate`
- `npm run package:smoke`
- `git diff --check origin/main...HEAD`

The synthetic tests cover DAG/task compilation, semantic outcome proposals, lazy capture loading, parsed/raw inspection, customer-name neutrality, and fail-closed rejection when no captures satisfy the freshness window.

## Current external limitation

This PR does not solve privileged trace acquisition. The public boundary deliberately starts with local files. A recent design-partner refresh is currently blocked upstream because bulk export exceeds its scan bound and the metadata API exposes no date-bounded export; stale traces are rejected rather than silently compiled.
