### PR TITLE
Add ABC benchmark-rigor checkpoints to eval skills

### DIFF
--- a/docs/benchmark-rigor.md
+++ b/docs/benchmark-rigor.md
@@ -1,0 +1,62 @@
+# Benchmark rigor: the ABC mapping
+
+How the Understudy evidence loop satisfies the **Agentic Benchmark Checklist
+(ABC)** from [uiuc-kang-lab/agentic-benchmarks](https://github.com/uiuc-kang-lab/agentic-benchmarks),
+and where it still falls short. ABC organizes benchmark rigor into three
+dimensions — **outcome validity** (the success signal genuinely means
+success), **task validity** (a task is solvable iff the capability exists),
+and **reporting** (results are reproducible and honestly qualified). Its
+canonical failure cases motivate several checkpoints below: a do-nothing
+agent scores 38% on tau-bench, SWE-Lancer agents read protected answer files,
+and WebArena's string-matching validators were exploitable.
+
+## Outcome validity
+
+| ABC item | Understudy mechanism |
+| --- | --- |
+| Success signal genuinely means success (no string-match exploits) | Final-state validators score *what got written*, not trajectory or string match ([`skills/design-simulated-environment/SKILL.md`](../skills/design-simulated-environment/SKILL.md)); schema pass is kept separate from quality pass, with verbatim-evidence and conditional-required grounding checks ([`skills/capture-evidence/SKILL.md`](../skills/capture-evidence/SKILL.md)) |
+| Resist reward hacking | Reward-hacking sentinels: no-op, wrong-values, and metric-gaming runs must all score near 0; precision and forbidden-write axes keep recall un-gameable ([`skills/design-simulated-environment/SKILL.md`](../skills/design-simulated-environment/SKILL.md) → Validator quality gates) |
+| Resist guessing | Contract-complexity guidance: multiple required keys/values plus forbidden writes, never a single boolean obligation (design-simulated-environment → Environment rigor checklist) |
+| Judge validity | LLM judges are position-debiased with swapped two-pass scoring; human-review packets are blind and order-randomized (capture-evidence → metric kinds) |
+
+## Task validity
+
+| ABC item | Understudy mechanism |
+| --- | --- |
+| Every task verified solvable; oracle solver exists | Scripted oracle must score 1.0 before any model score is trusted (design-simulated-environment recipe step 5 and rigor checklist) |
+| Agent isolated from ground truth | Gold-leakage audit: gold answers must not be reachable from seeded fixtures, tool results, or read calls (design-simulated-environment → Environment rigor checklist); frozen splits with sealed holdout and hash-bound artifacts ([`skills/optimize-workload/SKILL.md`](../skills/optimize-workload/SKILL.md) → Refusal Gate, Split Rules); contamination-safe selection in [`skills/curate-trajectories/SKILL.md`](../skills/curate-trajectories/SKILL.md) |
+| No residual state between runs | State isolation between rollouts: fresh deep copy of seeded state, back-to-back and order-shuffled reruns must match (design-simulated-environment → Environment rigor checklist); state contracts and reset/seed recording in agentic harnesses |
+| Tool/dependency versions pinned | `environment.json` records runtimes, lockfile status, and routes (capture-evidence); the verifiers generator is pinned to an audited upstream commit (design-simulated-environment) |
+
+## Reporting
+
+| ABC item | Understudy mechanism |
+| --- | --- |
+| Open, reproducible harness | Local auditable artifacts (`harness.json`, `metric.json`, `splits.json`, `baseline.json`) with provenance and SHA-256 hash chains; per-row `understudy.eval_result.v1` evidence |
+| Contamination prevention & update plan | Frozen splits with deterministic seeds/row ids and a "no holdout mutation" contract; contaminated results are marked and require a new split contract |
+| Trivial-agent (null) baselines | Trivial-agent floor recorded in `baseline.json` as `null_floor`; a claim is invalid if the do-nothing agent also clears the bar (capture-evidence step 7; claim rules in optimize-workload and ramp-and-verify) |
+| Confidence intervals | Bootstrap CIs over per-task scores; overlapping CIs are reported as a tie, never a winner ([`skills/compare-model-sweep/SKILL.md`](../skills/compare-model-sweep/SKILL.md) step 6; optimize-workload claim rules) |
+| Non-AI baselines | Incumbent baseline is always rerun on the frozen harness before any candidate claim; deterministic/scripted baselines are encouraged where the workload has one |
+| Flaw discussion | Claim packets require caveats, coverage matrices, uncovered strata, and counterexample review before any conclusion |
+
+## Current gaps (in progress)
+
+Honest accounting — these ABC items are specified in the skills but not yet
+enforced by tooling:
+
+- **Null-agent arm** — the do-nothing floor run is a documented requirement,
+  not yet an automatic arm in the CLI harnesses or `understudy traces
+  build-benchmark` output. In progress.
+- **Gold-leakage audit** — currently a manual grep/checklist step; no
+  automated scanner walks the reachable synthetic state for gold
+  keys/values. In progress.
+- **Confidence intervals** — bootstrap CIs are required by the sweep and
+  claim contracts but computed ad hoc; `summary.csv` and `claim.json` have no
+  enforced CI fields yet. In progress.
+- **Rigor report** — there is no single generated artifact attesting which
+  ABC checkpoints a given benchmark passed (oracle score, null floor,
+  leakage audit, isolation rerun). Planned as a companion to the canonical
+  benchmark manifest. In progress.
+
+When a gap matters for a decision, run the manual checkpoint from the
+relevant skill rather than waiting for the tooling.

--- a/skills/capture-evidence/SKILL.md
+++ b/skills/capture-evidence/SKILL.md
@@ -141,6 +141,17 @@ enough provenance for another agent to repeat the step without guessing.
    failure, never a missing value), `status` (`ok`/`error`/`skipped`/`unscored`),
    model, route, cost/tokens/latency when known, and a `provenance` block whose
    `harness_sha256`/`split_sha256` carry the same hash chain as `baseline.json`.
+7. Run the trivial-agent floor.
+   Alongside the incumbent, run a do-nothing agent — empty output, or for
+   agentic workloads an immediate `finish` with no writes — through the same
+   frozen harness, metric, and split, and record its score in `baseline.json`
+   as `null_floor`. This is the Agentic Benchmark Checklist's trivial-agent
+   baseline ([uiuc-kang-lab/agentic-benchmarks](https://github.com/uiuc-kang-lab/agentic-benchmarks));
+   a do-nothing agent scores 38% on tau-bench, so an unmeasured floor makes
+   every downstream number uninterpretable. If the null agent scores above
+   ~5%, the metric or gold set is miscalibrated — fix it before freezing.
+   Every later claim packet cites this floor: a savings or quality claim is
+   invalid if the null agent also clears the bar.
 
 ## Flow
 

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -108,11 +108,23 @@ comparison.
    free-text wording, scorer/rubric errors, labels, and harness/parser failures.
    Scope conclusions to represented coverage strata.
 
-6. **Compute the frontier.** A candidate is dominated when another candidate has
+6. **Quantify uncertainty before ranking.** Point estimates on a small N are
+   not a ranking. For each candidate, compute a bootstrap confidence interval
+   over per-task scores: resample the task rows with replacement (≥1,000
+   resamples), recompute the aggregate, take the 2.5/97.5 percentiles. Report
+   N, the CI, and per-task variance in `summary.csv` alongside the pass rate.
+   **Refuse to declare a winner when the top candidates' CIs overlap** — call
+   it a statistical tie and either expand the frozen row set or pick on the
+   secondary axes (cost, latency) while saying quality is tied. This is the
+   Agentic Benchmark Checklist's reporting bar
+   ([uiuc-kang-lab/agentic-benchmarks](https://github.com/uiuc-kang-lab/agentic-benchmarks));
+   see [`../../docs/benchmark-rigor.md`](../../docs/benchmark-rigor.md).
+
+7. **Compute the frontier.** A candidate is dominated when another candidate has
    equal or better quality and equal or lower cost and latency, with no worse
    error rate or safety result. Write `pareto.json` with dominated reasons.
 
-7. **Report the decision.** Write `report.md` with the top frontier candidates,
+8. **Report the decision.** Write `report.md` with the top frontier candidates,
    the best route for the agreed objective and constraints, and the next action:
    ship route, build retrieval/tooling, run GEPA, climb local model, or use remote.
    Candidate quality cells must come from measured rows or say `not run`;
@@ -156,7 +168,9 @@ next action.
 When the sweep informs a real route decision, also write the report as a
 **decision memo** the developer can paste to their team unedited:
 
-- a results table: candidate, pass rate against the production validator,
+- a results table: candidate, pass rate against the production validator
+  (with its bootstrap CI and N — a "winner" whose CI overlaps the runner-up
+  is reported as a tie),
   total cost, cost per unit of work the business counts (per deal, per ticket,
   per call — not per token), and the cost ratio vs the incumbent;
 - caching basis per row (see step 5) and any other comparability caveats;

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -123,6 +123,39 @@ Two checks beyond the scripted oracle, before any model score is trusted:
   validator separates "right answer" from "parseable in production"
   (implementation in the example env's `smoke.py`).
 
+## Environment rigor checklist (ABC)
+
+Before any cross-model comparison, the environment must pass this checklist,
+adapted from the Agentic Benchmark Checklist
+([uiuc-kang-lab/agentic-benchmarks](https://github.com/uiuc-kang-lab/agentic-benchmarks)).
+Canonical failures it prevents: a do-nothing agent scoring 38% on tau-bench,
+SWE-Lancer agents reading protected answer files, WebArena string-match
+exploits. Full mapping in
+[`../../docs/benchmark-rigor.md`](../../docs/benchmark-rigor.md).
+
+- **Oracle solver exists and scores 1.0.** Every task must be verified
+  solvable by the scripted oracle (recipe step 5) — a task no oracle can
+  complete measures nothing. Record the oracle run alongside the env.
+- **Null-agent floor run.** Run a do-nothing agent (immediately calls
+  `finish`, writes nothing) through the same driver and validator. If it
+  scores above ~5%, the benchmark is miscalibrated: too many obligations are
+  satisfied by default state, or the metric rewards absence. Fix the gold set
+  or the validator before trusting any model score.
+- **Gold-leakage audit.** Confirm the candidate cannot read the expected
+  final state: gold answers must not appear in seeded fixtures, tool results,
+  file listings, error messages, or record fields the read tools can reach.
+  Grep the reachable synthetic state for gold keys/values; anything findable
+  by a read call is a leak.
+- **State isolation between rollouts.** Each rollout must start from a fresh
+  deep copy of the seeded state — no residual writes from a previous run, no
+  shared mutable module-level state, no order dependence. Prove it: run the
+  same task twice back-to-back and once after an unrelated task; scores must
+  match.
+- **Contract complexity.** Single boolean obligations ("did it set the flag")
+  are guessable — a coin-flip agent clears them half the time. Prefer gold
+  states with multiple required keys/values plus forbidden writes, so recall,
+  precision, and policy must all hold at once.
+
 ## Running it as a real `verifiers` env
 
 One env, many uses: the *same* `verifiers` Environment serves eval, RL training,

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -201,7 +201,12 @@ Do not claim savings without:
 baseline contract, plus `baseline_sha256` and the frozen candidate hash. It
 must also include sample size, split used, score delta, latency basis, cost
 basis, price assumptions, request-volume assumption, confidence level, caveats,
-fallback route, and demotion trigger. For an agentic workload, latency and cost
+fallback route, and demotion trigger. Two rigor fields are also required
+(see [`../../docs/benchmark-rigor.md`](../../docs/benchmark-rigor.md)): the
+trivial-agent floor from `baseline.json` (`null_floor` — the claim is invalid
+if a do-nothing agent also clears the bar), and a bootstrap confidence
+interval over per-row holdout scores for both baseline and candidate — if the
+intervals overlap, report an optimization lead, not a win. For an agentic workload, latency and cost
 basis are per-rollout and mandatory, not optional: report the delta in tool-call
 count and end-to-end rollout cost alongside the rubric delta, so a quality gain
 bought with more calls or higher latency is visible rather than hidden.

--- a/skills/ramp-and-verify/SKILL.md
+++ b/skills/ramp-and-verify/SKILL.md
@@ -121,7 +121,12 @@ Keep the incumbent reachable (snapshot retained, rollback tested) for an
 agreed observation window. Then assemble the before/after: incumbent baseline
 vs routed steady-state on quality-from-captures, latency, and cost/call —
 into the claim packet. That packet, not the ramp log, is what any cost or
-quality statement cites.
+quality statement cites. It inherits the claim-packet rigor fields from
+[`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md): the
+trivial-agent floor (the claim is invalid if a do-nothing agent also clears
+the quality bar) and bootstrap confidence intervals on the before/after
+quality delta — an overlap means "no measured regression", never "measured
+improvement" (see [`../../docs/benchmark-rigor.md`](../../docs/benchmark-rigor.md)).
 
 ## Output Standard
 


### PR DESCRIPTION
Weaves checkpoints from the Agentic Benchmark Checklist (ABC, [uiuc-kang-lab/agentic-benchmarks](https://github.com/uiuc-kang-lab/agentic-benchmarks)) into the skills that make claims or build benchmark artifacts. Additive sections in each skill's existing voice — no rewrites, no frontmatter changes, no src/ or apps/ touches.

## Changes

- **skills/design-simulated-environment/SKILL.md** — new "Environment rigor checklist (ABC)" section: oracle solver must score 1.0, null-agent floor run (do-nothing agent scoring >~5% = miscalibrated benchmark), gold-leakage audit of reachable synthetic state, state isolation between rollouts with rerun proofs, contract-complexity guidance (single boolean obligations are guessable).
- **skills/capture-evidence/SKILL.md** — new required check 7: run a trivial-agent (do-nothing) floor through the frozen harness and record it as `null_floor` in `baseline.json`; a savings/quality claim is invalid if the null agent also clears the bar (tau-bench's 38% do-nothing score is the cautionary case).
- **skills/compare-model-sweep/SKILL.md** — new step 6: bootstrap confidence intervals over per-task scores, report N and per-task variance, refuse to declare a winner when CIs overlap (report a tie, expand rows or decide on cost/latency); decision-memo table now carries CI+N.
- **skills/optimize-workload/SKILL.md** — claim rules now require the `null_floor` citation and bootstrap CIs on holdout; overlapping intervals = optimization lead, not a win.
- **skills/ramp-and-verify/SKILL.md** — the after-100% claim packet inherits the same null-floor and CI requirements; CI overlap means "no measured regression", never "measured improvement".
- **docs/benchmark-rigor.md** (new) — maps each ABC item (outcome validity, task validity, reporting) to the Understudy mechanism that satisfies it (oracle runner, state contracts, frozen splits with hash chains, provenance rows) and honestly lists in-progress gaps: automated null-agent arm, leakage scanner, enforced CI fields, and a generated rigor report.

## Testing

- `npm run skills:validate` — ok, 34 public skills.
- `npm test` fails identically (153 failures) on clean `main` in this environment (missing optional runtime deps in `src/`); no delta from this docs/skills-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->