### PR TITLE
benchmark hub: multi-objective (Pareto) trade-offs view

### DIFF
--- a/apps/benchmark-hub/app/b/[slug]/page.tsx
+++ b/apps/benchmark-hub/app/b/[slug]/page.tsx
@@ -23,6 +23,8 @@ import { CopySlug } from "@/components/copy-slug";
 import { ProposedBenchmarkPage } from "@/components/proposed/benchmark-page";
 import { RunPanel } from "@/components/run-panel";
 import { CalibrationFloors } from "@/components/calibration-floors";
+import { ParetoSection } from "@/components/pareto";
+import { projectParetoPoints } from "@/lib/pareto";
 
 export const dynamic = "force-dynamic";
 
@@ -30,6 +32,7 @@ const RAIL = [
   { id: "run", label: "Run" },
   { id: "leaderboard", label: "Leaderboard" },
   { id: "insights", label: "Insights" },
+  { id: "tradeoffs", label: "Trade-offs" },
   { id: "evidence", label: "Evidence" },
   { id: "taxonomy", label: "Taxonomy" },
   { id: "tasks", label: "Tasks" },
@@ -330,6 +333,20 @@ export default async function BenchmarkDetail({ params }: { params: Promise<{ sl
             {scoredCategories >= 3 && insightSummaries.length >= 2 && (
               <CategoryRadar manifest={m} summaries={insightSummaries} />
             )}
+          </Section>
+
+          <Section
+            id="tradeoffs"
+            title="Trade-offs"
+            scope="all splits · flagged excluded · anomalous excluded"
+            explainer="Multi-objective view: quality (with bootstrap CIs) against cost, latency, or throughput. Dashed steps trace the Pareto frontier — the non-dominated arms; trivial calibration arms render as floor reference lines, never as candidates."
+          >
+            <ParetoSection
+              points={projectParetoPoints(entry.rows, {
+                excludeTaskIds: new Set(flaggedTaskIds),
+                benchmarkId: m.benchmark_id,
+              })}
+            />
           </Section>
 
           <Section

--- a/apps/benchmark-hub/components/pareto.tsx
+++ b/apps/benchmark-hub/components/pareto.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { formatCost, formatLatency, formatScore, TRIVIAL_ARM_LABELS } from "@/lib/scores";
+import {
+  availableAxes,
+  PARETO_AXES,
+  paretoFrontier,
+  paretoPointsToCsv,
+  paretoTieGroups,
+  type ParetoAxis,
+  type ParetoPoint,
+} from "@/lib/pareto";
+import { seriesColor } from "@/components/insights";
+
+/**
+ * "Trade-offs" — multi-objective Pareto view (the und-289 payoff shape):
+ * quality (y, CI whiskers) vs a selectable objective (cost | latency |
+ * tokens/sec), the non-dominated frontier traced as a step line, incumbent
+ * highlighted, trivial calibration floors as horizontal reference lines.
+ * Hand-rolled SVG on the trace-viewer theme contract, matching insights.tsx.
+ */
+
+const W = 640;
+const H = 340;
+const PAD = { top: 18, right: 120, bottom: 40, left: 48 }; // right pad hosts arm labels
+
+const GRID = "var(--border)";
+const MUTED = "var(--muted-foreground)";
+const ACCENT = "var(--primary)";
+
+function formatAxisValue(axis: ParetoAxis, v: number): string {
+  if (axis === "costPerTask") return formatCost(v);
+  if (axis === "latencyMeanMs") return formatLatency(v);
+  return v >= 100 ? Math.round(v) + " tok/s" : v.toFixed(1) + " tok/s";
+}
+
+export function ParetoSection({ points }: { points: ParetoPoint[] }) {
+  const axes = useMemo(() => availableAxes(points), [points]);
+  const [axis, setAxis] = useState<ParetoAxis | null>(null);
+  const activeAxis: ParetoAxis | null = axis && axes.includes(axis) ? axis : (axes[0] ?? null);
+
+  const csvHref = useMemo(
+    () => "data:text/csv;charset=utf-8," + encodeURIComponent(paretoPointsToCsv(points)),
+    [points],
+  );
+
+  if (activeAxis == null) {
+    // Sparse-data honesty: fewer than 2 arms carry any secondary objective —
+    // no trade-off exists, so say that instead of rendering an empty chart.
+    return (
+      <div className="u-card">
+        <h3>Trade-offs</h3>
+        <div className="u-state">
+          No trade-off to plot yet — fewer than 2 arms carry cost, latency, or throughput data alongside a score.
+          Rows need a numeric <code className="mono">cost</code>, <code className="mono">latency_ms</code>, or{" "}
+          <code className="mono">tokens_per_sec</code> field.
+        </div>
+        <p className="u-foot-note">
+          <a href={csvHref} download="pareto-points.csv" className="mono">
+            download projected points (CSV)
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ParetoChart
+      points={points}
+      axis={activeAxis}
+      axes={axes}
+      onAxisChange={setAxis}
+      csvHref={csvHref}
+    />
+  );
+}
+
+function ParetoChart({
+  points,
+  axis,
+  axes,
+  onAxisChange,
+  csvHref,
+}: {
+  points: ParetoPoint[];
+  axis: ParetoAxis;
+  axes: ParetoAxis[];
+  onAxisChange: (a: ParetoAxis) => void;
+  csvHref: string;
+}) {
+  const [hover, setHover] = useState<string | null>(null);
+  const axisMeta = PARETO_AXES.find((a) => a.key === axis)!;
+
+  const candidates = points.filter((p) => !p.trivial && p.quality != null && p[axis] != null);
+  const floors = points.filter((p) => p.trivial && p.quality != null);
+  const frontier = useMemo(
+    () =>
+      paretoFrontier(points, [
+        { key: "quality", direction: "max" },
+        { key: axis, direction: axisMeta.direction },
+      ]),
+    [points, axis, axisMeta.direction],
+  );
+  const frontierSet = new Set(frontier.map((p) => p.model));
+  const ties = useMemo(() => paretoTieGroups(points), [points]);
+  const allModels = points.filter((p) => !p.trivial).map((p) => p.model);
+
+  // x scale: log when every value is positive (cost/latency span orders of
+  // magnitude), linear otherwise (e.g. ≈$0 local arms; log10(0) is a lie).
+  const xs = candidates.map((p) => p[axis] as number);
+  const useLog = xs.every((v) => v > 0) && Math.max(...xs) / Math.min(...xs) > 20;
+  const xMinRaw = Math.min(...xs);
+  const xMaxRaw = Math.max(...xs);
+  const lo = useLog ? Math.log10(xMinRaw) - 0.2 : xMinRaw - Math.max((xMaxRaw - xMinRaw) * 0.06, 1e-9);
+  const hi = useLog ? Math.log10(xMaxRaw) + 0.2 : xMaxRaw + Math.max((xMaxRaw - xMinRaw) * 0.06, 1e-9);
+  const plotW = W - PAD.left - PAD.right;
+  const plotH = H - PAD.top - PAD.bottom;
+  const xPos = (x: number) =>
+    PAD.left + (((useLog ? Math.log10(x) : x) - lo) / Math.max(hi - lo, 1e-9)) * plotW;
+
+  // y domain fits the data (CI tops included) instead of squashing low scores.
+  const yDataMax = Math.max(...candidates.map((p) => p.ci?.hi ?? (p.quality as number)), ...floors.map((p) => p.quality as number), 0.01);
+  const yStep = [0.0125, 0.025, 0.05, 0.125, 0.25].find((s) => yDataMax * 1.1 <= s * 4) ?? 0.25;
+  const yTop = yStep * 4;
+  const yTicks = [0, 1, 2, 3, 4].map((i) => i * yStep);
+  const yPos = (y: number) => PAD.top + (1 - Math.min(y, yTop) / yTop) * plotH;
+
+  // x ticks: powers of 10 on log, 5 even ticks on linear.
+  const xTicks: number[] = [];
+  if (useLog) {
+    for (let e = Math.floor(lo); e <= Math.ceil(hi); e++) {
+      if (e >= lo && e <= hi) xTicks.push(Math.pow(10, e));
+    }
+  } else {
+    for (let i = 0; i <= 4; i++) xTicks.push(lo + ((hi - lo) * i) / 4);
+  }
+
+  // Frontier step path: walk the non-dominated set in x order and trace the
+  // staircase (each step holds the best quality until the next frontier arm).
+  const steps = frontier
+    .map((p) => ({ px: xPos(p[axis] as number), py: yPos(p.quality as number) }))
+    .sort((a, b) => a.px - b.px);
+  let frontierPath = "";
+  if (steps.length > 0) {
+    frontierPath = `M ${steps[0].px} ${steps[0].py}`;
+    for (let i = 1; i < steps.length; i++) frontierPath += ` H ${steps[i].px} V ${steps[i].py}`;
+  }
+
+  const tieLetter = (model: string) => {
+    const g = ties.get(model);
+    return g == null ? null : String.fromCharCode(65 + (g % 26));
+  };
+
+  return (
+    <div className="u-card">
+      <div className="u-card-tools" style={{ float: "right", display: "flex", gap: 6, alignItems: "center" }}>
+        {axes.map((a) => {
+          const meta = PARETO_AXES.find((m) => m.key === a)!;
+          return (
+            <button key={a} className="u-chip" aria-pressed={axis === a} onClick={() => onAxisChange(a)}>
+              x: {meta.label}
+            </button>
+          );
+        })}
+      </div>
+      <h3>Trade-offs</h3>
+      <p className="ch-sub">
+        Quality (95% CI whiskers) vs {axisMeta.label} ({axisMeta.direction === "min" ? "lower" : "higher"} is better
+        {useLog ? ", log x" : ""}) · dashed steps = Pareto frontier · shared letter = statistical tie
+      </p>
+      <svg viewBox={`0 0 ${W} ${H}`} className="u-chart" role="img" aria-label={`Quality versus ${axisMeta.label} Pareto scatter`}>
+        {/* y gridlines */}
+        {yTicks.map((t) => (
+          <g key={t}>
+            <line x1={PAD.left} x2={W - PAD.right} y1={yPos(t)} y2={yPos(t)} stroke={GRID} />
+            <text x={PAD.left - 6} y={yPos(t) + 3} textAnchor="end" fill={MUTED} className="mono" fontSize="9">
+              {Number.isInteger(t * 100) ? t * 100 : (t * 100).toFixed(2).replace(/0$/, "")}%
+            </text>
+          </g>
+        ))}
+        {/* x ticks */}
+        {xTicks.map((v, i) => (
+          <g key={i}>
+            <line x1={xPos(v)} x2={xPos(v)} y1={PAD.top} y2={H - PAD.bottom} stroke={GRID} />
+            <text x={xPos(v)} y={H - PAD.bottom + 14} textAnchor="middle" fill={MUTED} className="mono" fontSize="9">
+              {formatAxisValue(axis, v)}
+            </text>
+          </g>
+        ))}
+        {/* trivial-arm floors: horizontal reference lines, never candidates */}
+        {floors.map((p) => (
+          <g key={p.model}>
+            <line
+              x1={PAD.left}
+              x2={W - PAD.right}
+              y1={yPos(p.quality as number)}
+              y2={yPos(p.quality as number)}
+              stroke="var(--bad)"
+              strokeDasharray="2 4"
+              opacity="0.7"
+            />
+            <text
+              x={W - PAD.right + 4}
+              y={yPos(p.quality as number) + 3}
+              fill="var(--bad)"
+              className="mono"
+              fontSize="9"
+              opacity="0.85"
+            >
+              {(TRIVIAL_ARM_LABELS as Record<string, string>)[p.model] ?? p.model} floor {formatScore(p.quality)}
+            </text>
+          </g>
+        ))}
+        {/* Pareto frontier staircase */}
+        {frontierPath && (
+          <path d={frontierPath} fill="none" stroke={ACCENT} strokeWidth="1.5" strokeDasharray="5 3" opacity="0.85" />
+        )}
+        {/* arms: CI whisker + dot + label */}
+        {candidates.map((p) => {
+          const color = seriesColor(p.model, allModels);
+          const px = xPos(p[axis] as number);
+          const py = yPos(p.quality as number);
+          const onFrontier = frontierSet.has(p.model);
+          const isHover = hover === p.model;
+          const letter = tieLetter(p.model);
+          return (
+            <g key={p.model} onMouseEnter={() => setHover(p.model)} onMouseLeave={() => setHover(null)}>
+              <circle cx={px} cy={py} r={14} fill="transparent" />
+              {p.ci && p.ci.hi > p.ci.lo && (
+                <g stroke={color} strokeWidth="1.25" opacity="0.7">
+                  <line x1={px} x2={px} y1={yPos(p.ci.lo)} y2={yPos(p.ci.hi)} />
+                  <line x1={px - 3.5} x2={px + 3.5} y1={yPos(p.ci.lo)} y2={yPos(p.ci.lo)} />
+                  <line x1={px - 3.5} x2={px + 3.5} y1={yPos(p.ci.hi)} y2={yPos(p.ci.hi)} />
+                </g>
+              )}
+              {/* incumbent: accent ring around the dot */}
+              {p.incumbent && <circle cx={px} cy={py} r={isHover ? 9 : 8} fill="none" stroke={ACCENT} strokeWidth="1.5" opacity="0.9" />}
+              <circle
+                cx={px}
+                cy={py}
+                r={isHover ? 6 : 5}
+                fill={onFrontier ? color : "var(--surface-opaque)"}
+                stroke={onFrontier ? "var(--surface-opaque)" : color}
+                strokeWidth="2"
+              />
+              <text x={px + 9} y={py + 3} fill={isHover ? "var(--foreground)" : MUTED} className="mono" fontSize="9">
+                {p.model}
+                {p.incumbent ? " (incumbent)" : ""}
+                {letter ? ` ≈${letter}` : ""}
+              </text>
+              {isHover && (
+                <text x={px + 9} y={py + 15} fill={MUTED} className="mono" fontSize="9">
+                  {formatScore(p.quality)} · {formatAxisValue(axis, p[axis] as number)}
+                  {onFrontier ? " · on frontier" : " · dominated"}
+                </text>
+              )}
+            </g>
+          );
+        })}
+        <text x={W - PAD.right} y={H - 4} textAnchor="end" fill={MUTED} className="mono" fontSize="9">
+          filled = non-dominated · hollow = dominated
+        </text>
+      </svg>
+      <div className="u-legend">
+        {allModels.map((m) => (
+          <span key={m} className="li">
+            <span className="sw" style={{ background: seriesColor(m, allModels) }} />
+            {m}
+          </span>
+        ))}
+      </div>
+      <p className="u-foot-note">
+        {frontier.length} of {candidates.length} arms non-dominated on quality × {axisMeta.label}
+        {floors.length > 0 ? ` · ${floors.length} trivial floor${floors.length === 1 ? "" : "s"} shown as reference lines` : ""}
+        {" · "}
+        <a href={csvHref} download="pareto-points.csv" className="mono">
+          download projected points (CSV)
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/apps/benchmark-hub/lib/pareto.ts
+++ b/apps/benchmark-hub/lib/pareto.ts
@@ -1,0 +1,264 @@
+/**
+ * Multi-objective (Pareto) projection over eval rows — pure, deterministic.
+ *
+ * Derives one point per arm (model) from eval_result rows: quality is the
+ * MACRO-average of per-task mean scores (the same statistic the bootstrap CI
+ * brackets, so the CI whiskers always bracket the plotted dot — note this can
+ * differ from the leaderboard's per-row micro-average `overall` when tasks
+ * have unequal rollout counts), plus mean cost per task, mean rollout
+ * latency, and optional local-perf fields (tokens/sec, memory) when rows
+ * carry them. Anomaly-flagged rows are excluded exactly like the leaderboard
+ * (marked, never dropped from counts).
+ *
+ * `paretoFrontier` computes the non-dominated set for a chosen objective
+ * vector. Trivial calibration arms (null/spam agents) are never frontier
+ * candidates — they are floors, rendered as reference lines by the chart.
+ */
+
+import { bootstrapCI, perTaskMeans, type BootstrapCI } from "./bootstrap";
+import { isAnomalousRow, isTrivialArmRow } from "./scores";
+import type { EvalRow } from "./types";
+
+export type ParetoPoint = {
+  model: string;
+  /** Macro-average of per-task mean scores (the CI's statistic); null when no scored rows. */
+  quality: number | null;
+  /** Seeded percentile-bootstrap 95% CI over per-task means (error whiskers). */
+  ci: BootstrapCI | null;
+  /** Mean cost per scored row carrying a numeric cost; null when none do. */
+  costPerTask: number | null;
+  /** Mean latency_ms over scored rows carrying it; null when none do. */
+  latencyMeanMs: number | null;
+  /** Mean tokens/sec when rows carry a local-perf throughput field; else null. */
+  tokensPerSec: number | null;
+  /** Mean peak memory (MB) when rows carry a local-perf memory field; else null. */
+  memoryMb: number | null;
+  /** Distinct scored tasks (the CI's effective N). */
+  scoredTaskCount: number;
+  scoredRowCount: number;
+  /** Trivial calibration arm (null/spam agent): plottable floor, never on the frontier. */
+  trivial: boolean;
+  /** Capture-producing model rerun. */
+  incumbent: boolean;
+};
+
+/** One objective of the frontier: a numeric ParetoPoint field + direction. */
+export type ParetoObjective = {
+  key: "quality" | "costPerTask" | "latencyMeanMs" | "tokensPerSec" | "memoryMb";
+  direction: "min" | "max";
+};
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function finiteNumbers(rows: EvalRow[], pick: (r: EvalRow) => unknown): number[] {
+  const out: number[] = [];
+  for (const r of rows) {
+    const v = pick(r);
+    if (typeof v === "number" && Number.isFinite(v)) out.push(v);
+  }
+  return out;
+}
+
+/** First numeric value among candidate row fields (rows are open maps). */
+function perfField(row: EvalRow, keys: string[]): number | null {
+  for (const k of keys) {
+    const v = row[k];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+/** Throughput field candidates emitted by local perf harnesses. */
+const TOKENS_PER_SEC_KEYS = ["tokens_per_sec", "tokens_per_second", "tok_per_sec", "throughput_tok_s"];
+/** Memory field candidates (MB unless suffixed _gb). */
+const MEMORY_MB_KEYS = ["memory_mb", "peak_memory_mb", "rss_mb"];
+const MEMORY_GB_KEYS = ["memory_gb", "peak_memory_gb"];
+
+function memoryMbOf(row: EvalRow): number | null {
+  const mb = perfField(row, MEMORY_MB_KEYS);
+  if (mb != null) return mb;
+  const gb = perfField(row, MEMORY_GB_KEYS);
+  return gb != null ? gb * 1024 : null;
+}
+
+export type ProjectOptions = {
+  /** Tasks excluded before aggregation (e.g. open-flagged tasks). */
+  excludeTaskIds?: Set<string>;
+  /** CI seed prefix — pass the benchmark_id so CIs match the leaderboard's. */
+  benchmarkId?: string;
+};
+
+/**
+ * Project eval rows into per-arm Pareto points. Anomaly-flagged rows never
+ * enter aggregates; only status=ok rows with a numeric score count as scored.
+ * Output is sorted by model name (deterministic regardless of row order).
+ */
+export function projectParetoPoints(rows: EvalRow[], options: ProjectOptions = {}): ParetoPoint[] {
+  const excluded = options.excludeTaskIds ?? new Set<string>();
+  const byModel = new Map<string, EvalRow[]>();
+  for (const row of rows) {
+    if (excluded.has(row.task_id)) continue;
+    const model = row.model ?? "(unknown model)";
+    const list = byModel.get(model) ?? [];
+    list.push(row);
+    byModel.set(model, list);
+  }
+
+  const points: ParetoPoint[] = [];
+  for (const [model, modelRows] of byModel) {
+    const trusted = modelRows.filter((r) => !isAnomalousRow(r));
+    const scored = trusted.filter((r) => r.status === "ok" && typeof r.score === "number");
+    const taskMeans = perTaskMeans(scored.map((r) => [r.task_id, r.score as number]));
+    const seed = `${options.benchmarkId ?? "benchmark"}::${model}`;
+    points.push({
+      model,
+      quality: mean(taskMeans),
+      ci: bootstrapCI(taskMeans, { seed }),
+      costPerTask: mean(finiteNumbers(scored, (r) => r.cost)),
+      latencyMeanMs: mean(finiteNumbers(scored, (r) => r.latency_ms)),
+      tokensPerSec: mean(finiteNumbers(scored, (r) => perfField(r, TOKENS_PER_SEC_KEYS))),
+      memoryMb: mean(finiteNumbers(scored, (r) => memoryMbOf(r))),
+      scoredTaskCount: taskMeans.length,
+      scoredRowCount: scored.length,
+      trivial: modelRows.some(isTrivialArmRow),
+      incumbent: modelRows.some((r) => r.arm_kind === "incumbent"),
+    });
+  }
+  points.sort((a, b) => a.model.localeCompare(b.model));
+  return points;
+}
+
+/** Signed objective value: larger is always better after this transform. */
+function directed(point: ParetoPoint, obj: ParetoObjective): number | null {
+  const v = point[obj.key];
+  if (v == null || !Number.isFinite(v)) return null;
+  return obj.direction === "max" ? v : -v;
+}
+
+/**
+ * Non-dominated set for the given objectives. A point is dominated when some
+ * other eligible point is at least as good on EVERY objective and strictly
+ * better on at least one. Ties (identical objective vectors) dominate
+ * neither way, so all tied points stay on the frontier. Excluded up front:
+ * trivial calibration arms (floors, not candidates) and points missing any
+ * objective value. Output order is deterministic: by the first objective
+ * (best first), then model name.
+ */
+export function paretoFrontier(points: ParetoPoint[], objectives: ParetoObjective[]): ParetoPoint[] {
+  if (objectives.length === 0) return [];
+  const eligible = points
+    .filter((p) => !p.trivial)
+    .map((p) => ({ point: p, vec: objectives.map((o) => directed(p, o)) }))
+    .filter((e): e is { point: ParetoPoint; vec: number[] } => e.vec.every((v): v is number => v != null));
+
+  const frontier = eligible.filter((a) =>
+    !eligible.some(
+      (b) => b !== a && b.vec.every((v, i) => v >= a.vec[i]) && b.vec.some((v, i) => v > a.vec[i]),
+    ),
+  );
+  frontier.sort((a, b) => b.vec[0] - a.vec[0] || a.point.model.localeCompare(b.point.model));
+  return frontier.map((e) => e.point);
+}
+
+/**
+ * Statistical-tie groups over Pareto points, mirroring the leaderboard's
+ * discipline: sort non-trivial arms by quality (desc) and chain ADJACENT
+ * arms whose 95% CIs overlap. Returns model → group index only for groups of
+ * size >= 2. Overlapping CIs mean the quality separation is not supported at
+ * this N — the chart flags those labels instead of implying a real ordering.
+ */
+export function paretoTieGroups(points: ParetoPoint[]): Map<string, number> {
+  const ranked = points
+    .filter((p) => p.ci != null && p.quality != null && !p.trivial)
+    .sort((a, b) => (b.quality as number) - (a.quality as number) || a.model.localeCompare(b.model));
+  const groups = new Map<string, number>();
+  let group: ParetoPoint[] = [];
+  let groupIndex = 0;
+  const flush = () => {
+    if (group.length >= 2) {
+      for (const p of group) groups.set(p.model, groupIndex);
+      groupIndex += 1;
+    }
+    group = [];
+  };
+  for (const p of ranked) {
+    const prev = group[group.length - 1];
+    const overlaps = prev != null && prev.ci != null && p.ci != null && p.ci.hi >= prev.ci.lo && prev.ci.hi >= p.ci.lo;
+    if (!overlaps) flush();
+    group.push(p);
+  }
+  flush();
+  return groups;
+}
+
+/* ---- CSV escape hatch (the und-289 analyses lived in spreadsheets) ---- */
+
+const CSV_COLUMNS = [
+  "model",
+  "quality",
+  "ci_lo",
+  "ci_hi",
+  "cost_per_task",
+  "latency_mean_ms",
+  "tokens_per_sec",
+  "memory_mb",
+  "scored_task_count",
+  "scored_row_count",
+  "trivial",
+  "incumbent",
+] as const;
+
+function csvCell(value: string | number | boolean | null): string {
+  if (value == null) return "";
+  const s = String(value);
+  return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+}
+
+/** Render the projected points as a spreadsheet-ready CSV (header + one row per arm). */
+export function paretoPointsToCsv(points: ParetoPoint[]): string {
+  const lines = [CSV_COLUMNS.join(",")];
+  for (const p of points) {
+    lines.push(
+      [
+        p.model,
+        p.quality,
+        p.ci?.lo ?? null,
+        p.ci?.hi ?? null,
+        p.costPerTask,
+        p.latencyMeanMs,
+        p.tokensPerSec,
+        p.memoryMb,
+        p.scoredTaskCount,
+        p.scoredRowCount,
+        p.trivial,
+        p.incumbent,
+      ]
+        .map(csvCell)
+        .join(","),
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+/* ---- Axis availability (sparse-data honesty) ---- */
+
+export type ParetoAxis = "costPerTask" | "latencyMeanMs" | "tokensPerSec";
+
+export const PARETO_AXES: Array<{ key: ParetoAxis; label: string; direction: "min" | "max" }> = [
+  { key: "costPerTask", label: "cost / task", direction: "min" },
+  { key: "latencyMeanMs", label: "mean latency", direction: "min" },
+  { key: "tokensPerSec", label: "tokens / sec", direction: "max" },
+];
+
+/**
+ * Axes worth offering: at least 2 non-trivial arms carry both quality and the
+ * axis value (fewer can't form a trade-off — hide the option, not the chart).
+ */
+export function availableAxes(points: ParetoPoint[]): ParetoAxis[] {
+  return PARETO_AXES.filter(
+    (a) => points.filter((p) => !p.trivial && p.quality != null && p[a.key] != null).length >= 2,
+  ).map((a) => a.key);
+}

--- a/apps/benchmark-hub/tests/pareto.test.mjs
+++ b/apps/benchmark-hub/tests/pareto.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// Compiled by `tsc -p tests/tsconfig.json` (see package.json "test" script).
+import {
+  availableAxes,
+  paretoFrontier,
+  paretoPointsToCsv,
+  paretoTieGroups,
+  projectParetoPoints,
+} from "./.build/lib/pareto.js";
+
+const row = (over = {}) => ({
+  schema_version: "understudy.eval_result.v1",
+  run_id: "r1",
+  task_id: "t1",
+  status: "ok",
+  score: 1,
+  model: "m",
+  ...over,
+});
+
+const point = (over = {}) => ({
+  model: "m",
+  quality: 0.5,
+  ci: null,
+  costPerTask: 1,
+  latencyMeanMs: 100,
+  tokensPerSec: null,
+  memoryMb: null,
+  scoredTaskCount: 2,
+  scoredRowCount: 2,
+  trivial: false,
+  incumbent: false,
+  ...over,
+});
+
+const QC = [
+  { key: "quality", direction: "max" },
+  { key: "costPerTask", direction: "min" },
+];
+
+describe("projectParetoPoints", () => {
+  it("quality is the macro-average of per-task means; anomalous rows excluded", () => {
+    const rows = [
+      row({ task_id: "t1", score: 1 }),
+      row({ task_id: "t1", score: 0 }), // t1 mean = 0.5
+      row({ task_id: "t2", score: 1 }), // t2 mean = 1
+      row({ task_id: "t2", score: 0, anomaly: { kind: "loop", detail: "x" } }), // excluded
+    ];
+    const [p] = projectParetoPoints(rows, { benchmarkId: "b" });
+    assert.equal(p.quality, 0.75);
+    assert.equal(p.scoredTaskCount, 2);
+    assert.equal(p.scoredRowCount, 3);
+    assert.ok(p.ci);
+    assert.ok(p.ci.lo <= 0.75 && p.ci.hi >= 0.75);
+  });
+
+  it("null-cost handling: costPerTask is null when no rows carry cost, mean over carriers otherwise", () => {
+    const noCost = projectParetoPoints([row(), row({ task_id: "t2" })]);
+    assert.equal(noCost[0].costPerTask, null);
+    const mixed = projectParetoPoints([row({ cost: 0.2 }), row({ task_id: "t2" }), row({ task_id: "t3", cost: 0.4 })]);
+    assert.equal(mixed[0].costPerTask, 0.30000000000000004);
+    assert.equal(mixed[0].latencyMeanMs, null);
+  });
+
+  it("perf fields: tokens/sec and memory (gb normalized to mb) aggregate when present", () => {
+    const rows = [
+      row({ tokens_per_sec: 100, memory_gb: 2 }),
+      row({ task_id: "t2", tokens_per_sec: 200, memory_mb: 1024 }),
+    ];
+    const [p] = projectParetoPoints(rows);
+    assert.equal(p.tokensPerSec, 150);
+    assert.equal(p.memoryMb, 1536);
+  });
+
+  it("flags trivial and incumbent arms; excluded tasks never aggregate; output sorted by model", () => {
+    const rows = [
+      row({ model: "z-null", arm_kind: "null_agent", score: 0 }),
+      row({ model: "a-inc", arm_kind: "incumbent" }),
+      row({ model: "a-inc", task_id: "flagged", score: 0 }),
+    ];
+    const pts = projectParetoPoints(rows, { excludeTaskIds: new Set(["flagged"]) });
+    assert.deepEqual(pts.map((p) => p.model), ["a-inc", "z-null"]);
+    assert.equal(pts[0].incumbent, true);
+    assert.equal(pts[0].quality, 1); // flagged task excluded
+    assert.equal(pts[1].trivial, true);
+  });
+
+  it("deterministic: same rows in any order yield identical points (incl. CI)", () => {
+    const rows = [row({ task_id: "t1", score: 1 }), row({ task_id: "t2", score: 0 }), row({ task_id: "t3", score: 1 })];
+    const a = projectParetoPoints(rows, { benchmarkId: "b" });
+    const b = projectParetoPoints([...rows].reverse(), { benchmarkId: "b" });
+    assert.deepEqual(a, b);
+  });
+});
+
+describe("paretoFrontier", () => {
+  it("keeps only non-dominated points (maximize quality, minimize cost)", () => {
+    const pts = [
+      point({ model: "cheap-ok", quality: 0.6, costPerTask: 0.1 }),
+      point({ model: "pricey-great", quality: 0.9, costPerTask: 1 }),
+      point({ model: "pricey-bad", quality: 0.5, costPerTask: 2 }), // dominated twice over
+      point({ model: "mid-dominated", quality: 0.55, costPerTask: 0.5 }), // dominated by cheap-ok
+    ];
+    assert.deepEqual(paretoFrontier(pts, QC).map((p) => p.model), ["pricey-great", "cheap-ok"]);
+  });
+
+  it("degenerate: one arm dominates everything — frontier is that single arm", () => {
+    const pts = [
+      point({ model: "king", quality: 0.9, costPerTask: 0.1 }),
+      point({ model: "a", quality: 0.5, costPerTask: 0.5 }),
+      point({ model: "b", quality: 0.8, costPerTask: 0.2 }),
+    ];
+    assert.deepEqual(paretoFrontier(pts, QC).map((p) => p.model), ["king"]);
+  });
+
+  it("exact ties dominate neither way: both stay, ordered deterministically by model", () => {
+    const pts = [
+      point({ model: "zeta", quality: 0.7, costPerTask: 0.3 }),
+      point({ model: "alpha", quality: 0.7, costPerTask: 0.3 }),
+    ];
+    assert.deepEqual(paretoFrontier(pts, QC).map((p) => p.model), ["alpha", "zeta"]);
+  });
+
+  it("trivial floors and null-objective points never enter the frontier", () => {
+    const pts = [
+      point({ model: "null-agent", quality: 0.95, costPerTask: 0, trivial: true }),
+      point({ model: "no-cost", quality: 0.9, costPerTask: null }),
+      point({ model: "real", quality: 0.6, costPerTask: 0.5 }),
+    ];
+    assert.deepEqual(paretoFrontier(pts, QC).map((p) => p.model), ["real"]);
+  });
+
+  it("maximize-x objective (tokens/sec) flips domination direction", () => {
+    const pts = [
+      point({ model: "slow-good", quality: 0.9, tokensPerSec: 50 }),
+      point({ model: "fast-ok", quality: 0.6, tokensPerSec: 200 }),
+      point({ model: "slow-ok", quality: 0.6, tokensPerSec: 40 }), // dominated by both
+    ];
+    const f = paretoFrontier(pts, [
+      { key: "quality", direction: "max" },
+      { key: "tokensPerSec", direction: "max" },
+    ]);
+    assert.deepEqual(f.map((p) => p.model), ["slow-good", "fast-ok"]);
+  });
+});
+
+describe("paretoTieGroups", () => {
+  it("chains adjacent CI overlaps into groups; trivial arms never tie", () => {
+    const pts = [
+      point({ model: "a", quality: 0.8, ci: { lo: 0.7, hi: 0.9, mean: 0.8, iterations: 2000, taskN: 5 } }),
+      point({ model: "b", quality: 0.75, ci: { lo: 0.65, hi: 0.85, mean: 0.75, iterations: 2000, taskN: 5 } }),
+      point({ model: "c", quality: 0.3, ci: { lo: 0.25, hi: 0.35, mean: 0.3, iterations: 2000, taskN: 5 } }),
+      point({ model: "floor", quality: 0.79, trivial: true, ci: { lo: 0.7, hi: 0.9, mean: 0.79, iterations: 2000, taskN: 5 } }),
+    ];
+    const groups = paretoTieGroups(pts);
+    assert.equal(groups.get("a"), 0);
+    assert.equal(groups.get("b"), 0);
+    assert.equal(groups.has("c"), false);
+    assert.equal(groups.has("floor"), false);
+  });
+});
+
+describe("availableAxes / CSV", () => {
+  it("axes need >=2 non-trivial arms carrying quality + the value", () => {
+    const pts = [
+      point({ model: "a", costPerTask: 1, latencyMeanMs: 10, tokensPerSec: null }),
+      point({ model: "b", costPerTask: 2, latencyMeanMs: null, tokensPerSec: 100 }),
+      point({ model: "floor", costPerTask: 0, latencyMeanMs: 1, tokensPerSec: 500, trivial: true }),
+    ];
+    assert.deepEqual(availableAxes(pts), ["costPerTask"]);
+  });
+
+  it("CSV: header + one row per arm, nulls as empty cells, commas/quotes escaped", () => {
+    const csv = paretoPointsToCsv([
+      point({ model: 'weird, "model"', quality: 0.5, costPerTask: null, ci: { lo: 0.4, hi: 0.6, mean: 0.5, iterations: 2000, taskN: 3 } }),
+    ]);
+    const [header, line] = csv.trim().split("\n");
+    assert.equal(header.split(",").length, 12);
+    assert.ok(line.startsWith('"weird, ""model""",0.5,0.4,0.6,,100,'));
+    assert.ok(line.endsWith("false,false"));
+  });
+});

--- a/apps/benchmark-hub/tests/tsconfig.json
+++ b/apps/benchmark-hub/tests/tsconfig.json
@@ -15,6 +15,7 @@
     "../lib/types.ts",
     "../lib/benchmark-core.ts",
     "../lib/scores.ts",
+    "../lib/pareto.ts",
     "../lib/data-core.ts",
     "../app/api/flags/route.ts",
     "../app/api/reviews/route.ts",


### PR DESCRIPTION
## What

The und-289 Instacart experiment's payoff was Pareto frontiers over accuracy × throughput × cost across local arms + frontier models — analyses that lived in spreadsheets. The hub leaderboard ranks a single score; this adds a **Trade-offs** section to the promoted benchmark page that plots the multi-objective view directly, plus a CSV escape hatch for the spreadsheet workflow.

## Pieces

- **`apps/benchmark-hub/lib/pareto.ts`** (pure, deterministic):
  - `projectParetoPoints(rows)` — one point per arm: quality = **macro-average of per-task means** (the exact statistic the seeded bootstrap CI brackets, so whiskers always bracket the dot; documented where it can differ from the leaderboard's per-row micro-average), mean cost/task (null when no rows carry cost), mean rollout latency, and optional local-perf fields (`tokens_per_sec`/variants, `memory_mb`/`memory_gb`) probed from the open row map. Anomalous rows excluded via `isAnomalousRow`, flagged tasks excludable, output sorted by model.
  - `paretoFrontier(points, objectives)` — generic non-dominated set over directed objectives; exact-tie vectors both survive; trivial arms and null-objective points never enter; deterministic output order (first objective best-first, then model name).
  - `paretoTieGroups` (adjacent-CI-overlap chaining, mirroring the leaderboard's discipline), `paretoPointsToCsv` (RFC-escaped), `availableAxes` (axis offered only when ≥2 non-trivial arms carry it).
- **`apps/benchmark-hub/components/pareto.tsx`** — hand-rolled SVG on the trace-viewer theme contract, matching `insights.tsx`/`radar.tsx` conventions (`--viz-series-*` via `seriesColor`, `u-card`/`u-chip`/`u-legend`, mono axis labels): quality (y, 95% CI whiskers) vs selectable x (cost | latency | tokens/sec when available), frontier staircase, filled = non-dominated / hollow = dominated, incumbent accent ring, trivial floors as dashed horizontal reference lines, `≈A` tie letters on labels, honest empty state when no axis has ≥2 arms. Log x only when all values positive and span >20×. CSV download link (data URI) always present.
- **Page integration** (`app/b/[slug]/page.tsx`): new anchor-rail entry + section between Insights and Evidence; leaderboard untouched.

## Tests

`apps/benchmark-hub/tests/pareto.test.mjs`: projection (macro-average + anomaly exclusion, null-cost, perf-field normalization, trivial/incumbent flags, order-independence incl. CI), frontier (domination, all-dominated degenerate, exact ties, trivial/null exclusion, max-direction axis), tie groups, axis availability, CSV escaping.

All green: hub `npm test` (160 pass) + `next build`, root `npm test` (828 pass), `tsc --noEmit`, `skills:validate` (36 ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->