### PR TITLE
Skills: operate the full benchmark-lab lifecycle (MCP + CLI + daemons + desktop distribution)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -135,6 +135,16 @@ logprobs (which tokens?), and tool-trace forensics (why did this call fail?).
   models — any mix of local, gateway, or frontier — on one frozen eval and
   writes Pareto-style quality, latency, cost, reliability, and caveat artifacts
   for route decisions.
+- [`operate-benchmark-lab`](operate-benchmark-lab/SKILL.md) is the coding
+  agent's operator manual for a trace-compiled benchmark directory: the
+  benchmarks MCP server and CLI verbs across build → exception-based review
+  (auto-accepts, feedback → regenerate-env) → calibration (incumbent gate +
+  null/spam trivial floors) → candidate and prompt-override runs → the rigor
+  report — plus the run-executor daemon lifecycle
+  (`understudy runs execute --watch`, claiming, capability gates).
+- [`replay-app-harness`](replay-app-harness/SKILL.md) runs the user's own app
+  (via an `app-harness.json` sidecar) as an `app_replay` arm on the frozen
+  benchmark tasks — the regression verdict after editing the user's code.
 - [`compare-trajectories`](compare-trajectories/SKILL.md) is the behavioral
   complement to `compare-model-sweep`: it aligns two trajectory-run exports by
   task id, builds the outcome-delta matrix, measures per-step divergence

--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -72,6 +72,20 @@ comparison.
    export under `.understudy/model-sweeps/<timestamp>/candidate-runs/<candidate>/`,
    with per-row results in the required `understudy.eval_result.v1` eval-evidence format ([schema](../../schemas/understudy.eval_result.v1.schema.json)).
 
+   **Benchmark-dir sweeps run as arms of one request.** When the frozen eval
+   is a trace-compiled benchmark directory, don't hand-loop the harness:
+   queue one `understudy.run_request.v1` whose arms are the whole matrix —
+   candidate models, the incumbent (`incumbent_models`, feeding
+   `calibration.json`), the trivial floors
+   (`trivial_arms: ["null_agent", "spam_agent"]` — a candidate beating a
+   floor-exceeded benchmark proves nothing), and prompt experiments as
+   `prompt_overrides` arms — and let `understudy runs execute` score them all
+   through the identical contract scorer. Operating manual:
+   [`../operate-benchmark-lab/SKILL.md`](../operate-benchmark-lab/SKILL.md).
+   A built-in Pareto view and CSV export over these rows are landing now in
+   the hub; until they ship, project `rows-*.jsonl` into `summary.csv` /
+   `pareto.json` yourself per steps 5–7.
+
 5. **Summarize at the same grain.** Build `summary.csv` with candidate, route,
    route type, requested model, effective model, model family, tool-access mode,
    task count, pass rate, partial credit, total tokens, cost/task, run seconds,

--- a/skills/design-simulated-environment/SKILL.md
+++ b/skills/design-simulated-environment/SKILL.md
@@ -145,7 +145,14 @@ exploits. Full mapping in
   final state: gold answers must not appear in seeded fixtures, tool results,
   file listings, error messages, or record fields the read tools can reach.
   Grep the reachable synthetic state for gold keys/values; anything findable
-  by a read call is a leak.
+  by a read call is a leak. For trace-compiled environments this is now
+  partly automatic: `understudy traces build-benchmark` splits fixtures into
+  candidate-readable pre-state (`fixtures.json`, task_id-scoped) and
+  scorer-only post-state (`gold.json`, never served to a rollout), and runs a
+  tiered leakage audit — tier 1 verbatim matches are `findings`, tier 2 fuzzy
+  shingle/fingerprint matches are `advisory` — recorded report-only in
+  `manifest.leakage_audit`. Read that record first; keep the manual grep for
+  environments built any other way.
 - **State isolation between rollouts.** Each rollout must start from a fresh
   deep copy of the seeded state — no residual writes from a previous run, no
   shared mutable module-level state, no order dependence. Prove it: run the
@@ -155,6 +162,14 @@ exploits. Full mapping in
   are guessable — a coin-flip agent clears them half the time. Prefer gold
   states with multiple required keys/values plus forbidden writes, so recall,
   precision, and policy must all hold at once.
+- **Attest it.** For a benchmark directory, `understudy benchmarks rigor
+  <dir>` writes `rigor-report.md` — the ABC attestation over the artifacts on
+  disk (oracle solvability, null/spam trivial-arm floors from
+  `calibration.json`, incumbent calibration, per-task contract complexity,
+  anomaly counts, contamination provenance) with honest UNKNOWN rows for
+  items tooling cannot check yet. Queue the trivial floors themselves via the
+  run executor (`trivial_arms: ["null_agent", "spam_agent"]`); see
+  [`../operate-benchmark-lab/SKILL.md`](../operate-benchmark-lab/SKILL.md).
 
 ## Running it as a real `verifiers` env
 

--- a/skills/manage-local-models/SKILL.md
+++ b/skills/manage-local-models/SKILL.md
@@ -54,7 +54,13 @@ start/poll/cancel verified snapshot downloads into the same
 `~/.understudy/models` cache and already serves warm slots
 (`app.warm_models`) and exposes them through `understudy desktop chat` with
 canonical runtime evidence — reuse it instead of spawning your own MLX servers
-or a second download of the same weights.
+or a second download of the same weights. The concrete verbs:
+`understudy desktop model list` / `model catalog` (cached snapshots and the
+bundled certified catalog), `slot list|add|assign` (residency),
+`download list|start` (managed downloads), and `chat --slot <id>`. If the app
+is not installed, it ships as GitHub Releases on
+`understudylabs/understudy-agent-tools` (macOS Apple Silicon `.dmg`, tags
+`desktop-v*`); the headless CLI covers everything in this skill without it.
 
 ## Flow
 

--- a/skills/operate-benchmark-lab/SKILL.md
+++ b/skills/operate-benchmark-lab/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: operate-benchmark-lab
+description: Use when a coding agent must operate the full benchmark lifecycle over local benchmark dirs — "build a benchmark from my traces and run models on it", "review and calibrate the eval", "queue a prompt experiment", "is an executor running", "read the rigor report". Covers traces → build-benchmark → review/feedback → calibration floors → candidate and prompt-override runs → rigor/CI reading → app-replay regression, via the benchmarks MCP server or CLI verbs, plus the run-executor daemon lifecycle.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: true
+---
+
+# Operate the benchmark lab
+
+The operator's manual for the whole benchmark/experiment lifecycle a coding
+agent can drive end to end. Two interfaces over the same sidecar files:
+the **benchmarks MCP server** (preferred for agents — same validation code as
+the hub API) and the **CLI verbs**. Execution always happens in a separate
+executor process; the MCP server and hub never run models. Command matrix,
+artifact map, and daemon details in [`reference.md`](reference.md); the tool
+table and agent loop in `docs/agent-operator-surface.md`.
+
+## Resolve CLI
+
+Prefer the installed `understudy` binary. If it is unavailable inside a repo
+checkout, run through the package script:
+
+```sh
+npm run build
+node dist/bin.js benchmarks mcp --root <dir>
+```
+
+MCP registration (Claude Code `~/.claude.json` → `mcpServers`):
+`{ "understudy-benchmarks": { "type": "stdio", "command": "understudy", "args": ["benchmarks", "mcp"] } }`
+— default root `~/.understudy/benchmarks`; add `--root` per extra directory.
+
+## Safety Gates
+
+- **Queueing is not executing.** `queue_run` / `understudy runs queue` only
+  writes a request file. Model rollouts spend gateway money only when an
+  executor picks the request up; say which executor will, before queueing.
+- **One executor per benchmark dir.** Before starting `runs execute --watch`,
+  check for a live claim (`claimed_by` on the request, `executor_version` on
+  events) — a stale watcher built before a feature landed is the classic
+  corruption hazard; new requests carry `requires:[...]` so old executors skip
+  them with `run_unsupported` instead of running them bare.
+- Reviews and feedback are append-only ledgers; never edit
+  `reviews.jsonl`/`feedback.jsonl` lines in place. `apply_auto_accepts` is
+  itself the explicit user action — invoke it only when the developer asked
+  for the review pass.
+- Honest reporting only: anomaly rows (`rollout_timeout`,
+  `app_replay_unobserved`, structural sentinels) are excluded from aggregates
+  but reported, never fabricated as scores. Overlapping CIs are a tie.
+
+## The lifecycle
+
+1. **Build.** Captured traces → `understudy traces build-benchmark`, then
+   `understudy traces author-tasks` (gateway) for legible task definitions.
+   The generated environment already ships the fixtures pre/post split
+   (candidate-readable `fixtures.json` vs scorer-only `gold.json`) and the
+   tiered gold-leakage audit (tier 1 verbatim findings, tier 2 fuzzy
+   advisory) recorded in `manifest.leakage_audit` — read it, don't re-derive.
+2. **Review (exception-based).** `list_benchmarks` → `read_benchmark` →
+   `read_task`; run `apply_auto_accepts` so the review policy
+   (`review-policy.json`, defaults when absent) accepts the routine tasks,
+   leaving only exceptions for human/agent judgment via `submit_review`
+   (`accept | restrict | needs_more | reject`, newest line per task wins).
+   Task or environment wrong? `submit_feedback` appends the ledger entry and
+   returns the regenerate-env handoff (`understudy traces regenerate-env`).
+3. **Promote and calibrate.** `understudy traces promote` unlocks full runs.
+   Queue the incumbent (`--incumbent` / `incumbent_models`) plus
+   `trivial_arms: ["null_agent", "spam_agent"]`. Read `calibration.json`:
+   `null_floor`/`spam_floor` with `floor_exceeded: true` (> 5%) names the
+   `passed_task_ids` to fix; incumbent-failed tasks are flagged suspect —
+   fix the benchmark before trusting any candidate score.
+4. **Run candidates and prompt experiments.** `queue_run` with candidate
+   models; prompt experiments ride `prompt_overrides`
+   (`--prompt-override <arm_label>=<model>=<suffix-file>`, e.g. an SOP
+   suffix appended to each task's system prompt) so prompt and model arms
+   land in the same run under distinct arm labels.
+5. **Execute.** Make sure exactly one executor is running:
+   `understudy runs execute --benchmark <dir> --watch` (daemon; polls every
+   30s) or omit `--watch` for a single pass. Poll `run_status` until rows
+   land; `rollout_timeout` kills hung rollouts into anomaly rows.
+6. **Read results rigorously.** `read_rollout` / `diff_rollouts`
+   (`tool_sequence.diverges_at`, unmet obligations), then
+   `understudy benchmarks rigor <dir>` → `rigor-report.md` — the ABC
+   attestation (oracle solvability, floors, calibration, contract
+   complexity, anomalies, contamination provenance; honest UNKNOWN rows for
+   unchecked items). Bootstrap CIs per `docs/benchmark-rigor.md`.
+7. **Regression after code edits.** When the fix was to the user's app, run
+   the `app_replay` arm via [`../replay-app-harness/SKILL.md`](../replay-app-harness/SKILL.md)
+   — same frozen tasks, current code, rows never feed calibration.
+
+## Daemon lifecycle (executor + desktop)
+
+- **Check first**: `ps`/events for a live `runs execute` watcher; the first
+  stderr line prints `executor version <v> (pid <n>)`. A live foreign claim
+  is respected; a dead claim is taken over (staleness takeover).
+- **Start**: `understudy runs execute --benchmark <dir> --watch` in the
+  background; single-pass (no `--watch`) for one drain. Stop safely by
+  killing the watcher between polls — requests are re-claimable; in-flight
+  rollouts past the timeout become anomaly rows, never silent hangs.
+- **Desktop app daemon** (separate thing — local model serving, not the run
+  queue): `understudy daemon status` pid-checks and health-probes
+  `~/.understudy/agent-card.json`; then `understudy desktop capabilities` /
+  `status` / `model|slot|download|chat` verbs. See
+  [`reference.md`](reference.md) for what the app covers vs headless CLI.
+
+## Output Standard
+
+End with: benchmark dir and stage (proposed/promoted); ledger state (reviews,
+auto-accepts, feedback); calibration verdict (incumbent gate, null/spam floors,
+suspects); runs queued/executed and by which executor version; result type
+(validation, oracle, live, app-replay); artifact paths written
+(`calibration.json`, `rigor-report.md`, `rows-*.jsonl`); and one recommended
+next command.

--- a/skills/operate-benchmark-lab/reference.md
+++ b/skills/operate-benchmark-lab/reference.md
@@ -1,0 +1,137 @@
+# operate-benchmark-lab reference
+
+Command matrix, artifact map, daemon details, and the desktop-app boundary.
+Source of truth: `docs/agent-operator-surface.md`, `docs/app-harness.md`,
+`docs/benchmark-rigor.md`, `src/commands/runs.ts`, `src/commands/traces.ts`,
+`src/commands/benchmarks.ts`, `src/commands/daemon.ts`,
+`src/commands/desktop.ts`, `src/run-executor.ts`.
+
+## MCP tools (`understudy benchmarks mcp`)
+
+Ten tools, all backed by the same compiled modules as the hub API (no forked
+format logic):
+
+| Tool | What it does |
+| --- | --- |
+| `list_benchmarks` | benchmark dirs under the roots: stage, task counts, review summary |
+| `read_benchmark` | manifest + tasks with latest review decisions and score summaries |
+| `read_task` | prompt/statement, outcome contract, world-model summary, review history |
+| `read_rollout` | trajectory from `runs/live/<run>-<model>.jsonl` + per-obligation scoring |
+| `diff_rollouts` | side-by-side obligations + `tool_sequence.diverges_at` between two runs |
+| `submit_review` | appends `understudy.benchmark_review.v1` to `reviews.jsonl` |
+| `apply_auto_accepts` | appends `source:"auto"` accepts per `review-policy.json` (defaults when absent) |
+| `submit_feedback` | appends `understudy.task_feedback.v1` to `feedback.jsonl`; returns the regenerate-env handoff |
+| `queue_run` | writes `understudy.run_request.v1` into `runs/queue/` — never executes |
+| `run_status` | request status, row summary, and the calibration block (incumbent gate + trivial floors) |
+
+Guardrails baked in: `queue_run` on a *proposed* benchmark accepts exactly one
+accepted task with a validated environment; full runs require
+`understudy traces promote`. Read-only roots (demo/fixture) reject writes.
+Journals are read with line caps; malformed lines are skipped, never fatal.
+
+## CLI verbs
+
+```sh
+# Build
+understudy traces build-benchmark ...            # compile traces → benchmark dir + env
+understudy traces author-tasks --benchmark <dir> # LLM task authoring (gateway); --compare-models, --overview
+understudy traces regenerate-env --benchmark <dir>   # rebuild env (also the feedback handoff)
+understudy traces promote ...                    # proposed → promoted (unlocks full runs)
+
+# Queue + execute
+understudy runs list --benchmark <dir>
+understudy runs queue --benchmark <dir> --models <ids> \
+  [--split train|dev|holdout|all] [--tasks <ids>] [--rollouts N] \
+  [--incumbent <ids>] [--rollout-timeout <s>] \
+  [--prompt-override <arm_label>=<model>=<suffix-file>]   # repeatable
+understudy runs execute --benchmark <dir> [--watch] [--interval 30] \
+  [--concurrency 2] [--rollout-timeout <s>] [--runner verifiers|oracle]
+
+# Rigor + operator surface
+understudy benchmarks rigor <dir>     # writes rigor-report.md in the dir
+understudy benchmarks mcp [--root <dir>...]
+
+# App instrumentation sanity (before capture-based building)
+understudy instrument --check [--json]
+```
+
+`--runner oracle` is deterministic and zero-cost (offline validation);
+`verifiers` runs the real generated environment via uv with gateway creds from
+env or `~/.understudy/credentials.json`. Trivial arms are queued on the request
+(`trivial_arms: ["null_agent", "spam_agent"]` via the hub/MCP body) and run one
+rollout per task. `app_replay: true` requests always use the app-harness
+runner regardless of `--runner`; `incumbent_models` is rejected on them.
+
+## Artifacts in a benchmark dir
+
+| File | Meaning |
+| --- | --- |
+| `benchmark.json`, `tasks.jsonl` | manifest + task contracts |
+| `understudy_trace_env/servers/fixtures.json` | candidate-readable **pre-state only** (task_id-tagged) |
+| `gold.json` | scorer-side expected post-state — never served to a candidate |
+| `manifest.leakage_audit` | tiered gold-leakage audit: tier 1 verbatim = findings, tier 2 fuzzy = advisory; report-only |
+| `reviews.jsonl` | append-only review ledger; newest line per task wins |
+| `review-policy.json` | `understudy.review_policy.v1` auto-accept bar (optional; defaults apply) |
+| `feedback.jsonl` | `understudy.task_feedback.v1` entries → regenerate-env handoff |
+| `runs/queue/*.json` | `understudy.run_request.v1` requests (with `claimed_by`, `requires`, `unsupported`) |
+| `runs/live/<run>-<model>.jsonl` | per-arm rollout journals |
+| `rows-*.jsonl` | scored rows (`arm_kind`: model / `null_agent` / `spam_agent` / `prompt_override` label / `app_replay`) |
+| `calibration.json` | incumbent gate + `null_floor`/`spam_floor` (`floor_exceeded` when > 5%, with `passed_task_ids`) |
+| `rigor-report.md` | ABC attestation from `understudy benchmarks rigor` (UNKNOWN rows are honest gaps) |
+| `app-harness.json` | `understudy.app_harness.v1` sidecar for app-replay runs |
+
+Interpreting calibration: `floor_exceeded: true` means a do-nothing or
+ritual-tool-calling agent clears too many tasks — fix those tasks' contracts
+before any candidate claim. Tasks the incumbent fails on rerun are flagged
+**suspect** (`incumbent_failed`): either the task is wrong or the incumbent
+capture drifted; review them, don't average over them.
+
+## Executor daemon details
+
+- Every request carries `requires: [...]` against
+  `EXECUTOR_CAPABILITIES = ["trivial_arms", "calibration", "rollout_timeout",
+  "prompt_overrides", "app_replay"]`; an executor missing a capability records
+  `run_unsupported` (with its `executor_version` and the `missing` list) and
+  skips — it never runs the request with fields silently dropped.
+- Claiming: the executor writes `claimed_by` (pid, host, nonce,
+  `executor_version`) atomically and re-reads to confirm; a live foreign
+  claim is respected, a dead one is taken over. Diagnose stale-watcher
+  incidents from the first stderr line (`executor version <v> (pid <n>)`)
+  and the `executor_version` stamped on every event.
+- Stop: SIGTERM/SIGINT the watcher; queued requests stay claimable, and any
+  rollout past its timeout is killed into a `rollout_timeout` anomaly row.
+- Events stream to stderr; stdout stays parseable JSON.
+
+## Desktop app: what it is, how to get it, what it covers
+
+**Distribution (verified in-repo + on GitHub, 2026-07):** Understudy Desktop
+is a Tauri app released as GitHub Releases on
+`understudylabs/understudy-agent-tools`, tags `desktop-vX.Y.Z-mvp`. Each
+release ships `Understudy_<version>_aarch64.dmg` (macOS Apple Silicon — the
+only platform currently built), `Understudy.app.tar.gz` + `.sig`, and
+`latest.json` (the Tauri v2 updater manifest; canonical endpoint
+`https://github.com/understudylabs/understudy-agent-tools/releases/latest/download/latest.json`).
+To find/download it:
+
+```sh
+gh release list -R understudylabs/understudy-agent-tools --limit 5
+gh release download <tag> -R understudylabs/understudy-agent-tools -p '*.dmg'
+```
+
+The app self-updates via the signed updater once installed. There is no
+standalone download website in this repo — do not invent one; point users at
+the GitHub Releases page. No Intel-mac, Windows, or Linux builds exist yet;
+say so rather than guessing.
+
+**What the app manages vs headless CLI:**
+
+- The **app** owns the local daemon (`~/.understudy/agent-card.json`), warm
+  MLX model slots, model downloads, canonical chat runs, and supervision —
+  drive it with `understudy daemon status` then the `understudy desktop`
+  verbs (`contract`, `capabilities`, `status`, `model list|catalog`,
+  `slot list|add|assign`, `download list|start`, `chat`, `run cancel|events`,
+  `supervision export`, `tool-proof ...`).
+- The **benchmark lab is fully headless**: build/review/queue/execute/rigor
+  need only the CLI and (optionally) the MCP server — no desktop app
+  required. Use the app's daemon only when a run needs a locally served
+  model endpoint (see `run-local-model-lab`).

--- a/skills/optimize-agentic-workload/SKILL.md
+++ b/skills/optimize-agentic-workload/SKILL.md
@@ -190,6 +190,19 @@ single-output optimization does not need a tool environment.
    [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md); never tune
    on holdout.
 
+   **Prompt experiments as run arms (`prompt_overrides`).** When the workload
+   lives in a trace-compiled benchmark directory, test a prompt candidate
+   without touching the app: queue a run whose request carries
+   `prompt_overrides` — each `{arm_label, model, system_prompt_suffix}` arm
+   appends the suffix file's text to every task's system prompt at rollout
+   time (`understudy runs queue --prompt-override
+   <arm_label>=<model>=<suffix-file>`). The canonical use is the SOP-suffix
+   experiment: distill the workload's standard operating procedure (order of
+   operations, argument conventions, termination rules) into a short suffix
+   and run it as its own arm beside the bare model on the same frozen tasks —
+   one run, same scorer, per-arm rows. Operating detail in
+   [`../operate-benchmark-lab/SKILL.md`](../operate-benchmark-lab/SKILL.md).
+
 9. **Escalate to RL only as a true handoff, behind three gates.** If model swap
    and prompt/distillation stall while real headroom remains and the residual
    is genuinely *stateful* multi-step behavior, route to

--- a/skills/product-knowledge/SKILL.md
+++ b/skills/product-knowledge/SKILL.md
@@ -54,6 +54,30 @@ node dist/bin.js status --json
 - **Candidate results** — Test Results-style view that groups model-family task outcomes into passed, failed, running, skipped, score, latency, and drilldown rows.
 - **Training** — progression from evals to GEPA/prompt optimization, datasets, SFT, RL, and distributed rollout jobs.
 
+## Getting Understudy Desktop
+
+How the app is actually distributed today (say exactly this; do not invent a
+download site):
+
+- **GitHub Releases** on `understudylabs/understudy-agent-tools`, tags
+  `desktop-vX.Y.Z-mvp`. Each release carries
+  `Understudy_<version>_aarch64.dmg` plus a signed `Understudy.app.tar.gz`
+  and the Tauri updater manifest `latest.json`.
+- **macOS Apple Silicon only** for now — no Intel-mac, Windows, or Linux
+  builds exist. Mark them "not yet available" if asked.
+- **Self-updates** via the signed Tauri v2 updater against
+  `releases/latest/download/latest.json` once installed.
+- An agent can fetch it directly:
+  `gh release download <tag> -R understudylabs/understudy-agent-tools -p '*.dmg'`.
+
+What the app manages vs headless: the app owns the local daemon
+(`~/.understudy/agent-card.json`), warm model slots, managed downloads, chat
+runs, and supervision — inspect it with `understudy daemon status` and the
+`understudy desktop ...` verbs. The trace → benchmark → review → run → rigor
+lifecycle is fully headless via the CLI and the benchmarks MCP server
+(`understudy benchmarks mcp`); see
+[`../operate-benchmark-lab/SKILL.md`](../operate-benchmark-lab/SKILL.md).
+
 ## Explanation Pattern
 
 When explaining a feature, cover:

--- a/skills/run-local-model-lab/SKILL.md
+++ b/skills/run-local-model-lab/SKILL.md
@@ -70,6 +70,15 @@ and canonical image chat over its authenticated REST + CLI + MCP surface. Use
 streamed runtime events, cancellation, and immutable replay; do not drive the
 GUI or stand up a second server against the same weights and memory budget.
 
+**Local bundles as benchmark arms (landing now).** Support for running a
+local model bundle directly as an arm of a benchmark run request — beside
+gateway, incumbent, trivial-floor, and prompt-override arms — is landing in
+the run executor. Until it ships, serve the local model (daemon slot or your
+own MLX server) as an OpenAI-compatible endpoint and point the existing
+verifiers runner at it; see
+[`../operate-benchmark-lab/SKILL.md`](../operate-benchmark-lab/SKILL.md) for
+the run-queue side. Do not claim the bundle arm exists until it is merged.
+
 ## Flow
 
 1. **Inventory hardware + runtime.** Confirm Apple Silicon (M-series) and the

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -205,6 +205,15 @@ Identify the developer's current stage and load exactly one:
   workstation-hosted model through the same frozen workload/eval, choose a
   runtime, compare local vs remote, or satisfy ZDR / no-upload constraints →
   [`../run-local-model-lab/SKILL.md`](../run-local-model-lab/SKILL.md).
+- **Benchmark-lab lifecycle / run queue / rigor** — the developer has (or
+  wants) a trace-compiled benchmark directory and asks to operate it end to
+  end: review tasks, apply the auto-accept policy, calibrate with the
+  incumbent and null/spam trivial floors, queue candidate or prompt-override
+  runs, keep the run executor (`understudy runs execute --watch`) alive, read
+  `rigor-report.md`, or run an `app_replay` regression after code edits →
+  [`../operate-benchmark-lab/SKILL.md`](../operate-benchmark-lab/SKILL.md)
+  (MCP tools preferred; CLI verbs otherwise). For only the app-replay slice,
+  [`../replay-app-harness/SKILL.md`](../replay-app-harness/SKILL.md).
 - **Multi-model sweep / Pareto comparison** — the developer has a frozen eval and
   wants to run the same rows across several local, gateway, or frontier models to
   compare quality, latency, cost, and reliability →


### PR DESCRIPTION
## What

Skills/docs-only update so a coding agent can operate the full new capability surface that is already merged on main but not yet taught by any skill.

### New skill
- **`skills/operate-benchmark-lab/`** (SKILL.md + reference.md) — the operator's manual for the whole lifecycle: traces → `build-benchmark` (fixtures pre/post split + tiered leakage audit) → exception-based review (`apply_auto_accepts`, `submit_review`, `submit_feedback` → `regenerate-env`) → calibration (incumbent gate + null/spam trivial floors, `floor_exceeded`/suspect semantics) → candidate + `prompt_overrides` runs → `understudy benchmarks rigor` / CIs / anomalies → `app_replay` regression. Teaches both the benchmarks MCP server (10 tools, preferred for agents) and the CLI verbs, plus the executor-daemon lifecycle (`runs execute --watch`, atomic claiming/`claimed_by`, capability gates/`run_unsupported`, the stale-watcher hazard, safe stop) and the separate desktop daemon (`understudy daemon status`, `understudy desktop ...`).

### Updated skills (light-touch, additive)
- `understudy` — routing entry for the benchmark-lab loop (+ replay-app-harness pointer).
- `design-simulated-environment` — fixtures split + leakage tiers now automatic in build-benchmark; `benchmarks rigor` attestation step.
- `compare-model-sweep` — benchmark-dir sweeps as arms of one run request (incumbent, trivial floors, prompt overrides); Pareto/CSV hub view noted as *landing now*, not shipped.
- `optimize-agentic-workload` — `prompt_overrides` experiment flow and the SOP-suffix pattern (`--prompt-override <label>=<model>=<suffix-file>`).
- `run-local-model-lab` — local bundle-as-arm noted as *landing now*, with the honest interim path.
- `manage-local-models` — concrete `understudy desktop` verbs + release channel.
- `product-knowledge` — "Getting Understudy Desktop" section.
- `skills/README.md` — catalog entries for `operate-benchmark-lab` and the previously uncatalogued `replay-app-harness`.

### Desktop distribution (verified, stated honestly)
GitHub Releases on this repo, tags `desktop-vX.Y.Z-mvp`; assets are `Understudy_<ver>_aarch64.dmg`, signed `Understudy.app.tar.gz`, and the Tauri v2 updater `latest.json` (canonical `releases/latest/download/latest.json`). macOS Apple Silicon only; no download website; skills say "not yet available" for other platforms instead of inventing URLs.

## Verification
- `npm run skills:validate` — **ok 37 public skill(s)**.
- `npm test` — 582 pass / 150 fail, **identical on clean origin/main** (pre-existing `src/runtime/conversation/vercel-runtime.ts` TS build errors leave parts of `dist/` unbuilt); no test touches skills/docs.
- Every taught verb/field verified against `src/commands/{runs,traces,benchmarks,daemon,desktop,instrument}.ts`, `src/run-executor.ts`, `src/trace-foundry.ts`, and `docs/{agent-operator-surface,app-harness,benchmark-rigor}.md`. No `src/`/`apps/` files touched; unmerged in-flight work referenced only as "landing now".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->