### PR TITLE
Trivial-agent calibration arms (null/spam) + ABC rigor report

### DIFF
--- a/docs/benchmark-rigor.md
+++ b/docs/benchmark-rigor.md
@@ -39,24 +39,51 @@ and WebArena's string-matching validators were exploitable.
 | Non-AI baselines | Incumbent baseline is always rerun on the frozen harness before any candidate claim; deterministic/scripted baselines are encouraged where the workload has one |
 | Flaw discussion | Claim packets require caveats, coverage matrices, uncovered strata, and counterexample review before any conclusion |
 
+## Trivial calibration arms + the rigor report (tooling)
+
+The run executor now ships the ABC floor discipline directly:
+
+- **Null-agent arm** (`arm_kind: "null_agent"`) — deterministic, zero-cost:
+  makes NO tool calls and answers every task with the same boilerplate final
+  response, scored through the same full-contract scorer as real arms. Any
+  task it passes is satisfiable by doing nothing (the tau-bench 38% class).
+- **Spam-agent arm** (`arm_kind: "spam_agent"`) — deterministically calls
+  every tool in the benchmark's declared tool surface exactly once with
+  schema-minimal arguments (zero values per declared type, first observed
+  enum value; derived from the generated environment's `schemas.json`), then
+  stops. Catches contracts satisfiable by ritual tool calling.
+
+Queue them additively on `understudy.run_request.v1` with
+`trivial_arms: ["null_agent", "spam_agent"]` (omitted = prior shape; old
+readers unaffected). Trivial arms run one rollout per task (repeats of a
+deterministic agent add nothing), their rows are never anomaly-flagged (zero
+tool calls IS the design — the structural sentinels stay model-arm-only), and
+a finished run extends `calibration.json` additively with `null_floor` /
+`spam_floor`: the fraction of selected tasks each arm passes at the
+calibration threshold, with `floor_exceeded: true` plus the offending
+`passed_task_ids` when the floor exceeds 5%.
+
+`understudy benchmarks rigor <dir>` generates `rigor-report.md` in the
+benchmark dir — the ABC attestation artifact: oracle solvability, null/spam
+floors, incumbent calibration, per-task contract complexity (obligation
+counts by kind from `tasks.jsonl`), anomaly counts, and split/contamination
+provenance, derived purely from existing artifacts (no network, no model
+calls). Items it cannot check yet appear as honest UNKNOWN rows.
+
 ## Current gaps (in progress)
 
 Honest accounting — these ABC items are specified in the skills but not yet
 enforced by tooling:
 
-- **Null-agent arm** — the do-nothing floor run is a documented requirement,
-  not yet an automatic arm in the CLI harnesses or `understudy traces
-  build-benchmark` output. In progress.
 - **Gold-leakage audit** — currently a manual grep/checklist step; no
   automated scanner walks the reachable synthetic state for gold
-  keys/values. In progress.
+  keys/values. Reported as UNKNOWN in the rigor report. In progress.
 - **Confidence intervals** — bootstrap CIs are required by the sweep and
   claim contracts but computed ad hoc; `summary.csv` and `claim.json` have no
-  enforced CI fields yet. In progress.
-- **Rigor report** — there is no single generated artifact attesting which
-  ABC checkpoints a given benchmark passed (oracle score, null floor,
-  leakage audit, isolation rerun). Planned as a companion to the canonical
-  benchmark manifest. In progress.
+  enforced CI fields yet. Reported as UNKNOWN in the rigor report. In
+  progress.
+- **Hub display of trivial-arm floors** — `calibration.json` carries the
+  floors, but the benchmark-hub UI does not render them yet. Follow-up.
 
 When a gap matters for a decision, run the manual checkpoint from the
 relevant skill rather than waiting for the tooling.

--- a/src/commands/benchmarks.ts
+++ b/src/commands/benchmarks.ts
@@ -28,4 +28,18 @@ export function registerBenchmarksCommand(program: Command): void {
       const { runBenchmarksMcpServer } = await import("../benchmarks-mcp.js");
       await runBenchmarksMcpServer(options.root);
     });
+
+  benchmarks
+    .command("rigor <dir>")
+    .description(
+      "Generate rigor-report.md in the benchmark dir: ABC checklist (oracle solvability, null/spam trivial-agent " +
+        "floors, incumbent calibration, per-task contract complexity, anomaly counts, split provenance) derived " +
+        "purely from existing artifacts — no network, no model calls",
+    )
+    .action(async (dir: string) => {
+      const { writeRigorReport } = await import("../rigor-report.js");
+      const { path, report } = writeRigorReport(dir);
+      console.error(`wrote ${path}`);
+      console.log(JSON.stringify(report, null, 2));
+    });
 }

--- a/src/rigor-report.ts
+++ b/src/rigor-report.ts
@@ -1,0 +1,280 @@
+/**
+ * rigor-report — the ABC (Agentic Benchmark Checklist) rigor card for one
+ * benchmark directory, motivated by uiuc-kang-lab/agentic-benchmarks: a
+ * do-nothing agent scores 38% on tau-bench, so every benchmark needs its
+ * trivial-agent floors, oracle-solvability, and calibration evidence written
+ * down next to the artifacts.
+ *
+ * Pure derivation: everything is read from the benchmark dir's existing
+ * file-based artifacts (benchmark.json, tasks.jsonl, rows-*.jsonl,
+ * runs/events.jsonl, calibration.json) through the SHARED codecs. No network,
+ * no model calls. Items we cannot check yet (leakage audit, confidence
+ * intervals — being built separately) are reported as honest UNKNOWN rows,
+ * never silently omitted.
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { readJsonlFile, readRunEvents } from "./benchmark-artifacts.js";
+import {
+  DEFAULT_CALIBRATION_THRESHOLD,
+  TRIVIAL_FLOOR_LIMIT,
+  calibrationPath,
+  isAnomalousEvalRow,
+  runEventsPath,
+  type CalibrationSummary,
+  type TrivialArmKind,
+} from "./run-executor.js";
+
+type Obj = Record<string, any>;
+const asObject = (value: unknown): Obj => (value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {});
+
+export type RigorItemStatus = "PASS" | "FLAG" | "UNKNOWN";
+
+export type RigorItem = {
+  item: string;
+  status: RigorItemStatus;
+  value: string;
+  detail: string;
+};
+
+export type TaskComplexity = {
+  task_id: string;
+  split: string;
+  required_total: number;
+  /** Obligation counts by contract entry kind (state_effect, response_obligation, value_propagation, read_obligation). */
+  required_by_kind: Record<string, number>;
+  forbidden: number;
+  preserved: number;
+  anomalous_rows: number;
+};
+
+export type RigorReport = {
+  benchmark_id: string;
+  benchmark_dir: string;
+  generated_at: string;
+  provenance_origin: string;
+  split_counts: Record<string, number>;
+  threshold: number;
+  items: RigorItem[];
+  tasks: TaskComplexity[];
+  anomaly_counts: Record<string, number>;
+  row_counts: { total: number; by_arm_kind: Record<string, number> };
+};
+
+const percent = (fraction: number): string => `${(fraction * 100).toFixed(1)}%`;
+
+function readAllRows(dir: string): Obj[] {
+  let names: string[] = [];
+  try {
+    names = readdirSync(dir).filter((name) => /^rows-.*\.jsonl$/.test(name));
+  } catch {
+    return [];
+  }
+  return names.sort().flatMap((name) => readJsonlFile<Obj>(join(dir, name)).items);
+}
+
+/** Best ok, non-anomalous score per task for rows matching `keep`. */
+function bestScores(rows: Obj[], keep: (row: Obj) => boolean): Map<string, number> {
+  const best = new Map<string, number>();
+  for (const row of rows) {
+    if (!keep(row) || row.status !== "ok" || typeof row.score !== "number" || isAnomalousEvalRow(row)) continue;
+    const taskId = String(row.task_id);
+    best.set(taskId, Math.max(best.get(taskId) ?? -Infinity, Number(row.score)));
+  }
+  return best;
+}
+
+/** Floor item over one trivial arm's rows: fraction of covered tasks passing at the threshold. */
+function floorItem(label: string, kind: TrivialArmKind, rows: Obj[], taskIds: string[], threshold: number): RigorItem {
+  const armRows = rows.filter((row) => String(row.arm_kind ?? "") === kind);
+  if (armRows.length === 0) {
+    return { item: label, status: "UNKNOWN", value: "not run", detail: `no ${kind} rows — queue a run with trivial_arms: ["${kind}"]` };
+  }
+  const best = bestScores(armRows, () => true);
+  const universe = taskIds.length > 0 ? taskIds : [...best.keys()];
+  const passed = universe.filter((taskId) => (best.get(taskId) ?? -Infinity) >= threshold);
+  const floor = universe.length === 0 ? 0 : passed.length / universe.length;
+  const exceeded = floor > TRIVIAL_FLOOR_LIMIT;
+  return {
+    item: label,
+    status: exceeded ? "FLAG" : "PASS",
+    value: `${percent(floor)} (${passed.length}/${universe.length})`,
+    detail: exceeded
+      ? `floor exceeds ${percent(TRIVIAL_FLOOR_LIMIT)} — trivially satisfiable tasks: ${passed.join(", ")}`
+      : `at threshold ${threshold}; limit ${percent(TRIVIAL_FLOOR_LIMIT)}`,
+  };
+}
+
+/** Derive the full rigor report from a benchmark directory's artifacts. Throws on a missing/invalid benchmark.json. */
+export function deriveRigorReport(benchmarkDir: string, now: Date = new Date()): RigorReport {
+  const dir = resolve(benchmarkDir);
+  const manifest = asObject(JSON.parse(readFileSync(join(dir, "benchmark.json"), "utf8")));
+  const manifestTasks = (Array.isArray(manifest.tasks) ? manifest.tasks : []).map(asObject);
+  const taskIds = manifestTasks.map((task) => String(task.task_id));
+  const sidecars = new Map(readJsonlFile<Obj>(join(dir, "tasks.jsonl")).items.map((task) => [String(task.task_id), asObject(task)]));
+  const rows = readAllRows(dir);
+  const events = readRunEvents(runEventsPath(dir)).events;
+  const calibration = existsSync(calibrationPath(dir)) ? (asObject(JSON.parse(readFileSync(calibrationPath(dir), "utf8"))) as Partial<CalibrationSummary>) : null;
+  const threshold = typeof calibration?.threshold === "number" ? calibration.threshold : DEFAULT_CALIBRATION_THRESHOLD;
+
+  // Anomaly counts across every persisted row (marked, never dropped).
+  const anomalyCounts: Record<string, number> = {};
+  const anomalousByTask = new Map<string, number>();
+  for (const row of rows) {
+    if (!isAnomalousEvalRow(row)) continue;
+    anomalousByTask.set(String(row.task_id), (anomalousByTask.get(String(row.task_id)) ?? 0) + 1);
+    for (const anomaly of (Array.isArray(row.anomalies) ? row.anomalies : [row.anomaly]).map(asObject)) {
+      const kind = String(anomaly.kind ?? "unknown");
+      anomalyCounts[kind] = (anomalyCounts[kind] ?? 0) + 1;
+    }
+  }
+
+  const byArmKind: Record<string, number> = {};
+  for (const row of rows) {
+    const kind = String(row.arm_kind ?? "unlabeled");
+    byArmKind[kind] = (byArmKind[kind] ?? 0) + 1;
+  }
+
+  const items: RigorItem[] = [];
+
+  // Oracle solvability: rows produced by the deterministic oracle runner.
+  const oracleBest = bestScores(rows, (row) => Number(asObject(row.subscores).runner_oracle) === 1);
+  if (oracleBest.size === 0) {
+    items.push({ item: "Oracle solver", status: "UNKNOWN", value: "not run", detail: "no oracle-runner rows — run `understudy runs execute --runner oracle`" });
+  } else {
+    const covered = taskIds.filter((taskId) => oracleBest.has(taskId));
+    const passed = covered.filter((taskId) => (oracleBest.get(taskId) ?? 0) >= threshold);
+    const allPass = covered.length > 0 && passed.length === covered.length && covered.length === taskIds.length;
+    items.push({
+      item: "Oracle solver",
+      status: allPass ? "PASS" : "FLAG",
+      value: `${passed.length}/${taskIds.length} tasks pass`,
+      detail: allPass ? "every task is solvable by its own contract oracle" : `oracle-unsolvable or uncovered tasks: ${taskIds.filter((t) => !passed.includes(t)).join(", ") || "(coverage gap)"}`,
+    });
+  }
+
+  items.push(floorItem("Null-agent floor", "null_agent", rows, taskIds, threshold));
+  items.push(floorItem("Spam-agent floor", "spam_agent", rows, taskIds, threshold));
+
+  // Incumbent calibration from the calibration.json sidecar.
+  if (calibration && Array.isArray(calibration.incumbent_models) && calibration.incumbent_models.length > 0) {
+    const failed = Array.isArray(calibration.failed_task_ids) ? calibration.failed_task_ids : [];
+    items.push({
+      item: "Incumbent calibration",
+      status: failed.length === 0 ? "PASS" : "FLAG",
+      value: `${calibration.passed_count ?? 0} passed / ${calibration.failed_count ?? 0} failed @ ${threshold}`,
+      detail: failed.length === 0 ? `incumbent ${calibration.incumbent_models.join(", ")} reproduces every task` : `incumbent-failed (suspect) tasks: ${failed.join(", ")}`,
+    });
+  } else {
+    items.push({ item: "Incumbent calibration", status: "UNKNOWN", value: "not run", detail: "no calibration.json with an incumbent arm — queue a run with incumbent_models" });
+  }
+
+  // Anomaly sentinels summary.
+  const anomalyTotal = Object.values(anomalyCounts).reduce((a, b) => a + b, 0);
+  items.push({
+    item: "Rollout anomalies",
+    status: rows.length === 0 ? "UNKNOWN" : anomalyTotal === 0 ? "PASS" : "FLAG",
+    value: rows.length === 0 ? "no rows" : `${anomalyTotal} flags over ${rows.length} rows`,
+    detail:
+      rows.length === 0
+        ? "no eval rows recorded yet"
+        : anomalyTotal === 0
+          ? "no structural sentinel fired"
+          : Object.entries(anomalyCounts).map(([kind, count]) => `${kind}: ${count}`).join(", "),
+  });
+
+  // Split / contamination provenance (what the artifacts themselves record).
+  const splitCounts: Record<string, number> = {};
+  for (const task of manifestTasks) {
+    const split = String(task.split ?? "none");
+    splitCounts[split] = (splitCounts[split] ?? 0) + 1;
+  }
+  const origin = String(asObject(manifest.provenance).origin ?? "unknown");
+  const hasSplits = Object.keys(splitCounts).some((split) => split !== "none");
+  items.push({
+    item: "Split provenance",
+    status: hasSplits ? "PASS" : "FLAG",
+    value: Object.entries(splitCounts).map(([split, count]) => `${split}: ${count}`).join(", ") || "no tasks",
+    detail: `provenance.origin = ${origin}${hasSplits ? "" : "; no split assignment recorded — holdout discipline unverifiable"}`,
+  });
+
+  // Honest UNKNOWNs: checks this report does not perform (built separately).
+  items.push({ item: "Leakage / contamination audit", status: "UNKNOWN", value: "not checked", detail: "task-content leakage audit is a separate workstream; this report only records split provenance" });
+  items.push({ item: "Confidence intervals", status: "UNKNOWN", value: "not checked", detail: "score CIs / repeated-rollout variance reporting is being built separately" });
+
+  const tasks: TaskComplexity[] = taskIds.map((taskId) => {
+    const manifestTask = manifestTasks.find((task) => String(task.task_id) === taskId) ?? {};
+    const contract = asObject(sidecars.get(taskId)?.outcome_contract);
+    const required = (Array.isArray(contract.required) ? contract.required : []).map(asObject);
+    const byKind: Record<string, number> = {};
+    for (const rule of required) {
+      const kind = String(rule.type ?? "state_effect");
+      byKind[kind] = (byKind[kind] ?? 0) + 1;
+    }
+    return {
+      task_id: taskId,
+      split: String(manifestTask.split ?? "none"),
+      required_total: required.length,
+      required_by_kind: byKind,
+      forbidden: Array.isArray(contract.forbidden) ? contract.forbidden.length : 0,
+      preserved: Array.isArray(contract.preserved) ? contract.preserved.length : 0,
+      anomalous_rows: anomalousByTask.get(taskId) ?? 0,
+    };
+  });
+
+  return {
+    benchmark_id: String(manifest.benchmark_id ?? "unknown"),
+    benchmark_dir: dir,
+    generated_at: now.toISOString(),
+    provenance_origin: origin,
+    split_counts: splitCounts,
+    threshold,
+    items,
+    tasks,
+    anomaly_counts: anomalyCounts,
+    row_counts: { total: rows.length, by_arm_kind: byArmKind },
+  };
+}
+
+/** Render the report as the rigor-report.md the benchmark dir carries. */
+export function renderRigorReport(report: RigorReport): string {
+  const lines: string[] = [];
+  lines.push(`# Benchmark rigor report — ${report.benchmark_id}`);
+  lines.push("");
+  lines.push(`Generated ${report.generated_at} from local artifacts only (no network, no model calls).`);
+  lines.push(`Calibration threshold: ${report.threshold}. Trivial-arm floor limit: ${percent(TRIVIAL_FLOOR_LIMIT)}.`);
+  lines.push("");
+  lines.push("## ABC checklist");
+  lines.push("");
+  lines.push("| Item | Status | Value | Detail |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const item of report.items) {
+    lines.push(`| ${item.item} | ${item.status} | ${item.value} | ${item.detail} |`);
+  }
+  lines.push("");
+  lines.push("## Rows");
+  lines.push("");
+  const armKinds = Object.entries(report.row_counts.by_arm_kind).map(([kind, count]) => `${kind}: ${count}`).join(", ");
+  lines.push(`${report.row_counts.total} eval rows${armKinds ? ` (${armKinds})` : ""}.`);
+  lines.push("");
+  lines.push("## Per-task contract complexity");
+  lines.push("");
+  lines.push("| Task | Split | Required | By kind | Forbidden | Preserved | Anomalous rows |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- |");
+  for (const task of report.tasks) {
+    const byKind = Object.entries(task.required_by_kind).map(([kind, count]) => `${kind}: ${count}`).join(", ") || "—";
+    lines.push(`| ${task.task_id} | ${task.split} | ${task.required_total} | ${byKind} | ${task.forbidden} | ${task.preserved} | ${task.anomalous_rows} |`);
+  }
+  lines.push("");
+  lines.push("UNKNOWN rows are honest gaps, not passes: rerun `understudy benchmarks rigor` after the missing runs/audits exist.");
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** Derive + write <benchmark>/rigor-report.md; returns the written path. */
+export function writeRigorReport(benchmarkDir: string, now: Date = new Date()): { path: string; report: RigorReport } {
+  const report = deriveRigorReport(benchmarkDir, now);
+  const path = join(resolve(benchmarkDir), "rigor-report.md");
+  writeFileSync(path, renderRigorReport(report), { mode: 0o600 });
+  return { path, report };
+}

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -19,7 +19,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renam
 import { createHash } from "node:crypto";
 import { join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import { buildReplayInvocation, isMutatingTool, scoreState } from "./trace-foundry.js";
+import { buildReplayInvocation, isMutatingTool, scoreContract, scoreState } from "./trace-foundry.js";
 import { COST_PER_MTOKEN, resolveGatewayAuth } from "./trace-author.js";
 import { BENCHMARK_PROPOSAL_SCHEMA, BENCHMARK_SCHEMA, CALIBRATION_SCHEMA, EVAL_RESULT_SCHEMA, RUN_EVENT_SCHEMA, appendJournalEntry, readJsonlFile, serializeJsonlLine, serializeRunEvent } from "./benchmark-artifacts.js";
 
@@ -33,11 +33,21 @@ export type RunStatus = (typeof RUN_STATUSES)[number];
 export const RUN_SPLITS = ["train", "dev", "holdout", "all"] as const;
 export type RunSplit = (typeof RUN_SPLITS)[number];
 
-/** Row arm labels: "incumbent" = the model that produced the source captures, rerun; everything else is a "candidate". */
-export const ARM_KINDS = ["incumbent", "candidate"] as const;
+/**
+ * Row arm labels: "incumbent" = the model that produced the source captures,
+ * rerun; "candidate" = any other model arm; "null_agent"/"spam_agent" are the
+ * deterministic trivial calibration arms (extended additively — old readers
+ * only ever see incumbent/candidate on old rows).
+ */
+export const ARM_KINDS = ["incumbent", "candidate", "null_agent", "spam_agent"] as const;
 export type ArmKind = (typeof ARM_KINDS)[number];
+/** The trivial calibration arms (agentic-benchmarks floor discipline: a do-nothing agent must score ~0). */
+export const TRIVIAL_ARM_KINDS = ["null_agent", "spam_agent"] as const;
+export type TrivialArmKind = (typeof TRIVIAL_ARM_KINDS)[number];
 /** Default incumbent-pass threshold on the strict contract score. */
 export const DEFAULT_CALIBRATION_THRESHOLD = 1;
+/** A trivial arm passing more than this fraction of tasks flags the benchmark floor_exceeded. */
+export const TRIVIAL_FLOOR_LIMIT = 0.05;
 
 export type RunRequest = {
   schema_version: typeof RUN_REQUEST_SCHEMA;
@@ -64,6 +74,12 @@ export type RunRequest = {
   incumbent_models?: string[];
   /** Additive: strict-score pass threshold for the incumbent calibration gate (default 1). */
   calibration_threshold?: number;
+  /**
+   * Additive (absent when unused — old readers see the exact prior shape):
+   * trivial calibration arms to run alongside the model arms. Deterministic,
+   * zero-cost, one rollout per task; rows are labeled with the arm kind.
+   */
+  trivial_arms?: TrivialArmKind[];
 };
 
 /** Live journals live under <benchmark>/runs/live/ and stay after the run for replay-scrubbing. */
@@ -132,6 +148,8 @@ export type RunRequestInput = {
   incumbent_models?: unknown;
   /** Optional (additive): calibration pass threshold in (0, 1]. */
   calibration_threshold?: unknown;
+  /** Optional (additive): trivial calibration arms ("null_agent" / "spam_agent"). */
+  trivial_arms?: unknown;
 };
 
 export const MAX_MODELS_PER_RUN = 8;
@@ -179,13 +197,21 @@ export function validateRunRequestInput(input: RunRequestInput, knownTaskIds: st
   if (threshold !== undefined && (typeof threshold !== "number" || !Number.isFinite(threshold) || threshold <= 0 || threshold > 1)) {
     errors.push("calibration_threshold must be a number in (0, 1]");
   }
+  const trivial = input.trivial_arms;
+  if (trivial !== undefined) {
+    if (!Array.isArray(trivial) || !trivial.every((kind) => TRIVIAL_ARM_KINDS.includes(kind as TrivialArmKind))) {
+      errors.push(`trivial_arms must be an array of ${TRIVIAL_ARM_KINDS.join(" / ")}`);
+    } else if (new Set(trivial).size !== trivial.length) {
+      errors.push("trivial_arms must be unique");
+    }
+  }
   return errors;
 }
 
 /** Create + persist a queued run request. Caller validates first. */
 export function createRunRequest(
   benchmarkDir: string,
-  input: { benchmark_id: string; models: string[]; split: RunSplit; tasks: "all" | string[]; rollouts_per_task: number; incumbent_models?: string[]; calibration_threshold?: number },
+  input: { benchmark_id: string; models: string[]; split: RunSplit; tasks: "all" | string[]; rollouts_per_task: number; incumbent_models?: string[]; calibration_threshold?: number; trivial_arms?: TrivialArmKind[] },
   now: Date = new Date(),
 ): RunRequest {
   const request: RunRequest = {
@@ -205,6 +231,7 @@ export function createRunRequest(
     // Additive fields stay absent unless requested, so old readers see the exact prior shape.
     ...(input.incumbent_models && input.incumbent_models.length > 0 ? { incumbent_models: input.incumbent_models } : {}),
     ...(input.calibration_threshold !== undefined ? { calibration_threshold: input.calibration_threshold } : {}),
+    ...(input.trivial_arms && input.trivial_arms.length > 0 ? { trivial_arms: input.trivial_arms } : {}),
   };
   writeRunRequest(benchmarkDir, request);
   return request;
@@ -436,7 +463,21 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
     return request;
   }
 
-  const total = request.models.length * selected.length * request.rollouts_per_task;
+  // Arms = the requested model arms plus any trivial calibration arms. Trivial
+  // arms are deterministic, so they run exactly ONE rollout per task no matter
+  // what rollouts_per_task says (repeats add nothing but identical rows).
+  type Arm = { model: string; kind: ArmKind; runner: ArmRunner; rollouts: number };
+  const arms: Arm[] = request.models.map((model) => ({
+    model,
+    kind: ((request.incumbent_models ?? []).includes(model) ? "incumbent" : "candidate") as ArmKind,
+    runner: options.runner,
+    rollouts: request.rollouts_per_task,
+  }));
+  for (const kind of request.trivial_arms ?? []) {
+    if (!TRIVIAL_ARM_KINDS.includes(kind)) continue;
+    arms.push({ model: kind, kind, runner: kind === "null_agent" ? nullAgentRunner() : spamAgentRunner(), rollouts: 1 });
+  }
+  const total = arms.reduce((sum, arm) => sum + selected.length * arm.rollouts, 0);
   request = { ...request, status: "running", started_at: now().toISOString(), progress: { completed: 0, total } };
   writeRunRequest(dir, request);
   appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "run_started", progress: request.progress }, options.onEvent);
@@ -465,7 +506,8 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
   };
 
   try {
-    for (const model of request.models) {
+    for (const arm of arms) {
+      const model = arm.model;
       if (cancelled()) break;
       appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "arm_started", model }, options.onEvent);
       const rowsFile = rowsFilePath(dir, runId, model);
@@ -478,7 +520,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
       // Work items for this arm; a bounded pool honors --concurrency while the
       // cancel check between dequeues keeps the flip responsive.
       const queue: { task: Obj; rollout: number }[] = [];
-      for (const task of selected) for (let rollout = 0; rollout < request.rollouts_per_task; rollout += 1) queue.push({ task, rollout });
+      for (const task of selected) for (let rollout = 0; rollout < arm.rollouts; rollout += 1) queue.push({ task, rollout });
       let armCancelled = false;
       const worker = async (): Promise<void> => {
         for (;;) {
@@ -497,7 +539,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
           writeRunRequest(dir, request);
           let result: RolloutResult;
           try {
-            result = await options.runner({ benchmarkDir: dir, model, task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)), journalPath });
+            result = await arm.runner({ benchmarkDir: dir, model, task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)), journalPath });
           } catch (err) {
             result = { score: null, subscores: null, status: "error", latency_ms: null, cost: null, writes: [], error: err instanceof Error ? `${err.constructor.name}: ${err.message}` : String(err) };
           }
@@ -513,7 +555,10 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
           const envRow = envTaskRows.get(taskId);
           let journalBytes: number | null = null;
           try { journalBytes = statSync(journalPath).size; } catch { journalBytes = 0; }
-          const anomalies = detectRolloutAnomalies({
+          // Structural sentinels are MODEL-arm-only: a trivial arm making zero
+          // tool calls / an empty final response is behaving exactly as
+          // designed, never a harness anomaly (its floor is the signal).
+          const anomalies = (TRIVIAL_ARM_KINDS as readonly string[]).includes(arm.kind) ? [] : detectRolloutAnomalies({
             task: sidecar,
             result,
             promptSent: envRow === undefined ? undefined : String(envRow.prompt ?? ""),
@@ -529,9 +574,10 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
             subscores: result.subscores,
             status: result.status,
             model,
-            // Additive arm label: incumbent reruns are distinguishable from
-            // candidate arms everywhere downstream (hub badges, calibration).
-            arm_kind: (request.incumbent_models ?? []).includes(model) ? "incumbent" : "candidate",
+            // Additive arm label: incumbent reruns and trivial calibration
+            // arms are distinguishable from candidate arms everywhere
+            // downstream (hub badges, calibration, floors).
+            arm_kind: arm.kind,
             route: "gateway",
             latency_ms: result.latency_ms,
             cost: result.cost,
@@ -596,9 +642,10 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
   request = { ...(readRunRequest(file) ?? request), status: "done", finished_at: now().toISOString(), progress: { completed, total }, live: null };
   writeRunRequest(dir, request);
   appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "run_finished", progress: { completed, total } }, options.onEvent);
-  // Calibration gate: a finished run with an incumbent arm updates the
-  // benchmark's calibration.json sidecar from its own rows + run events.
-  if ((request.incumbent_models ?? []).length > 0) writeCalibrationSummary(dir, request, selected.map((t) => String(t.task_id)));
+  // Calibration gate: a finished run with an incumbent arm and/or trivial
+  // arms updates the benchmark's calibration.json sidecar from its own
+  // rows + run events.
+  if ((request.incumbent_models ?? []).length > 0 || (request.trivial_arms ?? []).length > 0) writeCalibrationSummary(dir, request, selected.map((t) => String(t.task_id)));
   return request;
 }
 
@@ -611,6 +658,21 @@ export function calibrationPath(benchmarkDir: string): string {
 }
 
 export type CalibrationTask = { task_id: string; score: number | null; passed: boolean; rollouts: number; anomalous_rollouts: number };
+
+/**
+ * Per-benchmark trivial-arm floor: the fraction of selected tasks the arm
+ * passes at the calibration threshold. A trivial agent passing tasks means
+ * the contract is satisfiable by doing nothing (null) or by ritual tool
+ * calling (spam) — floor > TRIVIAL_FLOOR_LIMIT flags the benchmark.
+ */
+export type TrivialFloor = {
+  arm_kind: TrivialArmKind;
+  /** passed / selected tasks, at the calibration threshold. Null when the arm produced no rows. */
+  floor: number | null;
+  /** The offending tasks: every selected task the trivial arm passes. */
+  passed_task_ids: string[];
+  floor_exceeded: boolean;
+};
 
 export type CalibrationSummary = {
   schema_version: typeof CALIBRATION_SCHEMA;
@@ -626,6 +688,10 @@ export type CalibrationSummary = {
   failed_count: number;
   /** Tasks the incumbent fails on rerun — the hub flags these incumbent_failed (suspect). */
   failed_task_ids: string[];
+  /** Additive: null-agent floor (absent when the run carried no null_agent arm — old readers see the prior shape). */
+  null_floor?: TrivialFloor;
+  /** Additive: spam-agent floor (absent when the run carried no spam_agent arm). */
+  spam_floor?: TrivialFloor;
 };
 
 /**
@@ -649,6 +715,8 @@ export function deriveCalibrationSummary(args: {
   selectedTaskIds: string[];
   rows: Obj[];
   events: Obj[];
+  /** Trivial arms the run carried; each contributes its floor to the summary. */
+  trivialArms?: TrivialArmKind[];
 }): CalibrationSummary {
   const threshold = args.threshold ?? DEFAULT_CALIBRATION_THRESHOLD;
   const incumbents = new Set(args.incumbentModels);
@@ -658,7 +726,9 @@ export function deriveCalibrationSummary(args: {
     return typeof event?.ts === "string" ? event.ts : null;
   };
   const rows = args.rows.filter((row) => row.run_id === args.runId && incumbents.has(String(row.model ?? "")));
-  const tasks: CalibrationTask[] = args.selectedTaskIds.map((taskId) => {
+  // A trivial-only run makes NO incumbent claim: tasks stay empty rather than
+  // reading "every task failed calibration" off arms that never ran.
+  const tasks: CalibrationTask[] = incumbents.size === 0 ? [] : args.selectedTaskIds.map((taskId) => {
     const taskRows = rows.filter((row) => String(row.task_id) === taskId);
     const anomalous = taskRows.filter(isAnomalousEvalRow);
     const scores = taskRows.filter((row) => !isAnomalousEvalRow(row) && row.status === "ok" && typeof row.score === "number").map((row) => Number(row.score));
@@ -666,6 +736,22 @@ export function deriveCalibrationSummary(args: {
     return { task_id: taskId, score: best, passed: best !== null && best >= threshold, rollouts: taskRows.length, anomalous_rollouts: anomalous.length };
   });
   const failed = tasks.filter((task) => !task.passed);
+  // Trivial-arm floors: a task "passes" for a trivial arm when its best ok,
+  // non-anomalous row for that arm_kind reaches the SAME threshold the
+  // incumbent gate uses. floor = passed / selected.
+  const runRows = args.rows.filter((row) => row.run_id === args.runId);
+  const floorFor = (kind: TrivialArmKind): TrivialFloor => {
+    const armRows = runRows.filter((row) => String(row.arm_kind ?? "") === kind);
+    const passedIds = args.selectedTaskIds.filter((taskId) => {
+      const scores = armRows
+        .filter((row) => String(row.task_id) === taskId && !isAnomalousEvalRow(row) && row.status === "ok" && typeof row.score === "number")
+        .map((row) => Number(row.score));
+      return scores.length > 0 && Math.max(...scores) >= threshold;
+    });
+    const floor = armRows.length === 0 ? null : args.selectedTaskIds.length === 0 ? 0 : passedIds.length / args.selectedTaskIds.length;
+    return { arm_kind: kind, floor, passed_task_ids: passedIds, floor_exceeded: floor !== null && floor > TRIVIAL_FLOOR_LIMIT };
+  };
+  const trivialArms = args.trivialArms ?? [];
   return {
     schema_version: CALIBRATION_SCHEMA,
     benchmark_id: args.benchmarkId,
@@ -678,6 +764,9 @@ export function deriveCalibrationSummary(args: {
     passed_count: tasks.length - failed.length,
     failed_count: failed.length,
     failed_task_ids: failed.map((task) => task.task_id),
+    // Additive floors: absent unless the run carried the arm.
+    ...(trivialArms.includes("null_agent") ? { null_floor: floorFor("null_agent") } : {}),
+    ...(trivialArms.includes("spam_agent") ? { spam_floor: floorFor("spam_agent") } : {}),
   };
 }
 
@@ -685,7 +774,7 @@ export function deriveCalibrationSummary(args: {
 function writeCalibrationSummary(benchmarkDir: string, request: RunRequest, selectedTaskIds: string[]): void {
   try {
     // Rows/events re-read through the SHARED tolerant codec (never a private parser).
-    const rows = (request.incumbent_models ?? []).flatMap((model) => readJsonlFile<Obj>(rowsFilePath(benchmarkDir, request.run_id, model)).items);
+    const rows = [...(request.incumbent_models ?? []), ...(request.trivial_arms ?? [])].flatMap((model) => readJsonlFile<Obj>(rowsFilePath(benchmarkDir, request.run_id, model)).items);
     const summary = deriveCalibrationSummary({
       benchmarkId: request.benchmark_id,
       runId: request.run_id,
@@ -694,6 +783,7 @@ function writeCalibrationSummary(benchmarkDir: string, request: RunRequest, sele
       selectedTaskIds,
       rows,
       events: readJsonlFile<Obj>(runEventsPath(benchmarkDir)).items,
+      trivialArms: request.trivial_arms ?? [],
     });
     const file = calibrationPath(benchmarkDir);
     const tmp = `${file}.tmp`;
@@ -751,6 +841,124 @@ export function oracleRunner(): ArmRunner {
       writes,
       tool_call_count: writes.length,
       final_response_chars: null,
+    };
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Trivial calibration arms (agentic-benchmarks floor discipline)      */
+/* ------------------------------------------------------------------ */
+
+/** The null agent's entire output: deterministic boilerplate, never task-derived. */
+export const NULL_AGENT_FINAL_RESPONSE = "I was unable to complete this task.";
+
+const trivialSubscores = (scored: Obj, label: "runner_null_agent" | "runner_spam_agent"): Record<string, number> => ({
+  final_state: Number(scored.strict ?? 0),
+  final_state_partial_credit: Number(scored.recall ?? 0),
+  recall: Number(scored.recall ?? 0),
+  precision: Number(scored.precision ?? 0),
+  policy: Number(scored.policy ?? 0),
+  [label]: 1,
+});
+
+/**
+ * Null-agent arm: adversarially inert. Makes NO tool calls and answers every
+ * task with the same boilerplate final response, scored through the SAME
+ * full-contract scorer real arms are judged by (scoreContract over the empty
+ * event stream). Deterministic, zero provider calls, zero cost. Any task this
+ * arm passes is satisfiable by doing nothing — the tau-bench 38% class.
+ */
+export function nullAgentRunner(): ArmRunner {
+  return async ({ task }) => {
+    const started = Date.now();
+    const scored = asObject(scoreContract(asObject(task), { calls: [], finalResponse: NULL_AGENT_FINAL_RESPONSE }));
+    return {
+      score: Number(scored.strict ?? 0),
+      subscores: trivialSubscores(scored, "runner_null_agent"),
+      status: "ok" as const,
+      latency_ms: Math.max(1, Date.now() - started),
+      cost: 0,
+      writes: [],
+      tool_call_count: 0,
+      final_response_chars: NULL_AGENT_FINAL_RESPONSE.length,
+    };
+  };
+}
+
+/**
+ * Deterministic schema-minimal arguments for one declared tool schema
+ * (environment/understudy_trace_env/servers/schemas.json entry): every
+ * required property gets the zero value of its declared type; observed enums
+ * get their first (sorted-stable as recorded) allowed value. No randomness,
+ * no task-derived content — the point is ritual, content-free tool calling.
+ */
+export function schemaMinimalArguments(schema: Obj): Obj {
+  const properties = asObject(schema.properties);
+  const enums = asObject(schema.enums_by_observation);
+  const zero = (type: unknown): unknown => {
+    if (type === "number" || type === "integer") return 0;
+    if (type === "boolean") return false;
+    if (type === "array") return [];
+    if (type === "object") return {};
+    return "";
+  };
+  const args: Obj = {};
+  const required = (Array.isArray(schema.required) ? schema.required : []).map(String);
+  for (const key of required) args[key] = zero(properties[key]);
+  // Observation-tightened requirements/enums keep the call schema-valid in
+  // the strict world server; only top-level paths are synthesized.
+  for (const path of (Array.isArray(schema.required_by_observation) ? schema.required_by_observation : []).map(String)) {
+    if (!path.includes(".") && args[path] === undefined) args[path] = zero(properties[path]);
+  }
+  for (const [path, allowed] of Object.entries(enums)) {
+    if (!path.includes(".") && Array.isArray(allowed) && allowed.length > 0) args[path] = allowed[0];
+  }
+  return args;
+}
+
+/** The benchmark's declared tool surface: schemas.json when present, else the tools named by the task's own contract (empty args). */
+export function spamToolSurface(benchmarkDir: string, task: Obj): { tool: string; arguments: Obj }[] {
+  try {
+    const schemas = asObject(JSON.parse(readFileSync(join(resolve(benchmarkDir), "environment", "understudy_trace_env", "servers", "schemas.json"), "utf8")));
+    const tools = Object.keys(schemas).sort();
+    if (tools.length > 0) return tools.map((tool) => ({ tool, arguments: schemaMinimalArguments(asObject(schemas[tool])) }));
+  } catch { /* no generated environment — fall back to the contract's tools */ }
+  const contract = asObject(task.outcome_contract);
+  const tools = new Set<string>();
+  for (const listName of ["required", "preserved", "forbidden"]) {
+    for (const rule of (Array.isArray(contract[listName]) ? (contract[listName] as unknown[]) : []).map(asObject)) {
+      if (typeof rule.tool === "string" && rule.tool) tools.add(rule.tool);
+    }
+  }
+  return [...tools].sort().map((tool) => ({ tool, arguments: {} }));
+}
+
+/**
+ * Spam-agent arm: deterministically calls EVERY tool in the benchmark's tool
+ * surface exactly once with schema-minimal arguments, then stops with a
+ * boilerplate final response. Scored through the same full-contract scorer.
+ * Any task this arm passes is satisfiable by ritual behavior (touch every
+ * tool, say nothing) rather than by understanding the task.
+ */
+export function spamAgentRunner(): ArmRunner {
+  const journal = appendJournalEntry;
+  return async ({ benchmarkDir, task, journalPath }) => {
+    const started = Date.now();
+    const calls = spamToolSurface(benchmarkDir, asObject(task));
+    for (const call of calls) {
+      journal(journalPath, { at: Date.now() / 1000, kind: "call", tool: call.tool, write: isMutatingTool(call.tool), status: "ok", arguments: JSON.stringify(call.arguments).slice(0, 800) });
+      journal(journalPath, { at: Date.now() / 1000, kind: "result", tool: call.tool, status: "ok", content: "{\"ok\": true}" });
+    }
+    const scored = asObject(scoreContract(asObject(task), { calls, finalResponse: NULL_AGENT_FINAL_RESPONSE }));
+    return {
+      score: Number(scored.strict ?? 0),
+      subscores: trivialSubscores(scored, "runner_spam_agent"),
+      status: "ok" as const,
+      latency_ms: Math.max(1, Date.now() - started),
+      cost: 0,
+      writes: calls.filter((call) => isMutatingTool(call.tool)),
+      tool_call_count: calls.length,
+      final_response_chars: NULL_AGENT_FINAL_RESPONSE.length,
     };
   };
 }

--- a/tests/rigor-report.test.mjs
+++ b/tests/rigor-report.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import { deriveRigorReport, renderRigorReport, writeRigorReport } from "../dist/rigor-report.js";
+import { createRunRequest, executeRunRequest, oracleRunner } from "../dist/run-executor.js";
+
+const roots = [];
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function makeBenchmarkDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rigor-"));
+  roots.push(dir);
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "rigor-bench",
+      provenance: { origin: "derived-from-traces" },
+      taxonomy: [{ category_id: "cat-a" }],
+      tasks: [
+        { task_id: "t1", category_id: "cat-a", genesis: "replayed", split: "train" },
+        { task_id: "t2", category_id: "cat-a", genesis: "replayed", split: "holdout" },
+      ],
+      environment: { format: "verifiers.v1", package_ref: "environment" },
+      verifier: { kind: "final-state", strict_metric: "task_completed_correctly", dense_metric: "final_state_partial_credit" },
+    }),
+  );
+  const sidecar = [
+    {
+      schema_version: "understudy.benchmark_task.v1",
+      task_id: "t1",
+      title: "Ritual-satisfiable",
+      outcome_contract: {
+        required: [{ type: "state_effect", tool: "update-record", observed_arguments: {} }],
+        preserved: [],
+        forbidden: [{ tool: "delete-record" }],
+        grading: "final_state_and_obligations",
+      },
+    },
+    {
+      schema_version: "understudy.benchmark_task.v1",
+      task_id: "t2",
+      title: "Anchored + response",
+      outcome_contract: {
+        required: [
+          { type: "state_effect", tool: "update-record", observed_arguments: { id: "record-12345" } },
+          { type: "response_obligation", kind: "json_parses" },
+        ],
+        preserved: [{ tool: "list-items" }],
+        forbidden: [],
+        grading: "final_state_and_obligations",
+      },
+    },
+  ];
+  fs.writeFileSync(path.join(dir, "tasks.jsonl"), sidecar.map((t) => JSON.stringify(t)).join("\n") + "\n");
+  const servers = path.join(dir, "environment", "understudy_trace_env", "servers");
+  fs.mkdirSync(servers, { recursive: true });
+  fs.writeFileSync(path.join(servers, "schemas.json"), JSON.stringify({ "update-record": { required: ["id"], properties: { id: "string" } } }));
+  return dir;
+}
+
+/** Golden fixture: a benchmark dir with an oracle run + trivial arms already executed. */
+async function makeExecutedDir() {
+  const dir = makeBenchmarkDir();
+  const run = createRunRequest(dir, {
+    benchmark_id: "rigor-bench",
+    models: ["oracle-inc"],
+    split: "all",
+    tasks: "all",
+    rollouts_per_task: 1,
+    incumbent_models: ["oracle-inc"],
+    trivial_arms: ["null_agent", "spam_agent"],
+  });
+  const result = await executeRunRequest(dir, run.run_id, { runner: oracleRunner() });
+  assert.equal(result.status, "done");
+  return dir;
+}
+
+describe("deriveRigorReport", () => {
+  it("reports honest UNKNOWNs on a benchmark with no runs at all", () => {
+    const report = deriveRigorReport(makeBenchmarkDir(), new Date("2026-07-22T00:00:00Z"));
+    const byItem = Object.fromEntries(report.items.map((i) => [i.item, i]));
+    assert.equal(byItem["Oracle solver"].status, "UNKNOWN");
+    assert.equal(byItem["Null-agent floor"].status, "UNKNOWN");
+    assert.equal(byItem["Spam-agent floor"].status, "UNKNOWN");
+    assert.equal(byItem["Incumbent calibration"].status, "UNKNOWN");
+    assert.equal(byItem["Rollout anomalies"].status, "UNKNOWN");
+    assert.equal(byItem["Leakage / contamination audit"].status, "UNKNOWN");
+    assert.equal(byItem["Confidence intervals"].status, "UNKNOWN");
+    assert.equal(byItem["Split provenance"].status, "PASS");
+    assert.deepEqual(report.split_counts, { train: 1, holdout: 1 });
+    assert.equal(report.row_counts.total, 0);
+  });
+
+  it("derives the ABC items + per-task complexity from an executed dir (golden fixture)", async () => {
+    const dir = await makeExecutedDir();
+    const report = deriveRigorReport(dir, new Date("2026-07-22T00:00:00Z"));
+    const byItem = Object.fromEntries(report.items.map((i) => [i.item, i]));
+
+    // Oracle solvability: the state-effect oracle passes t1 but honestly
+    // flags t2 (its response_obligation is not oracle-satisfiable by the
+    // offline oracle runner) — a real coverage gap, reported not hidden.
+    assert.equal(byItem["Oracle solver"].status, "FLAG");
+    assert.equal(byItem["Oracle solver"].value, "1/2 tasks pass");
+    assert.match(byItem["Oracle solver"].detail, /t2/);
+    // Null agent passes nothing here; spam passes the ritual-satisfiable t1.
+    assert.equal(byItem["Null-agent floor"].status, "PASS");
+    assert.match(byItem["Null-agent floor"].value, /0\.0% \(0\/2\)/);
+    assert.equal(byItem["Spam-agent floor"].status, "FLAG");
+    assert.match(byItem["Spam-agent floor"].value, /50\.0% \(1\/2\)/);
+    assert.match(byItem["Spam-agent floor"].detail, /t1/);
+    // Incumbent calibration from calibration.json: the oracle incumbent also
+    // fails t2's response obligation, so the gate flags it as suspect.
+    assert.equal(byItem["Incumbent calibration"].status, "FLAG");
+    assert.match(byItem["Incumbent calibration"].detail, /t2/);
+    assert.equal(byItem["Rollout anomalies"].status, "PASS");
+    // Honest UNKNOWNs stay UNKNOWN even on a fully executed dir.
+    assert.equal(byItem["Leakage / contamination audit"].status, "UNKNOWN");
+    assert.equal(byItem["Confidence intervals"].status, "UNKNOWN");
+
+    // Per-task contract complexity from tasks.jsonl.
+    const t2 = report.tasks.find((t) => t.task_id === "t2");
+    assert.equal(t2.required_total, 2);
+    assert.deepEqual(t2.required_by_kind, { state_effect: 1, response_obligation: 1 });
+    assert.equal(t2.preserved, 1);
+    assert.equal(t2.split, "holdout");
+    const t1 = report.tasks.find((t) => t.task_id === "t1");
+    assert.equal(t1.forbidden, 1);
+
+    // Row accounting by arm kind.
+    assert.deepEqual(report.row_counts.by_arm_kind, { incumbent: 2, null_agent: 2, spam_agent: 2 });
+  });
+});
+
+describe("renderRigorReport + writeRigorReport", () => {
+  it("writes rigor-report.md into the benchmark dir with the ABC table and per-task table", async () => {
+    const dir = await makeExecutedDir();
+    const { path: written, report } = writeRigorReport(dir, new Date("2026-07-22T00:00:00Z"));
+    assert.equal(written, path.join(dir, "rigor-report.md"));
+    const md = fs.readFileSync(written, "utf8");
+    assert.equal(md, renderRigorReport(report), "file content is exactly the renderer output");
+    assert.match(md, /# Benchmark rigor report — rigor-bench/);
+    assert.match(md, /Generated 2026-07-22T00:00:00\.000Z/);
+    assert.match(md, /\| Item \| Status \| Value \| Detail \|/);
+    assert.match(md, /\| Null-agent floor \| PASS \|/);
+    assert.match(md, /\| Spam-agent floor \| FLAG \|/);
+    assert.match(md, /\| Leakage \/ contamination audit \| UNKNOWN \|/);
+    assert.match(md, /\| Confidence intervals \| UNKNOWN \|/);
+    assert.match(md, /\| t2 \| holdout \| 2 \| response_obligation: 1, state_effect: 1|state_effect: 1, response_obligation: 1/);
+    assert.match(md, /no network, no model calls/);
+  });
+});

--- a/tests/trivial-arms.test.mjs
+++ b/tests/trivial-arms.test.mjs
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import {
+  NULL_AGENT_FINAL_RESPONSE,
+  TRIVIAL_FLOOR_LIMIT,
+  createRunRequest,
+  deriveCalibrationSummary,
+  executeRunRequest,
+  nullAgentRunner,
+  readRunRequest,
+  runRequestPath,
+  schemaMinimalArguments,
+  spamAgentRunner,
+  spamToolSurface,
+  validateRunRequestInput,
+} from "../dist/run-executor.js";
+
+const roots = [];
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+/**
+ * A benchmark with two tasks:
+ * - t1 is satisfiable by RITUAL: its required state effect has no anchor
+ *   arguments, so any call to update-record satisfies it (the spam class).
+ * - t2 anchors on a real id ("record-12345"), so schema-minimal arguments
+ *   never satisfy it.
+ */
+function makeBenchmarkDir({ withSchemas = true } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trivial-arms-"));
+  roots.push(dir);
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "trivial-bench",
+      provenance: { origin: "derived-from-traces" },
+      taxonomy: [{ category_id: "cat-a" }],
+      tasks: [
+        { task_id: "t1", category_id: "cat-a", genesis: "replayed", split: "train" },
+        { task_id: "t2", category_id: "cat-a", genesis: "replayed", split: "holdout" },
+      ],
+      environment: { format: "verifiers.v1", package_ref: "environment" },
+      verifier: { kind: "final-state", strict_metric: "task_completed_correctly", dense_metric: "final_state_partial_credit" },
+    }),
+  );
+  const sidecar = [
+    {
+      schema_version: "understudy.benchmark_task.v1",
+      task_id: "t1",
+      title: "Trivially satisfiable",
+      outcome_contract: { required: [{ type: "state_effect", tool: "update-record", observed_arguments: {} }], preserved: [], forbidden: [], grading: "final_state_and_obligations" },
+    },
+    {
+      schema_version: "understudy.benchmark_task.v1",
+      task_id: "t2",
+      title: "Anchored",
+      outcome_contract: { required: [{ type: "state_effect", tool: "update-record", observed_arguments: { id: "record-12345" } }], preserved: [], forbidden: [], grading: "final_state_and_obligations" },
+    },
+  ];
+  fs.writeFileSync(path.join(dir, "tasks.jsonl"), sidecar.map((t) => JSON.stringify(t)).join("\n") + "\n");
+  if (withSchemas) {
+    const servers = path.join(dir, "environment", "understudy_trace_env", "servers");
+    fs.mkdirSync(servers, { recursive: true });
+    fs.writeFileSync(
+      path.join(servers, "schemas.json"),
+      JSON.stringify({
+        "update-record": { required: ["id"], properties: { id: "string", active: "boolean" } },
+        "create-item": { required: ["name", "count"], properties: { name: "string", count: "integer" }, enums_by_observation: { kind: ["widget", "gadget"] } },
+        "list-items": { required: [], properties: {} },
+      }),
+    );
+  }
+  return dir;
+}
+
+const queueRun = (dir, overrides = {}) =>
+  createRunRequest(dir, {
+    benchmark_id: "trivial-bench",
+    models: ["candidate-model"],
+    split: "all",
+    tasks: "all",
+    rollouts_per_task: 1,
+    ...overrides,
+  });
+
+const readRows = (dir) =>
+  fs
+    .readdirSync(dir)
+    .filter((f) => /^rows-.*\.jsonl$/.test(f))
+    .flatMap((f) => fs.readFileSync(path.join(dir, f), "utf8").trim().split("\n").map((l) => JSON.parse(l)));
+
+const sidecarTask = (dir, taskId) =>
+  fs.readFileSync(path.join(dir, "tasks.jsonl"), "utf8").trim().split("\n").map((l) => JSON.parse(l)).find((t) => t.task_id === taskId);
+
+describe("run-request trivial_arms validation (additive)", () => {
+  const known = ["t1", "t2"];
+  const base = { models: ["m"], split: "all", tasks: "all", rollouts_per_task: 1 };
+  it("accepts valid trivial_arms and stays valid when omitted", () => {
+    assert.deepEqual(validateRunRequestInput(base, known), []);
+    assert.deepEqual(validateRunRequestInput({ ...base, trivial_arms: ["null_agent"] }, known), []);
+    assert.deepEqual(validateRunRequestInput({ ...base, trivial_arms: ["null_agent", "spam_agent"] }, known), []);
+  });
+  it("rejects unknown kinds, duplicates, and non-arrays", () => {
+    assert.ok(validateRunRequestInput({ ...base, trivial_arms: ["chaos_agent"] }, known).length > 0);
+    assert.ok(validateRunRequestInput({ ...base, trivial_arms: ["null_agent", "null_agent"] }, known).length > 0);
+    assert.ok(validateRunRequestInput({ ...base, trivial_arms: "null_agent" }, known).length > 0);
+  });
+  it("omits the field from the persisted request when unused (old readers see the prior shape)", () => {
+    const dir = makeBenchmarkDir();
+    const plain = queueRun(dir);
+    assert.ok(!("trivial_arms" in readRunRequest(runRequestPath(dir, plain.run_id))));
+    const withArms = queueRun(dir, { trivial_arms: ["null_agent"] });
+    assert.deepEqual(readRunRequest(runRequestPath(dir, withArms.run_id)).trivial_arms, ["null_agent"]);
+  });
+});
+
+describe("nullAgentRunner", () => {
+  it("makes zero tool calls, answers boilerplate, and is deterministic", async () => {
+    const dir = makeBenchmarkDir();
+    const runner = nullAgentRunner();
+    const args = { benchmarkDir: dir, model: "null_agent", task: sidecarTask(dir, "t1"), rollout: 0, selectedTaskIds: ["t1", "t2"], journalPath: null };
+    const a = await runner(args);
+    const b = await runner(args);
+    for (const result of [a, b]) {
+      assert.equal(result.status, "ok");
+      assert.equal(result.score, 0, "a do-nothing agent must not pass a state-effect contract");
+      assert.equal(result.cost, 0);
+      assert.equal(result.tool_call_count, 0);
+      assert.deepEqual(result.writes, []);
+      assert.equal(result.final_response_chars, NULL_AGENT_FINAL_RESPONSE.length);
+      assert.equal(result.subscores.runner_null_agent, 1);
+    }
+    // Deterministic in everything but wall-clock latency.
+    assert.deepEqual({ ...a, latency_ms: 0 }, { ...b, latency_ms: 0 });
+  });
+});
+
+describe("spamAgentRunner", () => {
+  it("derives schema-minimal arguments deterministically", () => {
+    const schema = { required: ["name", "count"], properties: { name: "string", count: "integer" }, enums_by_observation: { kind: ["widget", "gadget"] } };
+    assert.deepEqual(schemaMinimalArguments(schema), { name: "", count: 0, kind: "widget" });
+    assert.deepEqual(schemaMinimalArguments(schema), schemaMinimalArguments(schema));
+    assert.deepEqual(schemaMinimalArguments({ required: ["flag", "meta", "rows"], properties: { flag: "boolean", meta: "object", rows: "array" } }), { flag: false, meta: {}, rows: [] });
+  });
+
+  it("tool surface comes from schemas.json (sorted), falling back to the contract's tools", () => {
+    const dir = makeBenchmarkDir();
+    assert.deepEqual(spamToolSurface(dir, sidecarTask(dir, "t1")).map((c) => c.tool), ["create-item", "list-items", "update-record"]);
+    const bare = makeBenchmarkDir({ withSchemas: false });
+    assert.deepEqual(spamToolSurface(bare, sidecarTask(bare, "t2")), [{ tool: "update-record", arguments: {} }]);
+  });
+
+  it("calls every tool once, passes ritual-satisfiable contracts, fails anchored ones, deterministically", async () => {
+    const dir = makeBenchmarkDir();
+    const runner = spamAgentRunner();
+    const run = (taskId) => runner({ benchmarkDir: dir, model: "spam_agent", task: sidecarTask(dir, taskId), rollout: 0, selectedTaskIds: ["t1", "t2"], journalPath: null });
+    const t1a = await run("t1");
+    const t1b = await run("t1");
+    assert.equal(t1a.status, "ok");
+    assert.equal(t1a.score, 1, "an anchor-free contract is satisfiable by ritual tool calling — exactly what the floor must catch");
+    assert.equal(t1a.tool_call_count, 3);
+    assert.equal(t1a.cost, 0);
+    assert.deepEqual(t1a.writes.map((w) => w.tool), ["create-item", "update-record"]);
+    assert.deepEqual({ ...t1a, latency_ms: 0 }, { ...t1b, latency_ms: 0 });
+    const t2 = await run("t2");
+    assert.equal(t2.score, 0, "anchored arguments defeat schema-minimal spam");
+  });
+});
+
+describe("executor with trivial arms", () => {
+  it("runs trivial arms alongside model arms: labeled rows, one rollout per task, no anomaly sentinels, floors in calibration.json", async () => {
+    const dir = makeBenchmarkDir();
+    const run = queueRun(dir, { models: ["candidate-model"], rollouts_per_task: 2, trivial_arms: ["null_agent", "spam_agent"] });
+    // The candidate completes ok with a real call so its rows stay clean.
+    const runner = async ({ journalPath }) => {
+      if (journalPath) fs.appendFileSync(journalPath, JSON.stringify({ kind: "call", tool: "update-record", status: "ok" }) + "\n");
+      return { score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [{ tool: "update-record", arguments: { id: "record-12345" } }], tool_call_count: 1 };
+    };
+    const result = await executeRunRequest(dir, run.run_id, { runner });
+    assert.equal(result.status, "done");
+    // 1 model × 2 tasks × 2 rollouts + 2 trivial arms × 2 tasks × 1 rollout.
+    assert.deepEqual(result.progress, { completed: 8, total: 8 });
+
+    const rows = readRows(dir);
+    const nullRows = rows.filter((r) => r.arm_kind === "null_agent");
+    const spamRows = rows.filter((r) => r.arm_kind === "spam_agent");
+    assert.equal(rows.filter((r) => r.arm_kind === "candidate").length, 4);
+    assert.equal(nullRows.length, 2, "trivial arms run exactly one rollout per task");
+    assert.equal(spamRows.length, 2);
+    assert.ok(nullRows.every((r) => r.model === "null_agent" && r.cost === 0));
+
+    // Sentinels must NOT misfire on trivial arms: zero calls + zero score is
+    // the null agent working as designed, never an anomaly.
+    const nullT2 = nullRows.find((r) => r.task_id === "t2");
+    assert.equal(nullT2.score, 0);
+    assert.equal(nullT2.tool_call_count, 0);
+    assert.ok(!("anomaly" in nullT2) && !("anomalies" in nullT2), "trivial-arm rows are never anomaly-flagged");
+    assert.ok(spamRows.every((r) => !("anomaly" in r)));
+
+    const calibration = JSON.parse(fs.readFileSync(path.join(dir, "calibration.json"), "utf8"));
+    assert.equal(calibration.null_floor.floor, 0);
+    assert.equal(calibration.null_floor.floor_exceeded, false);
+    assert.deepEqual(calibration.null_floor.passed_task_ids, []);
+    assert.equal(calibration.spam_floor.floor, 0.5, "spam passes the ritual-satisfiable t1");
+    assert.equal(calibration.spam_floor.floor_exceeded, true);
+    assert.deepEqual(calibration.spam_floor.passed_task_ids, ["t1"]);
+    // Trivial-only floors make no incumbent claim.
+    assert.deepEqual(calibration.tasks, []);
+    assert.deepEqual(calibration.failed_task_ids, []);
+  });
+
+  it("still flags anomalies on candidate rows in the same run (candidate-arm-only sentinels, not sentinels-off)", async () => {
+    const dir = makeBenchmarkDir();
+    const run = queueRun(dir, { models: ["lazy-model"], trivial_arms: ["null_agent"] });
+    // The candidate silently does nothing — the classic silent zero.
+    const runner = async () => ({ score: 0, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [], tool_call_count: 0 });
+    await executeRunRequest(dir, run.run_id, { runner });
+    const rows = readRows(dir);
+    assert.ok(rows.filter((r) => r.arm_kind === "candidate").every((r) => r.anomaly), "candidate silent zeros stay flagged");
+    assert.ok(rows.filter((r) => r.arm_kind === "null_agent").every((r) => !r.anomaly), "trivial rows never flagged");
+  });
+
+  it("deriveCalibrationSummary keeps incumbent semantics and adds floors additively", () => {
+    const summary = deriveCalibrationSummary({
+      benchmarkId: "b",
+      runId: "run-x",
+      incumbentModels: ["inc"],
+      selectedTaskIds: ["t1", "t2"],
+      trivialArms: ["null_agent"],
+      rows: [
+        { run_id: "run-x", model: "inc", arm_kind: "incumbent", task_id: "t1", status: "ok", score: 1 },
+        { run_id: "run-x", model: "inc", arm_kind: "incumbent", task_id: "t2", status: "ok", score: 1 },
+        { run_id: "run-x", model: "null_agent", arm_kind: "null_agent", task_id: "t1", status: "ok", score: 1 },
+        { run_id: "run-x", model: "null_agent", arm_kind: "null_agent", task_id: "t2", status: "ok", score: 0 },
+      ],
+      events: [],
+    });
+    assert.equal(summary.passed_count, 2);
+    assert.equal(summary.null_floor.floor, 0.5);
+    assert.equal(summary.null_floor.floor_exceeded, true);
+    assert.deepEqual(summary.null_floor.passed_task_ids, ["t1"]);
+    assert.ok(!("spam_floor" in summary), "arms not run stay absent (additive)");
+    assert.ok(TRIVIAL_FLOOR_LIMIT > 0 && TRIVIAL_FLOOR_LIMIT < 1);
+  });
+
+  it("no trivial arms requested → no trivial rows, no floors (prior behavior intact)", async () => {
+    const dir = makeBenchmarkDir();
+    const run = queueRun(dir, { models: ["m1"], incumbent_models: ["m1"] });
+    const runner = async ({ journalPath }) => {
+      if (journalPath) fs.appendFileSync(journalPath, JSON.stringify({ kind: "call", tool: "update-record", status: "ok" }) + "\n");
+      return { score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [{ tool: "update-record", arguments: {} }], tool_call_count: 1 };
+    };
+    await executeRunRequest(dir, run.run_id, { runner });
+    assert.ok(readRows(dir).every((r) => r.arm_kind === "incumbent"));
+    const calibration = JSON.parse(fs.readFileSync(path.join(dir, "calibration.json"), "utf8"));
+    assert.ok(!("null_floor" in calibration) && !("spam_floor" in calibration));
+  });
+});


### PR DESCRIPTION
## What

ABC calibration floors for benchmark runs, motivated by [uiuc-kang-lab/agentic-benchmarks](https://github.com/uiuc-kang-lab/agentic-benchmarks): a do-nothing agent scores 38% on tau-bench, so every benchmark needs a trivial-agent floor recorded next to its artifacts.

- **Null-agent arm** (`arm_kind: "null_agent"`): deterministic, zero provider calls, zero cost — makes NO tool calls and answers every task with the same boilerplate final response, scored through the same full-contract scorer (`scoreContract`) as real arms.
- **Spam-agent arm** (`arm_kind: "spam_agent"`): deterministically calls every tool in the benchmark's declared surface (env `schemas.json`, contract-tool fallback) exactly once with schema-minimal arguments (zero value per declared type, first observed enum value), then stops. Catches contracts satisfiable by ritual behavior.
- **Run-request plumbing**: additive `trivial_arms: ["null_agent","spam_agent"]` on `understudy.run_request.v1` — omitted when unused, validated (subset/unique), executed alongside model arms with **one rollout per task** (repeating a deterministic agent adds nothing).
- **Sentinel discipline**: structural anomaly detection is model-arm-only; trivial rows are never flagged for zero tool calls / empty responses — that IS the design; the floor is the signal. Candidate silent zeros in the same run stay flagged.
- **Floor gate**: `calibration.json` extends additively with `null_floor` / `spam_floor` — fraction of selected tasks the arm passes at the calibration threshold; floor > 5% sets `floor_exceeded: true` with the offending `passed_task_ids`. Trivial-only runs make no incumbent claim (`tasks: []`).
- **Rigor report**: new `src/rigor-report.ts` + `understudy benchmarks rigor <dir>` writes `rigor-report.md`: ABC table (oracle solvability, null/spam floors, incumbent calibration, anomaly counts, split/contamination provenance), per-task contract complexity (obligation counts by kind from `tasks.jsonl`), and honest UNKNOWN rows for the leakage audit and CIs being built separately. Pure derivation from existing artifacts; no network, no model calls.

## Floor semantics decisions

- A task "passes" for a trivial arm when its best ok, non-anomalous row reaches the SAME threshold the incumbent gate uses (default 1 strict).
- `floor = passed / selected tasks`; `TRIVIAL_FLOOR_LIMIT = 0.05`.
- Floors are only written for arms the run actually carried (additive; old readers see the prior calibration shape).

## Tests

- `tests/trivial-arms.test.mjs`: runner determinism + scoring (null fails state contracts; spam passes anchor-free contracts, fails anchored ones), request-validation additivity, executor e2e (labels, one-rollout, no sentinel misfire, floors), candidate sentinels still fire, prior-behavior regression.
- `tests/rigor-report.test.mjs`: no-runs UNKNOWN report + executed-dir golden fixture + markdown render/write.
- Root: 741/741 pass, `tsc --noEmit` clean, hub tests 126/126 + build green, `skills:validate` ok 35.

## Follow-up

Hub display of `null_floor`/`spam_floor` and trivial-arm badges (hub components not touched per tonight's file ownership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->