### PR TITLE
Add instrument skill: zero-friction trace-capture on-ramp

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -68,6 +68,14 @@ group it belongs to.
   success criteria — before any model comparison or vibe-check questions are
   written. Single-run tool-call forensics live in its
   [`references/tool-trace-forensics.md`](understand-workload/references/tool-trace-forensics.md).
+- [`instrument`](instrument/SKILL.md) is the zero-friction on-ramp for
+  developers whose app is running but has no traces yet: it detects the
+  provider SDK, redirects it through the Understudy gateway (capture on by
+  default) via env vars with no app-code changes, verifies with a test call
+  that a capture actually landed (`understudy instrument --check` for the
+  local sanity check), and hands off to `ingest-traces`/`capture-evidence`
+  once traces exist. Per-SDK env-var behavior and fallback paths in its
+  [`reference.md`](instrument/reference.md).
 - [`ingest-traces`](ingest-traces/SKILL.md) is the front door for developers
   who arrive with data instead of a harness: it turns existing production
   traces (an object-store bucket, provider log exports, or a gateway capture

--- a/skills/instrument/SKILL.md
+++ b/skills/instrument/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: instrument
+description: Use when a developer's LLM app is running but has NO traces yet and wants capture flowing in about a minute with no code changes — "instrument my app", "start capturing my LLM calls", "I have no traces, get me some", "turn on tracing for my agent". Detects the provider SDK, redirects it through the Understudy gateway (capture on by default) via env vars, verifies a capture actually landed, then hands off to ingest-traces.
+metadata:
+  understudy:
+    mode: interactive
+    safety: auth-gated
+    cli_required: true
+---
+
+# Instrument
+
+[`../ingest-traces/SKILL.md`](../ingest-traces/SKILL.md) and
+[`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md) assume traces
+already exist. This worker is the on-ramp before that: a running app, zero
+traces, and a developer who wants captures flowing **without editing app
+code**. One redirect, one test call, one verified capture — then hand off.
+
+**Say this up front:** "This takes about 5 minutes: ~1 minute to detect your
+SDK, ~2 minutes to sign in if you haven't, ~1 minute to redirect and verify a
+test call. No code changes, and nothing leaves your machine without your
+approval."
+
+## Safety Gates
+
+- **No app-code edits on this path.** The whole point is env-var redirection.
+  If a codebase hardcodes a base URL so env vars cannot work, say so and offer
+  the code-patch recipes in `skills/onboard/` as an explicitly separate,
+  approval-gated step — do not silently edit.
+- **Redirecting traffic through the gateway is an external write of the
+  developer's prompts and completions** (that is what capture *is*). State
+  this plainly and get explicit approval before the first redirected call.
+- Never print, commit, or write `sk_*` values. Use `understudy run -- <cmd>`
+  to inject credentials into the child process only (see
+  [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)).
+- Set redirect env vars in the launch command or the developer's shell
+  session, not in checked-in files. Only write to `.env` if the developer
+  explicitly asks, and never commit it.
+- Do not declare success until a capture is verified to exist (step 4).
+
+## Step 1 — Detect what the app talks to (~1 min)
+
+Inspect the project read-only. Look at `package.json` /
+`requirements.txt` / `pyproject.toml` / lockfiles and grep call sites:
+
+| Found | Provider path |
+| --- | --- |
+| `@anthropic-ai/sdk`, `anthropic` (py) | Anthropic-shape → `ANTHROPIC_BASE_URL` |
+| `openai` (ts/py) | OpenAI-shape → `OPENAI_BASE_URL` |
+| `langchain`, `langchain-openai`, `langchain-anthropic` | Wraps the SDKs above — same env vars apply |
+| `ai` + `@ai-sdk/openai` / `@ai-sdk/anthropic` (Vercel AI SDK) | Usually needs a `baseURL` in the provider factory — check first; env redirect only works if the factory reads the env var |
+| `litellm` | OpenAI-shape → `OPENAI_BASE_URL` or litellm's own base-url config |
+| none of the above / hardcoded `baseURL` | Env redirect will not bite — see the honest fallbacks below |
+
+Per-SDK env-var behavior, base-URL shapes (`/v1` or not), and hardcoded-URL
+detection greps are in [`reference.md`](reference.md).
+
+Also confirm the developer can actually trigger one call: an npm script, a
+CLI invocation, a test, or a curl to their own app. If they cannot, stop —
+there is nothing to capture yet.
+
+## Step 2 — Sign in and pick the project (~2 min, skipped if done)
+
+Reuse the login/key flow in
+[`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md) —
+do not duplicate it here. In short: `understudy status --json`; if not signed
+in, the two-phase `understudy login --email` / `--code` flow; then confirm
+`understudy projects list --json`. Gateway capture is on by default for
+gateway traffic, so no extra capture toggle is needed.
+
+## Step 3 — Redirect with zero code changes
+
+Preferred: run the app (or one test invocation) through the wrapper, which
+injects `UNDERSTUDY_API_KEY` and `UNDERSTUDY_GATEWAY_URL` into the child
+process only, and set the SDK base-URL env var inline:
+
+```sh
+# Anthropic SDK app (note: no trailing /v1 — the SDK appends it)
+ANTHROPIC_BASE_URL="$UNDERSTUDY_GATEWAY_URL" understudy run -- <your app command>
+
+# OpenAI SDK app (OpenAI-shape wants the /v1 suffix)
+OPENAI_BASE_URL="${UNDERSTUDY_GATEWAY_URL:-https://api.understudylabs.com}/v1" \
+  understudy run -- <your app command>
+```
+
+`understudy run` resolves the stored credentials, so inside the child process
+`$UNDERSTUDY_GATEWAY_URL` is set; the SDK's own env var points it there. The
+provider API key env var can stay as-is — the gateway authenticates with the
+Understudy key that `understudy run` injects (see the gateway skill for
+key-header details per shape).
+
+## Step 4 — Verify a trace is actually flowing (do not skip)
+
+Trigger exactly one real call through the app, then confirm the capture
+landed before saying anything succeeded:
+
+```sh
+understudy captures list --json          # newest capture should match the test call
+understudy instrument --check --json     # local sanity: env redirect + capture presence
+```
+
+If `captures list` shows nothing new: check `understudy doctor --hosted`,
+re-grep for a hardcoded `baseURL` shadowing the env var, and confirm the app
+process actually inherited the env (a daemon started earlier did not).
+
+## Honest fallbacks when env redirect cannot work
+
+- **No local capture proxy exists in this CLI today.** There is no
+  `understudy`-served localhost endpoint that records calls and forwards to
+  the provider; do not promise one. The zero-code path is the gateway
+  redirect above.
+- **Hardcoded base URL / unsupported SDK:** offer the code-patch recipes in
+  `skills/onboard/` (`anthropic-typescript.md`, `openai-typescript.md`,
+  `universal-typescript.md`) as an explicit, approved edit — outside this
+  skill's no-code promise.
+- **Developer cannot or will not route through the gateway:** use provider
+  log exports (Anthropic/OpenAI console usage or logging exports, or the
+  app's own request logs) and go straight to
+  [`../ingest-traces/SKILL.md`](../ingest-traces/SKILL.md), which turns a
+  JSONL/CSV export in `.understudy/captures/` into local redacted eval sets.
+
+## Handoff
+
+Once roughly 20–50 captures exist (enough for a first slice), route onward:
+
+- Turn them into local redacted eval sets or profile the spend →
+  [`../ingest-traces/SKILL.md`](../ingest-traces/SKILL.md).
+- Build the measured baseline and frozen splits →
+  [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md).
+
+Report to the developer: what was redirected, how many captures exist, and
+which handoff you chose.

--- a/skills/instrument/reference.md
+++ b/skills/instrument/reference.md
@@ -1,0 +1,75 @@
+# Instrument — reference
+
+Details behind [`SKILL.md`](SKILL.md): per-SDK env-var behavior, base-URL
+shapes, hardcoded-URL detection, and the verification recipe.
+
+## Per-SDK env-var redirect support
+
+The redirect works only when the SDK constructor's base URL defaults to an
+environment variable. Verify against the installed SDK version — do not
+assume.
+
+| SDK | Env var it reads | Base-URL shape |
+| --- | --- | --- |
+| `@anthropic-ai/sdk` (TS) | `ANTHROPIC_BASE_URL` | gateway root, **no** trailing `/v1` (SDK appends `/v1/messages`) |
+| `anthropic` (Python) | `ANTHROPIC_BASE_URL` | same as above |
+| `openai` (TS) | `OPENAI_BASE_URL` | gateway root **plus** `/v1` |
+| `openai` (Python) | `OPENAI_BASE_URL` | gateway root plus `/v1` |
+| `langchain-openai` / `langchain-anthropic` | Delegates to the underlying SDK — the same env vars apply unless the integration passes an explicit `base_url` | as per underlying SDK |
+| Vercel AI SDK (`@ai-sdk/openai`, `@ai-sdk/anthropic`) | Provider factories accept `baseURL`; default-instance env-var pickup varies by version — check `node_modules/@ai-sdk/*/dist` or docs before promising a zero-code redirect | as per shape |
+| `litellm` | `OPENAI_BASE_URL` for OpenAI-shape routes; also `litellm.api_base` / per-call `api_base` | gateway root plus `/v1` |
+
+If the SDK version in the lockfile does not read the env var, this is a
+code-path case: route to the `skills/onboard/` recipes with explicit approval
+instead of claiming zero-code.
+
+## Detecting hardcoded base URLs
+
+An env var loses to an explicit constructor argument. Before redirecting,
+grep the app:
+
+```sh
+grep -rnE 'baseURL|base_url|api\.openai\.com|api\.anthropic\.com|openrouter|api_base' \
+  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.py' \
+  --exclude-dir=node_modules --exclude-dir=.venv .
+```
+
+- A constructor with `baseURL:`/`base_url=` pointing anywhere means the env
+  var is ignored for that client — fallbacks apply.
+- Frameworks that already run behind a router (OpenRouter, Together, a
+  company proxy) need a decision from the developer about which hop to
+  replace; do not stack proxies silently.
+
+## Verification recipe
+
+1. Trigger exactly one call you can recognize (a distinctive prompt string
+   helps).
+2. `understudy captures list --json` — the newest capture's timestamp/model
+   should match the test call. `understudy captures get <request-id>` shows
+   the redacted summary.
+3. `understudy instrument --check --json` — local, no network: reports which
+   redirect env vars are set, whether credentials exist, and whether any
+   local captures are present under `.understudy/captures`.
+4. Only after 2 (or a local file for the log-export path) confirms the trace,
+   tell the developer instrumentation is live.
+
+Common failure modes:
+
+- **Daemonized app started before the env change** — restart it under the
+  redirected env.
+- **Env var set but hardcoded `baseURL` wins** — see the grep above.
+- **Non-streaming request through the gateway times out at the edge** — the
+  gateway requires `stream: true`; see "Always stream gateway inference" in
+  [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+
+## Provider log-export fallback shapes
+
+When the developer will not route traffic, acceptable inputs for
+[`../ingest-traces/SKILL.md`](../ingest-traces/SKILL.md) include:
+
+- Provider console usage/logging exports (JSONL/CSV of historical calls).
+- The app's own request/response logs, if they include prompt + completion
+  (or at least token counts for cost profiling).
+
+Stage files under `.understudy/captures/` (gitignored) and hand off; that
+skill owns redaction and normalization.

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -151,6 +151,11 @@ Identify the developer's current stage and load exactly one:
   harness, traces, metric, splits, or incumbent baseline are missing, ambiguous,
   or stale → [`../capture-evidence/SKILL.md`](../capture-evidence/SKILL.md)
   (also owns repo inspection + eval-harness discovery/build).
+- **App is running but no traces exist yet** — the developer wants capture
+  flowing in minutes with no app-code changes ("instrument my app", "start
+  capturing my LLM calls") → [`../instrument/SKILL.md`](../instrument/SKILL.md)
+  (env-var redirect through the gateway, verified test call, then hands off
+  to `ingest-traces`).
 - **Traces already exist** — a bucket of captures, a provider log export, or
   gateway capture files are in hand and the developer wants them turned into
   local eval sets, profiled for where the spend goes, or triaged in bulk by

--- a/src/commands/instrument.ts
+++ b/src/commands/instrument.ts
@@ -1,0 +1,190 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { Command } from "commander";
+import kleur from "kleur";
+
+import { DEFAULT_GATEWAY_URL } from "../config/defaults.js";
+import { readCredentials } from "../config/credentials.js";
+import { isJsonMode, runAction } from "../internal/output.js";
+
+/**
+ * `understudy instrument --check` — local, no-network sanity check for the
+ * zero-code instrumentation path (skills/instrument/SKILL.md).
+ *
+ * Reports three things:
+ *   - which SDK base-URL redirect env vars are set, and whether they point
+ *     at the active Understudy gateway;
+ *   - whether stored credentials exist (so `understudy run` can inject a key);
+ *   - whether any local captures exist under `.understudy/captures` (or
+ *     `--source`), for the provider-log-import fallback path.
+ *
+ * Exit code 0 when at least one capture path is wired (a redirect env var is
+ * set, or local captures exist); 1 otherwise. Reads only the filesystem and
+ * the process environment — never the network.
+ */
+
+const REDIRECT_ENV_VARS = ["ANTHROPIC_BASE_URL", "OPENAI_BASE_URL"] as const;
+
+interface InstrumentCheckOpts {
+  source?: string;
+  env?: NodeJS.ProcessEnv;
+  json?: boolean;
+}
+
+interface RedirectEnvReport {
+  name: string;
+  value: string | null;
+  points_at_gateway: boolean;
+}
+
+export interface InstrumentCheckReport {
+  ok: boolean;
+  gateway_url: string;
+  gateway_url_source: "env" | "default";
+  redirect_env: RedirectEnvReport[];
+  redirect_wired: boolean;
+  credentials_present: boolean;
+  captures_dir: string;
+  captures_present: boolean;
+  capture_count: number;
+  newest_capture_mtime: string | null;
+  next_step: string;
+}
+
+export function registerInstrumentCommand(program: Command): void {
+  program
+    .command("instrument")
+    .description("Check that capture instrumentation is wired: redirect env vars, credentials, local captures.")
+    .option("--check", "Run the local instrumentation check (the only mode; kept explicit for clarity).")
+    .option("--source <path>", "Local capture directory to check.", ".understudy/captures")
+    .action(async function (this: Command, opts: { source?: string }) {
+      await runAction(this, async () => {
+        process.exitCode = runInstrumentCheck({ source: opts.source, json: isJsonMode(this) });
+      });
+    });
+}
+
+/**
+ * Exported so tests can call it without spinning up a Command tree.
+ * Returns the exit code the caller should use.
+ */
+export function runInstrumentCheck(opts: InstrumentCheckOpts = {}): 0 | 1 {
+  const report = buildInstrumentCheckReport(opts);
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(report)}\n`);
+  } else {
+    printHuman(report);
+  }
+  return report.ok ? 0 : 1;
+}
+
+export function buildInstrumentCheckReport(opts: InstrumentCheckOpts = {}): InstrumentCheckReport {
+  const env = opts.env ?? process.env;
+  const gatewayFromEnv = trimUrl(env.UNDERSTUDY_GATEWAY_URL);
+  const gatewayUrl = gatewayFromEnv ?? DEFAULT_GATEWAY_URL;
+  const gatewayHost = hostOf(gatewayUrl);
+
+  const redirectEnv: RedirectEnvReport[] = REDIRECT_ENV_VARS.map((name) => {
+    const value = trimUrl(env[name]);
+    return {
+      name,
+      value: value ?? null,
+      points_at_gateway: value !== null && gatewayHost !== null && hostOf(value) === gatewayHost,
+    };
+  });
+  const redirectWired = redirectEnv.some((entry) => entry.points_at_gateway);
+
+  const credentialsPresent = (() => {
+    try {
+      return readCredentials() !== null;
+    } catch {
+      return false;
+    }
+  })();
+
+  const capturesDir = opts.source ?? ".understudy/captures";
+  const { count, newestMtime } = scanCaptures(capturesDir);
+
+  const ok = redirectWired || count > 0;
+  return {
+    ok,
+    gateway_url: gatewayUrl,
+    gateway_url_source: gatewayFromEnv ? "env" : "default",
+    redirect_env: redirectEnv,
+    redirect_wired: redirectWired,
+    credentials_present: credentialsPresent,
+    captures_dir: capturesDir,
+    captures_present: count > 0,
+    capture_count: count,
+    newest_capture_mtime: newestMtime,
+    next_step: nextStep(redirectWired, credentialsPresent, count),
+  };
+}
+
+function nextStep(redirectWired: boolean, credentialsPresent: boolean, captureCount: number): string {
+  if (!credentialsPresent && captureCount === 0) {
+    return "Sign in first (understudy login --email you@company.com), then redirect your app: ANTHROPIC_BASE_URL=\"$UNDERSTUDY_GATEWAY_URL\" understudy run -- <your app command>.";
+  }
+  if (!redirectWired && captureCount === 0) {
+    return "Set a redirect env var and make one call: ANTHROPIC_BASE_URL=\"$UNDERSTUDY_GATEWAY_URL\" understudy run -- <your app command>, then verify with understudy captures list --json.";
+  }
+  if (redirectWired && captureCount === 0) {
+    return "Redirect is wired. Trigger one test call, then verify with understudy captures list --json (gateway captures are hosted, not local).";
+  }
+  return "Captures exist. Hand off to skills/ingest-traces to turn them into local eval sets.";
+}
+
+function scanCaptures(dir: string): { count: number; newestMtime: string | null } {
+  if (!existsSync(dir)) {
+    return { count: 0, newestMtime: null };
+  }
+  let count = 0;
+  let newest = 0;
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    let stats;
+    try {
+      stats = statSync(path);
+    } catch {
+      continue;
+    }
+    if (!stats.isFile()) continue;
+    count += 1;
+    if (stats.mtimeMs > newest) newest = stats.mtimeMs;
+  }
+  return { count, newestMtime: newest > 0 ? new Date(newest).toISOString() : null };
+}
+
+function trimUrl(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.replace(/\/+$/, "") : null;
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host || null;
+  } catch {
+    return null;
+  }
+}
+
+function printHuman(report: InstrumentCheckReport): void {
+  const mark = (ok: boolean) => (ok ? kleur.green("ok") : kleur.yellow("--"));
+  process.stdout.write(`${kleur.bold("instrument check")}\n`);
+  process.stdout.write(`  gateway url        ${report.gateway_url} (${report.gateway_url_source})\n`);
+  for (const entry of report.redirect_env) {
+    const detail = entry.value
+      ? entry.points_at_gateway
+        ? `${entry.value} → gateway`
+        : `${entry.value} (not the gateway)`
+      : "unset";
+    process.stdout.write(`  ${mark(entry.points_at_gateway)} ${entry.name.padEnd(18)} ${detail}\n`);
+  }
+  process.stdout.write(`  ${mark(report.credentials_present)} credentials        ${report.credentials_present ? "stored" : "not signed in"}\n`);
+  process.stdout.write(
+    `  ${mark(report.captures_present)} local captures     ${report.capture_count} file(s) in ${report.captures_dir}` +
+      `${report.newest_capture_mtime ? ` (newest ${report.newest_capture_mtime})` : ""}\n`,
+  );
+  process.stdout.write(`\n  next: ${report.next_step}\n`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import { registerTrainingCommand } from "./commands/training.js";
 import { registerSetupCodeCommand } from "./commands/setup-code.js";
 import { registerSetupCommand } from "./commands/setup.js";
 import { registerStatusCommand } from "./commands/status.js";
+import { registerInstrumentCommand } from "./commands/instrument.js";
 import { registerOptimizeWorkloadCommand } from "./commands/optimize-workload.js";
 import { registerWorkloadsCommand } from "./commands/workloads.js";
 import { registerExperimentsCommands, registerNextCommand } from "./commands/experiments.js";
@@ -848,6 +849,7 @@ export function buildProgram(): Command {
   registerLoginCommand(program);
   registerLogoutCommand(program);
   registerStatusCommand(program);
+  registerInstrumentCommand(program);
   registerKeysCommand(program);
   registerModelsCommand(program);
   registerProjectsCommand(program);

--- a/tests/instrument.test.mjs
+++ b/tests/instrument.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+
+const cli = ["node", resolve("dist/bin.js")];
+
+// Strip UNDERSTUDY_*, redirect vars, and FORCE_COLOR so host state cannot
+// leak into spawned CLIs. Each test explicitly sets only what it needs.
+const baseEnv = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([key]) =>
+      !/^UNDERSTUDY_/i.test(key) &&
+      key !== "ANTHROPIC_BASE_URL" &&
+      key !== "OPENAI_BASE_URL" &&
+      key !== "FORCE_COLOR",
+  ),
+);
+
+function runInstrument(args, env = {}) {
+  return spawnSync(cli[0], [cli[1], "instrument", ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: { ...baseEnv, UNDERSTUDY_TELEMETRY: "0", HOME: env.HOME ?? baseEnv.HOME, ...env },
+  });
+}
+
+describe("instrument --check (report logic)", () => {
+  it("reports nothing wired on a clean environment and exits 1", () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-instrument-"));
+    try {
+      const res = runInstrument(["--check", "--json", "--source", join(dir, "captures")], {
+        HOME: dir,
+      });
+      const report = JSON.parse(res.stdout);
+      assert.equal(report.ok, false);
+      assert.equal(res.status, 1);
+      assert.equal(report.redirect_wired, false);
+      assert.equal(report.captures_present, false);
+      assert.equal(report.capture_count, 0);
+      assert.equal(report.gateway_url_source, "default");
+      assert.match(report.next_step, /login|redirect/i);
+      const names = report.redirect_env.map((entry) => entry.name);
+      assert.deepEqual(names, ["ANTHROPIC_BASE_URL", "OPENAI_BASE_URL"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks the redirect wired when a base-URL env var points at the gateway", () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-instrument-"));
+    try {
+      const res = runInstrument(["--check", "--json", "--source", join(dir, "captures")], {
+        HOME: dir,
+        UNDERSTUDY_GATEWAY_URL: "https://gateway.example.test",
+        ANTHROPIC_BASE_URL: "https://gateway.example.test/",
+      });
+      const report = JSON.parse(res.stdout);
+      assert.equal(res.status, 0);
+      assert.equal(report.ok, true);
+      assert.equal(report.redirect_wired, true);
+      assert.equal(report.gateway_url_source, "env");
+      const anthropic = report.redirect_env.find((entry) => entry.name === "ANTHROPIC_BASE_URL");
+      assert.equal(anthropic.points_at_gateway, true);
+      const openai = report.redirect_env.find((entry) => entry.name === "OPENAI_BASE_URL");
+      assert.equal(openai.points_at_gateway, false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat a non-gateway base URL as wired", () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-instrument-"));
+    try {
+      const res = runInstrument(["--check", "--json", "--source", join(dir, "captures")], {
+        HOME: dir,
+        UNDERSTUDY_GATEWAY_URL: "https://gateway.example.test",
+        OPENAI_BASE_URL: "https://api.openai.com/v1",
+      });
+      const report = JSON.parse(res.stdout);
+      assert.equal(report.redirect_wired, false);
+      assert.equal(report.ok, false);
+      assert.equal(res.status, 1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("counts local capture files and points the next step at ingest-traces", () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-instrument-"));
+    try {
+      const captures = join(dir, "captures");
+      mkdirSync(join(captures, "nested"), { recursive: true });
+      writeFileSync(join(captures, "a.jsonl"), '{"ok":true}\n');
+      writeFileSync(join(captures, "b.jsonl"), '{"ok":true}\n');
+      // Directories are not counted as captures.
+      const res = runInstrument(["--check", "--json", "--source", captures], { HOME: dir });
+      const report = JSON.parse(res.stdout);
+      assert.equal(res.status, 0);
+      assert.equal(report.ok, true);
+      assert.equal(report.capture_count, 2);
+      assert.equal(report.captures_present, true);
+      assert.ok(report.newest_capture_mtime);
+      assert.match(report.next_step, /ingest-traces/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints a human-readable report without --json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "understudy-instrument-"));
+    try {
+      const res = runInstrument(["--check", "--source", join(dir, "captures")], { HOME: dir });
+      assert.match(res.stdout, /instrument check/);
+      assert.match(res.stdout, /ANTHROPIC_BASE_URL/);
+      assert.match(res.stdout, /next:/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("instrument skill catalog registration", () => {
+  it("ships a SKILL.md with valid frontmatter and honest scoping", () => {
+    const skill = readFileSync("skills/instrument/SKILL.md", "utf8");
+    assert.match(skill, /^---\nname: instrument\n/);
+    assert.match(skill, /^description: .+/m);
+    // The skill must not promise a local capture proxy the CLI does not ship.
+    assert.match(skill, /No local capture proxy exists/i);
+    // It must verify before declaring success and hand off downstream.
+    assert.match(skill, /understudy captures list --json/);
+    assert.match(skill, /understudy instrument --check/);
+    assert.match(skill, /ingest-traces\/SKILL\.md/);
+    assert.match(skill, /capture-evidence\/SKILL\.md/);
+    assert.match(skill, /use-understudy-gateway\/SKILL\.md/);
+  });
+
+  it("is registered in the authoritative skills index and the orchestrator", () => {
+    const index = readFileSync("skills/README.md", "utf8");
+    assert.match(index, /\[`instrument`\]\(instrument\/SKILL\.md\)/);
+    const orchestrator = readFileSync("skills/understudy/SKILL.md", "utf8");
+    assert.match(orchestrator, /\.\.\/instrument\/SKILL\.md/);
+  });
+
+  it("appears in the CLI skills listing", () => {
+    const res = spawnSync(cli[0], [cli[1], "skills", "--list"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...baseEnv, UNDERSTUDY_TELEMETRY: "0" },
+    });
+    assert.equal(res.status, 0);
+    assert.match(res.stdout, /- instrument \(skills\/instrument\/SKILL\.md\)/);
+  });
+});


### PR DESCRIPTION
## What

Today the ingest path (`skills/ingest-traces`, `skills/capture-evidence`) assumes captures already exist. This adds the missing one-minute path from "my app is running" to "I have traces" — inspired by Raindrop Workshop's `/instrument-agent`.

### New skill: `skills/instrument/`
- States expected time up front (~5 min), detects the provider SDK (Anthropic, OpenAI, LangChain, Vercel AI SDK, litellm) read-only.
- Preferred path: env-var base-URL redirect through the Understudy gateway (capture on by default) via `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` + `understudy run -- <cmd>` — **no app-code changes**. Reuses `use-understudy-gateway`'s login/key flow by reference.
- Honest scoping: the CLI ships **no local capture proxy** today, and the skill says so instead of promising one. Fallbacks: onboard code-patch recipes (explicitly approval-gated, outside the no-code promise) or provider log-export import via `ingest-traces`.
- Verifies a capture actually landed (`understudy captures list --json`) before declaring success; writes nothing external without explicit approval; hands off to `ingest-traces`/`capture-evidence` once traces exist.
- `reference.md`: per-SDK env-var support and `/v1` base-URL shapes, hardcoded-baseURL detection grep, verification recipe, failure modes.

### CLI: `understudy instrument --check`
Local-only, no network (`src/commands/instrument.ts`, registered in `src/index.ts`): reports redirect env vars vs the active gateway host, stored credentials, and local capture presence under `.understudy/captures` (or `--source`), with a concrete `next_step`. Exit 0 when a capture path is wired, 1 otherwise. Follows the `status`/`doctor` command patterns.

### Catalog registration
- `skills/README.md` (authoritative index, Understand & Capture group)
- `skills/understudy/SKILL.md` orchestrator routing ("app running but no traces yet")
- Auto-discovered by `understudy skills --list` (directory scan)

### Tests
`tests/instrument.test.mjs`: 8 tests — check-report logic (clean env, wired redirect, non-gateway URL not counted, capture counting, human output) and catalog registration (frontmatter, honest-scoping sentinel, index/orchestrator/CLI listing). Full suite: **676 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->