### PR TITLE
Statistical honesty + environment integrity: bootstrap CIs, gold-leakage audit, rollout isolation pin

### DIFF
--- a/apps/benchmark-hub/components/leaderboard.tsx
+++ b/apps/benchmark-hub/components/leaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { computeLeaderboard, formatCost, formatLatency, formatScore, hasSplits, isAnomalousRow } from "@/lib/scores";
+import { computeLeaderboard, formatCI, formatCost, formatLatency, formatScore, hasSplits, isAnomalousRow, statisticalTieGroups } from "@/lib/scores";
 import type { BenchmarkManifest, EvalRow, TaskSplit } from "@/lib/types";
 import { Badge, RouteBadge } from "@/components/badges";
 import { cn } from "@/lib/utils";
@@ -58,6 +58,11 @@ export function Leaderboard({
     });
     return list;
   }, [manifest, rows, flaggedTaskIds, excludeFlagged, localOnly, search, split, sortKey, sortDesc]);
+
+  // Statistical ties: adjacent arms (in overall order) whose 95% CIs overlap.
+  // Rank separations inside a tie group are not statistically supported, so
+  // their overall cells are greyed and top-3 shading is suppressed for them.
+  const tieGroups = useMemo(() => statisticalTieGroups(summaries), [summaries]);
 
   // Top-3 shading per numeric column. Lower is better for cost + latency.
   const topRanks = useMemo(() => {
@@ -196,16 +201,43 @@ export function Leaderboard({
                           {showRoute && <RouteBadge route={s.route} />}
                         </span>
                       </td>
-                      <td className="u-ovr" style={shade("overall", s.model)}>
-                        {formatScore(s.overall)}
-                      </td>
+                      {(() => {
+                        const tied = tieGroups.has(s.model);
+                        return (
+                          <td
+                            className="u-ovr"
+                            // Overlapping CIs => rank separation unsupported: grey the cell, drop the top-3 shading.
+                            style={tied ? { color: "var(--muted-foreground)" } : shade("overall", s.model)}
+                            title={
+                              tied
+                                ? `statistical tie — 95% CI ${formatCI(s.ci)} overlaps an adjacent rank (tie group ${(tieGroups.get(s.model) ?? 0) + 1})`
+                                : s.ci
+                                  ? `95% CI ${formatCI(s.ci)} (bootstrap over ${s.ci.taskN} task${s.ci.taskN === 1 ? "" : "s"})`
+                                  : undefined
+                            }
+                          >
+                            {formatScore(s.overall)}
+                            {s.ci && (
+                              <span className="text-xs" style={{ color: "var(--muted-foreground)", marginLeft: 6 }}>
+                                {formatCI(s.ci)}
+                                {tied && " ≈"}
+                              </span>
+                            )}
+                          </td>
+                        );
+                      })()}
                       <td className={s.costPerSuccess == null ? "na" : undefined} style={shade("costPerSuccess", s.model)}>
                         {formatCost(s.costPerSuccess)}
                       </td>
                       <td style={shade("p50", s.model)} className={s.p50LatencyMs == null ? "na" : undefined}>
                         {formatLatency(s.p50LatencyMs)}
                       </td>
-                      <td>{s.taskCount}</td>
+                      <td title={`${s.taskCount} distinct tasks · ${s.scoredCount} scored rollouts`}>
+                        {s.taskCount}
+                        <span className="text-xs" style={{ color: "var(--muted-foreground)", marginLeft: 4 }}>
+                          · {s.scoredCount}r
+                        </span>
+                      </td>
                     </tr>
                     {isOpen && (
                       <tr className="u-detail">
@@ -216,8 +248,16 @@ export function Leaderboard({
                               <div className="u-det-cat">
                                 <div className="h">Run quality</div>
                                 <div className="u-subt">
+                                  <span className="n">scored tasks (CI N)</span>
+                                  <span className="v">{s.scoredTaskCount}</span>
+                                </div>
+                                <div className="u-subt">
                                   <span className="n">scored rows</span>
                                   <span className="v">{s.scoredCount}</span>
+                                </div>
+                                <div className="u-subt">
+                                  <span className="n">95% CI</span>
+                                  <span className="v">{s.ci ? formatCI(s.ci) : "—"}</span>
                                 </div>
                                 <div className="u-subt">
                                   <span className="n">unscored</span>
@@ -272,6 +312,11 @@ export function Leaderboard({
       <div className="flex flex-col gap-0.5">
         <span className="u-foot-note">{"// overall = mean strict score (" + manifest.verifier.strict_metric + ") over scored rows (status ok, score present)"}</span>
         <span className="u-foot-note !mt-0">{"// cost p/ successful task = Σ cost ÷ scored rows ÷ mean strict score; blank when rows carry no cost or score is 0"}</span>
+        <span className="u-foot-note !mt-0">{"// [lo–hi] = 95% CI: seeded percentile bootstrap over per-task mean scores (2000 resamples; tasks are the resampling unit; anomalous rows excluded)"}</span>
+        {tieGroups.size > 0 && (
+          <span className="u-foot-note !mt-0">{"// ≈ statistical tie: greyed overall cells have 95% CIs overlapping an adjacent rank — the ordering between them is not supported at this N"}</span>
+        )}
+        <span className="u-foot-note !mt-0">{"// tasks column = distinct tasks · scored rollouts (Nr)"}</span>
         <span className="u-foot-note !mt-0">{"// dense metric: " + (denseMetric ?? "none declared in manifest")}</span>
         <span className="u-foot-note !mt-0">{"// shading marks the top 3 per column (score: higher better; cost + latency: lower better)"}</span>
         <span className="u-foot-note !mt-0">{"// per-category scores, unscored counts, and errors live in the row expansion (▸)"}</span>

--- a/apps/benchmark-hub/lib/bootstrap.ts
+++ b/apps/benchmark-hub/lib/bootstrap.ts
@@ -1,0 +1,98 @@
+/**
+ * Percentile-bootstrap confidence intervals over per-task mean scores.
+ *
+ * Pure and DETERMINISTIC: the PRNG is seeded (fnv1a over a caller-provided
+ * seed string + mulberry32) so the same rows always produce the same CI —
+ * no Math.random anywhere, so tests and reruns are exactly reproducible.
+ *
+ * The resampling unit is the TASK, not the row: rollout repeats of one task
+ * are correlated, so we first collapse rows to per-task means and then
+ * resample tasks with replacement. With one task the interval collapses to a
+ * degenerate [mean, mean] — honest (no between-task variance is observable),
+ * and the UI should treat everything as a tie at N=1.
+ */
+
+export type BootstrapCI = {
+  lo: number;
+  hi: number;
+  /** The statistic the interval brackets: the macro-average (mean of per-task means). */
+  mean: number;
+  iterations: number;
+  /** Number of distinct tasks resampled (the effective N). */
+  taskN: number;
+};
+
+/** fnv1a 32-bit string hash — a stable seed derivation for string keys. */
+export function fnv1a(text: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** mulberry32 — tiny deterministic PRNG, uniform in [0, 1). */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Linear-interpolated percentile over a SORTED ascending array (p in [0,1]). */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const idx = p * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.min(lo + 1, sorted.length - 1);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+export type BootstrapOptions = {
+  /** Resample count; the fixed project default is 2000. */
+  iterations?: number;
+  /** Seed string (e.g. `${benchmarkId}::${model}`); same seed => same CI. */
+  seed?: string;
+  /** Two-sided coverage, default 0.95 (percentile bounds at 2.5 / 97.5). */
+  coverage?: number;
+};
+
+/**
+ * Percentile-bootstrap CI over per-task mean scores. Returns null when there
+ * are no tasks to resample.
+ */
+export function bootstrapCI(perTaskMeans: number[], options: BootstrapOptions = {}): BootstrapCI | null {
+  const n = perTaskMeans.length;
+  if (n === 0) return null;
+  const iterations = options.iterations ?? 2000;
+  const coverage = options.coverage ?? 0.95;
+  const mean = perTaskMeans.reduce((a, b) => a + b, 0) / n;
+  if (n === 1) return { lo: mean, hi: mean, mean, iterations, taskN: 1 };
+  const rand = mulberry32(fnv1a(options.seed ?? "understudy-bootstrap"));
+  const stats: number[] = new Array(iterations);
+  for (let i = 0; i < iterations; i += 1) {
+    let sum = 0;
+    for (let j = 0; j < n; j += 1) sum += perTaskMeans[Math.floor(rand() * n)];
+    stats[i] = sum / n;
+  }
+  stats.sort((a, b) => a - b);
+  const alpha = (1 - coverage) / 2;
+  return { lo: percentile(stats, alpha), hi: percentile(stats, 1 - alpha), mean, iterations, taskN: n };
+}
+
+/** Group rows' scores by task and return per-task means (input: [taskId, score] pairs). */
+export function perTaskMeans(pairs: Array<[string, number]>): number[] {
+  const byTask = new Map<string, { sum: number; n: number }>();
+  for (const [taskId, score] of pairs) {
+    const cur = byTask.get(taskId) ?? { sum: 0, n: 0 };
+    cur.sum += score;
+    cur.n += 1;
+    byTask.set(taskId, cur);
+  }
+  return [...byTask.values()].map((v) => v.sum / v.n);
+}

--- a/apps/benchmark-hub/lib/scores.ts
+++ b/apps/benchmark-hub/lib/scores.ts
@@ -1,3 +1,4 @@
+import { bootstrapCI, perTaskMeans, type BootstrapCI } from "./bootstrap";
 import type { BenchmarkManifest, EvalRow, TaskSplit } from "./types";
 
 export type CategoryDetail = {
@@ -33,6 +34,14 @@ export type ModelSummary = {
   route: RouteKind;
   /** True when any row is labeled arm_kind "incumbent" (the capture-producing model rerun). */
   incumbent: boolean;
+  /**
+   * Seeded percentile-bootstrap 95% CI over PER-TASK mean scores (tasks are
+   * the resampling unit; anomalous rows excluded exactly like `overall`).
+   * Null when no scored tasks exist. At taskN=1 it is degenerate [m, m].
+   */
+  ci: BootstrapCI | null;
+  /** Distinct tasks with at least one scored row (the CI's effective N). */
+  scoredTaskCount: number;
 };
 
 export type LeaderboardOptions = {
@@ -143,6 +152,11 @@ export function computeLeaderboard(
       .map((r) => r.latency_ms)
       .filter((l): l is number => typeof l === "number" && Number.isFinite(l));
     const routes = new Set(modelRows.map((r) => normalizeRoute(r.route)).filter((r): r is Exclude<RouteKind, null> => r != null));
+    // CI over per-task means (rollout repeats of one task are correlated, so
+    // the task is the resampling unit). Seed = benchmark + model: deterministic
+    // across renders and test runs, distinct across arms.
+    const taskMeans = perTaskMeans(scored.map((r) => [r.task_id, r.score as number]));
+    const ci = bootstrapCI(taskMeans, { seed: `${manifest.benchmark_id}::${model}` });
     summaries.push({
       model,
       overall,
@@ -158,6 +172,8 @@ export function computeLeaderboard(
       p50LatencyMs: median(latencies),
       route: routes.size === 1 ? [...routes][0] : null,
       incumbent: modelRows.some((r) => r.arm_kind === "incumbent"),
+      ci,
+      scoredTaskCount: taskMeans.length,
     });
   }
   summaries.sort((a, b) => (b.overall ?? -1) - (a.overall ?? -1));
@@ -181,6 +197,44 @@ export function categoryScoreSummary(
     out[cat.category_id] = { score: mean(scored.map((r) => r.score as number)), n: scored.length };
   }
   return out;
+}
+
+/**
+ * Statistical-tie detection over the overall ranking: sort arms by overall
+ * (desc) and chain ADJACENT arms whose 95% CIs overlap into tie groups.
+ * Returns model → tie-group index only for models in a group of size >= 2;
+ * arms without a CI (no scored tasks) never tie. Overlapping CIs mean the
+ * rank separation is not statistically supported at this N — the leaderboard
+ * greys those separations out instead of implying a real ordering.
+ */
+export function statisticalTieGroups(summaries: ModelSummary[]): Map<string, number> {
+  const ranked = summaries
+    .filter((s) => s.ci != null && s.overall != null)
+    .sort((a, b) => (b.overall as number) - (a.overall as number));
+  const groups = new Map<string, number>();
+  let group: ModelSummary[] = [];
+  let groupIndex = 0;
+  const flush = () => {
+    if (group.length >= 2) {
+      for (const s of group) groups.set(s.model, groupIndex);
+      groupIndex += 1;
+    }
+    group = [];
+  };
+  for (const s of ranked) {
+    const prev = group[group.length - 1];
+    const overlaps = prev != null && prev.ci != null && s.ci != null && s.ci.hi >= prev.ci.lo && prev.ci.hi >= s.ci.lo;
+    if (!overlaps) flush();
+    group.push(s);
+  }
+  flush();
+  return groups;
+}
+
+/** Render a bootstrap CI as "[62–81%]" in the leaderboard's percent idiom. */
+export function formatCI(ci: BootstrapCI | null | undefined): string {
+  if (ci == null) return "";
+  return `[${(ci.lo * 100).toFixed(0)}–${(ci.hi * 100).toFixed(0)}%]`;
 }
 
 export function formatScore(score: number | null | undefined): string {

--- a/apps/benchmark-hub/tests/scores.test.mjs
+++ b/apps/benchmark-hub/tests/scores.test.mjs
@@ -168,3 +168,98 @@ describe("computeLeaderboard", () => {
     assert.equal(byModel["legacy-rows"], false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bootstrap 95% CIs + statistical-tie treatment (seeded, deterministic).
+// ---------------------------------------------------------------------------
+import { bootstrapCI, perTaskMeans } from "./.build/lib/bootstrap.js";
+import { formatCI, statisticalTieGroups } from "./.build/lib/scores.js";
+
+describe("bootstrapCI", () => {
+  const means = [0.2, 0.4, 0.6, 0.8, 1.0, 0.0, 0.5, 0.7];
+
+  it("is deterministic for the same seed (no Math.random)", () => {
+    const orig = Math.random;
+    Math.random = () => { throw new Error("Math.random must not be consulted"); };
+    try {
+      const a = bootstrapCI(means, { seed: "bench::model-a" });
+      const b = bootstrapCI(means, { seed: "bench::model-a" });
+      assert.deepEqual(a, b);
+      assert.equal(a.iterations, 2000);
+      assert.equal(a.taskN, means.length);
+      assert.ok(a.lo <= a.mean && a.mean <= a.hi);
+      assert.ok(a.lo < a.hi, "real between-task variance yields a non-degenerate interval");
+    } finally {
+      Math.random = orig;
+    }
+  });
+
+  it("different seeds resample differently (arms don't share draws)", () => {
+    const a = bootstrapCI(means, { seed: "bench::model-a" });
+    const b = bootstrapCI(means, { seed: "bench::model-b" });
+    assert.notDeepEqual([a.lo, a.hi], [b.lo, b.hi]);
+  });
+
+  it("N=1 task collapses to a degenerate [mean, mean] interval", () => {
+    const ci = bootstrapCI([0.75], { seed: "s" });
+    assert.deepEqual([ci.lo, ci.mean, ci.hi, ci.taskN], [0.75, 0.75, 0.75, 1]);
+  });
+
+  it("zero tasks yields null", () => {
+    assert.equal(bootstrapCI([], { seed: "s" }), null);
+  });
+
+  it("perTaskMeans collapses rollout repeats before resampling", () => {
+    assert.deepEqual(perTaskMeans([["t1", 1], ["t1", 0], ["t2", 1]]).sort(), [0.5, 1]);
+  });
+});
+
+describe("leaderboard CI + statistical ties", () => {
+  it("computeLeaderboard attaches a per-arm CI over per-task means, excluding anomalous rows", () => {
+    const rows = [
+      row({ score: 1 }),
+      row({ task_id: "t2", score: 0 }),
+      row({ task_id: "t3", score: 0.5 }),
+      row({ task_id: "t3", score: 0, anomaly: { kind: "no_tool_calls", detail: "x" } }),
+    ];
+    const [s] = computeLeaderboard(manifest, rows);
+    assert.equal(s.scoredTaskCount, 3);
+    assert.ok(s.ci);
+    assert.equal(s.ci.taskN, 3, "anomalous rollout never enters the resampled task means");
+    assert.ok(s.ci.lo <= s.ci.hi);
+    // Deterministic across recomputation (same benchmark + model seed).
+    const [again] = computeLeaderboard(manifest, rows);
+    assert.deepEqual(s.ci, again.ci);
+  });
+
+  it("all-anomalous arm has null CI and zero scored tasks", () => {
+    const rows = [
+      row({ score: 1, anomaly: { kind: "empty_prompt", detail: "x" } }),
+      row({ task_id: "t2", score: 1, anomaly: { kind: "empty_prompt", detail: "x" } }),
+    ];
+    const [s] = computeLeaderboard(manifest, rows);
+    assert.equal(s.overall, null);
+    assert.equal(s.ci, null);
+    assert.equal(s.scoredTaskCount, 0);
+  });
+
+  it("statisticalTieGroups chains adjacent overlapping CIs; clear separations stay ranked", () => {
+    const arm = (model, overall, lo, hi) => ({ model, overall, ci: { lo, hi, mean: overall, iterations: 2000, taskN: 5 } });
+    const groups = statisticalTieGroups([
+      arm("top", 0.9, 0.85, 0.95),
+      arm("mid-a", 0.6, 0.5, 0.7),
+      arm("mid-b", 0.55, 0.45, 0.65), // overlaps mid-a
+      arm("bottom", 0.1, 0.05, 0.15),
+      { model: "no-ci", overall: 0.5, ci: null },
+    ]);
+    assert.equal(groups.has("top"), false, "clear winner is not greyed");
+    assert.equal(groups.has("bottom"), false);
+    assert.equal(groups.has("no-ci"), false, "arms without a CI never tie");
+    assert.equal(groups.get("mid-a"), groups.get("mid-b"), "overlapping neighbors share a tie group");
+  });
+
+  it("formatCI renders the percent idiom", () => {
+    assert.equal(formatCI({ lo: 0.615, hi: 0.809, mean: 0.7, iterations: 2000, taskN: 4 }), "[62–81%]");
+    assert.equal(formatCI(null), "");
+  });
+});

--- a/src/trace-foundry.ts
+++ b/src/trace-foundry.ts
@@ -19,6 +19,8 @@ export type FoundryResult = {
   privacy: { local_only: true; contains_customer_payloads: true; upload_performed: false; provider_called: false };
   /** Generation-time structural self-check (understudy.foundry_self_check.v1): per-task failures + environment scan. */
   self_check?: Record<string, unknown>;
+  /** Gold-leakage audit (understudy.leakage_audit.v1): contract targets verbatim-readable in candidate-facing surfaces. Report-only. */
+  leakage_audit?: Record<string, unknown>;
 };
 
 export type TraceFoundryOptions = {
@@ -986,6 +988,122 @@ export function runFoundrySelfCheck(outputInput: string, tasks: Obj[]): Obj {
   };
 }
 
+/* ---------------------------------------------------------------------------
+ * Gold-leakage audit — environment-integrity check run at generation time.
+ *
+ * The candidate must be isolated from ground truth: if a contract target (a
+ * state_effect/read_obligation gold argument, a value_propagation value, or a
+ * response-obligation gold string) is verbatim-readable in a candidate-facing
+ * surface, the task can be passed by copying instead of doing the work.
+ *
+ * Candidate-readable surfaces scanned: fixtures.json (the seeded initial
+ * world state AND every tool-result template the world will return) and
+ * servers/schemas.json (validation schemas — observation-tightened enums and
+ * observed_error_example strings are echoed to the candidate in rejections).
+ * tasks.json's source_messages are NOT scanned: the taskset feeds the
+ * candidate only prompt + system_prompt, not the stored history.
+ *
+ * Benign-overlap heuristic (documented, deliberately conservative): a gold
+ * value is only a finding when it is NOT present in the task's own inputs
+ * (prompt, system prompt, or any user-role source message). Values the agent
+ * legitimately receives as inputs — the record id it is told to update — are
+ * expected everywhere and never flagged. Short strings (< MIN_GOLD_LEN
+ * normalized chars) are skipped: single tokens like "active" collide with
+ * ordinary fixture content and carry no copyable answer.
+ *
+ * REPORT-ONLY by design: findings land in the manifest (`leakage_audit`) and
+ * on stderr at build time. Nothing is auto-redacted — removing a value from
+ * a fixture changes task semantics, so a human (or a later reviewing agent)
+ * decides.
+ * ------------------------------------------------------------------------- */
+
+export type LeakageFinding = { task_id: string; location: string; kind: string; excerpt: string };
+export type LeakageAudit = { schema_version: "understudy.leakage_audit.v1"; status: "clean" | "findings"; checked_tasks: number; findings: LeakageFinding[]; heuristic: string };
+
+/** Minimum normalized length for a gold string to be leak-checkable (shorter values are un-copyable noise). */
+const MIN_GOLD_LEN = 12;
+
+const normalizeForLeak = (value: unknown): string =>
+  (typeof value === "string" ? value : JSON.stringify(value ?? "")).toLowerCase().replace(/\s+/g, " ").trim();
+
+/** All string leaf values of a JSON value (recursive; used over contract argument objects). */
+function stringLeaves(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(stringLeaves);
+  if (value !== null && typeof value === "object") return Object.values(value as Obj).flatMap(stringLeaves);
+  return [];
+}
+
+/** Gold/contract target values for one task, labeled by contract-entry kind. */
+function goldValues(task: Obj): Array<{ kind: string; value: string }> {
+  const out: Array<{ kind: string; value: string }> = [];
+  for (const ruleValue of asObject(task.outcome_contract).required ?? []) {
+    const rule = asObject(ruleValue);
+    const type = String(rule.type ?? "state_effect");
+    if (type === "state_effect" || type === "read_obligation") {
+      for (const leaf of [...stringLeaves(rule.observed_arguments), ...stringLeaves(rule.arguments_semantic)]) out.push({ kind: `${type}_value`, value: leaf });
+    } else if (type === "value_propagation" && typeof rule.value === "string") {
+      out.push({ kind: "value_propagation_value", value: rule.value });
+    } else if (type === "response_obligation" && typeof rule.expected === "string") {
+      out.push({ kind: "response_gold_string", value: rule.expected });
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan candidate-readable environment surfaces for verbatim contract targets.
+ * Pure over the already-generated artifacts; see the block comment above for
+ * the heuristic. Findings are deduped per (task, location, excerpt).
+ */
+export function auditGoldLeakage(tasks: Obj[], taskRows: Obj[], fixtures: Obj[], schemas: Obj): LeakageAudit {
+  const rowByTask = new Map(taskRows.map((row) => [String(asObject(row).task_id), asObject(row)]));
+  // Candidate-readable surfaces (global to the environment package).
+  const surfaces: Array<{ location: string; text: string }> = [
+    { location: "environment/understudy_trace_env/servers/fixtures.json", text: normalizeForLeak(fixtures) },
+    { location: "environment/understudy_trace_env/servers/schemas.json", text: normalizeForLeak(schemas) },
+  ];
+  const findings: LeakageFinding[] = [];
+  const seen = new Set<string>();
+  for (const task of tasks) {
+    const row = rowByTask.get(String(task.task_id)) ?? {};
+    const userMessages = ((row.source_messages ?? []) as unknown[]).map(asObject).filter((m) => m.role === "user");
+    const inputs = normalizeForLeak([row.prompt ?? "", row.system_prompt ?? "", ...userMessages.map((m) => m.content)]);
+    for (const gold of goldValues(task)) {
+      const needle = normalizeForLeak(gold.value);
+      if (needle.length < MIN_GOLD_LEN) continue;
+      if (inputs.includes(needle)) continue; // benign: the agent legitimately holds this value as an input
+      for (const surface of surfaces) {
+        if (!surface.text.includes(needle)) continue;
+        const key = `${task.task_id} ${surface.location} ${needle}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        findings.push({ task_id: String(task.task_id), location: surface.location, kind: gold.kind, excerpt: String(gold.value).slice(0, 160) });
+      }
+    }
+  }
+  return {
+    schema_version: "understudy.leakage_audit.v1",
+    status: findings.length > 0 ? "findings" : "clean",
+    checked_tasks: tasks.length,
+    findings,
+    heuristic: `flag contract/gold strings (>=${MIN_GOLD_LEN} normalized chars) verbatim in candidate-readable surfaces (fixtures.json, schemas.json) but absent from the task's own inputs (prompt / system prompt / user source messages); report-only, never auto-redacted`,
+  };
+}
+
+/** Build-time report: the audit is advisory, so it prints and moves on. */
+function printLeakageAudit(audit: LeakageAudit): void {
+  if (audit.status === "clean") {
+    console.error(`[leakage-audit] clean — no verbatim contract targets found in candidate-readable surfaces (${audit.checked_tasks} task(s) checked)`);
+    return;
+  }
+  console.error(`[leakage-audit] ${audit.findings.length} potential gold-leakage finding(s) across ${audit.checked_tasks} task(s) — recorded in manifest.leakage_audit (report-only, nothing redacted):`);
+  for (const finding of audit.findings.slice(0, 8)) {
+    console.error(`[leakage-audit]   ${finding.task_id} · ${finding.kind} · ${finding.location} · "${finding.excerpt.slice(0, 80)}"`);
+  }
+  if (audit.findings.length > 8) console.error(`[leakage-audit]   … ${audit.findings.length - 8} more (see manifest.json)`);
+}
+
 function writeVerifiersEnvironment(output: string, tasks: Obj[], sourceContext: Map<string, Obj>, auditedCommit: string, rows: Obj[] = []): Obj {
   const root = join(output, "environment"), pkg = join(root, "understudy_trace_env"), servers = join(pkg, "servers");
   mkdirSync(servers, { recursive: true });
@@ -1095,7 +1213,10 @@ function writeVerifiersEnvironment(output: string, tasks: Obj[], sourceContext: 
   const validation = tasks.map((task) => offlineValidationRow(task, validationSchemas));
   writeJson(join(root, "offline-validation.json"), { schema_version: "understudy.verifier_validation.v1", verifiers: { api: "v1", audited_commit: auditedCommit }, tasks: validation });
   const packageFiles = [join(root, "pyproject.toml"), join(pkg, "__init__.py"), join(pkg, "environment.py"), join(pkg, "taskset.py"), join(pkg, "servers", "world.py"), join(pkg, "servers", "fixtures.json"), join(pkg, "tasks.json")];
-  return { path: root, package_sha256: hash(packageFiles.map((path) => readFileSync(path, "utf8"))), verifiers_api: "v1", audited_commit: auditedCommit, oracle_pass: validation.every((row) => row.oracle.score === 1), sentinel_pass: validation.every((row) => Object.values(asObject(row.sentinels)).every((sentinel) => Number(asObject(sentinel).score ?? 0) < 1)) };
+  // Gold-leakage audit over the exact artifacts just written (report-only).
+  const leakageAudit = auditGoldLeakage(tasks, taskRows, fixtures, validationSchemas);
+  printLeakageAudit(leakageAudit);
+  return { path: root, package_sha256: hash(packageFiles.map((path) => readFileSync(path, "utf8"))), verifiers_api: "v1", audited_commit: auditedCommit, oracle_pass: validation.every((row) => row.oracle.score === 1), sentinel_pass: validation.every((row) => Object.values(asObject(row.sentinels)).every((sentinel) => Number(asObject(sentinel).score ?? 0) < 1)), leakage_audit: leakageAudit };
 }
 
 type ManifestOptions = { schemaVersion: string; benchmarkId: string; name: string; description: string; createdAt: string; sourceRefs: string[]; packageSha256: string | null; auditedCommit: string; heldoutNovel: boolean; status: string; executable: boolean; promotionBlockers: string[] };
@@ -1431,7 +1552,7 @@ function writeFoundryArtifacts(ctx: { source: string; output: string; files: str
   finalGoal.updated_at = now.toISOString();
   writeJson(join(output, "goal-state.json"), finalGoal);
   appendJsonl(join(output, "goal-events.jsonl"), [{ at: now.toISOString(), action: "finalize", input_hash: finalGoal.input_hash, validation: { dag_valid: dag.valid, oracle_pass: environment.oracle_pass, sentinel_pass: environment.sentinel_pass }, next_action: finalGoal.next_action }]);
-  const result: FoundryResult = { schema_version: TRACE_FOUNDRY_SCHEMA, source, output_dir: output, freshness: { max_age_days: ctx.maxAgeDays, cutoff_utc: cutoff.toISOString(), newest_capture_utc: rows.map((row) => row.captured_at).sort().at(-1) }, counts: { source_files: files.length, captures: rows.length, tasks: tasks.length, edges: dag.edges.length, stale_filtered: staleFiltered, invalid_timestamp_filtered: invalidTimestampFiltered }, artifacts: { normalized: "normalized-captures.jsonl", dag: "source-dag.json", tasks: "tasks.jsonl", benchmark: "benchmark.json", environment: toPortablePath(output, environment.path), ledger: "capture-ledger.jsonl", goal: "goal-state.json", viewer: toPortablePath(output, join(viewer, "index.html")) }, privacy: { local_only: true, contains_customer_payloads: true, upload_performed: false, provider_called: false }, self_check: selfCheck };
+  const result: FoundryResult = { schema_version: TRACE_FOUNDRY_SCHEMA, source, output_dir: output, freshness: { max_age_days: ctx.maxAgeDays, cutoff_utc: cutoff.toISOString(), newest_capture_utc: rows.map((row) => row.captured_at).sort().at(-1) }, counts: { source_files: files.length, captures: rows.length, tasks: tasks.length, edges: dag.edges.length, stale_filtered: staleFiltered, invalid_timestamp_filtered: invalidTimestampFiltered }, artifacts: { normalized: "normalized-captures.jsonl", dag: "source-dag.json", tasks: "tasks.jsonl", benchmark: "benchmark.json", environment: toPortablePath(output, environment.path), ledger: "capture-ledger.jsonl", goal: "goal-state.json", viewer: toPortablePath(output, join(viewer, "index.html")) }, privacy: { local_only: true, contains_customer_payloads: true, upload_performed: false, provider_called: false }, self_check: selfCheck, leakage_audit: environment.leakage_audit };
   writeJson(join(output, "manifest.json"), result); return result;
 }
 
@@ -1479,6 +1600,7 @@ export function regenerateEnvironment(benchmarkDirInput: string): { path: string
   if (existsSync(manifestPath)) {
     const manifest = asObject(JSON.parse(readFileSync(manifestPath, "utf8")));
     manifest.self_check = selfCheck;
+    manifest.leakage_audit = environment.leakage_audit;
     writeJson(manifestPath, manifest);
   }
   return { path: String(environment.path), oracle_pass: Boolean(environment.oracle_pass), sentinel_pass: Boolean(environment.sentinel_pass), repaired_empty_contracts: repaired } as { path: string; oracle_pass: boolean; sentinel_pass: boolean };

--- a/tests/trace-foundry.test.mjs
+++ b/tests/trace-foundry.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { once } from "node:events";
 import { compileTraceFoundry, createTraceReplayPlan, importTraceReviews, runTraceReplays } from "../dist/trace-foundry.js";
@@ -724,4 +725,158 @@ test("fallback rubric records binding anchor caps as visible cap_warning claims 
   assert.equal(capClaims.length, 1);
   assert.match(capClaims[0].claim, /kept 3 of 5/);
   assert.equal(task.outcome_contract.required.filter((rule) => rule.kind === "contains_category").length, 3);
+});
+
+// ---------------------------------------------------------------------------
+// Gold-leakage audit: contract targets must not be verbatim-readable in
+// candidate-facing surfaces (fixtures / schemas) unless the task's own inputs
+// already carry them. Report-only — nothing is redacted.
+// ---------------------------------------------------------------------------
+
+test("leakage audit: true positive (gold only in fixtures), benign input overlap, short values skipped", async () => {
+  const { auditGoldLeakage } = await import("../dist/trace-foundry.js");
+  const goldSecret = "confidential-report-Q3-final-9981";
+  const inputValue = "record-7781-target-identifier";
+  const tasks = [{
+    task_id: "t-leak",
+    outcome_contract: { required: [
+      // Gold argument the prompt never mentions — leaks via a fixture echo.
+      { type: "state_effect", tool: "update-record", observed_arguments: { document: goldSecret } },
+      // Gold argument the user PROMPT already carries — benign input.
+      { type: "state_effect", tool: "update-record", observed_arguments: { id: inputValue } },
+      // Short value — below MIN_GOLD_LEN, never flagged.
+      { type: "state_effect", tool: "update-record", observed_arguments: { status: "active" } },
+      // Response gold string readable in schemas.json's observed error example.
+      { type: "response_obligation", kind: "contains_category", expected: "the rollback completed without data loss" },
+    ], forbidden: [] },
+  }];
+  const taskRows = [{ task_id: "t-leak", prompt: `Please update ${inputValue} for me`, system_prompt: "", source_messages: [] }];
+  const fixtures = [
+    { tool: "get-record", arguments: {}, content: `{"id":"${inputValue}","document":"${goldSecret}","status":"active"}` },
+  ];
+  const schemas = { "update-record": { observed_error_example: "ERROR: the rollback completed without data loss" } };
+  const audit = auditGoldLeakage(tasks, taskRows, fixtures, schemas);
+  assert.equal(audit.status, "findings");
+  const kinds = audit.findings.map((f) => `${f.kind}@${f.location.split("/").pop()}`).sort();
+  assert.deepEqual(kinds, ["response_gold_string@schemas.json", "state_effect_value@fixtures.json"]);
+  const leak = audit.findings.find((f) => f.kind === "state_effect_value");
+  assert.equal(leak.task_id, "t-leak");
+  assert.equal(leak.excerpt, goldSecret);
+  assert.ok(!audit.findings.some((f) => f.excerpt.includes(inputValue)), "input-carried values are benign, not findings");
+  assert.ok(!audit.findings.some((f) => f.excerpt === "active"), "short values are skipped");
+});
+
+test("leakage audit: clean when contract targets never surface outside the inputs", async () => {
+  const { auditGoldLeakage } = await import("../dist/trace-foundry.js");
+  const tasks = [{ task_id: "t-clean", outcome_contract: { required: [
+    { type: "state_effect", tool: "update-record", observed_arguments: { note: "a long enough gold note value" } },
+    { type: "value_propagation", value: "propagated-target-value-123456", must_reach: { kind: "final_response" } },
+  ], forbidden: [] } }];
+  const taskRows = [{ task_id: "t-clean", prompt: "Do the thing", system_prompt: "", source_messages: [] }];
+  const audit = auditGoldLeakage(tasks, taskRows, [{ tool: "get-record", content: "{\"unrelated\": true}" }], { "update-record": { required: ["note"] } });
+  assert.equal(audit.status, "clean");
+  assert.deepEqual(audit.findings, []);
+  assert.equal(audit.checked_tasks, 1);
+});
+
+test("build-benchmark records the leakage audit additively in manifest.json", () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-foundry-leakage-"));
+  const source = join(root, "captures"), output = join(root, "out"); mkdirSync(source, { recursive: true });
+  const row = capture("round-1", "2026-07-20T12:00:00Z", [{ role: "user", content: "Set synthetic record 7 active" }], { content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }], stop_reason: "tool_use" });
+  writeFileSync(join(source, "captures.jsonl"), JSON.stringify(row) + "\n");
+  const result = compileTraceFoundry(source, output, 3, new Date("2026-07-21T12:00:00Z"));
+  assert.equal(result.leakage_audit.schema_version, "understudy.leakage_audit.v1");
+  assert.ok(["clean", "findings"].includes(result.leakage_audit.status));
+  assert.ok(Array.isArray(result.leakage_audit.findings));
+  const manifest = JSON.parse(readFileSync(join(output, "manifest.json"), "utf8"));
+  assert.deepEqual(manifest.leakage_audit, result.leakage_audit);
+});
+
+// ---------------------------------------------------------------------------
+// Rollout state isolation: every rollout must start from the seeded initial
+// world state. The generated world keeps ALL mutable state on the per-rollout
+// WorldState (events / writes / used_fixtures via pydantic default_factory) —
+// this test pins that guarantee by driving the REAL generated world.py twice
+// with a stub verifiers.v1 module (the offline harness this repo supports;
+// the pinned verifiers runtime instantiates a fresh WorldState per rollout).
+// ---------------------------------------------------------------------------
+
+// world.py uses PEP 604 annotations at module scope, so the driver needs
+// python >= 3.10 (pydantic itself is stubbed below — no packages required).
+const pythonBin = ["python3", "python3.13", "python3.12", "python3.11", "python3.14"].find(
+  (bin) => spawnSync(bin, ["-c", "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)"], { encoding: "utf8" }).status === 0,
+);
+
+test("two sequential rollouts: rollout 2 starts from the seeded initial state, no residue from rollout 1", { skip: !pythonBin }, () => {
+  const root = mkdtempSync(join(tmpdir(), "understudy-foundry-isolation-"));
+  const source = join(root, "captures"), output = join(root, "out"); mkdirSync(source, { recursive: true });
+  const rows = [
+    capture("round-1", "2026-07-20T12:00:00Z", [{ role: "user", content: "Set synthetic record 7 active" }], { content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }], stop_reason: "tool_use" }),
+    capture("round-2", "2026-07-20T12:00:01Z", [{ role: "user", content: "Set synthetic record 7 active" }, { role: "assistant", content: [{ type: "tool_use", id: "call-1", name: "update-record", input: { id: 7, status: "active" } }] }, { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: "{\"ok\":true,\"record\":7}" }] }], { content: [{ type: "text", text: "Done" }], stop_reason: "end_turn" }),
+  ];
+  writeFileSync(join(source, "captures.jsonl"), rows.map(JSON.stringify).join("\n") + "\n");
+  compileTraceFoundry(source, output, 3, new Date("2026-07-21T12:00:00Z"));
+  // Stub verifiers.v1 + pydantic: just enough surface for world.py to import
+  // and run — the point is to exercise the REAL generated world code, with
+  // per-rollout instantiation exactly as the pinned verifiers runtime does it.
+  const stub = join(root, "stub", "verifiers"); mkdirSync(stub, { recursive: true });
+  writeFileSync(join(stub, "__init__.py"), "");
+  writeFileSync(join(root, "stub", "pydantic.py"), [
+    "import copy",
+    "class _FieldMarker:",
+    "    def __init__(self, default_factory=None): self.default_factory = default_factory",
+    "def Field(default_factory=None, **kw): return _FieldMarker(default_factory)",
+    "class BaseModel:",
+    "    def __init__(self, **kw):",
+    "        for k in dir(type(self)):",
+    "            v = getattr(type(self), k)",
+    "            if isinstance(v, _FieldMarker):",
+    "                setattr(self, k, v.default_factory() if v.default_factory else None)",
+    "        self.__dict__.update(kw)",
+    "    def model_dump(self):",
+    "        return copy.deepcopy(self.__dict__)  # snapshot, like real pydantic",
+    "",
+  ].join("\n"));
+  writeFileSync(join(stub, "v1.py"), [
+    "from typing import Generic, TypeVar",
+    "from pydantic import BaseModel",
+    "A = TypeVar('A'); B = TypeVar('B')",
+    "class State(BaseModel): pass",
+    "class ToolsetConfig(BaseModel): pass",
+    "class Toolset(Generic[A, B]):",
+    "    def __init__(self, state): self.state = state",
+    "def tool(name=None):",
+    "    def deco(fn): return fn",
+    "    return deco",
+    "",
+  ].join("\n"));
+  const driver = [
+    "import asyncio, importlib.util, json, sys",
+    `sys.path.insert(0, ${JSON.stringify(join(root, "stub"))})`,
+    `spec = importlib.util.spec_from_file_location('world', ${JSON.stringify(join(output, "environment", "understudy_trace_env", "servers", "world.py"))})`,
+    "world = importlib.util.module_from_spec(spec); spec.loader.exec_module(world)",
+    "async def rollout():",
+    "    # per-rollout env instantiation: fresh WorldState, exactly what the pinned verifiers runtime does",
+    "    state = world.WorldState()",
+    "    ts = world.WorldToolset(state)",
+    "    initial = state.model_dump()",
+    "    reply = await ts.update_record(id=7, status='active')",
+    "    return initial, state.model_dump(), reply",
+    "i1, f1, r1 = asyncio.run(rollout())",
+    "i2, f2, r2 = asyncio.run(rollout())",
+    "print(json.dumps({'initial1': i1, 'final1': f1, 'initial2': i2, 'final2': f2, 'reply1': r1, 'reply2': r2}))",
+  ].join("\n");
+  const proc = spawnSync(pythonBin, ["-c", driver], { encoding: "utf8" });
+  assert.equal(proc.status, 0, proc.stderr);
+  const out = JSON.parse(proc.stdout.trim().split("\n").at(-1));
+  // Rollout 1 really mutated its world.
+  assert.equal(out.final1.writes.length, 1, "rollout 1 performed a write");
+  assert.ok(out.final1.events.length >= 1);
+  // Rollout 2's INITIAL state is the seeded initial state — zero residue.
+  assert.deepEqual(out.initial2, { events: [], writes: [], used_fixtures: [] }, "rollout 2 starts from the seeded initial world state");
+  assert.deepEqual(out.initial2, out.initial1, "both rollouts start identically");
+  // Fixture consumption restarts too: the first matching call in each rollout
+  // gets the same seeded fixture reply, not a continuation of rollout 1's cursor.
+  assert.equal(out.reply2, out.reply1, "fixture cursor resets per rollout");
+  assert.deepEqual(out.final2.used_fixtures, out.final1.used_fixtures);
 });


### PR DESCRIPTION
ABC-checklist follow-ups: report confidence intervals, isolate the candidate from ground truth, prove residual state clears between runs.

## 1. Bootstrap 95% CIs (hub leaderboard)
- New pure module `apps/benchmark-hub/lib/bootstrap.ts`: percentile bootstrap over **per-task mean scores** (task = resampling unit; rollout repeats are correlated), fixed 2000 iterations, **seeded deterministic PRNG** (fnv1a + mulberry32, seed = `benchmark_id::model`) — no `Math.random` anywhere (tests assert it by poisoning `Math.random`).
- `computeLeaderboard` attaches `ci` + `scoredTaskCount` per arm; anomalous rows are excluded exactly like every other aggregate. N=1 task → honest degenerate `[m, m]`; all-anomalous → null.
- Leaderboard shows `mean [lo–hi]`, tasks · rollouts N, and an explicit **statistical-tie** treatment: adjacent arms (overall order) with overlapping CIs are chained into tie groups, their overall cells greyed (`≈`, top-3 shading suppressed) with tooltips + footnotes stating the formula.

## 2. Gold-leakage audit (trace foundry)
- `auditGoldLeakage` runs inside `writeVerifiersEnvironment` over the exact artifacts written: candidate-readable surfaces = `fixtures.json` (seeded initial world state + tool-result templates) and `servers/schemas.json` (observation-tightened enums + `observed_error_example` echoed in rejections). `tasks.json.source_messages` are not scanned — the taskset feeds the candidate only prompt/system_prompt.
- Heuristic (documented in-code): flag contract targets (state_effect/read_obligation string args, value_propagation values, response-obligation gold strings) of ≥12 normalized chars that are verbatim in a candidate surface **and absent from the task's own inputs** (prompt / system prompt / user source messages). Input-carried values are benign by construction.
- **Report-only**: findings land additively in `manifest.leakage_audit` (`understudy.leakage_audit.v1`) and print at build time; nothing is auto-redacted (redaction changes task semantics — a human decides).
- In-tree demo (`experiments/benchmark-hub-demo/proposed-event-triage`, audited on a temp copy): **clean** — its fixtures are empty and the one long response-obligation gold JSON never surfaces in schemas.json.

## 3. Rollout state isolation (integration test)
- Drives the **real generated `world.py`** through two sequential rollouts on a mutating task (`update-record`) via a minimal stubbed `verifiers.v1`/`pydantic` (the offline harness this repo supports; the pinned runtime instantiates a fresh `WorldState` per rollout — this pins that guarantee at the generated-code level).
- Asserts rollout 1 really wrote, rollout 2's initial state is exactly the seeded `{events: [], writes: [], used_fixtures: []}`, and the fixture cursor resets (first reply identical across rollouts). Skips gracefully when no python ≥ 3.10 exists.

## Tests
- root `npm test`: 731 pass (42 in trace-foundry incl. leakage true/false positives + isolation)
- hub `npm test`: 135 pass (bootstrap determinism, N=1, all-anomalous, tie groups, formatCI)
- `tsc --noEmit` clean, `next build` green, `skills:validate` ok (35 skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->