### PR TITLE
GEPA-style prompt evolution driving prompt_overrides arms (benchmarks evolve)

### DIFF
--- a/docs/prompt-evolution.md
+++ b/docs/prompt-evolution.md
@@ -1,0 +1,79 @@
+# Prompt Evolution for Agentic Benchmarks
+
+`understudy benchmarks evolve <dir> --model <id>` is the automatic
+(GEPA-style) counterpart to the hand-written `--prompt-override` experiment:
+an authoring model proposes system-prompt suffixes, each proposal becomes a
+`prompt_overrides` arm ({arm_label, model, system_prompt_suffix}) of a normal
+run request, and the run's rows + live journals feed the next proposal. The
+loop lives in `src/prompt-evolution.ts`; the sidecar it writes is
+`<benchmark-dir>/evolution.jsonl` (`understudy.prompt_evolution.v1`).
+
+## The loop
+
+1. **Generation 0 (baseline).** One bare run of `--model` on the **train**
+   split. Its rows and live journal are the first failure evidence.
+2. **Propose.** The authoring model (`--author-model`, default
+   `resolveDefaultModel` on the gateway — the same trace-author plumbing that
+   authors tasks) receives:
+   - per-class tool-call **rejection counts** from the arm's live journal
+     (`unknown_tool`, `missing_required_field`, `missing_by_observation`,
+     `type_mismatch`, `enum_by_observation` — the generated world's
+     `_validate` classes), with example rejections;
+   - the **failing tasks and their unmet contract obligations** (from the
+     `tasks*.jsonl` sidecars) — the same analysis the first prompt experiment
+     did by hand;
+   - the current population (best suffixes + scores) to mutate/recombine.
+   It must answer with a strict JSON array of new suffixes.
+3. **Queue.** The proposals become override arms of ONE run request queued
+   through the shared `createRunRequest` writer. This command **never
+   executes models**: `understudy runs execute --benchmark <dir> --watch`
+   must be running; if the request sits unclaimed the command tells you to
+   start one (it will not spawn an executor itself).
+4. **Wait + score.** The run-request file is polled with backoff until it
+   settles; arm means come from the run's `rows-*.jsonl` (status ok,
+   non-anomalous rows only).
+5. **Record.** Every generation appends one `evolution.jsonl` line: suffix
+   text + sha256 (matching the executor's `runs/<run>-overrides.json`
+   provenance hash), per-arm scores, bare-arm score, and the generation
+   champion.
+6. Repeat for `--generations` (default 2), population kept deliberately small
+   (2–4 variants per generation) because every variant is a full agentic run
+   arm, not a single call.
+
+## Holdout discipline (claim rules)
+
+Mirrors `skills/optimize-workload`:
+
+- Generations evolve on the **train** split only; the cross-generation
+  champion is confirmed against bare on the **dev** split.
+- The **holdout is touched exactly once**: a final champion-vs-bare run,
+  queued only when the champion beat bare on dev. `queueEvolutionRun`
+  hard-rejects `holdout` (and `all`) for evolve-purpose runs.
+- The verdict is a **paired per-task comparison with a 95% CI**
+  (`pairedVerdict`); only a CI-positive holdout result is reported as `win`.
+  With `--no-final`, or if the champion loses on dev, the result is
+  `unverified` / `no_win` — never a win. Do not state an improvement claim
+  without the `holdout_final` record in `evolution.jsonl`.
+
+## Budget guidance
+
+Runs are the expensive unit, not tokens. One invocation queues
+`1 (baseline) + generations + 1 (dev select) + 1 (holdout final)` runs;
+`--budget-runs` hard-caps this and the command stops cleanly when exhausted.
+
+Per-generation cost on a real benchmark ≈
+`variants × train_tasks × rollouts_per_task` full agentic rollouts plus one
+authoring call (cents). On a cedar-sized benchmark (~29 tasks/split), a
+3-variant generation is ~90–120 rollouts (the bare arm reruns each
+generation) — wall-clock is dominated by the executor, so budget generations,
+not variants: 2 generations × 3 variants usually beats 6 × 1.
+
+## Future hook: rejection-guidance evolution
+
+The same evidence loop applies to the environment's rejection guidance
+(`guidance.json`, being made optimizable separately): instead of evolving the
+candidate's system prompt, evolve the *world's* rejection phrasing that
+teaches the candidate mid-rollout. When that lands, the proposal step here
+can emit guidance candidates alongside suffix candidates from the same
+per-class rejection evidence — referenced only; this driver does not depend
+on it.

--- a/skills/optimize-agentic-workload/SKILL.md
+++ b/skills/optimize-agentic-workload/SKILL.md
@@ -186,9 +186,32 @@ single-output optimization does not need a tool environment.
 8. **SECONDARY intervention — optimize the cheap model's prompt.** If a cheaper
    model wins on latency and cost but trails on quality, close the gap with a
    train/dev-only GEPA pass against the feedback-rich rubric, keeping the
-   latency/cost win. Hand this off to
-   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md); never tune
-   on holdout.
+   latency/cost win. When the workload already lives in a promoted benchmark
+   dir with frozen splits, run the automatic loop directly:
+
+   ```sh
+   # terminal 1 — the only thing that executes models
+   understudy runs execute --benchmark <benchmark-dir> --watch
+   # terminal 2 — proposes, queues override arms, waits, scores
+   understudy benchmarks evolve <benchmark-dir> --model <candidate-id> --budget-runs 6
+   ```
+
+   `evolve` is GEPA-style prompt evolution over `prompt_overrides` run arms:
+   an authoring model proposes system-prompt suffixes from the failure
+   evidence (per-class tool-call rejection counts and unmet contract
+   obligations read from the run journals), each proposal runs as a labeled
+   override arm, and every generation is recorded in `evolution.jsonl`
+   (suffix + sha256 + scores). See
+   [`../../docs/prompt-evolution.md`](../../docs/prompt-evolution.md) for the
+   loop and budget guidance. **Claim rules** mirror
+   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md): it evolves
+   on train, selects the champion on dev, touches the sealed holdout exactly
+   once for the final champion-vs-bare run, and reports a win only when that
+   holdout run's paired 95% CI excludes zero — a `no_win`/`unverified`/
+   `inconclusive` verdict must never be presented as an improvement. For
+   single-output workloads, hand off to
+   [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) instead;
+   never tune on holdout.
 
 9. **Escalate to RL only as a true handoff, behind three gates.** If model swap
    and prompt/distillation stall while real headroom remains and the residual

--- a/src/commands/benchmarks.ts
+++ b/src/commands/benchmarks.ts
@@ -30,6 +30,38 @@ export function registerBenchmarksCommand(program: Command): void {
     });
 
   benchmarks
+    .command("evolve <dir>")
+    .description(
+      "GEPA-style prompt evolution over run arms: propose suffixes with an authoring model (fed per-class " +
+        "rejection counts + failed obligations from the run journals), queue prompt_overrides runs on train, " +
+        "select the champion on dev, then verify champion-vs-bare ONCE on the sealed holdout. Queue-only: " +
+        "`understudy runs execute --watch` must be running in another terminal",
+    )
+    .requiredOption("--model <id>", "The base model whose system prompt is being evolved (every arm runs this model)")
+    .option("--author-model <id>", "Gateway model that authors suffix proposals (default: resolveDefaultModel)")
+    .option("--generations <n>", "Evolution generations on the train split (1-6)", "2")
+    .option("--variants <n>", "Suffix variants per generation (2-4)", "3")
+    .option("--rollouts <n>", "Rollouts per task per arm", "1")
+    .option("--budget-runs <n>", "Hard cap on runs queued by this invocation (baseline + generations + dev + holdout)")
+    .option("--no-final", "Skip the holdout run; the result is explicitly UNVERIFIED and never a win")
+    .action(async (dir: string, options: { model: string; authorModel?: string; generations: string; variants: string; rollouts: string; budgetRuns?: string; final: boolean }) => {
+      const { evolvePrompts } = await import("../prompt-evolution.js");
+      const result = await evolvePrompts(dir, {
+        model: options.model,
+        authorModel: options.authorModel,
+        generations: Number(options.generations),
+        variants: Number(options.variants),
+        rolloutsPerTask: Number(options.rollouts),
+        budgetRuns: options.budgetRuns === undefined ? undefined : Number(options.budgetRuns),
+        final: options.final,
+      });
+      console.log(JSON.stringify(result, null, 2));
+      if (result.verdict.verdict !== "win") {
+        console.error(`evolve: verdict is "${result.verdict.verdict}" — do not report a win without a CI-positive holdout run`);
+      }
+    });
+
+  benchmarks
     .command("rigor <dir>")
     .description(
       "Generate rigor-report.md in the benchmark dir: ABC checklist (oracle solvability, null/spam trivial-agent " +

--- a/src/prompt-evolution.ts
+++ b/src/prompt-evolution.ts
@@ -1,0 +1,770 @@
+/**
+ * GEPA-style prompt evolution over agentic benchmark run arms.
+ *
+ * `understudy benchmarks evolve <dir> --model <id>` runs the loop:
+ *   propose (authoring model, fed journal-derived failure evidence)
+ *   → queue ONE run with prompt_overrides arms (shared createRunRequest —
+ *     this module NEVER executes models; `understudy runs execute --watch`
+ *     must be running, or the user is told to start it)
+ *   → wait for the request file to settle → score rows → next generation.
+ *
+ * Split discipline mirrors skills/optimize-workload: generations evolve on
+ * the TRAIN split only, the cross-generation champion is selected on DEV,
+ * and the sealed HOLDOUT split is touched exactly once — a final
+ * champion-vs-bare run — without which no win may be reported.
+ * Every generation is recorded in an evolution.jsonl sidecar
+ * (understudy.prompt_evolution.v1): suffix text + sha256 + scores.
+ */
+import { appendFileSync, existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { readJsonlFile, parseJournalText, serializeJsonlLine } from "./benchmark-artifacts.js";
+import {
+  createRunRequest,
+  liveJournalPath,
+  promptSuffixHash,
+  readRunRequest,
+  runRequestPath,
+  selectTasks,
+  validateRunRequestInput,
+  type PromptOverride,
+  type RunRequest,
+  type RunSplit,
+} from "./run-executor.js";
+import { gatewayClient, resolveDefaultModel, resolveGatewayAuth, type AuthorClient, type AuthorUsage } from "./trace-author.js";
+
+type Obj = Record<string, any>;
+const asObject = (value: unknown): Obj => (value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {});
+
+/* ------------------------------------------------------------------ */
+/* evolution.jsonl sidecar                                             */
+/* ------------------------------------------------------------------ */
+
+export const PROMPT_EVOLUTION_SCHEMA = "understudy.prompt_evolution.v1";
+export const EVOLUTION_FILE = "evolution.jsonl";
+/** Hard cap on a proposed suffix (a "prompt" that smuggles in an essay is a bug, not a candidate). */
+export const MAX_SUFFIX_CHARS = 4_000;
+
+export type EvolutionVariant = {
+  arm_label: string;
+  system_prompt_suffix: string;
+  system_prompt_suffix_sha256: string;
+  mean_score: number | null;
+  rows: number;
+};
+
+export type EvolutionRecord = {
+  schema_version: typeof PROMPT_EVOLUTION_SCHEMA;
+  benchmark_id: string;
+  /** 0 = bare baseline run; 1..N = evolution generations; "dev_select" and "holdout_final" close the loop. */
+  generation: number | "dev_select" | "holdout_final";
+  split: RunSplit;
+  run_id: string;
+  base_model: string;
+  author_model: string | null;
+  created_at: string;
+  variants: EvolutionVariant[];
+  /** The bare (no-suffix) arm of the same run, when present. */
+  bare: { mean_score: number | null; rows: number } | null;
+  /** arm_label of the best-scoring arm of this record (bare = the base model id). */
+  champion: string | null;
+  author_cost_estimate_usd?: number;
+  verdict?: HoldoutVerdict | null;
+};
+
+export function evolutionPath(benchmarkDir: string): string {
+  return join(resolve(benchmarkDir), EVOLUTION_FILE);
+}
+
+export function appendEvolutionRecord(benchmarkDir: string, record: EvolutionRecord): void {
+  appendFileSync(evolutionPath(benchmarkDir), serializeJsonlLine(record), { mode: 0o600 });
+}
+
+export function readEvolutionRecords(benchmarkDir: string): EvolutionRecord[] {
+  return readJsonlFile<EvolutionRecord>(evolutionPath(benchmarkDir)).items.filter(
+    (r) => r?.schema_version === PROMPT_EVOLUTION_SCHEMA,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Failure evidence from live journals + rows                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Rejection classes of the generated world's `_validate` (trace-foundry's
+ * world server): the exact strings the world replies with, classified so the
+ * authoring model sees per-class counts instead of raw noise.
+ */
+export const REJECTION_CLASSES = [
+  "unknown_tool",
+  "missing_required_field",
+  "missing_by_observation",
+  "type_mismatch",
+  "enum_by_observation",
+  "other",
+] as const;
+export type RejectionClass = (typeof REJECTION_CLASSES)[number];
+
+export function classifyRejection(error: string): RejectionClass {
+  const text = String(error);
+  if (text.startsWith("unknown tool")) return "unknown_tool";
+  if (text.includes("required by observed usage")) {
+    return text.includes("must be one of") ? "enum_by_observation" : "missing_by_observation";
+  }
+  if (text.startsWith("missing required field")) return "missing_required_field";
+  if (/^field '.*' must be /.test(text)) return "type_mismatch";
+  return "other";
+}
+
+/**
+ * Pull the rejection error string out of a journal `result` entry's content.
+ * The world mirrors the tool family's production shape: {"ok":false,"error"},
+ * {"success":false,"error"}, or a plain "ERROR: ..." string.
+ */
+export function extractRejectionError(content: unknown): string | null {
+  if (typeof content !== "string" || !content) return null;
+  if (content.startsWith("ERROR:")) return content.slice("ERROR:".length).trim();
+  try {
+    const parsed = asObject(JSON.parse(content));
+    if (typeof parsed.error === "string" && (parsed.ok === false || parsed.success === false || parsed.error)) {
+      return parsed.error;
+    }
+  } catch {
+    /* not an envelope */
+  }
+  return null;
+}
+
+export type RejectionEvidence = {
+  /** Total journaled tool calls and how many the world rejected. */
+  calls: number;
+  rejected: number;
+  by_class: Partial<Record<RejectionClass, number>>;
+  /** Up to `maxExamples` distinct `tool: error` example strings. */
+  examples: string[];
+};
+
+/** Per-class rejection counts from one arm's live-journal text. */
+export function journalRejections(journalText: string, maxExamples = 8): RejectionEvidence {
+  const { lines } = parseJournalText(journalText);
+  const byClass: Partial<Record<RejectionClass, number>> = {};
+  const examples: string[] = [];
+  const seen = new Set<string>();
+  let calls = 0;
+  let rejected = 0;
+  let lastCallTool = "";
+  for (const line of lines) {
+    if (line.kind === "call") {
+      calls += 1;
+      lastCallTool = String(line.tool ?? "");
+      continue;
+    }
+    if (line.kind !== "result" || line.status !== "error") continue;
+    const error = extractRejectionError(line.content);
+    if (error === null) continue;
+    rejected += 1;
+    const cls = classifyRejection(error);
+    byClass[cls] = (byClass[cls] ?? 0) + 1;
+    const example = `${String(line.tool ?? lastCallTool)}: ${error}`;
+    if (!seen.has(example) && examples.length < maxExamples) {
+      seen.add(example);
+      examples.push(example);
+    }
+  }
+  return { calls, rejected, by_class: byClass, examples };
+}
+
+export type FailedTaskEvidence = {
+  task_id: string;
+  mean_score: number | null;
+  /** Compact summaries of the task's required contract entries — the obligations a failing arm left unmet. */
+  required: string[];
+};
+
+/** One arm's evidence packet: journal rejections + failing tasks with their obligations. */
+export type ArmEvidence = {
+  arm_label: string;
+  mean_score: number | null;
+  rows: number;
+  rejections: RejectionEvidence;
+  failed_tasks: FailedTaskEvidence[];
+};
+
+/** Compact one-line summary of a contract entry for the authoring prompt. */
+export function contractEntrySummary(rule: Obj): string {
+  const type = String(rule.type ?? "state_effect");
+  if (type === "response_obligation") return `response_obligation(${String(rule.kind ?? "?")}${rule.expected ? `: ${String(rule.expected).slice(0, 80)}` : ""})`;
+  if (type === "value_propagation") return `value_propagation(${String(rule.value ?? "").slice(0, 60)} → ${String(asObject(rule.must_reach).kind ?? asObject(rule.must_reach).tool ?? "?")})`;
+  return `${type}(${String(rule.tool ?? "?")})`;
+}
+
+/** task_id → outcome_contract from the benchmark dir's tasks*.jsonl sidecars. */
+export function loadTaskContracts(benchmarkDir: string): Map<string, Obj> {
+  const dir = resolve(benchmarkDir);
+  const out = new Map<string, Obj>();
+  let files: string[] = [];
+  try {
+    files = readdirSync(dir).filter((f) => /^tasks.*\.jsonl$/.test(f)).sort();
+  } catch {
+    return out;
+  }
+  for (const f of files) {
+    for (const item of readJsonlFile<Obj>(join(dir, f)).items) {
+      if (typeof item?.task_id === "string" && !out.has(item.task_id)) out.set(item.task_id, asObject(item.outcome_contract));
+    }
+  }
+  return out;
+}
+
+/** All eval rows for one run (scans rows-*.jsonl at the dir root, filtered by run_id). */
+export function readRunRows(benchmarkDir: string, runId: string): Obj[] {
+  const dir = resolve(benchmarkDir);
+  let files: string[] = [];
+  try {
+    files = readdirSync(dir).filter((f) => /^rows-.*\.jsonl$/.test(f)).sort();
+  } catch {
+    return [];
+  }
+  const rows: Obj[] = [];
+  for (const f of files) {
+    for (const row of readJsonlFile<Obj>(join(dir, f)).items) {
+      if (row?.run_id === runId) rows.push(row);
+    }
+  }
+  return rows;
+}
+
+/** Mean score of scoreable (status ok, non-anomalous) rows; null when none. */
+export function meanScore(rows: Obj[]): { mean: number | null; rows: number } {
+  const scored = rows.filter((r) => r.status === "ok" && r.anomaly == null && typeof r.score === "number");
+  if (scored.length === 0) return { mean: null, rows: 0 };
+  return { mean: scored.reduce((sum, r) => sum + (r.score as number), 0) / scored.length, rows: scored.length };
+}
+
+/** Build one arm's evidence packet from its rows and (optional) live-journal text. */
+export function collectArmEvidence(
+  armLabel: string,
+  armRows: Obj[],
+  journalText: string | null,
+  contracts: Map<string, Obj>,
+): ArmEvidence {
+  const { mean, rows } = meanScore(armRows);
+  const byTask = new Map<string, Obj[]>();
+  for (const row of armRows) {
+    const id = String(row.task_id ?? "");
+    if (!byTask.has(id)) byTask.set(id, []);
+    byTask.get(id)!.push(row);
+  }
+  const failed: FailedTaskEvidence[] = [];
+  for (const [taskId, taskRows] of byTask) {
+    const stat = meanScore(taskRows);
+    if (stat.mean !== null && stat.mean >= 1) continue;
+    const required = (asObject(contracts.get(taskId)).required ?? []) as Obj[];
+    failed.push({ task_id: taskId, mean_score: stat.mean, required: required.map((rule) => contractEntrySummary(asObject(rule))) });
+  }
+  failed.sort((a, b) => a.task_id.localeCompare(b.task_id));
+  return {
+    arm_label: armLabel,
+    mean_score: mean,
+    rows,
+    rejections: journalText === null ? { calls: 0, rejected: 0, by_class: {}, examples: [] } : journalRejections(journalText),
+    failed_tasks: failed,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Proposal step (authoring model via the trace-author gateway client) */
+/* ------------------------------------------------------------------ */
+
+export type PopulationMember = { system_prompt_suffix: string; mean_score: number | null; arm_label: string };
+
+/**
+ * The authoring prompt: failure evidence in, N candidate suffixes out.
+ * Deterministic text so tests can fixture it; the ONLY model-facing surface.
+ */
+export function buildProposalPrompt(input: {
+  benchmarkId: string;
+  baseModel: string;
+  generation: number;
+  variants: number;
+  bare: ArmEvidence | null;
+  population: PopulationMember[];
+  evidence: ArmEvidence[];
+}): { role: string; content: string }[] {
+  const lines: string[] = [
+    `You are optimizing the system prompt of an agentic tool-calling model (${input.baseModel}) on benchmark ${input.benchmarkId}.`,
+    `Each candidate is a SHORT system-prompt SUFFIX appended to the task's existing system prompt at rollout time; the base prompt is fixed.`,
+    ``,
+    `Scores are the fraction of tasks whose full outcome contract was satisfied (0..1, higher is better).`,
+  ];
+  const describe = (evidence: ArmEvidence, title: string) => {
+    lines.push(``, `## ${title} — mean score ${evidence.mean_score === null ? "n/a" : evidence.mean_score.toFixed(3)} over ${evidence.rows} rows`);
+    const classes = Object.entries(evidence.rejections.by_class).map(([cls, count]) => `${cls}=${count}`);
+    lines.push(`Tool-call rejections by the simulated world: ${evidence.rejections.rejected}/${evidence.rejections.calls} calls${classes.length ? ` (${classes.join(", ")})` : ""}.`);
+    for (const example of evidence.rejections.examples) lines.push(`- rejection: ${example}`);
+    if (evidence.failed_tasks.length > 0) {
+      lines.push(`Failing tasks and the contract obligations they must satisfy:`);
+      for (const task of evidence.failed_tasks.slice(0, 12)) {
+        lines.push(`- ${task.task_id} (score ${task.mean_score === null ? "n/a" : task.mean_score.toFixed(2)}): ${task.required.join("; ") || "(no contract sidecar found)"}`);
+      }
+    }
+  };
+  if (input.bare) describe(input.bare, `Bare model (no suffix)`);
+  for (const evidence of input.evidence) describe(evidence, `Candidate arm ${evidence.arm_label}`);
+  if (input.population.length > 0) {
+    lines.push(``, `## Current population (best first)`);
+    for (const member of input.population) {
+      lines.push(`- [${member.mean_score === null ? "n/a" : member.mean_score.toFixed(3)}] ${member.arm_label}:`, member.system_prompt_suffix, ``);
+    }
+  }
+  lines.push(
+    ``,
+    `Propose exactly ${input.variants} NEW system-prompt suffixes for generation ${input.generation}.`,
+    `Rules: each under ${MAX_SUFFIX_CHARS} characters; address the observed rejection classes and unmet obligations concretely (name required fields, enum values, response format obligations); mutate/recombine the best population members rather than restarting; no two proposals may be near-duplicates.`,
+    `Respond with ONLY a JSON array of ${input.variants} objects: [{"system_prompt_suffix": "..."}].`,
+  );
+  return [
+    { role: "system", content: "You are a careful prompt-optimization engine. You reply with strictly valid JSON and nothing else." },
+    { role: "user", content: lines.join("\n") },
+  ];
+}
+
+/** Parse the authoring model's reply into up to `variants` distinct suffixes. */
+export function parseProposedSuffixes(content: string, variants: number): string[] {
+  const text = String(content ?? "");
+  const start = text.indexOf("[");
+  const end = text.lastIndexOf("]");
+  if (start === -1 || end <= start) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of parsed) {
+    const suffix = typeof entry === "string" ? entry : asObject(entry).system_prompt_suffix;
+    if (typeof suffix !== "string") continue;
+    const trimmed = suffix.trim().slice(0, MAX_SUFFIX_CHARS);
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+    if (out.length >= variants) break;
+  }
+  return out;
+}
+
+/** Leaderboard/rows-file-safe arm label for generation g, variant i (1-based). */
+export function evolutionArmLabel(baseModel: string, generation: number, index: number): string {
+  return `${baseModel}+evo-g${generation}v${index}`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Queueing + waiting (queue only — NEVER execute)                     */
+/* ------------------------------------------------------------------ */
+
+export type QueueEvolutionRunInput = {
+  baseModel: string;
+  split: RunSplit;
+  overrides?: PromptOverride[];
+  rolloutsPerTask: number;
+  /** "evolve" runs are hard-blocked from holdout/"all"; only "final" may touch holdout. */
+  purpose: "evolve" | "final";
+};
+
+/**
+ * Validate + queue ONE run request through the SHARED run-executor writer
+ * (createRunRequest). Split sealing is enforced here: an evolve-purpose run
+ * can never carry the holdout split (or "all", which contains it).
+ */
+export function queueEvolutionRun(benchmarkDir: string, input: QueueEvolutionRunInput): RunRequest {
+  if (input.purpose === "evolve" && (input.split === "holdout" || input.split === "all")) {
+    throw new Error(`split sealing violation: evolution runs may only use train/dev, got "${input.split}" — the holdout is touched exactly once by the final champion-vs-bare run`);
+  }
+  const dir = resolve(benchmarkDir);
+  const manifest = asObject(JSON.parse(readFileSync(join(dir, "benchmark.json"), "utf8")));
+  if (manifest.schema_version !== "understudy.benchmark.v1" || typeof manifest.benchmark_id !== "string") {
+    throw new Error(`${join(dir, "benchmark.json")} is not a promoted understudy.benchmark.v1 manifest — promote the benchmark before evolving`);
+  }
+  const knownTaskIds = (Array.isArray(manifest.tasks) ? manifest.tasks : []).map((t: Obj) => String(asObject(t).task_id));
+  const body = {
+    benchmark_id: String(manifest.benchmark_id),
+    models: [input.baseModel],
+    split: input.split,
+    tasks: "all" as const,
+    rollouts_per_task: input.rolloutsPerTask,
+    ...(input.overrides && input.overrides.length > 0 ? { prompt_overrides: input.overrides } : {}),
+  };
+  const errors = validateRunRequestInput(body, knownTaskIds);
+  if (errors.length > 0) throw new Error(errors.join("; "));
+  if (selectTasks(manifest, { split: input.split, tasks: "all" }).length === 0) {
+    throw new Error(`no tasks in split "${input.split}" — freeze train/dev/holdout splits before evolving`);
+  }
+  return createRunRequest(dir, body);
+}
+
+export type WaitOptions = {
+  pollMs?: number;
+  maxPollMs?: number;
+  timeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  /** Called once if the request sits unclaimed — no executor is watching the queue. */
+  onIdle?: (request: RunRequest) => void;
+};
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Poll the run request file with backoff until it settles (done / failed /
+ * cancelled). Queue-only discipline: if nothing claims the request, the user
+ * is told (once) to start `understudy runs execute --watch` — this process
+ * never spawns an executor.
+ */
+export async function waitForRun(benchmarkDir: string, runId: string, options: WaitOptions = {}): Promise<RunRequest> {
+  const sleep = options.sleep ?? defaultSleep;
+  const timeoutMs = options.timeoutMs ?? 4 * 60 * 60 * 1000;
+  const maxPollMs = options.maxPollMs ?? 30_000;
+  let pollMs = options.pollMs ?? 2_000;
+  const started = Date.now();
+  let idleWarned = false;
+  let unclaimedPolls = 0;
+  for (;;) {
+    const request = readRunRequest(runRequestPath(benchmarkDir, runId));
+    if (!request) throw new Error(`run request ${runId} disappeared from ${benchmarkDir}`);
+    if (request.status === "done" || request.status === "failed" || request.status === "cancelled") return request;
+    if (request.status === "queued" && !request.claimed_by) {
+      unclaimedPolls += 1;
+      if (unclaimedPolls >= 3 && !idleWarned) {
+        idleWarned = true;
+        options.onIdle?.(request);
+      }
+    } else {
+      unclaimedPolls = 0;
+    }
+    if (Date.now() - started > timeoutMs) throw new Error(`timed out waiting for run ${runId} (status ${request.status})`);
+    await sleep(pollMs);
+    pollMs = Math.min(Math.round(pollMs * 1.5), maxPollMs);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Holdout verdict                                                     */
+/* ------------------------------------------------------------------ */
+
+export type HoldoutVerdict = {
+  champion_arm: string;
+  champion_mean: number | null;
+  bare_mean: number | null;
+  paired_tasks: number;
+  mean_diff: number | null;
+  ci95: [number, number] | null;
+  /** "win" only when the 95% CI of the paired per-task diff excludes zero from below. */
+  verdict: "win" | "no_win" | "inconclusive" | "unverified";
+};
+
+/** Paired per-task champion-vs-bare comparison with a normal-approximation 95% CI. */
+export function pairedVerdict(championArm: string, championRows: Obj[], bareRows: Obj[]): HoldoutVerdict {
+  const perTask = (rows: Obj[]) => {
+    const byTask = new Map<string, number[]>();
+    for (const row of rows) {
+      if (row.status !== "ok" || row.anomaly != null || typeof row.score !== "number") continue;
+      const id = String(row.task_id ?? "");
+      if (!byTask.has(id)) byTask.set(id, []);
+      byTask.get(id)!.push(row.score as number);
+    }
+    return new Map([...byTask].map(([id, scores]) => [id, scores.reduce((a, b) => a + b, 0) / scores.length]));
+  };
+  const champion = perTask(championRows);
+  const bare = perTask(bareRows);
+  const diffs: number[] = [];
+  for (const [taskId, score] of champion) {
+    const bareScore = bare.get(taskId);
+    if (bareScore !== undefined) diffs.push(score - bareScore);
+  }
+  const championMean = meanScore(championRows).mean;
+  const bareMean = meanScore(bareRows).mean;
+  if (diffs.length === 0) {
+    return { champion_arm: championArm, champion_mean: championMean, bare_mean: bareMean, paired_tasks: 0, mean_diff: null, ci95: null, verdict: "inconclusive" };
+  }
+  const meanDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length;
+  const variance = diffs.reduce((a, b) => a + (b - meanDiff) ** 2, 0) / Math.max(diffs.length - 1, 1);
+  const half = 1.96 * Math.sqrt(variance / diffs.length);
+  const ci: [number, number] = [meanDiff - half, meanDiff + half];
+  const verdict: HoldoutVerdict["verdict"] = ci[0] > 0 ? "win" : ci[1] < 0 ? "no_win" : "inconclusive";
+  return { champion_arm: championArm, champion_mean: championMean, bare_mean: bareMean, paired_tasks: diffs.length, mean_diff: meanDiff, ci95: ci, verdict };
+}
+
+/* ------------------------------------------------------------------ */
+/* The evolution driver                                                */
+/* ------------------------------------------------------------------ */
+
+/** IO seams so the loop is testable without a gateway or executor. */
+export type EvolveIo = {
+  queue: (input: QueueEvolutionRunInput) => RunRequest;
+  wait: (runId: string) => Promise<RunRequest>;
+  rows: (runId: string) => Obj[];
+  journal: (runId: string, armLabel: string) => string | null;
+  client: AuthorClient;
+  log: (line: string) => void;
+  now: () => Date;
+};
+
+export type EvolveOptions = {
+  model: string;
+  authorModel?: string;
+  generations?: number;
+  variants?: number;
+  rolloutsPerTask?: number;
+  /** Hard cap on runs queued by this invocation (baseline + generations + dev select + holdout final). */
+  budgetRuns?: number;
+  /** Skip the final holdout run; the result is then explicitly "unverified" — never a win. */
+  final?: boolean;
+  io?: Partial<EvolveIo>;
+};
+
+export type EvolveResult = {
+  benchmark_id: string;
+  base_model: string;
+  author_model: string;
+  runs_queued: number;
+  generations: number;
+  champion: PopulationMember | null;
+  verdict: HoldoutVerdict;
+  evolution_file: string;
+};
+
+const clamp = (value: number, low: number, high: number) => Math.min(Math.max(value, low), high);
+
+function defaultIo(benchmarkDir: string): EvolveIo {
+  let client: AuthorClient | null = null;
+  return {
+    queue: (input) => queueEvolutionRun(benchmarkDir, input),
+    wait: (runId) =>
+      waitForRun(benchmarkDir, runId, {
+        onIdle: () =>
+          console.error(
+            `[evolve] run request is queued but unclaimed — start an executor in another terminal:\n  understudy runs execute --benchmark ${resolve(benchmarkDir)} --watch`,
+          ),
+      }),
+    rows: (runId) => readRunRows(benchmarkDir, runId),
+    journal: (runId, armLabel) => {
+      const file = liveJournalPath(benchmarkDir, runId, armLabel);
+      try {
+        return existsSync(file) ? readFileSync(file, "utf8") : null;
+      } catch {
+        return null;
+      }
+    },
+    client: (request) => {
+      if (!client) {
+        const auth = resolveGatewayAuth();
+        client = gatewayClient(auth.baseUrl, auth.apiKey);
+      }
+      return client(request);
+    },
+    log: (line) => console.error(line),
+    now: () => new Date(),
+  };
+}
+
+const authorCost = (usage: AuthorUsage | undefined): number =>
+  (((usage?.prompt_tokens ?? 0) * 1 + (usage?.completion_tokens ?? 0) * 4) / 1_000_000); // conservative default-rate estimate
+
+export async function evolvePrompts(benchmarkDirInput: string, options: EvolveOptions): Promise<EvolveResult> {
+  const benchmarkDir = resolve(benchmarkDirInput);
+  const io: EvolveIo = { ...defaultIo(benchmarkDir), ...options.io };
+  const generations = clamp(options.generations ?? 2, 1, 6);
+  const variants = clamp(options.variants ?? 3, 2, 4); // small and honest — runs are expensive
+  const rollouts = clamp(options.rolloutsPerTask ?? 1, 1, 20);
+  const wantFinal = options.final !== false;
+  const budget = options.budgetRuns ?? generations + (wantFinal ? 3 : 2);
+  const contracts = loadTaskContracts(benchmarkDir);
+
+  let authorModel = options.authorModel ?? null;
+  if (!authorModel) {
+    const auth = resolveGatewayAuth();
+    authorModel = await resolveDefaultModel(auth.baseUrl, auth.apiKey);
+  }
+
+  let runsQueued = 0;
+  const spendRun = (label: string): void => {
+    runsQueued += 1;
+    if (runsQueued > budget) throw new Error(`--budget-runs exhausted (${budget}) before ${label}; raise the budget or lower --generations`);
+  };
+
+  const armEvidenceFor = (runId: string, rows: Obj[], armLabel: string): ArmEvidence =>
+    collectArmEvidence(armLabel, rows.filter((r) => r.model === armLabel), io.journal(runId, armLabel), contracts);
+
+  const variantRecord = (rows: Obj[], override: PromptOverride): EvolutionVariant => {
+    const stat = meanScore(rows.filter((r) => r.model === override.arm_label));
+    return {
+      arm_label: override.arm_label,
+      system_prompt_suffix: override.system_prompt_suffix,
+      system_prompt_suffix_sha256: promptSuffixHash(override.system_prompt_suffix),
+      mean_score: stat.mean,
+      rows: stat.rows,
+    };
+  };
+
+  // Generation 0: bare baseline on TRAIN — the evidence the first proposal feeds on.
+  spendRun("the train baseline run");
+  io.log(`[evolve] generation 0: bare ${options.model} on train`);
+  const baselineRun = io.queue({ baseModel: options.model, split: "train", rolloutsPerTask: rollouts, purpose: "evolve" });
+  const baselineDone = await io.wait(baselineRun.run_id);
+  if (baselineDone.status !== "done") throw new Error(`baseline run ${baselineRun.run_id} ended ${baselineDone.status}${baselineDone.error ? `: ${baselineDone.error.message}` : ""}`);
+  const baselineRows = io.rows(baselineRun.run_id);
+  let bareEvidence = armEvidenceFor(baselineRun.run_id, baselineRows, options.model);
+  const benchmarkId = String(baselineRun.benchmark_id);
+  appendEvolutionRecord(benchmarkDir, {
+    schema_version: PROMPT_EVOLUTION_SCHEMA,
+    benchmark_id: benchmarkId,
+    generation: 0,
+    split: "train",
+    run_id: baselineRun.run_id,
+    base_model: options.model,
+    author_model: null,
+    created_at: io.now().toISOString(),
+    variants: [],
+    bare: { mean_score: bareEvidence.mean_score, rows: bareEvidence.rows },
+    champion: options.model,
+  });
+
+  // Evolution generations on TRAIN only.
+  let population: PopulationMember[] = [];
+  let lastEvidence: ArmEvidence[] = [];
+  for (let generation = 1; generation <= generations; generation += 1) {
+    spendRun(`generation ${generation}`);
+    const messages = buildProposalPrompt({
+      benchmarkId,
+      baseModel: options.model,
+      generation,
+      variants,
+      bare: bareEvidence,
+      population,
+      evidence: lastEvidence,
+    });
+    const reply = await io.client({ model: authorModel, messages });
+    const cost = authorCost(reply.usage);
+    const suffixes = parseProposedSuffixes(reply.content, variants);
+    if (suffixes.length === 0) throw new Error(`authoring model ${authorModel} returned no parseable suffix proposals in generation ${generation}`);
+    const overrides: PromptOverride[] = suffixes.map((suffix, i) => ({
+      arm_label: evolutionArmLabel(options.model, generation, i + 1),
+      model: options.model,
+      system_prompt_suffix: suffix,
+    }));
+    io.log(`[evolve] generation ${generation}: ${overrides.length} variant arms on train`);
+    const run = io.queue({ baseModel: options.model, split: "train", overrides, rolloutsPerTask: rollouts, purpose: "evolve" });
+    const done = await io.wait(run.run_id);
+    if (done.status !== "done") throw new Error(`generation ${generation} run ${run.run_id} ended ${done.status}${done.error ? `: ${done.error.message}` : ""}`);
+    const rows = io.rows(run.run_id);
+    const recorded = overrides.map((override) => variantRecord(rows, override));
+    const bareStat = meanScore(rows.filter((r) => r.model === options.model));
+    lastEvidence = overrides.map((override) => armEvidenceFor(run.run_id, rows, override.arm_label));
+    // Each generation run also carries the bare arm (models: [baseModel]);
+    // refresh the bare evidence from the freshest run.
+    if (bareStat.rows > 0) bareEvidence = armEvidenceFor(run.run_id, rows, options.model);
+
+    population = [...population, ...recorded.map((v) => ({ system_prompt_suffix: v.system_prompt_suffix, mean_score: v.mean_score, arm_label: v.arm_label }))]
+      .sort((a, b) => (b.mean_score ?? -1) - (a.mean_score ?? -1))
+      .slice(0, 2); // parents for the next proposal — small and honest
+    const best = recorded.slice().sort((a, b) => (b.mean_score ?? -1) - (a.mean_score ?? -1))[0] ?? null;
+    appendEvolutionRecord(benchmarkDir, {
+      schema_version: PROMPT_EVOLUTION_SCHEMA,
+      benchmark_id: benchmarkId,
+      generation,
+      split: "train",
+      run_id: run.run_id,
+      base_model: options.model,
+      author_model: authorModel,
+      created_at: io.now().toISOString(),
+      variants: recorded,
+      bare: bareStat.rows > 0 ? { mean_score: bareStat.mean, rows: bareStat.rows } : null,
+      champion: best && (best.mean_score ?? -1) >= (bareEvidence.mean_score ?? -1) ? best.arm_label : options.model,
+      author_cost_estimate_usd: cost,
+    });
+  }
+
+  const trainChampion = population[0] ?? null;
+  if (!trainChampion) {
+    return { benchmark_id: benchmarkId, base_model: options.model, author_model: authorModel, runs_queued: runsQueued, generations, champion: null, verdict: { champion_arm: options.model, champion_mean: null, bare_mean: null, paired_tasks: 0, mean_diff: null, ci95: null, verdict: "unverified" }, evolution_file: evolutionPath(benchmarkDir) };
+  }
+
+  // DEV selection: champion vs bare on the dev split (still evolve-purpose — holdout stays sealed).
+  spendRun("the dev selection run");
+  const devOverride: PromptOverride = { arm_label: `${trainChampion.arm_label}+dev`, model: options.model, system_prompt_suffix: trainChampion.system_prompt_suffix };
+  io.log(`[evolve] dev selection: ${trainChampion.arm_label} vs bare ${options.model}`);
+  const devRun = io.queue({ baseModel: options.model, split: "dev", overrides: [devOverride], rolloutsPerTask: rollouts, purpose: "evolve" });
+  const devDone = await io.wait(devRun.run_id);
+  if (devDone.status !== "done") throw new Error(`dev selection run ${devRun.run_id} ended ${devDone.status}${devDone.error ? `: ${devDone.error.message}` : ""}`);
+  const devRows = io.rows(devRun.run_id);
+  const devVariant = variantRecord(devRows, devOverride);
+  const devBare = meanScore(devRows.filter((r) => r.model === options.model));
+  const devWin = (devVariant.mean_score ?? -1) > (devBare.mean ?? -1);
+  appendEvolutionRecord(benchmarkDir, {
+    schema_version: PROMPT_EVOLUTION_SCHEMA,
+    benchmark_id: benchmarkId,
+    generation: "dev_select",
+    split: "dev",
+    run_id: devRun.run_id,
+    base_model: options.model,
+    author_model: authorModel,
+    created_at: io.now().toISOString(),
+    variants: [devVariant],
+    bare: { mean_score: devBare.mean, rows: devBare.rows },
+    champion: devWin ? devVariant.arm_label : options.model,
+  });
+
+  const champion: PopulationMember = { ...trainChampion };
+  let verdict: HoldoutVerdict = { champion_arm: champion.arm_label, champion_mean: null, bare_mean: null, paired_tasks: 0, mean_diff: null, ci95: null, verdict: "unverified" };
+
+  if (!devWin) {
+    io.log(`[evolve] champion did not beat bare on dev — holdout stays sealed; no win to verify`);
+    verdict = { ...verdict, verdict: "no_win", champion_mean: devVariant.mean_score, bare_mean: devBare.mean };
+  } else if (!wantFinal) {
+    io.log(`[evolve] --no-final: holdout untouched. The result is UNVERIFIED — do not report a win without the heldout run.`);
+  } else {
+    // HOLDOUT — touched exactly once: champion vs bare, then the verdict.
+    spendRun("the holdout final run");
+    const finalOverride: PromptOverride = { arm_label: `${champion.arm_label}+holdout`, model: options.model, system_prompt_suffix: champion.system_prompt_suffix };
+    io.log(`[evolve] holdout final: ${champion.arm_label} vs bare ${options.model}`);
+    const finalRun = io.queue({ baseModel: options.model, split: "holdout", overrides: [finalOverride], rolloutsPerTask: rollouts, purpose: "final" });
+    const finalDone = await io.wait(finalRun.run_id);
+    if (finalDone.status !== "done") throw new Error(`holdout run ${finalRun.run_id} ended ${finalDone.status}${finalDone.error ? `: ${finalDone.error.message}` : ""}`);
+    const finalRows = io.rows(finalRun.run_id);
+    verdict = pairedVerdict(
+      finalOverride.arm_label,
+      finalRows.filter((r) => r.model === finalOverride.arm_label),
+      finalRows.filter((r) => r.model === options.model),
+    );
+    appendEvolutionRecord(benchmarkDir, {
+      schema_version: PROMPT_EVOLUTION_SCHEMA,
+      benchmark_id: benchmarkId,
+      generation: "holdout_final",
+      split: "holdout",
+      run_id: finalRun.run_id,
+      base_model: options.model,
+      author_model: authorModel,
+      created_at: io.now().toISOString(),
+      variants: [variantRecord(finalRows, finalOverride)],
+      bare: (() => {
+        const stat = meanScore(finalRows.filter((r) => r.model === options.model));
+        return { mean_score: stat.mean, rows: stat.rows };
+      })(),
+      champion: verdict.verdict === "win" ? finalOverride.arm_label : options.model,
+      verdict,
+    });
+  }
+
+  return {
+    benchmark_id: benchmarkId,
+    base_model: options.model,
+    author_model: authorModel,
+    runs_queued: runsQueued,
+    generations,
+    champion,
+    verdict,
+    evolution_file: evolutionPath(benchmarkDir),
+  };
+}

--- a/tests/prompt-evolution.test.mjs
+++ b/tests/prompt-evolution.test.mjs
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import {
+  PROMPT_EVOLUTION_SCHEMA,
+  appendEvolutionRecord,
+  buildProposalPrompt,
+  classifyRejection,
+  collectArmEvidence,
+  evolutionArmLabel,
+  evolvePrompts,
+  extractRejectionError,
+  journalRejections,
+  loadTaskContracts,
+  meanScore,
+  pairedVerdict,
+  parseProposedSuffixes,
+  queueEvolutionRun,
+  readEvolutionRecords,
+  waitForRun,
+} from "../dist/prompt-evolution.js";
+import { promptSuffixHash, readRunRequest, runRequestPath, writeRunRequest } from "../dist/run-executor.js";
+
+const roots = [];
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+/** Minimal promoted benchmark dir with frozen train/dev/holdout splits + contract sidecars. */
+function makeBenchmarkDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prompt-evo-"));
+  roots.push(dir);
+  const tasks = [
+    { task_id: "tr1", split: "train" },
+    { task_id: "tr2", split: "train" },
+    { task_id: "dv1", split: "dev" },
+    { task_id: "ho1", split: "holdout" },
+    { task_id: "ho2", split: "holdout" },
+  ];
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "evo-bench",
+      provenance: { origin: "derived-from-traces" },
+      taxonomy: [{ category_id: "cat-a" }],
+      tasks: tasks.map((t) => ({ ...t, category_id: "cat-a", genesis: "replayed" })),
+      environment: { format: "verifiers.v1", package_ref: "environment" },
+      verifier: { kind: "final-state", strict_metric: "task_completed_correctly" },
+    }),
+  );
+  const sidecar = tasks.map((t) => ({
+    schema_version: "understudy.benchmark_task.v1",
+    task_id: t.task_id,
+    outcome_contract: {
+      required: [
+        { type: "state_effect", tool: "update-record", observed_arguments: { id: "r1" } },
+        { type: "response_obligation", kind: "json_parses" },
+      ],
+      preserved: [],
+      forbidden: [],
+      grading: "final_state_and_obligations",
+    },
+  }));
+  fs.writeFileSync(path.join(dir, "tasks.jsonl"), sidecar.map((t) => JSON.stringify(t)).join("\n") + "\n");
+  return dir;
+}
+
+describe("rejection classification", () => {
+  it("classifies the generated world's _validate error strings", () => {
+    assert.equal(classifyRejection("unknown tool 'foo'"), "unknown_tool");
+    assert.equal(classifyRejection("missing required field 'id'"), "missing_required_field");
+    assert.equal(classifyRejection("missing field 'meta.user' — required by observed usage (9/9 calls)"), "missing_by_observation");
+    assert.equal(classifyRejection("field 'count' must be integer"), "type_mismatch");
+    assert.equal(classifyRejection('field \'status\' must be one of ["open"] — required by observed usage'), "enum_by_observation");
+    assert.equal(classifyRejection("network exploded"), "other");
+  });
+
+  it("extracts errors from all three rejection reply styles", () => {
+    assert.equal(extractRejectionError('ERROR: missing required field \'id\''), "missing required field 'id'");
+    assert.equal(extractRejectionError('{"success": false, "error": "field \'x\' must be string"}'), "field 'x' must be string");
+    assert.equal(extractRejectionError('{"ok": false, "error": "unknown tool \'z\'"}'), "unknown tool 'z'");
+    assert.equal(extractRejectionError('{"ok": true}'), null);
+    assert.equal(extractRejectionError(undefined), null);
+  });
+
+  it("counts per-class rejections from a live journal", () => {
+    const journal = [
+      { kind: "call", tool: "update-record", status: "ok", arguments: "{}" },
+      { kind: "result", tool: "update-record", status: "ok", content: '{"ok": true}' },
+      { kind: "call", tool: "update-record", status: "error", arguments: "{}" },
+      { kind: "result", tool: "update-record", status: "error", content: '{"ok": false, "error": "missing required field \'id\'"}' },
+      { kind: "call", tool: "close-ticket", status: "error", arguments: "{}" },
+      { kind: "result", tool: "close-ticket", status: "error", content: "ERROR: field 'status' must be one of [\"open\"] — required by observed usage" },
+    ]
+      .map((l) => JSON.stringify(l))
+      .join("\n");
+    const evidence = journalRejections(journal);
+    assert.equal(evidence.calls, 3);
+    assert.equal(evidence.rejected, 2);
+    assert.deepEqual(evidence.by_class, { missing_required_field: 1, enum_by_observation: 1 });
+    assert.equal(evidence.examples.length, 2);
+    assert.match(evidence.examples[0], /update-record: missing required field/);
+  });
+});
+
+describe("proposal prompt construction", () => {
+  it("builds the authoring prompt from fixture journals + contracts and asks for strict JSON", () => {
+    const dir = makeBenchmarkDir();
+    const contracts = loadTaskContracts(dir);
+    const rows = [
+      { run_id: "r", task_id: "tr1", status: "ok", score: 0, model: "m" },
+      { run_id: "r", task_id: "tr2", status: "ok", score: 1, model: "m" },
+    ];
+    const journal = JSON.stringify({ kind: "call", tool: "update-record", status: "error" }) + "\n" + JSON.stringify({ kind: "result", tool: "update-record", status: "error", content: 'ERROR: missing required field \'id\'' }) + "\n";
+    const evidence = collectArmEvidence("m", rows, journal, contracts);
+    assert.equal(evidence.mean_score, 0.5);
+    assert.equal(evidence.failed_tasks.length, 1);
+    assert.equal(evidence.failed_tasks[0].task_id, "tr1");
+    assert.match(evidence.failed_tasks[0].required.join(" "), /state_effect\(update-record\)/);
+    assert.match(evidence.failed_tasks[0].required.join(" "), /response_obligation\(json_parses\)/);
+
+    const messages = buildProposalPrompt({
+      benchmarkId: "evo-bench",
+      baseModel: "m",
+      generation: 1,
+      variants: 3,
+      bare: evidence,
+      population: [{ arm_label: "m+evo-g1v1", system_prompt_suffix: "Always include ids.", mean_score: 0.6 }],
+      evidence: [],
+    });
+    assert.equal(messages.length, 2);
+    const prompt = messages[1].content;
+    assert.match(prompt, /missing_required_field=1/);
+    assert.match(prompt, /tr1 \(score 0\.00\)/);
+    assert.match(prompt, /Always include ids\./);
+    assert.match(prompt, /exactly 3 NEW system-prompt suffixes/);
+    assert.match(prompt, /JSON array of 3 objects/);
+  });
+
+  it("parses proposals from noisy replies, dedupes, and caps at the requested count", () => {
+    const reply = 'Sure! Here you go:\n[{"system_prompt_suffix": "A"}, {"system_prompt_suffix": "A"}, "B", {"system_prompt_suffix": "C"}, {"system_prompt_suffix": "D"}]';
+    assert.deepEqual(parseProposedSuffixes(reply, 3), ["A", "B", "C"]);
+    assert.deepEqual(parseProposedSuffixes("no json here", 3), []);
+    assert.deepEqual(parseProposedSuffixes('{"not": "an array"}', 3), []);
+  });
+});
+
+describe("queueing + split sealing", () => {
+  it("queues a train run with override arms through the shared createRunRequest", () => {
+    const dir = makeBenchmarkDir();
+    const run = queueEvolutionRun(dir, {
+      baseModel: "m",
+      split: "train",
+      overrides: [{ arm_label: evolutionArmLabel("m", 1, 1), model: "m", system_prompt_suffix: "Be precise." }],
+      rolloutsPerTask: 1,
+      purpose: "evolve",
+    });
+    assert.equal(run.status, "queued");
+    assert.equal(run.split, "train");
+    assert.deepEqual(run.models, ["m"]);
+    assert.ok(run.requires.includes("prompt_overrides"));
+    const onDisk = readRunRequest(runRequestPath(dir, run.run_id));
+    assert.equal(onDisk.prompt_overrides[0].arm_label, "m+evo-g1v1");
+  });
+
+  it("hard-blocks holdout (and 'all') from evolve-purpose runs", () => {
+    const dir = makeBenchmarkDir();
+    assert.throws(() => queueEvolutionRun(dir, { baseModel: "m", split: "holdout", rolloutsPerTask: 1, purpose: "evolve" }), /split sealing violation/);
+    assert.throws(() => queueEvolutionRun(dir, { baseModel: "m", split: "all", rolloutsPerTask: 1, purpose: "evolve" }), /split sealing violation/);
+    // final purpose may touch holdout — exactly once, by the driver.
+    const final = queueEvolutionRun(dir, { baseModel: "m", split: "holdout", rolloutsPerTask: 1, purpose: "final" });
+    assert.equal(final.split, "holdout");
+  });
+
+  it("waitForRun polls the request file to completion and warns once when nothing claims it", async () => {
+    const dir = makeBenchmarkDir();
+    const run = queueEvolutionRun(dir, { baseModel: "m", split: "train", rolloutsPerTask: 1, purpose: "evolve" });
+    let idleWarnings = 0;
+    let polls = 0;
+    const settled = await waitForRun(dir, run.run_id, {
+      pollMs: 1,
+      sleep: async () => {
+        polls += 1;
+        if (polls === 6) writeRunRequest(dir, { ...run, status: "done" });
+      },
+      onIdle: () => {
+        idleWarnings += 1;
+      },
+    });
+    assert.equal(settled.status, "done");
+    assert.equal(idleWarnings, 1); // instruct the user to start `runs execute --watch`; never spawn one
+  });
+});
+
+describe("evolution.jsonl round-trip", () => {
+  it("appends and re-reads generation records, dropping foreign schema lines", () => {
+    const dir = makeBenchmarkDir();
+    const record = {
+      schema_version: PROMPT_EVOLUTION_SCHEMA,
+      benchmark_id: "evo-bench",
+      generation: 1,
+      split: "train",
+      run_id: "run-x",
+      base_model: "m",
+      author_model: "author",
+      created_at: new Date(0).toISOString(),
+      variants: [{ arm_label: "m+evo-g1v1", system_prompt_suffix: "S", system_prompt_suffix_sha256: promptSuffixHash("S"), mean_score: 0.5, rows: 2 }],
+      bare: { mean_score: 0.4, rows: 2 },
+      champion: "m+evo-g1v1",
+    };
+    appendEvolutionRecord(dir, record);
+    fs.appendFileSync(path.join(dir, "evolution.jsonl"), JSON.stringify({ schema_version: "something.else" }) + "\n");
+    const records = readEvolutionRecords(dir);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0], record);
+  });
+});
+
+describe("paired holdout verdict", () => {
+  it("computes paired diffs with a CI and only calls a CI-positive result a win", () => {
+    const rows = (model, scores) => Object.entries(scores).map(([task_id, score]) => ({ run_id: "r", task_id, model, status: "ok", score }));
+    const win = pairedVerdict("champ", rows("champ", { a: 1, b: 1, c: 1, d: 1, e: 1 }), rows("m", { a: 0, b: 0, c: 0, d: 0, e: 1 }));
+    assert.equal(win.verdict, "win");
+    assert.equal(win.paired_tasks, 5);
+    const inconclusive = pairedVerdict("champ", rows("champ", { a: 1, b: 0 }), rows("m", { a: 0, b: 1 }));
+    assert.equal(inconclusive.verdict, "inconclusive");
+    const empty = pairedVerdict("champ", [], []);
+    assert.equal(empty.verdict, "inconclusive");
+    assert.equal(empty.paired_tasks, 0);
+  });
+});
+
+describe("evolvePrompts driver (mocked gateway + executor)", () => {
+  /** Fake executor: queue for real (split-sealing exercised), then synthesize rows. */
+  function fakeIo(dir, { scores }) {
+    const queued = [];
+    const rowsByRun = new Map();
+    return {
+      requests: queued,
+      io: {
+        queue: (input) => {
+          const run = queueEvolutionRun(dir, input);
+          queued.push({ ...input, run_id: run.run_id });
+          const splitTasks = { train: ["tr1", "tr2"], dev: ["dv1"], holdout: ["ho1", "ho2"] }[input.split];
+          const rows = [];
+          const arms = [{ label: input.baseModel, key: "bare" }, ...(input.overrides ?? []).map((o) => ({ label: o.arm_label, key: "variant" }))];
+          for (const arm of arms) {
+            for (const taskId of splitTasks) {
+              rows.push({ run_id: run.run_id, task_id: taskId, model: arm.label, status: "ok", score: scores(arm.key, taskId, input.split) });
+            }
+          }
+          rowsByRun.set(run.run_id, rows);
+          return run;
+        },
+        wait: async (runId) => ({ schema_version: "understudy.run_request.v1", run_id: runId, status: "done", benchmark_id: "evo-bench" }),
+        rows: (runId) => rowsByRun.get(runId) ?? [],
+        journal: () => JSON.stringify({ kind: "result", tool: "update-record", status: "error", content: "ERROR: missing required field 'id'" }) + "\n",
+        client: async ({ messages }) => {
+          assert.match(messages[1].content, /missing_required_field/); // proposal prompt carries journal evidence
+          return { content: '[{"system_prompt_suffix": "Include the record id."}, {"system_prompt_suffix": "Reply in JSON."}]', usage: { prompt_tokens: 10, completion_tokens: 10 } };
+        },
+        log: () => {},
+        now: () => new Date(0),
+      },
+    };
+  }
+
+  it("runs the full loop, seals holdout to exactly one final run, and records every generation", async () => {
+    const dir = makeBenchmarkDir();
+    const { io, requests } = fakeIo(dir, { scores: (key) => (key === "variant" ? 1 : 0) });
+    const result = await evolvePrompts(dir, {
+      model: "m",
+      authorModel: "author-model",
+      generations: 2,
+      variants: 2,
+      io,
+    });
+    // Request task-list discipline: holdout appears ONLY in the single final run.
+    const holdoutRuns = requests.filter((r) => r.split === "holdout");
+    assert.equal(holdoutRuns.length, 1);
+    assert.equal(holdoutRuns[0].purpose, "final");
+    assert.ok(requests.filter((r) => r.purpose === "evolve").every((r) => r.split === "train" || r.split === "dev"));
+    assert.equal(requests.length, 5); // baseline + 2 generations + dev select + holdout final
+    assert.equal(result.runs_queued, 5);
+    assert.equal(result.verdict.verdict, "win");
+    assert.equal(result.champion.system_prompt_suffix, "Include the record id.");
+    const records = readEvolutionRecords(dir);
+    assert.deepEqual(records.map((r) => r.generation), [0, 1, 2, "dev_select", "holdout_final"]);
+    assert.ok(records[1].variants.every((v) => v.system_prompt_suffix_sha256 === promptSuffixHash(v.system_prompt_suffix)));
+    assert.equal(records.at(-1).verdict.verdict, "win");
+  });
+
+  it("keeps the holdout sealed and reports no_win when the champion loses on dev", async () => {
+    const dir = makeBenchmarkDir();
+    const { io, requests } = fakeIo(dir, { scores: (key) => (key === "variant" ? 0 : 1) });
+    const result = await evolvePrompts(dir, { model: "m", authorModel: "author-model", generations: 1, variants: 2, io });
+    assert.equal(requests.filter((r) => r.split === "holdout").length, 0);
+    assert.equal(result.verdict.verdict, "no_win");
+  });
+
+  it("refuses to report a win under --no-final (holdout untouched, verdict unverified)", async () => {
+    const dir = makeBenchmarkDir();
+    const { io, requests } = fakeIo(dir, { scores: (key) => (key === "variant" ? 1 : 0) });
+    const result = await evolvePrompts(dir, { model: "m", authorModel: "author-model", generations: 1, variants: 2, final: false, io });
+    assert.equal(requests.filter((r) => r.split === "holdout").length, 0);
+    assert.equal(result.verdict.verdict, "unverified");
+  });
+
+  it("enforces --budget-runs before queueing past the cap", async () => {
+    const dir = makeBenchmarkDir();
+    const { io } = fakeIo(dir, { scores: () => 1 });
+    await assert.rejects(
+      evolvePrompts(dir, { model: "m", authorModel: "author-model", generations: 3, variants: 2, budgetRuns: 2, io }),
+      /--budget-runs exhausted/,
+    );
+  });
+
+  it("scoring helper ignores anomalous and errored rows", () => {
+    const { mean, rows } = meanScore([
+      { status: "ok", score: 1 },
+      { status: "ok", score: 0, anomaly: { kind: "x" } },
+      { status: "error", score: 1 },
+      { status: "ok", score: 0 },
+    ]);
+    assert.equal(rows, 2);
+    assert.equal(mean, 0.5);
+  });
+});


### PR DESCRIPTION
## What

Wires the automatic prompt-evolution loop for agentic benchmarks: `understudy benchmarks evolve <dir> --model <id> [--budget-runs N]`. GEPA-style evolution where each proposed system-prompt suffix becomes a `prompt_overrides` arm ({arm_label, model, system_prompt_suffix}, PR #340) of a normal queued run.

## The loop

1. **Generation 0**: bare baseline run on the **train** split.
2. **Propose**: an authoring model (existing trace-author gateway plumbing — `gatewayClient` / `resolveDefaultModel`) is fed the failure evidence the hand-run prompt experiment computed manually: per-class tool-call **rejection counts** from the live journals (`unknown_tool` / `missing_required_field` / `missing_by_observation` / `type_mismatch` / `enum_by_observation` — the generated world's `_validate` classes, extracted from all three rejection-reply styles) plus **failing tasks and their unmet contract obligations** from the tasks sidecars, and the current population to mutate. Strict-JSON reply, 2-4 variants/generation (runs are the expensive unit).
3. **Queue**: one run request per generation via the shared `createRunRequest` writer — this command never executes models. It polls the request file with backoff and, if nothing claims it, tells the user (once) to start `understudy runs execute --benchmark <dir> --watch`; it never spawns an executor.
4. **Record**: every generation appends to `evolution.jsonl` (`understudy.prompt_evolution.v1`): suffix text + sha256 (matching the executor's overrides-sidecar provenance hash) + per-arm scores + champion.

## Holdout discipline (claim rules, mirrors optimize-workload)

- Evolve on **train** only; champion confirmed vs bare on **dev**.
- `queueEvolutionRun` hard-rejects `holdout`/`all` for evolve-purpose runs.
- Holdout is touched **exactly once** — final champion-vs-bare run, queued only after a dev win — and the verdict is a paired per-task 95% CI (`pairedVerdict`). Only CI-positive = `win`; `--no-final` yields an explicit `unverified` verdict and the CLI prints a do-not-claim warning.

## Files

- `src/prompt-evolution.ts` — driver + evidence/proposal/queue/wait/verdict primitives (IO seams injectable for tests)
- `src/commands/benchmarks.ts` — new `evolve` subcommand (additive)
- `docs/prompt-evolution.md` — loop, claim rules, budget guidance, and the future hook to rejection-guidance (`guidance.json`) evolution (referenced, not depended on)
- `skills/optimize-agentic-workload/SKILL.md` — evolve flow + claim rules in step 8
- `tests/prompt-evolution.test.mjs` — 15 tests: rejection classification/journal counting, proposal-prompt construction from fixture journals, proposal parsing, split sealing (holdout blocked from evolve runs; full-driver assertion that holdout appears in exactly one final-purpose request), waitForRun idle-warning behavior, evolution.jsonl round-trip, paired-CI verdict, budget cap, no-win/holdout-sealed paths. Gateway and executor fully mocked — no live runs.

## Verification

- `npm run build`, `npm run typecheck`, `npm test` (843 pass), `npm run skills:validate` (36 ok) all green.

## Cost of a live cedar evolution

Per generation ≈ `variants x train_tasks x rollouts` agentic rollouts + one authoring call: on a cedar-sized benchmark (~29 tasks/split), 3 variants + the bare arm ≈ ~115 rollouts/generation, dominated by executor wall-clock; authoring is cents. Default budget (2 generations) queues 5 runs total (baseline + 2 gens + dev select + holdout final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->