### PR TITLE
Fuzzy tier for the gold-leakage audit (shingles + fingerprints)

### DIFF
--- a/src/rigor-report.ts
+++ b/src/rigor-report.ts
@@ -8,9 +8,10 @@
  * Pure derivation: everything is read from the benchmark dir's existing
  * file-based artifacts (benchmark.json, tasks.jsonl, rows-*.jsonl,
  * runs/events.jsonl, calibration.json) through the SHARED codecs. No network,
- * no model calls. Items we cannot check yet (leakage audit, confidence
- * intervals — being built separately) are reported as honest UNKNOWN rows,
- * never silently omitted.
+ * no model calls. The gold-leakage audit row reads the build-time
+ * manifest.json leakage_audit when present. Items we cannot check yet
+ * (confidence intervals — being built separately) are reported as honest
+ * UNKNOWN rows, never silently omitted.
  */
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -198,8 +199,35 @@ export function deriveRigorReport(benchmarkDir: string, now: Date = new Date()):
     detail: `provenance.origin = ${origin}${hasSplits ? "" : "; no split assignment recorded — holdout discipline unverifiable"}`,
   });
 
+  // Gold-leakage audit: read the build-time audit (manifest.json's
+  // leakage_audit, understudy.leakage_audit.v1) written next to benchmark.json
+  // by the trace foundry. Verbatim findings FLAG; fuzzy findings are advisory
+  // (they ride the detail, not the status) so heuristic matches don't create
+  // alarm fatigue. Pre-tier manifests (findings without a `tier`) count as
+  // verbatim — that is all the v1 audit could detect.
+  const foundryManifestPath = join(dir, "manifest.json");
+  const leakageAudit = existsSync(foundryManifestPath) ? asObject(asObject(JSON.parse(readFileSync(foundryManifestPath, "utf8"))).leakage_audit) : {};
+  if (String(leakageAudit.schema_version ?? "").startsWith("understudy.leakage_audit.")) {
+    const findings = (Array.isArray(leakageAudit.findings) ? leakageAudit.findings : []).map(asObject);
+    const verbatim = findings.filter((finding) => String(finding.tier ?? "verbatim") === "verbatim").length;
+    const fuzzy = findings.filter((finding) => String(finding.tier ?? "") === "fuzzy").length;
+    const other = findings.length - verbatim - fuzzy;
+    items.push({
+      item: "Leakage / contamination audit",
+      status: verbatim > 0 ? "FLAG" : "PASS",
+      value: `${verbatim} verbatim / ${fuzzy} fuzzy over ${Number(leakageAudit.checked_tasks ?? 0)} task(s)`,
+      detail:
+        verbatim > 0
+          ? `contract targets verbatim-readable in candidate surfaces — see manifest.leakage_audit${fuzzy > 0 ? `; plus ${fuzzy} advisory fuzzy finding(s)` : ""}`
+          : fuzzy > 0 || other > 0
+            ? `no verbatim leaks; ${fuzzy + other} advisory (fuzzy/semantic) finding(s) recorded in manifest.leakage_audit — review, do not alarm`
+            : "no contract target readable (verbatim or fuzzy) in candidate-facing fixtures/schemas",
+    });
+  } else {
+    items.push({ item: "Leakage / contamination audit", status: "UNKNOWN", value: "not checked", detail: "no manifest.json leakage_audit found — rebuild with `understudy traces build-benchmark` (the foundry writes the audit at generation time)" });
+  }
+
   // Honest UNKNOWNs: checks this report does not perform (built separately).
-  items.push({ item: "Leakage / contamination audit", status: "UNKNOWN", value: "not checked", detail: "task-content leakage audit is a separate workstream; this report only records split provenance" });
   items.push({ item: "Confidence intervals", status: "UNKNOWN", value: "not checked", detail: "score CIs / repeated-rollout variance reporting is being built separately" });
 
   const tasks: TaskComplexity[] = taskIds.map((taskId) => {

--- a/src/trace-foundry.ts
+++ b/src/trace-foundry.ts
@@ -1011,20 +1011,127 @@ export function runFoundrySelfCheck(outputInput: string, tasks: Obj[]): Obj {
  * normalized chars) are skipped: single tokens like "active" collide with
  * ordinary fixture content and carry no copyable answer.
  *
+ * TIERS. Tier 1 ("verbatim") is exact normalized-substring matching. Tier 2
+ * ("fuzzy") catches paraphrased/restructured leaks with two deterministic,
+ * offline heuristics (no model calls, no network — this runs at build time):
+ *
+ *   (a) Token n-gram containment: the gold and each surface are tokenized;
+ *       the gold's LEAK_SHINGLE_SIZE-token shingles that do NOT already
+ *       appear in the task's own inputs are checked against the surface's
+ *       shingle set. Containment >= LEAK_SHINGLE_CONTAINMENT of those
+ *       informative shingles flags a fuzzy finding — a reordered or lightly
+ *       edited gold still shares most of its 5-token runs.
+ *   (b) Number/entity fingerprints: rare, copyable tokens are extracted from
+ *       the gold (emails, ISO dates, id-shaped tokens like `acct_401`,
+ *       digit runs of >= LEAK_MIN_DIGITS digits with thousands separators
+ *       stripped, so "$12,450" carries `12450`). A paraphrase of "the
+ *       meeting summary for acct_401 totaling $12,450" still carries
+ *       `acct_401` and `12450`; any fingerprint absent from the inputs but
+ *       present in a surface flags a fuzzy finding.
+ *
+ * Thresholds are deliberately conservative (documented on the constants
+ * below); the benign rule is unchanged — anything the task's own inputs
+ * already carry is never a finding at any tier. Verbatim findings keep the
+ * alarm status ("findings"); fuzzy-only audits report status "advisory" so
+ * heuristic matches don't create alarm fatigue.
+ *
  * REPORT-ONLY by design: findings land in the manifest (`leakage_audit`) and
  * on stderr at build time. Nothing is auto-redacted — removing a value from
  * a fixture changes task semantics, so a human (or a later reviewing agent)
  * decides.
  * ------------------------------------------------------------------------- */
 
-export type LeakageFinding = { task_id: string; location: string; kind: string; excerpt: string };
-export type LeakageAudit = { schema_version: "understudy.leakage_audit.v1"; status: "clean" | "findings"; checked_tasks: number; findings: LeakageFinding[]; heuristic: string };
+export type LeakageFindingTier = "verbatim" | "fuzzy" | "semantic";
+export type LeakageFinding = {
+  task_id: string;
+  location: string;
+  kind: string;
+  excerpt: string;
+  /** Which detection tier produced the finding. `semantic` is reserved for the tier-3 seam below. */
+  tier: LeakageFindingTier;
+  /** 1 for verbatim; shingle containment or fingerprint match fraction (0–1] for fuzzy; model-defined for semantic. */
+  similarity: number;
+  /** Human-readable evidence: which detector fired and what matched (e.g. "fingerprint: acct_401, 12450"). */
+  signal: string;
+};
+export type LeakageAudit = {
+  schema_version: "understudy.leakage_audit.v1";
+  /** "findings" = at least one verbatim hit; "advisory" = fuzzy/semantic hits only; "clean" otherwise. */
+  status: "clean" | "findings" | "advisory";
+  checked_tasks: number;
+  findings: LeakageFinding[];
+  tier_counts: Record<LeakageFindingTier, number>;
+  heuristic: string;
+};
+
+/**
+ * Tier-3 seam (NOT implemented): a future semantic pass via a LOCAL model
+ * (never a provider call — the audit must stay offline and deterministic per
+ * model+seed). An implementation judges whether a candidate-readable surface
+ * paraphrases a gold that tiers 1–2 missed, and returns findings in the SAME
+ * `LeakageFinding` shape with `tier: "semantic"` and its own `similarity`
+ * (e.g. an embedding cosine or judge confidence) — the audit record, manifest
+ * schema, and rigor-report wiring all accept it unchanged.
+ *
+ * TODO(tier-3): implement against the local-model lab runtime and pass an
+ * instance into `auditGoldLeakage`; findings merge after the fuzzy tier and
+ * keep the "advisory" status semantics.
+ */
+export interface SemanticLeakageChecker {
+  readonly tier: "semantic";
+  /** Must be pure/offline; `taskInputs` is the normalized benign-input text for the task. */
+  check(gold: { kind: string; value: string }, surface: { location: string; text: string }, taskInputs: string): Array<Pick<LeakageFinding, "similarity" | "signal">>;
+}
 
 /** Minimum normalized length for a gold string to be leak-checkable (shorter values are un-copyable noise). */
 const MIN_GOLD_LEN = 12;
+/** Shingle width for fuzzy containment: 5 consecutive tokens is a distinctive phrase, not vocabulary overlap. */
+const LEAK_SHINGLE_SIZE = 5;
+/** A gold needs at least this many tokens before shingle containment is meaningful (>= 4 shingles). */
+const LEAK_MIN_SHINGLE_TOKENS = LEAK_SHINGLE_SIZE + 3;
+/** Conservative: at least half the gold's informative (not-in-inputs) shingles must appear in the surface. */
+const LEAK_SHINGLE_CONTAINMENT = 0.5;
+/** Digit runs shorter than this are too common to fingerprint (avoids years, small counts, HTTP codes). */
+const LEAK_MIN_DIGITS = 5;
+/** Non-numeric fingerprints (ids, emails, dates) shorter than this are skipped as collision-prone. */
+const LEAK_MIN_FINGERPRINT_LEN = 6;
 
 const normalizeForLeak = (value: unknown): string =>
   (typeof value === "string" ? value : JSON.stringify(value ?? "")).toLowerCase().replace(/\s+/g, " ").trim();
+
+/** Tokenize normalized text for shingling; keeps id-shaped tokens (acct_401, 2026-07-22) whole. */
+const leakTokens = (normalized: string): string[] => normalized.match(/[a-z0-9]+(?:[_.\-][a-z0-9]+)*/g) ?? [];
+
+/** Strip thousands separators so "$12,450" and "12450" fingerprint identically. */
+const stripThousands = (text: string): string => text.replace(/(\d),(?=\d{3}(?:\D|$))/g, "$1");
+
+function leakShingles(tokens: string[]): Set<string> {
+  const out = new Set<string>();
+  for (let i = 0; i + LEAK_SHINGLE_SIZE <= tokens.length; i++) out.add(tokens.slice(i, i + LEAK_SHINGLE_SIZE).join(" "));
+  return out;
+}
+
+/**
+ * Rare, copyable tokens carried by a gold value: emails, ISO dates, id-shaped
+ * tokens (letters + separator + digits, e.g. acct_401 / INV-2024-0091), and
+ * long digit runs (>= LEAK_MIN_DIGITS, thousands separators stripped). These
+ * survive paraphrase — restating a summary still names the same account id
+ * and amount. Deliberately excludes bare short numbers and plain words.
+ */
+export function leakFingerprints(value: string): string[] {
+  const lower = stripThousands(value.toLowerCase());
+  const out = new Set<string>();
+  for (const email of lower.match(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/g) ?? []) out.add(email);
+  for (const date of lower.match(/\d{4}-\d{2}-\d{2}/g) ?? []) out.add(date);
+  for (const id of lower.match(/[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*[_-][a-z0-9]*\d[a-z0-9_-]*/g) ?? []) {
+    if (id.length >= LEAK_MIN_FINGERPRINT_LEN) out.add(id);
+  }
+  for (const digits of lower.match(/\d+(?:\.\d+)?/g) ?? []) {
+    if (digits.replace(/\D/g, "").length >= LEAK_MIN_DIGITS) out.add(digits);
+  }
+  // Drop fingerprints contained in a longer one (the id already carries its digits).
+  return [...out].filter((fp) => ![...out].some((other) => other !== fp && other.includes(fp)));
+}
 
 /** All string leaf values of a JSON value (recursive; used over contract argument objects). */
 function stringLeaves(value: unknown): string[] {
@@ -1052,54 +1159,94 @@ function goldValues(task: Obj): Array<{ kind: string; value: string }> {
 }
 
 /**
- * Scan candidate-readable environment surfaces for verbatim contract targets.
- * Pure over the already-generated artifacts; see the block comment above for
- * the heuristic. Findings are deduped per (task, location, excerpt).
+ * Scan candidate-readable environment surfaces for verbatim (tier 1) and
+ * fuzzy (tier 2: shingle-containment + fingerprint) contract targets.
+ * Pure, deterministic, offline over the already-generated artifacts; see the
+ * block comment above for the heuristics. Findings are deduped per
+ * (task, location, tier, excerpt). `semanticChecker` is the tier-3 seam —
+ * see SemanticLeakageChecker; no implementation exists yet.
  */
-export function auditGoldLeakage(tasks: Obj[], taskRows: Obj[], fixtures: Obj[], schemas: Obj): LeakageAudit {
+export function auditGoldLeakage(tasks: Obj[], taskRows: Obj[], fixtures: Obj[], schemas: Obj, semanticChecker?: SemanticLeakageChecker): LeakageAudit {
   const rowByTask = new Map(taskRows.map((row) => [String(asObject(row).task_id), asObject(row)]));
   // Candidate-readable surfaces (global to the environment package).
-  const surfaces: Array<{ location: string; text: string }> = [
+  const surfaces = [
     { location: "environment/understudy_trace_env/servers/fixtures.json", text: normalizeForLeak(fixtures) },
     { location: "environment/understudy_trace_env/servers/schemas.json", text: normalizeForLeak(schemas) },
-  ];
+  ].map((surface) => ({ ...surface, numText: stripThousands(surface.text), shingles: leakShingles(leakTokens(surface.text)) }));
   const findings: LeakageFinding[] = [];
   const seen = new Set<string>();
+  const record = (finding: LeakageFinding): void => {
+    const key = `${finding.task_id} ${finding.location} ${finding.tier} ${finding.excerpt}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    findings.push(finding);
+  };
   for (const task of tasks) {
     const row = rowByTask.get(String(task.task_id)) ?? {};
     const userMessages = ((row.source_messages ?? []) as unknown[]).map(asObject).filter((m) => m.role === "user");
     const inputs = normalizeForLeak([row.prompt ?? "", row.system_prompt ?? "", ...userMessages.map((m) => m.content)]);
+    const inputsNum = stripThousands(inputs);
+    const inputShingles = leakShingles(leakTokens(inputs));
     for (const gold of goldValues(task)) {
       const needle = normalizeForLeak(gold.value);
       if (needle.length < MIN_GOLD_LEN) continue;
       if (inputs.includes(needle)) continue; // benign: the agent legitimately holds this value as an input
+      const excerpt = String(gold.value).slice(0, 160);
       for (const surface of surfaces) {
-        if (!surface.text.includes(needle)) continue;
-        const key = `${task.task_id} ${surface.location} ${needle}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        findings.push({ task_id: String(task.task_id), location: surface.location, kind: gold.kind, excerpt: String(gold.value).slice(0, 160) });
+        // Tier 1 — verbatim normalized substring.
+        if (surface.text.includes(needle)) {
+          record({ task_id: String(task.task_id), location: surface.location, kind: gold.kind, excerpt, tier: "verbatim", similarity: 1, signal: "verbatim normalized substring" });
+          continue; // a verbatim hit subsumes the fuzzy detectors for this surface
+        }
+        // Tier 2a — token n-gram containment over shingles the inputs don't already carry.
+        const goldTokens = leakTokens(needle);
+        if (goldTokens.length >= LEAK_MIN_SHINGLE_TOKENS) {
+          const informative = [...leakShingles(goldTokens)].filter((shingle) => !inputShingles.has(shingle));
+          const matched = informative.filter((shingle) => surface.shingles.has(shingle));
+          const containment = informative.length === 0 ? 0 : matched.length / informative.length;
+          if (containment >= LEAK_SHINGLE_CONTAINMENT) {
+            record({ task_id: String(task.task_id), location: surface.location, kind: gold.kind, excerpt, tier: "fuzzy", similarity: Number(containment.toFixed(3)), signal: `shingle containment ${matched.length}/${informative.length} (${LEAK_SHINGLE_SIZE}-gram)` });
+            continue; // strongest fuzzy signal already recorded for this surface
+          }
+        }
+        // Tier 2b — number/entity fingerprints (ids, emails, amounts, dates).
+        const fingerprints = leakFingerprints(String(gold.value)).filter((fp) => !inputsNum.includes(fp));
+        const hit = fingerprints.filter((fp) => surface.numText.includes(fp));
+        if (hit.length > 0) {
+          record({ task_id: String(task.task_id), location: surface.location, kind: gold.kind, excerpt, tier: "fuzzy", similarity: Number((hit.length / fingerprints.length).toFixed(3)), signal: `fingerprint: ${hit.slice(0, 6).join(", ")}` });
+          continue;
+        }
+        // Tier 3 seam — future semantic pass via a local model (see SemanticLeakageChecker).
+        if (semanticChecker) {
+          for (const partial of semanticChecker.check({ kind: gold.kind, value: String(gold.value) }, { location: surface.location, text: surface.text }, inputs)) {
+            record({ task_id: String(task.task_id), location: surface.location, kind: gold.kind, excerpt, tier: "semantic", similarity: partial.similarity, signal: partial.signal });
+          }
+        }
       }
     }
   }
+  const tier_counts: Record<LeakageFindingTier, number> = { verbatim: 0, fuzzy: 0, semantic: 0 };
+  for (const finding of findings) tier_counts[finding.tier] += 1;
   return {
     schema_version: "understudy.leakage_audit.v1",
-    status: findings.length > 0 ? "findings" : "clean",
+    status: tier_counts.verbatim > 0 ? "findings" : findings.length > 0 ? "advisory" : "clean",
     checked_tasks: tasks.length,
     findings,
-    heuristic: `flag contract/gold strings (>=${MIN_GOLD_LEN} normalized chars) verbatim in candidate-readable surfaces (fixtures.json, schemas.json) but absent from the task's own inputs (prompt / system prompt / user source messages); report-only, never auto-redacted`,
+    tier_counts,
+    heuristic: `tier 1 (verbatim, status "findings"): flag contract/gold strings (>=${MIN_GOLD_LEN} normalized chars) verbatim in candidate-readable surfaces (fixtures.json, schemas.json) but absent from the task's own inputs (prompt / system prompt / user source messages); tier 2 (fuzzy, status "advisory"): ${LEAK_SHINGLE_SIZE}-token shingle containment >= ${LEAK_SHINGLE_CONTAINMENT} over input-novel shingles (golds >= ${LEAK_MIN_SHINGLE_TOKENS} tokens), plus rare-token fingerprints (emails, ISO dates, id-shaped tokens >= ${LEAK_MIN_FINGERPRINT_LEN} chars, digit runs >= ${LEAK_MIN_DIGITS} digits with thousands separators stripped) absent from inputs but present in a surface; report-only, never auto-redacted`,
   };
 }
 
 /** Build-time report: the audit is advisory, so it prints and moves on. */
 function printLeakageAudit(audit: LeakageAudit): void {
   if (audit.status === "clean") {
-    console.error(`[leakage-audit] clean — no verbatim contract targets found in candidate-readable surfaces (${audit.checked_tasks} task(s) checked)`);
+    console.error(`[leakage-audit] clean — no verbatim or fuzzy contract targets found in candidate-readable surfaces (${audit.checked_tasks} task(s) checked)`);
     return;
   }
-  console.error(`[leakage-audit] ${audit.findings.length} potential gold-leakage finding(s) across ${audit.checked_tasks} task(s) — recorded in manifest.leakage_audit (report-only, nothing redacted):`);
+  const tierSummary = `${audit.tier_counts.verbatim} verbatim, ${audit.tier_counts.fuzzy} fuzzy (advisory)${audit.tier_counts.semantic > 0 ? `, ${audit.tier_counts.semantic} semantic` : ""}`;
+  console.error(`[leakage-audit] ${audit.findings.length} potential gold-leakage finding(s) [${tierSummary}] across ${audit.checked_tasks} task(s) — recorded in manifest.leakage_audit (report-only, nothing redacted):`);
   for (const finding of audit.findings.slice(0, 8)) {
-    console.error(`[leakage-audit]   ${finding.task_id} · ${finding.kind} · ${finding.location} · "${finding.excerpt.slice(0, 80)}"`);
+    console.error(`[leakage-audit]   ${finding.task_id} · ${finding.tier} (${finding.similarity}) · ${finding.kind} · ${finding.location} · "${finding.excerpt.slice(0, 80)}"`);
   }
   if (audit.findings.length > 8) console.error(`[leakage-audit]   … ${audit.findings.length - 8} more (see manifest.json)`);
 }

--- a/tests/rigor-report.test.mjs
+++ b/tests/rigor-report.test.mjs
@@ -137,6 +137,54 @@ describe("deriveRigorReport", () => {
   });
 });
 
+describe("leakage-audit wiring", () => {
+  function writeAudit(dir, audit) {
+    fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify({ schema_version: "understudy.trace_foundry.v1", leakage_audit: audit }));
+  }
+
+  it("flips the leakage row to PASS from a clean manifest.json audit", () => {
+    const dir = makeBenchmarkDir();
+    writeAudit(dir, { schema_version: "understudy.leakage_audit.v1", status: "clean", checked_tasks: 2, findings: [], tier_counts: { verbatim: 0, fuzzy: 0, semantic: 0 }, heuristic: "test" });
+    const byItem = Object.fromEntries(deriveRigorReport(dir).items.map((i) => [i.item, i]));
+    assert.equal(byItem["Leakage / contamination audit"].status, "PASS");
+    assert.equal(byItem["Leakage / contamination audit"].value, "0 verbatim / 0 fuzzy over 2 task(s)");
+  });
+
+  it("FLAGs on verbatim findings and stays PASS (advisory) on fuzzy-only findings", () => {
+    const verbatimDir = makeBenchmarkDir();
+    writeAudit(verbatimDir, {
+      schema_version: "understudy.leakage_audit.v1", status: "findings", checked_tasks: 2, heuristic: "test",
+      findings: [{ task_id: "t1", location: "fixtures.json", kind: "state_effect_value", excerpt: "x", tier: "verbatim", similarity: 1, signal: "verbatim" }],
+      tier_counts: { verbatim: 1, fuzzy: 0, semantic: 0 },
+    });
+    const verbatimRow = deriveRigorReport(verbatimDir).items.find((i) => i.item === "Leakage / contamination audit");
+    assert.equal(verbatimRow.status, "FLAG");
+    assert.match(verbatimRow.value, /1 verbatim \/ 0 fuzzy/);
+
+    const fuzzyDir = makeBenchmarkDir();
+    writeAudit(fuzzyDir, {
+      schema_version: "understudy.leakage_audit.v1", status: "advisory", checked_tasks: 2, heuristic: "test",
+      findings: [{ task_id: "t1", location: "fixtures.json", kind: "state_effect_value", excerpt: "x", tier: "fuzzy", similarity: 0.6, signal: "shingle containment 3/5" }],
+      tier_counts: { verbatim: 0, fuzzy: 1, semantic: 0 },
+    });
+    const fuzzyRow = deriveRigorReport(fuzzyDir).items.find((i) => i.item === "Leakage / contamination audit");
+    assert.equal(fuzzyRow.status, "PASS", "fuzzy findings are advisory, not alarms");
+    assert.match(fuzzyRow.value, /0 verbatim \/ 1 fuzzy/);
+    assert.match(fuzzyRow.detail, /advisory/);
+  });
+
+  it("treats pre-tier findings (no tier field) as verbatim", () => {
+    const dir = makeBenchmarkDir();
+    writeAudit(dir, {
+      schema_version: "understudy.leakage_audit.v1", status: "findings", checked_tasks: 1, heuristic: "test",
+      findings: [{ task_id: "t1", location: "fixtures.json", kind: "state_effect_value", excerpt: "x" }],
+    });
+    const row = deriveRigorReport(dir).items.find((i) => i.item === "Leakage / contamination audit");
+    assert.equal(row.status, "FLAG");
+    assert.match(row.value, /1 verbatim/);
+  });
+});
+
 describe("renderRigorReport + writeRigorReport", () => {
   it("writes rigor-report.md into the benchmark dir with the ABC table and per-task table", async () => {
     const dir = await makeExecutedDir();

--- a/tests/trace-foundry.test.mjs
+++ b/tests/trace-foundry.test.mjs
@@ -790,6 +790,92 @@ test("build-benchmark records the leakage audit additively in manifest.json", ()
   assert.ok(Array.isArray(result.leakage_audit.findings));
   const manifest = JSON.parse(readFileSync(join(output, "manifest.json"), "utf8"));
   assert.deepEqual(manifest.leakage_audit, result.leakage_audit);
+  assert.equal(typeof result.leakage_audit.tier_counts, "object");
+});
+
+test("leakage audit fuzzy tier: shingle containment catches a restructured gold that verbatim misses", async () => {
+  const { auditGoldLeakage } = await import("../dist/trace-foundry.js");
+  const gold = "the quarterly rollback completed without any data loss across all seventeen regional replicas";
+  const tasks = [{ task_id: "t-para", outcome_contract: { required: [
+    { type: "response_obligation", kind: "contains_category", expected: gold },
+  ], forbidden: [] } }];
+  const taskRows = [{ task_id: "t-para", prompt: "Summarize the rollback status", system_prompt: "", source_messages: [] }];
+  // Fixture paraphrases: reorders and inserts words so no 12+ char verbatim
+  // normalized substring of ALL of the gold appears... actually verbatim
+  // substring matching needs the WHOLE gold; here only fragments survive.
+  const fixtures = [{ tool: "get-status", content: "Note: the quarterly rollback completed without any data loss (confirmed) across all seventeen regional replicas as of Friday." }];
+  // The whole normalized gold is NOT a substring (the "(confirmed)" insertion
+  // splits it) — tier 1 misses; most 5-gram shingles still match — tier 2a hits.
+  const audit = auditGoldLeakage(tasks, taskRows, fixtures, {});
+  assert.equal(audit.status, "advisory", "fuzzy-only findings are advisory, not alarms");
+  assert.equal(audit.tier_counts.verbatim, 0);
+  assert.equal(audit.tier_counts.fuzzy, 1);
+  const finding = audit.findings[0];
+  assert.equal(finding.tier, "fuzzy");
+  assert.ok(finding.similarity >= 0.5 && finding.similarity <= 1);
+  assert.match(finding.signal, /shingle containment/);
+  assert.equal(finding.task_id, "t-para");
+});
+
+test("leakage audit fuzzy tier: number/entity fingerprints survive full paraphrase", async () => {
+  const { auditGoldLeakage } = await import("../dist/trace-foundry.js");
+  const gold = "Send the meeting summary for acct_401 totaling $12,450 to ops-review@example.com by 2026-08-01";
+  const tasks = [{ task_id: "t-fp", outcome_contract: { required: [
+    { type: "state_effect", tool: "send-summary", observed_arguments: { body: gold } },
+  ], forbidden: [] } }];
+  const taskRows = [{ task_id: "t-fp", prompt: "Handle the pending account follow-ups", system_prompt: "", source_messages: [] }];
+  // Fully rewritten fixture text — zero shared 5-gram shingles — but the
+  // account id, the amount (different thousands formatting), the email, and
+  // the date all ride along.
+  const fixtures = [{ tool: "get-notes", content: "Reminder: account acct_401 owes 12450 dollars; loop in ops-review@example.com before 2026-08-01." }];
+  const audit = auditGoldLeakage(tasks, taskRows, fixtures, {});
+  assert.equal(audit.status, "advisory");
+  assert.equal(audit.tier_counts.fuzzy, 1);
+  const finding = audit.findings[0];
+  assert.equal(finding.tier, "fuzzy");
+  assert.match(finding.signal, /fingerprint:/);
+  assert.match(finding.signal, /acct_401/);
+  assert.match(finding.signal, /12450/);
+  assert.match(finding.signal, /ops-review@example\.com/);
+  assert.equal(finding.similarity, 1, "all informative fingerprints leaked");
+});
+
+test("leakage audit fuzzy tier: benign guards — common words, input-carried entities, short numbers", async () => {
+  const { auditGoldLeakage } = await import("../dist/trace-foundry.js");
+  const tasks = [{ task_id: "t-benign", outcome_contract: { required: [
+    // Common-word gold: shares vocabulary but no 5-gram run with the fixture.
+    { type: "response_obligation", kind: "contains_category", expected: "please update the record status and confirm the change was saved correctly today" },
+    // Entity gold whose id/date the PROMPT already carries — benign inputs.
+    { type: "state_effect", tool: "update-record", observed_arguments: { note: "close ticket tick_9077 opened 2026-07-01 per policy" } },
+    // Small numbers only (below the 5-digit fingerprint floor).
+    { type: "state_effect", tool: "update-record", observed_arguments: { note: "set retries to 3 and timeout to 900 for env 42" } },
+  ], forbidden: [] } }];
+  const taskRows = [{ task_id: "t-benign", prompt: "Please close tick_9077 (opened 2026-07-01) following the standard procedure", system_prompt: "", source_messages: [] }];
+  const fixtures = [{
+    tool: "get-record",
+    content: "The record was saved. Please confirm the status change today and update correctly. tick_9077 2026-07-01 retries 3 timeout 900 env 42",
+  }];
+  const audit = auditGoldLeakage(tasks, taskRows, fixtures, {});
+  assert.equal(audit.status, "clean", `expected clean, got: ${JSON.stringify(audit.findings)}`);
+  assert.deepEqual(audit.tier_counts, { verbatim: 0, fuzzy: 0, semantic: 0 });
+});
+
+test("leakage audit: verbatim finding keeps alarm status and subsumes fuzzy for the same surface; deterministic", async () => {
+  const { auditGoldLeakage } = await import("../dist/trace-foundry.js");
+  const gold = "confidential-report-Q3-final-9981 grand total 98765 dollars";
+  const tasks = [{ task_id: "t-mix", outcome_contract: { required: [
+    { type: "state_effect", tool: "update-record", observed_arguments: { document: gold } },
+  ], forbidden: [] } }];
+  const taskRows = [{ task_id: "t-mix", prompt: "Do the filing", system_prompt: "", source_messages: [] }];
+  const fixtures = [{ tool: "get-record", content: gold }];
+  const first = auditGoldLeakage(tasks, taskRows, fixtures, {});
+  assert.equal(first.status, "findings", "verbatim hits keep the alarm status");
+  assert.equal(first.tier_counts.verbatim, 1);
+  assert.equal(first.tier_counts.fuzzy, 0, "no duplicate fuzzy finding for a verbatim-hit surface");
+  assert.equal(first.findings[0].similarity, 1);
+  // Deterministic: identical inputs → identical audit (byte-for-byte).
+  const second = auditGoldLeakage(tasks, taskRows, fixtures, {});
+  assert.deepEqual(second, first);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Strengthens the gold-leakage audit (`auditGoldLeakage` in `src/trace-foundry.ts`) beyond verbatim matching with a deterministic, offline fuzzy tier — no model calls, no network; it still runs at environment build time.

## Tier 2 (fuzzy) heuristics

- **Token n-gram containment**: gold and surfaces are tokenized (id-shaped tokens like `acct_401` / `2026-07-22` kept whole); the gold's 5-token shingles that are NOT already carried by the task's own inputs are checked against the surface's shingle set. Containment >= 0.5 flags; golds under 8 tokens skip this detector (too few shingles to be meaningful).
- **Number/entity fingerprints**: emails, ISO dates, id-shaped tokens (>= 6 chars), and digit runs of >= 5 digits (thousands separators stripped, so `$12,450` carries `12450`) are extracted from the gold and matched individually. A fully paraphrased "meeting summary for acct_401 totaling $12,450" still leaks `acct_401`, `12450`, the email, and the date.
- The **benign rule is unchanged**: anything present in the task's own inputs (prompt / system prompt / user source messages) is never a finding at any tier. Verbatim hits subsume fuzzy for the same gold+surface (no duplicates). Thresholds are conservative and documented on named constants (`LEAK_SHINGLE_SIZE`, `LEAK_SHINGLE_CONTAINMENT`, `LEAK_MIN_DIGITS`, `LEAK_MIN_FINGERPRINT_LEN`) and echoed in the audit's `heuristic` string.

## Schema (additive, still `understudy.leakage_audit.v1`)

- Findings gain `tier: "verbatim" | "fuzzy" | "semantic"`, `similarity` (1 for verbatim; containment or fingerprint fraction for fuzzy), and a human-readable `signal` (e.g. `fingerprint: acct_401, 12450`).
- Audit gains `tier_counts` and a distinct `"advisory"` status for fuzzy-only results, so heuristic matches don't create alarm fatigue; verbatim keeps the alarm status `"findings"`. Still report-only, nothing redacted.

## Tier-3 seam

`SemanticLeakageChecker` (interface + TODO, no implementation): a future local-model semantic pass plugs into `auditGoldLeakage` as an optional argument and emits findings in the same record shape with `tier: "semantic"` — manifest schema and rigor wiring accept it unchanged.

## Rigor report

`src/rigor-report.ts`'s leakage row flips from honest UNKNOWN to the build-time audit read from the benchmark dir's `manifest.json`: FLAG on verbatim findings, PASS with advisory detail on fuzzy-only, PASS on clean, UNKNOWN when no audit exists. Pre-tier manifests (findings without `tier`) count as verbatim — that's all v1 could detect.

## Tests

- Restructured gold (word insertion splits the verbatim substring) — verbatim misses, shingle containment catches (advisory, similarity ~0.56).
- Fully paraphrased gold — zero shared shingles, fingerprints catch (`acct_401`, `12450` across formatting, email, ISO date; similarity 1).
- False-positive guards: common-vocabulary overlap without 5-gram runs, input-carried entities, sub-threshold numbers — all clean.
- Determinism (identical inputs → deepEqual audits), verbatim-subsumes-fuzzy, tier counts, rigor wiring incl. pre-tier fallback.

All suites green: root `npm test` (767 pass), `tsc --noEmit`, hub tests (140 pass) + `next build`, `skills:validate` (35 skills ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->