### PR TITLE
Fix benchmark-hub visual-QA findings (hydration, floors, feedback ids, pills, dev preflight)

### DIFF
--- a/apps/benchmark-hub/README.md
+++ b/apps/benchmark-hub/README.md
@@ -94,6 +94,12 @@ injecting `data-theme` on `<html>` at serve time.
 
 ## Run
 
+**Prerequisite:** build the CLI at the repo root first (`npm run build` in the
+repo root). The hub's server modules (`lib/data-core.ts` and friends) import
+the compiled `../../../dist/*.js`; in a clean worktree those files don't exist
+and every page 500s. `bun run dev`/`build` run a preflight
+(`scripts/check-dist.mjs`) that fails fast with this message.
+
 ```sh
 cd apps/benchmark-hub
 bun install        # or npm install

--- a/apps/benchmark-hub/app/icon.svg
+++ b/apps/benchmark-hub/app/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Understudy design language: black field + clay/mint/amber accents.
+       Leaderboard-bars glyph for the benchmark hub. Served by Next's
+       app-router icon convention (app/icon.svg). -->
+  <rect width="32" height="32" rx="7" fill="#0c0c0d"/>
+  <rect x="6" y="17" width="5" height="9" rx="1" fill="#d97757"/>
+  <rect x="13.5" y="10" width="5" height="16" rx="1" fill="#7fd4ad"/>
+  <rect x="21" y="13.5" width="5" height="12.5" rx="1" fill="#e2b93b"/>
+</svg>

--- a/apps/benchmark-hub/components/trajectory/conversation.tsx
+++ b/apps/benchmark-hub/components/trajectory/conversation.tsx
@@ -144,6 +144,32 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
+/**
+ * Turn header toggle: a div with button semantics (role/tabIndex/keyboard)
+ * instead of a real <button>, because the header CONTAINS the CopyButton —
+ * nesting a button in a button is invalid HTML and breaks React hydration.
+ */
+function TurnHead({ open, onToggle, children }: { open: boolean; onToggle: () => void; children: React.ReactNode }) {
+  return (
+    <div
+      className="u-turn-head"
+      role="button"
+      tabIndex={0}
+      aria-expanded={open}
+      onClick={onToggle}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return; // let the inner CopyButton keep its own keys
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
 function TurnRow({
   turn,
   open,
@@ -159,7 +185,7 @@ function TurnRow({
   const suffix = calls.length > 0 ? ` → ${calls.map((c) => `${c.name}()`).join(", ")}` : "";
   return (
     <div className={"u-turn" + (turn.role === "assistant" ? " assistant" : "") + (highlight ? " hit" : "")}>
-      <button className="u-turn-head" onClick={onToggle} aria-expanded={open}>
+      <TurnHead open={open} onToggle={onToggle}>
         <span className="u-role-chip" data-role={turn.role}>{turn.role}</span>
         <span className="u-turn-snippet">
           {firstLine(turn.text || (turn.chips[0] ? `${turn.chips[0].name} ${payloadPreview(turn.chips[0].payload, 80)}` : ""), 160)}
@@ -167,7 +193,7 @@ function TurnRow({
         </span>
         <CopyButton text={turn.text || JSON.stringify(turn.chips.map((c) => ({ [c.kind]: c.name, payload: c.payload })))} />
         <span className="u-turn-chev" aria-hidden="true">{open ? "▾" : "▸"}</span>
-      </button>
+      </TurnHead>
       {open && (
         <div className="u-turn-body">
           {turn.text && <MdBlocks text={turn.text} />}
@@ -245,7 +271,7 @@ export function ConversationView({
 
       {system && (
         <div className="u-turn system">
-          <button className="u-turn-head" onClick={() => setSystemOpen(!systemOpen)} aria-expanded={systemOpen}>
+          <TurnHead open={systemOpen} onToggle={() => setSystemOpen(!systemOpen)}>
             <span className="u-role-chip" data-role="system">system</span>
             <span className="u-turn-snippet">
               {firstLine(system, 160)}
@@ -253,7 +279,7 @@ export function ConversationView({
             </span>
             <CopyButton text={system} />
             <span className="u-turn-chev" aria-hidden="true">{systemOpen ? "▾" : "▸"}</span>
-          </button>
+          </TurnHead>
           {systemOpen && (
             <div className="u-turn-body">
               <pre className="u-pre" style={{ maxHeight: 320 }}>{system}</pre>

--- a/apps/benchmark-hub/components/trajectory/replay.tsx
+++ b/apps/benchmark-hub/components/trajectory/replay.tsx
@@ -387,9 +387,12 @@ export function ReplayView({ slug, taskId }: { slug: string; taskId: string }) {
             aria-pressed={arm?.key === a.key}
             className={"u-tab mono" + (arm?.key === a.key ? " on" : "")}
             style={{ border: "1px solid var(--border)", borderRadius: 6, padding: "3px 8px", fontSize: 11 }}
+            title={`run ${a.run_id}`}
             onClick={() => setArmKey(a.key)}
           >
-            {a.model} <span style={{ color: scoreColor(a.mean_score ?? 0) }}>{formatScore(a.mean_score)}</span>
+            {a.model} <span style={{ color: scoreColor(a.mean_score ?? 0) }}>{formatScore(a.mean_score)}</span>{" "}
+            {/* short run-id suffix: identical model+score pills from different runs stay distinguishable */}
+            <span className="text-faint" style={{ fontSize: 9 }}>{a.run_id.slice(-6)}</span>
           </button>
         ))}
         {liveRun && (

--- a/apps/benchmark-hub/package.json
+++ b/apps/benchmark-hub/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
+    "predev": "node scripts/check-dist.mjs",
     "dev": "BENCHMARK_HUB_DEMO=1 next dev -p 1421",
+    "prebuild": "node scripts/check-dist.mjs",
     "build": "next build",
     "start": "next start -p 1421",
     "start:demo": "BENCHMARK_HUB_DEMO=1 next start -p 1421",

--- a/apps/benchmark-hub/scripts/check-dist.mjs
+++ b/apps/benchmark-hub/scripts/check-dist.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Preflight for `next dev`/`next build`: lib/data-core.ts (and friends)
+ * import the ROOT repo's compiled dist/*.js — in a clean worktree those
+ * files don't exist yet and every page 500s with an opaque module-not-found.
+ * Fail fast with the fix instead.
+ */
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const required = [
+  "benchmark-artifacts.js",
+  "benchmark-hub-core.js",
+  "benchmark-hub-types.js",
+  "benchmark-replay.js",
+  "benchmark.js",
+  "run-executor.js",
+  "trace-author.js",
+].map((f) => resolve(repoRoot, "dist", f));
+const missing = required.filter((f) => !existsSync(f));
+
+if (missing.length > 0) {
+  console.error("benchmark-hub preflight: the repo-root CLI build is missing:");
+  for (const f of missing) console.error(`  - ${f}`);
+  console.error("\nThe hub imports these compiled modules (lib/data-core.ts → ../../../dist/*.js).");
+  console.error("Fix: run `npm run build` at the repo root first, then retry.");
+  process.exit(1);
+}

--- a/apps/benchmark-hub/tests/exception-review-api.test.mjs
+++ b/apps/benchmark-hub/tests/exception-review-api.test.mjs
@@ -140,6 +140,7 @@ describe("POST /api/feedback", () => {
     const lines = fs.readFileSync(path.join(outDir, "feedback.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
     assert.equal(lines.length, 1);
     assert.equal(lines[0].task_id, "t-low");
-    assert.equal(lines[0].benchmark_id, "prop");
+    // The proposal-stamped benchmark.json's benchmark_id, NOT the dir basename ("prop").
+    assert.equal(lines[0].benchmark_id, "prop-bench");
   });
 });

--- a/schemas/understudy.task_feedback.v1.schema.json
+++ b/schemas/understudy.task_feedback.v1.schema.json
@@ -14,7 +14,7 @@
     "benchmark_id": {
       "type": "string",
       "minLength": 1,
-      "description": "Slug of the foundry output directory the task belongs to (the directory basename). Note: NOT an understudy.benchmark.v1 benchmark_id — proposed benchmarks have no promoted manifest yet. No absolute paths are recorded (portability rule)."
+      "description": "The proposal-stamped benchmark.json's benchmark_id (read at write time) when available, else the foundry output directory basename. Legacy lines recorded the directory basename only — consumers must accept either id when matching a line to a benchmark. No absolute paths are recorded (portability rule)."
     },
     "task_id": {
       "type": "string",

--- a/src/benchmark-artifacts.ts
+++ b/src/benchmark-artifacts.ts
@@ -276,12 +276,14 @@ export function latestReviewByTask(reviews: BenchmarkReview[]): Record<string, B
  * feedback and hands the user a copyable agent prompt (the hub never
  * executes); a coding agent — or a future daemon verb — consumes open lines
  * and runs `understudy traces regenerate-env` after editing the task. No
- * absolute paths are recorded (portability rule): benchmark_id is the foundry
- * output dir basename, same convention as reviews.jsonl.
+ * absolute paths are recorded (portability rule): benchmark_id is the
+ * proposal-stamped benchmark.json's benchmark_id (read at write time), with
+ * the foundry output dir basename as fallback. Legacy lines recorded the dir
+ * basename — readers must accept both (see feedbackBelongsTo).
  */
 export type TaskFeedback = {
   schema_version: typeof TASK_FEEDBACK_SCHEMA;
-  /** Foundry output dir slug (directory basename), NOT a benchmark.v1 benchmark_id. */
+  /** The proposal manifest's benchmark_id when available, else the foundry output dir basename (legacy lines always used the basename). */
   benchmark_id: string;
   task_id: string;
   /** The reviewer's own words describing what is wrong / should change. */
@@ -327,6 +329,21 @@ export function makeTaskFeedback(input: {
 
 export function serializeTaskFeedbackLine(feedback: TaskFeedback): string {
   return serializeJsonlLine(feedback);
+}
+
+/**
+ * Accept-both benchmark matcher for feedback rows. Newer lines record the
+ * proposal manifest's benchmark_id; legacy lines recorded the foundry output
+ * dir basename. A row belongs to the benchmark when it matches EITHER id.
+ */
+export function feedbackBelongsTo(
+  row: TaskFeedback,
+  ids: { benchmarkId?: string | null; dirBasename?: string | null },
+): boolean {
+  return (
+    (ids.benchmarkId != null && row.benchmark_id === ids.benchmarkId) ||
+    (ids.dirBasename != null && row.benchmark_id === ids.dirBasename)
+  );
 }
 
 /** Valid feedback rows from a feedback.jsonl file (invalid rows dropped, lines tolerant). */

--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -1052,8 +1052,12 @@ export function submitTaskFeedback(
   if (typeof input.task_id !== "string" || !entry.tasks.some((t) => t.task_id === input.task_id)) {
     return { ok: false, error: "unknown task_id", status: 404 };
   }
+  // Record the proposal-stamped benchmark.json's benchmark_id (the id the
+  // manifest and eval rows carry), read at write time; the directory basename
+  // is only a fallback. Readers accept BOTH — existing feedback.jsonl lines
+  // recorded the dir basename before this reconciliation.
   const feedback = makeTaskFeedback({
-    benchmark_id: path.basename(entry.dir),
+    benchmark_id: readProposalBenchmarkId(entry.dir) ?? path.basename(entry.dir),
     task_id: input.task_id,
     feedback: input.feedback.trim(),
   });

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -1099,6 +1099,10 @@ export type TrivialFloor = {
   /** The offending tasks: every selected task the trivial arm passes. */
   passed_task_ids: string[];
   floor_exceeded: boolean;
+  /** Additive provenance, set when a floor is carried forward from a PRIOR calibration run instead of recomputed by this one. */
+  source_run_id?: string;
+  /** Timestamp (finished_at, else started_at) of the run that actually computed the carried floor. */
+  source_ts?: string | null;
 };
 
 export type CalibrationSummary = {
@@ -1200,6 +1204,40 @@ export function deriveCalibrationSummary(args: {
   };
 }
 
+/**
+ * Carry trivial-arm floors forward across calibration rewrites: a newer
+ * incumbent-only run (no trivial arms) must NOT drop the null/spam/majority
+ * floor blocks a previous calibproof run computed. Any floor this run
+ * recomputed wins; any floor absent from `next` but present in `prior` is
+ * carried with honest provenance (the run_id + timestamp that computed it).
+ */
+export function mergeCalibrationFloors(prior: CalibrationSummary | null, next: CalibrationSummary): CalibrationSummary {
+  if (!prior) return next;
+  const merged: CalibrationSummary = { ...next };
+  for (const key of ["null_floor", "spam_floor", "majority_floor"] as const) {
+    const previous = prior[key];
+    if (merged[key] === undefined && previous !== undefined) {
+      merged[key] = {
+        ...previous,
+        // Preserve the ORIGINAL computing run when the prior block was itself carried.
+        source_run_id: previous.source_run_id ?? prior.run_id,
+        source_ts: previous.source_ts !== undefined ? previous.source_ts : prior.finished_at ?? prior.started_at,
+      };
+    }
+  }
+  return merged;
+}
+
+/** Best-effort read of the prior calibration sidecar (null when absent/unreadable/foreign). */
+function readPriorCalibration(benchmarkDir: string): CalibrationSummary | null {
+  try {
+    const parsed = JSON.parse(readFileSync(calibrationPath(benchmarkDir), "utf8")) as CalibrationSummary;
+    return parsed?.schema_version === CALIBRATION_SCHEMA ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Rebuild calibration.json from a finished incumbent run's rows + events. Best-effort: never fails the run. */
 function writeCalibrationSummary(benchmarkDir: string, request: RunRequest, selectedTaskIds: string[]): void {
   try {
@@ -1215,9 +1253,12 @@ function writeCalibrationSummary(benchmarkDir: string, request: RunRequest, sele
       events: readJsonlFile<Obj>(runEventsPath(benchmarkDir)).items,
       trivialArms: request.trivial_arms ?? [],
     });
+    // Floors survive incumbent-only reruns: carry forward the most recent
+    // prior floor blocks (with source provenance) unless this run recomputed them.
+    const merged = mergeCalibrationFloors(readPriorCalibration(benchmarkDir), summary);
     const file = calibrationPath(benchmarkDir);
     const tmp = `${file}.tmp`;
-    writeFileSync(tmp, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(tmp, `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 });
     renameSync(tmp, file);
   } catch {
     // calibration is a derived sidecar — a write failure must not fail the run

--- a/tests/exception-review.test.mjs
+++ b/tests/exception-review.test.mjs
@@ -19,6 +19,7 @@ import {
   meetsConfidenceBar,
   readReviewPolicy,
   TASK_FEEDBACK_SCHEMA,
+  feedbackBelongsTo,
   isTaskFeedback,
   latestReviewByTask,
   makeTaskFeedback,
@@ -337,6 +338,34 @@ describe("task feedback contract (understudy.task_feedback.v1)", () => {
     assert.ok(result.handoff.includes("wrong required tool"));
     assert.ok(result.handoff.includes("t1"));
     assert.equal(result.handoff, buildTaskFeedbackHandoff(dir, "t1", "wrong required tool"));
+  });
+
+  it("records the manifest benchmark_id (not the dir basename), falling back to the basename without benchmark.json", () => {
+    const dir = path.join(tmpDir(), "cedar-automation");
+    writeFoundryDir(dir, [task("t1")]);
+    const entry = loadProposedEntryFromDir(dir, "data-dir", "data--cedar-automation", false);
+    const result = submitTaskFeedback(entry, { task_id: "t1", feedback: "wrong tool" });
+    assert.equal(result.ok, true);
+    assert.equal(result.feedback.benchmark_id, "prop-bench", "the proposal-stamped benchmark_id wins over the dir basename");
+
+    // Fallback: no benchmark.json → dir basename (the legacy convention).
+    const bare = path.join(tmpDir(), "cedar-automation");
+    writeFoundryDir(bare, [task("t1")]);
+    fs.rmSync(path.join(bare, "benchmark.json"));
+    const bareEntry = loadProposedEntryFromDir(bare, "data-dir", "data--cedar-automation", false);
+    const bareResult = submitTaskFeedback(bareEntry, { task_id: "t1", feedback: "wrong tool" });
+    assert.equal(bareResult.ok, true);
+    assert.equal(bareResult.feedback.benchmark_id, "cedar-automation");
+  });
+
+  it("feedbackBelongsTo accepts BOTH the manifest id and the legacy dir-basename id", () => {
+    const legacy = makeTaskFeedback({ benchmark_id: "cedar-automation", task_id: "t1", feedback: "old line" });
+    const modern = makeTaskFeedback({ benchmark_id: "trace-23a3902b7a7b6126", task_id: "t1", feedback: "new line" });
+    const ids = { benchmarkId: "trace-23a3902b7a7b6126", dirBasename: "cedar-automation" };
+    assert.ok(feedbackBelongsTo(legacy, ids));
+    assert.ok(feedbackBelongsTo(modern, ids));
+    assert.ok(!feedbackBelongsTo(makeTaskFeedback({ benchmark_id: "other", task_id: "t1", feedback: "x" }), ids));
+    assert.ok(!feedbackBelongsTo(legacy, { benchmarkId: null, dirBasename: null }));
   });
 
   it("rejects read-only entries and non-proposed stages", () => {

--- a/tests/trivial-arms.test.mjs
+++ b/tests/trivial-arms.test.mjs
@@ -10,6 +10,7 @@ import {
   createRunRequest,
   deriveCalibrationSummary,
   executeRunRequest,
+  mergeCalibrationFloors,
   nullAgentRunner,
   readRunRequest,
   runRequestPath,
@@ -213,6 +214,54 @@ describe("executor with trivial arms", () => {
     // Trivial-only floors make no incumbent claim.
     assert.deepEqual(calibration.tasks, []);
     assert.deepEqual(calibration.failed_task_ids, []);
+  });
+
+  it("carries trivial floors forward across an incumbent-only rerun, and a new trivial run recomputes them", async () => {
+    const dir = makeBenchmarkDir();
+    const okRunner = async () => ({ score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0, writes: [{ tool: "update-record", arguments: { id: "record-12345" } }], tool_call_count: 1 });
+    const calibration = () => JSON.parse(fs.readFileSync(path.join(dir, "calibration.json"), "utf8"));
+
+    // 1. calibproof run: trivial arms compute the floors.
+    const first = queueRun(dir, { trivial_arms: ["null_agent", "spam_agent"] });
+    await executeRunRequest(dir, first.run_id, { runner: okRunner });
+    const before = calibration();
+    assert.equal(before.spam_floor.floor, 0.5);
+    assert.ok(!("source_run_id" in before.spam_floor), "a floor this run computed carries no carry-forward provenance");
+
+    // 2. incumbent-only rerun (no trivial arms): floors must SURVIVE, with
+    //    honest provenance pointing at the run that computed them.
+    const second = queueRun(dir, { incumbent_models: ["candidate-model"] });
+    await executeRunRequest(dir, second.run_id, { runner: okRunner });
+    const after = calibration();
+    assert.equal(after.run_id, second.run_id);
+    assert.ok(after.tasks.length > 0, "the incumbent rerun's own claim is intact");
+    assert.equal(after.null_floor.floor, before.null_floor.floor);
+    assert.equal(after.spam_floor.floor, before.spam_floor.floor);
+    assert.deepEqual(after.spam_floor.passed_task_ids, ["t1"]);
+    assert.equal(after.null_floor.source_run_id, first.run_id);
+    assert.equal(after.spam_floor.source_run_id, first.run_id);
+    assert.equal(after.spam_floor.source_ts, before.finished_at);
+
+    // 3. a NEW trivial run recomputes its own arm (no stale provenance) and
+    //    still carries the arm it did not rerun — preserving the ORIGINAL
+    //    computing run across a double carry.
+    const third = queueRun(dir, { trivial_arms: ["null_agent"] });
+    await executeRunRequest(dir, third.run_id, { runner: okRunner });
+    const final = calibration();
+    assert.equal(final.run_id, third.run_id);
+    assert.ok(!("source_run_id" in final.null_floor), "recomputed floors win and drop carry provenance");
+    assert.equal(final.spam_floor.source_run_id, first.run_id, "double-carried floors keep the original computing run");
+  });
+
+  it("mergeCalibrationFloors: recomputed floors win; missing floors carry with provenance; no prior file is a no-op", () => {
+    const floor = (extra = {}) => ({ arm_kind: "null_agent", floor: 0, passed_task_ids: [], floor_exceeded: false, ...extra });
+    const next = { schema_version: "understudy.benchmark_calibration.v1", run_id: "run-new", finished_at: "2026-07-22T01:00:00Z", started_at: null, null_floor: floor({ floor: 0.25 }) };
+    assert.deepEqual(mergeCalibrationFloors(null, next), next);
+    const prior = { run_id: "run-old", finished_at: "2026-07-20T00:00:00Z", started_at: null, null_floor: floor(), spam_floor: floor({ arm_kind: "spam_agent", floor: 0.5 }) };
+    const merged = mergeCalibrationFloors(prior, next);
+    assert.equal(merged.null_floor.floor, 0.25, "this run recomputed null_floor — it wins");
+    assert.ok(!("source_run_id" in merged.null_floor));
+    assert.deepEqual(merged.spam_floor, { ...prior.spam_floor, source_run_id: "run-old", source_ts: "2026-07-20T00:00:00Z" });
   });
 
   it("still flags anomalies on candidate rows in the same run (candidate-arm-only sentinels, not sentinels-off)", async () => {


### PR DESCRIPTION
Fixes the five confirmed findings from tonight's visual QA pass of the benchmark hub.

## 1. Nested-button hydration error (every task page)
`components/trajectory/conversation.tsx` rendered `CopyButton` inside the `u-turn-head` `<button>` (invalid HTML → React hydration error). Turn and system headers are now `div role="button"` with `tabIndex`, `aria-expanded`, and Enter/Space keyboard handling — interaction identical, no button-in-button.

## 2. Calibration floors lost on rerun
`writeCalibrationSummary` (`src/run-executor.ts`) overwrote `calibration.json`, so an incumbent-only rerun dropped the `null_floor`/`spam_floor` blocks from the previous calibproof run (how cedar lost its floor display). New exported `mergeCalibrationFloors` carries forward the most recent prior floor blocks — stamped with `source_run_id` + `source_ts` (the run that actually computed them) for honest provenance — unless this run recomputed them, in which case the recomputed floor wins and drops the carry provenance. Tested both directions, including double-carry preserving the original computing run.

## 3. feedback.jsonl benchmark_id inconsistency
`submitTaskFeedback` recorded the directory basename (`cedar-automation`) while the manifest id is `trace-23a3902b7a7b6126`. It now reads the proposal-stamped `benchmark.json` `benchmark_id` at write time (basename fallback when absent). New `feedbackBelongsTo` matcher accepts BOTH ids on read so existing lines stay valid; the `understudy.task_feedback.v1` schema description is updated (the field was only constrained descriptively).

## 4. Replay arm-pill ambiguity
Identical "model 0%" pills from different runs now carry a short run-id suffix plus a full `run <id>` title tooltip (`components/trajectory/replay.tsx`).

## 5. Dev ergonomics
- `predev`/`prebuild` preflight (`scripts/check-dist.mjs`) fails fast with "run `npm run build` at the repo root first" instead of 500ing when `dist/*.js` is missing in a clean worktree; README "Run" section documents the prerequisite.
- Added the missing favicon as `app/icon.svg` (Next app-router icon convention, per moraine-viewer precedent): black field + clay/mint/amber leaderboard-bars glyph per the design language.

## Tests
- New: floors carry-forward integration + `mergeCalibrationFloors` unit tests (`tests/trivial-arms.test.mjs`); manifest-id write + basename fallback + accept-both read (`tests/exception-review.test.mjs`); hub API test updated to expect the manifest id.
- All green: root `npm test` (878 pass), `tsc --noEmit`, hub `npm test` (160 pass) + `next build`, `skills:validate` (37 ok).

Not touched (redesign agent ownership): `components/proposed/*`, review-queue, review-bar, task-page.tsx, benchmark-page.tsx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->