### PR TITLE
Live rollout watching + fair anchor scoring + world validation + judgeability guarantee

### DIFF
--- a/apps/benchmark-hub/app/api/runs/live/route.ts
+++ b/apps/benchmark-hub/app/api/runs/live/route.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import path from "node:path";
+import { NextResponse } from "next/server";
+// Relative imports (not "@/…") so the node:test harness can compile and load
+// this route handler directly, same as the runs/flags routes.
+import { getEntry, loadTaskSidecars } from "../../../../lib/data-core";
+import { readRunRequest, runRequestPath } from "../../../../lib/runs-core";
+import { accumulateReplay, type ReplayCall } from "../../../../lib/replay-core";
+
+export const dynamic = "force-dynamic";
+
+type Obj = Record<string, unknown>;
+const asObject = (v: unknown): Obj => (v !== null && typeof v === "object" && !Array.isArray(v) ? (v as Obj) : {});
+
+/** Cap the journal read; live journals are per-arm and small, but never trust a file size. */
+const MAX_JOURNAL_LINES = 5_000;
+
+/**
+ * GET /api/runs/live?slug&run=<run_id>[&task=<task_id>][&since=N] →
+ * live watch feed for a running arm: the journal lines the generated world
+ * server appended so far (from line offset `since` for cheap polling) plus a
+ * deterministic contract accumulation computed SERVER-SIDE from those events
+ * with the same shared scorer as the Replay tab — tool-call-level streaming
+ * (token streaming is deferred). Same slug hardening as /api/runs.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const slug = url.searchParams.get("slug");
+  const runId = url.searchParams.get("run");
+  const taskParam = url.searchParams.get("task");
+  const since = Math.max(0, Number(url.searchParams.get("since") ?? 0) || 0);
+  if (!slug || !runId) return NextResponse.json({ error: "slug and run query params are required" }, { status: 400 });
+  if (!/^[A-Za-z0-9_-]+$/.test(runId)) return NextResponse.json({ error: "invalid run id" }, { status: 400 });
+  const entry = getEntry(slug);
+  if (!entry || entry.kind === "invalid") return NextResponse.json({ error: "unknown benchmark" }, { status: 404 });
+
+  const runFile = runRequestPath(entry.dir, runId);
+  const run = fs.existsSync(runFile) ? readRunRequest(runFile) : null;
+  if (!run) return NextResponse.json({ error: "unknown run_id" }, { status: 404 });
+
+  // Journal: the request advertises the active arm's journal while running;
+  // otherwise fall back to the newest journal for this run (post-run replay).
+  let journal: string | null = null;
+  const advertised = asObject(run.live as unknown).journal;
+  if (typeof advertised === "string" && !advertised.includes("..")) {
+    journal = path.join(entry.dir, advertised);
+  } else {
+    const liveDir = path.join(entry.dir, "runs", "live");
+    try {
+      const candidates = fs
+        .readdirSync(liveDir)
+        .filter((name) => name.startsWith(`${runId}-`) && name.endsWith(".jsonl"))
+        .map((name) => path.join(liveDir, name))
+        .sort((a, b) => fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs);
+      journal = candidates.at(-1) ?? null;
+    } catch {
+      journal = null;
+    }
+  }
+
+  const lines: Obj[] = [];
+  let total = 0;
+  if (journal && fs.existsSync(journal)) {
+    const raw = fs.readFileSync(journal, "utf8").split("\n").filter(Boolean).slice(0, MAX_JOURNAL_LINES);
+    total = raw.length;
+    for (const line of raw.slice(since)) {
+      try {
+        lines.push(JSON.parse(line) as Obj);
+      } catch {
+        // torn tail line mid-append — the next poll gets it whole
+        total -= 1;
+        break;
+      }
+    }
+  }
+
+  // Deterministic live accumulation: journal call events against the task's
+  // contract, through the SAME shared scorer as the Replay tab.
+  const taskId = taskParam ?? (Array.isArray(run.tasks) && run.tasks.length === 1 ? run.tasks[0] : null) ?? asObject(run.live as unknown).task_id ?? null;
+  let accumulation: Obj | null = null;
+  if (typeof taskId === "string" && taskId) {
+    let task: Obj | null = null;
+    if (entry.kind === "proposed") task = (entry.tasks.find((t) => t.task_id === taskId) as unknown as Obj) ?? null;
+    else task = loadTaskSidecars(entry)[taskId] ?? null;
+    if (task) {
+      // Full journal (not just the `since` window) so met-flips are stable.
+      const allLines: Obj[] = [];
+      if (journal && fs.existsSync(journal)) {
+        for (const line of fs.readFileSync(journal, "utf8").split("\n").filter(Boolean).slice(0, MAX_JOURNAL_LINES)) {
+          try {
+            allLines.push(JSON.parse(line) as Obj);
+          } catch {
+            break;
+          }
+        }
+      }
+      const calls: ReplayCall[] = allLines
+        .filter((l) => l.kind === "call")
+        .map((l) => {
+          let args: unknown = l.arguments ?? {};
+          if (typeof args === "string") {
+            try {
+              args = JSON.parse(args);
+            } catch {
+              /* keep the summary string */
+            }
+          }
+          return { name: String(l.tool ?? ""), arguments: args, ...(l.status === "error" ? { status: "error" } : {}) } as ReplayCall & { status?: string };
+        });
+      accumulation = accumulateReplay(task, calls) as unknown as Obj;
+    }
+  }
+
+  return NextResponse.json({
+    run_id: runId,
+    status: run.status,
+    progress: run.progress,
+    live: run.live ?? null,
+    task_id: taskId,
+    since,
+    next: total,
+    lines,
+    accumulation,
+  });
+}

--- a/apps/benchmark-hub/components/proposed/benchmark-page.tsx
+++ b/apps/benchmark-hub/components/proposed/benchmark-page.tsx
@@ -2,14 +2,8 @@ import Link from "next/link";
 import { taskDisplayName, type ProposedHubEntry } from "@/lib/types";
 import { complexityLabel } from "@/lib/trajectory-core";
 import { Badge, SourceBadge, StageBadge } from "@/components/badges";
-import { AnchorRail } from "@/components/anchor-rail";
 import { EmptyState } from "@/components/empty-state";
 import { TaskTable } from "@/components/task-table";
-
-const RAIL = [
-  { id: "narrative", label: "Narrative" },
-  { id: "tasks", label: "Tasks" },
-];
 
 /**
  * The foundry's promotion blockers for machine-compiled outputs. Mirrored
@@ -46,13 +40,47 @@ export function ProposedBenchmarkPage({ entry }: { entry: ProposedHubEntry }) {
           <SourceBadge entry={entry} />
           <Badge>machine-compiled · review pending</Badge>
         </div>
-        <p className="u-desc">
-          Compiled from captured traces by the trace foundry. Every task below is a machine proposal — human final
-          judgment gates promotion to an executable benchmark.
-        </p>
-        <div className="u-id">
-          <span>local only · contains customer payloads · no upload performed</span>
-        </div>
+
+        {/* workload-summary-slot */}
+        {entry.overview && (
+          <div className="mt-4">
+                <div className="u-card">
+                  <h3>What we&apos;ve seen in your workload</h3>
+                  {entry.overview.workload_summary ? (
+                    <WorkloadSummary text={entry.overview.workload_summary} />
+                  ) : (
+                    <p className="mono mt-2 text-xs text-faint">the overview pass produced no workload summary</p>
+                  )}
+                  {(entry.overview.system_prompt_clusters ?? []).length > 0 && (
+                    <details className="mt-3">
+                      <summary className="mono cursor-pointer text-[11px] text-ink-muted">
+                        {(entry.overview.system_prompt_clusters ?? []).length === 1
+                          ? "one canonical system prompt"
+                          : `this workload runs ${(entry.overview.system_prompt_clusters ?? []).length} prompt variants`}
+                        {" · deterministic evidence"}
+                      </summary>
+                      <div className="mt-2 flex flex-col gap-2">
+                        {(entry.overview.system_prompt_clusters ?? []).map((c) => (
+                          <div key={c.hash}>
+                            <span className="mono text-[10px] text-faint">
+                              {c.hash} · {c.count} capture{c.count === 1 ? "" : "s"} · {(c.coverage * 100).toFixed(0)}% coverage
+                            </span>
+                            <pre className="u-pre mt-1" style={{ maxHeight: 140 }}>{c.representative_excerpt}</pre>
+                          </div>
+                        ))}
+                        {(entry.overview.tool_usage ?? []).length > 0 && (
+                          <ToolUsageTable rows={entry.overview.tool_usage ?? []} />
+                        )}
+                      </div>
+                    </details>
+                  )}
+                  <p className="mono mt-2 text-[10px] text-faint">
+                    authored by {entry.overview.model ?? "unknown model"}
+                    {entry.overview.authored_at ? ` · ${entry.overview.authored_at.slice(0, 10)}` : ""}
+                  </p>
+                </div>
+          </div>
+        )}
 
         <div className="u-stats">
           <div className="u-stat">
@@ -105,92 +133,7 @@ export function ProposedBenchmarkPage({ entry }: { entry: ProposedHubEntry }) {
         )}
       </header>
 
-      <div className="u-layout">
-        <AnchorRail sections={RAIL} />
-        <div>
-          <section className="u-sec" id="narrative">
-            <h2>How this became a benchmark</h2>
-            {entry.overview ? (
-              <div className="mt-4 flex flex-col gap-4">
-                <div className="u-card">
-                  <h3>What we&apos;ve seen in your workload</h3>
-                  {entry.overview.workload_summary ? (
-                    <WorkloadSummary text={entry.overview.workload_summary} />
-                  ) : (
-                    <p className="mono mt-2 text-xs text-faint">the overview pass produced no workload summary</p>
-                  )}
-                  {(entry.overview.system_prompt_clusters ?? []).length > 0 && (
-                    <details className="mt-3">
-                      <summary className="mono cursor-pointer text-[11px] text-ink-muted">
-                        {(entry.overview.system_prompt_clusters ?? []).length === 1
-                          ? "one canonical system prompt"
-                          : `this workload runs ${(entry.overview.system_prompt_clusters ?? []).length} prompt variants`}
-                        {" · deterministic evidence"}
-                      </summary>
-                      <div className="mt-2 flex flex-col gap-2">
-                        {(entry.overview.system_prompt_clusters ?? []).map((c) => (
-                          <div key={c.hash}>
-                            <span className="mono text-[10px] text-faint">
-                              {c.hash} · {c.count} capture{c.count === 1 ? "" : "s"} · {(c.coverage * 100).toFixed(0)}% coverage
-                            </span>
-                            <pre className="u-pre mt-1" style={{ maxHeight: 140 }}>{c.representative_excerpt}</pre>
-                          </div>
-                        ))}
-                        {(entry.overview.tool_usage ?? []).length > 0 && (
-                          <ToolUsageTable rows={entry.overview.tool_usage ?? []} />
-                        )}
-                      </div>
-                    </details>
-                  )}
-                  <p className="mono mt-2 text-[10px] text-faint">
-                    authored by {entry.overview.model ?? "unknown model"}
-                    {entry.overview.authored_at ? ` · ${entry.overview.authored_at.slice(0, 10)}` : ""}
-                  </p>
-                </div>
-                <div>
-                  <h3 className="mb-2">The tasks we&apos;ve identified</h3>
-                  <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                    {entry.overview.categories.map((c) => {
-                      const members = new Set(c.representative_task_ids);
-                      const representatives = entry.tasks.filter((t) => members.has(t.task_id));
-                      return (
-                        <div key={c.category_id} className="u-card">
-                          <div className="flex flex-wrap items-baseline gap-2">
-                            <span className="text-sm font-bold">{c.archetype_title ?? c.category_id}</span>
-                            <Badge>{c.task_count ?? c.representative_task_ids.length} task{(c.task_count ?? 1) === 1 ? "" : "s"}</Badge>
-                          </div>
-                          {c.archetype_description && <p className="mt-2 text-xs text-ink-muted">{c.archetype_description}</p>}
-                          {representatives.length > 0 && (
-                            <ul className="mt-3 flex list-none flex-col gap-1 p-0">
-                              {representatives.map((t) => {
-                                const cx = entry.overview?.task_complexity?.[t.task_id];
-                                return (
-                                  <li key={t.task_id} className="text-xs">
-                                    <Link href={`/b/${entry.slug}/task/${encodeURIComponent(t.task_id)}`}>{taskDisplayName(t)}</Link>
-                                    {cx?.frontier && (
-                                      <span className="mono ml-1 text-[10px]" style={{ color: "var(--warn-ink)" }}>
-                                        upper bound: {complexityLabel(cx)}
-                                      </span>
-                                    )}
-                                  </li>
-                                );
-                              })}
-                            </ul>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <EmptyState
-                what="No benchmark narrative yet — the overview pass writes a workload summary and per-category task archetypes grounded on the authored task blocks."
-                next={`understudy traces author-tasks --benchmark ${entry.dir} --overview`}
-              />
-            )}
-          </section>
-
+      <div>
           <section className="u-sec" id="tasks">
             <h2>Task inbox</h2>
             <p className="exp">
@@ -248,7 +191,43 @@ export function ProposedBenchmarkPage({ entry }: { entry: ProposedHubEntry }) {
             )}
           </section>
 
-        </div>
+        {entry.overview && entry.overview.categories.length > 0 && (
+          <section className="u-sec" id="identified">
+            <h2>The tasks we&apos;ve identified</h2>
+                  <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                    {entry.overview.categories.map((c) => {
+                      const members = new Set(c.representative_task_ids);
+                      const representatives = entry.tasks.filter((t) => members.has(t.task_id));
+                      return (
+                        <div key={c.category_id} className="u-card">
+                          <div className="flex flex-wrap items-baseline gap-2">
+                            <span className="text-sm font-bold">{c.archetype_title ?? c.category_id}</span>
+                            <Badge>{c.task_count ?? c.representative_task_ids.length} task{(c.task_count ?? 1) === 1 ? "" : "s"}</Badge>
+                          </div>
+                          {c.archetype_description && <p className="mt-2 text-xs text-ink-muted">{c.archetype_description}</p>}
+                          {representatives.length > 0 && (
+                            <ul className="mt-3 flex list-none flex-col gap-1 p-0">
+                              {representatives.map((t) => {
+                                const cx = entry.overview?.task_complexity?.[t.task_id];
+                                return (
+                                  <li key={t.task_id} className="text-xs">
+                                    <Link href={`/b/${entry.slug}/task/${encodeURIComponent(t.task_id)}`}>{taskDisplayName(t)}</Link>
+                                    {cx?.frontier && (
+                                      <span className="mono ml-1 text-[10px]" style={{ color: "var(--warn-ink)" }}>
+                                        upper bound: {complexityLabel(cx)}
+                                      </span>
+                                    )}
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/apps/benchmark-hub/components/run-panel.tsx
+++ b/apps/benchmark-hub/components/run-panel.tsx
@@ -13,6 +13,7 @@ type RunRequest = {
   status: "queued" | "running" | "done" | "failed" | "cancelled";
   progress: { completed: number; total: number };
   error?: { class: string; message: string } | null;
+  live?: { journal: string; model: string; task_id: string | null } | null;
 };
 
 const SPLITS = ["holdout", "dev", "train", "all"] as const;
@@ -213,6 +214,11 @@ export function RunPanel({
                 <span className="mono text-[11px] text-ink-muted">
                   {r.progress.completed}/{r.progress.total}
                 </span>
+                {r.status === "running" && r.live && (
+                  <span className="mono text-[11px]" style={{ color: "var(--live)" }}>
+                    ● live: {r.live.model}{r.live.task_id ? ` · ${r.live.task_id}` : ""}
+                  </span>
+                )}
                 {(r.status === "queued" || r.status === "running") && (
                   <button type="button" className="mono text-[11px] text-bad" onClick={() => cancel(r.run_id)}>
                     cancel

--- a/apps/benchmark-hub/components/trajectory/replay.tsx
+++ b/apps/benchmark-hub/components/trajectory/replay.tsx
@@ -18,13 +18,25 @@ type ReplayStep = {
   met_count: number;
   partial_credit: number;
 };
-type Verdict = { recall: number; precision: number; policy: number; strict: number; score: number; task_completed_correctly: boolean };
+type Verdict = {
+  judgeable?: boolean;
+  recall: number | null;
+  precision: number | null;
+  policy: number | null;
+  strict: number;
+  score: number | null;
+  task_completed_correctly: boolean;
+};
+type RuleEvaluation = { kind: string; label: string; criterion: string; met: boolean; met_at: number | null; provenance: string | null };
 type Accumulation = {
   required: ReplayRequired[];
   forbidden_tools: string[];
   forbidden_values?: number;
   steps: ReplayStep[];
   verdict: Verdict;
+  rules_evaluated?: RuleEvaluation[];
+  writes_mapped?: { step: number; tool: string; mapped_to: number | null }[];
+  forbidden_evaluated?: { label: string; violated: boolean }[];
 };
 type Arm = Accumulation & {
   key: string;
@@ -141,7 +153,7 @@ function AccumulationView({
               </span>
             </li>
           ))}
-          {data.required.length === 0 && <li className="mono text-xs text-faint">no required effects — trivially satisfied</li>}
+          {data.required.length === 0 && <li className="mono text-xs text-warn">contract has no required entries — not judgeable</li>}
           {data.forbidden_tools.length > 0 && (
             <li className="mono text-xs text-warn">forbidden: {data.forbidden_tools.join(", ")} — any call zeroes the score</li>
           )}
@@ -185,7 +197,21 @@ function AccumulationView({
         </div>
       </div>
 
-      {/* Final verdict + rubric contribution bars */}
+      {/* Final verdict + rubric contribution bars. An empty contract is a
+          DISTINCT state (defensive: the foundry now guarantees a fallback
+          rubric, so this should be unreachable on fresh builds). */}
+      {v.judgeable === false ? (
+        <div className="u-card" style={{ padding: "12px 14px", borderColor: "var(--warn-ink)" }}>
+          <h3>Final verdict</h3>
+          <p className="mono mt-2 text-base font-bold" style={{ color: "var(--warn-ink)" }}>
+            not judgeable — no obligations in this task&apos;s contract
+          </p>
+          <p className="mono mt-1 text-xs text-ink-muted">no rules to evaluate — recall/precision/policy are undefined, not 100%</p>
+          <p className="mono mt-2 text-[11px] text-faint">
+            run `understudy traces regenerate-env` (fallback rubric synthesis) or `understudy traces author-tasks` to give this task a judgeable rubric.
+          </p>
+        </div>
+      ) : (
       <div className="u-card" style={{ padding: "12px 14px", borderColor: v.task_completed_correctly ? "var(--ok)" : "var(--bad)" }}>
         <h3>Final verdict</h3>
         <div className="mt-2 flex flex-wrap items-baseline gap-3">
@@ -198,7 +224,65 @@ function AccumulationView({
           </span>
         </div>
         <RubricBars rewardFunctions={rewardFunctions} values={rubricValues} />
+        {(data.rules_evaluated?.length ?? 0) > 0 && (
+          <details className="mt-3">
+            <summary className="mono cursor-pointer text-[11px] text-ink-muted">
+              rules evaluated — what each number is made of
+            </summary>
+            <div className="mt-2 flex flex-col gap-2">
+              <div>
+                <span className="mono text-[10px] uppercase tracking-wide text-faint">
+                  recall = {data.rules_evaluated!.filter((r) => r.met).length}/{data.rules_evaluated!.length} required rules met
+                </span>
+                <ul className="mt-1 flex list-none flex-col gap-1 p-0">
+                  {data.rules_evaluated!.map((r, i) => (
+                    <li key={i} className="mono flex flex-wrap items-center gap-2 text-[11px]">
+                      <span style={{ color: r.met ? "var(--ok)" : "var(--bad)" }}>{r.met ? "✓" : "✗"}</span>
+                      <Badge className="text-ink-bright">{r.label}</Badge>
+                      <span className="text-faint">{r.kind}</span>
+                      {r.provenance && <Badge className="border-warn/40 text-warn">{r.provenance}</Badge>}
+                      <span className="text-ink-muted">criterion: {r.criterion}</span>
+                      <span className="text-faint">{r.met_at !== null ? `→ satisfied by event #${r.met_at + 1}` : "never met"}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              {(data.writes_mapped?.length ?? 0) > 0 && (
+                <div>
+                  <span className="mono text-[10px] uppercase tracking-wide text-faint">
+                    precision = {data.writes_mapped!.filter((w) => w.mapped_to !== null).length}/{data.writes_mapped!.length} candidate writes mapped to required effects
+                  </span>
+                  <ul className="mt-1 flex list-none flex-col gap-0.5 p-0">
+                    {data.writes_mapped!.map((w, i) => (
+                      <li key={i} className="mono text-[11px] text-ink-muted">
+                        event #{w.step + 1} {w.tool} —{" "}
+                        {w.mapped_to !== null ? `maps to required[${w.mapped_to + 1}]` : "unmapped (counts against precision)"}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <div>
+                <span className="mono text-[10px] uppercase tracking-wide text-faint">
+                  policy — {data.forbidden_evaluated?.length ?? 0} forbidden rule{(data.forbidden_evaluated?.length ?? 0) === 1 ? "" : "s"} checked
+                </span>
+                {(data.forbidden_evaluated?.length ?? 0) > 0 ? (
+                  <ul className="mt-1 flex list-none flex-col gap-0.5 p-0">
+                    {data.forbidden_evaluated!.map((f, i) => (
+                      <li key={i} className="mono text-[11px]" style={{ color: f.violated ? "var(--bad)" : "var(--muted-foreground)" }}>
+                        {f.violated ? "✗ violated" : "✓ clear"} — {f.label}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mono mt-1 text-[11px] text-faint">no forbidden rules in this contract — policy passes by absence</p>
+                )}
+              </div>
+            </div>
+          </details>
+        )}
       </div>
+      )}
     </div>
   );
 }
@@ -209,10 +293,21 @@ function AccumulationView({
  * accumulation replay per model arm — each fed through the environment's own
  * scoring code server-side. No LLM judging anywhere in this view.
  */
+type LiveRun = { run_id: string; model: string; status: string };
+type LivePayload = {
+  status: string;
+  progress: { completed: number; total: number };
+  next: number;
+  accumulation: Accumulation | null;
+};
+
 export function ReplayView({ slug, taskId }: { slug: string; taskId: string }) {
   const [data, setData] = useState<ReplayPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [armKey, setArmKey] = useState<string>("oracle");
+  const [liveRun, setLiveRun] = useState<LiveRun | null>(null);
+  const [live, setLive] = useState<LivePayload | null>(null);
+  const [lastLiveRunId, setLastLiveRunId] = useState<string | null>(null);
 
   const load = useCallback(() => {
     let cancelled = false;
@@ -231,6 +326,42 @@ export function ReplayView({ slug, taskId }: { slug: string; taskId: string }) {
     };
   }, [slug, taskId]);
   useEffect(() => load(), [load]);
+
+  // LIVE watch: while a task-scoped run is queued/running, poll the journal
+  // feed ~1.5s — events land as the world server appends them, required
+  // chips flip met in real time. Tool-call-level only (token streaming is
+  // deferred); the finished run swaps seamlessly to its scored arm.
+  useEffect(() => {
+    if (!liveRun) {
+      setLive(null);
+      return;
+    }
+    setArmKey("live");
+    setLastLiveRunId(liveRun.run_id);
+    let stopped = false;
+    const poll = () => {
+      fetch(`/api/runs/live?slug=${encodeURIComponent(slug)}&run=${encodeURIComponent(liveRun.run_id)}&task=${encodeURIComponent(taskId)}`)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((body: LivePayload | null) => {
+          if (!stopped && body) setLive(body);
+        })
+        .catch(() => {});
+    };
+    poll();
+    const timer = setInterval(poll, 1_500);
+    return () => {
+      stopped = true;
+      clearInterval(timer);
+    };
+  }, [liveRun, slug, taskId]);
+
+  // Seamless handoff: when the watched run finishes and its rows land, select
+  // that run's scored arm instead of snapping back to the oracle.
+  useEffect(() => {
+    if (liveRun || armKey !== "live" || !data || !lastLiveRunId) return;
+    const finished = data.arms.find((a) => a.run_id === lastLiveRunId);
+    setArmKey(finished ? finished.key : "oracle");
+  }, [liveRun, armKey, data, lastLiveRunId]);
 
   if (error) return <p className="mono text-xs text-warn">{error}</p>;
   if (!data) return <p className="mono text-xs text-ink-muted">computing deterministic replay…</p>;
@@ -261,10 +392,46 @@ export function ReplayView({ slug, taskId }: { slug: string; taskId: string }) {
             {a.model} <span style={{ color: scoreColor(a.mean_score ?? 0) }}>{formatScore(a.mean_score)}</span>
           </button>
         ))}
+        {liveRun && (
+          <button
+            type="button"
+            aria-pressed={armKey === "live"}
+            className={"u-tab mono" + (armKey === "live" ? " on" : "")}
+            style={{ border: "1px solid var(--live)", borderRadius: 6, padding: "3px 8px", fontSize: 11, color: "var(--live)" }}
+            onClick={() => setArmKey("live")}
+          >
+            <span style={{ display: "inline-block", width: 7, height: 7, borderRadius: "50%", background: "var(--live)", marginRight: 6, animation: "u-live-pulse 1.2s ease-in-out infinite" }} />
+            LIVE · {liveRun.model} {liveRun.status === "queued" ? "(waiting for executor)" : ""}
+          </button>
+        )}
         <span className="mono text-[10px] text-faint">deterministic — no LLM judging in this view</span>
+        <style>{`@keyframes u-live-pulse { 0%,100% { opacity: 1 } 50% { opacity: .25 } }`}</style>
       </div>
 
-      {arm === null ? (
+      {armKey === "live" && liveRun ? (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="mono text-xs font-bold" style={{ color: "var(--live)" }}>
+              LIVE — {liveRun.model}
+            </span>
+            <span className="mono text-[10px] text-faint">
+              {live ? `${live.progress.completed}/${live.progress.total} rollouts · ${live.next} journal events · polling 1.5s` : "attaching to the live journal…"}
+            </span>
+          </div>
+          {live?.accumulation ? (
+            <AccumulationView
+              data={live.accumulation}
+              rewardFunctions={data.reward_functions}
+              subscores={null}
+              emptyStepsNote={liveRun.status === "queued" ? "waiting for the executor daemon to pick this run up…" : "no tool events yet — the model is thinking"}
+            />
+          ) : (
+            <p className="mono text-xs text-ink-muted">
+              {liveRun.status === "queued" ? "run queued — start `understudy runs execute --watch` to execute it" : "waiting for the first journal event…"}
+            </p>
+          )}
+        </>
+      ) : arm === null ? (
         <>
           <div className="flex flex-wrap items-center gap-2">
             <Badge className="text-ink-bright">{data.label}</Badge>
@@ -334,6 +501,7 @@ export function ReplayView({ slug, taskId }: { slug: string; taskId: string }) {
           <RunTaskControls
             slug={slug}
             taskId={taskId}
+            onActiveRun={setLiveRun}
             canRun={
               data.stage === "promoted" ||
               (data.task_review === "accept" && data.environment.exists && data.environment.oracle_pass === true)

--- a/apps/benchmark-hub/components/trajectory/run-task.tsx
+++ b/apps/benchmark-hub/components/trajectory/run-task.tsx
@@ -35,6 +35,7 @@ export function RunTaskControls({
   canRun,
   disabledReason,
   onRunFinished,
+  onActiveRun,
 }: {
   slug: string;
   taskId: string;
@@ -44,6 +45,8 @@ export function RunTaskControls({
   disabledReason: string | null;
   /** Called when a task-scoped run reaches a terminal state (rows landed). */
   onRunFinished: () => void;
+  /** Reports the active (queued/running) task-scoped run for the live watch view; null when idle. */
+  onActiveRun?: (run: { run_id: string; model: string; status: string } | null) => void;
 }) {
   const [models, setModels] = useState<string[]>([]);
   const [modelsError, setModelsError] = useState<string | null>(null);
@@ -77,6 +80,10 @@ export function RunTaskControls({
 
   // Poll while a task-scoped run is in flight; refetch the replay when it lands.
   const active = runs.some((r) => r.status === "queued" || r.status === "running");
+  useEffect(() => {
+    const current = runs.find((r) => r.status === "running") ?? runs.find((r) => r.status === "queued") ?? null;
+    onActiveRun?.(current ? { run_id: current.run_id, model: current.models[0] ?? "", status: current.status } : null);
+  }, [runs, onActiveRun]);
   useEffect(() => {
     if (!active) return;
     const timer = setInterval(async () => {

--- a/apps/benchmark-hub/lib/replay-core.ts
+++ b/apps/benchmark-hub/lib/replay-core.ts
@@ -11,7 +11,7 @@
  * foundry (dist/) — the same contractEntryMet/scoreContract/isMutatingTool
  * the generated environment's scorer uses — never forked.
  */
-import { contractEntryMet, forbiddenEntryViolated, isMutatingTool, scoreContract } from "../../../dist/trace-foundry.js";
+import { anchorArguments, contractEntryMet, forbiddenEntryViolated, isMutatingTool, scoreContract, stateEffectMet } from "../../../dist/trace-foundry.js";
 // Re-exported so route handlers import every dist symbol through this module
 // (one relative path to keep working under the tests' .build output — the
 // apps/dist symlink covers the compiled depth).
@@ -22,7 +22,7 @@ type Obj = Record<string, unknown>;
 
 const asObject = (v: unknown): Obj => (v !== null && typeof v === "object" && !Array.isArray(v) ? (v as Obj) : {});
 
-export type ReplayCall = { id?: string | null; name: string; arguments: unknown };
+export type ReplayCall = { id?: string | null; name: string; arguments: unknown; status?: string };
 
 export type ReplayRequired = {
   /** Entry kind: state_effect | read_obligation | value_propagation | response_obligation. */
@@ -52,12 +52,25 @@ export type ReplayStep = {
 };
 
 export type ReplayVerdict = {
-  recall: number;
-  precision: number;
-  policy: number;
+  /** False when the contract has no required entries — nothing to judge; no vacuous 100%s. */
+  judgeable: boolean;
+  recall: number | null;
+  precision: number | null;
+  policy: number | null;
   strict: number;
-  score: number;
+  score: number | null;
   task_completed_correctly: boolean;
+};
+
+/** One row of the "rules evaluated" disclosure: exactly what each number is made of. */
+export type RuleEvaluation = {
+  kind: string;
+  label: string;
+  /** The matching criterion actually used for this entry. */
+  criterion: string;
+  met: boolean;
+  met_at: number | null;
+  provenance: string | null;
 };
 
 export type OracleReplay = {
@@ -66,6 +79,12 @@ export type OracleReplay = {
   forbidden_values: number;
   steps: ReplayStep[];
   verdict: ReplayVerdict;
+  /** Deterministic transparency: every rule with its criterion + result. */
+  rules_evaluated: RuleEvaluation[];
+  /** precision inputs: each candidate write mapped to the rule it satisfies (or unmapped). */
+  writes_mapped: { step: number; tool: string; mapped_to: number | null }[];
+  /** policy inputs: each forbidden rule and whether it was violated. */
+  forbidden_evaluated: { label: string; violated: boolean }[];
 };
 
 const entryLabel = (rule: Obj): string => {
@@ -107,7 +126,7 @@ export function accumulateReplay(task: Obj, calls: ReplayCall[], finalResponse?:
   const steps: ReplayStep[] = [];
   let violated = false;
   let metCount = 0;
-  const events: { name: string; arguments: unknown }[] = [];
+  const events: { name: string; arguments: unknown; status?: string }[] = [];
   const record = (index: number, tool: string, event: "call" | "final_response", args: unknown, seen: { calls: typeof events; finalResponse?: string | null }): void => {
     const satisfies: number[] = [];
     requiredRules.forEach((rule, i) => {
@@ -130,12 +149,15 @@ export function accumulateReplay(task: Obj, calls: ReplayCall[], finalResponse?:
       satisfies,
       forbidden_violation: forbidden,
       met_count: metCount,
-      // Forbidden violations zero the running credit outright.
-      partial_credit: violated ? 0 : requiredRules.length === 0 ? 1 : metCount / requiredRules.length,
+      // Forbidden violations zero the running credit; zero rules = zero
+      // credit (an empty contract is not judgeable, never a vacuous 1.0).
+      partial_credit: violated || requiredRules.length === 0 ? 0 : metCount / requiredRules.length,
     });
   };
   calls.forEach((call, index) => {
-    events.push({ name: call.name, arguments: call.arguments ?? {} });
+    // A validation-rejected call (status=error) rides along so the shared
+    // scorer can refuse it — rejects stay VISIBLE in the step walk.
+    events.push({ name: call.name, arguments: call.arguments ?? {}, ...(call.status === "error" ? { status: "error" } : {}) });
     record(index, call.name, "call", call.arguments ?? {}, { calls: events });
   });
   if (typeof finalResponse === "string" && finalResponse.length > 0) {
@@ -143,13 +165,64 @@ export function accumulateReplay(task: Obj, calls: ReplayCall[], finalResponse?:
   }
 
   const scored = scoreContract(task, { calls: events, finalResponse: finalResponse ?? "" }) as {
-    recall: number; precision: number; policy: number; strict: number; score: number;
+    judgeable?: boolean; recall: number | null; precision: number | null; policy: number | null; strict: number; score: number | null;
   };
+  const judgeable = scored.judgeable !== false && requiredRules.length > 0;
+
+  // "Show me the rule being evaluated": name the criterion each entry was
+  // matched with, so recall/precision/policy are inspectable, never opaque.
+  const criterionOf = (rule: Obj): string => {
+    const type = String(rule.type ?? "state_effect");
+    if (type === "state_effect") {
+      const semantic = asObject(rule.arguments_semantic);
+      if (Object.keys(anchorArguments(semantic)).length > 0) return "authored arguments_semantic (anchored)";
+      const anchors = anchorArguments(asObject(rule.observed_arguments));
+      return Object.keys(anchors).length > 0
+        ? `anchors of observed arguments (${Object.keys(anchors).join(", ")})`
+        : "tool call with any arguments (no discrete anchors in observed args)";
+    }
+    if (type === "read_obligation") return "authored arguments_semantic (anchored, read)";
+    if (type === "value_propagation") return "value tokens present at destination";
+    if (type === "response_obligation") return `final response: ${String(rule.kind ?? "")}`;
+    return type;
+  };
+  const rulesEvaluated = requiredRules.map((rule, i) => ({
+    kind: String(rule.type ?? "state_effect"),
+    label: entryLabel(rule),
+    criterion: criterionOf(rule),
+    met: required[i].met_at !== null,
+    met_at: required[i].met_at,
+    provenance: typeof rule.provenance === "string" ? rule.provenance : null,
+  }));
+  const stateRules = requiredRules.filter((rule) => String(rule.type ?? "state_effect") === "state_effect");
+  const writesMapped = steps
+    .filter((step) => step.mutating)
+    .map((step) => {
+      const call = { tool: step.tool, arguments: step.arguments };
+      const ruleIndex = requiredRules.findIndex((rule, i) => stateRules.includes(rule) && stateEffectMet(rule, call));
+      return { step: step.index, tool: step.tool, mapped_to: ruleIndex >= 0 ? ruleIndex : null };
+    });
+  const forbiddenEvaluated = forbiddenRules.map((rule) => ({
+    label: String(rule.type ?? "") === "forbidden_value" ? `value "${String(rule.value ?? "")}"` : `tool ${String(rule.tool ?? "")}`,
+    violated: forbiddenEntryViolated(rule, { calls: events, finalResponse: finalResponse ?? "" }) as boolean,
+  }));
+
   return {
     required,
     forbidden_tools: forbiddenTools,
     forbidden_values: forbiddenValues.length,
     steps,
-    verdict: { recall: scored.recall, precision: scored.precision, policy: scored.policy, strict: scored.strict, score: scored.score, task_completed_correctly: scored.strict === 1 },
+    rules_evaluated: rulesEvaluated,
+    writes_mapped: writesMapped,
+    forbidden_evaluated: forbiddenEvaluated,
+    verdict: {
+      judgeable,
+      recall: judgeable ? scored.recall : null,
+      precision: judgeable ? scored.precision : null,
+      policy: judgeable ? scored.policy : null,
+      strict: scored.strict,
+      score: judgeable ? scored.score : null,
+      task_completed_correctly: judgeable && scored.strict === 1,
+    },
   };
 }

--- a/apps/benchmark-hub/lib/runs-core.ts
+++ b/apps/benchmark-hub/lib/runs-core.ts
@@ -8,6 +8,9 @@
  */
 export {
   cancelRunRequest,
+  liveJournalPath,
+  readRunRequest,
+  runRequestPath,
   createRunRequest,
   listRunRequests,
   selectTasks,

--- a/apps/benchmark-hub/tests/replay.test.mjs
+++ b/apps/benchmark-hub/tests/replay.test.mjs
@@ -68,11 +68,13 @@ describe("accumulateReplay", () => {
     assert.equal(replay.verdict.task_completed_correctly, false);
   });
 
-  it("an empty contract accumulates full partial credit but never passes strict (env-scorer parity)", () => {
+  it("an empty contract is NOT JUDGEABLE: zero partial credit, null metrics, distinct verdict", () => {
     const replay = accumulateReplay(task([]), [{ name: "lookup-record", arguments: {} }]);
-    assert.equal(replay.steps[0].partial_credit, 1);
-    // scoreState deliberately refuses strict=1 when nothing was required —
-    // the replay verdict matches the generated environment exactly.
+    // No vacuous 100%s anywhere — nothing was required, so nothing accumulates.
+    assert.equal(replay.steps[0].partial_credit, 0);
+    assert.equal(replay.verdict.judgeable, false);
+    assert.equal(replay.verdict.recall, null);
+    assert.equal(replay.verdict.score, null);
     assert.equal(replay.verdict.strict, 0);
     assert.equal(replay.verdict.task_completed_correctly, false);
   });

--- a/apps/benchmark-hub/tests/runs-live-api.test.mjs
+++ b/apps/benchmark-hub/tests/runs-live-api.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import { GET } from "./.build/app/api/runs/live/route.js";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-hub-live-"));
+process.env.BENCHMARK_HUB_DATA_DIR = tmp;
+after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+// A promoted benchmark with a foundry tasks.jsonl sidecar and a running run.
+const dir = path.join(tmp, "livebench");
+fs.mkdirSync(path.join(dir, "runs", "queue"), { recursive: true });
+fs.mkdirSync(path.join(dir, "runs", "live"), { recursive: true });
+fs.writeFileSync(
+  path.join(dir, "benchmark.json"),
+  JSON.stringify({
+    schema_version: "understudy.benchmark.v1",
+    benchmark_id: "live-bench",
+    provenance: { origin: "derived-from-traces" },
+    taxonomy: [{ category_id: "cat-a" }],
+    tasks: [{ task_id: "t1", category_id: "cat-a", genesis: "replayed", split: "holdout" }],
+    environment: { format: "verifiers.v1", package_ref: "environment" },
+    verifier: { kind: "final-state", strict_metric: "task_completed_correctly" },
+  }),
+);
+fs.writeFileSync(
+  path.join(dir, "tasks.jsonl"),
+  JSON.stringify({
+    schema_version: "understudy.benchmark_task.v1",
+    task_id: "t1",
+    outcome_contract: { required: [{ type: "state_effect", tool: "update-record", observed_arguments: { id: "rec-1234567890123456" } }], preserved: [], forbidden: [], grading: "g" },
+  }) + "\n",
+);
+const runId = "run-live0000000001";
+fs.writeFileSync(
+  path.join(dir, "runs", "queue", `${runId}.json`),
+  JSON.stringify({
+    schema_version: "understudy.run_request.v1",
+    run_id: runId,
+    benchmark_id: "live-bench",
+    models: ["m1"],
+    split: "all",
+    tasks: ["t1"],
+    rollouts_per_task: 1,
+    created_at: "2026-07-22T00:00:00Z",
+    status: "running",
+    progress: { completed: 0, total: 1 },
+    live: { journal: `runs/live/${runId}-m1.jsonl`, model: "m1", task_id: "t1" },
+  }),
+);
+const journal = path.join(dir, "runs", "live", `${runId}-m1.jsonl`);
+fs.writeFileSync(
+  journal,
+  [
+    JSON.stringify({ at: 1, kind: "call", tool: "lookup-record", write: false, status: "ok", arguments: '{"id":"rec-1234567890123456"}' }),
+    JSON.stringify({ at: 2, kind: "result", tool: "lookup-record", status: "ok", content: "{}" }),
+    JSON.stringify({ at: 3, kind: "call", tool: "update-record", write: true, status: "ok", arguments: '{"id":"rec-1234567890123456"}' }),
+  ].join("\n") + "\n",
+);
+
+const get = (qs) => GET(new Request(`http://localhost/api/runs/live?${qs}`));
+
+describe("GET /api/runs/live", () => {
+  it("400s without params and on an invalid run id", async () => {
+    assert.equal((await get("slug=data--livebench")).status, 400);
+    assert.equal((await get("slug=data--livebench&run=../escape")).status, 400);
+  });
+
+  it("404s on unknown slug or run", async () => {
+    assert.equal((await get("slug=data--nope&run=run-x")).status, 404);
+    assert.equal((await get("slug=data--livebench&run=run-doesnotexist1")).status, 404);
+  });
+
+  it("serves journal lines with a since offset and a live accumulation from the shared scorer", async () => {
+    const res = await get(`slug=data--livebench&run=${runId}&task=t1`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.status, "running");
+    assert.equal(body.lines.length, 3);
+    assert.equal(body.next, 3);
+    // The live accumulation flips the required effect met at the matching call.
+    assert.equal(body.accumulation.required.length, 1);
+    assert.notEqual(body.accumulation.required[0].met_at, null);
+    assert.equal(body.accumulation.verdict.task_completed_correctly, true);
+
+    const offset = await (await get(`slug=data--livebench&run=${runId}&task=t1&since=2`)).json();
+    assert.equal(offset.lines.length, 1);
+    assert.equal(offset.lines[0].tool, "update-record");
+    assert.equal(offset.next, 3);
+
+    // New line lands → next poll picks it up from the offset.
+    fs.appendFileSync(journal, JSON.stringify({ at: 4, kind: "result", tool: "update-record", status: "ok", content: "{}" }) + "\n");
+    const grown = await (await get(`slug=data--livebench&run=${runId}&task=t1&since=3`)).json();
+    assert.equal(grown.lines.length, 1);
+    assert.equal(grown.next, 4);
+  });
+
+  it("rejected calls in the journal do not satisfy the contract", async () => {
+    const run2 = "run-live0000000002";
+    fs.writeFileSync(
+      path.join(dir, "runs", "queue", `${run2}.json`),
+      JSON.stringify({
+        schema_version: "understudy.run_request.v1",
+        run_id: run2,
+        benchmark_id: "live-bench",
+        models: ["m1"],
+        split: "all",
+        tasks: ["t1"],
+        rollouts_per_task: 1,
+        created_at: "2026-07-22T00:00:00Z",
+        status: "running",
+        progress: { completed: 0, total: 1 },
+        live: { journal: `runs/live/${run2}-m1.jsonl`, model: "m1", task_id: "t1" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(dir, "runs", "live", `${run2}-m1.jsonl`),
+      JSON.stringify({ at: 1, kind: "call", tool: "update-record", write: false, status: "error", arguments: '{"id":"rec-1234567890123456"}' }) + "\n",
+    );
+    const body = await (await get(`slug=data--livebench&run=${run2}&task=t1`)).json();
+    assert.equal(body.accumulation.required[0].met_at, null, "validation-rejected call never satisfies");
+  });
+});

--- a/apps/benchmark-hub/tests/tsconfig.json
+++ b/apps/benchmark-hub/tests/tsconfig.json
@@ -26,6 +26,7 @@
     "../lib/replay-core.ts",
     "../app/api/replay/route.ts",
     "../lib/runs-core.ts",
-    "../app/api/runs/route.ts"
+    "../app/api/runs/route.ts",
+    "../app/api/runs/live/route.ts"
   ]
 }

--- a/src/commands/traces.ts
+++ b/src/commands/traces.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { join, resolve } from "node:path";
 import { compileTraceFoundry, createTraceReplayPlan, importTraceReviews, promoteTraceBenchmark, runTraceReplays, regenerateEnvironment } from "../trace-foundry.js";
 import { serveTraceFoundry } from "../trace-foundry-server.js";
-import { authorOverview, authorTasks, compareAuthoringModels, gatewayClient, resolveDefaultModel, resolveGatewayAuth } from "../trace-author.js";
+import { authorOverview, authorTasks, compareAuthoringModels, gatewayClient, resolveDefaultModel, resolveEscalationModel, resolveGatewayAuth } from "../trace-author.js";
 import { renderTraceViewer } from "../trace-viewer.js";
 
 export function registerTracesCommand(program: Command): void {
@@ -73,7 +73,10 @@ export function registerTracesCommand(program: Command): void {
         else console.log(JSON.stringify(report, null, 2));
         return;
       }
-      const result = await authorTasks(resolve(options.benchmark), { model, client, limit, taskIds, onlyUnauthored: options.onlyUnauthored, concurrency, maxContextTokens, progressStream: process.stderr });
+      // Grounding failures are largely arm-specific: retry once with the
+      // strongest listed arm before falling back to the deterministic contract.
+      const escalationModel = (await resolveEscalationModel(auth.baseUrl, auth.apiKey)) ?? undefined;
+      const result = await authorTasks(resolve(options.benchmark), { model, client, limit, taskIds, onlyUnauthored: options.onlyUnauthored, concurrency, maxContextTokens, escalationModel: escalationModel !== model ? escalationModel : undefined, progressStream: process.stderr });
       console.log(JSON.stringify({ ...result, results: undefined }, null, 2));
     });
   traces.command("import-reviews")

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -17,7 +17,7 @@
  */
 import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { buildReplayInvocation, isMutatingTool, scoreState } from "./trace-foundry.js";
 import { COST_PER_MTOKEN, resolveGatewayAuth } from "./trace-author.js";
@@ -47,7 +47,14 @@ export type RunRequest = {
   finished_at?: string | null;
   /** Present when status is failed: the honest error class + message. */
   error?: { class: string; message: string } | null;
+  /** While running: the active arm's live journal (path relative to the benchmark dir) + what's executing. */
+  live?: { journal: string; model: string; task_id: string | null } | null;
 };
+
+/** Live journals live under <benchmark>/runs/live/ and stay after the run for replay-scrubbing. */
+export function liveJournalPath(benchmarkDir: string, runId: string, model: string): string {
+  return join(runsDir(benchmarkDir), "live", `${sanitizeForFile(runId)}-${sanitizeForFile(model)}.jsonl`);
+}
 
 export function runsDir(benchmarkDir: string): string {
   return join(resolve(benchmarkDir), "runs");
@@ -206,6 +213,8 @@ export type ArmRunner = (args: {
   rollout: number;
   /** Every task_id the run request selected — arm-level runners scope their eval to exactly these. */
   selectedTaskIds: string[];
+  /** Live journal file for this arm (runners/worlds append one JSON line per tool call/result); null disables. */
+  journalPath: string | null;
 }) => Promise<RolloutResult>;
 
 export type RunEvent = {
@@ -310,6 +319,12 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
       if (cancelled()) break;
       appendEvent(dir, { schema_version: "understudy.run_event.v1", ts: now().toISOString(), run_id: runId, type: "arm_started", model }, options.onEvent);
       const rowsFile = rowsFilePath(dir, runId, model);
+      // Live journal for this arm: the world/runner appends tool events the
+      // moment they happen; the hub's live endpoint tails it. The path is
+      // advertised on the request file so the UI knows what's executing.
+      const journalPath = liveJournalPath(dir, runId, model);
+      mkdirSync(join(runsDir(dir), "live"), { recursive: true });
+      const journalRel = relative(dir, journalPath);
       // Work items for this arm; a bounded pool honors --concurrency while the
       // cancel check between dequeues keeps the flip responsive.
       const queue: { task: Obj; rollout: number }[] = [];
@@ -325,11 +340,22 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
           if (!item) return;
           const taskId = String(item.task.task_id);
           const sidecar = sidecarTasks.get(taskId) ?? item.task;
+          // Advertise what's executing (journal + model + task) on the request
+          // file so the hub can attach a live watcher.
+          const current = readRunRequest(file) ?? request;
+          request = { ...current, live: { journal: journalRel, model, task_id: taskId } };
+          writeRunRequest(dir, request);
           let result: RolloutResult;
           try {
-            result = await options.runner({ benchmarkDir: dir, model, task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)) });
+            result = await options.runner({ benchmarkDir: dir, model, task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)), journalPath });
           } catch (err) {
             result = { score: null, subscores: null, status: "error", latency_ms: null, cost: null, writes: [], error: err instanceof Error ? `${err.constructor.name}: ${err.message}` : String(err) };
+          }
+          // Defensive: an empty contract is not judgeable — rows are unscored,
+          // never ok-with-vacuous-numbers. (The foundry now guarantees a
+          // fallback rubric, so this should be unreachable on fresh builds.)
+          if (((asObject(sidecar.outcome_contract).required ?? []) as unknown[]).length === 0 && result.status === "ok") {
+            result = { ...result, score: null, subscores: null, status: "unscored", error: "empty contract — not judgeable; regenerate-env synthesizes a fallback rubric" };
           }
           const row: Obj = {
             schema_version: "understudy.eval_result.v1",
@@ -383,20 +409,20 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
     // surfaced honestly: events carry the message, the request records the class.
     const message = err instanceof Error ? err.message : String(err);
     const errorClass = err instanceof Error ? err.constructor.name : "Error";
-    request = { ...(readRunRequest(file) ?? request), status: "failed", finished_at: now().toISOString(), progress: { completed, total }, error: { class: errorClass, message } };
+    request = { ...(readRunRequest(file) ?? request), status: "failed", finished_at: now().toISOString(), progress: { completed, total }, live: null, error: { class: errorClass, message } };
     writeRunRequest(dir, request);
     appendEvent(dir, { schema_version: "understudy.run_event.v1", ts: now().toISOString(), run_id: runId, type: "run_failed", error: `${errorClass}: ${message}`, progress: { completed, total } }, options.onEvent);
     return request;
   }
 
   if (cancelled()) {
-    request = { ...(readRunRequest(file) ?? request), progress: { completed, total } };
+    request = { ...(readRunRequest(file) ?? request), progress: { completed, total }, live: null };
     writeRunRequest(dir, request);
     appendEvent(dir, { schema_version: "understudy.run_event.v1", ts: now().toISOString(), run_id: runId, type: "run_cancelled", progress: { completed, total } }, options.onEvent);
     return request;
   }
 
-  request = { ...(readRunRequest(file) ?? request), status: "done", finished_at: now().toISOString(), progress: { completed, total } };
+  request = { ...(readRunRequest(file) ?? request), status: "done", finished_at: now().toISOString(), progress: { completed, total }, live: null };
   writeRunRequest(dir, request);
   appendEvent(dir, { schema_version: "understudy.run_event.v1", ts: now().toISOString(), run_id: runId, type: "run_finished", progress: { completed, total } }, options.onEvent);
   return request;
@@ -424,9 +450,17 @@ export async function executeQueuedRuns(benchmarkDir: string, options: ExecuteOp
  * spend. Rows are labeled honestly via subscores.runner_oracle = 1.
  */
 export function oracleRunner(): ArmRunner {
-  return async ({ task }) => {
+  const journal = (path: string | null, entry: Obj): void => {
+    if (!path) return;
+    try { appendFileSync(path, `${JSON.stringify(entry)}\n`, { mode: 0o600 }); } catch { /* live journal is best-effort */ }
+  };
+  return async ({ task, journalPath }) => {
     const started = Date.now();
-    const writes = (asObject(task.outcome_contract).required ?? []).map((rule: Obj) => ({ tool: String(rule.tool), arguments: rule.observed_arguments ?? {} }));
+    const writes = (asObject(task.outcome_contract).required ?? []).filter((rule: Obj) => String(rule.type ?? "state_effect") === "state_effect").map((rule: Obj) => ({ tool: String(rule.tool), arguments: rule.observed_arguments ?? {} }));
+    for (const write of writes) {
+      journal(journalPath, { at: Date.now() / 1000, kind: "call", tool: write.tool, write: true, status: "ok", arguments: JSON.stringify(write.arguments).slice(0, 800) });
+      journal(journalPath, { at: Date.now() / 1000, kind: "result", tool: write.tool, status: "ok", content: "{\"ok\": true}" });
+    }
     const scored = asObject(scoreState(asObject(task), writes));
     return {
       score: Number(scored.strict ?? 0),
@@ -545,7 +579,7 @@ export function projectVerifiersTrace(trace: Obj, model: string): { taskId: stri
  * dir's outputs/) is projected onto per-task results. Throws
  * HarnessExecutionError with the subprocess tail on failure.
  */
-export function runVerifiersArm(benchmarkDir: string, model: string, maxExamples: number, parentEnv: NodeJS.ProcessEnv = process.env, taskIds: string[] | null = null): Map<string, RolloutResult> {
+export function runVerifiersArm(benchmarkDir: string, model: string, maxExamples: number, parentEnv: NodeJS.ProcessEnv = process.env, taskIds: string[] | null = null, journalPath: string | null = null): Map<string, RolloutResult> {
   const dir = resolve(benchmarkDir);
   const environment = join(dir, "environment");
   // Scope the eval to exactly the requested tasks (a single-task run on a
@@ -559,13 +593,13 @@ export function runVerifiersArm(benchmarkDir: string, model: string, maxExamples
   const splits = filteredRows === null ? ["train", "dev", "holdout"] : [...new Set(filteredRows.map((row) => String(row.split)))];
   if (filteredRows !== null) writeFileSync(taskRowsPath, `${JSON.stringify(filteredRows, null, 2)}\n`, { mode: 0o600 });
   try {
-    return runVerifiersSplits(dir, environment, model, maxExamples, parentEnv, splits);
+    return runVerifiersSplits(dir, environment, model, maxExamples, parentEnv, splits, journalPath);
   } finally {
     if (sourceTaskRows !== null) writeFileSync(taskRowsPath, `${JSON.stringify(sourceTaskRows, null, 2)}\n`, { mode: 0o600 });
   }
 }
 
-function runVerifiersSplits(dir: string, environment: string, model: string, maxExamples: number, parentEnv: NodeJS.ProcessEnv, splits: string[]): Map<string, RolloutResult> {
+function runVerifiersSplits(dir: string, environment: string, model: string, maxExamples: number, parentEnv: NodeJS.ProcessEnv, splits: string[], journalPath: string | null = null): Map<string, RolloutResult> {
   // Gateway creds resolve the CLI's canonical way (env first, then
   // ~/.understudy/credentials.json) and are handed to buildReplayInvocation
   // through its own env contract — the executor ONLY talks to the Understudy
@@ -579,6 +613,10 @@ function runVerifiersSplits(dir: string, environment: string, model: string, max
   const failures: string[] = [];
   for (const split of splits) {
     const invocation = buildReplayInvocation(environment, model, "authentic_history", maxExamples, false, runnerEnv);
+    // Live watching: the generated world server journals every tool call and
+    // result to this file the moment it happens (no-op when unset). The var
+    // rides the eval subprocess env, which the subprocess runtime inherits.
+    if (journalPath !== null) invocation.env.UNDERSTUDY_LIVE_JOURNAL = journalPath;
     invocation.args.push("--env.taskset.split", split);
     const started = Date.now();
     const child = spawnSync("uv", invocation.args, { cwd: dir, encoding: "utf8", env: invocation.env, maxBuffer: 64 * 1024 * 1024 });
@@ -611,11 +649,11 @@ function runVerifiersSplits(dir: string, environment: string, model: string, max
  */
 export function verifiersRunner(parentEnv: NodeJS.ProcessEnv = process.env): ArmRunner {
   const armCache = new Map<string, Map<string, RolloutResult> | Error>();
-  return async ({ benchmarkDir, model, task, selectedTaskIds }) => {
+  return async ({ benchmarkDir, model, task, selectedTaskIds, journalPath }) => {
     const key = `${benchmarkDir}::${model}::${[...selectedTaskIds].sort().join(",")}`;
     if (!armCache.has(key)) {
       try {
-        armCache.set(key, runVerifiersArm(benchmarkDir, model, 1000, parentEnv, selectedTaskIds));
+        armCache.set(key, runVerifiersArm(benchmarkDir, model, 1000, parentEnv, selectedTaskIds, journalPath));
       } catch (err) {
         armCache.set(key, err instanceof Error ? err : new Error(String(err)));
       }

--- a/src/trace-author.ts
+++ b/src/trace-author.ts
@@ -42,7 +42,24 @@ export type AuthorTasksOptions = {
   progressTotal?: number;
   /** Concurrent in-flight authoring calls (promise pool); calls are independent. */
   concurrency?: number;
+  /** Strongest available arm: a grounding failure auto-retries once with it (recorded in authoring-events). */
+  escalationModel?: string;
 };
+
+/** Escalation-arm preference order (strongest grounding fidelity first, per the authoring comparison panel). */
+const ESCALATION_PREFERENCE = ["gpt-5.5", "claude-opus-4-8", "claude-sonnet-4-6", "kimi-k2.6", "glm-5.2"];
+
+/** Pick the strongest available escalation arm from the gateway's model list; null when none is listed. */
+export async function resolveEscalationModel(baseUrl: string, apiKey: string, fetchImpl: typeof fetch = fetch): Promise<string | null> {
+  try {
+    const response = await fetchImpl(`${baseUrl}/models`, { headers: { authorization: `Bearer ${apiKey}` } });
+    if (!response.ok) return null;
+    const ids = new Set(((asObject(await response.json()).data ?? []) as Obj[]).map((entry) => String(entry.id)));
+    return ESCALATION_PREFERENCE.find((id) => ids.has(id)) ?? null;
+  } catch {
+    return null;
+  }
+}
 
 async function promisePool<T>(items: T[], limit: number, worker: (item: T, index: number) => Promise<void>): Promise<void> {
   let next = 0;
@@ -418,7 +435,14 @@ export function groundAuthoredTask(task: Obj, authored: Obj, calls: Obj[], evide
     if (!matching.some((call) => semanticArgumentsMatch(asObject(entry.arguments_semantic), asObject(call.arguments)))) violations.push(`required[${index}]: arguments_semantic for "${tool}" do not token-match any observed call arguments`);
     for (const id of Array.isArray(entry.maps_to_observed) ? entry.maps_to_observed : []) if (!callIds.has(String(id))) violations.push(`required[${index}]: maps_to_observed id "${id}" not present in observed evidence`);
   }
-  for (const rule of deterministicRequired) if (!required.some((entry) => entry.tool === rule.tool)) violations.push(`required: authored contract omits deterministically observed effect "${rule.tool}"`);
+  // Coverage applies to deterministically OBSERVED state effects only —
+  // synthesized fallback_minimal entries and merged obligations are not
+  // "observed effects" the author must re-state.
+  for (const rule of deterministicRequired) {
+    if (String(rule.type ?? "state_effect") !== "state_effect") continue;
+    if (rule.provenance === "fallback_minimal") continue;
+    if (!required.some((entry) => entry.tool === rule.tool)) violations.push(`required: authored contract omits deterministically observed effect "${rule.tool}"`);
+  }
   groundObligations(violations, task, contract, calls, evidence);
   for (const [kind, entries] of [["preserved", contract.preserved], ["forbidden", contract.forbidden]] as const) {
     for (const [index, entryValue] of (Array.isArray(entries) ? entries : []).entries()) {
@@ -555,12 +579,35 @@ export async function authorTasks(benchmarkDirInput: string, options: AuthorTask
       callError = (error as Error).message;
       violations = [`llm_call_failed: ${callError}`];
     }
-    const grounding = authored ? groundAuthoredTask(task, authored, calls, evidence) : { status: "failed" as const, violations };
-    const cost = costEstimate(options.model, usage);
+    let grounding = authored ? groundAuthoredTask(task, authored, calls, evidence) : { status: "failed" as const, violations };
+    let usedModel = options.model;
+    let cost = costEstimate(options.model, usage);
+    // Authoring escalation: grounding failures are largely arm-specific, so a
+    // failed cheap-arm pass auto-retries ONCE with the strongest available arm
+    // before any fallback. The escalation is recorded in authoring-events.
+    if (grounding.status === "failed" && options.escalationModel && options.escalationModel !== options.model) {
+      try {
+        const retry = await client({ model: options.escalationModel, messages: [{ role: "system", content: SYSTEM_PROMPT }, { role: "user", content: `EVIDENCE:\n${JSON.stringify(context)}\nOUTPUT:` }] });
+        cost += costEstimate(options.escalationModel, retry.usage ?? {});
+        const parsedRetry = parseAuthoredJson(retry.content);
+        if (parsedRetry !== null) {
+          const regrounding = groundAuthoredTask(task, parsedRetry, calls, evidence);
+          appendJsonl(eventsPath, [{ schema_version: "understudy.authoring_event.v1", at: new Date().toISOString(), task_id: task.task_id, model: options.escalationModel, escalated_from: options.model, status: "ok", grounding: regrounding.status, violations: regrounding.violations, tokens: { prompt: retry.usage?.prompt_tokens ?? null, completion: retry.usage?.completion_tokens ?? null }, cost_estimate_usd: costEstimate(options.escalationModel, retry.usage ?? {}) }]);
+          if (regrounding.status === "verified") {
+            authored = parsedRetry;
+            grounding = regrounding;
+            usedModel = options.escalationModel;
+            usage = retry.usage ?? {};
+          }
+        }
+      } catch (error) {
+        appendJsonl(eventsPath, [{ schema_version: "understudy.authoring_event.v1", at: new Date().toISOString(), task_id: task.task_id, model: options.escalationModel, escalated_from: options.model, status: "error", error: (error as Error).message }]);
+      }
+    }
     const ms = Date.now() - startedAt;
     const authoredBlock = {
       schema_version: AUTHORING_SCHEMA_VERSION,
-      model: options.model,
+      model: usedModel,
       authored_at: now.toISOString(),
       grounding: grounding.status,
       grounding_violations: grounding.violations,

--- a/src/trace-foundry.ts
+++ b/src/trace-foundry.ts
@@ -370,6 +370,9 @@ function tasksFrom(dag: Obj, rows: Obj[], catalog: Obj[] = []): Obj[] {
       task.close_call = true;
       task.claims.push({ kind: "inferred", claim: `workflow may be incomplete; spans workloads ${(task.trace.workloads_spanned as string[]).join(", ")}`, confidence: "medium" });
     }
+    // Judgeability guarantee: an empty contract never leaves the foundry —
+    // synthesize the fallback rubric from the captured final response + prompt.
+    ensureJudgeableContract(task, finalResponseText(asObject(captures.at(-1)?.response)), contentText(first.content ?? ""));
     task.capability_fit = capabilityFit(task, catalog);
     task.task_hash = hash({ title: task.title, tools: task.tool_surface, contract: task.outcome_contract, source: task.source });
     return task;
@@ -406,10 +409,120 @@ export function semanticArgumentsMatch(observed: Obj, actual: Obj): boolean {
   return Object.values(observed ?? {}).every((value) => contentTokens(value).every((token) => hay.includes(token)));
 }
 
+/**
+ * ANCHOR fields of an observed-arguments object: the discrete values that
+ * identify WHAT was acted on — numbers, booleans, id-shaped strings (uuid /
+ * long alnum / path-like), and short strings (≤6 canonical tokens). Long free
+ * text (email bodies, document prose) is dropped entirely: requiring token
+ * containment of the incumbent's full prose zeroed every honest candidate
+ * rollout that wrote its own good document. Recurses ONE level into nested
+ * objects; arrays and deeper nesting are dropped with the prose.
+ */
+export function anchorArguments(observed: Obj, depth = 0): Obj {
+  const idShaped = (raw: string): boolean => {
+    const s = raw.trim();
+    if (/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(s)) return true;
+    if (/\s/.test(s)) return false;
+    return /[A-Za-z0-9_-]{16,}/.test(s) || s.includes("/");
+  };
+  const out: Obj = {};
+  for (const [key, value] of Object.entries(observed ?? {})) {
+    if (typeof value === "number" || typeof value === "boolean") out[key] = value;
+    else if (typeof value === "string") {
+      if (idShaped(value) || contentTokens(value).length <= 6) out[key] = value;
+    } else if (value !== null && typeof value === "object" && !Array.isArray(value) && depth < 1) {
+      const nested = anchorArguments(value as Obj, depth + 1);
+      if (Object.keys(nested).length > 0) out[key] = nested;
+    }
+  }
+  return out;
+}
+
+/**
+ * state_effect met: tool matches AND the rule's discrete argument anchors are
+ * semantically present in the candidate's arguments. Authored
+ * arguments_semantic (merged entries) wins when present; the mechanical
+ * fallback is anchorArguments(observed_arguments). A rule with NO authored
+ * semantics and NO anchors (pure-prose observed args) is satisfied by calling
+ * the tool with any arguments — the tool call itself is the only deterministic
+ * signal left once prose is (rightly) out of bounds.
+ */
+const ANCHOR_VALUE_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[A-Za-z0-9][A-Za-z0-9_-]{15,}/g;
+
+/**
+ * Fallback minimal rubric — the FLOOR of the judgeability guarantee: when
+ * deterministic extraction finds no required entries, synthesize them from
+ * the incumbent's captured final response (json_parses/schema_valid for
+ * structured output; contains_category anchor-value checks otherwise) and
+ * from prompt anchors that propagated into the final response. No LLM. Every
+ * entry carries provenance:"fallback_minimal".
+ */
+export function fallbackRubricEntries(finalText: string, promptText: string): Obj[] {
+  const entries: Obj[] = [];
+  const trimmed = (finalText ?? "").trim();
+  let parsed: unknown;
+  try { parsed = trimmed.startsWith("{") || trimmed.startsWith("[") ? JSON.parse(trimmed) : undefined; } catch { parsed = undefined; }
+  if (parsed !== undefined) {
+    entries.push({ type: "response_obligation", kind: "json_parses", provenance: "fallback_minimal" });
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const keys = Object.keys(parsed as Obj).slice(0, 8);
+      if (keys.length > 0) entries.push({ type: "response_obligation", kind: "schema_valid", expected_keys: keys, provenance: "fallback_minimal" });
+    }
+    return entries;
+  }
+  // Unstructured response: id-shaped anchor values that must appear (same
+  // anchor canonicalization discipline as anchorArguments — discrete, never prose).
+  const idAnchors = [...new Set((trimmed.match(ANCHOR_VALUE_RE) ?? []).filter((v) => !/^[A-Za-z]+$/.test(v)))].slice(0, 3);
+  for (const anchor of idAnchors) entries.push({ type: "response_obligation", kind: "contains_category", expected: anchor, provenance: "fallback_minimal" });
+  // Prompt anchors that propagated into the final response.
+  const promptAnchors = [...new Set(((promptText ?? "").match(ANCHOR_VALUE_RE) ?? []).filter((v) => !/^[A-Za-z]+$/.test(v)))]
+    .filter((v) => !idAnchors.includes(v) && valueTokensPresent(v, trimmed))
+    .slice(0, 3);
+  for (const anchor of promptAnchors) entries.push({ type: "value_propagation", value: anchor, must_reach: { kind: "final_response" }, provenance: "fallback_minimal" });
+  if (entries.length === 0 && trimmed.length > 0) {
+    // Last resort: the response's most distinctive short line as a category check.
+    const line = trimmed.split("\n").map((l) => l.trim()).find((l) => l.length >= 8 && contentTokens(l).length <= 6) ?? trimmed.slice(0, 48);
+    if (contentTokens(line).length > 0) entries.push({ type: "response_obligation", kind: "contains_category", expected: line, provenance: "fallback_minimal" });
+  }
+  return entries;
+}
+
+/**
+ * Judgeability guarantee: no generated task may carry an empty contract.
+ * Fills empty required with the fallback rubric (title as the absolute last
+ * resort), demotes to needs_review, and records a claim so the thinness is
+ * visible in review. Returns true when the task was modified.
+ */
+export function ensureJudgeableContract(task: Obj, finalText: string, promptText: string): boolean {
+  const contract = asObject(task.outcome_contract);
+  if ((Array.isArray(contract.required) ? contract.required : []).length > 0) return false;
+  const entries = fallbackRubricEntries(finalText, promptText);
+  if (entries.length === 0) entries.push({ type: "response_obligation", kind: "contains_category", expected: String(task.title ?? task.task_id), provenance: "fallback_minimal" });
+  contract.required = entries;
+  contract.status = "fallback_minimal";
+  task.outcome_contract = contract;
+  task.status = "needs_review";
+  task.close_call = true;
+  task.claims = [...(Array.isArray(task.claims) ? task.claims : []), { kind: "inferred", claim: "rubric is a minimal oracle-response check — confirm or enrich", confidence: "low", provenance: "fallback_minimal" }];
+  return true;
+}
+
+export function stateEffectMet(rule: Obj, call: Obj): boolean {
+  if (String(call.tool ?? call.name ?? "") !== rule.tool) return false;
+  const semantic = asObject(rule.arguments_semantic);
+  if (Object.keys(semantic).length > 0) {
+    if (semanticArgumentsMatch(anchorArguments(semantic), asObject(call.arguments))) return true;
+  }
+  return semanticArgumentsMatch(anchorArguments(asObject(rule.observed_arguments)), asObject(call.arguments));
+}
+
 export function scoreState(task: Obj, writes: Obj[]): Obj {
   const required = task.outcome_contract?.required ?? [];
-  const matched = required.filter((rule: Obj) => writes.some((write) => write.tool === rule.tool && semanticArgumentsMatch(asObject(rule.observed_arguments), asObject(write.arguments)))).length;
-  const recall = required.length === 0 ? 1 : matched / required.length;
+  // Empty contract = NOT JUDGEABLE: no vacuous 100%s anywhere. (Callers render
+  // a distinct state and eval rows become unscored.)
+  if (required.length === 0) return { judgeable: false, recall: null, precision: null, policy: null, strict: 0, score: null };
+  const matched = required.filter((rule: Obj) => writes.some((write) => stateEffectMet(rule, write))).length;
+  const recall = matched / required.length;
   const precision = writes.length === 0 ? (required.length === 0 ? 1 : 0) : matched / writes.length;
   const forbidden = writes.some((write) => task.outcome_contract?.forbidden?.some((rule: Obj) => rule.tool === write.tool)) ? 0 : 1;
   // Forbidden-effect violations zero the strict score outright.
@@ -474,8 +587,11 @@ export function contractEntryMet(rule: Obj, events: ContractEvents): boolean {
   const type = String(rule.type ?? "state_effect");
   const calls = events.calls ?? [];
   const finalText = String(events.finalResponse ?? "");
-  if (type === "state_effect") return calls.some((call) => toolOf(call) === rule.tool && semanticArgumentsMatch(asObject(rule.observed_arguments), asObject(call.arguments)));
-  if (type === "read_obligation") return calls.some((call) => toolOf(call) === rule.tool && semanticArgumentsMatch(asObject(rule.arguments_semantic), asObject(call.arguments)));
+  // Validation precedes matching: a call the world rejected (status=error)
+  // can never satisfy a state_effect or read_obligation.
+  const validCalls = calls.filter((call) => String(asObject(call).status ?? "") !== "error");
+  if (type === "state_effect") return validCalls.some((call) => stateEffectMet(rule, call));
+  if (type === "read_obligation") return validCalls.some((call) => toolOf(call) === rule.tool && semanticArgumentsMatch(anchorArguments(asObject(rule.arguments_semantic)), asObject(call.arguments)));
   if (type === "value_propagation") {
     const destination = asObject(rule.must_reach);
     if (destination.kind === "final_response") return valueTokensPresent(rule.value, finalText);
@@ -513,6 +629,9 @@ export function forbiddenEntryViolated(rule: Obj, events: ContractEvents): boole
 export function scoreContract(task: Obj, events: ContractEvents): Obj {
   const contract = asObject(task.outcome_contract);
   const required = (Array.isArray(contract.required) ? contract.required : []).map(asObject);
+  // Empty contract = NOT JUDGEABLE — never vacuous 100%s. (The foundry
+  // guarantees a fallback rubric, so this is a defensive state.)
+  if (required.length === 0) return { judgeable: false, recall: null, precision: null, policy: null, strict: 0, score: null, met: [] };
   const met = required.map((rule) => contractEntryMet(rule, events));
   const matched = met.filter(Boolean).length;
   const stateRules = required.filter((rule) => String(rule.type ?? "state_effect") === "state_effect");
@@ -563,7 +682,14 @@ export function oracleEventsFor(task: Obj): ContractEvents {
  */
 export function offlineValidationRow(task: Obj): Obj {
   const oracle = oracleEventsFor(task);
-  const wrongCalls = oracle.calls.map((call) => ({ ...call, arguments: { __wrong__: true } }));
+  // wrong_value corrupts the ANCHOR values (the discrete fields matching now
+  // keys on). A call whose rule has NO anchors is satisfied by any-args by
+  // design, so the sentinel corrupts its TOOL instead — the gate must still
+  // discriminate.
+  const wrongCalls = oracle.calls.map((call) =>
+    Object.keys(anchorArguments(asObject(call.arguments))).length > 0
+      ? { ...call, arguments: { __wrong__: true } }
+      : { ...call, tool: `${call.tool}--wrong-sentinel` });
   return {
     task_id: task.task_id,
     oracle: scoreContract(task, oracle),
@@ -600,6 +726,32 @@ function writeVerifiersEnvironment(output: string, tasks: Obj[], sourceContext: 
   for (const task of tasks) for (const rule of task.outcome_contract?.required ?? []) if (typeof rule.tool === "string" && !observedByTool.has(rule.tool)) observedByTool.set(rule.tool, asObject(rule.observed_arguments));
   const schemaByTool = new Map<string, Obj>();
   for (const task of tasks) for (const definitionValue of task.tool_definitions ?? []) { const definition = asObject(definitionValue), fn = asObject(definition.function), name = String(definition.name ?? fn.name ?? ""); if (name && !schemaByTool.has(name)) schemaByTool.set(name, asObject(definition.input_schema ?? fn.parameters)); }
+  // Validation schemas for the world: the DECLARED JSON schema (captured from
+  // the incumbent's tool_definitions) when present; otherwise a minimal one
+  // synthesized from observed calls — required = keys present (non-null) in
+  // EVERY observed call of that tool — marked "inferred". Better than
+  // accepting anything.
+  const observedCallsByTool = new Map<string, Obj[]>();
+  for (const task of tasks) {
+    for (const rule of task.outcome_contract?.required ?? []) if (typeof rule.tool === "string") observedCallsByTool.set(rule.tool, [...(observedCallsByTool.get(rule.tool) ?? []), asObject(rule.observed_arguments)]);
+    for (const obs of task.world_model?.initial_state?.observations ?? []) if (typeof obs.tool === "string") observedCallsByTool.set(obs.tool, [...(observedCallsByTool.get(obs.tool) ?? []), asObject(obs.arguments)]);
+  }
+  const jsonType = (value: unknown): string => typeof value === "boolean" ? "boolean" : typeof value === "number" ? "number" : Array.isArray(value) ? "array" : value !== null && typeof value === "object" ? "object" : "string";
+  const validationSchemaFor = (name: string): Obj => {
+    const declared = asObject(schemaByTool.get(name));
+    const declaredProperties = asObject(declared.properties);
+    if (Object.keys(declaredProperties).length > 0) {
+      return {
+        inferred: false,
+        required: (Array.isArray(declared.required) ? declared.required : []).map(String),
+        properties: Object.fromEntries(Object.entries(declaredProperties).map(([key, value]) => [key, String(asObject(value).type ?? "")])),
+      };
+    }
+    const observed = observedCallsByTool.get(name) ?? [];
+    const keys = observed.length > 0 ? Object.keys(observed[0]).filter((key) => observed.every((o) => o[key] !== undefined && o[key] !== null)) : [];
+    return { inferred: true, required: keys, properties: Object.fromEntries(keys.map((key) => [key, jsonType(observed[0][key])])) };
+  };
+  writeJson(join(servers, "schemas.json"), Object.fromEntries(toolNames.map((name) => [name, validationSchemaFor(name)])));
   const pyType = (value: unknown): string => typeof value === "boolean" ? "bool" : typeof value === "number" ? "float" : Array.isArray(value) ? "list" : value && typeof value === "object" ? "dict" : "str";
   const schemaType = (schema: Obj, fallback: unknown): string => schema.type === "boolean" ? "bool" : ["number", "integer"].includes(schema.type) ? "float" : schema.type === "array" ? "list" : schema.type === "object" ? "dict" : schema.type === "string" ? "str" : pyType(fallback);
   const methods = toolNames.map((name) => {
@@ -608,7 +760,7 @@ function writeVerifiersEnvironment(output: string, tasks: Obj[], sourceContext: 
     const parameters = keys.map((key) => `${pyName(key)}: ${schemaType(asObject(properties[key]), observed[key])} | None = None`).join(", ");
     const args = keys.map((key) => `${JSON.stringify(key)}: ${pyName(key)}`).join(", ");
     const mutating = mutationPrefixes.some((prefix) => name.toLowerCase().startsWith(prefix));
-    return `    @vf.tool(name=${JSON.stringify(name)})\n    async def ${pyName(name)}(self${parameters ? `, ${parameters}` : ""}) -> str:\n        \"\"\"Execute the trace-derived ${name} transition against per-rollout state.\"\"\"\n        event = {\"tool\": ${JSON.stringify(name)}, \"arguments\": {${args}}}\n        self.state.events.append(event)\n${mutating ? "        self.state.writes.append(event)\n" : ""}        return json.dumps({\"ok\": True, **event})`;
+    return `    @vf.tool(name=${JSON.stringify(name)})\n    async def ${pyName(name)}(self${parameters ? `, ${parameters}` : ""}) -> str:\n        \"\"\"Execute the trace-derived ${name} transition against per-rollout state.\"\"\"\n        return self._accept({\"tool\": ${JSON.stringify(name)}, \"arguments\": {${args}}}, ${mutating ? "True" : "False"})`;
   }).join("\n\n");
   const fixtures = tasks.flatMap((task) => task.world_model?.initial_state?.observations ?? []).map((result: Obj) => ({ tool: result.tool, arguments: result.arguments ?? {}, status: result.status, content: result.content }));
   // Stateful per-rollout world: fixtures are matched token-normalized (not
@@ -620,11 +772,15 @@ function writeVerifiersEnvironment(output: string, tasks: Obj[], sourceContext: 
   // true/false/null (Python spells them True/False/None; a real customer
   // environment died with `NameError: name 'false' is not defined`).
   writeJson(join(servers, "fixtures.json"), fixtures);
-  const worldMethods = `    FIXTURES = json.loads((Path(__file__).parent / "fixtures.json").read_text())\n\n${fixtureReply}\n\n${methods.replaceAll('        return json.dumps({"ok": True, **event})', "        return self._fixture_reply(event)")}`;
+  // _accept: schema validation gates every call (rejects are recorded as
+  // status=error events — never writes — and still journal live, so recovery
+  // after a rejected call is visible in the watch view, AutomationBench-style).
+  const acceptHelper = `    def _accept(self, event: dict, mutating: bool) -> str:\n        error = _validate(event["tool"], event["arguments"] or {})\n        _journal({"at": time.time(), "kind": "call", "tool": event["tool"], "write": bool(mutating and not error), "status": "error" if error else "ok", "arguments": _summary(event["arguments"] or {})})\n        if error:\n            self.state.events.append({**event, "status": "error", "error": error})\n            reply = json.dumps({"ok": False, "error": error})\n        else:\n            self.state.events.append(event)\n            if mutating:\n                self.state.writes.append(event)\n            reply = self._fixture_reply(event)\n        _journal({"at": time.time(), "kind": "result", "tool": event["tool"], "status": "error" if error else "ok", "content": _summary(reply or "")})\n        return reply`;
+  const worldMethods = `    FIXTURES = json.loads((Path(__file__).parent / "fixtures.json").read_text())\n\n${fixtureReply}\n\n${acceptHelper}\n\n${methods}`;
   const taskRows = tasks.map((task) => ({ task_id: task.task_id, prompt: (()=>{ const msgs = (sourceContext.get(task.task_id)?.messages ?? []) as Obj[]; const firstUser = msgs.find((m) => m.role === "user"); const text = firstUser ? contentText(firstUser.content) : ""; return text.trim() || task.title; })(), system_prompt: (()=>{ const sys = sourceContext.get(task.task_id)?.system; if (sys == null) return null; return typeof sys === "string" ? sys : contentText(sys); })(), source_messages: sourceContext.get(task.task_id)?.messages ?? [], split: task.split === "construction" ? "train" : task.split === "fit" ? "dev" : "holdout", outcome_contract: task.outcome_contract, tool_surface: task.tool_surface }));
   writeJson(join(pkg, "tasks.json"), taskRows);
-  writeFileSync(join(pkg, "servers", "world.py"), `import json\nimport re\nfrom pathlib import Path\nfrom pydantic import Field\nimport verifiers.v1 as vf\n\n\ndef _tokens(value):\n    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)\n    return [token for token in re.split(r"[^a-z0-9#]+", text.lower()) if len(token) > 2 or token.isdigit()]\n\n\ndef _arguments_match(observed: dict, actual: dict) -> bool:\n    \"\"\"Semantic compare: every content token of each observed value appears in the canonicalized actual arguments.\"\"\"\n    hay = json.dumps(actual or {}, sort_keys=True).lower()\n    return all(token in hay for value in (observed or {}).values() for token in _tokens(value))\n\n\nclass WorldState(vf.State):\n    events: list[dict] = Field(default_factory=list)\n    writes: list[dict] = Field(default_factory=list)\n    used_fixtures: list[int] = Field(default_factory=list)\n\nclass WorldToolset(vf.Toolset[vf.ToolsetConfig, WorldState]):\n    TOOL_PREFIX = \"\"\n\n${worldMethods || "    pass"}\n\nif __name__ == \"__main__\":\n    WorldToolset.run()\n`, { mode: 0o600 });
-  writeFileSync(join(pkg, "taskset.py"), `import json\nfrom pathlib import Path\nimport verifiers.v1 as vf\nfrom understudy_trace_env.servers.world import WorldState, WorldToolset, _arguments_match, _tokens\n\nROWS = json.loads((Path(__file__).parent / \"tasks.json\").read_text())\n\n\ndef _value_present(value, hay: str) -> bool:\n    \"\"\"Token-normalized value containment — the same canonicalization _arguments_match uses.\"\"\"\n    toks = _tokens(value)\n    return bool(toks) and all(t in hay for t in toks)\n\n\ndef _final_text(trace) -> str:\n    \"\"\"Last assistant text of the rollout (the final response the contract's response/value obligations judge).\"\"\"\n    for attr in (\"messages\", \"completion\", \"history\"):\n        msgs = getattr(trace, attr, None)\n        if isinstance(msgs, list) and msgs:\n            texts = []\n            for m in msgs:\n                if isinstance(m, dict) and m.get(\"role\") == \"assistant\":\n                    c = m.get(\"content\")\n                    if isinstance(c, str):\n                        texts.append(c)\n                    elif isinstance(c, list):\n                        texts.extend(str(b.get(\"text\") or \"\") for b in c if isinstance(b, dict) and b.get(\"type\") == \"text\")\n            if texts:\n                return texts[-1]\n    return str(getattr(trace, \"final_response\", \"\") or \"\")\n\n\ndef _parsed_json(text: str):\n    t = (text or \"\").strip()\n    if not t.startswith((\"{\", \"[\")):\n        return None\n    try:\n        return json.loads(t)\n    except Exception:\n        return None\n\n\ndef _entry_met(rule: dict, calls: list, final_text: str) -> bool:\n    \"\"\"Deterministic met/unmet per contract entry kind: state_effect,\n    read_obligation, value_propagation, response_obligation. Mirrors the\n    foundry's contractEntryMet exactly — never an LLM at eval time.\"\"\"\n    kind = rule.get(\"type\") or \"state_effect\"\n    if kind == \"state_effect\":\n        return any(c.get(\"tool\") == rule.get(\"tool\") and _arguments_match(rule.get(\"observed_arguments\") or {}, c.get(\"arguments\") or {}) for c in calls)\n    if kind == \"read_obligation\":\n        return any(c.get(\"tool\") == rule.get(\"tool\") and _arguments_match(rule.get(\"arguments_semantic\") or {}, c.get(\"arguments\") or {}) for c in calls)\n    if kind == \"value_propagation\":\n        dest = rule.get(\"must_reach\") or {}\n        if dest.get(\"kind\") == \"final_response\":\n            return _value_present(rule.get(\"value\"), (final_text or \"\").lower())\n        return any((not dest.get(\"tool\") or c.get(\"tool\") == dest.get(\"tool\")) and _value_present(rule.get(\"value\"), json.dumps(c.get(\"arguments\") or {}).lower()) for c in calls)\n    if kind == \"response_obligation\":\n        parsed = _parsed_json(final_text)\n        if rule.get(\"kind\") == \"json_parses\":\n            return parsed is not None\n        if rule.get(\"kind\") == \"schema_valid\":\n            return isinstance(parsed, dict) and all(str(k) in parsed for k in (rule.get(\"expected_keys\") or []))\n        if rule.get(\"kind\") == \"contains_category\":\n            return _value_present(rule.get(\"expected\"), (final_text or \"\").lower())\n    return False\n\n\ndef _forbidden_violated(rule: dict, calls: list, final_text: str) -> bool:\n    if (rule.get(\"type\") or \"\") == \"forbidden_value\":\n        hay = (final_text or \"\").lower()\n        return _value_present(rule.get(\"value\"), hay) or any(_value_present(rule.get(\"value\"), json.dumps(c.get(\"arguments\") or {}).lower()) for c in calls)\n    return any(c.get(\"tool\") == rule.get(\"tool\") for c in calls)\n\n\nclass TraceData(vf.TaskData):\n    task_id: str\n    outcome_contract: dict\n    split: str\n\nclass TraceTask(vf.Task[TraceData, WorldState]):\n    @vf.stop\n    async def bounded(self, trace: vf.Trace) -> bool:\n        return trace.num_turns >= 24\n\n    def _effects(self, trace: vf.Trace) -> tuple[int, int, bool]:\n        \"\"\"Full-contract comparison over the per-rollout world state AND the\n        final assistant response: state effects and read obligations match\n        tool events semantically (token-normalized), value propagations and\n        response obligations judge the final response deterministically.\n        Forbidden tools/values are violations.\"\"\"\n        events = list(getattr(trace.state, \"events\", None) or [])\n        writes = list(getattr(trace.state, \"writes\", None) or [])\n        final_text = _final_text(trace)\n        contract = self.data.outcome_contract\n        required = contract.get(\"required\", [])\n        satisfied = sum(1 for rule in required if _entry_met(rule, events, final_text))\n        violated = any(_forbidden_violated(rule, writes, final_text) for rule in contract.get(\"forbidden\", []))\n        return satisfied, len(required), violated\n\n    @vf.reward(weight=1.0)\n    async def final_state(self, trace: vf.Trace) -> float:\n        satisfied, total, violated = self._effects(trace)\n        if violated:\n            return 0.0\n        return float(total > 0 and satisfied == total)\n\n    @vf.metric\n    async def final_state_partial_credit(self, trace: vf.Trace) -> float:\n        satisfied, total, violated = self._effects(trace)\n        return 0.0 if violated else satisfied / max(total, 1)\n\n    async def validate(self, runtime: vf.Runtime) -> bool:\n        required = self.data.outcome_contract.get(\"required\", [])\n        def well_formed(r):\n            kind = r.get(\"type\") or \"state_effect\"\n            if kind == \"state_effect\":\n                return isinstance(r.get(\"tool\"), str) and isinstance(r.get(\"observed_arguments\"), dict)\n            if kind == \"read_obligation\":\n                return isinstance(r.get(\"tool\"), str) and isinstance(r.get(\"arguments_semantic\"), dict)\n            if kind == \"value_propagation\":\n                return bool(r.get(\"value\")) and (r.get(\"must_reach\") or {}).get(\"kind\") in (\"final_response\", \"tool_args\")\n            if kind == \"response_obligation\":\n                return r.get(\"kind\") in (\"json_parses\", \"schema_valid\", \"contains_category\")\n            return False\n        return bool(required) and all(well_formed(r) for r in required)\n\nclass TraceConfig(vf.TasksetConfig):\n    split: str = \"train\"\n    context_variant: str = \"authentic_history\"\n    tools: vf.ToolsetConfig = vf.ToolsetConfig()\n\nclass TraceTaskset(vf.Taskset[TraceTask, TraceConfig]):\n    tools = (WorldToolset,)\n    def load(self) -> list[TraceTask]:\n        return [TraceTask(TraceData(idx=i, task_id=r[\"task_id\"], prompt=r[\"prompt\"], system_prompt=r.get(\"system_prompt\"), outcome_contract=r[\"outcome_contract\"], split=r[\"split\"]), self.config.task) for i, r in enumerate(ROWS) if r[\"split\"] == self.config.split]\n`, { mode: 0o600 });
+  writeFileSync(join(pkg, "servers", "world.py"), `import json\nimport os\nimport re\nimport time\nfrom pathlib import Path\nfrom pydantic import Field\nimport verifiers.v1 as vf\n\n\ndef _tokens(value):\n    text = json.dumps(value, sort_keys=True) if isinstance(value, (dict, list)) else str(value)\n    return [token for token in re.split(r"[^a-z0-9#]+", text.lower()) if len(token) > 2 or token.isdigit()]\n\n\ndef _arguments_match(observed: dict, actual: dict) -> bool:\n    \"\"\"Semantic compare: every content token of each observed value appears in the canonicalized actual arguments.\"\"\"\n    hay = json.dumps(actual or {}, sort_keys=True).lower()\n    return all(token in hay for value in (observed or {}).values() for token in _tokens(value))\n\n\ndef _anchor_arguments(observed: dict, depth: int = 0) -> dict:\n    \"\"\"ANCHOR fields only: numbers, booleans, id-shaped strings (uuid / long alnum / path-like)\n    and short strings (<=6 canonical tokens). Long free text is dropped — requiring token\n    containment of the incumbent's full prose zeroed every honest candidate rollout.\n    Recurses one level into nested dicts; arrays and deeper nesting are dropped too.\"\"\"\n    out = {}\n    for key, value in (observed or {}).items():\n        if isinstance(value, bool) or isinstance(value, (int, float)):\n            out[key] = value\n        elif isinstance(value, str):\n            s = value.strip()\n            no_space = not any(ch.isspace() for ch in s)\n            id_shaped = bool(re.search(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", s, re.I)) or (no_space and (bool(re.search(r"[A-Za-z0-9_-]{16,}", s)) or "/" in s))\n            if id_shaped or len(_tokens(s)) <= 6:\n                out[key] = value\n        elif isinstance(value, dict) and depth < 1:\n            nested = _anchor_arguments(value, depth + 1)\n            if nested:\n                out[key] = nested\n    return out\n\n\n# Live rollout journal: one JSON line per tool call and result, written the\n# moment it happens, gated on UNDERSTUDY_LIVE_JOURNAL (no-op when unset).\n_JOURNAL_PATH = os.environ.get("UNDERSTUDY_LIVE_JOURNAL")\n\n\ndef _journal(entry: dict) -> None:\n    if not _JOURNAL_PATH:\n        return\n    try:\n        fd = os.open(_JOURNAL_PATH, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)\n        with os.fdopen(fd, "a") as fh:\n            fh.write(json.dumps(entry) + "\\\\n")\n    except Exception:\n        pass\n\n\ndef _summary(value, cap: int = 800) -> str:\n    text = value if isinstance(value, str) else json.dumps(value, sort_keys=True)\n    return text if len(text) <= cap else text[: cap - 1] + "…"\n\n\n# Declared tool schemas (captured from the incumbent's requests); tools with\n# no declared schema carry one inferred from observed calls (inferred: true).\nSCHEMAS = json.loads((Path(__file__).parent / "schemas.json").read_text())\n_TYPES = {"string": str, "number": (int, float), "integer": (int, float), "boolean": bool, "object": dict, "array": list}\n\n\ndef _validate(tool: str, arguments: dict) -> str | None:\n    \"\"\"AutomationBench-style call validation: required properties present and\n    basic type checks against the declared (or inferred) schema. Unknown tools\n    are unroutable by construction (only defined tools are exposed).\"\"\"\n    schema = SCHEMAS.get(tool)\n    if schema is None:\n        return f"unknown tool '{tool}'"\n    for key in schema.get("required") or []:\n        if arguments.get(key) is None:\n            return f"missing required field '{key}'"\n    for key, declared in (schema.get("properties") or {}).items():\n        value = arguments.get(key)\n        if value is None:\n            continue\n        expected = _TYPES.get(declared)\n        if expected is None:\n            continue\n        if declared in ("number", "integer") and isinstance(value, bool):\n            return f"field '{key}' must be {declared}"\n        if not isinstance(value, expected):\n            return f"field '{key}' must be {declared}"\n    return None\n\n\nclass WorldState(vf.State):\n    events: list[dict] = Field(default_factory=list)\n    writes: list[dict] = Field(default_factory=list)\n    used_fixtures: list[int] = Field(default_factory=list)\n\nclass WorldToolset(vf.Toolset[vf.ToolsetConfig, WorldState]):\n    TOOL_PREFIX = \"\"\n\n${worldMethods || "    pass"}\n\nif __name__ == \"__main__\":\n    WorldToolset.run()\n`, { mode: 0o600 });
+  writeFileSync(join(pkg, "taskset.py"), `import json\nfrom pathlib import Path\nimport verifiers.v1 as vf\nfrom understudy_trace_env.servers.world import WorldState, WorldToolset, _anchor_arguments, _arguments_match, _tokens\n\nROWS = json.loads((Path(__file__).parent / \"tasks.json\").read_text())\n\n\ndef _value_present(value, hay: str) -> bool:\n    \"\"\"Token-normalized value containment — the same canonicalization _arguments_match uses.\"\"\"\n    toks = _tokens(value)\n    return bool(toks) and all(t in hay for t in toks)\n\n\ndef _final_text(trace) -> str:\n    \"\"\"Last assistant text of the rollout (the final response the contract's response/value obligations judge).\"\"\"\n    for attr in (\"messages\", \"completion\", \"history\"):\n        msgs = getattr(trace, attr, None)\n        if isinstance(msgs, list) and msgs:\n            texts = []\n            for m in msgs:\n                if isinstance(m, dict) and m.get(\"role\") == \"assistant\":\n                    c = m.get(\"content\")\n                    if isinstance(c, str):\n                        texts.append(c)\n                    elif isinstance(c, list):\n                        texts.extend(str(b.get(\"text\") or \"\") for b in c if isinstance(b, dict) and b.get(\"type\") == \"text\")\n            if texts:\n                return texts[-1]\n    return str(getattr(trace, \"final_response\", \"\") or \"\")\n\n\ndef _parsed_json(text: str):\n    t = (text or \"\").strip()\n    if not t.startswith((\"{\", \"[\")):\n        return None\n    try:\n        return json.loads(t)\n    except Exception:\n        return None\n\n\ndef _entry_met(rule: dict, calls: list, final_text: str) -> bool:\n    \"\"\"Deterministic met/unmet per contract entry kind: state_effect,\n    read_obligation, value_propagation, response_obligation. Mirrors the\n    foundry's contractEntryMet exactly — never an LLM at eval time.\"\"\"\n    kind = rule.get(\"type\") or \"state_effect\"\n    # Validation precedes matching: rejected calls (status=error) never satisfy anything.\n    calls = [c for c in calls if c.get(\"status\") != \"error\"]\n    if kind == \"state_effect\":\n        # Anchor matching: authored arguments_semantic first, then the discrete\n        # anchors of the observed arguments (long prose dropped). Zero anchors +\n        # no semantics => the tool call itself (with any args) satisfies.\n        sem = _anchor_arguments(rule.get(\"arguments_semantic\") or {})\n        anchors = _anchor_arguments(rule.get(\"observed_arguments\") or {})\n        for c in calls:\n            if c.get(\"tool\") != rule.get(\"tool\"):\n                continue\n            if sem and _arguments_match(sem, c.get(\"arguments\") or {}):\n                return True\n            if _arguments_match(anchors, c.get(\"arguments\") or {}):\n                return True\n        return False\n    if kind == \"read_obligation\":\n        return any(c.get(\"tool\") == rule.get(\"tool\") and _arguments_match(_anchor_arguments(rule.get(\"arguments_semantic\") or {}), c.get(\"arguments\") or {}) for c in calls)\n    if kind == \"value_propagation\":\n        dest = rule.get(\"must_reach\") or {}\n        if dest.get(\"kind\") == \"final_response\":\n            return _value_present(rule.get(\"value\"), (final_text or \"\").lower())\n        return any((not dest.get(\"tool\") or c.get(\"tool\") == dest.get(\"tool\")) and _value_present(rule.get(\"value\"), json.dumps(c.get(\"arguments\") or {}).lower()) for c in calls)\n    if kind == \"response_obligation\":\n        parsed = _parsed_json(final_text)\n        if rule.get(\"kind\") == \"json_parses\":\n            return parsed is not None\n        if rule.get(\"kind\") == \"schema_valid\":\n            return isinstance(parsed, dict) and all(str(k) in parsed for k in (rule.get(\"expected_keys\") or []))\n        if rule.get(\"kind\") == \"contains_category\":\n            return _value_present(rule.get(\"expected\"), (final_text or \"\").lower())\n    return False\n\n\ndef _forbidden_violated(rule: dict, calls: list, final_text: str) -> bool:\n    if (rule.get(\"type\") or \"\") == \"forbidden_value\":\n        hay = (final_text or \"\").lower()\n        return _value_present(rule.get(\"value\"), hay) or any(_value_present(rule.get(\"value\"), json.dumps(c.get(\"arguments\") or {}).lower()) for c in calls)\n    return any(c.get(\"tool\") == rule.get(\"tool\") for c in calls)\n\n\nclass TraceData(vf.TaskData):\n    task_id: str\n    outcome_contract: dict\n    split: str\n\nclass TraceTask(vf.Task[TraceData, WorldState]):\n    @vf.stop\n    async def bounded(self, trace: vf.Trace) -> bool:\n        return trace.num_turns >= 24\n\n    def _effects(self, trace: vf.Trace) -> tuple[int, int, bool]:\n        \"\"\"Full-contract comparison over the per-rollout world state AND the\n        final assistant response: state effects and read obligations match\n        tool events semantically (token-normalized), value propagations and\n        response obligations judge the final response deterministically.\n        Forbidden tools/values are violations.\"\"\"\n        events = list(getattr(trace.state, \"events\", None) or [])\n        writes = list(getattr(trace.state, \"writes\", None) or [])\n        final_text = _final_text(trace)\n        contract = self.data.outcome_contract\n        required = contract.get(\"required\", [])\n        satisfied = sum(1 for rule in required if _entry_met(rule, events, final_text))\n        violated = any(_forbidden_violated(rule, writes, final_text) for rule in contract.get(\"forbidden\", []))\n        return satisfied, len(required), violated\n\n    @vf.reward(weight=1.0)\n    async def final_state(self, trace: vf.Trace) -> float:\n        satisfied, total, violated = self._effects(trace)\n        if violated:\n            return 0.0\n        return float(total > 0 and satisfied == total)\n\n    @vf.metric\n    async def final_state_partial_credit(self, trace: vf.Trace) -> float:\n        satisfied, total, violated = self._effects(trace)\n        return 0.0 if violated else satisfied / max(total, 1)\n\n    async def validate(self, runtime: vf.Runtime) -> bool:\n        required = self.data.outcome_contract.get(\"required\", [])\n        def well_formed(r):\n            kind = r.get(\"type\") or \"state_effect\"\n            if kind == \"state_effect\":\n                return isinstance(r.get(\"tool\"), str) and isinstance(r.get(\"observed_arguments\"), dict)\n            if kind == \"read_obligation\":\n                return isinstance(r.get(\"tool\"), str) and isinstance(r.get(\"arguments_semantic\"), dict)\n            if kind == \"value_propagation\":\n                return bool(r.get(\"value\")) and (r.get(\"must_reach\") or {}).get(\"kind\") in (\"final_response\", \"tool_args\")\n            if kind == \"response_obligation\":\n                return r.get(\"kind\") in (\"json_parses\", \"schema_valid\", \"contains_category\")\n            return False\n        return bool(required) and all(well_formed(r) for r in required)\n\nclass TraceConfig(vf.TasksetConfig):\n    split: str = \"train\"\n    context_variant: str = \"authentic_history\"\n    tools: vf.ToolsetConfig = vf.ToolsetConfig()\n\nclass TraceTaskset(vf.Taskset[TraceTask, TraceConfig]):\n    tools = (WorldToolset,)\n    def load(self) -> list[TraceTask]:\n        return [TraceTask(TraceData(idx=i, task_id=r[\"task_id\"], prompt=r[\"prompt\"], system_prompt=r.get(\"system_prompt\"), outcome_contract=r[\"outcome_contract\"], split=r[\"split\"]), self.config.task) for i, r in enumerate(ROWS) if r[\"split\"] == self.config.split]\n`, { mode: 0o600 });
   writeFileSync(join(pkg, "environment.py"), `import verifiers.v1 as vf\nfrom understudy_trace_env.taskset import TraceConfig, TraceTaskset\n\nclass TraceHarnessConfig(vf.HarnessConfig):\n    max_turns: int = 24\n\nclass TraceHarness(vf.Harness[TraceHarnessConfig]):\n    pass\n\ndef load_taskset(config: TraceConfig) -> TraceTaskset:\n    return TraceTaskset(config=config)\n\ndef load_harness(config: TraceHarnessConfig) -> TraceHarness:\n    return TraceHarness(config=config)\n\ndef load_environment(config: vf.EnvConfig) -> vf.Env:\n    return vf.Env(taskset=vf.load_taskset(config.taskset), harness=vf.load_harness(config.harness))\n`, { mode: 0o600 });
   writeFileSync(join(pkg, "__init__.py"), "from understudy_trace_env.environment import load_environment, load_harness, load_taskset\nfrom understudy_trace_env.taskset import TraceTaskset\n\n__all__ = [\"TraceTaskset\", \"load_environment\", \"load_harness\", \"load_taskset\"]\n", { mode: 0o600 });
   writeFileSync(join(servers, "__init__.py"), "", { mode: 0o600 });
@@ -985,7 +1141,23 @@ export function regenerateEnvironment(benchmarkDirInput: string): { path: string
       return [task.task_id, { system: row?.request?.system ?? null, messages: row?.request?.messages ?? [] }] as [string, Obj];
     }),
   );
+  // Judgeability repair for dirs compiled before the guarantee: synthesize
+  // fallback rubrics for any empty-contract task from its group's fullest
+  // capture, and persist the enriched tasks.jsonl.
+  let repaired = 0;
+  for (const task of tasks) {
+    if ((asObject(task.outcome_contract).required ?? []).length > 0) continue;
+    const captureKeys = (asObject(task.source).captures ?? []).map((c: Obj) => c.capture_key);
+    const lastRow = [...captureKeys].reverse().map((key: string) => byKey.get(key)).find(Boolean);
+    const firstUser = (lastRow?.request?.messages ?? []).find((m: Obj) => m.role === "user");
+    const promptText = typeof firstUser?.content === "string" ? firstUser.content : JSON.stringify(firstUser?.content ?? "");
+    if (ensureJudgeableContract(task, finalResponseText(asObject(lastRow?.response)), promptText)) {
+      task.task_hash = hash({ title: task.title, tools: task.tool_surface, contract: task.outcome_contract, source: task.source });
+      repaired += 1;
+    }
+  }
+  if (repaired > 0) writeJsonl(join(output, "tasks.jsonl"), tasks);
   const environment = writeVerifiersEnvironment(output, tasks, sourceContext, "cb9c84969186f8a0954b1027320f225e6b6b0afb");
   refreshOfflineValidation(output, tasks);
-  return { path: String(environment.path), oracle_pass: Boolean(environment.oracle_pass), sentinel_pass: Boolean(environment.sentinel_pass) };
+  return { path: String(environment.path), oracle_pass: Boolean(environment.oracle_pass), sentinel_pass: Boolean(environment.sentinel_pass), repaired_empty_contracts: repaired } as { path: string; oracle_pass: boolean; sentinel_pass: boolean };
 }

--- a/tests/run-executor.test.mjs
+++ b/tests/run-executor.test.mjs
@@ -248,3 +248,40 @@ describe("projectVerifiersTrace (golden fixture from a real pinned-commit eval r
     assert.deepEqual(result.writes.map((w) => w.tool), ["create-automation"]);
   });
 });
+
+describe("live journal wiring", () => {
+  it("passes a per-arm journal path to the runner, advertises live on the request file, and clears it at the end", async () => {
+    const { liveJournalPath } = await import("../dist/run-executor.js");
+    const dir = makeBenchmarkDir();
+    const run = queueRun(dir, { models: ["m1"], rollouts_per_task: 1 });
+    const seen = { journalPaths: [], liveSnapshots: [] };
+    const runner = async ({ journalPath }) => {
+      seen.journalPaths.push(journalPath);
+      seen.liveSnapshots.push(readRunRequest(runRequestPath(dir, run.run_id)).live);
+      return { score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [] };
+    };
+    const result = await executeRunRequest(dir, run.run_id, { runner });
+    assert.equal(result.status, "done");
+    assert.equal(result.live, null, "live cleared at terminal state");
+    assert.equal(seen.journalPaths.length, 2);
+    assert.equal(seen.journalPaths[0], liveJournalPath(dir, run.run_id, "m1"));
+    for (const live of seen.liveSnapshots) {
+      assert.equal(live.model, "m1");
+      assert.ok(live.journal.startsWith("runs/live/"), "journal path advertised relative to the benchmark dir");
+      assert.ok(["t1", "t2"].includes(live.task_id));
+    }
+  });
+
+  it("oracle runner journals call+result lines as it executes (zero-cost live proof)", async () => {
+    const dir = makeBenchmarkDir();
+    const run = queueRun(dir, { models: ["oracle-live"], rollouts_per_task: 1 });
+    const result = await executeRunRequest(dir, run.run_id, { runner: oracleRunner() });
+    assert.equal(result.status, "done");
+    const journal = path.join(dir, "runs", "live", `${run.run_id}-oracle-live.jsonl`);
+    assert.ok(fs.existsSync(journal), "journal file written");
+    const lines = fs.readFileSync(journal, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    assert.ok(lines.some((l) => l.kind === "call" && l.write === true));
+    assert.ok(lines.some((l) => l.kind === "result" && l.status === "ok"));
+    assert.equal(lines.length, 4); // 2 tasks × (call + result)
+  });
+});

--- a/tests/trace-author.test.mjs
+++ b/tests/trace-author.test.mjs
@@ -280,7 +280,11 @@ test("authoring context exposes the captured final response as the oracle for ob
   const byKey = new Map(captures.map((row) => [row.capture_key, row]));
   const context = buildAuthoringContext(tasks[0], byKey, 20000);
   assert.match(context.final_response, /external_customer/);
-  assert.equal(tasks[0].outcome_contract.required.length, 0, "tool-less task starts with an EMPTY (unjudgeable) contract");
+  // Judgeability guarantee: the tool-less task starts with a FALLBACK rubric
+  // synthesized from the oracle response (never an empty contract).
+  assert.ok(tasks[0].outcome_contract.required.length > 0, "no task leaves the foundry with an empty contract");
+  assert.ok(tasks[0].outcome_contract.required.every((entry) => entry.provenance === "fallback_minimal"));
+  assert.ok(tasks[0].claims.some((c) => String(c.claim).includes("minimal oracle-response check")));
 });
 
 test("tool-less task: grounded obligations merge into the deterministic contract and become judgeable", async () => {
@@ -288,11 +292,16 @@ test("tool-less task: grounded obligations merge into the deterministic contract
   const run = await authorTasks(output, { model: "fake-model", client: fakeClient(toolLessAuthored), now: new Date("2026-07-21T13:00:00Z") });
   assert.deepEqual(run.grounding, { verified: 1, failed: 0 });
   assert.equal(run.contracts.tasks_extended, 1);
-  assert.equal(run.contracts.merged_obligation_entries, 4);
+  // The fallback rubric already carries json_parses + schema_valid; the
+  // grounded merge adds the entries the fallback couldn't know (dedup by
+  // canonical key keeps the rest).
+  assert.ok(run.contracts.merged_obligation_entries > 0);
   const task = readFileSync(join(output, "tasks.jsonl"), "utf8").split("\n").filter(Boolean).map(JSON.parse)[0];
-  const types = task.outcome_contract.required.map((entry) => entry.type).sort();
-  assert.deepEqual(types, ["response_obligation", "response_obligation", "response_obligation", "value_propagation"]);
-  assert.ok(task.outcome_contract.required.every((entry) => entry.provenance?.grounded === true));
+  const grounded = task.outcome_contract.required.filter((entry) => entry.provenance?.grounded === true);
+  const fallback = task.outcome_contract.required.filter((entry) => entry.provenance === "fallback_minimal");
+  assert.ok(grounded.length > 0 && fallback.length > 0, "grounded obligations merge ON TOP of the fallback rubric");
+  assert.ok(grounded.some((entry) => entry.type === "value_propagation"));
+  assert.ok(grounded.some((entry) => entry.type === "response_obligation" && entry.kind === "contains_category"));
   assert.equal(task.outcome_contract.grading, "final_state_and_obligations");
   // task_hash recomputed to reflect the widened contract
   assert.equal(typeof task.task_hash, "string");
@@ -330,7 +339,10 @@ test("ungroundable obligations fail grounding with recorded violations and merge
   assert.ok(violations.some((v) => v.includes('kind "not_a_kind"')));
   assert.ok(violations.some((v) => v.includes("forbidden_values[0]") && v.includes("contradiction")));
   const task = readFileSync(join(output, "tasks.jsonl"), "utf8").split("\n").filter(Boolean).map(JSON.parse)[0];
-  assert.equal(task.outcome_contract.required.length, 0, "failed grounding merges nothing — deterministic contract stays authoritative");
+  // Failed grounding merges nothing: the contract keeps ONLY the synthesized
+  // fallback rubric (deterministic authority), no grounded entries.
+  assert.ok(task.outcome_contract.required.length > 0, "fallback rubric stays — never an empty contract");
+  assert.ok(task.outcome_contract.required.every((entry) => entry.provenance === "fallback_minimal"));
 });
 
 test("grounding unit: read obligations and tool_args value propagation verify against observed evidence", async () => {

--- a/tests/trace-foundry.test.mjs
+++ b/tests/trace-foundry.test.mjs
@@ -430,3 +430,91 @@ test("fixtures with bare JSON booleans generate valid Python (fixtures.json side
   const fixtures = JSON.parse(readFileSync(join(output, "environment", "understudy_trace_env", "servers", "fixtures.json"), "utf8"));
   assert.ok(fixtures.some((f) => f.tool === "get-record"));
 });
+
+test("anchorArguments keeps ids/numbers/short values and drops prose", async () => {
+  const { anchorArguments, stateEffectMet } = await import("../dist/trace-foundry.js");
+  const anchors = anchorArguments({
+    conversationId: "1980f239-2073-4231-9d5c-3174fe334214",
+    path: "deals/2026/summary.md",
+    count: 3,
+    enabled: true,
+    stage: "closed won",
+    body: "Hey team, great chatting today! Quick recap of everything we discussed on the call about the renewal and the follow-ups we promised to send over…",
+    nested: { dealId: "d-12345678901234567890", notes: "a very long free text paragraph that should absolutely not be required for a match to succeed here" },
+  });
+  assert.deepEqual(Object.keys(anchors).sort(), ["conversationId", "count", "enabled", "nested", "path", "stage"]);
+  assert.deepEqual(Object.keys(anchors.nested), ["dealId"]);
+
+  // met/unmet under the anchor rule: right tool + right anchors + candidate's OWN prose = met.
+  const rule = { type: "state_effect", tool: "write-document", observed_arguments: { conversationId: "1980f239-2073-4231-9d5c-3174fe334214", content: "the incumbent's entire original document body, hundreds of words long..." } };
+  assert.equal(stateEffectMet(rule, { tool: "write-document", arguments: { conversationId: "1980f239-2073-4231-9d5c-3174fe334214", content: "a DIFFERENT but perfectly good document" } }), true, "candidate prose no longer blocks the match");
+  assert.equal(stateEffectMet(rule, { tool: "write-document", arguments: { conversationId: "wrong-conversation" } }), false, "anchor mismatch still fails");
+  assert.equal(stateEffectMet(rule, { tool: "update-record", arguments: {} }), false, "tool mismatch fails");
+  // Authored arguments_semantic wins when present.
+  const authoredRule = { ...rule, arguments_semantic: { conversationId: "1980f239-2073-4231-9d5c-3174fe334214" } };
+  assert.equal(stateEffectMet(authoredRule, { tool: "write-document", arguments: { conversationId: "1980f239-2073-4231-9d5c-3174fe334214" } }), true);
+  // Zero anchors + no semantics => tool call with any args suffices (documented).
+  const proseOnly = { type: "state_effect", tool: "send-email", observed_arguments: { body: "long free text only, nothing discrete in here at all beyond ordinary words" } };
+  assert.equal(stateEffectMet(proseOnly, { tool: "send-email", arguments: { anything: 1 } }), true);
+});
+
+test("wrong_value sentinel corrupts anchors (or the tool when there are none) — the gate still discriminates", async () => {
+  const { offlineValidationRow } = await import("../dist/trace-foundry.js");
+  const anchored = offlineValidationRow({ task_id: "t-anchored", outcome_contract: { required: [{ type: "state_effect", tool: "update-record", observed_arguments: { id: "record-12345678901234567", note: "long prose here that anchors ignore entirely for the match" } }], forbidden: [], grading: "g" } });
+  assert.equal(anchored.oracle.strict, 1);
+  assert.equal(anchored.sentinels.noop.strict, 0);
+  assert.equal(anchored.sentinels.wrong_value.strict, 0);
+  const proseOnly = offlineValidationRow({ task_id: "t-prose", outcome_contract: { required: [{ type: "state_effect", tool: "send-email", observed_arguments: { body: "only long free text in the observed arguments of this call" } }], forbidden: [], grading: "g" } });
+  assert.equal(proseOnly.oracle.strict, 1);
+  assert.equal(proseOnly.sentinels.wrong_value.strict, 0, "tool corrupted when no anchors exist");
+});
+
+test("rejected calls (status=error) never satisfy contract entries", async () => {
+  const { contractEntryMet } = await import("../dist/trace-foundry.js");
+  const rule = { type: "state_effect", tool: "update-record", observed_arguments: { id: 7 } };
+  assert.equal(contractEntryMet(rule, { calls: [{ tool: "update-record", arguments: { id: 7 }, status: "error" }] }), false);
+  assert.equal(contractEntryMet(rule, { calls: [{ tool: "update-record", arguments: { id: 7 } }] }), true);
+});
+
+test("empty contract is not judgeable: no vacuous 100%s from either scorer entrypoint", async () => {
+  const { scoreState, scoreContract } = await import("../dist/trace-foundry.js");
+  const empty = { task_id: "t", outcome_contract: { required: [], forbidden: [], grading: "g" } };
+  const s1 = scoreState(empty, []);
+  assert.equal(s1.judgeable, false);
+  assert.equal(s1.recall, null);
+  assert.equal(s1.score, null);
+  const s2 = scoreContract(empty, { calls: [], finalResponse: "" });
+  assert.equal(s2.judgeable, false);
+  assert.equal(s2.recall, null);
+});
+
+test("generated world validates calls against declared/inferred schemas and journals live", () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-foundry-validate-")), source = join(root, "captures"), output = join(root, "out"); mkdirSync(source, { recursive: true });
+  writeFileSync(join(source, "one.json"), JSON.stringify(capture("one", "2026-07-20T00:00:00Z", [{ role: "user", content: "Create it" }], { content: [{ type: "tool_use", id: "x", name: "update-record", input: { id: 1, status: "active" } }] })));
+  compileTraceFoundry(source, output, 3, new Date("2026-07-21T00:00:00Z"));
+  const world = readFileSync(join(output, "environment", "understudy_trace_env", "servers", "world.py"), "utf8");
+  assert.match(world, /def _validate\(/, "schema validation gate exists");
+  assert.match(world, /SCHEMAS = json\.loads/, "schemas load from the sidecar");
+  assert.match(world, /missing required field/, "AutomationBench-style rejection payloads");
+  assert.match(world, /UNDERSTUDY_LIVE_JOURNAL/, "live journal is env-gated");
+  assert.match(world, /def _accept\(/, "every tool routes through the validating, journaling acceptor");
+  assert.match(world, /self\._accept\(/);
+  const schemas = JSON.parse(readFileSync(join(output, "environment", "understudy_trace_env", "servers", "schemas.json"), "utf8"));
+  assert.ok(schemas["update-record"], "contract tool has a schema");
+  assert.equal(schemas["update-record"].inferred, true, "observed-only tools get an inferred schema");
+  assert.ok(schemas["update-record"].required.includes("id"));
+  // taskset filters rejected events before matching
+  const taskset = readFileSync(join(output, "environment", "understudy_trace_env", "taskset.py"), "utf8");
+  assert.match(taskset, /status.*!= .error./, "invalid calls never satisfy contract entries");
+  assert.match(taskset, /_anchor_arguments/, "python scorer uses the same anchor rule");
+});
+
+test("fallback rubric synthesis: structured and unstructured oracle responses", async () => {
+  const { fallbackRubricEntries } = await import("../dist/trace-foundry.js");
+  const structured = fallbackRubricEntries('{"status": "created", "automation_id": "auto-1"}', "req-1");
+  assert.deepEqual(structured.map((e) => e.kind), ["json_parses", "schema_valid"]);
+  assert.ok(structured.every((e) => e.provenance === "fallback_minimal"));
+  const unstructured = fallbackRubricEntries("Done — created automation auto-33019284756102 for request req-8021847362514908.", "please handle request req-8021847362514908");
+  assert.ok(unstructured.length > 0);
+  assert.ok(unstructured.every((e) => e.provenance === "fallback_minimal"));
+});


### PR DESCRIPTION
Anchor-based state-effect matching (both scorers), world-model schema validation of tool calls, the judgeability guarantee (fallback rubrics — empty contracts unreachable), authoring escalation, and tool-call-level live rollout watching (journal + /api/runs/live + LIVE arm in the Replay tab).

Proof on cedar-automation: regenerate-env repaired 2 empty contracts (sentinel_pass → true); real gemma re-run on task-544005901ca52894 went 0/4 → 2/4 met (partial 0.5) with a 12.9KB live journal written during the rollout.

Suites: repo 663 pass (1 pre-existing /tmp-realpath installer failure), hub 115 pass, validate-public-skills ok. Headless-browser check on index/benchmark/task/Replay pages: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->