### PR TITLE
Experiment-lineage layer: understudy.experiment.v1 sidecar + CLI/MCP surfaces

### DIFF
--- a/docs/experiment-lineage.md
+++ b/docs/experiment-lineage.md
@@ -1,0 +1,97 @@
+# Experiment lineage (`understudy.experiment.v1`)
+
+Real experiments — the UND-289 Instacart SFT decision is the reference shape —
+link **data selection → training config → approval gates → checkpoint → eval
+runs → verdict** only in prose. `experiments.jsonl` makes that chain
+machine-readable using the repo's established sidecar pattern
+(`reviews.jsonl` / `feedback.jsonl` / `calibration.json`).
+
+## The sidecar
+
+- **File:** `<benchmark-dir>/experiments.jsonl`, next to `manifest.json` /
+  `benchmark.json`. Works for proposed AND promoted benchmarks.
+- **Rule:** append-only; one `understudy.experiment.v1` JSON object per line;
+  the **newest line per `experiment_id` wins** (same superseding rule as
+  `reviews.jsonl`). Updates append the FULL merged record — history is never
+  rewritten.
+- **Schema:** [`schemas/understudy.experiment.v1.schema.json`](../schemas/understudy.experiment.v1.schema.json).
+- **Code:** constants + codec (`makeExperiment`, `appendExperiment`,
+  `readExperiments`, `latestExperiments`, `validateExperiment`) live in
+  `src/benchmark-artifacts.ts`; entry-gated write ops (`createExperiment`,
+  `updateExperiment`, `listExperiments`, `experimentsSummary`) in
+  `src/benchmark-hub-core.ts`. The CLI and MCP tools both call these — one
+  implementation, never forked.
+
+## Record shape (the und-289 mapping)
+
+| Field | und-289 example |
+| --- | --- |
+| `hypothesis` | "full-parameter SFT on qwen3-8b reaches ≥90% exact L3 on the frozen holdout" |
+| `status` | `draft` → `training` → `evaluating` → `concluded` \| `abandoned` |
+| `data_selection.selection_hash` | the curate-trajectories selection hash of the 4,272/546/559 grouped split |
+| `data_selection.source` | "instacart shopper high-confidence CSV (5,377 rows post-dedup)" |
+| `data_selection.splits_sha256` | sha256 of the frozen split artifact |
+| `training` | `{method: "sft", base_model: "qwen3-8b", provider: "fireworks", config: {max_context_length: 1024, class_weights: "clip(sqrt(...), 0.5, 4.0)", …}, cost_estimate: {short_prompt_usd: 3, fuse_usd: 25}}` |
+| `training.approvals` | `[{gate: "consensus_audit", …}, {gate: "customer_data_upload", …}, {gate: "provider_training_spend", …}]` |
+| `produced_artifact` | `{kind: "checkpoint", ref: "<fireworks model id>", sha256: "…"}` |
+| `baseline_run_id` | the frozen `gemma-4-31b-it` incumbent run |
+| `eval_run_ids` | holdout eval runs of the checkpoint |
+| `verdict` | `{decision: "promote" \| "shadow" \| "collect" \| "stop", summary, decided_at}` |
+
+**Approval gates are first-class.** `training.approvals` records gates already
+CLEARED, in order, and appends monotonically across superseding lines (a patch
+can add gates, never drop them). A consumer must refuse to upload customer
+data or create a provider job while the corresponding gate entry
+(`customer_data_upload`, `provider_training_spend`, …) is absent. The record
+itself never spends — it is lineage, not a launcher.
+
+## Surfaces
+
+CLI (JSON in / JSON out; `--input` accepts inline JSON or `@file`):
+
+```sh
+understudy benchmarks experiment create <dir> --input '{"hypothesis": …, "data_selection": …, "training": …}'
+understudy benchmarks experiment update <dir> <experiment_id> --input '{"status": "training", "training": {"approvals": [ … ]}}'
+understudy benchmarks experiment list <dir>
+understudy benchmarks experiment show <dir> <experiment_id>
+```
+
+MCP (`understudy benchmarks mcp`): `create_experiment`, `update_experiment`,
+`list_experiments`; `read_benchmark` additively surfaces
+`experiments: {count, latest: [{experiment_id, status, decision, summary}]}`.
+
+## Run linkage (`experiment_id` on the run request)
+
+`queue_run` / `queueOrCancelRun` accept an additive `experiment_id`. It is
+
+1. shape-validated in `validateRunRequestInput` (`[A-Za-z0-9_.-]+`),
+2. existence-checked against the benchmark's `experiments.jsonl` (404 when the
+   experiment does not exist — create it first), and
+3. passed through `createRunRequest` onto the persisted
+   `understudy.run_request.v1` file.
+
+No executor change: eval rows and `runs/events.jsonl` entries already carry
+`run_id`, so any consumer joins **row/event → run_id → run request →
+experiment_id → experiment**. Close the loop the other way by appending the
+run to the experiment: `update_experiment … {"eval_run_ids": ["run-…"]}`
+(append-only union). Old executors ignore the field harmlessly — it is pure
+provenance, so it deliberately adds no `requires` capability.
+
+## Where the inputs come from
+
+- **`data_selection.selection_hash`** — the `curate-trajectories` skill stamps
+  every contamination-checked selection with a content hash; record that hash
+  (and the frozen-split sha256) here so the train pool is auditable against
+  the benchmark's dev/holdout freeze.
+- **`training.config` / `cost_estimate`** — the `plan-hosted-run` skill's
+  plan/preview/cost artifacts (provider, token math, fuse amounts) drop
+  straight into `training.config` and `training.cost_estimate`; its approval
+  graph maps to `training.approvals` gates.
+- **`produced_artifact`** — the `local-distillation-lab` skill's trained
+  checkpoints/adapters (or a hosted provider's model id) become
+  `{kind, ref, sha256}`.
+- **`baseline_run_id` / `eval_run_ids`** — queue runs through the hub or the
+  benchmarks MCP with `experiment_id` set, then append the resulting run ids
+  via `update_experiment`.
+- **`verdict`** — the distill-classifier four-way
+  (promote / shadow / collect / stop) with the evidence summary and timestamp.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -53,6 +53,17 @@ authenticated MCP/CLI from operations not yet versioned in REST.
 `understudy desktop contract --json` prints the packaged document without
 requiring Desktop to be running.
 
+## `understudy.experiment.v1`
+
+[`understudy.experiment.v1.schema.json`](understudy.experiment.v1.schema.json)
+is one experiment-lineage record in a benchmark dir's `experiments.jsonl`
+sidecar (append-only; newest line per `experiment_id` wins): data selection by
+content hash, training method + config with explicit approval gates BEFORE any
+provider spend, the produced artifact, baseline + eval run ids, and the final
+promote/shadow/collect/stop verdict. Runs link back via the run request's
+additive `experiment_id`. See
+[`docs/experiment-lineage.md`](../docs/experiment-lineage.md).
+
 ## `understudy.eval_result.v1`
 
 [`understudy.eval_result.v1.schema.json`](understudy.eval_result.v1.schema.json)

--- a/schemas/understudy.experiment.v1.schema.json
+++ b/schemas/understudy.experiment.v1.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.experiment.v1.schema.json",
+  "title": "understudy.experiment.v1",
+  "description": "One machine-readable experiment-lineage record: what data was selected (a curate-trajectories selection hash), how a candidate was trained (method + config + explicit approval gates BEFORE any provider spend), what artifact the training produced, which eval runs scored it against which baseline, and the final verdict. Stored as one JSON object per line in an experiments.jsonl file next to the benchmark manifest (manifest.json or benchmark.json), append-only; the newest line per experiment_id supersedes older ones. Eval rows link back via the run request's additive experiment_id → run_id join. Producers may add extra fields; consumers must ignore fields they do not understand.",
+  "type": "object",
+  "required": ["schema_version", "experiment_id", "created_at", "hypothesis", "status", "data_selection", "training", "eval_run_ids"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "understudy.experiment.v1",
+      "description": "Version stamp for this experiment shape."
+    },
+    "experiment_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+$",
+      "description": "Stable id for the experiment across superseding lines (e.g. exp-a1b2c3d4e5f6 or und-289-sft). Immutable once created."
+    },
+    "created_at": {
+      "type": "string",
+      "description": "ISO-8601 timestamp of the FIRST record for this experiment_id. Superseding lines carry it forward unchanged."
+    },
+    "hypothesis": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The falsifiable claim the experiment tests, in the author's words (e.g. 'full-parameter SFT on qwen3-8b reaches >=90% exact L3 on the frozen holdout at <$25 training spend')."
+    },
+    "status": {
+      "enum": ["draft", "training", "evaluating", "concluded", "abandoned"],
+      "description": "Lifecycle: draft (planned, gates pending) -> training -> evaluating -> concluded (verdict recorded) | abandoned."
+    },
+    "data_selection": {
+      "type": "object",
+      "required": ["selection_hash", "source"],
+      "additionalProperties": true,
+      "description": "Provenance of the training/eval data, by content hash — never by path.",
+      "properties": {
+        "selection_hash": {
+          "type": "string",
+          "minLength": 1,
+          "description": "curate-trajectories selection hash (or an equivalent content hash stamped on the selection artifact)."
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where the rows came from (dataset name, capture export, foundry dir slug…)."
+        },
+        "splits_sha256": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional sha256 of the frozen train/dev/holdout split artifact the selection honors."
+        }
+      }
+    },
+    "training": {
+      "type": "object",
+      "required": ["method", "base_model", "config", "provider", "approvals"],
+      "additionalProperties": true,
+      "properties": {
+        "method": {
+          "enum": ["sft", "lora", "distill", "rl", "prompt_only", "none"],
+          "description": "Training method; prompt_only = no weights change (GEPA/prompt experiments); none = baseline-only record."
+        },
+        "base_model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The model trained or prompted (provider id or local model id)."
+        },
+        "config": {
+          "type": "object",
+          "description": "Freeform provider/tool config (epochs, lr, lora_rank, max_context_length, class weights…)."
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Training location: 'local' or a provider id ('fireworks', 'tinker'…)."
+        },
+        "cost_estimate": {
+          "type": ["number", "object"],
+          "description": "Optional pre-spend estimate: a number (USD) or a structured breakdown object (e.g. token counts per prompt format)."
+        },
+        "approvals": {
+          "type": "array",
+          "description": "Approval gates CLEARED so far, in order (append-only across superseding lines). Gates before provider spend are first-class: a consumer must refuse to upload customer data or create a provider job while the corresponding gate entry (e.g. 'customer_data_upload', 'provider_training_spend') is absent.",
+          "items": {
+            "type": "object",
+            "required": ["gate", "approved_by", "at"],
+            "additionalProperties": true,
+            "properties": {
+              "gate": { "type": "string", "minLength": 1, "description": "Gate id (e.g. consensus_audit, customer_data_upload, provider_training_spend)." },
+              "approved_by": { "type": "string", "minLength": 1, "description": "Who cleared it (human name/handle; never 'auto' for spend gates)." },
+              "at": { "type": "string", "minLength": 1, "description": "ISO-8601 timestamp of the approval." }
+            }
+          }
+        }
+      }
+    },
+    "produced_artifact": {
+      "type": "object",
+      "required": ["kind", "ref", "sha256"],
+      "additionalProperties": true,
+      "description": "What the training produced; absent until it exists.",
+      "properties": {
+        "kind": { "type": "string", "minLength": 1, "description": "Artifact kind (checkpoint, adapter, prompt, model_id…)." },
+        "ref": { "type": "string", "minLength": 1, "description": "Where it lives (provider model id, local path, registry ref)." },
+        "sha256": { "type": "string", "minLength": 1, "description": "Content hash of the artifact (or of its manifest for provider-hosted weights)." }
+      }
+    },
+    "baseline_run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional: the frozen-incumbent baseline run (understudy.run_request.v1 run_id) this experiment is judged against."
+    },
+    "eval_run_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "run_ids that evaluated the produced artifact (append-only across superseding lines). Runs also point back: their run request carries the additive experiment_id."
+    },
+    "verdict": {
+      "type": "object",
+      "required": ["decision", "summary", "decided_at"],
+      "additionalProperties": true,
+      "description": "Final judgment; absent until the experiment concludes.",
+      "properties": {
+        "decision": {
+          "enum": ["promote", "shadow", "collect", "stop"],
+          "description": "Four-way outcome: promote (ship it), shadow (run alongside prod), collect (need more data), stop (abandon the direction)."
+        },
+        "summary": { "type": "string", "minLength": 1, "description": "The evidence behind the decision, in prose." },
+        "decided_at": { "type": "string", "minLength": 1, "description": "ISO-8601 timestamp of the decision." }
+      }
+    }
+  }
+}

--- a/src/benchmark-artifacts.ts
+++ b/src/benchmark-artifacts.ts
@@ -57,6 +57,8 @@ export const TASK_FEEDBACK_SCHEMA = "understudy.task_feedback.v1";
 export const REVIEW_POLICY_SCHEMA = "understudy.review_policy.v1";
 /** app-harness.json sidecar: how to launch the user's OWN app per task (the app_replay arm). */
 export const APP_HARNESS_SCHEMA = "understudy.app_harness.v1";
+/** experiments.jsonl sidecar: data-selection → training → artifact → eval → verdict lineage (append-only). */
+export const EXPERIMENT_SCHEMA = "understudy.experiment.v1";
 
 /* ------------------------------------------------------------------ */
 /* JSONL codec                                                         */
@@ -396,6 +398,243 @@ export function readReviewPolicy(benchmarkDir: string): ReviewPolicy {
       ? { require_incumbent_pass: parsed.require_incumbent_pass }
       : {}),
   };
+}
+
+/* ------------------------------------------------------------------ */
+/* Experiments (<benchmark>/experiments.jsonl — append-only sidecar)   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * understudy.experiment.v1 — one machine-readable record of an experiment's
+ * full lineage: what data was selected (a curate-trajectories selection hash),
+ * how a candidate was trained (method + config + explicit approval gates
+ * BEFORE any provider spend — the und-289 shape), what artifact the training
+ * produced, which eval runs scored it against which baseline, and the final
+ * verdict (promote / shadow / collect / stop — the distill-classifier
+ * four-way). Stored append-only next to the benchmark manifest; the newest
+ * line per experiment_id supersedes older ones (same superseding rule as
+ * reviews.jsonl). Eval rows link back via run_request.experiment_id → run_id.
+ */
+export const EXPERIMENT_STATUSES = ["draft", "training", "evaluating", "concluded", "abandoned"] as const;
+export type ExperimentStatus = (typeof EXPERIMENT_STATUSES)[number];
+
+export const EXPERIMENT_METHODS = ["sft", "lora", "distill", "rl", "prompt_only", "none"] as const;
+export type ExperimentMethod = (typeof EXPERIMENT_METHODS)[number];
+
+export const EXPERIMENT_DECISIONS = ["promote", "shadow", "collect", "stop"] as const;
+export type ExperimentDecision = (typeof EXPERIMENT_DECISIONS)[number];
+
+/** One cleared approval gate (e.g. "consensus_audit", "customer_data_upload", "provider_training_spend"). */
+export type ExperimentApproval = { gate: string; approved_by: string; at: string };
+
+export type Experiment = {
+  schema_version: typeof EXPERIMENT_SCHEMA;
+  experiment_id: string;
+  created_at: string;
+  /** The falsifiable claim the experiment tests, in the author's words. */
+  hypothesis: string;
+  status: ExperimentStatus;
+  /** What training/eval data was selected, by provenance hash — never by path. */
+  data_selection: {
+    /** curate-trajectories selection hash (or an equivalent content hash of the selection). */
+    selection_hash: string;
+    /** Where the rows came from (dataset name, capture export, foundry dir slug…). */
+    source: string;
+    /** Optional: sha256 of the frozen train/dev/holdout split artifact. */
+    splits_sha256?: string;
+  };
+  training: {
+    method: ExperimentMethod;
+    base_model: string;
+    /** Freeform provider/tool config (epochs, lr, lora_rank, max_context_length…). */
+    config: Record<string, unknown>;
+    /** Training location: "local" or a provider id ("fireworks", "tinker"…). */
+    provider: string;
+    /** Optional freeform estimate (number = USD, or a structured breakdown object). */
+    cost_estimate?: number | Record<string, unknown>;
+    /**
+     * Approval gates CLEARED so far, in order. Gates before provider spend are
+     * first-class: a consumer must refuse to upload/train while the record
+     * lacks the corresponding gate entry.
+     */
+    approvals: ExperimentApproval[];
+  };
+  /** What the training produced (absent until it exists). */
+  produced_artifact?: { kind: string; ref: string; sha256: string };
+  /** The frozen-incumbent baseline run this experiment is judged against. */
+  baseline_run_id?: string;
+  /** understudy.run_request.v1 run_ids that evaluated the produced artifact. */
+  eval_run_ids: string[];
+  /** Final judgment (absent until concluded). */
+  verdict?: { decision: ExperimentDecision; summary: string; decided_at: string };
+};
+
+export function experimentsPath(benchmarkDir: string): string {
+  return join(benchmarkDir, "experiments.jsonl");
+}
+
+const isNonEmptyString = (v: unknown): v is string => typeof v === "string" && v.length > 0;
+
+/**
+ * Field-level validation for one experiment record. Returns human-readable
+ * errors; empty means valid. Shared by makeExperiment/appendExperiment, the
+ * hub-core write ops, the CLI, and the MCP tools — one implementation.
+ */
+export function validateExperiment(row: unknown): string[] {
+  const errors: string[] = [];
+  const r = asObject(row);
+  if (r.schema_version !== EXPERIMENT_SCHEMA) errors.push(`schema_version must be ${EXPERIMENT_SCHEMA}`);
+  if (!isNonEmptyString(r.experiment_id) || !/^[A-Za-z0-9_.-]+$/.test(r.experiment_id as string)) {
+    errors.push("experiment_id must be a non-empty string of [A-Za-z0-9_.-]");
+  }
+  if (!isNonEmptyString(r.created_at)) errors.push("created_at must be an ISO-8601 string");
+  if (!isNonEmptyString(r.hypothesis)) errors.push("hypothesis must be a non-empty string");
+  if (!EXPERIMENT_STATUSES.includes(r.status as ExperimentStatus)) {
+    errors.push(`status must be one of ${EXPERIMENT_STATUSES.join(", ")}`);
+  }
+  const ds = asObject(r.data_selection);
+  if (!isNonEmptyString(ds.selection_hash)) errors.push("data_selection.selection_hash must be a non-empty string");
+  if (!isNonEmptyString(ds.source)) errors.push("data_selection.source must be a non-empty string");
+  if (ds.splits_sha256 !== undefined && !isNonEmptyString(ds.splits_sha256)) {
+    errors.push("data_selection.splits_sha256 must be a non-empty string when present");
+  }
+  const tr = asObject(r.training);
+  if (!EXPERIMENT_METHODS.includes(tr.method as ExperimentMethod)) {
+    errors.push(`training.method must be one of ${EXPERIMENT_METHODS.join(", ")}`);
+  }
+  if (!isNonEmptyString(tr.base_model)) errors.push("training.base_model must be a non-empty string");
+  if (tr.config === undefined || tr.config === null || typeof tr.config !== "object" || Array.isArray(tr.config)) {
+    errors.push("training.config must be an object (may be empty)");
+  }
+  if (!isNonEmptyString(tr.provider)) errors.push('training.provider must be "local" or a provider id string');
+  if (
+    tr.cost_estimate !== undefined &&
+    typeof tr.cost_estimate !== "number" &&
+    (tr.cost_estimate === null || typeof tr.cost_estimate !== "object" || Array.isArray(tr.cost_estimate))
+  ) {
+    errors.push("training.cost_estimate must be a number (USD) or an object when present");
+  }
+  if (!Array.isArray(tr.approvals)) {
+    errors.push("training.approvals must be an array (empty = no gates cleared yet)");
+  } else {
+    tr.approvals.forEach((a, i) => {
+      const g = asObject(a);
+      if (!isNonEmptyString(g.gate) || !isNonEmptyString(g.approved_by) || !isNonEmptyString(g.at)) {
+        errors.push(`training.approvals[${i}] must be {gate, approved_by, at} non-empty strings`);
+      }
+    });
+  }
+  if (r.produced_artifact !== undefined) {
+    const pa = asObject(r.produced_artifact);
+    if (!isNonEmptyString(pa.kind) || !isNonEmptyString(pa.ref) || !isNonEmptyString(pa.sha256)) {
+      errors.push("produced_artifact must be {kind, ref, sha256} non-empty strings when present");
+    }
+  }
+  if (r.baseline_run_id !== undefined && !isNonEmptyString(r.baseline_run_id)) {
+    errors.push("baseline_run_id must be a non-empty string when present");
+  }
+  if (!Array.isArray(r.eval_run_ids) || !(r.eval_run_ids as unknown[]).every(isNonEmptyString)) {
+    errors.push("eval_run_ids must be an array of run_id strings (empty until runs exist)");
+  }
+  if (r.verdict !== undefined) {
+    const v = asObject(r.verdict);
+    if (!EXPERIMENT_DECISIONS.includes(v.decision as ExperimentDecision)) {
+      errors.push(`verdict.decision must be one of ${EXPERIMENT_DECISIONS.join(", ")}`);
+    }
+    if (!isNonEmptyString(v.summary)) errors.push("verdict.summary must be a non-empty string");
+    if (!isNonEmptyString(v.decided_at)) errors.push("verdict.decided_at must be an ISO-8601 string");
+  }
+  return errors;
+}
+
+/** Reader-side acceptance test for one experiments.jsonl row. */
+export function isExperiment(row: unknown): row is Experiment {
+  return validateExperiment(row).length === 0;
+}
+
+export type ExperimentInput = {
+  experiment_id?: string;
+  created_at?: string;
+  hypothesis: string;
+  status?: ExperimentStatus;
+  data_selection: Experiment["data_selection"];
+  training: {
+    method: ExperimentMethod;
+    base_model: string;
+    config?: Record<string, unknown>;
+    provider: string;
+    cost_estimate?: number | Record<string, unknown>;
+    approvals?: ExperimentApproval[];
+  };
+  produced_artifact?: Experiment["produced_artifact"];
+  baseline_run_id?: string;
+  eval_run_ids?: string[];
+  verdict?: Experiment["verdict"];
+};
+
+/**
+ * The ONE constructor every experiment producer uses. Fills the stamp,
+ * a deterministic-enough id when absent, and the lifecycle defaults
+ * (status draft, no approvals, no eval runs), then VALIDATES — throws on an
+ * invalid record so a malformed experiment can never reach the sidecar.
+ */
+export function makeExperiment(input: ExperimentInput): Experiment {
+  const createdAt = input.created_at ?? new Date().toISOString();
+  const experiment: Experiment = {
+    schema_version: EXPERIMENT_SCHEMA,
+    experiment_id:
+      input.experiment_id ??
+      `exp-${createHash("sha256").update(JSON.stringify({ input, createdAt, nonce: Math.random() })).digest("hex").slice(0, 12)}`,
+    created_at: createdAt,
+    hypothesis: input.hypothesis,
+    status: input.status ?? "draft",
+    data_selection: input.data_selection,
+    training: {
+      method: input.training?.method,
+      base_model: input.training?.base_model,
+      config: input.training?.config ?? {},
+      provider: input.training?.provider,
+      ...(input.training?.cost_estimate !== undefined ? { cost_estimate: input.training.cost_estimate } : {}),
+      approvals: input.training?.approvals ?? [],
+    },
+    ...(input.produced_artifact !== undefined ? { produced_artifact: input.produced_artifact } : {}),
+    ...(input.baseline_run_id !== undefined ? { baseline_run_id: input.baseline_run_id } : {}),
+    eval_run_ids: input.eval_run_ids ?? [],
+    ...(input.verdict !== undefined ? { verdict: input.verdict } : {}),
+  };
+  const errors = validateExperiment(experiment);
+  if (errors.length > 0) throw new Error(`invalid experiment: ${errors.join("; ")}`);
+  return experiment;
+}
+
+export function serializeExperimentLine(experiment: Experiment): string {
+  return serializeJsonlLine(experiment);
+}
+
+/**
+ * Validate + append one experiment line to <benchmarkDir>/experiments.jsonl.
+ * Append-only: updates append a FULL superseding record for the same
+ * experiment_id (never rewrite the file). Throws on an invalid record.
+ */
+export function appendExperiment(benchmarkDir: string, experiment: Experiment): string {
+  const errors = validateExperiment(experiment);
+  if (errors.length > 0) throw new Error(`invalid experiment: ${errors.join("; ")}`);
+  const file = experimentsPath(benchmarkDir);
+  appendJsonlRows(file, [experiment]);
+  return file;
+}
+
+/** Valid experiments from an experiments.jsonl file (invalid rows dropped, lines tolerant). */
+export function readExperiments(file: string): { experiments: Experiment[]; skipped: number } {
+  const { items, skipped } = readJsonlFile(file);
+  return { experiments: items.filter(isExperiment), skipped };
+}
+
+/** Superseding rule: append-only file, newest line per experiment_id wins. */
+export function latestExperiments(experiments: Experiment[]): Record<string, Experiment> {
+  const latest: Record<string, Experiment> = {};
+  for (const experiment of experiments) latest[experiment.experiment_id] = experiment;
+  return latest;
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -32,6 +32,15 @@ import {
   serializeReviewLine,
   serializeTaskFeedbackLine,
   DEFAULT_REVIEW_POLICY,
+  appendExperiment,
+  experimentsPath,
+  latestExperiments,
+  makeExperiment,
+  readExperiments,
+  validateExperiment,
+  EXPERIMENT_SCHEMA,
+  type Experiment,
+  type ExperimentInput,
   type ReviewPolicy,
   type TaskFeedback,
 } from "./benchmark-artifacts.js";
@@ -728,6 +737,8 @@ export type QueueRunBody = {
   calibration_threshold?: unknown;
   /** Optional (additive): replay the user's own app per app-harness.json (arm_kind "app_replay"; capability-gated). */
   app_replay?: unknown;
+  /** Optional (additive): experiments.jsonl experiment this run evaluates (must exist in the sidecar). */
+  experiment_id?: unknown;
 };
 
 export type QueueRunResult = { ok: true; run: RunRequest; execute_hint?: string } | WriteFailure;
@@ -825,9 +836,20 @@ export function queueOrCancelRun(entry: AnyHubEntry | null, body: QueueRunBody):
     // Additive: current-code app replay (validated as a boolean; the executor
     // is capability-gated on "app_replay" so old executors skip, never corrupt).
     app_replay: body.app_replay,
+    // Additive: experiment-lineage cross-link (validated for shape below and
+    // for existence against experiments.jsonl right after).
+    experiment_id: body.experiment_id,
   };
   const errors = validateRunRequestInput(input, knownTaskIds);
   if (errors.length > 0) return { ok: false, error: errors.join("; "), status: 400 };
+  // Cross-link validation: a declared experiment must already exist in the
+  // benchmark's experiments.jsonl sidecar (create_experiment first).
+  if (typeof input.experiment_id === "string") {
+    const { experiments } = readExperiments(experimentsPath(entry.dir));
+    if (!latestExperiments(experiments)[input.experiment_id]) {
+      return { ok: false, error: `unknown experiment_id: ${input.experiment_id} (create_experiment first)`, status: 404 };
+    }
+  }
   // Reject selections that resolve to zero tasks up front (clear 400, not a
   // queued request the executor immediately fails).
   const selected = selectTasks(manifestForSelection, {
@@ -847,6 +869,7 @@ export function queueOrCancelRun(entry: AnyHubEntry | null, body: QueueRunBody):
     incumbent_models: input.incumbent_models as string[] | undefined,
     calibration_threshold: input.calibration_threshold as number | undefined,
     app_replay: input.app_replay as boolean | undefined,
+    experiment_id: input.experiment_id as string | undefined,
   });
   return { ok: true, run, execute_hint: `understudy runs execute --benchmark ${entry.dir} --watch` };
 }
@@ -1059,4 +1082,128 @@ export function submitTaskFeedback(
   });
   fs.appendFileSync(path.join(entry.dir, "feedback.jsonl"), serializeTaskFeedbackLine(feedback), "utf8");
   return { ok: true, feedback, handoff: buildTaskFeedbackHandoff(entry.dir, input.task_id, feedback.feedback) };
+}
+
+/* ------------------------------------------------------------------ */
+/* Experiment lineage (experiments.jsonl — append-only, newest per     */
+/* experiment_id wins). NEW exported functions only.                   */
+/* ------------------------------------------------------------------ */
+
+export type ExperimentWriteResult = { ok: true; experiment: Experiment; file: string } | WriteFailure;
+
+/** Both proposed and promoted benchmarks may carry experiments; read-only entries may not. */
+function experimentWriteGate(entry: AnyHubEntry | null): WriteFailure | null {
+  if (!entry || entry.kind === "invalid") return { ok: false, error: "unknown benchmark", status: 404 };
+  if (entry.readOnly) {
+    return {
+      ok: false,
+      error: "This entry is read-only (demo/fixture source); experiments cannot be written here.",
+      status: 403,
+    };
+  }
+  return null;
+}
+
+/**
+ * Validate + append one NEW understudy.experiment.v1 line to
+ * experiments.jsonl next to the benchmark manifest. Refuses to create an
+ * experiment_id that already exists (use updateExperiment to supersede).
+ */
+export function createExperiment(entry: AnyHubEntry | null, input: ExperimentInput): ExperimentWriteResult {
+  const gate = experimentWriteGate(entry);
+  if (gate) return gate;
+  const dir = (entry as HubEntry | ProposedHubEntry).dir;
+  let experiment: Experiment;
+  try {
+    experiment = makeExperiment(input);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 400 };
+  }
+  const existing = latestExperiments(readExperiments(experimentsPath(dir)).experiments);
+  if (existing[experiment.experiment_id]) {
+    return { ok: false, error: `experiment_id already exists: ${experiment.experiment_id} (use update)`, status: 409 };
+  }
+  const file = appendExperiment(dir, experiment);
+  return { ok: true, experiment, file };
+}
+
+/**
+ * Supersede one experiment: merge a patch over its newest record and append
+ * the FULL merged record (append-only, newest-wins — history is never
+ * rewritten). Top-level fields replace wholesale except `training.approvals`
+ * and `eval_run_ids`, which APPEND (an approval gate, once cleared and
+ * recorded, is never silently dropped by a later patch).
+ */
+export function updateExperiment(
+  entry: AnyHubEntry | null,
+  experimentId: unknown,
+  patch: Record<string, unknown>,
+): ExperimentWriteResult {
+  const gate = experimentWriteGate(entry);
+  if (gate) return gate;
+  const dir = (entry as HubEntry | ProposedHubEntry).dir;
+  if (typeof experimentId !== "string" || experimentId.length === 0) {
+    return { ok: false, error: "experiment_id (string) is required", status: 400 };
+  }
+  const latest = latestExperiments(readExperiments(experimentsPath(dir)).experiments)[experimentId];
+  if (!latest) return { ok: false, error: `unknown experiment_id: ${experimentId}`, status: 404 };
+
+  const patchTraining = (patch.training ?? null) as Record<string, unknown> | null;
+  const merged = {
+    ...latest,
+    ...patch,
+    // Immutable identity/lineage fields — a patch can never rewrite them.
+    schema_version: EXPERIMENT_SCHEMA,
+    experiment_id: experimentId,
+    created_at: latest.created_at,
+    training: {
+      ...latest.training,
+      ...(patchTraining ?? {}),
+      approvals: [
+        ...latest.training.approvals,
+        ...(Array.isArray(patchTraining?.approvals) ? (patchTraining.approvals as Experiment["training"]["approvals"]) : []),
+      ],
+    },
+    eval_run_ids: [
+      ...new Set([
+        ...latest.eval_run_ids,
+        ...(Array.isArray(patch.eval_run_ids) ? (patch.eval_run_ids as string[]) : []),
+      ]),
+    ],
+  } as Experiment;
+  const errors = validateExperiment(merged);
+  if (errors.length > 0) return { ok: false, error: errors.join("; "), status: 400 };
+  const file = appendExperiment(dir, merged);
+  return { ok: true, experiment: merged, file };
+}
+
+export type ListExperimentsResult = {
+  /** Latest record per experiment_id, oldest created_at first. */
+  experiments: Experiment[];
+  /** Total superseding lines in the sidecar (history depth). */
+  total_lines: number;
+  skipped: number;
+};
+
+/** Latest record per experiment_id from a benchmark dir's experiments.jsonl. */
+export function listExperiments(dir: string): ListExperimentsResult {
+  const { experiments, skipped } = readExperiments(experimentsPath(dir));
+  const latest = Object.values(latestExperiments(experiments)).sort(
+    (a, b) => a.created_at.localeCompare(b.created_at) || a.experiment_id.localeCompare(b.experiment_id),
+  );
+  return { experiments: latest, total_lines: experiments.length, skipped };
+}
+
+/** Compact additive projection for read_benchmark: count + latest per-experiment status/verdict. */
+export function experimentsSummary(dir: string): { count: number; latest: { experiment_id: string; status: string; decision: string | null; summary: string | null }[] } {
+  const { experiments } = listExperiments(dir);
+  return {
+    count: experiments.length,
+    latest: experiments.map((e) => ({
+      experiment_id: e.experiment_id,
+      status: e.status,
+      decision: e.verdict?.decision ?? null,
+      summary: e.verdict?.summary ?? null,
+    })),
+  };
 }

--- a/src/benchmarks-mcp.ts
+++ b/src/benchmarks-mcp.ts
@@ -21,7 +21,11 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import {
   applyAutoAccepts,
+  createExperiment,
+  experimentsSummary,
   getEntry,
+  listExperiments,
+  updateExperiment,
   loadHub,
   loadTaskSidecars,
   queueOrCancelRun,
@@ -296,6 +300,8 @@ function toolReadBenchmark(args: Obj): unknown {
       // defaults when the file is absent) + the incumbent/trivial calibration.
       review_policy: entry.reviewPolicy ?? null,
       calibration: calibrationOut(entry.calibration),
+      // Additive: experiment-lineage sidecar summary (experiments.jsonl).
+      experiments: experimentsSummary(entry.dir),
       cross_check_errors: entry.crossCheckErrors,
       tasks: entry.tasks.map((t) => ({
         task_id: t.task_id,
@@ -322,6 +328,8 @@ function toolReadBenchmark(args: Obj): unknown {
     // (incumbent gate counts and trivial-arm floors when arms ran).
     calibration_present: entry.calibration != null,
     calibration: calibrationOut(entry.calibration),
+    // Additive: experiment-lineage sidecar summary (experiments.jsonl).
+    experiments: experimentsSummary(entry.dir),
     tasks: entry.manifest.tasks.map((t) => ({
       task_id: t.task_id,
       split: t.split,
@@ -526,6 +534,8 @@ function toolQueueRun(args: Obj): unknown {
     // Additive: incumbent-baseline arm + calibration threshold pass-through.
     incumbent_models: args.incumbent_models,
     calibration_threshold: args.calibration_threshold,
+    // Additive: experiment-lineage cross-link (validated against experiments.jsonl).
+    experiment_id: args.experiment_id,
   });
   if (!result.ok) throw new ToolError(result.error);
   return { ok: true, run_id: result.run.run_id, run: result.run, execute_hint: result.execute_hint };
@@ -557,6 +567,31 @@ function toolRunStatus(args: Obj): unknown {
     rows: rowsSummary(rows),
     per_task: [...new Set(rows.map((r) => r.task_id))].sort().map((taskId) => ({ task_id: taskId, ...taskScores(rows, taskId) })),
   };
+}
+
+/* ---------------- experiment lineage (experiments.jsonl) ---------------- */
+
+function toolCreateExperiment(args: Obj): unknown {
+  const slug = requireString(args, "slug");
+  // Shared validation + append (dist/benchmark-hub-core.js →
+  // dist/benchmark-artifacts.js) — one understudy.experiment.v1 line into
+  // experiments.jsonl next to the benchmark manifest.
+  const result = createExperiment(getEntry(slug), asObject(args.experiment) as never);
+  if (!result.ok) throw new ToolError(result.error);
+  return { ok: true, experiment: result.experiment, file: result.file };
+}
+
+function toolUpdateExperiment(args: Obj): unknown {
+  const slug = requireString(args, "slug");
+  const result = updateExperiment(getEntry(slug), args.experiment_id, asObject(args.patch));
+  if (!result.ok) throw new ToolError(result.error);
+  return { ok: true, experiment: result.experiment, file: result.file };
+}
+
+function toolListExperiments(args: Obj): unknown {
+  const entry = requireEntry(requireString(args, "slug"));
+  if (entry.kind === "invalid") throw new ToolError(`benchmark dir is invalid: ${entry.errors.join("; ")}`);
+  return listExperiments(entry.dir);
 }
 
 /* ---------------- MCP wiring ---------------- */
@@ -704,8 +739,69 @@ export const BENCHMARKS_TOOLS = [
           maximum: 1,
           description: "Incumbent calibration pass threshold on the strict score (default 1).",
         },
+        experiment_id: {
+          type: "string",
+          description:
+            "Optional understudy.experiment.v1 experiment this run evaluates; must already exist in the " +
+            "benchmark's experiments.jsonl (create_experiment first). Recorded on the run request so rows/" +
+            "events join back to the experiment via run_id.",
+        },
       },
       required: ["slug", "models"],
+    },
+  },
+  {
+    name: "create_experiment",
+    description:
+      "Append one NEW understudy.experiment.v1 line to experiments.jsonl next to the benchmark manifest: " +
+      "hypothesis, data_selection (curate-trajectories selection hash + source), training plan (method, " +
+      "base_model, config, provider, cost_estimate, cleared approval gates), optional produced_artifact / " +
+      "baseline_run_id / eval_run_ids / verdict. Append-only; refuses an existing experiment_id (use " +
+      "update_experiment). Records lineage only — never uploads data or spends.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: { type: "string", description: "Slug from list_benchmarks." },
+        experiment: {
+          type: "object",
+          description:
+            "The experiment record. Required: hypothesis (string), data_selection {selection_hash, source, " +
+            "splits_sha256?}, training {method sft|lora|distill|rl|prompt_only|none, base_model, provider " +
+            "('local' or a provider id), config?, cost_estimate?, approvals?: [{gate, approved_by, at}]}. " +
+            "Optional: experiment_id (generated when omitted), status (default draft), produced_artifact " +
+            "{kind, ref, sha256}, baseline_run_id, eval_run_ids, verdict {decision promote|shadow|collect|stop, summary, decided_at}.",
+        },
+      },
+      required: ["slug", "experiment"],
+    },
+  },
+  {
+    name: "update_experiment",
+    description:
+      "Supersede one experiment: merge a patch over its newest experiments.jsonl record and append the FULL " +
+      "merged record (append-only, newest per experiment_id wins — history is never rewritten). " +
+      "training.approvals and eval_run_ids APPEND (cleared gates are never dropped); experiment_id and " +
+      "created_at are immutable. Typical patches: status flips, a new approval gate, produced_artifact after " +
+      "training, eval_run_ids after runs, the final verdict.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: { type: "string" },
+        experiment_id: { type: "string" },
+        patch: { type: "object", description: "Partial understudy.experiment.v1 fields to merge over the newest record." },
+      },
+      required: ["slug", "experiment_id", "patch"],
+    },
+  },
+  {
+    name: "list_experiments",
+    description:
+      "Latest understudy.experiment.v1 record per experiment_id from the benchmark's experiments.jsonl " +
+      "(append-only sidecar; newest line per experiment_id wins), plus total superseding line count.",
+    inputSchema: {
+      type: "object",
+      properties: { slug: { type: "string" } },
+      required: ["slug"],
     },
   },
   {
@@ -734,6 +830,9 @@ export function callBenchmarksTool(name: string, args: Obj): unknown {
     case "submit_feedback": return toolSubmitFeedback(args);
     case "queue_run": return toolQueueRun(args);
     case "run_status": return toolRunStatus(args);
+    case "create_experiment": return toolCreateExperiment(args);
+    case "update_experiment": return toolUpdateExperiment(args);
+    case "list_experiments": return toolListExperiments(args);
     default: throw new ToolError(`unknown tool: ${name}`);
   }
 }

--- a/src/commands/benchmarks.ts
+++ b/src/commands/benchmarks.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { Command } from "commander";
 
 /**
@@ -27,6 +28,74 @@ export function registerBenchmarksCommand(program: Command): void {
     .action(async (options: { root: string[] }) => {
       const { runBenchmarksMcpServer } = await import("../benchmarks-mcp.js");
       await runBenchmarksMcpServer(options.root);
+    });
+
+  // Experiment lineage (experiments.jsonl — understudy.experiment.v1,
+  // append-only, newest line per experiment_id wins). JSON in / JSON out so
+  // agents can round-trip records; shared read/write cores with the MCP tools.
+  const experiment = benchmarks
+    .command("experiment")
+    .description("Machine-readable experiment lineage: data selection → training (+approval gates) → artifact → eval runs → verdict");
+
+  /** Parse --input (inline JSON or @file) into an object. */
+  const parseJsonOption = (raw: string): Record<string, unknown> => {
+    const text = raw.startsWith("@") ? readFileSync(raw.slice(1), "utf8") : raw;
+    const parsed = JSON.parse(text);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("--input must be a JSON object");
+    return parsed as Record<string, unknown>;
+  };
+
+  const loadDirEntry = async (dir: string) => {
+    const path = await import("node:path");
+    const { loadEntryFromDir } = await import("../benchmark-hub-core.js");
+    const resolved = path.resolve(dir);
+    const entry = loadEntryFromDir(resolved, "data-dir", path.basename(resolved), false);
+    if (!entry) throw new Error(`not a benchmark dir (no benchmark.json or manifest.json): ${resolved}`);
+    return entry;
+  };
+
+  experiment
+    .command("create <dir>")
+    .description("Append one NEW understudy.experiment.v1 line to <dir>/experiments.jsonl (validated; JSON out)")
+    .requiredOption("--input <json>", "Experiment record as inline JSON or @file (hypothesis, data_selection, training, ...)")
+    .action(async (dir: string, options: { input: string }) => {
+      const { createExperiment } = await import("../benchmark-hub-core.js");
+      const result = createExperiment(await loadDirEntry(dir), parseJsonOption(options.input) as never);
+      if (!result.ok) throw new Error(result.error);
+      console.error(`appended ${result.file}`);
+      console.log(JSON.stringify(result.experiment, null, 2));
+    });
+
+  experiment
+    .command("update <dir> <experiment_id>")
+    .description("Supersede one experiment: merge --input over its newest record and append the full merged record (approvals + eval_run_ids append; JSON out)")
+    .requiredOption("--input <json>", "Partial understudy.experiment.v1 fields as inline JSON or @file")
+    .action(async (dir: string, experimentId: string, options: { input: string }) => {
+      const { updateExperiment } = await import("../benchmark-hub-core.js");
+      const result = updateExperiment(await loadDirEntry(dir), experimentId, parseJsonOption(options.input));
+      if (!result.ok) throw new Error(result.error);
+      console.error(`appended ${result.file}`);
+      console.log(JSON.stringify(result.experiment, null, 2));
+    });
+
+  experiment
+    .command("list <dir>")
+    .description("Latest record per experiment_id from <dir>/experiments.jsonl (JSON out)")
+    .action(async (dir: string) => {
+      const path = await import("node:path");
+      const { listExperiments } = await import("../benchmark-hub-core.js");
+      console.log(JSON.stringify(listExperiments(path.resolve(dir)), null, 2));
+    });
+
+  experiment
+    .command("show <dir> <experiment_id>")
+    .description("Newest record for one experiment_id (JSON out; exits non-zero when unknown)")
+    .action(async (dir: string, experimentId: string) => {
+      const path = await import("node:path");
+      const { listExperiments } = await import("../benchmark-hub-core.js");
+      const found = listExperiments(path.resolve(dir)).experiments.find((e) => e.experiment_id === experimentId);
+      if (!found) throw new Error(`unknown experiment_id: ${experimentId}`);
+      console.log(JSON.stringify(found, null, 2));
     });
 
   benchmarks

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -160,6 +160,12 @@ export type RunRequest = {
    * claim. Capability-gated via requires: ["app_replay"].
    */
   app_replay?: boolean;
+  /**
+   * Additive (absent when unused): the understudy.experiment.v1 experiment_id
+   * this run evaluates. Pure passthrough provenance — rows/events join back
+   * to the experiment via run_id → this request; executors need no capability.
+   */
+  experiment_id?: string;
   /** Additive: the executor that atomically claimed this request (stale-watcher hijack guard). */
   claimed_by?: RunClaim | null;
   /** Additive: recorded when an executor skipped this request because it lacks a required capability. */
@@ -298,6 +304,8 @@ export type RunRequestInput = {
   prompt_overrides?: unknown;
   /** Optional (additive): replay the user's own app per app-harness.json (arm_kind "app_replay"). */
   app_replay?: unknown;
+  /** Optional (additive): understudy.experiment.v1 experiment_id this run evaluates (provenance passthrough). */
+  experiment_id?: unknown;
 };
 
 export const MAX_MODELS_PER_RUN = 8;
@@ -357,6 +365,10 @@ export function validateRunRequestInput(input: RunRequestInput, knownTaskIds: st
   if (timeout !== undefined && (typeof timeout !== "number" || !Number.isFinite(timeout) || timeout <= 0)) {
     errors.push("rollout_timeout_seconds must be a positive number of seconds");
   }
+  const experimentId = input.experiment_id;
+  if (experimentId !== undefined && (typeof experimentId !== "string" || !/^[A-Za-z0-9_.-]+$/.test(experimentId))) {
+    errors.push("experiment_id must be a non-empty string of [A-Za-z0-9_.-]");
+  }
   const appReplay = input.app_replay;
   if (appReplay !== undefined && typeof appReplay !== "boolean") {
     errors.push("app_replay must be a boolean");
@@ -391,7 +403,7 @@ export function validateRunRequestInput(input: RunRequestInput, knownTaskIds: st
 /** Create + persist a queued run request. Caller validates first. */
 export function createRunRequest(
   benchmarkDir: string,
-  input: { benchmark_id: string; models: string[]; split: RunSplit; tasks: "all" | string[]; rollouts_per_task: number; incumbent_models?: string[]; calibration_threshold?: number; trivial_arms?: TrivialArmKind[]; rollout_timeout_seconds?: number; prompt_overrides?: PromptOverride[]; app_replay?: boolean },
+  input: { benchmark_id: string; models: string[]; split: RunSplit; tasks: "all" | string[]; rollouts_per_task: number; incumbent_models?: string[]; calibration_threshold?: number; trivial_arms?: TrivialArmKind[]; rollout_timeout_seconds?: number; prompt_overrides?: PromptOverride[]; app_replay?: boolean; experiment_id?: string },
   now: Date = new Date(),
 ): RunRequest {
   // Writers declare the capabilities their feature use depends on, so an old
@@ -424,6 +436,9 @@ export function createRunRequest(
     ...(input.rollout_timeout_seconds !== undefined ? { rollout_timeout_seconds: input.rollout_timeout_seconds } : {}),
     ...(input.prompt_overrides && input.prompt_overrides.length > 0 ? { prompt_overrides: input.prompt_overrides } : {}),
     ...(input.app_replay === true ? { app_replay: true } : {}),
+    // Additive provenance passthrough — no capability entry needed: an old
+    // executor ignoring it changes nothing (rows join via run_id anyway).
+    ...(input.experiment_id !== undefined ? { experiment_id: input.experiment_id } : {}),
     ...(requires.length > 0 ? { requires } : {}),
   };
   writeRunRequest(benchmarkDir, request);

--- a/tests/benchmarks-mcp.test.mjs
+++ b/tests/benchmarks-mcp.test.mjs
@@ -491,8 +491,10 @@ describe("server wiring", () => {
       names,
       [
         "apply_auto_accepts",
+        "create_experiment",
         "diff_rollouts",
         "list_benchmarks",
+        "list_experiments",
         "queue_run",
         "read_benchmark",
         "read_rollout",
@@ -500,6 +502,7 @@ describe("server wiring", () => {
         "run_status",
         "submit_feedback",
         "submit_review",
+        "update_experiment",
       ],
     );
     assert.equal(responses.get(2).result.tools.length, BENCHMARKS_TOOLS.length);

--- a/tests/experiment-lineage.test.mjs
+++ b/tests/experiment-lineage.test.mjs
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+// Everything is exercised through the compiled dist — the same anti-drift
+// pattern as tests/benchmarks-mcp.test.mjs.
+import {
+  EXPERIMENT_SCHEMA,
+  EXPERIMENT_STATUSES,
+  EXPERIMENT_METHODS,
+  EXPERIMENT_DECISIONS,
+  appendExperiment,
+  experimentsPath,
+  latestExperiments,
+  makeExperiment,
+  readExperiments,
+  validateExperiment,
+} from "../dist/benchmark-artifacts.js";
+import { createExperiment, listExperiments, loadEntryFromDir, queueOrCancelRun, updateExperiment } from "../dist/benchmark-hub-core.js";
+import { callBenchmarksTool } from "../dist/benchmarks-mcp.js";
+import { createRunRequest, readRunRequest, runRequestPath, validateRunRequestInput } from "../dist/run-executor.js";
+
+const bin = path.resolve("dist/bin.js");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "experiment-lineage-"));
+process.env.BENCHMARK_HUB_DATA_DIR = tmp;
+delete process.env.BENCHMARK_HUB_DEMO;
+after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+const schema = JSON.parse(fs.readFileSync(path.resolve("schemas/understudy.experiment.v1.schema.json"), "utf8"));
+
+/* ---------------- fixtures ---------------- */
+
+// A minimal VALID promoted benchmark dir (validateBenchmarkManifest must pass).
+const benchDir = path.join(tmp, "bench");
+fs.mkdirSync(benchDir, { recursive: true });
+fs.writeFileSync(
+  path.join(benchDir, "benchmark.json"),
+  JSON.stringify({
+    schema_version: "understudy.benchmark.v1",
+    benchmark_id: "lineage-bench",
+    name: "Lineage bench",
+    provenance: { origin: "authored" },
+    taxonomy: [{ category_id: "cat-a" }],
+    tasks: [{ task_id: "t1", category_id: "cat-a", genesis: "synthesized", split: "holdout" }],
+    environment: { format: "verifiers.v1", package_ref: "pkg" },
+    verifier: { kind: "reward-fns", strict_metric: "strict" },
+  }),
+);
+const entry = () => loadEntryFromDir(benchDir, "data-dir", "bench", false);
+const slug = "data--bench";
+
+// The und-289 shape.
+const und289 = () => ({
+  experiment_id: "und-289-sft",
+  hypothesis: "Fireworks full-parameter SFT on qwen3-8b reaches >=90% exact L3 on the frozen holdout",
+  data_selection: {
+    selection_hash: "sel-abc123",
+    source: "instacart shopper high-confidence CSV (5,377 rows post-dedup)",
+    splits_sha256: "deadbeef",
+  },
+  training: {
+    method: "sft",
+    base_model: "qwen3-8b",
+    provider: "fireworks",
+    config: { max_context_length: 1024, epochs: 3 },
+    cost_estimate: { short_prompt_usd: 3, fuse_usd: 25 },
+    approvals: [{ gate: "consensus_audit", approved_by: "luis", at: "2026-07-21T00:00:00Z" }],
+  },
+});
+
+/* ---------------- schema + codec ---------------- */
+
+describe("understudy.experiment.v1 schema + codec", () => {
+  it("makeExperiment fills stamp/defaults and satisfies the JSON schema's contract", () => {
+    const exp = makeExperiment(und289());
+    assert.equal(exp.schema_version, EXPERIMENT_SCHEMA);
+    assert.equal(exp.status, "draft");
+    assert.deepEqual(exp.eval_run_ids, []);
+    assert.ok(exp.created_at);
+    for (const key of schema.required) assert.ok(key in exp, `experiment is missing ${key}`);
+    assert.deepEqual(schema.properties.status.enum, [...EXPERIMENT_STATUSES]);
+    assert.deepEqual(schema.properties.training.properties.method.enum, [...EXPERIMENT_METHODS]);
+    assert.deepEqual(schema.properties.verdict.properties.decision.enum, [...EXPERIMENT_DECISIONS]);
+    assert.equal(schema.properties.schema_version.const, EXPERIMENT_SCHEMA);
+    assert.deepEqual(validateExperiment(exp), []);
+  });
+
+  it("generates an experiment_id when omitted", () => {
+    const { experiment_id, ...rest } = und289();
+    const exp = makeExperiment(rest);
+    assert.match(exp.experiment_id, /^exp-[0-9a-f]{12}$/);
+  });
+
+  it("validation rejects bad status, method, decision, approvals, and artifact shapes", () => {
+    const base = makeExperiment(und289());
+    assert.ok(validateExperiment({ ...base, status: "done" }).some((e) => e.includes("status")));
+    assert.ok(validateExperiment({ ...base, training: { ...base.training, method: "dpo" } }).some((e) => e.includes("method")));
+    assert.ok(validateExperiment({ ...base, verdict: { decision: "ship", summary: "s", decided_at: "t" } }).some((e) => e.includes("decision")));
+    assert.ok(validateExperiment({ ...base, training: { ...base.training, approvals: [{ gate: "x" }] } }).some((e) => e.includes("approvals")));
+    assert.ok(validateExperiment({ ...base, produced_artifact: { kind: "checkpoint" } }).some((e) => e.includes("produced_artifact")));
+    assert.ok(validateExperiment({ ...base, data_selection: { source: "s" } }).some((e) => e.includes("selection_hash")));
+    assert.throws(() => makeExperiment({ ...und289(), hypothesis: "" }), /invalid experiment/);
+  });
+
+  it("append is append-only and the newest line per experiment_id wins", () => {
+    const dir = fs.mkdtempSync(path.join(tmp, "codec-"));
+    const first = makeExperiment(und289());
+    appendExperiment(dir, first);
+    appendExperiment(dir, { ...first, status: "training" });
+    appendExperiment(dir, makeExperiment({ ...und289(), experiment_id: "other" }));
+    const { experiments, skipped } = readExperiments(experimentsPath(dir));
+    assert.equal(skipped, 0);
+    assert.equal(experiments.length, 3);
+    const latest = latestExperiments(experiments);
+    assert.equal(latest["und-289-sft"].status, "training");
+    assert.equal(latest["other"].status, "draft");
+    assert.throws(() => appendExperiment(dir, { ...first, status: "nope" }), /invalid experiment/);
+    // invalid appended lines (foreign writers) are dropped, never fatal
+    fs.appendFileSync(experimentsPath(dir), '{"schema_version":"other"}\nnot json\n');
+    const reread = readExperiments(experimentsPath(dir));
+    assert.equal(reread.experiments.length, 3);
+    assert.equal(reread.skipped, 1);
+  });
+});
+
+/* ---------------- hub-core write ops ---------------- */
+
+describe("createExperiment / updateExperiment / listExperiments", () => {
+  it("creates, rejects duplicates, and supersedes with approval/eval-run append semantics", () => {
+    const created = createExperiment(entry(), und289());
+    assert.equal(created.ok, true);
+    assert.equal(created.experiment.experiment_id, "und-289-sft");
+
+    const dup = createExperiment(entry(), und289());
+    assert.equal(dup.ok, false);
+    assert.equal(dup.status, 409);
+
+    const bad = createExperiment(entry(), { ...und289(), experiment_id: "bad", training: { method: "sft" } });
+    assert.equal(bad.ok, false);
+    assert.equal(bad.status, 400);
+
+    const updated = updateExperiment(entry(), "und-289-sft", {
+      status: "evaluating",
+      created_at: "1999-01-01T00:00:00Z", // immutable — must be ignored
+      training: { approvals: [{ gate: "provider_training_spend", approved_by: "luis", at: "2026-07-22T00:00:00Z" }] },
+      produced_artifact: { kind: "checkpoint", ref: "fireworks/qwen3-8b-und289", sha256: "cafe" },
+      eval_run_ids: ["run-1"],
+    });
+    assert.equal(updated.ok, true);
+    assert.equal(updated.experiment.status, "evaluating");
+    assert.equal(updated.experiment.created_at, created.experiment.created_at);
+    assert.deepEqual(updated.experiment.training.approvals.map((a) => a.gate), ["consensus_audit", "provider_training_spend"]);
+    assert.equal(updated.experiment.training.base_model, "qwen3-8b"); // merged, not replaced
+    assert.deepEqual(updated.experiment.eval_run_ids, ["run-1"]);
+
+    const again = updateExperiment(entry(), "und-289-sft", { eval_run_ids: ["run-1", "run-2"] });
+    assert.deepEqual(again.experiment.eval_run_ids, ["run-1", "run-2"]); // union, no dup
+
+    assert.equal(updateExperiment(entry(), "nope", { status: "abandoned" }).status, 404);
+
+    const listed = listExperiments(benchDir);
+    assert.equal(listed.experiments.length, 1);
+    assert.equal(listed.total_lines, 3); // create + 2 superseding updates
+    assert.equal(listed.experiments[0].status, "evaluating");
+  });
+});
+
+/* ---------------- MCP tools ---------------- */
+
+describe("benchmarks MCP experiment tools", () => {
+  it("create/update/list round-trip through callBenchmarksTool", () => {
+    const created = callBenchmarksTool("create_experiment", {
+      slug,
+      experiment: { ...und289(), experiment_id: "mcp-exp" },
+    });
+    assert.equal(created.ok, true);
+
+    const updated = callBenchmarksTool("update_experiment", {
+      slug,
+      experiment_id: "mcp-exp",
+      patch: { status: "concluded", verdict: { decision: "collect", summary: "tail classes underrepresented", decided_at: "2026-07-22T01:00:00Z" } },
+    });
+    assert.equal(updated.experiment.verdict.decision, "collect");
+
+    const listed = callBenchmarksTool("list_experiments", { slug });
+    assert.deepEqual(listed.experiments.map((e) => e.experiment_id).sort(), ["mcp-exp", "und-289-sft"]);
+
+    assert.throws(() => callBenchmarksTool("update_experiment", { slug, experiment_id: "ghost", patch: {} }), /unknown experiment_id/);
+    assert.throws(
+      () => callBenchmarksTool("create_experiment", { slug, experiment: { hypothesis: "x" } }),
+      /invalid experiment/,
+    );
+  });
+
+  it("read_benchmark additively surfaces experiment count + latest verdicts", () => {
+    const out = callBenchmarksTool("read_benchmark", { slug });
+    assert.equal(out.experiments.count, 2);
+    const mcp = out.experiments.latest.find((e) => e.experiment_id === "mcp-exp");
+    assert.equal(mcp.decision, "collect");
+    assert.equal(mcp.status, "concluded");
+  });
+});
+
+/* ---------------- run-request passthrough ---------------- */
+
+describe("run_request experiment_id passthrough", () => {
+  it("validateRunRequestInput accepts a well-formed id and rejects bad shapes", () => {
+    const base = { benchmark_id: "b", models: ["m"], split: "all", tasks: "all", rollouts_per_task: 1 };
+    assert.deepEqual(validateRunRequestInput({ ...base, experiment_id: "und-289-sft" }, []), []);
+    assert.deepEqual(validateRunRequestInput(base, []), []); // absent = fine
+    assert.ok(validateRunRequestInput({ ...base, experiment_id: "" }, []).some((e) => e.includes("experiment_id")));
+    assert.ok(validateRunRequestInput({ ...base, experiment_id: "a b" }, []).some((e) => e.includes("experiment_id")));
+    assert.ok(validateRunRequestInput({ ...base, experiment_id: 7 }, []).some((e) => e.includes("experiment_id")));
+  });
+
+  it("createRunRequest persists the field only when present (old shape otherwise)", () => {
+    const dir = fs.mkdtempSync(path.join(tmp, "runs-"));
+    const withExp = createRunRequest(dir, { benchmark_id: "b", models: ["m"], split: "all", tasks: "all", rollouts_per_task: 1, experiment_id: "und-289-sft" });
+    const persisted = readRunRequest(runRequestPath(dir, withExp.run_id));
+    assert.equal(persisted.experiment_id, "und-289-sft");
+    assert.ok(!("requires" in persisted), "provenance passthrough must not add a capability gate");
+    const bare = createRunRequest(dir, { benchmark_id: "b", models: ["m"], split: "all", tasks: "all", rollouts_per_task: 1 });
+    assert.ok(!("experiment_id" in readRunRequest(runRequestPath(dir, bare.run_id))));
+  });
+
+  it("queue_run cross-checks the experiment against experiments.jsonl", () => {
+    const missing = queueOrCancelRun(entry(), { models: ["m"], tasks: "all", split: "all", rollouts_per_task: 1, experiment_id: "ghost" });
+    assert.equal(missing.ok, false);
+    assert.equal(missing.status, 404);
+    const ok = queueOrCancelRun(entry(), { models: ["m"], tasks: "all", split: "all", rollouts_per_task: 1, experiment_id: "und-289-sft" });
+    assert.equal(ok.ok, true);
+    assert.equal(ok.run.experiment_id, "und-289-sft");
+  });
+});
+
+/* ---------------- CLI round-trip ---------------- */
+
+describe("understudy benchmarks experiment CLI", () => {
+  const run = (...args) => spawnSync(process.execPath, [bin, "benchmarks", "experiment", ...args], { encoding: "utf8" });
+
+  it("create/list/show/update round-trip JSON", () => {
+    const cliDir = path.join(tmp, "cli-bench");
+    fs.mkdirSync(cliDir, { recursive: true });
+    fs.copyFileSync(path.join(benchDir, "benchmark.json"), path.join(cliDir, "benchmark.json"));
+
+    const created = run("create", cliDir, "--input", JSON.stringify({ ...und289(), experiment_id: "cli-exp" }));
+    assert.equal(created.status, 0, created.stderr);
+    assert.equal(JSON.parse(created.stdout).experiment_id, "cli-exp");
+
+    const updated = run("update", cliDir, "cli-exp", "--input", JSON.stringify({ status: "training" }));
+    assert.equal(updated.status, 0, updated.stderr);
+    assert.equal(JSON.parse(updated.stdout).status, "training");
+
+    const listed = run("list", cliDir);
+    assert.equal(listed.status, 0, listed.stderr);
+    const list = JSON.parse(listed.stdout);
+    assert.equal(list.experiments.length, 1);
+    assert.equal(list.total_lines, 2);
+
+    const shown = run("show", cliDir, "cli-exp");
+    assert.equal(shown.status, 0, shown.stderr);
+    assert.equal(JSON.parse(shown.stdout).status, "training");
+
+    const ghost = run("show", cliDir, "ghost");
+    assert.notEqual(ghost.status, 0);
+
+    const invalid = run("create", cliDir, "--input", JSON.stringify({ hypothesis: "no training block" }));
+    assert.notEqual(invalid.status, 0);
+  });
+});


### PR DESCRIPTION
## What

Makes the und-289-Instacart-style experiment chain — data selection → training config → approval gates → checkpoint → eval runs → verdict — machine-readable via an `experiments.jsonl` sidecar in the benchmark dir, following the established reviews.jsonl/calibration.json pattern.

- **Schema** `understudy.experiment.v1` (`schemas/understudy.experiment.v1.schema.json`): hypothesis, status lifecycle (draft|training|evaluating|concluded|abandoned), `data_selection` by curate-trajectories selection hash + frozen-split sha256, `training` (method sft|lora|distill|rl|prompt_only|none, base_model, freeform config, provider/local, cost_estimate) with **first-class approval gates before provider spend** (`approvals: [{gate, approved_by, at}]`, append-only across superseding lines), `produced_artifact {kind, ref, sha256}`, `baseline_run_id`, `eval_run_ids`, and a promote|shadow|collect|stop verdict.
- **Codec** in `src/benchmark-artifacts.ts` (`makeExperiment` / `appendExperiment` / `readExperiments` / `latestExperiments` / `validateExperiment`); append-only, newest line per experiment_id wins, tolerant reads.
- **Write ops** in `src/benchmark-hub-core.ts` (new exports): `createExperiment` (409 on duplicate id), `updateExperiment` (full superseding record; approvals + eval_run_ids append monotonically; experiment_id/created_at immutable), `listExperiments`, `experimentsSummary`.
- **CLI**: `understudy benchmarks experiment create|update|list|show` — JSON in (`--input`, inline or `@file`) / JSON out.
- **MCP**: `create_experiment`, `update_experiment`, `list_experiments`; `read_benchmark` additively surfaces `experiments: {count, latest: [...verdicts]}` for both proposed and promoted entries.
- **Run linkage** (tiny additive diff in `src/run-executor.ts`): `experiment_id` shape-validated in `validateRunRequestInput`, passed through `createRunRequest` onto the persisted run request (no `requires` capability — pure provenance); the queue path (`queueOrCancelRun` + MCP `queue_run`) also existence-checks it against experiments.jsonl. Rows/events join back via run_id.
- **Docs**: `docs/experiment-lineage.md` (und-289 field mapping, how curate-trajectories hashes and local-distillation-lab / plan-hosted-run outputs feed the record) + schemas/README entry.

## Tests

- New `tests/experiment-lineage.test.mjs` (11 tests): schema/constant agreement, validation rejections, append-only newest-wins, hub-core create/update semantics, MCP round-trip + additive read_benchmark, run-request passthrough + queue cross-check, CLI round-trip via dist/bin.js.
- Root `npm test`: 839/839 pass. `tsc --noEmit`: clean. Hub `npm test`: 147/147 + `next build`: clean. `skills:validate`: 36 ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->