### PR TITLE
Oracle full-contract coverage: response obligations verified against stored gold

### DIFF
--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -685,7 +685,13 @@ export function environmentReadiness(dir: string, taskId: string): { ready: bool
       (t: { task_id?: string }) => t?.task_id === taskId,
     );
     if (!row) return { ready: false, reason: "task has no offline validation entry" };
-    if (row.oracle?.strict !== 1) return { ready: false, reason: "oracle validation does not pass for this task" };
+    if (row.oracle?.strict !== 1) {
+      // Missing-gold is a distinct not-runnable class: the task is
+      // UNVERIFIABLE (gold final response absent from the artifacts), not broken.
+      const missing = Array.isArray(row.oracle?.missing_gold) ? row.oracle.missing_gold : [];
+      if (missing.length > 0) return { ready: false, reason: `oracle unverifiable: gold evidence missing from the artifacts (${missing.join(", ")})` };
+      return { ready: false, reason: "oracle validation does not pass for this task" };
+    }
     return { ready: true, reason: "" };
   } catch {
     return { ready: false, reason: "offline-validation.json missing or unreadable" };

--- a/src/rigor-report.ts
+++ b/src/rigor-report.ts
@@ -138,18 +138,35 @@ export function deriveRigorReport(benchmarkDir: string, now: Date = new Date()):
   const items: RigorItem[] = [];
 
   // Oracle solvability: rows produced by the deterministic oracle runner.
+  // FULL-contract coverage: the oracle runner scores every obligation kind
+  // (state effects + read/response/value obligations) against the contract's
+  // own tool calls plus the stored gold final response. Tasks whose gold is
+  // missing from the artifacts (`row.oracle.missing_gold`) are UNVERIFIABLE —
+  // reported distinctly from oracle-failing ("broken") tasks.
+  const oracleRows = rows.filter((row) => Number(asObject(row.subscores).runner_oracle) === 1);
   const oracleBest = bestScores(rows, (row) => Number(asObject(row.subscores).runner_oracle) === 1);
-  if (oracleBest.size === 0) {
+  const missingGoldTasks = new Set<string>();
+  for (const row of oracleRows) {
+    const missing = asObject(row.oracle).missing_gold;
+    if (Array.isArray(missing) && missing.length > 0) missingGoldTasks.add(String(row.task_id));
+  }
+  if (oracleRows.length === 0) {
     items.push({ item: "Oracle solver", status: "UNKNOWN", value: "not run", detail: "no oracle-runner rows — run `understudy runs execute --runner oracle`" });
   } else {
-    const covered = taskIds.filter((taskId) => oracleBest.has(taskId));
-    const passed = covered.filter((taskId) => (oracleBest.get(taskId) ?? 0) >= threshold);
-    const allPass = covered.length > 0 && passed.length === covered.length && covered.length === taskIds.length;
+    const passed = taskIds.filter((taskId) => (oracleBest.get(taskId) ?? 0) >= threshold);
+    const unverifiable = taskIds.filter((taskId) => missingGoldTasks.has(taskId) && !passed.includes(taskId));
+    const failing = taskIds.filter((taskId) => !passed.includes(taskId) && !unverifiable.includes(taskId));
+    const allPass = passed.length === taskIds.length && taskIds.length > 0;
     items.push({
       item: "Oracle solver",
       status: allPass ? "PASS" : "FLAG",
-      value: `${passed.length}/${taskIds.length} tasks pass`,
-      detail: allPass ? "every task is solvable by its own contract oracle" : `oracle-unsolvable or uncovered tasks: ${taskIds.filter((t) => !passed.includes(t)).join(", ") || "(coverage gap)"}`,
+      value: `${passed.length}/${taskIds.length} tasks pass (full contract)${unverifiable.length > 0 ? `, ${unverifiable.length} unverifiable (missing gold)` : ""}`,
+      detail: allPass
+        ? "every task's full contract (state + response/value obligations) is satisfied by its own oracle rollout"
+        : [
+            unverifiable.length > 0 ? `unverifiable (gold final response missing from artifacts): ${unverifiable.join(", ")}` : "",
+            failing.length > 0 ? `oracle-failing or uncovered tasks: ${failing.join(", ")}` : "",
+          ].filter(Boolean).join("; ") || "(coverage gap)",
     });
   }
 

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -19,7 +19,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renam
 import { createHash } from "node:crypto";
 import { join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import { buildReplayInvocation, isMutatingTool, scoreContract, scoreState } from "./trace-foundry.js";
+import { buildReplayInvocation, goldFinalResponseFor, isMutatingTool, oracleEventsFor, readCapturesByKey, responseJudgedRequired, scoreContract } from "./trace-foundry.js";
 import { COST_PER_MTOKEN, resolveGatewayAuth } from "./trace-author.js";
 import { BENCHMARK_PROPOSAL_SCHEMA, BENCHMARK_SCHEMA, CALIBRATION_SCHEMA, EVAL_RESULT_SCHEMA, RUN_EVENT_SCHEMA, appendJournalEntry, readJsonlFile, serializeJsonlLine, serializeRunEvent } from "./benchmark-artifacts.js";
 
@@ -270,6 +270,13 @@ export type RolloutResult = {
   tool_call_count?: number | null;
   /** Character count of the final assistant response; null = the runner cannot tell (never treated as empty). */
   final_response_chars?: number | null;
+  /**
+   * Additive oracle diagnostic (oracle runner only): obligation groups whose
+   * gold evidence is missing from the artifacts (e.g. ["response"] when the
+   * captured incumbent final response is not recoverable). Distinguishes
+   * "unverifiable" from "broken" — absent on every other runner's results.
+   */
+  oracle?: { missing_gold: string[] } | null;
   error?: string | null;
 };
 
@@ -590,6 +597,8 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
             writes: result.writes,
             ...(typeof result.tool_call_count === "number" ? { tool_call_count: result.tool_call_count } : {}),
             ...(typeof result.final_response_chars === "number" ? { final_response_chars: result.final_response_chars } : {}),
+            // Additive oracle diagnostic: missing-gold rows render "unverifiable", never a bare fail.
+            ...(result.oracle && result.oracle.missing_gold.length > 0 ? { oracle: result.oracle } : {}),
             // Marked, not dropped: the primary anomaly plus the full list.
             ...(anomalies.length > 0 ? { anomaly: anomalies[0], anomalies } : {}),
             ...(result.error ? { error: result.error } : {}),
@@ -810,21 +819,37 @@ export async function executeQueuedRuns(benchmarkDir: string, options: ExecuteOp
 
 /**
  * Offline validation-oracle runner: deterministic, zero-cost, no provider
- * calls. Replays each task's own outcome contract (the oracle writes) through
- * the SAME scoreState the generated environment uses, so the whole queue →
- * events → rows → leaderboard/replay loop is provable end to end without
- * spend. Rows are labeled honestly via subscores.runner_oracle = 1.
+ * calls. Constructs each task's FULL oracle rollout — the contract's own tool
+ * calls (state effects, read obligations, tool-args value propagations) PLUS
+ * the stored GOLD final response (the captured incumbent's final assistant
+ * text from normalized-captures.jsonl) — and scores it through the SAME
+ * full-contract scorer real arms are judged by (scoreContract), so EVERY
+ * obligation kind is oracle-verified offline, not just state effects.
+ *
+ * A well-formed task must score strict 1. When the gold final response is
+ * missing from the artifacts, response/value obligations cannot be verified:
+ * the row records the additive diagnostic `oracle.missing_gold: ["response"]`
+ * so the hub can render "unverifiable" distinctly from "broken".
+ * Rows are labeled honestly via subscores.runner_oracle = 1.
  */
 export function oracleRunner(): ArmRunner {
   const journal = appendJournalEntry;
-  return async ({ task, journalPath }) => {
+  const capturesCache = new Map<string, Map<string, Obj>>();
+  return async ({ benchmarkDir, task, journalPath }) => {
     const started = Date.now();
-    const writes = (asObject(task.outcome_contract).required ?? []).filter((rule: Obj) => String(rule.type ?? "state_effect") === "state_effect").map((rule: Obj) => ({ tool: String(rule.tool), arguments: rule.observed_arguments ?? {} }));
-    for (const write of writes) {
-      journal(journalPath, { at: Date.now() / 1000, kind: "call", tool: write.tool, write: true, status: "ok", arguments: JSON.stringify(write.arguments).slice(0, 800) });
-      journal(journalPath, { at: Date.now() / 1000, kind: "result", tool: write.tool, status: "ok", content: "{\"ok\": true}" });
+    const sidecar = asObject(task);
+    const calls = oracleEventsFor(sidecar).calls;
+    for (const call of calls) {
+      journal(journalPath, { at: Date.now() / 1000, kind: "call", tool: String(call.tool), write: isMutatingTool(String(call.tool)), status: "ok", arguments: JSON.stringify(call.arguments ?? {}).slice(0, 800) });
+      journal(journalPath, { at: Date.now() / 1000, kind: "result", tool: String(call.tool), status: "ok", content: "{\"ok\": true}" });
     }
-    const scored = asObject(scoreState(asObject(task), writes));
+    if (!capturesCache.has(benchmarkDir)) capturesCache.set(benchmarkDir, readCapturesByKey(benchmarkDir));
+    const gold = goldFinalResponseFor(sidecar, capturesCache.get(benchmarkDir)!);
+    const missingGold = gold === null && responseJudgedRequired(sidecar).length > 0 ? ["response"] : [];
+    const scored = asObject(scoreContract(sidecar, { calls, finalResponse: gold ?? "" }));
+    // The hub replays accumulation from row.writes: keep it the contract's
+    // state effects exactly (the rules the state scorer judges), as before.
+    const writes = ((asObject(sidecar.outcome_contract).required ?? []) as unknown[]).map(asObject).filter((rule) => String(rule.type ?? "state_effect") === "state_effect").map((rule) => ({ tool: String(rule.tool), arguments: rule.observed_arguments ?? {} }));
     return {
       score: Number(scored.strict ?? 0),
       subscores: {
@@ -839,8 +864,9 @@ export function oracleRunner(): ArmRunner {
       latency_ms: Math.max(1, Date.now() - started),
       cost: 0,
       writes,
-      tool_call_count: writes.length,
-      final_response_chars: null,
+      tool_call_count: calls.length,
+      final_response_chars: gold === null ? null : gold.trim().length,
+      ...(missingGold.length > 0 ? { oracle: { missing_gold: missingGold } } : {}),
     };
   };
 }

--- a/src/trace-foundry.ts
+++ b/src/trace-foundry.ts
@@ -708,6 +708,44 @@ export function scoreContract(task: Obj, events: ContractEvents): Obj {
   return { recall, precision, policy, strict, score: policy === 0 ? 0 : (recall + precision + policy) / 3, met };
 }
 
+/** Required contract entries judged against the FINAL RESPONSE: response obligations plus final-response value propagations. */
+export function responseJudgedRequired(task: Obj): Obj[] {
+  const required: Obj[] = (Array.isArray(asObject(task.outcome_contract).required) ? asObject(task.outcome_contract).required : []).map(asObject);
+  return required.filter((rule) => {
+    const type = String(rule.type ?? "state_effect");
+    return type === "response_obligation" || (type === "value_propagation" && asObject(rule.must_reach).kind === "final_response");
+  });
+}
+
+/**
+ * The GOLD final response for a task: the captured incumbent's final
+ * assistant text, resolved from the task's own source captures (newest node
+ * first). This is the same evidence grounding validated response/value
+ * obligations against at authoring time — the oracle answer for them.
+ * Null = not recoverable from the artifacts (missing capture or empty text).
+ */
+export function goldFinalResponseFor(task: Obj, capturesByKey: Map<string, Obj>): string | null {
+  const nodeIds = (Array.isArray(asObject(task.source).node_ids) ? asObject(task.source).node_ids : []) as unknown[];
+  for (let index = nodeIds.length - 1; index >= 0; index -= 1) {
+    const capture = capturesByKey.get(String(nodeIds[index]));
+    if (!capture) continue;
+    const text = finalResponseText(asObject(capture.response));
+    if (text.trim().length > 0) return text;
+  }
+  return null;
+}
+
+/** capture_key → normalized capture map for one benchmark dir's normalized-captures.jsonl (empty when absent). Older fixtures keyed node_ids by capture_id; both resolve. */
+export function readCapturesByKey(benchmarkDir: string): Map<string, Obj> {
+  const rows = readJsonl(join(resolve(benchmarkDir), "normalized-captures.jsonl"));
+  const byKey = new Map<string, Obj>();
+  for (const row of rows) {
+    if (typeof row.capture_id === "string" && !byKey.has(row.capture_id)) byKey.set(row.capture_id, row);
+    if (typeof row.capture_key === "string") byKey.set(row.capture_key, row);
+  }
+  return byKey;
+}
+
 /**
  * Synthesize the ORACLE event stream a contract's own entries imply — used by
  * offline validation so a contract must be satisfiable by construction.
@@ -853,9 +891,23 @@ const setPath = (obj: Obj, path: string, value: unknown): Obj => {
  * schemas are supplied, an additional enum_violation sentinel proves that a
  * call rejected by observation-tightened validation (out-of-enum value)
  * scores 0.
+ *
+ * `goldFinalResponse` (additive third argument) is the CAPTURED incumbent
+ * final response — the real gold for response/value obligations:
+ *   - undefined → legacy behavior: the oracle response is synthesized from
+ *     the contract's own expected values (self-satisfying by construction).
+ *   - a string → the oracle is scored against the real gold; a contract its
+ *     own captured response cannot satisfy is honestly broken (strict < 1).
+ *   - null → the gold is missing from the artifacts: response-judged
+ *     obligations cannot be verified, so the oracle fails them AND the row
+ *     records `oracle.missing_gold: ["response"]` — distinguishable from a
+ *     broken contract ("unverifiable" vs "broken").
  */
-export function offlineValidationRow(task: Obj, schemas?: Obj): Obj {
+export function offlineValidationRow(task: Obj, schemas?: Obj, goldFinalResponse?: string | null): Obj {
   const oracle = oracleEventsFor(task);
+  const responseJudged = responseJudgedRequired(task);
+  const missingGold = goldFinalResponse === null && responseJudged.length > 0 ? ["response"] : [];
+  if (goldFinalResponse !== undefined) oracle.finalResponse = goldFinalResponse ?? "";
   // wrong_value corrupts the ANCHOR values (the discrete fields matching now
   // keys on). A call whose rule has NO anchors is satisfied by any-args by
   // design, so the sentinel corrupts its TOOL instead — the gate must still
@@ -885,7 +937,8 @@ export function offlineValidationRow(task: Obj, schemas?: Obj): Obj {
       sentinels.enum_violation = scoreContract(task, { calls: enumCalls, finalResponse: oracle.finalResponse });
     }
   }
-  return { task_id: task.task_id, oracle: scoreContract(task, oracle), sentinels };
+  const scored = scoreContract(task, oracle);
+  return { task_id: task.task_id, oracle: missingGold.length > 0 ? { ...scored, missing_gold: missingGold } : scored, sentinels };
 }
 
 /**
@@ -901,7 +954,10 @@ export function refreshOfflineValidation(benchmarkDir: string, tasks: Obj[]): bo
   const validation = asObject(JSON.parse(readFileSync(path, "utf8")));
   const rows = (Array.isArray(validation.tasks) ? validation.tasks : []).map(asObject);
   const byId = new Map(rows.map((row) => [row.task_id, row]));
-  for (const task of tasks) byId.set(task.task_id, offlineValidationRow(task, schemas));
+  // Real-gold verification: score response/value obligations against the
+  // captured incumbent's final response when the captures are on disk.
+  const capturesByKey = readCapturesByKey(resolve(benchmarkDir));
+  for (const task of tasks) byId.set(task.task_id, offlineValidationRow(task, schemas, capturesByKey.size > 0 ? goldFinalResponseFor(task, capturesByKey) : undefined));
   validation.tasks = [...byId.values()];
   writeJson(path, validation);
   return true;
@@ -1210,7 +1266,11 @@ function writeVerifiersEnvironment(output: string, tasks: Obj[], sourceContext: 
   writeFileSync(join(pkg, "__init__.py"), "from understudy_trace_env.environment import load_environment, load_harness, load_taskset\nfrom understudy_trace_env.taskset import TraceTaskset\n\n__all__ = [\"TraceTaskset\", \"load_environment\", \"load_harness\", \"load_taskset\"]\n", { mode: 0o600 });
   writeFileSync(join(servers, "__init__.py"), "", { mode: 0o600 });
   writeFileSync(join(root, "pyproject.toml"), `[project]\nname = "understudy-trace-env"\nversion = "0.1.0"\nrequires-python = ">=3.11,<3.14"\ndependencies = ["verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@${auditedCommit}"]\n\n[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n\n[tool.hatch.metadata]\nallow-direct-references = true\n\n[tool.hatch.build.targets.wheel]\npackages = ["understudy_trace_env"]\n`, { mode: 0o600 });
-  const validation = tasks.map((task) => offlineValidationRow(task, validationSchemas));
+  // Response/value obligations are oracle-verified against the CAPTURED
+  // incumbent final response (the real gold) whenever the build has the
+  // normalized captures; without them the legacy synthesized oracle stands.
+  const capturesByKey = new Map<string, Obj>(rows.map((row) => [String(row.capture_key), row]));
+  const validation = tasks.map((task) => offlineValidationRow(task, validationSchemas, capturesByKey.size > 0 ? goldFinalResponseFor(task, capturesByKey) : undefined));
   writeJson(join(root, "offline-validation.json"), { schema_version: "understudy.verifier_validation.v1", verifiers: { api: "v1", audited_commit: auditedCommit }, tasks: validation });
   const packageFiles = [join(root, "pyproject.toml"), join(pkg, "__init__.py"), join(pkg, "environment.py"), join(pkg, "taskset.py"), join(pkg, "servers", "world.py"), join(pkg, "servers", "fixtures.json"), join(pkg, "tasks.json")];
   // Gold-leakage audit over the exact artifacts just written (report-only).

--- a/tests/rigor-report.test.mjs
+++ b/tests/rigor-report.test.mjs
@@ -102,12 +102,13 @@ describe("deriveRigorReport", () => {
     const report = deriveRigorReport(dir, new Date("2026-07-22T00:00:00Z"));
     const byItem = Object.fromEntries(report.items.map((i) => [i.item, i]));
 
-    // Oracle solvability: the state-effect oracle passes t1 but honestly
-    // flags t2 (its response_obligation is not oracle-satisfiable by the
-    // offline oracle runner) — a real coverage gap, reported not hidden.
+    // Oracle solvability (full contract): the oracle passes t1; t2 carries a
+    // response_obligation but this dir has no normalized-captures.jsonl, so
+    // its gold final response is missing — reported as UNVERIFIABLE (missing
+    // gold), distinct from a broken contract.
     assert.equal(byItem["Oracle solver"].status, "FLAG");
-    assert.equal(byItem["Oracle solver"].value, "1/2 tasks pass");
-    assert.match(byItem["Oracle solver"].detail, /t2/);
+    assert.equal(byItem["Oracle solver"].value, "1/2 tasks pass (full contract), 1 unverifiable (missing gold)");
+    assert.match(byItem["Oracle solver"].detail, /unverifiable.*t2/);
     // Null agent passes nothing here; spam passes the ritual-satisfiable t1.
     assert.equal(byItem["Null-agent floor"].status, "PASS");
     assert.match(byItem["Null-agent floor"].value, /0\.0% \(0\/2\)/);

--- a/tests/run-executor.test.mjs
+++ b/tests/run-executor.test.mjs
@@ -538,3 +538,77 @@ describe("rollout anomaly sentinels (the silent-zero gate)", () => {
     assert.match(warning.warning, new RegExp(String(cap)));
   });
 });
+
+describe("oracle full-contract coverage (response obligations vs stored gold)", () => {
+  /** Benchmark dir with one task carrying state + response + value obligations; gold optional. */
+  function makeResponseBenchmarkDir({ withGold }) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "run-exec-gold-"));
+    roots.push(dir);
+    fs.writeFileSync(
+      path.join(dir, "benchmark.json"),
+      JSON.stringify({
+        schema_version: "understudy.benchmark.v1",
+        benchmark_id: "gold-bench",
+        provenance: { origin: "derived-from-traces" },
+        taxonomy: [{ category_id: "cat-a" }],
+        tasks: [{ task_id: "t1", category_id: "cat-a", genesis: "replayed", split: "train" }],
+        environment: { format: "verifiers.v1", package_ref: "environment" },
+        verifier: { kind: "final-state", strict_metric: "task_completed_correctly" },
+      }),
+    );
+    const sidecar = {
+      schema_version: "understudy.benchmark_task.v1",
+      task_id: "t1",
+      source: { node_ids: ["cap-1"] },
+      outcome_contract: {
+        required: [
+          { type: "state_effect", tool: "update-record", observed_arguments: { id: "r1" } },
+          { type: "response_obligation", kind: "contains_category", expected: "external_customer" },
+          { type: "value_propagation", source: { kind: "prompt" }, value: "Jordan Doe", must_reach: { kind: "final_response" } },
+        ],
+        preserved: [],
+        forbidden: [],
+        grading: "final_state_and_obligations",
+      },
+    };
+    fs.writeFileSync(path.join(dir, "tasks.jsonl"), JSON.stringify(sidecar) + "\n");
+    if (withGold) {
+      const capture = {
+        schema_version: "understudy.normalized_capture.v1",
+        capture_key: "cap-1",
+        capture_id: "cap-1",
+        response: { body: { content: [{ type: "text", text: "Jordan Doe is an external_customer contact." }] } },
+      };
+      fs.writeFileSync(path.join(dir, "normalized-captures.jsonl"), JSON.stringify(capture) + "\n");
+    }
+    return dir;
+  }
+
+  it("scores 1.0 on EVERY obligation kind when the stored gold final response is present", async () => {
+    const dir = makeResponseBenchmarkDir({ withGold: true });
+    const run = createRunRequest(dir, { benchmark_id: "gold-bench", models: ["oracle"], split: "all", tasks: "all", rollouts_per_task: 1 });
+    const result = await executeRunRequest(dir, run.run_id, { runner: oracleRunner() });
+    assert.equal(result.status, "done");
+    const rows = readRows(dir);
+    assert.equal(rows.length, 1);
+    const row = rows[0];
+    assert.equal(row.status, "ok");
+    assert.equal(row.score, 1, "full-contract oracle strict score (state + response + value)");
+    assert.equal(row.subscores.runner_oracle, 1);
+    assert.equal(row.oracle, undefined, "gold present — no missing-gold diagnostic");
+    assert.ok(row.final_response_chars > 0, "the gold final response is the oracle's response");
+    assert.ok(row.writes.length === 1 && row.writes[0].tool === "update-record", "writes stay the contract's state effects");
+  });
+
+  it("records oracle.missing_gold (unverifiable, not broken) when the gold response is absent from the artifacts", async () => {
+    const dir = makeResponseBenchmarkDir({ withGold: false });
+    const run = createRunRequest(dir, { benchmark_id: "gold-bench", models: ["oracle"], split: "all", tasks: "all", rollouts_per_task: 1 });
+    const result = await executeRunRequest(dir, run.run_id, { runner: oracleRunner() });
+    assert.equal(result.status, "done");
+    const row = readRows(dir)[0];
+    assert.equal(row.status, "ok");
+    assert.equal(row.score, 0, "response obligations cannot be verified without gold — the task flips to not-runnable");
+    assert.deepEqual(row.oracle, { missing_gold: ["response"] }, "distinct diagnostic so the hub renders unverifiable, not broken");
+    assert.equal(row.final_response_chars, undefined, "unknown final response is never persisted as 0 chars");
+  });
+});

--- a/tests/trace-foundry.test.mjs
+++ b/tests/trace-foundry.test.mjs
@@ -418,7 +418,9 @@ test("offlineValidationRow: obligation contracts pass their own oracle and fail 
 test("refreshOfflineValidation rewrites only the changed tasks' rows", async () => {
   const { refreshOfflineValidation } = await import("../dist/trace-foundry.js");
   const root = mkdtempSync(join(tmpdir(), "understudy-foundry-refresh-")), source = join(root, "captures"), output = join(root, "out"); mkdirSync(source, { recursive: true });
-  writeFileSync(join(source, "one.json"), JSON.stringify(capture("one", "2026-07-20T00:00:00Z", [{ role: "user", content: "Create it" }], { content: [{ type: "tool_use", id: "x", name: "update-record", input: { id: 1, status: "active" } }] })));
+  // The captured final response carries the gold text the widened response
+  // obligation is verified against (real-gold oracle, not self-satisfying).
+  writeFileSync(join(source, "one.json"), JSON.stringify(capture("one", "2026-07-20T00:00:00Z", [{ role: "user", content: "Create it" }], { content: [{ type: "tool_use", id: "x", name: "update-record", input: { id: 1, status: "active" } }, { type: "text", text: "All done." }] })));
   compileTraceFoundry(source, output, 3, new Date("2026-07-21T00:00:00Z"));
   const task = JSON.parse(readFileSync(join(output, "tasks.jsonl"), "utf8"));
   task.outcome_contract.required.push({ type: "response_obligation", kind: "contains_category", expected: "done" });
@@ -427,6 +429,13 @@ test("refreshOfflineValidation rewrites only the changed tasks' rows", async () 
   const row = validation.tasks.find((r) => r.task_id === task.task_id);
   assert.equal(row.oracle.strict, 1);
   assert.equal(row.oracle.met.length, 2, "refreshed row scores the widened contract");
+  assert.equal(row.oracle.missing_gold, undefined, "gold present — no missing-gold diagnostic");
+  // An obligation the CAPTURED gold response cannot satisfy is honestly broken.
+  const broken = { ...task, outcome_contract: { ...task.outcome_contract, required: [...task.outcome_contract.required, { type: "response_obligation", kind: "contains_category", expected: "never-in-the-gold-response" }] } };
+  assert.equal(refreshOfflineValidation(output, [broken]), true);
+  const brokenRow = JSON.parse(readFileSync(join(output, "environment", "offline-validation.json"), "utf8")).tasks.find((r) => r.task_id === task.task_id);
+  assert.equal(brokenRow.oracle.strict, 0);
+  assert.equal(brokenRow.oracle.missing_gold, undefined, "gold present but unsatisfied — broken, not unverifiable");
 });
 
 test("responseProjection extracts OpenAI chat.completion tool calls so their mutations reach the contract", () => {


### PR DESCRIPTION
## Gap

The rigor report (src/rigor-report.ts) surfaced that the offline oracle runner (`oracleRunner` in src/run-executor.ts) replayed each task's contract through `scoreState` — state effects only. Tasks with `response_obligation` / final-response `value_propagation` entries were never oracle-verified offline against real gold, so the runnability gate (oracle strict === 1) under-covered them: the offline-validation oracle satisfied response obligations with a response synthesized from the contract's own expected values (self-satisfying by construction).

## What changed

- **oracleRunner builds the full oracle rollout**: the contract's own tool calls (state effects, read obligations, tool-args value propagations via the shared `oracleEventsFor`) **plus the stored gold final response** — the captured incumbent's final assistant text resolved from `normalized-captures.jsonl` via new shared helpers `goldFinalResponseFor` / `readCapturesByKey` — scored through `scoreContract`, the same full-contract scorer real arms are judged by. Every obligation kind must score 1.0 on a well-formed task.
- **Missing gold is a distinct diagnostic, not a bare fail**: when the gold response is not recoverable from the artifacts, the eval row (and offline-validation row) carries the additive field `oracle.missing_gold: ["response"]` so the hub can render **unverifiable** vs **broken**. Gold present but unsatisfied stays an honest fail.
- **Real-gold offline validation**: `offlineValidationRow` takes an additive third argument; environment generation and `refreshOfflineValidation` pass the captured gold whenever normalized captures are on disk. Without captures the legacy synthesized oracle stands (no behavior change for callers that cannot know).
- **Runnability gate semantics** (`environmentReadiness` in src/benchmark-hub-core.ts): oracle strict < 1 still means not runnable (correct — an unverifiable task must not gate runs open), but missing-gold now returns a distinct reason: `oracle unverifiable: gold evidence missing from the artifacts (response)`.
- **Rigor report Oracle solver row** reflects full-contract coverage: `N/M tasks pass (full contract), K unverifiable (missing gold)`, with unverifiable and oracle-failing tasks listed separately.

## Fixture flip audit (item 3)

Audited every in-tree foundry-sidecar fixture (`experiments/benchmark-hub-demo/proposed-event-triage`, the only in-tree dir with `tasks.jsonl` + `normalized-captures.jsonl`): **0 of 3 tasks change runnability**. Two state-effect tasks pass under old and new oracles; one empty-contract task fails under both (not judgeable, unchanged). No in-tree fixture carries response-judged obligations, so no mass flip — the new coverage is exercised by the added tests instead.

## Tests

- New: oracle full-contract pass on a fixture task with state + response + value obligations against stored gold; missing-gold diagnostic row (`oracle.missing_gold`, unverifiable-not-broken); real-gold and broken-contract cases for `refreshOfflineValidation`; rigor report row updated to assert the unverifiable distinction.
- Green: root `npm test` (762/762), `tsc --noEmit`, benchmark-hub `npm test` (140/140) + `next build`, `npm run skills:validate` (35 skills ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->