### PR TITLE
fix(skills): add missing Resolve CLI section to instrument skill (unbreak main gates)

### DIFF
--- a/skills/instrument/SKILL.md
+++ b/skills/instrument/SKILL.md
@@ -21,6 +21,16 @@ SDK, ~2 minutes to sign in if you haven't, ~1 minute to redirect and verify a
 test call. No code changes, and nothing leaves your machine without your
 approval."
 
+## Resolve CLI
+
+Prefer the installed `understudy` binary. If it is unavailable inside a repo
+checkout, run through the package script:
+
+```sh
+npm run build
+node dist/bin.js instrument --check --json
+```
+
 ## Safety Gates
 
 - **No app-code edits on this path.** The whole point is env-var redirection.


### PR DESCRIPTION
PR #331 shipped skills/instrument with cli_required: true but no `## Resolve CLI` section; scripts/validate-public-skills.mjs fails, so main's gates are red. This adds the standard section. `npm run skills:validate` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->