### PR TITLE
Local trained-artifact arms + majority-class floor for the benchmark run executor

### DIFF
--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -12,11 +12,13 @@ import {
   validateRunRequestInput,
   verifiersRunner,
   type ArmRunner,
+  type ModelArmEntry,
   type PromptOverride,
   type RunEvent,
   type RunSplit,
 } from "../run-executor.js";
 import { appReplayRunner } from "../app-harness.js";
+import { mlxServingRig } from "../local-serving.js";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -40,7 +42,17 @@ export function registerRunsCommand(program: Command): void {
     .command("queue")
     .description("Queue a run request (validated by the same shared schema the hub API uses); execute it with `understudy runs execute`")
     .requiredOption("--benchmark <dir>", "Promoted benchmark directory")
-    .requiredOption("--models <ids>", "Comma-separated model ids")
+    .option("--models <ids>", "Comma-separated gateway model ids")
+    .option(
+      "--local-arm <label=ref...>",
+      "Local trained-artifact arm: <label>=<path to a .understudy-model bundle or MLX model dir>; the executor serves it via the MLX rig for the arm (repeatable; requires the local_arms capability)",
+      (value: string, prior: { ref: string; label?: string }[] = []) => {
+        const match = /^([^=]+)=(.+)$/.exec(value);
+        if (!match) throw new Error(`--local-arm must be <label>=<ref>, got: ${value}`);
+        return [...prior, { label: match[1], ref: match[2] }];
+      },
+    )
+    .option("--trivial-arms <kinds>", "Comma-separated trivial calibration arms: null_agent, spam_agent, majority_class")
     .option("--split <split>", "train | dev | holdout | all", "all")
     .option("--tasks <ids>", 'Comma-separated task ids (default "all")')
     .option("--rollouts <count>", "Rollouts per task", "1")
@@ -55,19 +67,25 @@ export function registerRunsCommand(program: Command): void {
         return [...prior, { arm_label: match[1], model: match[2], system_prompt_suffix: readFileSync(resolve(match[3]), "utf8").trim() }];
       },
     )
-    .action((options: { benchmark: string; models: string; split: string; tasks?: string; rollouts: string; incumbent?: string; rolloutTimeout?: string; promptOverride?: PromptOverride[] }) => {
+    .action((options: { benchmark: string; models?: string; localArm?: { ref: string; label?: string }[]; trivialArms?: string; split: string; tasks?: string; rollouts: string; incumbent?: string; rolloutTimeout?: string; promptOverride?: PromptOverride[] }) => {
       const benchmark = resolve(options.benchmark);
       const manifest = JSON.parse(readFileSync(join(benchmark, "benchmark.json"), "utf8")) as Record<string, unknown>;
       const knownTaskIds = (Array.isArray(manifest.tasks) ? (manifest.tasks as Record<string, unknown>[]) : []).map((t) => String(t.task_id));
+      // Arms = gateway ids (strings, unchanged) + local artifact arms (objects).
+      const models: ModelArmEntry[] = [
+        ...(options.models ? options.models.split(",").map((m) => m.trim()).filter(Boolean) : []),
+        ...(options.localArm ?? []),
+      ];
       const input = {
         benchmark_id: String(manifest.benchmark_id),
-        models: options.models.split(",").map((m) => m.trim()).filter(Boolean),
+        models,
         split: options.split as RunSplit,
         tasks: options.tasks ? options.tasks.split(",").map((t) => t.trim()).filter(Boolean) : ("all" as const),
         rollouts_per_task: Number(options.rollouts),
         incumbent_models: options.incumbent ? options.incumbent.split(",").map((m) => m.trim()).filter(Boolean) : undefined,
         rollout_timeout_seconds: options.rolloutTimeout !== undefined ? Number(options.rolloutTimeout) : undefined,
         prompt_overrides: options.promptOverride,
+        trivial_arms: options.trivialArms ? (options.trivialArms.split(",").map((t) => t.trim()).filter(Boolean) as Parameters<typeof createRunRequest>[1]["trivial_arms"]) : undefined,
       };
       const errors = validateRunRequestInput(input, knownTaskIds);
       if (errors.length > 0) throw new Error(`invalid run request: ${errors.join("; ")}`);
@@ -119,7 +137,9 @@ export function registerRunsCommand(program: Command): void {
         // app_replay requests (request.app_replay) always use the app-harness
         // runner regardless of --runner; providing it here is what advertises
         // the "app_replay" capability to the queue.
-        const results = await executeQueuedRuns(benchmark, { runner, appReplayRunner: appReplayRunner(), concurrency, rolloutTimeoutSeconds, onEvent });
+        // localServing advertises the "local_arms" capability: local-artifact
+        // arms are served through the MLX rig for the arm's duration.
+        const results = await executeQueuedRuns(benchmark, { runner, appReplayRunner: appReplayRunner(), localServing: mlxServingRig({ onLog: (line) => console.error(`[local-serving] ${line}`) }), concurrency, rolloutTimeoutSeconds, onEvent });
         if (results.length > 0) console.log(JSON.stringify(results, null, 2));
         else if (!options.watch) console.error("queue empty — nothing to execute");
         if (options.watch) await sleep(interval);

--- a/src/local-serving.ts
+++ b/src/local-serving.ts
@@ -1,0 +1,317 @@
+/**
+ * Local trained-artifact serving for benchmark run arms.
+ *
+ * Reuses the run-local-model-lab MLX serving conventions rather than
+ * inventing a new rig:
+ *   - an arm's `ref` is a local `.understudy-model` bundle (manifest.json =
+ *     understudy.task_model.v1: base model + optional LoRA adapter, see
+ *     docs/task-model-bundles.md) OR a plain MLX model directory;
+ *   - bundles/dirs may ship `understudy.serving.json` with the exact serve
+ *     command (the certified `-understudy` snapshot convention) — when
+ *     present it is used verbatim (with {port}/{model} placeholders), never
+ *     silently replaced;
+ *   - otherwise the rig serves via the skill's standard OpenAI-compatible
+ *     servers: the managed `mlx_vlm.server` binary when the managed runtime
+ *     is healthy, else `python3 -m mlx_lm.server --model <dir>
+ *     [--adapter-path <adapter>] --port <port>` (the lab's default), waiting
+ *     on `GET /v1/models` for readiness;
+ *   - a `serving.base_url` on the arm spec reuses an ALREADY-RUNNING server
+ *     (the rig never starts or tears anything down in that case).
+ *
+ * Perf: the rig samples the spawned server's RSS (`ps -o rss=`) while it is
+ * up, so `stats().peak_memory_bytes` is the observed peak; per-rollout
+ * tokens/sec comes from the verifiers trace usage (completion tokens over
+ * generation wall time), not from here. Reused servers report null stats —
+ * honest "not obtainable", never a guess.
+ */
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { createServer } from "node:net";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+
+import { mlxVlmRuntimeStatus } from "./runtime/mlx-vlm/lifecycle.js";
+
+type Obj = Record<string, any>;
+const asObject = (value: unknown): Obj => (value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {});
+
+/** understudy.serving.json sidecar name (certified snapshot convention). */
+export const SERVING_SIDECAR = "understudy.serving.json";
+
+/* ------------------------------------------------------------------ */
+/* Artifact resolution + provenance                                    */
+/* ------------------------------------------------------------------ */
+
+/** Additive row stamp: exactly WHICH local artifact this arm served. */
+export type LocalArtifactStamp = {
+  /** Relative to the executor's cwd when the ref lives under it; absolute otherwise. */
+  bundle_path: string;
+  /** Deterministic content hash of the bundle file/dir (see bundleSha256). */
+  bundle_sha256: string;
+  /** The base model the artifact rides on (bundle manifest / serving sidecar / dir name). */
+  base_model: string;
+  /** True when the artifact carries a LoRA adapter. */
+  adapter: boolean;
+};
+
+export type ResolvedLocalArm = {
+  label: string;
+  /** Absolute path to the bundle/model dir (or bundle zip file). */
+  ref: string;
+  artifact: LocalArtifactStamp;
+  serving: Obj;
+};
+
+/**
+ * Deterministic sha256 of a bundle: file → content hash; directory → hash of
+ * the sorted "relpath\n<file sha256>\n" manifest of every regular file, so
+ * the SAME artifact hashes identically wherever it sits on disk.
+ */
+export function bundleSha256(ref: string): string {
+  const root = resolve(ref);
+  const st = statSync(root);
+  if (st.isFile()) return createHash("sha256").update(readFileSync(root)).digest("hex");
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = join(dir, name);
+      const s = statSync(path);
+      if (s.isDirectory()) walk(path);
+      else if (s.isFile()) files.push(path);
+    }
+  };
+  walk(root);
+  const digest = createHash("sha256");
+  for (const file of files.sort()) {
+    digest.update(`${relative(root, file)}\n${createHash("sha256").update(readFileSync(file)).digest("hex")}\n`);
+  }
+  return digest.digest("hex");
+}
+
+const readJsonIfPresent = (path: string): Obj | null => {
+  try {
+    return existsSync(path) ? asObject(JSON.parse(readFileSync(path, "utf8"))) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** True when the artifact dir carries a LoRA adapter (bundle model/adapter/ layout or a bare adapter dir). */
+export function artifactHasAdapter(ref: string): boolean {
+  const root = resolve(ref);
+  try {
+    if (!statSync(root).isDirectory()) return false;
+  } catch {
+    return false;
+  }
+  const candidates = [
+    join(root, "adapter_config.json"),
+    join(root, "adapters.safetensors"),
+    join(root, "adapter", "adapter_config.json"),
+    join(root, "model", "adapter", "adapter_config.json"),
+    join(root, "model", "adapter", "adapters.safetensors"),
+  ];
+  return candidates.some((path) => existsSync(path));
+}
+
+/** The base model an artifact rides on: bundle manifest → serving sidecar → HF-style config → the dir name itself. */
+export function artifactBaseModel(ref: string): string {
+  const root = resolve(ref);
+  const manifest = readJsonIfPresent(join(root, "manifest.json"));
+  for (const key of ["base_model", "base_model_id", "base"]) {
+    const value = manifest?.[key] ?? asObject(manifest?.model)[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  const serving = readJsonIfPresent(join(root, SERVING_SIDECAR));
+  const servingModel = serving?.base_model ?? serving?.model;
+  if (typeof servingModel === "string" && servingModel.trim()) return servingModel.trim();
+  return basename(root.replace(/\/+$/, ""));
+}
+
+/**
+ * Resolve one local arm spec ({ref, label?, serving?}) into the artifact
+ * provenance stamped onto every row. Throws when the ref does not exist —
+ * a missing artifact must fail queueing/execution loudly, never run as an
+ * empty gateway id.
+ */
+export function resolveLocalArm(spec: { ref: string; label?: string; serving?: Obj }, cwd: string = process.cwd()): ResolvedLocalArm {
+  const ref = resolve(cwd, spec.ref);
+  if (!existsSync(ref)) throw new Error(`local arm ref does not exist: ${spec.ref}`);
+  const label = spec.label?.trim() || basename(ref.replace(/\/+$/, ""));
+  const rel = relative(cwd, ref);
+  return {
+    label,
+    ref,
+    artifact: {
+      bundle_path: rel.startsWith("..") || isAbsolute(rel) ? ref : rel,
+      bundle_sha256: bundleSha256(ref),
+      base_model: artifactBaseModel(ref),
+      adapter: artifactHasAdapter(ref),
+    },
+    serving: asObject(spec.serving),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Serving rig                                                         */
+/* ------------------------------------------------------------------ */
+
+export type LocalServerStats = { peak_memory_bytes: number | null };
+
+export type LocalServerHandle = {
+  /** OpenAI-compatible base URL including the /v1 prefix. */
+  baseUrl: string;
+  /** The model id the eval subprocess must pass with -m (MLX servers accept the weights path). */
+  modelId: string;
+  /** True when an already-running server was reused (never torn down by us). */
+  reused: boolean;
+  stop: () => Promise<void>;
+  stats: () => LocalServerStats;
+};
+
+export type LocalServingRig = {
+  start: (arm: ResolvedLocalArm) => Promise<LocalServerHandle>;
+};
+
+export function freePort(): Promise<number> {
+  return new Promise((accept, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address !== null ? address.port : 0;
+      server.close(() => accept(port));
+    });
+  });
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitReady(baseUrl: string, timeoutMs: number, child?: ChildProcess): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (child && child.exitCode !== null) throw new Error(`local model server exited with ${child.exitCode} before becoming ready`);
+    try {
+      const response = await fetch(`${baseUrl}/models`, { signal: AbortSignal.timeout(2_000) });
+      if (response.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() > deadline) throw new Error(`local model server at ${baseUrl} did not become ready within ${Math.round(timeoutMs / 1000)}s`);
+    await sleep(500);
+  }
+}
+
+function rssBytes(pid: number): number | null {
+  const result = spawnSync("ps", ["-o", "rss=", "-p", String(pid)], { encoding: "utf8", timeout: 2_000 });
+  const kb = Number(String(result.stdout ?? "").trim());
+  return result.status === 0 && Number.isFinite(kb) && kb > 0 ? kb * 1024 : null;
+}
+
+/** The model weights path/id to hand the server + the eval's -m: bundle base model when adapted, else the dir itself. */
+export function servingModelPath(arm: ResolvedLocalArm): { model: string; adapterPath: string | null } {
+  if (typeof arm.serving.model_id === "string" && arm.serving.model_id.trim()) return { model: arm.serving.model_id.trim(), adapterPath: null };
+  if (!arm.artifact.adapter) return { model: arm.ref, adapterPath: null };
+  // Bundle layout (docs/task-model-bundles.md): base weights live in the
+  // shared model cache (~/.understudy/models/<base>) or are an HF id; the
+  // adapter rides the bundle.
+  const adapterDir = [join(arm.ref, "model", "adapter"), join(arm.ref, "adapter"), arm.ref].find((dir) => existsSync(join(dir, "adapter_config.json")) || existsSync(join(dir, "adapters.safetensors"))) ?? null;
+  const base = arm.artifact.base_model;
+  const cached = join(homedir(), ".understudy", "models", base);
+  return { model: existsSync(cached) ? cached : base, adapterPath: adapterDir };
+}
+
+/** Substitute {port}/{model}/{adapter} placeholders in a serving-sidecar command. */
+export function renderServeCommand(command: string[], vars: { port: number; model: string; adapter: string | null }): string[] {
+  return command.map((part) => part.replaceAll("{port}", String(vars.port)).replaceAll("{model}", vars.model).replaceAll("{adapter}", vars.adapter ?? ""));
+}
+
+/** Default serve command per the run-local-model-lab conventions (sidecar wins; managed mlx_vlm next; mlx_lm.server last). */
+export function defaultServeCommand(arm: ResolvedLocalArm, port: number, env: NodeJS.ProcessEnv = process.env): string[] {
+  const { model, adapterPath } = servingModelPath(arm);
+  const sidecar = readJsonIfPresent(join(arm.ref, SERVING_SIDECAR));
+  const sidecarCommand = Array.isArray(sidecar?.command) ? sidecar!.command.map(String) : null;
+  if (sidecarCommand && sidecarCommand.length > 0) return renderServeCommand(sidecarCommand, { port, model, adapter: adapterPath });
+  // Managed mlx-vlm runtime (certified QAT snapshots) when healthy and the
+  // artifact carries no adapter (mlx_vlm.server has no adapter flag).
+  if (!adapterPath) {
+    try {
+      const status = mlxVlmRuntimeStatus();
+      if (status.healthy) return [status.server_binary, "--model", model, "--port", String(port)];
+    } catch {
+      /* fall through to mlx_lm.server */
+    }
+  }
+  const python = env.UNDERSTUDY_MLX_PYTHON?.trim() || (existsSync(".understudy/venvs/mlx/bin/python") ? ".understudy/venvs/mlx/bin/python" : "python3");
+  return [python, "-m", "mlx_lm.server", "--model", model, "--port", String(port), ...(adapterPath ? ["--adapter-path", adapterPath] : [])];
+}
+
+export type MlxServingRigOptions = {
+  env?: NodeJS.ProcessEnv;
+  /** Server-readiness budget (default 180s — first load includes weight mmap). */
+  readyTimeoutMs?: number;
+  /** RSS sampling cadence for peak-memory stats. */
+  sampleIntervalMs?: number;
+  onLog?: (line: string) => void;
+};
+
+/**
+ * The default serving rig: reuse `serving.base_url` when the arm points at a
+ * running server, else spawn the conventional MLX server on a free loopback
+ * port, wait for /v1/models, sample peak RSS while it runs, and SIGTERM →
+ * SIGKILL on stop.
+ */
+export function mlxServingRig(options: MlxServingRigOptions = {}): LocalServingRig {
+  const env = options.env ?? process.env;
+  return {
+    async start(arm: ResolvedLocalArm): Promise<LocalServerHandle> {
+      const { model } = servingModelPath(arm);
+      // Reuse a running server the arm explicitly points at (the rig supports
+      // reuse; it never tears down a server it did not start).
+      const reuseUrl = typeof arm.serving.base_url === "string" && arm.serving.base_url.trim() ? arm.serving.base_url.trim().replace(/\/+$/, "") : null;
+      if (reuseUrl) {
+        await waitReady(reuseUrl, 10_000);
+        return { baseUrl: reuseUrl, modelId: model, reused: true, stop: async () => {}, stats: () => ({ peak_memory_bytes: null }) };
+      }
+      const port = typeof arm.serving.port === "number" && Number.isInteger(arm.serving.port) && arm.serving.port > 0 ? arm.serving.port : await freePort();
+      const command = defaultServeCommand(arm, port, env);
+      const child = spawn(command[0], command.slice(1), { env: { ...env }, stdio: ["ignore", "pipe", "pipe"] });
+      for (const stream of [child.stdout, child.stderr]) {
+        stream?.setEncoding("utf8");
+        stream?.on("data", (chunk: string) => {
+          for (const line of chunk.split(/\r?\n/).filter(Boolean)) options.onLog?.(line);
+        });
+      }
+      let peak: number | null = null;
+      const sampler = setInterval(() => {
+        if (child.pid === undefined || child.exitCode !== null) return;
+        const rss = rssBytes(child.pid);
+        if (rss !== null && (peak === null || rss > peak)) peak = rss;
+      }, options.sampleIntervalMs ?? 2_000);
+      sampler.unref?.();
+      const baseUrl = `http://127.0.0.1:${port}/v1`;
+      try {
+        await waitReady(baseUrl, options.readyTimeoutMs ?? 180_000, child);
+      } catch (err) {
+        clearInterval(sampler);
+        child.kill("SIGKILL");
+        throw err;
+      }
+      return {
+        baseUrl,
+        modelId: model,
+        reused: false,
+        stats: () => ({ peak_memory_bytes: peak }),
+        stop: async () => {
+          clearInterval(sampler);
+          if (child.exitCode !== null) return;
+          child.kill("SIGTERM");
+          const deadline = Date.now() + 10_000;
+          while (child.exitCode === null && Date.now() < deadline) await sleep(200);
+          if (child.exitCode === null) child.kill("SIGKILL");
+        },
+      };
+    },
+  };
+}

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -23,6 +23,7 @@ import { spawnSync } from "node:child_process";
 import { buildReplayInvocation, goldFinalResponseFor, isMutatingTool, oracleEventsFor, readCapturesByKey, responseJudgedRequired, scoreContract } from "./trace-foundry.js";
 import { COST_PER_MTOKEN, resolveGatewayAuth } from "./trace-author.js";
 import { BENCHMARK_PROPOSAL_SCHEMA, BENCHMARK_SCHEMA, CALIBRATION_SCHEMA, EVAL_RESULT_SCHEMA, RUN_EVENT_SCHEMA, appendJournalEntry, readJsonlFile, serializeJsonlLine, serializeRunEvent } from "./benchmark-artifacts.js";
+import { resolveLocalArm, type LocalServerHandle, type LocalServingRig, type ResolvedLocalArm } from "./local-serving.js";
 
 type Obj = Record<string, any>;
 const asObject = (value: unknown): Obj => (value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {});
@@ -53,7 +54,7 @@ export const EXECUTOR_VERSION: string = (() => {
  * Old executors predate `requires` entirely, hence the belt-and-braces
  * EXECUTOR_VERSION stamps above.
  */
-export const EXECUTOR_CAPABILITIES = ["trivial_arms", "calibration", "rollout_timeout", "prompt_overrides", "app_replay"] as const;
+export const EXECUTOR_CAPABILITIES = ["trivial_arms", "calibration", "rollout_timeout", "prompt_overrides", "app_replay", "local_arms", "majority_class"] as const;
 
 /** The `requires` entries of a request this executor cannot honor (empty = safe to run). */
 export function unsupportedRequirements(request: Pick<RunRequest, "requires">, capabilities: readonly string[] = EXECUTOR_CAPABILITIES): string[] {
@@ -70,11 +71,46 @@ export type RunSplit = (typeof RUN_SPLITS)[number];
  * deterministic trivial calibration arms (extended additively — old readers
  * only ever see incumbent/candidate on old rows).
  */
-export const ARM_KINDS = ["incumbent", "candidate", "null_agent", "spam_agent", "app_replay"] as const;
+export const ARM_KINDS = ["incumbent", "candidate", "null_agent", "spam_agent", "app_replay", "majority_class"] as const;
 export type ArmKind = (typeof ARM_KINDS)[number];
-/** The trivial calibration arms (agentic-benchmarks floor discipline: a do-nothing agent must score ~0). */
-export const TRIVIAL_ARM_KINDS = ["null_agent", "spam_agent"] as const;
+/**
+ * The trivial calibration arms (agentic-benchmarks floor discipline: a
+ * do-nothing agent must score ~0). "majority_class" is the imbalanced-
+ * classifier floor: on classification-shaped tasks it deterministically
+ * answers the most frequent TRAIN-split gold label (capability-gated via
+ * requires: ["majority_class"] so old executors skip, never mislabel).
+ */
+export const TRIVIAL_ARM_KINDS = ["null_agent", "spam_agent", "majority_class"] as const;
 export type TrivialArmKind = (typeof TRIVIAL_ARM_KINDS)[number];
+
+/**
+ * A run-request model arm (additive union): the historical bare gateway model
+ * id string, OR a LOCAL trained-artifact arm — a path to a
+ * `.understudy-model` bundle or an MLX model dir (base + optional LoRA
+ * adapter), served by the executor through the MLX serving rig for the
+ * duration of the arm. Object entries require the "local_arms" capability;
+ * requests without them keep the exact prior shape.
+ */
+export type LocalModelArm = {
+  /** Local path to a .understudy-model bundle or an MLX model directory. */
+  ref: string;
+  /** Leaderboard/rows arm label (default: the ref's basename). */
+  label?: string;
+  /** Serving hints: {base_url} reuses a running server; {port, model_id, command} tune the spawn. */
+  serving?: Record<string, unknown>;
+};
+export type ModelArmEntry = string | LocalModelArm;
+
+export const isLocalArmEntry = (entry: ModelArmEntry): entry is LocalModelArm => typeof entry !== "string";
+
+/** The row/rows-file/leaderboard label of one model arm entry. */
+export function armLabelOf(entry: ModelArmEntry): string {
+  if (typeof entry === "string") return entry;
+  const label = entry.label?.trim();
+  if (label) return label;
+  const ref = String(entry.ref ?? "").replace(/\/+$/, "");
+  return ref.split("/").filter(Boolean).pop() ?? ref;
+}
 /**
  * A prompt-override experiment arm: the SAME model as `model`, with
  * `system_prompt_suffix` appended to the task's system/operating prompt at
@@ -108,7 +144,8 @@ export type RunRequest = {
   schema_version: typeof RUN_REQUEST_SCHEMA;
   run_id: string;
   benchmark_id: string;
-  models: string[];
+  /** Arm entries: gateway model id strings (unchanged) and/or additive local-artifact objects. */
+  models: ModelArmEntry[];
   split: RunSplit;
   tasks: "all" | string[];
   rollouts_per_task: number;
@@ -313,11 +350,32 @@ export const VERIFIERS_MAX_EXAMPLES = 1000;
 export function validateRunRequestInput(input: RunRequestInput, knownTaskIds: string[]): string[] {
   const errors: string[] = [];
   const models = input.models;
-  if (!Array.isArray(models) || models.length === 0 || !models.every((m) => typeof m === "string" && m.trim().length > 0)) {
-    errors.push("models must be a non-empty array of model id strings");
+  // Arm labels of the valid entries (string ids as-is; local arms via
+  // armLabelOf) — every downstream membership/uniqueness check keys on these.
+  let armLabels: string[] | null = null;
+  if (!Array.isArray(models) || models.length === 0) {
+    errors.push("models must be a non-empty array of model id strings or {ref, label?, serving?} local arms");
   } else {
+    const labels: string[] = [];
+    for (const entry of models) {
+      if (typeof entry === "string") {
+        if (entry.trim().length === 0) errors.push("models: model id strings must be non-empty");
+        else labels.push(entry);
+      } else if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+        const o = asObject(entry);
+        if (typeof o.ref !== "string" || o.ref.trim().length === 0) {
+          errors.push("models: local arm entries need a non-empty ref (path to a .understudy-model bundle or an MLX model dir)");
+        }
+        if (o.label !== undefined && (typeof o.label !== "string" || o.label.trim().length === 0)) errors.push("models: local arm label must be a non-empty string when present");
+        if (o.serving !== undefined && (o.serving === null || typeof o.serving !== "object" || Array.isArray(o.serving))) errors.push("models: local arm serving must be an object when present");
+        if (typeof o.ref === "string" && o.ref.trim().length > 0) labels.push(armLabelOf(o as LocalModelArm));
+      } else {
+        errors.push("models entries must be model id strings or {ref, label?, serving?} objects");
+      }
+    }
     if (models.length > MAX_MODELS_PER_RUN) errors.push(`at most ${MAX_MODELS_PER_RUN} models per run`);
-    if (new Set(models).size !== models.length) errors.push("models must be unique");
+    if (new Set(labels).size !== labels.length) errors.push("model arm labels must be unique");
+    armLabels = labels;
   }
   if (!RUN_SPLITS.includes(input.split as RunSplit)) errors.push(`split must be one of ${RUN_SPLITS.join(", ")}`);
   const tasks = input.tasks;
@@ -337,7 +395,7 @@ export function validateRunRequestInput(input: RunRequestInput, knownTaskIds: st
   if (incumbents !== undefined) {
     if (!Array.isArray(incumbents) || !incumbents.every((m) => typeof m === "string" && m.trim().length > 0)) {
       errors.push("incumbent_models must be an array of model id strings");
-    } else if (Array.isArray(models) && !incumbents.every((m) => models.includes(m))) {
+    } else if (armLabels !== null && !incumbents.every((m) => armLabels!.includes(m))) {
       errors.push("incumbent_models must be a subset of models");
     }
   }
@@ -378,9 +436,9 @@ export function validateRunRequestInput(input: RunRequestInput, knownTaskIds: st
         else labels.add(label);
         // The label is a leaderboard arm AND a rows-file key: it must never
         // collide with a bare model arm (that would merge two arms' rows).
-        if (label && Array.isArray(models) && models.includes(label)) errors.push(`prompt_overrides: arm_label ${label} collides with a model arm`);
+        if (label && armLabels !== null && armLabels.includes(label)) errors.push(`prompt_overrides: arm_label ${label} collides with a model arm`);
         if (typeof o.model !== "string" || !o.model.trim()) errors.push("prompt_overrides: model must be a non-empty string");
-        else if (Array.isArray(models) && !models.includes(o.model)) errors.push(`prompt_overrides: model ${o.model} must be one of the run's models`);
+        else if (armLabels !== null && !armLabels.includes(o.model)) errors.push(`prompt_overrides: model ${o.model} must be one of the run's models`);
         if (typeof o.system_prompt_suffix !== "string" || !o.system_prompt_suffix.trim()) errors.push("prompt_overrides: system_prompt_suffix must be a non-empty string");
       }
     }
@@ -391,7 +449,7 @@ export function validateRunRequestInput(input: RunRequestInput, knownTaskIds: st
 /** Create + persist a queued run request. Caller validates first. */
 export function createRunRequest(
   benchmarkDir: string,
-  input: { benchmark_id: string; models: string[]; split: RunSplit; tasks: "all" | string[]; rollouts_per_task: number; incumbent_models?: string[]; calibration_threshold?: number; trivial_arms?: TrivialArmKind[]; rollout_timeout_seconds?: number; prompt_overrides?: PromptOverride[]; app_replay?: boolean },
+  input: { benchmark_id: string; models: ModelArmEntry[]; split: RunSplit; tasks: "all" | string[]; rollouts_per_task: number; incumbent_models?: string[]; calibration_threshold?: number; trivial_arms?: TrivialArmKind[]; rollout_timeout_seconds?: number; prompt_overrides?: PromptOverride[]; app_replay?: boolean },
   now: Date = new Date(),
 ): RunRequest {
   // Writers declare the capabilities their feature use depends on, so an old
@@ -399,6 +457,10 @@ export function createRunRequest(
   // dropping the fields (the stale-watcher hijack class).
   const requires: string[] = [];
   if (input.trivial_arms && input.trivial_arms.length > 0) requires.push("trivial_arms");
+  // Old executors know "trivial_arms" but not the majority_class kind; a
+  // distinct capability keeps them from running the arm as an unknown no-op.
+  if ((input.trivial_arms ?? []).includes("majority_class")) requires.push("majority_class");
+  if (input.models.some(isLocalArmEntry)) requires.push("local_arms");
   if ((input.incumbent_models && input.incumbent_models.length > 0) || input.calibration_threshold !== undefined) requires.push("calibration");
   if (input.rollout_timeout_seconds !== undefined) requires.push("rollout_timeout");
   if (input.prompt_overrides && input.prompt_overrides.length > 0) requires.push("prompt_overrides");
@@ -491,6 +553,12 @@ export type RolloutResult = {
    * executor-detected sentinels — honest partial evidence, never a fake score.
    */
   anomaly?: RolloutAnomaly | null;
+  /**
+   * Additive perf evidence (local arms; where obtainable): generation
+   * throughput derived from the runner's own usage/timing data. Never
+   * estimated when the runner cannot tell.
+   */
+  perf?: { tokens_per_sec?: number | null } | null;
   error?: string | null;
 };
 
@@ -605,6 +673,8 @@ export type ArmRunner = (args: {
   armLabel?: string;
   /** Additive (prompt-override arms only): suffix appended to each task's system prompt at rollout time, run-scoped (task files are never mutated). */
   systemPromptSuffix?: string;
+  /** Additive (local arms only): the served artifact's endpoint — runners point their client at it instead of the gateway. */
+  local?: { baseUrl: string; modelId: string };
 }) => Promise<RolloutResult>;
 
 export type RunEvent = {
@@ -662,6 +732,16 @@ export type ExecuteOptions = {
    * are skipped-with-record — never executed as a model arm by mistake.
    */
   appReplayRunner?: ArmRunner;
+  /**
+   * Additive: the serving rig for LOCAL trained-artifact arms ({ref, …}
+   * model entries). The executor starts the server for the arm (or reuses a
+   * running one when the arm's serving.base_url points at it), hands the
+   * runner the endpoint, and tears the server down after the arm. When
+   * absent, this executor does not advertise the "local_arms" capability, so
+   * such requests are skipped-with-record — never run against the gateway
+   * with the ref silently dropped.
+   */
+  localServing?: LocalServingRig;
   /** Rollouts in flight per arm (the concurrency flag). */
   concurrency?: number;
   /** Per-rollout wall-clock budget in seconds; the request's rollout_timeout_seconds wins when present. */
@@ -699,8 +779,10 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
   // with the unknown fields silently dropped (the stale-watcher hijack class).
   // Status stays "queued" so a capable executor can still pick it up.
   const baseCapabilities = options.capabilities ?? EXECUTOR_CAPABILITIES;
-  // "app_replay" is only honestly supported when an app-replay runner was wired in.
-  const capabilities = options.appReplayRunner ? baseCapabilities : baseCapabilities.filter((c) => c !== "app_replay");
+  // "app_replay"/"local_arms" are only honestly supported when their runner/rig was wired in.
+  const capabilities = baseCapabilities
+    .filter((c) => c !== "app_replay" || options.appReplayRunner !== undefined)
+    .filter((c) => c !== "local_arms" || options.localServing !== undefined);
   const missing = unsupportedRequirements(initial, capabilities);
   if (missing.length > 0) {
     const note = { executor_version: EXECUTOR_VERSION, missing, at: now().toISOString() };
@@ -740,17 +822,26 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
   // Arms = the requested model arms plus any trivial calibration arms. Trivial
   // arms are deterministic, so they run exactly ONE rollout per task no matter
   // what rollouts_per_task says (repeats add nothing but identical rows).
-  type Arm = { model: string; kind: ArmKind; runner: ArmRunner; rollouts: number; override?: PromptOverride };
+  type Arm = { model: string; kind: ArmKind; runner: ArmRunner; rollouts: number; override?: PromptOverride; local?: ResolvedLocalArm };
   // app_replay requests replay the user's OWN app (labels stay per "model"
   // entry — typically the app/route name); the capability gate above already
   // guaranteed options.appReplayRunner is present when app_replay is true.
   const appReplay = request.app_replay === true && options.appReplayRunner !== undefined;
-  const arms: Arm[] = request.models.map((model) => ({
-    model,
-    kind: appReplay ? ("app_replay" as ArmKind) : (((request.incumbent_models ?? []).includes(model) ? "incumbent" : "candidate") as ArmKind),
-    runner: appReplay ? options.appReplayRunner! : options.runner,
-    rollouts: request.rollouts_per_task,
-  }));
+  const arms: Arm[] = request.models.map((entry) => {
+    const model = armLabelOf(entry);
+    // Local trained-artifact arm: resolve the ref NOW (provenance hash + base
+    // model + adapter flag) so a missing/renamed bundle fails the run up
+    // front, never mid-arm. The capability gate above guaranteed
+    // options.localServing is present when any local entry exists.
+    const local = isLocalArmEntry(entry) ? resolveLocalArm(entry) : undefined;
+    return {
+      model,
+      kind: appReplay ? ("app_replay" as ArmKind) : (((request.incumbent_models ?? []).includes(model) ? "incumbent" : "candidate") as ArmKind),
+      runner: appReplay ? options.appReplayRunner! : options.runner,
+      rollouts: request.rollouts_per_task,
+      ...(local ? { local } : {}),
+    };
+  });
   // Prompt-override experiment arms: same underlying model, a run-scoped
   // system-prompt suffix, rows labeled with the arm_label. ALWAYS candidates —
   // an override arm is not the incumbent baseline, so it never feeds
@@ -760,7 +851,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
   }
   for (const kind of request.trivial_arms ?? []) {
     if (!TRIVIAL_ARM_KINDS.includes(kind)) continue;
-    arms.push({ model: kind, kind, runner: kind === "null_agent" ? nullAgentRunner() : spamAgentRunner(), rollouts: 1 });
+    arms.push({ model: kind, kind, runner: kind === "null_agent" ? nullAgentRunner() : kind === "spam_agent" ? spamAgentRunner() : majorityClassRunner(), rollouts: 1 });
   }
   const total = arms.reduce((sum, arm) => sum + selected.length * arm.rollouts, 0);
   request = { ...request, status: "running", started_at: now().toISOString(), progress: { completed: 0, total } };
@@ -795,6 +886,12 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
       const model = arm.model;
       if (cancelled()) break;
       appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "arm_started", model }, options.onEvent);
+      // Local arm: stand the artifact's server up for the WHOLE arm (or reuse
+      // a running one the spec points at) and tear it down after — the runner
+      // gets the endpoint instead of the gateway.
+      let localServer: LocalServerHandle | null = null;
+      if (arm.local) localServer = await options.localServing!.start(arm.local);
+      try {
       const rowsFile = rowsFilePath(dir, runId, model);
       // Live journal for this arm: the world/runner appends tool events the
       // moment they happen; the hub's live endpoint tails it. The path is
@@ -834,7 +931,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
           try {
             // Override arms invoke the BASE model; the arm label only labels
             // rows/files. The suffix + label ride the additive runner args.
-            const attempt = arm.runner({ benchmarkDir: dir, model: arm.override?.model ?? model, task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)), journalPath, runId, rolloutTimeoutSeconds: timeoutSeconds, ...(arm.override ? { armLabel: arm.override.arm_label, systemPromptSuffix: arm.override.system_prompt_suffix } : {}) });
+            const attempt = arm.runner({ benchmarkDir: dir, model: arm.override?.model ?? model, task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)), journalPath, runId, rolloutTimeoutSeconds: timeoutSeconds, ...(arm.override ? { armLabel: arm.override.arm_label, systemPromptSuffix: arm.override.system_prompt_suffix } : {}), ...(localServer ? { local: { baseUrl: localServer.baseUrl, modelId: localServer.modelId } } : {}) });
             const raced = await Promise.race([attempt, new Promise<typeof TIMED_OUT>((res) => { timer = setTimeout(() => res(TIMED_OUT), Math.max(1, Math.round(timeoutSeconds * 1000))); })]);
             if (raced === TIMED_OUT) {
               attempt.catch(() => { /* late settle of the abandoned rollout is irrelevant */ });
@@ -893,7 +990,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
             arm_kind: arm.kind,
             // Additive attribution stamp: which executor build produced this row.
             executor_version: EXECUTOR_VERSION,
-            route: "gateway",
+            route: arm.local ? "local" : "gateway",
             latency_ms: result.latency_ms,
             cost: result.cost,
             created_at: now().toISOString(),
@@ -908,6 +1005,12 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
             // Additive override provenance: base model + suffix hash (full
             // text lives in runs/<run_id>-overrides.json, never on rows).
             ...(arm.override ? { prompt_override: { arm_label: arm.override.arm_label, base_model: arm.override.model, system_prompt_suffix_sha256: promptSuffixHash(arm.override.system_prompt_suffix) } } : {}),
+            // Additive local-artifact provenance + perf (local arms only):
+            // exactly which bundle was served, plus throughput/peak memory
+            // where the runner/rig can actually tell (never estimated).
+            ...(arm.local ? { local_artifact: arm.local.artifact } : {}),
+            ...(typeof result.perf?.tokens_per_sec === "number" ? { tokens_per_sec: result.perf.tokens_per_sec } : {}),
+            ...(localServer && typeof localServer.stats().peak_memory_bytes === "number" ? { peak_memory_bytes: localServer.stats().peak_memory_bytes } : {}),
             // Additive oracle diagnostic: missing-gold rows render "unverifiable", never a bare fail.
             ...(result.oracle && result.oracle.missing_gold.length > 0 ? { oracle: result.oracle } : {}),
             // Marked, not dropped: the primary anomaly plus the full list.
@@ -940,6 +1043,10 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
       await Promise.all(Array.from({ length: Math.min(concurrency, queue.length) }, () => worker()));
       appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "arm_finished", model, progress: { completed, total } }, options.onEvent);
       if (armCancelled) break;
+      } finally {
+        // Teardown after the arm — a server the rig REUSED is never ours to stop.
+        if (localServer && !localServer.reused) await localServer.stop();
+      }
     }
   } catch (err) {
     // A hard arm failure (e.g. HarnessError from the verifiers subprocess) is
@@ -1012,6 +1119,8 @@ export type CalibrationSummary = {
   null_floor?: TrivialFloor;
   /** Additive: spam-agent floor (absent when the run carried no spam_agent arm). */
   spam_floor?: TrivialFloor;
+  /** Additive: majority-class floor (absent when the run carried no majority_class arm) — the imbalanced-classifier trap. */
+  majority_floor?: TrivialFloor;
 };
 
 /**
@@ -1087,6 +1196,7 @@ export function deriveCalibrationSummary(args: {
     // Additive floors: absent unless the run carried the arm.
     ...(trivialArms.includes("null_agent") ? { null_floor: floorFor("null_agent") } : {}),
     ...(trivialArms.includes("spam_agent") ? { spam_floor: floorFor("spam_agent") } : {}),
+    ...(trivialArms.includes("majority_class") ? { majority_floor: floorFor("majority_class") } : {}),
   };
 }
 
@@ -1190,7 +1300,7 @@ export function oracleRunner(): ArmRunner {
 /** The null agent's entire output: deterministic boilerplate, never task-derived. */
 export const NULL_AGENT_FINAL_RESPONSE = "I was unable to complete this task.";
 
-const trivialSubscores = (scored: Obj, label: "runner_null_agent" | "runner_spam_agent"): Record<string, number> => ({
+const trivialSubscores = (scored: Obj, label: "runner_null_agent" | "runner_spam_agent" | "runner_majority_class"): Record<string, number> => ({
   final_state: Number(scored.strict ?? 0),
   final_state_partial_credit: Number(scored.recall ?? 0),
   recall: Number(scored.recall ?? 0),
@@ -1301,6 +1411,92 @@ export function spamAgentRunner(): ArmRunner {
   };
 }
 
+/* ------------------------------------------------------------------ */
+/* Majority-class floor arm (the imbalanced-classifier trap)           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The gold LABEL of a classification-shaped task, or null when the task is
+ * not classification-shaped. Classification-shaped = the outcome contract's
+ * required obligations are EXACTLY ONE response obligation whose gold is a
+ * label (`contains_category` with a string `expected`) — a task with state
+ * effects or multiple obligations is an agentic task, not a classifier row.
+ */
+export function classificationGoldLabel(task: Obj): string | null {
+  const required = ((asObject(task.outcome_contract).required ?? []) as unknown[]).map(asObject);
+  if (required.length !== 1) return null;
+  const rule = required[0];
+  if (String(rule.type ?? "state_effect") !== "response_obligation" || String(rule.kind ?? "") !== "contains_category") return null;
+  const expected = typeof rule.expected === "string" ? rule.expected.trim() : "";
+  return expected.length > 0 ? expected : null;
+}
+
+/**
+ * The most frequent classification gold label across the benchmark's TRAIN
+ * split — NEVER holdout/dev: the majority arm must not read the answer
+ * distribution of the split it is scored on. Ties break deterministically to
+ * the lexicographically smallest label. Null when the train split has no
+ * classification-shaped tasks.
+ */
+export function majorityTrainLabel(manifestTasks: Obj[], sidecarTasksById: Map<string, Obj>): string | null {
+  const counts = new Map<string, number>();
+  for (const task of manifestTasks.map(asObject)) {
+    if (String(task.split ?? "") !== "train") continue; // holdout/dev structurally excluded
+    const sidecar = sidecarTasksById.get(String(task.task_id));
+    const label = sidecar ? classificationGoldLabel(sidecar) : null;
+    if (label !== null) counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  let best: string | null = null;
+  for (const [label, count] of counts) {
+    if (best === null || count > counts.get(best)! || (count === counts.get(best)! && label < best)) best = label;
+  }
+  return best;
+}
+
+/** Read the benchmark's majority train label from its own artifacts (benchmark.json splits + tasks.jsonl contracts). */
+export function benchmarkMajorityTrainLabel(benchmarkDir: string): string | null {
+  const dir = resolve(benchmarkDir);
+  let manifestTasks: Obj[] = [];
+  try {
+    manifestTasks = (asObject(JSON.parse(readFileSync(join(dir, "benchmark.json"), "utf8"))).tasks ?? []).map(asObject);
+  } catch {
+    return null;
+  }
+  const sidecar = new Map(readJsonl(join(dir, "tasks.jsonl")).map((t) => [String(t.task_id), t]));
+  return majorityTrainLabel(manifestTasks, sidecar);
+}
+
+/**
+ * Majority-class arm: on classification-shaped tasks it deterministically
+ * answers the benchmark's most frequent TRAIN-split gold label (computed from
+ * the tasks' split assignment — never holdout); on every other task shape it
+ * behaves exactly like the null agent. Zero tool calls, zero cost, scored
+ * through the same full-contract scorer. Any classification benchmark this
+ * arm passes at a high rate is dominated by its majority label — the
+ * imbalanced-classifier trap a naive accuracy leaderboard hides.
+ */
+export function majorityClassRunner(): ArmRunner {
+  const labelCache = new Map<string, string | null>();
+  return async ({ benchmarkDir, task }) => {
+    const started = Date.now();
+    if (!labelCache.has(benchmarkDir)) labelCache.set(benchmarkDir, benchmarkMajorityTrainLabel(benchmarkDir));
+    const majority = labelCache.get(benchmarkDir) ?? null;
+    // Non-classification tasks (or no train-split labels at all): null-agent behavior.
+    const response = classificationGoldLabel(asObject(task)) !== null && majority !== null ? majority : NULL_AGENT_FINAL_RESPONSE;
+    const scored = asObject(scoreContract(asObject(task), { calls: [], finalResponse: response }));
+    return {
+      score: Number(scored.strict ?? 0),
+      subscores: trivialSubscores(scored, "runner_majority_class"),
+      status: "ok" as const,
+      latency_ms: Math.max(1, Date.now() - started),
+      cost: 0,
+      writes: [],
+      tool_call_count: 0,
+      final_response_chars: response.length,
+    };
+  };
+}
+
 /**
  * Per-invocation work directory for one verifiers eval subprocess. The eval
  * writes outputs/ relative to its CWD, so giving every (run, arm) invocation
@@ -1359,7 +1555,7 @@ export class HarnessExecutionError extends Error {
  * (Shape pinned by the golden fixture in tests/run-executor.test.mjs from a
  * real `uv run eval` run against the pinned commit.)
  */
-export function projectVerifiersTrace(trace: Obj, model: string): { taskId: string | null; result: RolloutResult } {
+export function projectVerifiersTrace(trace: Obj, model: string, options: { local?: boolean } = {}): { taskId: string | null; result: RolloutResult } {
   const taskId = (asObject(asObject(trace.task).data).task_id as string | undefined) ?? null;
   const rewards = asObject(trace.rewards);
   const metrics = asObject(trace.metrics);
@@ -1377,7 +1573,12 @@ export function projectVerifiersTrace(trace: Obj, model: string): { taskId: stri
     completionTokens += Number(usage.completion_tokens ?? 0);
   }
   const rate = COST_PER_MTOKEN[model] ?? COST_PER_MTOKEN.default;
-  const cost = calls.length > 0 ? (promptTokens * rate.input + completionTokens * rate.output) / 1_000_000 : null;
+  // A LOCAL artifact arm costs $0 by construction (no provider tokens are
+  // billed); the gateway heuristic would fabricate spend from a made-up rate.
+  const cost = options.local ? 0 : calls.length > 0 ? (promptTokens * rate.input + completionTokens * rate.output) / 1_000_000 : null;
+  // Local-arm throughput evidence: completion tokens over measured model-call
+  // wall time — only when both are actually present in the trace.
+  const tokensPerSec = options.local && completionTokens > 0 && latencyMs > 0 ? Number(((completionTokens * 1000) / latencyMs).toFixed(2)) : null;
   // Mutating tool calls from the trace's message nodes → per-arm replay input.
   // Total call count (reads AND writes) + final assistant text feed the
   // structural anomaly sentinels.
@@ -1413,6 +1614,7 @@ export function projectVerifiersTrace(trace: Obj, model: string): { taskId: stri
       writes,
       tool_call_count: toolCallCount,
       final_response_chars: finalAssistantText === null ? null : finalAssistantText.trim().length,
+      ...(tokensPerSec !== null ? { perf: { tokens_per_sec: tokensPerSec } } : {}),
       error: failed ? String(errors[0]?.type ?? "RolloutError") + ": " + String(errors[0]?.message ?? "rollout not ok").slice(0, 500) : null,
     },
   };
@@ -1432,6 +1634,8 @@ export type VerifiersArmOptions = {
   invocationTag?: string | null;
   /** Run-scoped prompt-override suffix: appended to each selected task's system prompt for THIS invocation only (the temp-rewrite pattern; the source rows are restored after). */
   systemPromptSuffix?: string | null;
+  /** Local-artifact arm: the served endpoint replaces the gateway creds for THIS invocation (the eval's -m gets modelId — MLX servers accept the weights path). */
+  local?: { baseUrl: string; modelId: string } | null;
 };
 
 /** Apply a run-scoped override suffix to one generated-environment task row (pure; used by the temp-rewrite below and its tests). */
@@ -1479,8 +1683,18 @@ function runVerifiersSplits(dir: string, environment: string, model: string, max
   // ~/.understudy/credentials.json) and are handed to buildReplayInvocation
   // through its own env contract — the executor ONLY talks to the Understudy
   // gateway, never a stray OPENAI_* pointing elsewhere.
-  const auth = resolveGatewayAuth(parentEnv);
-  const runnerEnv: NodeJS.ProcessEnv = { ...parentEnv, UNDERSTUDY_GATEWAY_URL: auth.baseUrl, UNDERSTUDY_API_KEY: auth.apiKey, OPENAI_BASE_URL: undefined, OPENAI_API_KEY: undefined };
+  // Local arms point the runner's OpenAI-compatible client at the served
+  // artifact instead — buildReplayInvocation's own env contract carries the
+  // base URL/key either way (no gateway credential is ever required for a
+  // fully-local arm).
+  const local = options.local ?? null;
+  const runnerEnv: NodeJS.ProcessEnv = local !== null
+    ? { ...parentEnv, UNDERSTUDY_GATEWAY_URL: local.baseUrl, UNDERSTUDY_API_KEY: "local", OPENAI_BASE_URL: undefined, OPENAI_API_KEY: undefined }
+    : (() => {
+        const auth = resolveGatewayAuth(parentEnv);
+        return { ...parentEnv, UNDERSTUDY_GATEWAY_URL: auth.baseUrl, UNDERSTUDY_API_KEY: auth.apiKey, OPENAI_BASE_URL: undefined, OPENAI_API_KEY: undefined };
+      })();
+  const evalModel = local?.modelId ?? model;
   // The generated taskset loads ONE split per eval (config default train), so
   // an arm covers all tasks by running each split; a split with no tasks
   // fails its own eval harmlessly (the merged map decides success below).
@@ -1493,7 +1707,7 @@ function runVerifiersSplits(dir: string, environment: string, model: string, max
   const workDir = options.invocationTag ? verifiersWorkDir(dir, options.invocationTag) : dir;
   if (workDir !== dir) mkdirSync(workDir, { recursive: true });
   for (const split of splits) {
-    const invocation = buildReplayInvocation(environment, model, "authentic_history", maxExamples, false, runnerEnv);
+    const invocation = buildReplayInvocation(environment, evalModel, "authentic_history", maxExamples, false, runnerEnv);
     // Live watching: the generated world server journals every tool call and
     // result to this file the moment it happens (no-op when unset). The var
     // rides the eval subprocess env, which the subprocess runtime inherits.
@@ -1518,7 +1732,7 @@ function runVerifiersSplits(dir: string, environment: string, model: string, max
     for (const file of files) {
       for (const line of readJsonl(file)) {
         for (const trace of (Array.isArray(line.traces) ? line.traces : []).map(asObject)) {
-          const { taskId, result } = projectVerifiersTrace(trace, model);
+          const { taskId, result } = projectVerifiersTrace(trace, model, { local: local !== null });
           if (taskId && !results.has(taskId)) results.set(taskId, result);
         }
       }
@@ -1549,11 +1763,11 @@ function runVerifiersSplits(dir: string, environment: string, model: string, max
  */
 export function verifiersRunner(parentEnv: NodeJS.ProcessEnv = process.env): ArmRunner {
   const armCache = new Map<string, Map<string, RolloutResult> | Error>();
-  return async ({ benchmarkDir, model, task, selectedTaskIds, journalPath, runId, rolloutTimeoutSeconds, armLabel, systemPromptSuffix }) => {
+  return async ({ benchmarkDir, model, task, selectedTaskIds, journalPath, runId, rolloutTimeoutSeconds, armLabel, systemPromptSuffix, local }) => {
     // Cache/work-dir key on the arm LABEL: an override arm never shares its
     // memoized eval (or its output isolation) with the bare model arm.
     const arm = armLabel ?? model;
-    const key = `${benchmarkDir}::${runId ?? ""}::${arm}::${systemPromptSuffix ? promptSuffixHash(systemPromptSuffix) : ""}::${[...selectedTaskIds].sort().join(",")}`;
+    const key = `${benchmarkDir}::${runId ?? ""}::${arm}::${systemPromptSuffix ? promptSuffixHash(systemPromptSuffix) : ""}::${local ? local.baseUrl : ""}::${[...selectedTaskIds].sort().join(",")}`;
     if (!armCache.has(key)) {
       try {
         armCache.set(key, runVerifiersArm(benchmarkDir, model, VERIFIERS_MAX_EXAMPLES, parentEnv, selectedTaskIds, journalPath, {
@@ -1561,6 +1775,8 @@ export function verifiersRunner(parentEnv: NodeJS.ProcessEnv = process.env): Arm
           // run_id + arm in the path: structural per-invocation isolation.
           invocationTag: runId ? `${runId}--${arm}` : null,
           systemPromptSuffix: systemPromptSuffix ?? null,
+          // Local artifact arm: the eval talks to the served endpoint, never the gateway.
+          local: local ?? null,
         }));
       } catch (err) {
         armCache.set(key, err instanceof Error ? err : new Error(String(err)));

--- a/tests/local-arms.test.mjs
+++ b/tests/local-arms.test.mjs
@@ -1,0 +1,450 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import {
+  NULL_AGENT_FINAL_RESPONSE,
+  armLabelOf,
+  benchmarkMajorityTrainLabel,
+  classificationGoldLabel,
+  createRunRequest,
+  deriveCalibrationSummary,
+  executeRunRequest,
+  majorityClassRunner,
+  majorityTrainLabel,
+  readRunRequest,
+  runEventsPath,
+  runRequestPath,
+  validateRunRequestInput,
+} from "../dist/run-executor.js";
+import { artifactBaseModel, artifactHasAdapter, bundleSha256, renderServeCommand, resolveLocalArm, servingModelPath } from "../dist/local-serving.js";
+
+const roots = [];
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+const tmpdir = (prefix) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  roots.push(dir);
+  return dir;
+};
+
+/* ------------------------------------------------------------------ */
+/* Fixtures                                                            */
+/* ------------------------------------------------------------------ */
+
+/** A .understudy-model bundle dir: manifest + LoRA adapter (docs/task-model-bundles.md layout). */
+function makeBundle({ adapter = true, base = "gemma-4-e2b-it" } = {}) {
+  const dir = path.join(tmpdir("local-bundle-"), "triage.understudy-model");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify({ schema_version: "understudy.task_model.v1", base_model: base }));
+  if (adapter) {
+    const adapterDir = path.join(dir, "model", "adapter");
+    fs.mkdirSync(adapterDir, { recursive: true });
+    fs.writeFileSync(path.join(adapterDir, "adapter_config.json"), JSON.stringify({ lora_rank: 8 }));
+    fs.writeFileSync(path.join(adapterDir, "adapters.safetensors"), "fake-weights");
+  }
+  return dir;
+}
+
+/**
+ * A classification-shaped benchmark: every task's contract is a single
+ * response obligation whose gold is a label. Train split: billing×2, tech×1
+ * → majority = billing. Holdout is tech-heavy so counting it would flip the
+ * majority (the exclusion test).
+ */
+function makeClassificationBenchmark() {
+  const dir = tmpdir("majority-bench-");
+  const tasks = [
+    { task_id: "t1", split: "train", gold: "billing" },
+    { task_id: "t2", split: "train", gold: "billing" },
+    { task_id: "t3", split: "train", gold: "tech" },
+    { task_id: "h1", split: "holdout", gold: "tech" },
+    { task_id: "h2", split: "holdout", gold: "tech" },
+    { task_id: "h3", split: "holdout", gold: "billing" },
+  ];
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "majority-bench",
+      tasks: tasks.map((t) => ({ task_id: t.task_id, category_id: "cat", split: t.split })),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(dir, "tasks.jsonl"),
+    tasks
+      .map((t) =>
+        JSON.stringify({
+          schema_version: "understudy.benchmark_task.v1",
+          task_id: t.task_id,
+          title: `classify ${t.task_id}`,
+          outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: t.gold }], preserved: [], forbidden: [], grading: "final_state_and_obligations" },
+        }),
+      )
+      .join("\n") + "\n",
+  );
+  return dir;
+}
+
+/** A minimal agentic benchmark (state-effect contract) for local-arm executor runs. */
+function makeAgenticBenchmark() {
+  const dir = tmpdir("local-arms-bench-");
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "local-arms-bench",
+      tasks: [{ task_id: "t1", category_id: "cat", split: "train" }],
+    }),
+  );
+  fs.writeFileSync(
+    path.join(dir, "tasks.jsonl"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark_task.v1",
+      task_id: "t1",
+      title: "do the thing",
+      outcome_contract: { required: [{ type: "state_effect", tool: "update-record", observed_arguments: { id: "r-1" } }], preserved: [], forbidden: [], grading: "final_state_and_obligations" },
+    }) + "\n",
+  );
+  return dir;
+}
+
+const readRows = (dir) =>
+  fs
+    .readdirSync(dir)
+    .filter((f) => /^rows-.*\.jsonl$/.test(f))
+    .flatMap((f) => fs.readFileSync(path.join(dir, f), "utf8").trim().split("\n").map((l) => JSON.parse(l)));
+
+const readEvents = (dir) => fs.readFileSync(runEventsPath(dir), "utf8").trim().split("\n").map((l) => JSON.parse(l));
+
+/* ------------------------------------------------------------------ */
+/* 1. Arm-spec validation (additive union)                             */
+/* ------------------------------------------------------------------ */
+
+describe("run-request local-arm validation", () => {
+  const known = ["t1"];
+  const base = { split: "all", tasks: "all", rollouts_per_task: 1 };
+
+  it("old string-only shape validates exactly as before", () => {
+    assert.deepEqual(validateRunRequestInput({ ...base, models: ["gpt-x", "gemma-4-e2b-it"] }, known), []);
+    assert.ok(validateRunRequestInput({ ...base, models: [] }, known).length > 0);
+    assert.ok(validateRunRequestInput({ ...base, models: ["a", "a"] }, known).length > 0);
+  });
+
+  it("accepts a string/object mix and keys uniqueness on arm labels", () => {
+    assert.deepEqual(validateRunRequestInput({ ...base, models: ["gpt-x", { ref: "./bundle.understudy-model", label: "local-lora" }] }, known), []);
+    assert.deepEqual(validateRunRequestInput({ ...base, models: [{ ref: "/models/gemma-e2b" }] }, known), []);
+    // Label defaulting: ref basename — colliding with a string arm is an error.
+    const errors = validateRunRequestInput({ ...base, models: ["gemma-e2b", { ref: "/models/gemma-e2b" }] }, known);
+    assert.ok(errors.some((e) => e.includes("unique")), errors.join("; "));
+  });
+
+  it("rejects malformed local arm objects", () => {
+    assert.ok(validateRunRequestInput({ ...base, models: [{ label: "no-ref" }] }, known).length > 0);
+    assert.ok(validateRunRequestInput({ ...base, models: [{ ref: "  " }] }, known).length > 0);
+    assert.ok(validateRunRequestInput({ ...base, models: [{ ref: "/x", label: "" }] }, known).length > 0);
+    assert.ok(validateRunRequestInput({ ...base, models: [{ ref: "/x", serving: "http://" }] }, known).length > 0);
+    assert.ok(validateRunRequestInput({ ...base, models: [42] }, known).length > 0);
+  });
+
+  it("incumbent_models and prompt_overrides key on arm labels (local labels included)", () => {
+    const models = ["gw", { ref: "/models/x", label: "local-x" }];
+    assert.deepEqual(validateRunRequestInput({ ...base, models, incumbent_models: ["local-x"] }, known), []);
+    assert.deepEqual(validateRunRequestInput({ ...base, models, prompt_overrides: [{ arm_label: "ov", model: "local-x", system_prompt_suffix: "be terse" }] }, known), []);
+    assert.ok(validateRunRequestInput({ ...base, models, incumbent_models: ["missing"] }, known).length > 0);
+  });
+
+  it("armLabelOf: explicit label, then ref basename", () => {
+    assert.equal(armLabelOf("gpt-x"), "gpt-x");
+    assert.equal(armLabelOf({ ref: "/a/b/bundle.understudy-model", label: "nice" }), "nice");
+    assert.equal(armLabelOf({ ref: "/a/b/bundle.understudy-model/" }), "bundle.understudy-model");
+  });
+
+  it("createRunRequest stamps the local_arms capability requirement (and not on old-shape requests)", () => {
+    const dir = makeAgenticBenchmark();
+    const bundle = makeBundle();
+    const plain = createRunRequest(dir, { benchmark_id: "b", models: ["gw"], split: "all", tasks: "all", rollouts_per_task: 1 });
+    assert.ok(!(plain.requires ?? []).includes("local_arms"));
+    const local = createRunRequest(dir, { benchmark_id: "b", models: ["gw", { ref: bundle, label: "local" }], split: "all", tasks: "all", rollouts_per_task: 1 });
+    assert.ok(local.requires.includes("local_arms"));
+    // The persisted request round-trips the object entry intact.
+    assert.deepEqual(readRunRequest(runRequestPath(dir, local.run_id)).models, ["gw", { ref: bundle, label: "local" }]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 2. Bundle hash provenance + artifact resolution                     */
+/* ------------------------------------------------------------------ */
+
+describe("bundle provenance", () => {
+  it("bundleSha256 is deterministic, location-independent, and content-sensitive", () => {
+    const a = makeBundle();
+    const b = makeBundle();
+    assert.equal(bundleSha256(a), bundleSha256(a));
+    assert.equal(bundleSha256(a), bundleSha256(b), "identical bundles hash identically wherever they sit");
+    fs.writeFileSync(path.join(b, "model", "adapter", "adapters.safetensors"), "different-weights");
+    assert.notEqual(bundleSha256(a), bundleSha256(b), "changing a member changes the hash");
+  });
+
+  it("resolves base model + adapter flag from the bundle manifest", () => {
+    const bundle = makeBundle({ base: "gemma-4-e4b-it" });
+    assert.equal(artifactBaseModel(bundle), "gemma-4-e4b-it");
+    assert.equal(artifactHasAdapter(bundle), true);
+    const bare = makeBundle({ adapter: false });
+    assert.equal(artifactHasAdapter(bare), false);
+    const resolved = resolveLocalArm({ ref: bundle, label: "lora-arm" });
+    assert.equal(resolved.label, "lora-arm");
+    assert.equal(resolved.artifact.base_model, "gemma-4-e4b-it");
+    assert.equal(resolved.artifact.adapter, true);
+    assert.equal(resolved.artifact.bundle_sha256, bundleSha256(bundle));
+  });
+
+  it("bundle_path is cwd-relative when the ref lives under cwd, absolute otherwise", () => {
+    const bundle = makeBundle();
+    const inside = resolveLocalArm({ ref: bundle }, path.dirname(bundle));
+    assert.equal(inside.artifact.bundle_path, path.basename(bundle));
+    const outside = resolveLocalArm({ ref: bundle }, tmpdir("elsewhere-"));
+    assert.ok(path.isAbsolute(outside.artifact.bundle_path));
+  });
+
+  it("throws on a missing ref (a vanished artifact must fail loudly)", () => {
+    assert.throws(() => resolveLocalArm({ ref: "/nonexistent/bundle.understudy-model" }), /does not exist/);
+  });
+
+  it("servingModelPath: adapter bundles serve base + --adapter-path; plain dirs serve themselves; sidecar placeholders render", () => {
+    const bundle = makeBundle({ base: "not-a-local-dir-base" });
+    const adapted = servingModelPath(resolveLocalArm({ ref: bundle }));
+    assert.equal(adapted.model, "not-a-local-dir-base", "uncached base falls back to the id itself");
+    assert.ok(adapted.adapterPath.endsWith(path.join("model", "adapter")));
+    const bare = makeBundle({ adapter: false });
+    const plain = servingModelPath(resolveLocalArm({ ref: bare }));
+    assert.equal(plain.model, path.resolve(bare));
+    assert.equal(plain.adapterPath, null);
+    assert.deepEqual(renderServeCommand(["serve", "--model", "{model}", "--port", "{port}"], { port: 8123, model: "/m", adapter: null }), ["serve", "--model", "/m", "--port", "8123"]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 3. Executor with a fake serving harness (no real MLX in CI)         */
+/* ------------------------------------------------------------------ */
+
+describe("executor with local arms (stubbed serving rig)", () => {
+  it("starts the rig per local arm, hands the runner the endpoint, stamps provenance + perf, tears down after the arm", async () => {
+    const dir = makeAgenticBenchmark();
+    const bundle = makeBundle();
+    const run = createRunRequest(dir, { benchmark_id: "local-arms-bench", models: ["gw-model", { ref: bundle, label: "gemma-local" }], split: "all", tasks: "all", rollouts_per_task: 1 });
+
+    const lifecycle = [];
+    let peak = 1024 * 1024 * 512;
+    const fakeRig = {
+      async start(arm) {
+        lifecycle.push(`start:${arm.label}`);
+        return {
+          baseUrl: "http://127.0.0.1:9999/v1",
+          modelId: "/served/base-model",
+          reused: false,
+          stats: () => ({ peak_memory_bytes: peak }),
+          stop: async () => lifecycle.push(`stop:${arm.label}`),
+        };
+      },
+    };
+    const seen = [];
+    const runner = async ({ model, local, journalPath }) => {
+      seen.push({ model, local: local ?? null });
+      if (journalPath) fs.appendFileSync(journalPath, JSON.stringify({ kind: "call", tool: "update-record", status: "ok" }) + "\n");
+      return {
+        score: 1,
+        subscores: null,
+        status: "ok",
+        latency_ms: 10,
+        cost: local ? 0 : 0.01,
+        writes: [{ tool: "update-record", arguments: { id: "r-1" } }],
+        tool_call_count: 1,
+        ...(local ? { perf: { tokens_per_sec: 187.5 } } : {}),
+      };
+    };
+    const result = await executeRunRequest(dir, run.run_id, { runner, localServing: fakeRig });
+    assert.equal(result.status, "done");
+    assert.deepEqual(lifecycle, ["start:gemma-local", "stop:gemma-local"], "server up for exactly the local arm, torn down after");
+
+    const gatewayCall = seen.find((s) => s.model === "gw-model");
+    assert.equal(gatewayCall.local, null, "gateway arms never get a local endpoint");
+    const localCall = seen.find((s) => s.model === "gemma-local");
+    assert.deepEqual(localCall.local, { baseUrl: "http://127.0.0.1:9999/v1", modelId: "/served/base-model" });
+
+    const rows = readRows(dir);
+    const localRow = rows.find((r) => r.model === "gemma-local");
+    assert.equal(localRow.route, "local");
+    assert.equal(localRow.arm_kind, "candidate");
+    assert.deepEqual(localRow.local_artifact, {
+      bundle_path: localRow.local_artifact.bundle_path,
+      bundle_sha256: bundleSha256(bundle),
+      base_model: "gemma-4-e2b-it",
+      adapter: true,
+    });
+    assert.equal(localRow.tokens_per_sec, 187.5);
+    assert.equal(localRow.peak_memory_bytes, peak);
+    const gatewayRow = rows.find((r) => r.model === "gw-model");
+    assert.equal(gatewayRow.route, "gateway");
+    assert.ok(!("local_artifact" in gatewayRow) && !("tokens_per_sec" in gatewayRow) && !("peak_memory_bytes" in gatewayRow), "gateway rows keep the prior shape");
+  });
+
+  it("a REUSED server (serving.base_url) is never stopped by the executor", async () => {
+    const dir = makeAgenticBenchmark();
+    const bundle = makeBundle();
+    const run = createRunRequest(dir, { benchmark_id: "local-arms-bench", models: [{ ref: bundle, label: "reused-arm", serving: { base_url: "http://127.0.0.1:8080/v1" } }], split: "all", tasks: "all", rollouts_per_task: 1 });
+    let stopped = false;
+    const fakeRig = {
+      async start() {
+        return { baseUrl: "http://127.0.0.1:8080/v1", modelId: "m", reused: true, stats: () => ({ peak_memory_bytes: null }), stop: async () => { stopped = true; } };
+      },
+    };
+    const runner = async ({ journalPath }) => {
+      if (journalPath) fs.appendFileSync(journalPath, JSON.stringify({ kind: "call", tool: "update-record", status: "ok" }) + "\n");
+      return { score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [{ tool: "update-record", arguments: { id: "r-1" } }], tool_call_count: 1 };
+    };
+    const result = await executeRunRequest(dir, run.run_id, { runner, localServing: fakeRig });
+    assert.equal(result.status, "done");
+    assert.equal(stopped, false, "a server the rig reused is not ours to stop");
+  });
+
+  it("capability gating: an executor without a serving rig skips-with-record, never runs the arm against the gateway", async () => {
+    const dir = makeAgenticBenchmark();
+    const bundle = makeBundle();
+    const run = createRunRequest(dir, { benchmark_id: "local-arms-bench", models: [{ ref: bundle, label: "local" }], split: "all", tasks: "all", rollouts_per_task: 1 });
+    assert.ok(run.requires.includes("local_arms"));
+    let ran = false;
+    const runner = async () => {
+      ran = true;
+      return { score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [] };
+    };
+    const result = await executeRunRequest(dir, run.run_id, { runner }); // no localServing
+    assert.equal(result.status, "queued", "stays queued for a capable executor");
+    assert.deepEqual(result.unsupported.missing, ["local_arms"]);
+    assert.equal(ran, false, "the runner must never fire");
+    assert.ok(readEvents(dir).some((e) => e.type === "run_unsupported"));
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 4. Majority-class floor arm                                         */
+/* ------------------------------------------------------------------ */
+
+describe("majority-class arm", () => {
+  it("classificationGoldLabel: single contains_category obligation only", () => {
+    const label = (contract) => classificationGoldLabel({ outcome_contract: contract });
+    assert.equal(label({ required: [{ type: "response_obligation", kind: "contains_category", expected: "billing" }] }), "billing");
+    assert.equal(label({ required: [{ type: "response_obligation", kind: "json_parses" }] }), null);
+    assert.equal(label({ required: [{ type: "state_effect", tool: "t" }] }), null);
+    assert.equal(label({ required: [{ type: "response_obligation", kind: "contains_category", expected: "a" }, { type: "response_obligation", kind: "contains_category", expected: "b" }] }), null, "multi-obligation tasks are not classification-shaped");
+    assert.equal(label({ required: [] }), null);
+  });
+
+  it("derives the majority label from the TRAIN split only — holdout is structurally excluded", () => {
+    const dir = makeClassificationBenchmark();
+    // train: billing×2 tech×1; holdout: tech×2 billing×1 (counting all six would tie 3-3 and break to "billing" anyway — so ALSO verify with a tech-flipping holdout)
+    assert.equal(benchmarkMajorityTrainLabel(dir), "billing");
+    const manifestTasks = [
+      { task_id: "t1", split: "train" },
+      { task_id: "h1", split: "holdout" },
+      { task_id: "h2", split: "holdout" },
+    ];
+    const sidecar = new Map([
+      ["t1", { outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "billing" }] } }],
+      ["h1", { outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "tech" }] } }],
+      ["h2", { outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "tech" }] } }],
+    ]);
+    assert.equal(majorityTrainLabel(manifestTasks, sidecar), "billing", "holdout tech votes must not flip the majority");
+    // Deterministic tie-break: lexicographically smallest.
+    const tied = new Map([
+      ["t1", { outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "zeta" }] } }],
+      ["t2", { outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "alpha" }] } }],
+    ]);
+    assert.equal(majorityTrainLabel([{ task_id: "t1", split: "train" }, { task_id: "t2", split: "train" }], tied), "alpha");
+    assert.equal(majorityTrainLabel([], new Map()), null);
+  });
+
+  it("answers the majority label on classification tasks, null-agent boilerplate otherwise", async () => {
+    const dir = makeClassificationBenchmark();
+    const runner = majorityClassRunner();
+    const sidecar = (id) => fs.readFileSync(path.join(dir, "tasks.jsonl"), "utf8").trim().split("\n").map((l) => JSON.parse(l)).find((t) => t.task_id === id);
+    const args = (id) => ({ benchmarkDir: dir, model: "majority_class", task: sidecar(id), rollout: 0, selectedTaskIds: ["h1", "h3"], journalPath: null });
+    const onBillingGold = await runner(args("h3")); // holdout gold billing → majority "billing" passes
+    assert.equal(onBillingGold.score, 1);
+    assert.equal(onBillingGold.final_response_chars, "billing".length);
+    const onTechGold = await runner(args("h1")); // holdout gold tech → majority "billing" fails
+    assert.equal(onTechGold.score, 0);
+    assert.equal(onTechGold.tool_call_count, 0);
+    assert.equal(onTechGold.cost, 0);
+    assert.equal(onTechGold.subscores.runner_majority_class, 1);
+    // Non-classification benchmark → behaves like the null agent.
+    const agentic = makeAgenticBenchmark();
+    const agenticTask = JSON.parse(fs.readFileSync(path.join(agentic, "tasks.jsonl"), "utf8").trim());
+    const fallback = await majorityClassRunner()({ benchmarkDir: agentic, model: "majority_class", task: agenticTask, rollout: 0, selectedTaskIds: ["t1"], journalPath: null });
+    assert.equal(fallback.final_response_chars, NULL_AGENT_FINAL_RESPONSE.length);
+    assert.equal(fallback.score, 0);
+  });
+
+  it("validation accepts majority_class in trivial_arms; createRunRequest stamps the capability", () => {
+    const known = ["t1"];
+    const base = { models: ["m"], split: "all", tasks: "all", rollouts_per_task: 1 };
+    assert.deepEqual(validateRunRequestInput({ ...base, trivial_arms: ["null_agent", "majority_class"] }, known), []);
+    assert.ok(validateRunRequestInput({ ...base, trivial_arms: ["majority_class", "majority_class"] }, known).length > 0);
+    const dir = makeClassificationBenchmark();
+    const run = createRunRequest(dir, { benchmark_id: "majority-bench", models: ["m"], split: "all", tasks: "all", rollouts_per_task: 1, trivial_arms: ["majority_class"] });
+    assert.ok(run.requires.includes("trivial_arms") && run.requires.includes("majority_class"));
+  });
+
+  it("an old executor (no majority_class capability) skips the request with a record", async () => {
+    const dir = makeClassificationBenchmark();
+    const run = createRunRequest(dir, { benchmark_id: "majority-bench", models: ["m"], split: "all", tasks: "all", rollouts_per_task: 1, trivial_arms: ["majority_class"] });
+    const result = await executeRunRequest(dir, run.run_id, {
+      runner: async () => ({ score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [] }),
+      capabilities: ["trivial_arms", "calibration", "rollout_timeout", "prompt_overrides"],
+    });
+    assert.equal(result.status, "queued");
+    assert.deepEqual(result.unsupported.missing, ["majority_class"]);
+  });
+
+  it("executor wires the arm + majority_floor into calibration with floor_exceeded semantics", async () => {
+    const dir = makeClassificationBenchmark();
+    // Holdout split: gold tech, tech, billing → majority ("billing") passes 1/3.
+    const run = createRunRequest(dir, { benchmark_id: "majority-bench", models: ["cand"], split: "holdout", tasks: "all", rollouts_per_task: 2, trivial_arms: ["majority_class"] });
+    const runner = async () => ({ score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [], tool_call_count: 1, final_response_chars: 5 });
+    const result = await executeRunRequest(dir, run.run_id, { runner });
+    assert.equal(result.status, "done");
+    // 1 model × 3 tasks × 2 rollouts + majority arm × 3 tasks × 1 rollout.
+    assert.deepEqual(result.progress, { completed: 9, total: 9 });
+    const rows = readRows(dir);
+    const majorityRows = rows.filter((r) => r.arm_kind === "majority_class");
+    assert.equal(majorityRows.length, 3, "trivial arms run one rollout per task");
+    assert.ok(majorityRows.every((r) => r.model === "majority_class" && r.cost === 0 && !("anomaly" in r)), "majority rows are never anomaly-flagged");
+    const calibration = JSON.parse(fs.readFileSync(path.join(dir, "calibration.json"), "utf8"));
+    assert.ok(Math.abs(calibration.majority_floor.floor - 1 / 3) < 1e-9);
+    assert.equal(calibration.majority_floor.floor_exceeded, true, "1/3 > TRIVIAL_FLOOR_LIMIT — the imbalanced-classifier trap fires");
+    assert.deepEqual(calibration.majority_floor.passed_task_ids, ["h3"]);
+    assert.equal(calibration.majority_floor.arm_kind, "majority_class");
+  });
+
+  it("deriveCalibrationSummary adds majority_floor additively (absent when the arm did not run)", () => {
+    const summary = deriveCalibrationSummary({
+      benchmarkId: "b",
+      runId: "r",
+      incumbentModels: [],
+      selectedTaskIds: ["a", "b"],
+      trivialArms: ["majority_class"],
+      rows: [
+        { run_id: "r", model: "majority_class", arm_kind: "majority_class", task_id: "a", status: "ok", score: 1 },
+        { run_id: "r", model: "majority_class", arm_kind: "majority_class", task_id: "b", status: "ok", score: 0 },
+      ],
+      events: [],
+    });
+    assert.equal(summary.majority_floor.floor, 0.5);
+    assert.equal(summary.majority_floor.floor_exceeded, true);
+    const without = deriveCalibrationSummary({ benchmarkId: "b", runId: "r", incumbentModels: [], selectedTaskIds: ["a"], rows: [], events: [] });
+    assert.ok(!("majority_floor" in without));
+  });
+});


### PR DESCRIPTION
## What

Closes the und-289 gap: trained local artifacts (.understudy-model bundles / MLX model dirs, base + optional LoRA) can now be queued as benchmark arms next to gateway ids — no more ~50 ad-hoc scripts per experiment.

### 1. Local-artifact arms (additive arm-spec union)
- `run_request.models` entries may be strings (gateway ids, byte-for-byte unchanged) **or** `{ref, label?, serving?}` objects. Requests carrying object entries are capability-gated via `requires: ["local_arms"]`; old executors skip-with-record (`run_unsupported`), never run the ref as a gateway id.
- The executor resolves the artifact up front (`src/local-serving.ts`): deterministic `bundle_sha256` (content hash, location-independent), `base_model` from the bundle manifest / serving sidecar, `adapter` flag from the bundle layout.
- **Serving rig reuse** (run-local-model-lab conventions, not a new rig): `understudy.serving.json` command sidecar wins verbatim (certified `-understudy` snapshot convention, `{port}`/`{model}`/`{adapter}` placeholders) → managed `mlx_vlm.server` binary when the pinned runtime is healthy → `mlx_lm.server --model … [--adapter-path …]` on the lab venv. Free loopback port, readiness on `GET /v1/models`, SIGTERM→SIGKILL teardown after the arm. `serving.base_url` reuses an already-running server (never torn down by us).
- The verifiers runner's `UNDERSTUDY_GATEWAY_URL` env contract carries the local endpoint instead of the gateway; the eval's `-m` gets the weights path (MLX servers accept it). Local rollout `cost` is 0 by construction — never the fabricated gateway heuristic.
- Rows: `model` = arm label, `route: "local"`, additive `local_artifact {bundle_path (cwd-relative where possible), bundle_sha256, base_model, adapter}`, `tokens_per_sec` (completion tokens over measured model-call wall time from the verifiers trace), `peak_memory_bytes` (rig-side RSS sampling of the spawned server; null for reused servers — honest "not obtainable").
- CLI: `understudy runs queue --local-arm <label>=<ref>` (repeatable) + `--trivial-arms`; `runs execute` wires `mlxServingRig()` in, which is what advertises the `local_arms` capability.

### 2. Majority-class floor arm (`arm_kind: "majority_class"`)
- New trivial calibration arm: on classification-shaped tasks (contract = exactly one `contains_category` response obligation whose gold is a label) it deterministically answers the most frequent gold label across the **train split only** — holdout/dev are structurally excluded from the count; ties break lexicographically. Non-classification tasks get null-agent behavior.
- Wired into `calibration.json` as `majority_floor` with the exact null/spam `floor_exceeded` semantics — an imbalanced classification benchmark now flags itself.
- Capability-gated via `requires: ["majority_class"]` (old executors know `trivial_arms` but not this kind, so a distinct capability keeps them from running it as an unknown no-op).

### Tests (`tests/local-arms.test.mjs`, 21 new)
Arm-spec validation (string/object mix, old shape unchanged, label uniqueness/collisions), fake serving-rig fixture (start/handoff/teardown + reused-server semantics, no real MLX in CI), bundle hash provenance, majority label derivation with holdout exclusion + tie-break, calibration floors, and capability gating for both features.

### Verification
- root `npm test`: 849/849 pass
- `tsc --noEmit`: clean
- benchmark-hub `npm test` (147 pass) + `next build`: clean
- `npm run skills:validate`: ok (36 skills)

Out of scope per tonight's file ownership: `benchmarks-mcp.ts`, `benchmark-hub-core.ts` (queue passthrough works untouched — the shared validator accepts object entries), hub leaderboard components, `rigor-report.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->