### PR TITLE
Exception-based benchmark review: auto-accept policy + conversational task edit

### DIFF
--- a/apps/benchmark-hub/app/api/feedback/route.ts
+++ b/apps/benchmark-hub/app/api/feedback/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+// Relative imports (not "@/…") so the node:test harness can compile and load
+// this route handler directly; data-core is the server-only-free loader.
+import { getEntry, submitTaskFeedback } from "../../../lib/data-core";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST { slug, task_id, feedback } →
+ * (a) appends one understudy.task_feedback.v1 line to feedback.jsonl next to
+ *     the foundry manifest (append-only sidecar; shared writer in
+ *     dist/benchmark-hub-core.js), and
+ * (b) returns a copyable, pre-filled agent handoff prompt referencing
+ *     `understudy traces regenerate-env`.
+ *
+ * The hub NEVER executes the edit itself — no model calls, no subprocesses
+ * (architectural boundary). The user's coding agent, the benchmarks MCP
+ * surface, or a future daemon verb consumes the recorded feedback unchanged.
+ */
+export async function POST(request: Request) {
+  let body: { slug?: string; task_id?: string; feedback?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const entry = body.slug ? getEntry(body.slug) : null;
+  const result = submitTaskFeedback(entry, body);
+  if (!result.ok) return NextResponse.json({ error: result.error }, { status: result.status });
+  return NextResponse.json({ ok: true, feedback: result.feedback, handoff: result.handoff });
+}

--- a/apps/benchmark-hub/app/api/reviews/auto/route.ts
+++ b/apps/benchmark-hub/app/api/reviews/auto/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+// Relative imports (not "@/…") so the node:test harness can compile and load
+// this route handler directly; data-core is the server-only-free loader.
+import { applyAutoAccepts, getEntry } from "../../../../lib/data-core";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST { slug } → apply the auto-accept policy: recompute
+ * deriveAutoReviewProposals against the entry as loaded and append one
+ * `accept` line per AUTO_ACCEPT task to reviews.jsonl, stamped
+ * `source: "auto"`. This route exists ONLY behind the explicit
+ * "Apply N auto-accepts" click — the hub never writes auto-decisions on page
+ * load. Reversible: reviews.jsonl stays append-only, newest line per task
+ * wins, so any human decision (including via the per-task review bar)
+ * supersedes an auto line.
+ *
+ * All validation + the appends live in the shared applyAutoAccepts
+ * (dist/benchmark-hub-core.js); this route only maps HTTP.
+ */
+export async function POST(request: Request) {
+  let body: { slug?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const entry = body.slug ? getEntry(body.slug) : null;
+  const result = applyAutoAccepts(entry);
+  if (!result.ok) return NextResponse.json({ error: result.error }, { status: result.status });
+  return NextResponse.json({ ok: true, applied: result.applied, exceptions: result.exceptions });
+}

--- a/apps/benchmark-hub/components/proposed/benchmark-page.tsx
+++ b/apps/benchmark-hub/components/proposed/benchmark-page.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 import { taskDisplayName, type ProposedHubEntry } from "@/lib/types";
+import { deriveAutoReviewProposals } from "@/lib/data";
 import { complexityLabel } from "@/lib/trajectory-core";
 import { Badge, SourceBadge, StageBadge } from "@/components/badges";
 import { EmptyState } from "@/components/empty-state";
 import { TaskTable } from "@/components/task-table";
+import { ReviewQueue, type QueueTask } from "@/components/proposed/review-queue";
 
 /**
  * The foundry's promotion blockers for machine-compiled outputs. Mirrored
@@ -27,6 +29,27 @@ export function ProposedBenchmarkPage({ entry }: { entry: ProposedHubEntry }) {
   // Generation-time self-check (foundry structural sentinels), stamped on
   // each task; older builds without the block simply show nothing.
   const selfCheckFailed = entry.tasks.filter((t) => t.self_check != null && t.self_check.ok === false);
+
+  // Exception-first review: classify pending tasks server-side (pure policy,
+  // nothing written) and project serializable props for the client queue.
+  const proposals = deriveAutoReviewProposals(entry);
+  const toQueueTask = (taskId: string, reasons: string[]): QueueTask => {
+    const task = entry.tasks.find((t) => t.task_id === taskId);
+    return {
+      taskId,
+      displayName: task ? taskDisplayName(task) : taskId,
+      href: `/b/${entry.slug}/task/${encodeURIComponent(taskId)}`,
+      reasons,
+    };
+  };
+  const autoAccepts = proposals.filter((p) => p.verdict === "auto_accept").map((p) => toQueueTask(p.task_id, []));
+  const exceptions = proposals.filter((p) => p.verdict === "exception");
+  const exceptionsByReason = ["low_confidence", "self_check_failed", "incumbent_failed", "schema_conflict", "anomaly"]
+    .map((reason) => ({
+      reason,
+      tasks: exceptions.filter((p) => p.reasons.includes(reason as (typeof p.reasons)[number])).map((p) => toQueueTask(p.task_id, p.reasons)),
+    }))
+    .filter((g) => g.tasks.length > 0);
 
   return (
     <div className="u-page">
@@ -151,6 +174,14 @@ export function ProposedBenchmarkPage({ entry }: { entry: ProposedHubEntry }) {
       </header>
 
       <div>
+          {/* Exception queue LEADS the page — auto-accepts collapse to one action. */}
+          <ReviewQueue
+            slug={entry.slug}
+            readOnly={entry.readOnly}
+            exceptionsByReason={exceptionsByReason}
+            autoAccepts={autoAccepts}
+          />
+
           <section className="u-sec" id="tasks">
             <h2>Task inbox</h2>
             <p className="exp">

--- a/apps/benchmark-hub/components/proposed/review-queue.tsx
+++ b/apps/benchmark-hub/components/proposed/review-queue.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/badges";
+
+/** Serializable projection of one policy proposal for client rendering. */
+export type QueueTask = {
+  taskId: string;
+  displayName: string;
+  href: string;
+  reasons: string[];
+};
+
+/** Why a task landed in the exception queue — human labels for the machine reasons. */
+const REASON_LABELS: Record<string, { label: string; detail: string }> = {
+  low_confidence: {
+    label: "low confidence",
+    detail: "machine confidence below the auto-accept bar, or the boundary was a close call",
+  },
+  self_check_failed: {
+    label: "self-check failed",
+    detail: "the foundry's generation-time structural self-check flagged this task",
+  },
+  incumbent_failed: {
+    label: "incumbent failed",
+    detail: "the production model failed its own task in the incumbent calibration rerun",
+  },
+  schema_conflict: {
+    label: "schema conflict",
+    detail: "tasks.jsonl and benchmark.json disagree about this task id",
+  },
+  anomaly: {
+    label: "anomaly",
+    detail: "an executor anomaly sentinel fired on an eval row for this task",
+  },
+};
+
+const REASON_STYLE: Record<string, string> = {
+  low_confidence: "text-warn border-warn/40",
+  self_check_failed: "text-bad border-bad/40",
+  incumbent_failed: "text-bad border-bad/40",
+  schema_conflict: "text-warn border-warn/40",
+  anomaly: "text-bad border-bad/40",
+};
+
+/**
+ * Exception-first review queue for one proposed benchmark. Leads with the
+ * tasks that NEED human judgment, grouped by machine-readable reason; the
+ * auto-acceptable remainder collapses into one summary card with a single
+ * explicit "Apply N auto-accepts" action (the ONLY thing that writes
+ * source:"auto" accept lines — never the page load) and an expandable list.
+ * Everything stays reversible: the per-task review bar overrides any auto
+ * decision (append-only reviews.jsonl, newest per task wins).
+ */
+export function ReviewQueue({
+  slug,
+  readOnly,
+  exceptionsByReason,
+  autoAccepts,
+}: {
+  slug: string;
+  readOnly: boolean;
+  /** reason → tasks carrying it (a task may appear under several reasons). */
+  exceptionsByReason: { reason: string; tasks: QueueTask[] }[];
+  autoAccepts: QueueTask[];
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [appliedCount, setAppliedCount] = useState<number | null>(null);
+  const exceptionCount = new Set(exceptionsByReason.flatMap((g) => g.tasks.map((t) => t.taskId))).size;
+
+  const apply = async () => {
+    setBusy(true);
+    setError(null);
+    const res = await fetch("/api/reviews/auto", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug }),
+    });
+    setBusy(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? `Auto-accept write failed (${res.status})`);
+      return;
+    }
+    const body = await res.json();
+    setAppliedCount(Array.isArray(body.applied) ? body.applied.length : 0);
+    router.refresh();
+  };
+
+  if (exceptionCount === 0 && autoAccepts.length === 0) return null;
+
+  return (
+    <section className="u-sec" id="review-queue">
+      <h2>Review queue</h2>
+      <p className="exp">
+        Only exceptions need your judgment — everything the machine is confident about collapses into one action
+        below. Any auto decision can be overridden per task later (newest review wins).
+      </p>
+
+      {/* EXCEPTIONS FIRST: the human work, grouped by reason. */}
+      {exceptionCount > 0 && (
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-baseline gap-2">
+            <span className="text-sm font-bold">Needs your judgment</span>
+            <Badge className="text-warn border-warn/40">
+              {exceptionCount} task{exceptionCount === 1 ? "" : "s"}
+            </Badge>
+          </div>
+          {exceptionsByReason.map(({ reason, tasks }) => {
+            const meta = REASON_LABELS[reason] ?? { label: reason, detail: "" };
+            return (
+              <div key={reason} className="u-card" style={{ padding: "12px 14px" }}>
+                <div className="flex flex-wrap items-baseline gap-2">
+                  <Badge className={REASON_STYLE[reason] ?? "text-warn border-warn/40"}>{meta.label}</Badge>
+                  <Badge>
+                    {tasks.length} task{tasks.length === 1 ? "" : "s"}
+                  </Badge>
+                  <span className="mono text-[11px] text-faint">{reason}</span>
+                </div>
+                {meta.detail && <p className="mt-2 text-xs text-ink-muted">{meta.detail}</p>}
+                <ul className="mt-2 flex list-none flex-col gap-1 p-0">
+                  {tasks.map((t) => (
+                    <li key={t.taskId} className="text-xs">
+                      <Link href={t.href}>{t.displayName}</Link>
+                      {t.reasons.length > 1 && (
+                        <span className="mono ml-1 text-[10px] text-faint">
+                          also: {t.reasons.filter((r) => r !== reason).map((r) => (REASON_LABELS[r]?.label ?? r)).join(", ")}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* AUTO-ACCEPTS: one summary card, one explicit click, expandable list. */}
+      {autoAccepts.length > 0 && (
+        <div className="u-card mt-3" style={{ padding: "12px 14px" }}>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-bold">Clean by every machine signal</span>
+            <Badge className="text-ok border-ok/50">
+              {autoAccepts.length} task{autoAccepts.length === 1 ? "" : "s"}
+            </Badge>
+            {readOnly ? (
+              <span className="u-foot-note !mt-0">{"// read-only entry — auto-accepts cannot be written here"}</span>
+            ) : (
+              <button className="u-chip" disabled={busy} onClick={apply} style={{ color: "var(--live)" }}>
+                {busy ? "applying…" : `Apply ${autoAccepts.length} auto-accept${autoAccepts.length === 1 ? "" : "s"}`}
+              </button>
+            )}
+          </div>
+          <p className="mt-2 text-xs text-ink-muted">
+            High machine confidence, self-check clean, no incumbent failure, no schema conflict, no anomaly. Nothing is
+            written until you click — each accept lands in reviews.jsonl stamped <span className="mono">source: &quot;auto&quot;</span>{" "}
+            and stays reversible from the task page.
+          </p>
+          {appliedCount != null && (
+            <p className="mono mt-2 text-xs" style={{ color: "var(--live)" }}>
+              applied {appliedCount} auto-accept{appliedCount === 1 ? "" : "s"}
+            </p>
+          )}
+          {error && <p className="mt-2 text-xs text-bad">{error}</p>}
+          <details className="mt-2">
+            <summary className="mono cursor-pointer text-[11px] text-ink-muted">
+              show the {autoAccepts.length} task{autoAccepts.length === 1 ? "" : "s"}
+            </summary>
+            <ul className="mt-2 flex list-none flex-col gap-1 p-0">
+              {autoAccepts.map((t) => (
+                <li key={t.taskId} className="text-xs">
+                  <Link href={t.href}>{t.displayName}</Link>
+                </li>
+              ))}
+            </ul>
+          </details>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/benchmark-hub/components/proposed/task-feedback.tsx
+++ b/apps/benchmark-hub/components/proposed/task-feedback.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Conversational task edit: "What's wrong with this task?" free text →
+ * POST /api/feedback, which records one understudy.task_feedback.v1 line in
+ * the benchmark's feedback.jsonl sidecar and returns a copyable, pre-filled
+ * agent handoff (an `understudy traces regenerate-env` prompt). The hub never
+ * executes the edit itself — the user pastes the handoff into their coding
+ * agent (or the benchmarks MCP surface picks the recorded feedback up).
+ */
+export function TaskFeedbackBox({ slug, taskId, readOnly }: { slug: string; taskId: string; readOnly: boolean }) {
+  const router = useRouter();
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [handoff, setHandoff] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  if (readOnly) {
+    return (
+      <span className="u-foot-note !mt-0">
+        {"// read-only entry (repo fixture) — task feedback cannot be recorded here"}
+      </span>
+    );
+  }
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    const res = await fetch("/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug, task_id: taskId, feedback: text }),
+    });
+    setBusy(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error ?? `Feedback write failed (${res.status})`);
+      return;
+    }
+    const body = await res.json();
+    setHandoff(typeof body.handoff === "string" ? body.handoff : null);
+    setText("");
+    router.refresh();
+  };
+
+  return (
+    <div className="u-card flex flex-col gap-2.5" style={{ padding: "14px 16px" }}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="u-cats-label">What&apos;s wrong with this task?</span>
+        <span className="mono text-[10px] text-faint">your words become the edit instruction</span>
+      </div>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="e.g. the required update-record call should not demand an exact id — any record in the active set counts"
+        rows={3}
+        className="rounded-lg border border-rule-strong bg-card px-2.5 py-1.5 text-xs text-ink focus:border-stamp focus:outline-2 focus:outline-stamp"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <button className="u-chip" disabled={busy || text.trim().length === 0} onClick={submit}>
+          {busy ? "recording…" : "Record & build agent handoff"}
+        </button>
+        <span className="mono text-[10px] text-faint">
+          recorded to feedback.jsonl (understudy.task_feedback.v1) — the hub never edits the task itself
+        </span>
+      </div>
+      {error && <span className="text-xs text-bad">{error}</span>}
+      {handoff && (
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="mono text-[11px] text-ink-muted">
+              hand this to your coding agent (it edits the task, then runs regenerate-env):
+            </span>
+            <button
+              className="u-copy"
+              aria-label="Copy agent handoff prompt"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(handoff);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 1200);
+                } catch {
+                  /* clipboard unavailable (http, permissions) — no-op */
+                }
+              }}
+            >
+              {copied ? "copied" : "copy"}
+            </button>
+          </div>
+          <pre className="u-pre mt-1" style={{ maxHeight: 260 }}>{handoff}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/benchmark-hub/components/proposed/task-page.tsx
+++ b/apps/benchmark-hub/components/proposed/task-page.tsx
@@ -5,6 +5,7 @@ import { taskProvenance } from "@/lib/data";
 import { Badge, ConfidenceChip, DecisionBadge } from "@/components/badges";
 import { TaskViews } from "@/components/trajectory/task-views";
 import { AuthoredPanel, AuthoredStatementCard } from "@/components/trajectory/authored-panel";
+import { TaskFeedbackBox } from "@/components/proposed/task-feedback";
 
 function RequiredEffects({ items }: { items: FoundryContractItem[] }) {
   if (items.length === 0) return <p className="mono mt-2 text-xs text-faint">no required effects proposed</p>;
@@ -145,6 +146,7 @@ export function ProposedTaskPage({ entry, taskId }: { entry: ProposedHubEntry; t
             still shows, and a frontier-complexity contradiction stays loud. */}
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <DecisionBadge decision={review?.decision ?? null} />
+          {review?.source === "auto" && <Badge>auto-accepted · override below</Badge>}
           {task.authored?.difficulty === "easy" && entry.overview?.task_complexity?.[task.task_id]?.frontier && (
             <Badge className="border-bad/40 text-bad">authored easy · frontier-complex</Badge>
           )}
@@ -179,6 +181,19 @@ export function ProposedTaskPage({ entry, taskId }: { entry: ProposedHubEntry; t
       </section>
 
       <AuthoredPanel slug={entry.slug} task={task} review={review} readOnly={entry.readOnly} />
+
+      {/* Conversational edit: the user's words become the task-modification
+          instruction — recorded to feedback.jsonl, executed by THEIR agent
+          via the copyable regenerate-env handoff (the hub never executes). */}
+      <section className="u-section" id="feedback">
+        <div className="u-sec-head">
+          <span className="u-sec-no">03</span>
+          <h2>Fix this task</h2>
+        </div>
+        <div className="mt-4">
+          <TaskFeedbackBox slug={entry.slug} taskId={task.task_id} readOnly={entry.readOnly} />
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/benchmark-hub/lib/data-core.ts
+++ b/apps/benchmark-hub/lib/data-core.ts
@@ -7,7 +7,12 @@
  * app code should import via lib/data.ts.
  */
 export {
+  applyAutoAccepts,
+  AUTO_ACCEPT_CONFIDENCE_THRESHOLD,
+  AUTO_REVIEW_REASONS,
+  buildTaskFeedbackHandoff,
   captureBodyPath,
+  deriveAutoReviewProposals,
   captureFilePath,
   computeWarnings,
   environmentReadiness,
@@ -17,16 +22,23 @@ export {
   loadProposedEntryFromDir,
   loadTaskSidecars,
   loadTraceRecords,
+  MAX_FEEDBACK_LENGTH,
   MAX_REVIEW_NOTE_LENGTH,
   queueOrCancelRun,
   readProposalBenchmarkId,
   submitReview,
+  submitTaskFeedback,
   taskProvenance,
 } from "../../../dist/benchmark-hub-core.js";
 export type {
+  ApplyAutoAcceptsResult,
+  AutoReviewProposal,
+  AutoReviewReason,
   QueueRunBody,
   QueueRunResult,
   SubmitReviewInput,
   SubmitReviewResult,
+  SubmitTaskFeedbackInput,
+  SubmitTaskFeedbackResult,
   WriteFailure,
 } from "../../../dist/benchmark-hub-core.js";

--- a/apps/benchmark-hub/lib/data.ts
+++ b/apps/benchmark-hub/lib/data.ts
@@ -8,6 +8,7 @@ import "server-only";
 export {
   captureFilePath,
   computeWarnings,
+  deriveAutoReviewProposals,
   getEntry,
   loadEntryFromDir,
   loadHub,

--- a/apps/benchmark-hub/tests/exception-review-api.test.mjs
+++ b/apps/benchmark-hub/tests/exception-review-api.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import { POST as postAuto } from "./.build/app/api/reviews/auto/route.js";
+import { POST as postFeedback } from "./.build/app/api/feedback/route.js";
+import { POST as postReview } from "./.build/app/api/reviews/route.js";
+
+const feedbackSchema = JSON.parse(
+  fs.readFileSync(path.resolve("../../schemas/understudy.task_feedback.v1.schema.json"), "utf8"),
+);
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bench-hub-exception-"));
+process.env.BENCHMARK_HUB_DATA_DIR = tmp;
+delete process.env.BENCHMARK_HUB_DEMO;
+after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+// A hand-written foundry proposal: one clean high-confidence task (auto),
+// one low-confidence task (exception), one self-check failure (exception).
+function task(id, overrides = {}) {
+  return {
+    schema_version: "understudy.benchmark_task.v1",
+    task_id: id,
+    execution_group: "g1",
+    title: `task ${id}`,
+    status: "machine_proposed",
+    split: "construction",
+    candidate_boundary: "b",
+    machine_confidence: "high",
+    close_call: false,
+    tool_surface: [],
+    outcome_contract: { required: [], preserved: [], forbidden: [], grading: "final_state" },
+    world_model: {},
+    source: { node_ids: [], edges: [], captures: [] },
+    claims: [],
+    sentinels: [],
+    review: { decision: "pending" },
+    ...overrides,
+  };
+}
+const tasks = [
+  task("t-clean"),
+  task("t-low", { machine_confidence: "low" }),
+  task("t-selfcheck", { self_check: { ok: false, failures: [{ check: "empty_contract", detail: "d" }] } }),
+];
+const outDir = path.join(tmp, "prop");
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(
+  path.join(outDir, "manifest.json"),
+  JSON.stringify({
+    schema_version: "understudy.trace_foundry.v1",
+    freshness: { max_age_days: 30, cutoff_utc: "2026-07-01T00:00:00Z", newest_capture_utc: "2026-07-20T00:00:00Z" },
+    counts: { source_files: 1, captures: 1, tasks: tasks.length, edges: 0, stale_filtered: 0, invalid_timestamp_filtered: 0 },
+  }),
+);
+fs.writeFileSync(path.join(outDir, "tasks.jsonl"), tasks.map((t) => JSON.stringify(t)).join("\n") + "\n");
+fs.writeFileSync(
+  path.join(outDir, "benchmark.json"),
+  JSON.stringify({
+    schema_version: "understudy.benchmark_proposal.v1",
+    benchmark_id: "prop-bench",
+    tasks: tasks.map((t) => ({ task_id: t.task_id })),
+  }),
+);
+
+function post(handler, url, body) {
+  return handler(
+    new Request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/reviews/auto", () => {
+  it("rejects a non-JSON body with 400 and an unknown slug with 404", async () => {
+    assert.equal((await post(postAuto, "http://localhost/api/reviews/auto", "not json")).status, 400);
+    assert.equal((await post(postAuto, "http://localhost/api/reviews/auto", { slug: "data--nope" })).status, 404);
+  });
+
+  it("applies auto-accepts for clean tasks only, stamped source:'auto'", async () => {
+    const res = await post(postAuto, "http://localhost/api/reviews/auto", { slug: "data--prop" });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body.applied, ["t-clean"]);
+    assert.equal(body.exceptions, 2);
+
+    const lines = fs.readFileSync(path.join(outDir, "reviews.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].task_id, "t-clean");
+    assert.equal(lines[0].decision, "accept");
+    assert.equal(lines[0].source, "auto");
+  });
+
+  it("second apply is a no-op; a human review-bar POST supersedes the auto line", async () => {
+    const again = await post(postAuto, "http://localhost/api/reviews/auto", { slug: "data--prop" });
+    assert.deepEqual((await again.json()).applied, []);
+
+    const override = await post(postReview, "http://localhost/api/reviews", {
+      slug: "data--prop",
+      task_id: "t-clean",
+      decision: "restrict",
+      note: "narrow the contract",
+    });
+    assert.equal(override.status, 200);
+    const { getEntry } = await import("./.build/lib/data-core.js");
+    const latest = getEntry("data--prop").latestReviewByTask["t-clean"];
+    assert.equal(latest.decision, "restrict");
+    assert.equal(latest.source, undefined);
+  });
+});
+
+describe("POST /api/feedback", () => {
+  it("rejects bad input: non-JSON 400, unknown slug 404, empty feedback 400, unknown task 404", async () => {
+    assert.equal((await post(postFeedback, "http://localhost/api/feedback", "not json")).status, 400);
+    assert.equal((await post(postFeedback, "http://localhost/api/feedback", { slug: "data--nope", task_id: "t-low", feedback: "x" })).status, 404);
+    assert.equal((await post(postFeedback, "http://localhost/api/feedback", { slug: "data--prop", task_id: "t-low", feedback: "   " })).status, 400);
+    assert.equal((await post(postFeedback, "http://localhost/api/feedback", { slug: "data--prop", task_id: "t-999", feedback: "x" })).status, 404);
+  });
+
+  it("appends a schema-valid understudy.task_feedback.v1 line and returns the agent handoff", async () => {
+    const res = await post(postFeedback, "http://localhost/api/feedback", {
+      slug: "data--prop",
+      task_id: "t-low",
+      feedback: "the boundary is wrong — the second capture belongs to a different task",
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.feedback.schema_version, "understudy.task_feedback.v1");
+    for (const key of feedbackSchema.required) assert.notEqual(body.feedback[key], undefined, `missing ${key}`);
+    assert.equal(body.feedback.status, "open");
+    assert.ok(body.handoff.includes("understudy traces regenerate-env --benchmark"));
+    assert.ok(body.handoff.includes("t-low"));
+    assert.ok(body.handoff.includes("the boundary is wrong"));
+
+    const lines = fs.readFileSync(path.join(outDir, "feedback.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].task_id, "t-low");
+    assert.equal(lines[0].benchmark_id, "prop");
+  });
+});

--- a/apps/benchmark-hub/tests/tsconfig.json
+++ b/apps/benchmark-hub/tests/tsconfig.json
@@ -18,6 +18,8 @@
     "../lib/data-core.ts",
     "../app/api/flags/route.ts",
     "../app/api/reviews/route.ts",
+    "../app/api/reviews/auto/route.ts",
+    "../app/api/feedback/route.ts",
     "../app/api/captures/route.ts",
     "../lib/trace-viewer-core.ts",
     "../app/api/trace-viewer/route.ts",

--- a/schemas/understudy.task_feedback.v1.schema.json
+++ b/schemas/understudy.task_feedback.v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.task_feedback.v1.schema.json",
+  "title": "understudy.task_feedback.v1",
+  "description": "One free-text 'what is wrong with this task' line against a machine-proposed benchmark task. Stored as one JSON object per line in a feedback.jsonl file next to the foundry's manifest.json (understudy.trace_foundry.v1), append-only. The hub only records the feedback and surfaces a copyable agent handoff (referencing `understudy traces regenerate-env`); a coding agent, the benchmarks MCP surface, or a future daemon verb consumes open lines to modify the task. Producers may add extra fields; consumers must ignore fields they do not understand.",
+  "type": "object",
+  "required": ["schema_version", "benchmark_id", "task_id", "feedback", "created_at", "status"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "understudy.task_feedback.v1",
+      "description": "Version stamp for this feedback shape."
+    },
+    "benchmark_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Slug of the foundry output directory the task belongs to (the directory basename). Note: NOT an understudy.benchmark.v1 benchmark_id — proposed benchmarks have no promoted manifest yet. No absolute paths are recorded (portability rule)."
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "task_id of the understudy.benchmark_task.v1 line in tasks.jsonl this feedback targets."
+    },
+    "feedback": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The reviewer's own words describing what is wrong with the task or how it should change."
+    },
+    "created_at": {
+      "type": "string",
+      "description": "ISO-8601 timestamp the feedback was recorded."
+    },
+    "source": {
+      "type": "string",
+      "description": "Producing surface: 'hub' for the review UI; agents may append with their own label."
+    },
+    "status": {
+      "enum": ["open", "addressed"],
+      "description": "Lifecycle for a consumer verb: open (awaiting an agent edit) or addressed (a consumer edited the task and appended a superseding line). Append-only file; the newest line per task_id wins."
+    }
+  }
+}

--- a/src/benchmark-artifacts.ts
+++ b/src/benchmark-artifacts.ts
@@ -51,6 +51,8 @@ export const CALIBRATION_SCHEMA = "understudy.calibration.v1";
 export const AUTHORING_EVENT_SCHEMA = "understudy.authoring_event.v1";
 /** Foundry generation-time structural self-check (manifest.self_check + task.self_check). */
 export const FOUNDRY_SELF_CHECK_SCHEMA = "understudy.foundry_self_check.v1";
+/** feedback.jsonl sidecar: free-text "what's wrong with this task" lines (append-only). */
+export const TASK_FEEDBACK_SCHEMA = "understudy.task_feedback.v1";
 
 /* ------------------------------------------------------------------ */
 /* JSONL codec                                                         */
@@ -201,6 +203,13 @@ export type BenchmarkReview = {
   decision: ReviewDecision;
   note: string;
   created_at: string;
+  /**
+   * Additive: who recorded the decision. "auto" = the hub's exception-review
+   * auto-accept policy (applied only on an explicit user click, never on page
+   * load); absent/"human" = a human clicked the review bar. Reversible either
+   * way — the append-only newest-per-task rule is unchanged.
+   */
+  source?: "auto" | "human";
 };
 
 /** The reader-side acceptance test for one reviews.jsonl row. */
@@ -220,6 +229,7 @@ export function makeBenchmarkReview(input: {
   decision: ReviewDecision;
   note?: string | null;
   created_at?: string;
+  source?: "auto" | "human";
 }): BenchmarkReview {
   return {
     schema_version: BENCHMARK_REVIEW_SCHEMA,
@@ -228,6 +238,8 @@ export function makeBenchmarkReview(input: {
     decision: input.decision,
     note: typeof input.note === "string" ? input.note : "",
     created_at: input.created_at ?? new Date().toISOString(),
+    // Additive: omitted entirely when unspecified so legacy lines stay byte-identical.
+    ...(input.source ? { source: input.source } : {}),
   };
 }
 
@@ -246,6 +258,75 @@ export function latestReviewByTask(reviews: BenchmarkReview[]): Record<string, B
   const latest: Record<string, BenchmarkReview> = {};
   for (const review of reviews) latest[review.task_id] = review;
   return latest;
+}
+
+/* ------------------------------------------------------------------ */
+/* Task feedback (<benchmark>/feedback.jsonl — append-only sidecar)    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * understudy.task_feedback.v1 — one free-text "what's wrong with this task"
+ * line from the hub's conversational edit box. The hub only RECORDS the
+ * feedback and hands the user a copyable agent prompt (the hub never
+ * executes); a coding agent — or a future daemon verb — consumes open lines
+ * and runs `understudy traces regenerate-env` after editing the task. No
+ * absolute paths are recorded (portability rule): benchmark_id is the foundry
+ * output dir basename, same convention as reviews.jsonl.
+ */
+export type TaskFeedback = {
+  schema_version: typeof TASK_FEEDBACK_SCHEMA;
+  /** Foundry output dir slug (directory basename), NOT a benchmark.v1 benchmark_id. */
+  benchmark_id: string;
+  task_id: string;
+  /** The reviewer's own words describing what is wrong / should change. */
+  feedback: string;
+  created_at: string;
+  /** Producing surface ("hub" for the review UI; agents may append with their own label). */
+  source: string;
+  /** Lifecycle for a future consumer verb: open → addressed. Append-only file; newest line per task_id wins. */
+  status: "open" | "addressed";
+};
+
+/** Reader-side acceptance test for one feedback.jsonl row. */
+export function isTaskFeedback(row: unknown): row is TaskFeedback {
+  const r = asObject(row);
+  return (
+    r.schema_version === TASK_FEEDBACK_SCHEMA &&
+    typeof r.benchmark_id === "string" &&
+    typeof r.task_id === "string" &&
+    typeof r.feedback === "string" &&
+    (r.status === "open" || r.status === "addressed")
+  );
+}
+
+/** The ONE constructor every feedback producer uses. */
+export function makeTaskFeedback(input: {
+  benchmark_id: string;
+  task_id: string;
+  feedback: string;
+  source?: string;
+  status?: "open" | "addressed";
+  created_at?: string;
+}): TaskFeedback {
+  return {
+    schema_version: TASK_FEEDBACK_SCHEMA,
+    benchmark_id: input.benchmark_id,
+    task_id: input.task_id,
+    feedback: input.feedback,
+    created_at: input.created_at ?? new Date().toISOString(),
+    source: input.source ?? "hub",
+    status: input.status ?? "open",
+  };
+}
+
+export function serializeTaskFeedbackLine(feedback: TaskFeedback): string {
+  return serializeJsonlLine(feedback);
+}
+
+/** Valid feedback rows from a feedback.jsonl file (invalid rows dropped, lines tolerant). */
+export function readTaskFeedback(file: string): { feedback: TaskFeedback[]; skipped: number } {
+  const { items, skipped } = readJsonlFile(file);
+  return { feedback: items.filter(isTaskFeedback), skipped };
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -25,8 +25,11 @@ import {
   isBenchmarkReview,
   latestReviewByTask as sharedLatestReviewByTask,
   makeBenchmarkReview,
+  makeTaskFeedback,
   readJsonlFile,
   serializeReviewLine,
+  serializeTaskFeedbackLine,
+  type TaskFeedback,
 } from "./benchmark-artifacts.js";
 import {
   cancelRunRequest,
@@ -330,6 +333,9 @@ export function loadProposedEntryFromDir(
     diagnostics,
     crossCheckErrors,
     overview: loadOverview(dir),
+    // Additive: a pre-promotion incumbent rerun's calibration sidecar feeds
+    // the exception-review policy (incumbent_failed).
+    calibration: loadCalibration(dir, proposalBenchmarkId),
   };
 }
 
@@ -824,4 +830,206 @@ export function queueOrCancelRun(entry: AnyHubEntry | null, body: QueueRunBody):
     calibration_threshold: input.calibration_threshold as number | undefined,
   });
   return { ok: true, run, execute_hint: `understudy runs execute --benchmark ${entry.dir} --watch` };
+}
+
+/* ------------------------------------------------------------------ */
+/* Exception-based review: auto-accept policy + conversational task    */
+/* feedback. NEW exported functions only — nothing above is rewritten. */
+/* ------------------------------------------------------------------ */
+
+/** Machine-readable reasons a pending task needs human judgment. */
+export const AUTO_REVIEW_REASONS = [
+  "low_confidence",
+  "self_check_failed",
+  "incumbent_failed",
+  "schema_conflict",
+  "anomaly",
+] as const;
+export type AutoReviewReason = (typeof AUTO_REVIEW_REASONS)[number];
+
+export type AutoReviewProposal = {
+  task_id: string;
+  verdict: "auto_accept" | "exception";
+  /** Empty for auto_accept; ordered by AUTO_REVIEW_REASONS otherwise. */
+  reasons: AutoReviewReason[];
+};
+
+/**
+ * The confidence bar for auto-acceptance. machine_confidence is an ordered
+ * enum (high > medium > low); a task clears the bar only at "high", and a
+ * high-confidence close_call is still treated as low_confidence — the machine
+ * itself flagged the boundary as borderline.
+ */
+export const AUTO_ACCEPT_CONFIDENCE_THRESHOLD: FoundryTask["machine_confidence"] = "high";
+
+/**
+ * Pure classification of every PENDING task (tasks whose newest review line,
+ * if any, already decided them are skipped — auto-accept never re-decides).
+ *
+ * AUTO_ACCEPT requires ALL of:
+ * - machine_confidence ≥ AUTO_ACCEPT_CONFIDENCE_THRESHOLD and not close_call
+ *   (else: low_confidence)
+ * - the foundry self_check, when stamped, passed (else: self_check_failed;
+ *   pre-self-check builds without the block count as clean)
+ * - calibration.json absent, or absent for this task, or the incumbent passed
+ *   it (else: incumbent_failed)
+ * - tasks.jsonl and benchmark.json agree on this task id (else: schema_conflict)
+ * - no eval row for the task carries an executor anomaly sentinel (else: anomaly)
+ *
+ * Classification only — nothing is written here. Writes happen in
+ * applyAutoAccepts, and only on an explicit user action.
+ */
+export function deriveAutoReviewProposals(entry: ProposedHubEntry): AutoReviewProposal[] {
+  const calibrationByTask = new Map<string, boolean>();
+  for (const t of entry.calibration?.tasks ?? []) calibrationByTask.set(t.task_id, t.passed);
+  const failedIds = new Set(entry.calibration?.failed_task_ids ?? []);
+  const anomalousTaskIds = new Set(entry.rows.filter((r) => r.anomaly != null).map((r) => r.task_id));
+
+  const proposals: AutoReviewProposal[] = [];
+  for (const task of entry.tasks) {
+    if (entry.latestReviewByTask[task.task_id]) continue; // already decided (newest-wins)
+    const reasons: AutoReviewReason[] = [];
+    if (task.machine_confidence !== AUTO_ACCEPT_CONFIDENCE_THRESHOLD || task.close_call) {
+      reasons.push("low_confidence");
+    }
+    if (task.self_check != null && task.self_check.ok === false) reasons.push("self_check_failed");
+    const calibrated = calibrationByTask.get(task.task_id);
+    if (calibrated === false || failedIds.has(task.task_id)) reasons.push("incumbent_failed");
+    if (entry.crossCheckErrors.some((e) => e.includes(task.task_id))) reasons.push("schema_conflict");
+    if (anomalousTaskIds.has(task.task_id)) reasons.push("anomaly");
+    proposals.push({
+      task_id: task.task_id,
+      verdict: reasons.length === 0 ? "auto_accept" : "exception",
+      reasons,
+    });
+  }
+  return proposals;
+}
+
+export type ApplyAutoAcceptsResult =
+  | { ok: true; applied: string[]; exceptions: number; reviews: BenchmarkReview[] }
+  | WriteFailure;
+
+/**
+ * The ONE write path for auto-decisions: recompute the policy against the
+ * entry as loaded and append one `accept` line per AUTO_ACCEPT task, stamped
+ * `source: "auto"` (additive field). Called only from an explicit user action
+ * ("Apply N auto-accepts") — never on page load. Fully reversible: a later
+ * human line for the same task supersedes it (append-only, newest-wins).
+ */
+export function applyAutoAccepts(entry: AnyHubEntry | null): ApplyAutoAcceptsResult {
+  if (!entry || entry.kind === "invalid") return { ok: false, error: "unknown benchmark", status: 404 };
+  if (entry.kind !== "proposed") {
+    return { ok: false, error: "auto-accept only applies to proposed (trace-foundry) benchmarks", status: 400 };
+  }
+  if (entry.readOnly) {
+    return {
+      ok: false,
+      error: "This entry is read-only (demo/fixture source); reviews cannot be written here.",
+      status: 403,
+    };
+  }
+  const proposals = deriveAutoReviewProposals(entry);
+  const reviews: BenchmarkReview[] = [];
+  for (const p of proposals) {
+    if (p.verdict !== "auto_accept") continue;
+    reviews.push(
+      makeBenchmarkReview({
+        benchmark_id: path.basename(entry.dir),
+        task_id: p.task_id,
+        decision: "accept",
+        note: "auto-accepted: high machine confidence, self-check clean, no incumbent/schema/anomaly evidence against it",
+        source: "auto",
+      }) as BenchmarkReview,
+    );
+  }
+  if (reviews.length > 0) {
+    fs.appendFileSync(
+      path.join(entry.dir, "reviews.jsonl"),
+      reviews.map((r) => serializeReviewLine(r)).join(""),
+      "utf8",
+    );
+  }
+  return {
+    ok: true,
+    applied: reviews.map((r) => r.task_id),
+    exceptions: proposals.filter((p) => p.verdict === "exception").length,
+    reviews,
+  };
+}
+
+/** Hard cap on conversational task feedback length (413 above this). */
+export const MAX_FEEDBACK_LENGTH = 4000;
+
+export type SubmitTaskFeedbackInput = { task_id?: unknown; feedback?: unknown };
+export type SubmitTaskFeedbackResult =
+  | { ok: true; feedback: TaskFeedback; handoff: string }
+  | WriteFailure;
+
+/**
+ * Build the copyable agent-handoff prompt for one recorded feedback line. The
+ * hub NEVER executes this itself (architectural boundary: the hub never spawns
+ * model calls or subprocesses) — the user pastes it into their coding agent,
+ * or the benchmarks MCP surface (docs/agent-operator-surface.md) picks it up.
+ * A future daemon verb consumes the same understudy.task_feedback.v1 record.
+ */
+export function buildTaskFeedbackHandoff(dir: string, taskId: string, feedback: string): string {
+  return [
+    `You are modifying one machine-proposed benchmark task in place.`,
+    ``,
+    `Benchmark dir: ${dir}`,
+    `Task: ${taskId}`,
+    ``,
+    `The reviewer says this is wrong with the task:`,
+    `"""`,
+    feedback,
+    `"""`,
+    ``,
+    `1. Read ${path.join(dir, "tasks.jsonl")} and find the line with task_id ${taskId}; also read any`,
+    `   understudy.task_feedback.v1 lines for it in ${path.join(dir, "feedback.jsonl")} for history.`,
+    `2. Edit that task line to address the feedback (title, outcome_contract, world_model, or the`,
+    `   authored block), keeping schema_version understudy.benchmark_task.v1 and the task_id stable.`,
+    `3. Rebuild the generated environment in place (tasks, reviews, and authored blocks are untouched):`,
+    `   understudy traces regenerate-env --benchmark ${dir}`,
+    `4. Confirm ${path.join(dir, "environment", "offline-validation.json")} passes for ${taskId}, then`,
+    `   report exactly what you changed and why it addresses the feedback.`,
+  ].join("\n");
+}
+
+/**
+ * Validate + append one understudy.task_feedback.v1 line to feedback.jsonl
+ * next to the foundry manifest (append-only sidecar; the shared codec is the
+ * writer). Storage + handoff only — the hub never executes the edit.
+ */
+export function submitTaskFeedback(
+  entry: AnyHubEntry | null,
+  input: SubmitTaskFeedbackInput,
+): SubmitTaskFeedbackResult {
+  if (!entry || entry.kind === "invalid") return { ok: false, error: "unknown benchmark", status: 404 };
+  if (entry.kind !== "proposed") {
+    return { ok: false, error: "task feedback only applies to proposed (trace-foundry) benchmarks", status: 400 };
+  }
+  if (entry.readOnly) {
+    return {
+      ok: false,
+      error: "This entry is read-only (demo/fixture source); feedback cannot be written here.",
+      status: 403,
+    };
+  }
+  if (typeof input.feedback !== "string" || input.feedback.trim().length === 0) {
+    return { ok: false, error: "feedback must be a non-empty string", status: 400 };
+  }
+  if (input.feedback.length > MAX_FEEDBACK_LENGTH) {
+    return { ok: false, error: `feedback too long (max ${MAX_FEEDBACK_LENGTH} characters)`, status: 413 };
+  }
+  if (typeof input.task_id !== "string" || !entry.tasks.some((t) => t.task_id === input.task_id)) {
+    return { ok: false, error: "unknown task_id", status: 404 };
+  }
+  const feedback = makeTaskFeedback({
+    benchmark_id: path.basename(entry.dir),
+    task_id: input.task_id,
+    feedback: input.feedback.trim(),
+  });
+  fs.appendFileSync(path.join(entry.dir, "feedback.jsonl"), serializeTaskFeedbackLine(feedback), "utf8");
+  return { ok: true, feedback, handoff: buildTaskFeedbackHandoff(entry.dir, input.task_id, feedback.feedback) };
 }

--- a/src/benchmark-hub-types.ts
+++ b/src/benchmark-hub-types.ts
@@ -189,6 +189,8 @@ export type BenchmarkReview = {
   decision: ReviewDecision;
   note: string;
   created_at: string;
+  /** Additive: "auto" = hub auto-accept policy (user-triggered apply); absent/"human" = review bar. */
+  source?: "auto" | "human";
 };
 
 /** understudy.trace_foundry.v1 manifest.json (subset the hub renders). */
@@ -407,6 +409,8 @@ export type ProposedHubEntry = {
   crossCheckErrors: string[];
   /** benchmark-overview.json (understudy.benchmark_overview.v1) when the --overview pass has run. */
   overview: BenchmarkOverview | null;
+  /** understudy.calibration.v1 sidecar from a pre-promotion incumbent rerun, when present (additive). */
+  calibration?: CalibrationSummary | null;
 };
 
 export type AnyHubEntry = HubEntry | InvalidHubEntry | ProposedHubEntry;

--- a/tests/exception-review.test.mjs
+++ b/tests/exception-review.test.mjs
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import {
+  applyAutoAccepts,
+  buildTaskFeedbackHandoff,
+  deriveAutoReviewProposals,
+  loadProposedEntryFromDir,
+  submitReview,
+  submitTaskFeedback,
+  MAX_FEEDBACK_LENGTH,
+} from "../dist/benchmark-hub-core.js";
+import {
+  TASK_FEEDBACK_SCHEMA,
+  isTaskFeedback,
+  latestReviewByTask,
+  makeTaskFeedback,
+  readReviews,
+  readTaskFeedback,
+  serializeTaskFeedbackLine,
+} from "../dist/benchmark-artifacts.js";
+
+const tmpDirs = [];
+after(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+function tmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "exception-review-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+/* ------------------------------------------------------------------ */
+/* Pure policy matrix                                                  */
+/* ------------------------------------------------------------------ */
+
+function task(id, overrides = {}) {
+  return {
+    schema_version: "understudy.benchmark_task.v1",
+    task_id: id,
+    execution_group: "g1",
+    title: `task ${id}`,
+    status: "machine_proposed",
+    split: "construction",
+    candidate_boundary: "b",
+    machine_confidence: "high",
+    close_call: false,
+    tool_surface: [],
+    outcome_contract: { required: [], preserved: [], forbidden: [], grading: "final_state" },
+    world_model: {},
+    source: { node_ids: [], edges: [], captures: [] },
+    claims: [],
+    sentinels: [],
+    review: { decision: "pending" },
+    ...overrides,
+  };
+}
+
+function entryWith(overrides = {}) {
+  return {
+    kind: "proposed",
+    slug: "data--x",
+    source: "data-dir",
+    readOnly: false,
+    dir: "/tmp/x",
+    manifestPath: "/tmp/x/manifest.json",
+    foundry: { schema_version: "understudy.trace_foundry.v1" },
+    tasks: [],
+    dag: null,
+    captureIndex: [],
+    rows: [],
+    reviews: [],
+    latestReviewByTask: {},
+    diagnostics: { skippedLines: 0, droppedRows: 0, foreignRows: 0, foreignFlags: 0 },
+    crossCheckErrors: [],
+    overview: null,
+    calibration: null,
+    ...overrides,
+  };
+}
+
+describe("deriveAutoReviewProposals — classification matrix", () => {
+  it("high confidence + clean self_check + no calibration ⇒ auto_accept", () => {
+    const proposals = deriveAutoReviewProposals(entryWith({ tasks: [task("t1")] }));
+    assert.deepEqual(proposals, [{ task_id: "t1", verdict: "auto_accept", reasons: [] }]);
+  });
+
+  it("absent self_check block counts as clean (pre-self-check builds)", () => {
+    const t = task("t1");
+    delete t.self_check;
+    const [p] = deriveAutoReviewProposals(entryWith({ tasks: [t] }));
+    assert.equal(p.verdict, "auto_accept");
+  });
+
+  it("confidence below the bar ⇒ exception(low_confidence), for medium and low", () => {
+    for (const level of ["medium", "low"]) {
+      const [p] = deriveAutoReviewProposals(entryWith({ tasks: [task("t1", { machine_confidence: level })] }));
+      assert.equal(p.verdict, "exception");
+      assert.deepEqual(p.reasons, ["low_confidence"]);
+    }
+  });
+
+  it("a high-confidence close_call is still low_confidence", () => {
+    const [p] = deriveAutoReviewProposals(entryWith({ tasks: [task("t1", { close_call: true })] }));
+    assert.deepEqual(p.reasons, ["low_confidence"]);
+  });
+
+  it("failed self_check ⇒ exception(self_check_failed); passing self_check stays clean", () => {
+    const failed = task("t1", { self_check: { ok: false, failures: [{ check: "empty_contract", detail: "d" }] } });
+    const passed = task("t2", { self_check: { ok: true, failures: [] } });
+    const proposals = deriveAutoReviewProposals(entryWith({ tasks: [failed, passed] }));
+    assert.deepEqual(proposals[0].reasons, ["self_check_failed"]);
+    assert.equal(proposals[1].verdict, "auto_accept");
+  });
+
+  it("calibration present: incumbent pass ⇒ auto_accept, fail ⇒ incumbent_failed, unlisted ⇒ no evidence", () => {
+    const calibration = {
+      schema_version: "understudy.calibration.v1",
+      benchmark_id: "b",
+      run_id: "r",
+      incumbent_models: ["m"],
+      threshold: 0.5,
+      started_at: null,
+      finished_at: null,
+      tasks: [
+        { task_id: "t-pass", score: 1, passed: true, rollouts: 1 },
+        { task_id: "t-fail", score: 0, passed: false, rollouts: 1 },
+      ],
+      passed_count: 1,
+      failed_count: 1,
+      failed_task_ids: ["t-fail"],
+    };
+    const proposals = deriveAutoReviewProposals(
+      entryWith({ tasks: [task("t-pass"), task("t-fail"), task("t-unlisted")], calibration }),
+    );
+    assert.equal(proposals[0].verdict, "auto_accept");
+    assert.deepEqual(proposals[1].reasons, ["incumbent_failed"]);
+    assert.equal(proposals[2].verdict, "auto_accept");
+  });
+
+  it("cross-check disagreement ⇒ schema_conflict; anomalous eval row ⇒ anomaly", () => {
+    const proposals = deriveAutoReviewProposals(
+      entryWith({
+        tasks: [task("t-conflict"), task("t-anomaly")],
+        crossCheckErrors: ["t-conflict missing from benchmark.json"],
+        rows: [
+          { schema_version: "understudy.eval_result.v1", run_id: "r", task_id: "t-anomaly", status: "ok", anomaly: { kind: "runaway", detail: "d" } },
+        ],
+      }),
+    );
+    assert.deepEqual(proposals[0].reasons, ["schema_conflict"]);
+    assert.deepEqual(proposals[1].reasons, ["anomaly"]);
+  });
+
+  it("reasons compound (low_confidence + self_check_failed + incumbent_failed)", () => {
+    const calibration = {
+      schema_version: "understudy.calibration.v1",
+      benchmark_id: "b",
+      run_id: "r",
+      incumbent_models: ["m"],
+      threshold: 0.5,
+      started_at: null,
+      finished_at: null,
+      tasks: [{ task_id: "t1", score: 0, passed: false, rollouts: 1 }],
+      passed_count: 0,
+      failed_count: 1,
+      failed_task_ids: ["t1"],
+    };
+    const [p] = deriveAutoReviewProposals(
+      entryWith({
+        tasks: [task("t1", { machine_confidence: "low", self_check: { ok: false, failures: [] } })],
+        calibration,
+      }),
+    );
+    assert.deepEqual(p.reasons, ["low_confidence", "self_check_failed", "incumbent_failed"]);
+  });
+
+  it("already-decided tasks are skipped — auto never re-decides (newest-wins respected)", () => {
+    const proposals = deriveAutoReviewProposals(
+      entryWith({
+        tasks: [task("t1"), task("t2")],
+        latestReviewByTask: {
+          t1: { schema_version: "understudy.benchmark_review.v1", benchmark_id: "b", task_id: "t1", decision: "reject", note: "", created_at: "x" },
+        },
+      }),
+    );
+    assert.deepEqual(proposals.map((p) => p.task_id), ["t2"]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Write path: applyAutoAccepts over a real foundry dir                */
+/* ------------------------------------------------------------------ */
+
+function writeFoundryDir(dir, tasks) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "manifest.json"),
+    JSON.stringify({
+      schema_version: "understudy.trace_foundry.v1",
+      freshness: { max_age_days: 30, cutoff_utc: "2026-07-01T00:00:00Z", newest_capture_utc: "2026-07-20T00:00:00Z" },
+      counts: { source_files: 1, captures: 1, tasks: tasks.length, edges: 0, stale_filtered: 0, invalid_timestamp_filtered: 0 },
+    }),
+  );
+  fs.writeFileSync(path.join(dir, "tasks.jsonl"), tasks.map((t) => JSON.stringify(t)).join("\n") + "\n");
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark_proposal.v1",
+      benchmark_id: "prop-bench",
+      tasks: tasks.map((t) => ({ task_id: t.task_id })),
+    }),
+  );
+}
+
+describe("applyAutoAccepts — write path", () => {
+  it("appends accept lines stamped source:'auto' for auto-accepts only, on explicit call", () => {
+    const dir = path.join(tmpDir(), "prop");
+    writeFoundryDir(dir, [task("t-clean"), task("t-shaky", { machine_confidence: "low" })]);
+    const entry = loadProposedEntryFromDir(dir, "data-dir", "data--prop", false);
+
+    const result = applyAutoAccepts(entry);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.applied, ["t-clean"]);
+    assert.equal(result.exceptions, 1);
+
+    const { reviews, skipped } = readReviews(path.join(dir, "reviews.jsonl"));
+    assert.equal(skipped, 0);
+    assert.equal(reviews.length, 1);
+    assert.equal(reviews[0].task_id, "t-clean");
+    assert.equal(reviews[0].decision, "accept");
+    assert.equal(reviews[0].source, "auto");
+    assert.equal(reviews[0].benchmark_id, "prop");
+  });
+
+  it("is idempotent (second apply writes nothing) and reversible (human line supersedes)", () => {
+    const dir = path.join(tmpDir(), "prop");
+    writeFoundryDir(dir, [task("t-clean")]);
+    applyAutoAccepts(loadProposedEntryFromDir(dir, "data-dir", "data--prop", false));
+
+    // Second apply: the task is already decided — no new lines.
+    const again = applyAutoAccepts(loadProposedEntryFromDir(dir, "data-dir", "data--prop", false));
+    assert.equal(again.ok, true);
+    assert.deepEqual(again.applied, []);
+    assert.equal(readReviews(path.join(dir, "reviews.jsonl")).reviews.length, 1);
+
+    // Human override through the SAME shared submitReview: newest line wins.
+    const entry = loadProposedEntryFromDir(dir, "data-dir", "data--prop", false);
+    const override = submitReview(entry, { task_id: "t-clean", decision: "reject", note: "bad gold after all" });
+    assert.equal(override.ok, true);
+    const { reviews } = readReviews(path.join(dir, "reviews.jsonl"));
+    assert.equal(reviews.length, 2);
+    assert.equal(latestReviewByTask(reviews)["t-clean"].decision, "reject");
+    assert.equal(latestReviewByTask(reviews)["t-clean"].source, undefined);
+  });
+
+  it("rejects read-only and non-proposed entries", () => {
+    const dir = path.join(tmpDir(), "prop");
+    writeFoundryDir(dir, [task("t1")]);
+    const readOnly = loadProposedEntryFromDir(dir, "fixture", "fixture--prop", true);
+    assert.equal(applyAutoAccepts(readOnly).status, 403);
+    assert.equal(applyAutoAccepts(null).status, 404);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Task feedback: append + schema + handoff                            */
+/* ------------------------------------------------------------------ */
+
+const feedbackSchema = JSON.parse(
+  fs.readFileSync(path.resolve("schemas", "understudy.task_feedback.v1.schema.json"), "utf8"),
+);
+
+function schemaErrors(schema, value, at = "$") {
+  const errors = [];
+  if ("const" in schema && value !== schema.const) errors.push(`${at}: expected const`);
+  if (schema.enum && !schema.enum.includes(value)) errors.push(`${at}: not in enum`);
+  if (schema.type === "object" || schema.properties || schema.required) {
+    if (typeof value === "object" && value !== null) {
+      for (const key of schema.required ?? []) if (!(key in value)) errors.push(`${at}: missing ${key}`);
+      for (const [key, sub] of Object.entries(schema.properties ?? {})) {
+        if (key in value) errors.push(...schemaErrors(sub, value[key], `${at}.${key}`));
+      }
+    }
+  }
+  if (schema.type === "string" && typeof value !== "string") errors.push(`${at}: not a string`);
+  return errors;
+}
+
+describe("task feedback contract (understudy.task_feedback.v1)", () => {
+  it("make→serialize→read roundtrips and validates against the schema file", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "feedback.jsonl");
+    const fb = makeTaskFeedback({
+      benchmark_id: "prop",
+      task_id: "t1",
+      feedback: "the gold contract is over-specified\nrelax the id match",
+      created_at: "2026-07-22T00:00:00.000Z",
+    });
+    assert.equal(fb.schema_version, TASK_FEEDBACK_SCHEMA);
+    fs.writeFileSync(file, serializeTaskFeedbackLine(fb));
+    const read = readTaskFeedback(file);
+    assert.equal(read.skipped, 0);
+    assert.deepEqual(read.feedback, [fb]);
+    assert.ok(isTaskFeedback(fb));
+    assert.deepEqual(schemaErrors(feedbackSchema, fb), []);
+  });
+
+  it("submitTaskFeedback validates, appends, and returns the regenerate-env handoff", () => {
+    const dir = path.join(tmpDir(), "prop");
+    writeFoundryDir(dir, [task("t1")]);
+    const entry = loadProposedEntryFromDir(dir, "data-dir", "data--prop", false);
+
+    assert.equal(submitTaskFeedback(entry, { task_id: "t1", feedback: "" }).status, 400);
+    assert.equal(submitTaskFeedback(entry, { task_id: "nope", feedback: "x" }).status, 404);
+    assert.equal(submitTaskFeedback(entry, { task_id: "t1", feedback: "x".repeat(MAX_FEEDBACK_LENGTH + 1) }).status, 413);
+
+    const result = submitTaskFeedback(entry, { task_id: "t1", feedback: "  wrong required tool  " });
+    assert.equal(result.ok, true);
+    assert.equal(result.feedback.feedback, "wrong required tool");
+    assert.equal(result.feedback.status, "open");
+    assert.deepEqual(schemaErrors(feedbackSchema, result.feedback), []);
+
+    const read = readTaskFeedback(path.join(dir, "feedback.jsonl"));
+    assert.equal(read.feedback.length, 1);
+    assert.equal(read.feedback[0].task_id, "t1");
+
+    // The handoff is a concrete agent prompt: dir, task, the user's words, the CLI verb.
+    assert.ok(result.handoff.includes(`understudy traces regenerate-env --benchmark ${dir}`));
+    assert.ok(result.handoff.includes("wrong required tool"));
+    assert.ok(result.handoff.includes("t1"));
+    assert.equal(result.handoff, buildTaskFeedbackHandoff(dir, "t1", "wrong required tool"));
+  });
+
+  it("rejects read-only entries and non-proposed stages", () => {
+    const dir = path.join(tmpDir(), "prop");
+    writeFoundryDir(dir, [task("t1")]);
+    const readOnly = loadProposedEntryFromDir(dir, "fixture", "fixture--prop", true);
+    assert.equal(submitTaskFeedback(readOnly, { task_id: "t1", feedback: "x" }).status, 403);
+    assert.equal(submitTaskFeedback(null, { task_id: "t1", feedback: "x" }).status, 404);
+  });
+});


### PR DESCRIPTION
## What

Inverts the proposed-benchmark review UX from "accept every machine task by hand" to **auto-accept with exception-based review**, plus a conversational "what's wrong with this task" edit path.

### Auto-accept policy (pure, shared)
`deriveAutoReviewProposals(entry)` in `src/benchmark-hub-core.ts` classifies each pending task:
- **AUTO_ACCEPT** iff machine_confidence is `high` and not `close_call`, foundry `self_check` clean (absent = clean on pre-self-check builds), incumbent passed calibration (or no calibration evidence for the task), no tasks.jsonl↔benchmark.json conflict, no executor anomaly row.
- **EXCEPTION** otherwise, with machine-readable reasons: `low_confidence`, `self_check_failed`, `incumbent_failed`, `schema_conflict`, `anomaly`.

Nothing is written on page load. `applyAutoAccepts` (POST `/api/reviews/auto`, behind the explicit **Apply N auto-accepts** click) appends `accept` lines stamped `source: "auto"` (additive field on `understudy.benchmark_review.v1`; schema already allows extras). Fully reversible: append-only reviews.jsonl, newest-per-task wins, review bar overrides autos (badge on the task page marks auto decisions).

### Exception-first UI
The proposed benchmark page now leads with a **Review queue**: exceptions grouped by reason with count badges and per-reason explanations; auto-acceptable tasks collapse into one summary card with the one-click apply and an expandable list. Task inbox/table unchanged below.

### Conversational task edit
Task page gains a "What's wrong with this task?" box → POST `/api/feedback`:
1. appends an `understudy.task_feedback.v1` line to a `feedback.jsonl` sidecar (shared writer `submitTaskFeedback` in benchmark-hub-core; codec + schema-id constant in `src/benchmark-artifacts.ts`; JSON schema file added under `schemas/`), with `status: open` so a future daemon verb can consume it unchanged;
2. returns a copyable, pre-filled agent handoff prompt referencing `understudy traces regenerate-env --benchmark <dir>` plus the user's words. The hub never executes the edit itself (architectural boundary: no model calls / subprocesses from the hub server).

### Not touched
`src/run-executor.ts`, `lib/scores.ts`, `leaderboard.tsx`, `writeVerifiersEnvironment` — existing `submitReview`/`queueOrCancelRun` unchanged; all new logic is new exported functions (per parallel-agent file ownership).

## Tests
- `tests/exception-review.test.mjs`: policy matrix (confidence × self_check × calibration × conflict × anomaly, compounding reasons, decided-task skip), auto-apply write path (`source:"auto"`, idempotence, human supersedes), feedback roundtrip + schema validation + handoff content.
- `apps/benchmark-hub/tests/exception-review-api.test.mjs`: route-level coverage for `/api/reviews/auto` and `/api/feedback`.
- All green: root `npm test` (742 pass), `tsc --noEmit`, hub tests (131 pass) + `next build`, `skills:validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->