### PR TITLE
Surface follow-ups: floors rendering, MCP policy tools, configurable auto-accept

### DIFF
--- a/apps/benchmark-hub/app/b/[slug]/page.tsx
+++ b/apps/benchmark-hub/app/b/[slug]/page.tsx
@@ -22,6 +22,7 @@ import { AnchorRail } from "@/components/anchor-rail";
 import { CopySlug } from "@/components/copy-slug";
 import { ProposedBenchmarkPage } from "@/components/proposed/benchmark-page";
 import { RunPanel } from "@/components/run-panel";
+import { CalibrationFloors } from "@/components/calibration-floors";
 
 export const dynamic = "force-dynamic";
 
@@ -274,13 +275,17 @@ export default async function BenchmarkDetail({ params }: { params: Promise<{ sl
             explainer="Queue a benchmark run against gateway models. The hub only writes a run request file; a local `understudy runs execute --watch` daemon executes it and rows stream back into the leaderboard below."
           >
             {calibration ? (
-              <p className="mono mt-3 text-xs" style={{ color: calibration.failed_count > 0 ? "var(--warn-ink)" : "var(--ok)" }}>
-                calibration: incumbent ({calibration.incumbent_models.join(", ")}) passed {calibration.passed_count}/
-                {calibration.passed_count + calibration.failed_count} tasks at threshold {calibration.threshold} · run{" "}
-                {calibration.run_id}
-                {calibration.finished_at ? ` · ${calibration.finished_at.slice(0, 19)}Z` : ""}
-                {calibration.failed_count > 0 && " — failed tasks are marked suspect below"}
-              </p>
+              <>
+                <p className="mono mt-3 text-xs" style={{ color: calibration.failed_count > 0 ? "var(--warn-ink)" : "var(--ok)" }}>
+                  calibration: incumbent ({calibration.incumbent_models.join(", ")}) passed {calibration.passed_count}/
+                  {calibration.passed_count + calibration.failed_count} tasks at threshold {calibration.threshold} · run{" "}
+                  {calibration.run_id}
+                  {calibration.finished_at ? ` · ${calibration.finished_at.slice(0, 19)}Z` : ""}
+                  {calibration.failed_count > 0 && " — failed tasks are marked suspect below"}
+                </p>
+                {/* Trivial-arm floors: red flag + offending-task links when exceeded. */}
+                <CalibrationFloors calibration={calibration} slug={entry.slug} />
+              </>
             ) : (
               incumbentModel && (
                 <p className="mono mt-3 text-xs text-faint">

--- a/apps/benchmark-hub/app/b/[slug]/task/[taskId]/page.tsx
+++ b/apps/benchmark-hub/app/b/[slug]/task/[taskId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getEntry, loadTaskSidecars } from "@/lib/data";
+import { trivialPassesForTask } from "@/lib/scores";
 import { FlagBadge, SplitChip, Badge } from "@/components/badges";
 import { FlagForm } from "@/components/flag-form";
 import { ProposedTaskPage } from "@/components/proposed/task-page";
@@ -117,6 +118,13 @@ export default async function TaskInspector({
           {entry.calibration?.failed_task_ids.includes(task.task_id) && (
             <Badge className="border-bad/40 text-bad">incumbent failed on rerun · suspect</Badge>
           )}
+          {/* A trivial calibration arm passing this task means its contract
+              is satisfiable with no real work — same suspect idiom. */}
+          {trivialPassesForTask(entry.calibration, task.task_id).map((f) => (
+            <Badge key={f.armKind} className="border-bad/40 text-bad">
+              {f.label} passes this task · suspect
+            </Badge>
+          ))}
           <FlagBadge count={openFlags.length} />
         </div>
         <div className="mt-4 flex flex-col gap-2">

--- a/apps/benchmark-hub/components/calibration-floors.tsx
+++ b/apps/benchmark-hub/components/calibration-floors.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { calibrationFloors, formatFloor } from "@/lib/scores";
+import type { CalibrationSummary } from "@/lib/types";
+import { Badge } from "@/components/badges";
+
+/**
+ * Trivial-arm floors from the calibration sidecar (null_floor / spam_floor):
+ * one mono line per arm that ran. A floor above the executor's 5% limit is a
+ * red structural flag — the benchmark's contracts are satisfiable by doing
+ * nothing (null agent) or by ritual tool calling (spam agent) — and the
+ * offending passed tasks link straight to their task pages. Same footnote
+ * idiom as the incumbent-calibration line it sits next to.
+ */
+export function CalibrationFloors({ calibration, slug }: { calibration: CalibrationSummary; slug: string }) {
+  const floors = calibrationFloors(calibration);
+  if (floors.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-col gap-1">
+      {floors.map((f) => (
+        <p key={f.armKind} className="mono text-xs" style={{ color: f.exceeded ? "var(--bad)" : "var(--muted-foreground)" }}>
+          {f.exceeded && <Badge className="border-bad/40 text-bad mr-2">floor exceeded</Badge>}
+          {f.label} floor: {formatFloor(f.floor)}
+          {f.exceeded
+            ? ` — above the 5% trivial-floor limit; ${f.passedTaskIds.length} task${f.passedTaskIds.length === 1 ? "" : "s"} pass${f.passedTaskIds.length === 1 ? "es" : ""} with no real work: `
+            : f.floor != null && f.passedTaskIds.length > 0
+              ? ` — passes ${f.passedTaskIds.length} task${f.passedTaskIds.length === 1 ? "" : "s"}: `
+              : f.floor == null
+                ? " — the arm produced no rows"
+                : " — passes no tasks"}
+          {f.passedTaskIds.map((taskId, i) => (
+            <span key={taskId}>
+              {i > 0 && ", "}
+              <Link href={`/b/${slug}/task/${encodeURIComponent(taskId)}`} style={{ textDecoration: "underline" }}>
+                {taskId}
+              </Link>
+            </span>
+          ))}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/apps/benchmark-hub/components/leaderboard.tsx
+++ b/apps/benchmark-hub/components/leaderboard.tsx
@@ -65,10 +65,13 @@ export function Leaderboard({
   const tieGroups = useMemo(() => statisticalTieGroups(summaries), [summaries]);
 
   // Top-3 shading per numeric column. Lower is better for cost + latency.
+  // Trivial arms (null/spam agent) never rank — they are calibration
+  // furniture, not candidates.
   const topRanks = useMemo(() => {
     const ranks = new Map<ShadeCol, Map<string, number>>();
     const rank = (col: ShadeCol, get: (s: (typeof summaries)[number]) => number | null, asc: boolean) => {
       const vals = summaries
+        .filter((s) => !s.trivial)
         .map((s) => ({ model: s.model, v: get(s) }))
         .filter((x): x is { model: string; v: number } => x.v != null)
         .sort((a, b) => (asc ? a.v - b.v : b.v - a.v));
@@ -190,14 +193,27 @@ export function Leaderboard({
                 const isOpen = expanded.has(s.model);
                 return (
                   <Fragment key={s.model}>
-                    <tr className={cn("row", isOpen && "open")} onClick={() => toggleExpanded(s.model)} aria-expanded={isOpen}>
+                    <tr
+                      className={cn("row", isOpen && "open")}
+                      onClick={() => toggleExpanded(s.model)}
+                      aria-expanded={isOpen}
+                      // Trivial arms render muted: floors, not candidates.
+                      style={s.trivial ? { opacity: 0.55 } : undefined}
+                    >
                       <td className="u-rank">
                         <span className="u-exp">▸</span>
                       </td>
                       <td className="l">
                         <span className="u-mdl">
-                          <span className="nm">{s.model}</span>
+                          <span className="nm" style={s.trivial ? { color: "var(--muted-foreground)" } : undefined}>
+                            {s.model}
+                          </span>
                           {s.incumbent && <Badge className="border-warn/40 text-warn">incumbent</Badge>}
+                          {s.trivial && (
+                            <span title="trivial calibration arm — its score is the benchmark's floor, not a candidate result">
+                              <Badge className="text-faint">floor</Badge>
+                            </span>
+                          )}
                           {showRoute && <RouteBadge route={s.route} />}
                         </span>
                       </td>
@@ -327,6 +343,9 @@ export function Leaderboard({
         )}
         {summaries.some((s) => s.incumbent) && (
           <span className="u-foot-note !mt-0">{"// incumbent = the model that produced the source captures, rerun through the environment (the calibration arm)"}</span>
+        )}
+        {summaries.some((s) => s.trivial) && (
+          <span className="u-foot-note !mt-0">{"// floor = trivial calibration arm (null/spam agent) — muted, excluded from top-3 shading and tie groups; its score is what doing nothing (or ritual tool calling) earns"}</span>
         )}
         <span className="u-foot-note !mt-0">
           {excludeFlagged

--- a/apps/benchmark-hub/components/proposed/benchmark-page.tsx
+++ b/apps/benchmark-hub/components/proposed/benchmark-page.tsx
@@ -6,6 +6,7 @@ import { Badge, SourceBadge, StageBadge } from "@/components/badges";
 import { EmptyState } from "@/components/empty-state";
 import { TaskTable } from "@/components/task-table";
 import { ReviewQueue, type QueueTask } from "@/components/proposed/review-queue";
+import { CalibrationFloors } from "@/components/calibration-floors";
 
 /**
  * The foundry's promotion blockers for machine-compiled outputs. Mirrored
@@ -157,6 +158,9 @@ export function ProposedBenchmarkPage({ entry }: { entry: ProposedHubEntry }) {
               (selfCheckFailed.length > 5 ? ` … and ${selfCheckFailed.length - 5} more` : "")}
           </span>
         )}
+        {/* Trivial-arm floors from a pre-promotion calibration run: red flag +
+            offending-task links when a null/spam agent clears the 5% limit. */}
+        {entry.calibration && <CalibrationFloors calibration={entry.calibration} slug={entry.slug} />}
         {entry.crossCheckErrors.length > 0 && (
           <span className="u-foot-note" style={{ color: "var(--warn-ink)" }}>
             {"// tasks.jsonl and benchmark.json disagree on task ids: " + entry.crossCheckErrors.join("; ")}
@@ -180,6 +184,12 @@ export function ProposedBenchmarkPage({ entry }: { entry: ProposedHubEntry }) {
             readOnly={entry.readOnly}
             exceptionsByReason={exceptionsByReason}
             autoAccepts={autoAccepts}
+            policyNote={
+              entry.reviewPolicy &&
+              (entry.reviewPolicy.min_confidence !== "high" || !entry.reviewPolicy.require_incumbent_pass)
+                ? `min_confidence ${entry.reviewPolicy.min_confidence} · require_incumbent_pass ${entry.reviewPolicy.require_incumbent_pass}`
+                : null
+            }
           />
 
           <section className="u-sec" id="tasks">

--- a/apps/benchmark-hub/components/proposed/review-queue.tsx
+++ b/apps/benchmark-hub/components/proposed/review-queue.tsx
@@ -59,12 +59,15 @@ export function ReviewQueue({
   readOnly,
   exceptionsByReason,
   autoAccepts,
+  policyNote,
 }: {
   slug: string;
   readOnly: boolean;
   /** reason → tasks carrying it (a task may appear under several reasons). */
   exceptionsByReason: { reason: string; tasks: QueueTask[] }[];
   autoAccepts: QueueTask[];
+  /** Non-default review-policy.json in force, rendered as a footnote (null = defaults). */
+  policyNote?: string | null;
 }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -100,6 +103,7 @@ export function ReviewQueue({
         Only exceptions need your judgment — everything the machine is confident about collapses into one action
         below. Any auto decision can be overridden per task later (newest review wins).
       </p>
+      {policyNote && <span className="u-foot-note">{"// custom review-policy.json in force: " + policyNote}</span>}
 
       {/* EXCEPTIONS FIRST: the human work, grouped by reason. */}
       {exceptionCount > 0 && (

--- a/apps/benchmark-hub/components/proposed/task-page.tsx
+++ b/apps/benchmark-hub/components/proposed/task-page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { taskDisplayName, type FoundryContractItem, type ProposedHubEntry } from "@/lib/types";
 import { taskProvenance } from "@/lib/data";
+import { trivialPassesForTask } from "@/lib/scores";
 import { Badge, ConfidenceChip, DecisionBadge } from "@/components/badges";
 import { TaskViews } from "@/components/trajectory/task-views";
 import { AuthoredPanel, AuthoredStatementCard } from "@/components/trajectory/authored-panel";
@@ -147,6 +148,16 @@ export function ProposedTaskPage({ entry, taskId }: { entry: ProposedHubEntry; t
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <DecisionBadge decision={review?.decision ?? null} />
           {review?.source === "auto" && <Badge>auto-accepted · override below</Badge>}
+          {/* Suspect signals: incumbent failed its own task, or a trivial
+              (null/spam) agent passes it with no real work. */}
+          {entry.calibration?.failed_task_ids.includes(task.task_id) && (
+            <Badge className="border-bad/40 text-bad">incumbent failed on rerun · suspect</Badge>
+          )}
+          {trivialPassesForTask(entry.calibration, task.task_id).map((f) => (
+            <Badge key={f.armKind} className="border-bad/40 text-bad">
+              {f.label} passes this task · suspect
+            </Badge>
+          ))}
           {task.authored?.difficulty === "easy" && entry.overview?.task_complexity?.[task.task_id]?.frontier && (
             <Badge className="border-bad/40 text-bad">authored easy · frontier-complex</Badge>
           )}

--- a/apps/benchmark-hub/lib/scores.ts
+++ b/apps/benchmark-hub/lib/scores.ts
@@ -1,5 +1,5 @@
 import { bootstrapCI, perTaskMeans, type BootstrapCI } from "./bootstrap";
-import type { BenchmarkManifest, EvalRow, TaskSplit } from "./types";
+import type { BenchmarkManifest, CalibrationSummary, EvalRow, TaskSplit, TrivialFloor } from "./types";
 
 export type CategoryDetail = {
   /** Mean strict score over scored rows in this category. */
@@ -35,6 +35,12 @@ export type ModelSummary = {
   /** True when any row is labeled arm_kind "incumbent" (the capture-producing model rerun). */
   incumbent: boolean;
   /**
+   * True when any row is labeled a trivial calibration arm (null_agent /
+   * spam_agent). Trivial arms are calibration furniture, not candidates:
+   * rendered muted, excluded from top-3 shading and statistical-tie groups.
+   */
+  trivial: boolean;
+  /**
    * Seeded percentile-bootstrap 95% CI over PER-TASK mean scores (tasks are
    * the resampling unit; anomalous rows excluded exactly like `overall`).
    * Null when no scored tasks exist. At taskN=1 it is degenerate [m, m].
@@ -54,6 +60,14 @@ export type LeaderboardOptions = {
 /** True when the executor's structural sentinels flagged this row (row.anomaly is an object with a kind). */
 export function isAnomalousRow(row: EvalRow): boolean {
   return row.anomaly != null && typeof row.anomaly === "object" && typeof row.anomaly.kind === "string";
+}
+
+/** Trivial calibration arms (mirrors run-executor's TRIVIAL_ARM_KINDS). */
+export const TRIVIAL_ARM_KINDS = ["null_agent", "spam_agent"] as const;
+
+/** True when the row belongs to a trivial calibration arm (null/spam agent). */
+export function isTrivialArmRow(row: EvalRow): boolean {
+  return row.arm_kind === "null_agent" || row.arm_kind === "spam_agent";
 }
 
 function mean(values: number[]): number | null {
@@ -172,6 +186,7 @@ export function computeLeaderboard(
       p50LatencyMs: median(latencies),
       route: routes.size === 1 ? [...routes][0] : null,
       incumbent: modelRows.some((r) => r.arm_kind === "incumbent"),
+      trivial: modelRows.some(isTrivialArmRow),
       ci,
       scoredTaskCount: taskMeans.length,
     });
@@ -206,10 +221,12 @@ export function categoryScoreSummary(
  * arms without a CI (no scored tasks) never tie. Overlapping CIs mean the
  * rank separation is not statistically supported at this N — the leaderboard
  * greys those separations out instead of implying a real ordering.
+ * Trivial calibration arms never enter tie groups — they are floors, not
+ * candidates, so "tied with the null agent" is not a rank statement we make.
  */
 export function statisticalTieGroups(summaries: ModelSummary[]): Map<string, number> {
   const ranked = summaries
-    .filter((s) => s.ci != null && s.overall != null)
+    .filter((s) => s.ci != null && s.overall != null && !s.trivial)
     .sort((a, b) => (b.overall as number) - (a.overall as number));
   const groups = new Map<string, number>();
   let group: ModelSummary[] = [];
@@ -247,6 +264,52 @@ export function formatCost(cost: number | null | undefined): string {
   if (cost === 0) return "$0";
   if (cost < 0.01) return "$" + cost.toFixed(5).replace(/0+$/, "").replace(/\.$/, "");
   return "$" + cost.toFixed(cost < 1 ? 3 : 2);
+}
+
+/* ---- Trivial-arm floors (calibration.json null_floor / spam_floor) ---- */
+
+export type FloorView = {
+  armKind: TrivialFloor["arm_kind"];
+  /** Human label: "null agent" / "spam agent". */
+  label: string;
+  floor: number | null;
+  passedTaskIds: string[];
+  exceeded: boolean;
+};
+
+export const TRIVIAL_ARM_LABELS: Record<TrivialFloor["arm_kind"], string> = {
+  null_agent: "null agent",
+  spam_agent: "spam agent",
+};
+
+/**
+ * Normalize a calibration summary's trivial-arm floors for rendering
+ * (in file-schema order: null then spam). Floors absent from the sidecar
+ * (arms that never ran — pre-floors runs) yield nothing.
+ */
+export function calibrationFloors(calibration: CalibrationSummary | null | undefined): FloorView[] {
+  const floors: FloorView[] = [];
+  for (const floor of [calibration?.null_floor, calibration?.spam_floor]) {
+    if (!floor) continue;
+    floors.push({
+      armKind: floor.arm_kind,
+      label: TRIVIAL_ARM_LABELS[floor.arm_kind] ?? floor.arm_kind,
+      floor: floor.floor,
+      passedTaskIds: floor.passed_task_ids,
+      exceeded: floor.floor_exceeded,
+    });
+  }
+  return floors;
+}
+
+/** "0%" / "50%" / "no rows" — the floor cell in the calibration line. */
+export function formatFloor(floor: number | null): string {
+  return floor == null ? "no rows" : formatScore(floor);
+}
+
+/** The trivial arms whose floor pass-list includes this task — a suspect signal ("null agent passes this task"). */
+export function trivialPassesForTask(calibration: CalibrationSummary | null | undefined, taskId: string): FloorView[] {
+  return calibrationFloors(calibration).filter((f) => f.passedTaskIds.includes(taskId));
 }
 
 export function formatLatency(ms: number | null | undefined): string {

--- a/apps/benchmark-hub/lib/types.ts
+++ b/apps/benchmark-hub/lib/types.ts
@@ -34,6 +34,7 @@ export type {
   ManifestTask,
   ProposedHubEntry,
   ReviewDecision,
+  ReviewPolicy,
   SourceDag,
   SourceDagEdge,
   SourceDagNode,
@@ -42,4 +43,5 @@ export type {
   TaskSplit,
   TaxonomyCategory,
   ToolUsageRow,
+  TrivialFloor,
 } from "../../../dist/benchmark-hub-types.js";

--- a/apps/benchmark-hub/tests/floors.test.mjs
+++ b/apps/benchmark-hub/tests/floors.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// Compiled by `tsc -p tests/tsconfig.json` — same pattern as scores.test.mjs.
+import {
+  calibrationFloors,
+  computeLeaderboard,
+  formatFloor,
+  isTrivialArmRow,
+  statisticalTieGroups,
+  trivialPassesForTask,
+  TRIVIAL_ARM_KINDS,
+} from "./.build/lib/scores.js";
+
+const manifest = {
+  schema_version: "understudy.benchmark.v1",
+  benchmark_id: "bench-f",
+  provenance: { origin: "authored" },
+  taxonomy: [{ category_id: "cat-a" }],
+  tasks: [
+    { task_id: "t1", category_id: "cat-a", genesis: "authored", split: "holdout" },
+    { task_id: "t2", category_id: "cat-a", genesis: "authored", split: "holdout" },
+  ],
+  environment: { format: "verifiers.v1", package_ref: "x" },
+  verifier: { kind: "reward-fns", strict_metric: "strict" },
+};
+
+const row = (over = {}) => ({
+  schema_version: "understudy.eval_result.v1",
+  run_id: "r1",
+  task_id: "t1",
+  status: "ok",
+  score: 1,
+  model: "m",
+  ...over,
+});
+
+const calibration = {
+  schema_version: "understudy.calibration.v1",
+  benchmark_id: "bench-f",
+  run_id: "run-cal",
+  incumbent_models: ["m"],
+  threshold: 1,
+  started_at: null,
+  finished_at: null,
+  tasks: [],
+  passed_count: 0,
+  failed_count: 0,
+  failed_task_ids: [],
+  null_floor: { arm_kind: "null_agent", floor: 0, passed_task_ids: [], floor_exceeded: false },
+  spam_floor: { arm_kind: "spam_agent", floor: 0.5, passed_task_ids: ["t1"], floor_exceeded: true },
+};
+
+describe("trivial-arm row detection", () => {
+  it("flags null_agent and spam_agent rows, not incumbent/candidate", () => {
+    assert.deepEqual([...TRIVIAL_ARM_KINDS], ["null_agent", "spam_agent"]);
+    assert.equal(isTrivialArmRow(row({ arm_kind: "null_agent" })), true);
+    assert.equal(isTrivialArmRow(row({ arm_kind: "spam_agent" })), true);
+    assert.equal(isTrivialArmRow(row({ arm_kind: "incumbent" })), false);
+    assert.equal(isTrivialArmRow(row({ arm_kind: "candidate" })), false);
+    assert.equal(isTrivialArmRow(row({})), false);
+  });
+
+  it("computeLeaderboard marks trivial arms; candidates stay unmarked", () => {
+    const rows = [
+      row({ model: "null_agent", arm_kind: "null_agent", score: 0 }),
+      row({ model: "candidate-x", score: 1 }),
+    ];
+    const byModel = new Map(computeLeaderboard(manifest, rows).map((s) => [s.model, s]));
+    assert.equal(byModel.get("null_agent").trivial, true);
+    assert.equal(byModel.get("candidate-x").trivial, false);
+  });
+
+  it("trivial arms never enter statistical-tie groups (floors are not candidates)", () => {
+    // Two identically-scored arms would tie; the trivial one is excluded, so
+    // no tie group forms at all (groups need >= 2 members).
+    const rows = [
+      row({ model: "spam_agent", arm_kind: "spam_agent", score: 0.5 }),
+      row({ model: "spam_agent", arm_kind: "spam_agent", task_id: "t2", score: 0.5 }),
+      row({ model: "candidate-x", score: 0.5 }),
+      row({ model: "candidate-x", task_id: "t2", score: 0.5 }),
+    ];
+    const summaries = computeLeaderboard(manifest, rows);
+    const ties = statisticalTieGroups(summaries);
+    assert.equal(ties.size, 0);
+    // Sanity: without the trivial label the same numbers DO tie.
+    const untied = summaries.map((s) => ({ ...s, trivial: false }));
+    assert.equal(statisticalTieGroups(untied).size, 2);
+  });
+});
+
+describe("calibration floors rendering helpers", () => {
+  it("calibrationFloors normalizes null then spam, with labels and exceeded flags", () => {
+    const floors = calibrationFloors(calibration);
+    assert.deepEqual(floors.map((f) => f.armKind), ["null_agent", "spam_agent"]);
+    assert.deepEqual(floors.map((f) => f.label), ["null agent", "spam agent"]);
+    assert.equal(floors[0].exceeded, false);
+    assert.equal(floors[1].exceeded, true);
+    assert.deepEqual(floors[1].passedTaskIds, ["t1"]);
+  });
+
+  it("handles absent floors and absent calibration (pre-floors sidecars stay renderable)", () => {
+    assert.deepEqual(calibrationFloors(null), []);
+    assert.deepEqual(calibrationFloors(undefined), []);
+    const { null_floor, spam_floor, ...legacy } = calibration;
+    assert.deepEqual(calibrationFloors(legacy), []);
+    const nullOnly = { ...legacy, null_floor };
+    assert.deepEqual(calibrationFloors(nullOnly).map((f) => f.armKind), ["null_agent"]);
+  });
+
+  it("formatFloor renders percents and the no-rows case", () => {
+    assert.equal(formatFloor(0), "0%");
+    assert.equal(formatFloor(0.5), "50%");
+    assert.equal(formatFloor(null), "no rows");
+  });
+
+  it("trivialPassesForTask surfaces the suspect signal per task", () => {
+    const passes = trivialPassesForTask(calibration, "t1");
+    assert.equal(passes.length, 1);
+    assert.equal(passes[0].armKind, "spam_agent");
+    assert.equal(passes[0].label, "spam agent");
+    assert.deepEqual(trivialPassesForTask(calibration, "t2"), []);
+    assert.deepEqual(trivialPassesForTask(null, "t1"), []);
+  });
+});

--- a/docs/agent-operator-surface.md
+++ b/docs/agent-operator-surface.md
@@ -26,8 +26,10 @@ Claude Code registration (`~/.claude.json` → `mcpServers`):
 | `read_rollout` | trajectory from `runs/live/<run>-<model>.jsonl` + per-obligation contract scoring | `dist/benchmark-replay.js` `accumulateReplay` (the Replay tab's scorer) |
 | `diff_rollouts` | side-by-side obligations + first tool-call divergence between two runs | same |
 | `submit_review` | appends `understudy.benchmark_review.v1` to `reviews.jsonl` | `submitReview` — the exact validation behind `POST /api/reviews` |
+| `apply_auto_accepts` | appends `source:"auto"` accept lines per the review policy (`review-policy.json`, defaults when absent) — the tool call **is** the explicit user action | `applyAutoAccepts` — the exact code behind `POST /api/reviews/auto` |
+| `submit_feedback` | appends `understudy.task_feedback.v1` to `feedback.jsonl` and returns the regenerate-env agent handoff | `submitTaskFeedback` — the exact code behind `POST /api/feedback` |
 | `queue_run` | writes `understudy.run_request.v1` into `runs/queue/` — **never executes** | `queueOrCancelRun` — the exact validation behind `POST /api/runs` |
-| `run_status` | request status + row summary as `rows-*.jsonl` land | `run-executor` readers |
+| `run_status` | request status + row summary as `rows-*.jsonl` land, plus the calibration block (incumbent gate + null/spam trivial-arm floors) | `run-executor` readers |
 
 Execution stays where it always was: `understudy runs execute --benchmark
 <dir> --watch` (or the daemon) picks queued requests up. The MCP server is a

--- a/schemas/understudy.review_policy.v1.schema.json
+++ b/schemas/understudy.review_policy.v1.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.review_policy.v1.schema.json",
+  "title": "understudy.review_policy.v1",
+  "description": "Optional review-policy.json sidecar next to a foundry manifest.json (understudy.trace_foundry.v1), configuring the exception-review auto-accept bar for that benchmark. A sidecar rather than a manifest field: the manifest is machine-written and regenerated on rebuilds, while this policy is operator-owned post-generation state (same ownership split as reviews.jsonl / feedback.jsonl). An absent, unreadable, or wrong-schema file means the defaults (min_confidence 'high', require_incumbent_pass true) — exactly the pre-policy behavior. Readers apply recognized fields individually and ignore unrecognized values (a typo must not silently loosen the bar). Producers may add extra fields; consumers must ignore fields they do not understand.",
+  "type": "object",
+  "required": ["schema_version"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "understudy.review_policy.v1",
+      "description": "Version stamp for this policy shape."
+    },
+    "min_confidence": {
+      "enum": ["high", "medium", "low"],
+      "description": "Lowest machine_confidence that can auto-accept (ordered high > medium > low; default high). A close_call task is always an exception regardless of this bar."
+    },
+    "require_incumbent_pass": {
+      "type": "boolean",
+      "description": "When true (default), a task the incumbent failed in the calibration rerun cannot auto-accept (reason incumbent_failed). Set false to drop the incumbent gate from the auto-accept policy."
+    }
+  }
+}

--- a/src/benchmark-artifacts.ts
+++ b/src/benchmark-artifacts.ts
@@ -53,6 +53,8 @@ export const AUTHORING_EVENT_SCHEMA = "understudy.authoring_event.v1";
 export const FOUNDRY_SELF_CHECK_SCHEMA = "understudy.foundry_self_check.v1";
 /** feedback.jsonl sidecar: free-text "what's wrong with this task" lines (append-only). */
 export const TASK_FEEDBACK_SCHEMA = "understudy.task_feedback.v1";
+/** review-policy.json sidecar: configurable exception-review auto-accept bar. */
+export const REVIEW_POLICY_SCHEMA = "understudy.review_policy.v1";
 
 /* ------------------------------------------------------------------ */
 /* JSONL codec                                                         */
@@ -327,6 +329,71 @@ export function serializeTaskFeedbackLine(feedback: TaskFeedback): string {
 export function readTaskFeedback(file: string): { feedback: TaskFeedback[]; skipped: number } {
   const { items, skipped } = readJsonlFile(file);
   return { feedback: items.filter(isTaskFeedback), skipped };
+}
+
+/* ------------------------------------------------------------------ */
+/* Review policy (<benchmark>/review-policy.json — optional sidecar)   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * understudy.review_policy.v1 — configures the exception-review auto-accept
+ * bar. A SIDECAR (not a manifest field) on purpose: manifest.json is
+ * machine-written by the foundry and regenerated on rebuilds, while the
+ * policy is human/operator-owned post-generation state — the same ownership
+ * split as reviews.jsonl and feedback.jsonl. Absent/invalid file = defaults,
+ * which reproduce the pre-policy behavior exactly.
+ */
+export type MachineConfidence = "high" | "medium" | "low";
+
+export type ReviewPolicy = {
+  schema_version: typeof REVIEW_POLICY_SCHEMA;
+  /** Lowest machine_confidence that can auto-accept (close_call still always excepts). */
+  min_confidence: MachineConfidence;
+  /** When false, an incumbent calibration failure no longer blocks auto-accept. */
+  require_incumbent_pass: boolean;
+};
+
+export const DEFAULT_REVIEW_POLICY: ReviewPolicy = {
+  schema_version: REVIEW_POLICY_SCHEMA,
+  min_confidence: "high",
+  require_incumbent_pass: true,
+};
+
+const CONFIDENCE_RANK: Record<MachineConfidence, number> = { high: 2, medium: 1, low: 0 };
+
+/** True when `level` clears the policy's min_confidence bar (high > medium > low). */
+export function meetsConfidenceBar(level: string | null | undefined, minConfidence: MachineConfidence): boolean {
+  const rank = CONFIDENCE_RANK[level as MachineConfidence];
+  return rank !== undefined && rank >= CONFIDENCE_RANK[minConfidence];
+}
+
+export function reviewPolicyPath(benchmarkDir: string): string {
+  return join(benchmarkDir, "review-policy.json");
+}
+
+/**
+ * Read the policy in force for a benchmark dir. TOLERANT + field-wise
+ * additive: a missing/unreadable/wrong-schema file yields the defaults, and
+ * recognized fields override the defaults individually (unknown values are
+ * ignored, never fatal — a typo'd policy must not silently loosen the bar).
+ */
+export function readReviewPolicy(benchmarkDir: string): ReviewPolicy {
+  let parsed: Obj;
+  try {
+    parsed = asObject(JSON.parse(readFileSync(reviewPolicyPath(benchmarkDir), "utf8")));
+  } catch {
+    return { ...DEFAULT_REVIEW_POLICY };
+  }
+  if (parsed.schema_version !== REVIEW_POLICY_SCHEMA) return { ...DEFAULT_REVIEW_POLICY };
+  return {
+    ...DEFAULT_REVIEW_POLICY,
+    ...(parsed.min_confidence === "high" || parsed.min_confidence === "medium" || parsed.min_confidence === "low"
+      ? { min_confidence: parsed.min_confidence }
+      : {}),
+    ...(typeof parsed.require_incumbent_pass === "boolean"
+      ? { require_incumbent_pass: parsed.require_incumbent_pass }
+      : {}),
+  };
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -26,9 +26,13 @@ import {
   latestReviewByTask as sharedLatestReviewByTask,
   makeBenchmarkReview,
   makeTaskFeedback,
+  meetsConfidenceBar,
   readJsonlFile,
+  readReviewPolicy,
   serializeReviewLine,
   serializeTaskFeedbackLine,
+  DEFAULT_REVIEW_POLICY,
+  type ReviewPolicy,
   type TaskFeedback,
 } from "./benchmark-artifacts.js";
 import {
@@ -336,6 +340,9 @@ export function loadProposedEntryFromDir(
     // Additive: a pre-promotion incumbent rerun's calibration sidecar feeds
     // the exception-review policy (incumbent_failed).
     calibration: loadCalibration(dir, proposalBenchmarkId),
+    // Additive: the auto-accept policy in force (review-policy.json sidecar,
+    // defaults when absent — pre-policy behavior).
+    reviewPolicy: readReviewPolicy(dir),
   };
 }
 
@@ -855,24 +862,28 @@ export type AutoReviewProposal = {
 };
 
 /**
- * The confidence bar for auto-acceptance. machine_confidence is an ordered
- * enum (high > medium > low); a task clears the bar only at "high", and a
- * high-confidence close_call is still treated as low_confidence — the machine
- * itself flagged the boundary as borderline.
+ * The DEFAULT confidence bar for auto-acceptance. machine_confidence is an
+ * ordered enum (high > medium > low); by default a task clears the bar only
+ * at "high". A review-policy.json sidecar (understudy.review_policy.v1) can
+ * lower the bar per benchmark; a close_call is still ALWAYS treated as
+ * low_confidence regardless of policy — the machine itself flagged the
+ * boundary as borderline.
  */
-export const AUTO_ACCEPT_CONFIDENCE_THRESHOLD: FoundryTask["machine_confidence"] = "high";
+export const AUTO_ACCEPT_CONFIDENCE_THRESHOLD: FoundryTask["machine_confidence"] =
+  DEFAULT_REVIEW_POLICY.min_confidence;
 
 /**
  * Pure classification of every PENDING task (tasks whose newest review line,
  * if any, already decided them are skipped — auto-accept never re-decides).
  *
- * AUTO_ACCEPT requires ALL of:
- * - machine_confidence ≥ AUTO_ACCEPT_CONFIDENCE_THRESHOLD and not close_call
+ * The bar comes from the entry's review-policy.json (entry.reviewPolicy,
+ * defaults when absent). AUTO_ACCEPT requires ALL of:
+ * - machine_confidence ≥ policy.min_confidence and not close_call
  *   (else: low_confidence)
  * - the foundry self_check, when stamped, passed (else: self_check_failed;
  *   pre-self-check builds without the block count as clean)
- * - calibration.json absent, or absent for this task, or the incumbent passed
- *   it (else: incumbent_failed)
+ * - when policy.require_incumbent_pass: calibration.json absent, or absent
+ *   for this task, or the incumbent passed it (else: incumbent_failed)
  * - tasks.jsonl and benchmark.json agree on this task id (else: schema_conflict)
  * - no eval row for the task carries an executor anomaly sentinel (else: anomaly)
  *
@@ -880,6 +891,7 @@ export const AUTO_ACCEPT_CONFIDENCE_THRESHOLD: FoundryTask["machine_confidence"]
  * applyAutoAccepts, and only on an explicit user action.
  */
 export function deriveAutoReviewProposals(entry: ProposedHubEntry): AutoReviewProposal[] {
+  const policy: ReviewPolicy = entry.reviewPolicy ?? DEFAULT_REVIEW_POLICY;
   const calibrationByTask = new Map<string, boolean>();
   for (const t of entry.calibration?.tasks ?? []) calibrationByTask.set(t.task_id, t.passed);
   const failedIds = new Set(entry.calibration?.failed_task_ids ?? []);
@@ -889,12 +901,14 @@ export function deriveAutoReviewProposals(entry: ProposedHubEntry): AutoReviewPr
   for (const task of entry.tasks) {
     if (entry.latestReviewByTask[task.task_id]) continue; // already decided (newest-wins)
     const reasons: AutoReviewReason[] = [];
-    if (task.machine_confidence !== AUTO_ACCEPT_CONFIDENCE_THRESHOLD || task.close_call) {
+    if (!meetsConfidenceBar(task.machine_confidence, policy.min_confidence) || task.close_call) {
       reasons.push("low_confidence");
     }
     if (task.self_check != null && task.self_check.ok === false) reasons.push("self_check_failed");
     const calibrated = calibrationByTask.get(task.task_id);
-    if (calibrated === false || failedIds.has(task.task_id)) reasons.push("incumbent_failed");
+    if (policy.require_incumbent_pass && (calibrated === false || failedIds.has(task.task_id))) {
+      reasons.push("incumbent_failed");
+    }
     if (entry.crossCheckErrors.some((e) => e.includes(task.task_id))) reasons.push("schema_conflict");
     if (anomalousTaskIds.has(task.task_id)) reasons.push("anomaly");
     proposals.push({
@@ -929,6 +943,7 @@ export function applyAutoAccepts(entry: AnyHubEntry | null): ApplyAutoAcceptsRes
       status: 403,
     };
   }
+  const policy = entry.reviewPolicy ?? DEFAULT_REVIEW_POLICY;
   const proposals = deriveAutoReviewProposals(entry);
   const reviews: BenchmarkReview[] = [];
   for (const p of proposals) {
@@ -938,7 +953,7 @@ export function applyAutoAccepts(entry: AnyHubEntry | null): ApplyAutoAcceptsRes
         benchmark_id: path.basename(entry.dir),
         task_id: p.task_id,
         decision: "accept",
-        note: "auto-accepted: high machine confidence, self-check clean, no incumbent/schema/anomaly evidence against it",
+        note: `auto-accepted: machine confidence ≥ ${policy.min_confidence}, self-check clean, no ${policy.require_incumbent_pass ? "incumbent/" : ""}schema/anomaly evidence against it`,
         source: "auto",
       }) as BenchmarkReview,
     );

--- a/src/benchmark-hub-types.ts
+++ b/src/benchmark-hub-types.ts
@@ -100,8 +100,8 @@ export type EvalRow = {
   subscores?: Record<string, number | null> | null;
   status: "ok" | "error" | "skipped" | "unscored";
   model?: string | null;
-  /** Additive arm label from the executor: "incumbent" rerun vs "candidate". */
-  arm_kind?: "incumbent" | "candidate" | null;
+  /** Additive arm label from the executor: "incumbent" rerun, "candidate", or a trivial calibration arm ("null_agent" / "spam_agent"). */
+  arm_kind?: "incumbent" | "candidate" | "null_agent" | "spam_agent" | null;
   route?: string | null;
   latency_ms?: number | null;
   created_at?: string | null;
@@ -411,6 +411,8 @@ export type ProposedHubEntry = {
   overview: BenchmarkOverview | null;
   /** understudy.calibration.v1 sidecar from a pre-promotion incumbent rerun, when present (additive). */
   calibration?: CalibrationSummary | null;
+  /** understudy.review_policy.v1 in force (review-policy.json, defaults when absent — additive). */
+  reviewPolicy?: ReviewPolicy;
 };
 
 export type AnyHubEntry = HubEntry | InvalidHubEntry | ProposedHubEntry;
@@ -461,4 +463,41 @@ export type CalibrationSummary = {
   passed_count: number;
   failed_count: number;
   failed_task_ids: string[];
+  /** Additive: null-agent floor (absent when the run carried no null_agent arm). */
+  null_floor?: TrivialFloor;
+  /** Additive: spam-agent floor (absent when the run carried no spam_agent arm). */
+  spam_floor?: TrivialFloor;
+};
+
+/**
+ * Per-benchmark trivial-arm floor (mirrors run-executor's TrivialFloor): the
+ * fraction of selected tasks a do-nothing (null) or ritual-tool-calling
+ * (spam) agent passes at the calibration threshold. floor > the executor's
+ * TRIVIAL_FLOOR_LIMIT stamps floor_exceeded — the benchmark's contracts are
+ * trivially satisfiable and the passing tasks are suspect.
+ */
+export type TrivialFloor = {
+  arm_kind: "null_agent" | "spam_agent";
+  /** passed / selected tasks at the calibration threshold; null when the arm produced no rows. */
+  floor: number | null;
+  /** Every selected task the trivial arm passes — the offending tasks. */
+  passed_task_ids: string[];
+  floor_exceeded: boolean;
+};
+
+/** Machine-confidence enum, ordered high > medium > low. */
+export type MachineConfidence = "high" | "medium" | "low";
+
+/**
+ * understudy.review_policy.v1 — optional review-policy.json sidecar next to
+ * the foundry manifest. Configures the exception-review auto-accept bar;
+ * absent file = the defaults (min_confidence "high", require_incumbent_pass
+ * true), i.e. exactly the pre-policy behavior.
+ */
+export type ReviewPolicy = {
+  schema_version: "understudy.review_policy.v1";
+  /** Lowest machine_confidence that can auto-accept (close_call still always excepts). */
+  min_confidence: MachineConfidence;
+  /** When false, an incumbent calibration failure no longer blocks auto-accept. */
+  require_incumbent_pass: boolean;
 };

--- a/src/benchmarks-mcp.ts
+++ b/src/benchmarks-mcp.ts
@@ -20,13 +20,15 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import {
+  applyAutoAccepts,
   getEntry,
   loadHub,
   loadTaskSidecars,
   queueOrCancelRun,
   submitReview,
+  submitTaskFeedback,
 } from "./benchmark-hub-core.js";
-import type { AnyHubEntry, EvalRow, FoundryTask, ProposedHubEntry, ReviewDecision } from "./benchmark-hub-types.js";
+import type { AnyHubEntry, CalibrationSummary, EvalRow, FoundryTask, ProposedHubEntry, ReviewDecision } from "./benchmark-hub-types.js";
 import { REVIEW_DECISIONS, taskDisplayName } from "./benchmark-hub-types.js";
 import { isAnomalousEvalRow, liveJournalPath, readRunRequest, runRequestPath, RUN_SPLITS } from "./run-executor.js";
 import { accumulateReplay, type OracleReplay, type ReplayCall } from "./benchmark-replay.js";
@@ -105,6 +107,26 @@ function requireString(args: Obj, key: string): string {
   const v = args[key];
   if (typeof v !== "string" || v.length === 0) throw new ToolError(`${key} (string) is required`);
   return v;
+}
+
+/**
+ * Compact projection of the understudy.calibration.v1 sidecar for tool
+ * outputs (additive): incumbent gate counts plus the trivial-arm floors
+ * (null_agent / spam_agent) when the calibrating run carried those arms.
+ */
+function calibrationOut(calibration: CalibrationSummary | null | undefined): Obj | null {
+  if (!calibration) return null;
+  return {
+    run_id: calibration.run_id,
+    threshold: calibration.threshold,
+    passed_count: calibration.passed_count,
+    failed_count: calibration.failed_count,
+    failed_task_ids: calibration.failed_task_ids,
+    // Additive: trivial-arm floors — floor_exceeded means the benchmark's
+    // contracts are trivially satisfiable and passed_task_ids are suspect.
+    null_floor: calibration.null_floor ?? null,
+    spam_floor: calibration.spam_floor ?? null,
+  };
 }
 
 function requireEntry(slug: string): AnyHubEntry {
@@ -270,6 +292,10 @@ function toolReadBenchmark(args: Obj): unknown {
       dir: entry.dir,
       manifest: entry.foundry,
       review_summary: reviewSummary(entry),
+      // Additive: the auto-accept policy in force (review-policy.json sidecar,
+      // defaults when the file is absent) + the incumbent/trivial calibration.
+      review_policy: entry.reviewPolicy ?? null,
+      calibration: calibrationOut(entry.calibration),
       cross_check_errors: entry.crossCheckErrors,
       tasks: entry.tasks.map((t) => ({
         task_id: t.task_id,
@@ -292,8 +318,10 @@ function toolReadBenchmark(args: Obj): unknown {
     dir: entry.dir,
     manifest: entry.manifest,
     warnings: entry.warnings,
-    // Additive: incumbent-rerun calibration sidecar presence.
+    // Additive: incumbent-rerun calibration sidecar presence + its summary
+    // (incumbent gate counts and trivial-arm floors when arms ran).
     calibration_present: entry.calibration != null,
+    calibration: calibrationOut(entry.calibration),
     tasks: entry.manifest.tasks.map((t) => ({
       task_id: t.task_id,
       split: t.split,
@@ -457,6 +485,33 @@ function toolSubmitReview(args: Obj): unknown {
   return { ok: true, review: result.review };
 }
 
+function toolApplyAutoAccepts(args: Obj): unknown {
+  const slug = requireString(args, "slug");
+  // Shared policy + append (dist/benchmark-hub-core.js) — the exact code
+  // behind the hub's POST /api/reviews/auto ("Apply N auto-accepts" button).
+  // Explicit-invocation semantics: calling this tool IS the user action;
+  // nothing is ever auto-applied on read.
+  const result = applyAutoAccepts(getEntry(slug));
+  if (!result.ok) throw new ToolError(result.error);
+  return {
+    ok: true,
+    applied: result.applied,
+    applied_count: result.applied.length,
+    exceptions: result.exceptions,
+    reviews: result.reviews,
+  };
+}
+
+function toolSubmitFeedback(args: Obj): unknown {
+  const slug = requireString(args, "slug");
+  // Shared validation + append (dist/benchmark-hub-core.js) — the exact code
+  // behind the hub's POST /api/feedback. Records the feedback line and
+  // returns the agent handoff prompt; nothing is executed here.
+  const result = submitTaskFeedback(getEntry(slug), { task_id: args.task_id, feedback: args.feedback });
+  if (!result.ok) throw new ToolError(result.error);
+  return { ok: true, feedback: result.feedback, handoff: result.handoff };
+}
+
 function toolQueueRun(args: Obj): unknown {
   const slug = requireString(args, "slug");
   // Shared validation + queue write (dist/benchmark-hub-core.js +
@@ -485,9 +540,10 @@ function toolRunStatus(args: Obj): unknown {
   const run = existsSync(file) ? readRunRequest(file) : null;
   if (!run) throw new ToolError(`unknown run_id: ${runId}`);
   const rows = entryRows(entry).filter((r) => r.run_id === runId);
-  // Additive: incumbent arm + calibration sidecar presence (promoted entries
-  // carry calibration.json after an incumbent rerun finishes).
-  const calibration = entry.kind === "ok" ? (entry.calibration ?? null) : null;
+  // Additive: incumbent arm + calibration sidecar (both stages carry
+  // calibration.json after an incumbent/trivial-arm run finishes), including
+  // the null/spam trivial-arm floors.
+  const calibration = entry.calibration ?? null;
   return {
     run_id: runId,
     status: run.status,
@@ -497,15 +553,7 @@ function toolRunStatus(args: Obj): unknown {
     models: run.models,
     tasks: run.tasks,
     incumbent_models: run.incumbent_models ?? [],
-    calibration: calibration
-      ? {
-          run_id: calibration.run_id,
-          threshold: calibration.threshold,
-          passed_count: calibration.passed_count,
-          failed_count: calibration.failed_count,
-          failed_task_ids: calibration.failed_task_ids,
-        }
-      : null,
+    calibration: calibrationOut(calibration),
     rows: rowsSummary(rows),
     per_task: [...new Set(rows.map((r) => r.task_id))].sort().map((taskId) => ({ task_id: taskId, ...taskScores(rows, taskId) })),
   };
@@ -596,6 +644,37 @@ export const BENCHMARKS_TOOLS = [
     },
   },
   {
+    name: "apply_auto_accepts",
+    description:
+      "Apply the exception-review auto-accept policy to one PROPOSED benchmark: recompute the classification " +
+      "(review-policy.json bar; defaults min_confidence=high, require_incumbent_pass=true) and append one " +
+      "accept line per clean pending task to reviews.jsonl, stamped source:\"auto\" — the same shared code as " +
+      "the hub's 'Apply N auto-accepts' button. Calling this tool IS the explicit user action; reads never " +
+      "auto-apply. Reversible: newest review line per task wins.",
+    inputSchema: {
+      type: "object",
+      properties: { slug: { type: "string", description: "Slug from list_benchmarks (proposed stage only)." } },
+      required: ["slug"],
+    },
+  },
+  {
+    name: "submit_feedback",
+    description:
+      "Record one understudy.task_feedback.v1 line ('what's wrong with this task') to feedback.jsonl next to " +
+      "the foundry manifest (append-only; proposed benchmarks only) and return the copyable agent-handoff " +
+      "prompt for actually editing the task + regenerating its environment. Nothing is executed here — the " +
+      "same storage-plus-handoff contract as the hub's task feedback box.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: { type: "string" },
+        task_id: { type: "string" },
+        feedback: { type: "string", maxLength: 4000, description: "Reviewer's own words on what is wrong / should change." },
+      },
+      required: ["slug", "task_id", "feedback"],
+    },
+  },
+  {
     name: "queue_run",
     description:
       "Write one understudy.run_request.v1 into <benchmark>/runs/queue/ (validated by the same shared schema " +
@@ -651,6 +730,8 @@ export function callBenchmarksTool(name: string, args: Obj): unknown {
     case "read_rollout": return toolReadRollout(args);
     case "diff_rollouts": return toolDiffRollouts(args);
     case "submit_review": return toolSubmitReview(args);
+    case "apply_auto_accepts": return toolApplyAutoAccepts(args);
+    case "submit_feedback": return toolSubmitFeedback(args);
     case "queue_run": return toolQueueRun(args);
     case "run_status": return toolRunStatus(args);
     default: throw new ToolError(`unknown tool: ${name}`);

--- a/tests/benchmarks-mcp.test.mjs
+++ b/tests/benchmarks-mcp.test.mjs
@@ -307,6 +307,163 @@ describe("queue_run / run_status", () => {
   });
 });
 
+/* ---------------- apply_auto_accepts + submit_feedback ---------------- */
+
+// A hand-written foundry dir with deterministic confidences for the policy tools.
+function writeFoundryFixture(dir, tasks) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "manifest.json"),
+    JSON.stringify({
+      schema_version: "understudy.trace_foundry.v1",
+      freshness: { max_age_days: 30, cutoff_utc: "2026-07-01T00:00:00Z", newest_capture_utc: "2026-07-20T00:00:00Z" },
+      counts: { source_files: 1, captures: 1, tasks: tasks.length, edges: 0, stale_filtered: 0, invalid_timestamp_filtered: 0 },
+    }),
+  );
+  fs.writeFileSync(path.join(dir, "tasks.jsonl"), tasks.map((t) => JSON.stringify(t)).join("\n") + "\n");
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({ schema_version: "understudy.benchmark_proposal.v1", benchmark_id: "mcp-policy-bench", tasks: tasks.map((t) => ({ task_id: t.task_id })) }),
+  );
+}
+
+function foundryTask(id, overrides = {}) {
+  return {
+    schema_version: "understudy.benchmark_task.v1",
+    task_id: id,
+    execution_group: "g1",
+    title: `task ${id}`,
+    status: "machine_proposed",
+    split: "construction",
+    candidate_boundary: "b",
+    machine_confidence: "high",
+    close_call: false,
+    tool_surface: [],
+    outcome_contract: { required: [], preserved: [], forbidden: [], grading: "final_state" },
+    world_model: {},
+    source: { node_ids: [], edges: [], captures: [] },
+    claims: [],
+    sentinels: [],
+    review: { decision: "pending" },
+    ...overrides,
+  };
+}
+
+const policyDir = path.join(tmp, "prop-policy");
+const policySlug = "data--prop-policy";
+writeFoundryFixture(policyDir, [foundryTask("t-clean"), foundryTask("t-shaky", { machine_confidence: "medium" })]);
+
+describe("apply_auto_accepts", () => {
+  it("applies the shared policy on explicit invocation only, stamping source:'auto'", () => {
+    // Reading the benchmark never writes anything.
+    callBenchmarksTool("read_benchmark", { slug: policySlug });
+    assert.equal(fs.existsSync(path.join(policyDir, "reviews.jsonl")), false);
+
+    const out = callBenchmarksTool("apply_auto_accepts", { slug: policySlug });
+    assert.equal(out.ok, true);
+    assert.deepEqual(out.applied, ["t-clean"]);
+    assert.equal(out.applied_count, 1);
+    assert.equal(out.exceptions, 1);
+    const lines = fs.readFileSync(path.join(policyDir, "reviews.jsonl"), "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].task_id, "t-clean");
+    assert.equal(lines[0].decision, "accept");
+    assert.equal(lines[0].source, "auto");
+
+    // Idempotent: already-decided tasks are never re-decided.
+    const again = callBenchmarksTool("apply_auto_accepts", { slug: policySlug });
+    assert.deepEqual(again.applied, []);
+  });
+
+  it("honors a review-policy.json sidecar (min_confidence medium) and surfaces it in read_benchmark", () => {
+    fs.writeFileSync(
+      path.join(policyDir, "review-policy.json"),
+      JSON.stringify({ schema_version: "understudy.review_policy.v1", min_confidence: "medium" }),
+    );
+    const bench = callBenchmarksTool("read_benchmark", { slug: policySlug });
+    assert.equal(bench.review_policy.min_confidence, "medium");
+    assert.equal(bench.review_policy.require_incumbent_pass, true);
+
+    const out = callBenchmarksTool("apply_auto_accepts", { slug: policySlug });
+    assert.deepEqual(out.applied, ["t-shaky"], "the medium-confidence task now clears the configured bar");
+  });
+
+  it("rejects promoted entries and unknown slugs", () => {
+    assert.throws(() => callBenchmarksTool("apply_auto_accepts", { slug: promotedSlug }), /auto-accept only applies to proposed/);
+    assert.throws(() => callBenchmarksTool("apply_auto_accepts", { slug: "data--nope" }), /unknown benchmark/);
+  });
+});
+
+describe("submit_feedback", () => {
+  it("appends an understudy.task_feedback.v1 line and returns the agent handoff", () => {
+    const out = callBenchmarksTool("submit_feedback", { slug: policySlug, task_id: "t-clean", feedback: "gold contract over-specified" });
+    assert.equal(out.ok, true);
+    assert.equal(out.feedback.schema_version, "understudy.task_feedback.v1");
+    assert.equal(out.feedback.task_id, "t-clean");
+    assert.equal(out.feedback.status, "open");
+    assert.ok(out.handoff.includes(`understudy traces regenerate-env --benchmark ${policyDir}`));
+    assert.ok(out.handoff.includes("gold contract over-specified"));
+    const lines = fs.readFileSync(path.join(policyDir, "feedback.jsonl"), "utf8").trim().split("\n");
+    assert.equal(lines.length, 1);
+  });
+
+  it("validates through the shared write path (unknown task, empty feedback, promoted stage)", () => {
+    assert.throws(() => callBenchmarksTool("submit_feedback", { slug: policySlug, task_id: "nope", feedback: "x" }), /unknown task_id/);
+    assert.throws(() => callBenchmarksTool("submit_feedback", { slug: policySlug, task_id: "t-clean", feedback: "  " }), /non-empty string/);
+    assert.throws(() => callBenchmarksTool("submit_feedback", { slug: promotedSlug, task_id: "t1", feedback: "x" }), /only applies to proposed/);
+  });
+});
+
+/* ---------------- trivial-arm floors in read outputs ---------------- */
+
+describe("floors in read_benchmark / run_status (additive)", () => {
+  const calibration = {
+    schema_version: "understudy.calibration.v1",
+    benchmark_id: "promoted-bench",
+    run_id: "run-cal",
+    incumbent_models: ["modelA"],
+    threshold: 1,
+    started_at: null,
+    finished_at: null,
+    tasks: [
+      { task_id: "t1", score: 1, passed: true, rollouts: 1 },
+      { task_id: "t2", score: 0, passed: false, rollouts: 1 },
+    ],
+    passed_count: 1,
+    failed_count: 1,
+    failed_task_ids: ["t2"],
+    null_floor: { arm_kind: "null_agent", floor: 0, passed_task_ids: [], floor_exceeded: false },
+    spam_floor: { arm_kind: "spam_agent", floor: 0.5, passed_task_ids: ["t1"], floor_exceeded: true },
+  };
+
+  it("read_benchmark surfaces the calibration block with null/spam floors", () => {
+    fs.writeFileSync(path.join(promotedDir, "calibration.json"), JSON.stringify(calibration));
+    const out = callBenchmarksTool("read_benchmark", { slug: promotedSlug });
+    assert.equal(out.calibration_present, true);
+    assert.deepEqual(out.calibration.failed_task_ids, ["t2"]);
+    assert.equal(out.calibration.null_floor.floor, 0);
+    assert.equal(out.calibration.null_floor.floor_exceeded, false);
+    assert.equal(out.calibration.spam_floor.floor_exceeded, true);
+    assert.deepEqual(out.calibration.spam_floor.passed_task_ids, ["t1"]);
+  });
+
+  it("run_status carries the same floors block", () => {
+    const queued = callBenchmarksTool("queue_run", { slug: promotedSlug, models: ["modelE"], tasks: "all", split: "all" });
+    const status = callBenchmarksTool("run_status", { slug: promotedSlug, run_id: queued.run_id });
+    assert.equal(status.calibration.run_id, "run-cal");
+    assert.equal(status.calibration.spam_floor.floor, 0.5);
+    assert.equal(status.calibration.spam_floor.floor_exceeded, true);
+    assert.equal(status.calibration.null_floor.floor_exceeded, false);
+    fs.rmSync(path.join(promotedDir, "calibration.json"));
+  });
+
+  it("stays additive: without a sidecar the calibration block is null", () => {
+    const out = callBenchmarksTool("read_benchmark", { slug: promotedSlug });
+    assert.equal(out.calibration_present, false);
+    assert.equal(out.calibration, null);
+  });
+});
+
 /* ---------------- roots + stdio protocol ---------------- */
 
 describe("server wiring", () => {
@@ -332,7 +489,18 @@ describe("server wiring", () => {
     const names = responses.get(2).result.tools.map((t) => t.name).sort();
     assert.deepEqual(
       names,
-      ["diff_rollouts", "list_benchmarks", "queue_run", "read_benchmark", "read_rollout", "read_task", "run_status", "submit_review"],
+      [
+        "apply_auto_accepts",
+        "diff_rollouts",
+        "list_benchmarks",
+        "queue_run",
+        "read_benchmark",
+        "read_rollout",
+        "read_task",
+        "run_status",
+        "submit_feedback",
+        "submit_review",
+      ],
     );
     assert.equal(responses.get(2).result.tools.length, BENCHMARKS_TOOLS.length);
     const body = JSON.parse(responses.get(3).result.content[0].text);

--- a/tests/exception-review.test.mjs
+++ b/tests/exception-review.test.mjs
@@ -14,6 +14,10 @@ import {
   MAX_FEEDBACK_LENGTH,
 } from "../dist/benchmark-hub-core.js";
 import {
+  DEFAULT_REVIEW_POLICY,
+  REVIEW_POLICY_SCHEMA,
+  meetsConfidenceBar,
+  readReviewPolicy,
   TASK_FEEDBACK_SCHEMA,
   isTaskFeedback,
   latestReviewByTask,
@@ -341,5 +345,136 @@ describe("task feedback contract (understudy.task_feedback.v1)", () => {
     const readOnly = loadProposedEntryFromDir(dir, "fixture", "fixture--prop", true);
     assert.equal(submitTaskFeedback(readOnly, { task_id: "t1", feedback: "x" }).status, 403);
     assert.equal(submitTaskFeedback(null, { task_id: "t1", feedback: "x" }).status, 404);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Configurable review policy (understudy.review_policy.v1 sidecar)    */
+/* ------------------------------------------------------------------ */
+
+const policySchema = JSON.parse(
+  fs.readFileSync(path.resolve("schemas", "understudy.review_policy.v1.schema.json"), "utf8"),
+);
+
+describe("readReviewPolicy — sidecar codec", () => {
+  it("absent / unreadable / wrong-schema files yield the defaults (pre-policy behavior)", () => {
+    const dir = tmpDir();
+    assert.deepEqual(readReviewPolicy(dir), DEFAULT_REVIEW_POLICY);
+    fs.writeFileSync(path.join(dir, "review-policy.json"), "{not json");
+    assert.deepEqual(readReviewPolicy(dir), DEFAULT_REVIEW_POLICY);
+    fs.writeFileSync(path.join(dir, "review-policy.json"), JSON.stringify({ min_confidence: "low" }));
+    assert.deepEqual(readReviewPolicy(dir), DEFAULT_REVIEW_POLICY, "no schema stamp ⇒ defaults");
+  });
+
+  it("recognized fields override individually; unrecognized values never loosen the bar", () => {
+    const dir = tmpDir();
+    fs.writeFileSync(
+      path.join(dir, "review-policy.json"),
+      JSON.stringify({ schema_version: REVIEW_POLICY_SCHEMA, min_confidence: "medium" }),
+    );
+    assert.deepEqual(readReviewPolicy(dir), { ...DEFAULT_REVIEW_POLICY, min_confidence: "medium" });
+    fs.writeFileSync(
+      path.join(dir, "review-policy.json"),
+      JSON.stringify({ schema_version: REVIEW_POLICY_SCHEMA, min_confidence: "yolo", require_incumbent_pass: "no" }),
+    );
+    assert.deepEqual(readReviewPolicy(dir), DEFAULT_REVIEW_POLICY, "typo'd values fall back per field");
+    assert.deepEqual(
+      schemaErrors(policySchema, { schema_version: REVIEW_POLICY_SCHEMA, min_confidence: "medium", require_incumbent_pass: false }),
+      [],
+    );
+  });
+
+  it("defaults match the historical hardcoded bar and confidence ordering is high > medium > low", () => {
+    assert.equal(DEFAULT_REVIEW_POLICY.min_confidence, "high");
+    assert.equal(DEFAULT_REVIEW_POLICY.require_incumbent_pass, true);
+    assert.equal(meetsConfidenceBar("high", "high"), true);
+    assert.equal(meetsConfidenceBar("medium", "high"), false);
+    assert.equal(meetsConfidenceBar("medium", "medium"), true);
+    assert.equal(meetsConfidenceBar("low", "medium"), false);
+    assert.equal(meetsConfidenceBar("low", "low"), true);
+    assert.equal(meetsConfidenceBar("bogus", "low"), false, "unknown levels never clear any bar");
+  });
+});
+
+describe("deriveAutoReviewProposals — policy matrix (non-default review_policy)", () => {
+  const failCalibration = {
+    schema_version: "understudy.calibration.v1",
+    benchmark_id: "b",
+    run_id: "r",
+    incumbent_models: ["m"],
+    threshold: 0.5,
+    started_at: null,
+    finished_at: null,
+    tasks: [{ task_id: "t1", score: 0, passed: false, rollouts: 1 }],
+    passed_count: 0,
+    failed_count: 1,
+    failed_task_ids: ["t1"],
+  };
+
+  it("min_confidence medium auto-accepts medium, still excepts low and close calls", () => {
+    const reviewPolicy = { ...DEFAULT_REVIEW_POLICY, min_confidence: "medium" };
+    const proposals = deriveAutoReviewProposals(
+      entryWith({
+        reviewPolicy,
+        tasks: [
+          task("t-high"),
+          task("t-med", { machine_confidence: "medium" }),
+          task("t-low", { machine_confidence: "low" }),
+          task("t-close", { machine_confidence: "high", close_call: true }),
+        ],
+      }),
+    );
+    assert.deepEqual(proposals.map((p) => p.verdict), ["auto_accept", "auto_accept", "exception", "exception"]);
+    assert.deepEqual(proposals[3].reasons, ["low_confidence"], "close_call always excepts regardless of the bar");
+  });
+
+  it("require_incumbent_pass=false drops the incumbent gate; other gates still hold", () => {
+    const reviewPolicy = { ...DEFAULT_REVIEW_POLICY, require_incumbent_pass: false };
+    const [p] = deriveAutoReviewProposals(entryWith({ reviewPolicy, tasks: [task("t1")], calibration: failCalibration }));
+    assert.equal(p.verdict, "auto_accept", "incumbent failure no longer blocks");
+    const [q] = deriveAutoReviewProposals(
+      entryWith({
+        reviewPolicy,
+        tasks: [task("t1", { self_check: { ok: false, failures: [] } })],
+        calibration: failCalibration,
+      }),
+    );
+    assert.deepEqual(q.reasons, ["self_check_failed"], "incumbent_failed absent even when compounding");
+  });
+
+  it("an entry without reviewPolicy behaves exactly like the defaults", () => {
+    const [withDefault] = deriveAutoReviewProposals(
+      entryWith({ tasks: [task("t1", { machine_confidence: "medium" })] }),
+    );
+    const [withExplicit] = deriveAutoReviewProposals(
+      entryWith({ reviewPolicy: { ...DEFAULT_REVIEW_POLICY }, tasks: [task("t1", { machine_confidence: "medium" })] }),
+    );
+    assert.deepEqual(withDefault, withExplicit);
+    assert.deepEqual(withDefault.reasons, ["low_confidence"]);
+  });
+});
+
+describe("review policy — end to end over a real foundry dir", () => {
+  it("loadProposedEntryFromDir picks up review-policy.json and applyAutoAccepts honors it", () => {
+    const dir = path.join(tmpDir(), "prop");
+    writeFoundryDir(dir, [task("t-med", { machine_confidence: "medium" }), task("t-low", { machine_confidence: "low" })]);
+
+    // Default policy: nothing auto-accepts.
+    const before = applyAutoAccepts(loadProposedEntryFromDir(dir, "data-dir", "data--prop", false));
+    assert.deepEqual(before.applied, []);
+    assert.equal(before.exceptions, 2);
+
+    fs.writeFileSync(
+      path.join(dir, "review-policy.json"),
+      JSON.stringify({ schema_version: REVIEW_POLICY_SCHEMA, min_confidence: "medium" }),
+    );
+    const entry = loadProposedEntryFromDir(dir, "data-dir", "data--prop", false);
+    assert.deepEqual(entry.reviewPolicy, { ...DEFAULT_REVIEW_POLICY, min_confidence: "medium" });
+    const result = applyAutoAccepts(entry);
+    assert.deepEqual(result.applied, ["t-med"]);
+    assert.equal(result.exceptions, 1);
+    const { reviews } = readReviews(path.join(dir, "reviews.jsonl"));
+    assert.equal(reviews[0].source, "auto");
+    assert.ok(reviews[0].note.includes("≥ medium"), "auto note names the policy bar in force");
   });
 });


### PR DESCRIPTION
Three deferred surface follow-ups on top of the trivial-arms (#333) and exception-review (#335) work.

## 1. Hub floors / trivial-arm rendering
- **Calibration section** (promoted Run section + proposed header): `null_floor` / `spam_floor` from `calibration.json` render as mono footnote lines; `floor_exceeded` gets a red **floor exceeded** badge and the offending `passed_task_ids` link straight to their task pages (`components/calibration-floors.tsx`, shared by both stages).
- **Leaderboard**: arms with `arm_kind: null_agent | spam_agent` render muted with a `floor` badge, are excluded from top-3 shading and from statistical-tie groups (they are calibration furniture, not candidates), with a footnote stating the rule.
- **Task pages** (promoted + proposed): a "null/spam agent passes this task · suspect" badge appears alongside the existing incumbent-failed badge, driven by the floors' pass lists.

## 2. MCP tools (src/benchmarks-mcp.ts, 8 → 10 tools)
- `apply_auto_accepts`: runs `deriveAutoReviewProposals` + `applyAutoAccepts` from `benchmark-hub-core` — the exact code behind the hub's "Apply N auto-accepts" button. Calling the tool IS the explicit user action; reads never write.
- `submit_feedback`: `submitTaskFeedback` shared write path; returns the recorded `understudy.task_feedback.v1` line plus the regenerate-env agent handoff prompt.
- `read_benchmark` (both stages) and `run_status` now additively carry the calibration block including the null/spam floors; proposed `read_benchmark` also exposes the review policy in force. No forked logic anywhere — everything routes through the shared dist modules.

## 3. Configurable auto-accept threshold
- New **`review-policy.json` sidecar** (`understudy.review_policy.v1`, constant registered in `src/benchmark-artifacts.ts`, JSON schema added under `schemas/`): `{ min_confidence: high|medium|low, require_incumbent_pass: boolean }`.
- **Why a sidecar, not a manifest field**: `manifest.json` is machine-written by the foundry and regenerated on rebuilds — a human policy edit there would be clobbered and would also mutate a stamped machine artifact. The policy is operator-owned post-generation state, the same ownership split as `reviews.jsonl` / `feedback.jsonl` / `calibration.json`, so it lives beside them.
- Reader is tolerant and fails closed: absent/unreadable/wrong-schema file ⇒ defaults (`min_confidence: "high"`, `require_incumbent_pass: true` — byte-for-byte the old hardcoded behavior); recognized fields override individually; a typo'd value can never loosen the bar. `close_call` always excepts regardless of policy.
- Loaded onto `ProposedHubEntry.reviewPolicy`, so the hub exception queue (which also footnotes a non-default policy) and the MCP tools honor it through the same `deriveAutoReviewProposals`.

## Tests
- `tests/exception-review.test.mjs`: policy codec (defaults / per-field override / fail-closed), policy matrix with non-default configs (medium bar, incumbent gate off, compounding reasons), e2e over a real foundry dir incl. policy-aware auto note.
- `tests/benchmarks-mcp.test.mjs`: both new tools (explicit-invocation, idempotency, policy honored, validation errors), floors in `read_benchmark`/`run_status`, additive null case, tool list updated.
- `apps/benchmark-hub/tests/floors.test.mjs`: trivial-row detection, leaderboard `trivial` flag, tie-group exclusion (with counterfactual), `calibrationFloors`/`formatFloor`/`trivialPassesForTask`.

## Test results
- root `npm test`: 775 pass / 0 fail
- root `tsc --noEmit`: clean
- hub `npm test`: 147 pass / 0 fail; hub `next build`: clean
- `npm run skills:validate`: ok (35 skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->