### PR TITLE
Merge-train tooling: gated PR train, wave-ownership checker, retro doc

### DIFF
--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -1,0 +1,88 @@
+# Merge train: running many agent PRs into main safely
+
+Distilled from the 2026-07 merge night: 27 agent-built PRs merged into main in
+24 hours with ad-hoc bash. This document codifies what worked, what almost
+broke, and the tooling that now replaces the ad-hoc parts.
+
+## Tooling
+
+- **`scripts/merge-train.sh <pr> [<pr>...]`** — merges a sequence of PRs in
+  order with strict gating and an on-GitHub audit trail. Supports `--dry-run`.
+- **`scripts/wave-ownership.mjs`** — checks a branch's changed files against a
+  `wave.json` ownership manifest; exits nonzero on violations.
+
+## The rules, and why
+
+### 1. Gate on check *conclusions*, never on mergeability alone
+
+`mergeable: MERGEABLE` only means "no textual conflicts". The one red-main
+incident during the merge night came from merging a PR that was MERGEABLE but
+whose checks had not passed. The train therefore:
+
+- waits out GitHub's asynchronous `UNKNOWN` mergeability recompute (it happens
+  after every base-branch update, i.e. after every previous merge in the train),
+- runs `gh pr checks --watch` until checks settle,
+- then requires every completed check to conclude SUCCESS / NEUTRAL / SKIPPED.
+  Any FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED, or STARTUP_FAILURE stops
+  the train with the failing check named.
+
+### 2. Admin-merge audit-comment convention
+
+Merges use `gh pr merge --merge --admin`, which bypasses branch protection.
+That is acceptable only if the verification evidence lives somewhere durable:
+**before** merging, the train posts a comment on the PR containing a checks
+table and the merge rationale. Anyone auditing main later can see, on the PR
+itself, exactly what was green at merge time and why the admin merge was taken.
+
+### 3. Worktree isolation + explicit file ownership per wave
+
+Agents in a wave each work in their own git worktree on their own branch, and
+each wave declares which files each agent owns. During the merge night this
+contract was only verbal, and there were two near-misses: multiple agents
+extending `src/benchmark-artifacts.ts`, and three agents touching
+`run-executor.ts` in one wave.
+
+The contract is now a manifest:
+
+```json
+{
+  "agents": [
+    { "branch": "anthro/foo", "owns": ["src/foo/**", "tests/foo*"], "forbidden": ["src/run-executor.ts"] },
+    { "branch": "anthro/bar", "owns": ["src/bar/**"] }
+  ]
+}
+```
+
+Check any branch before (or while) it opens a PR:
+
+```sh
+node scripts/wave-ownership.mjs --wave wave.json --branch anthro/foo --pr 123
+node scripts/wave-ownership.mjs --wave wave.json --branch anthro/foo --base origin/main
+```
+
+A file is a violation if it matches the agent's `forbidden` globs, or matches
+another agent's `owns` globs without also matching this agent's own `owns`.
+Shared files should either be forbidden to everyone (route changes through a
+dedicated agent) or explicitly co-owned with a reconcile plan.
+
+### 4. Reconcile agents do semantic unions
+
+When a PR turns CONFLICTING mid-train (the train stops and says so), do not
+resolve conflicts by picking a side. The pattern that worked: dispatch a
+reconcile agent whose only job is to merge the base into the branch and produce
+a **semantic union** — both features' behavior preserved, tests from both sides
+green — then push and resume the train from that PR. Blind "ours"/"theirs"
+resolution is how one wave's work silently deletes another's.
+
+### 5. Order the train, keep it serial
+
+Merge PRs one at a time, in dependency order. Every merge changes the base for
+everything behind it, so the train re-waits mergeability and re-gates checks
+per PR rather than trusting a snapshot taken at the start.
+
+## Follow-up
+
+- **Evaluate GitHub's native merge queue** for this repo. It automates the
+  serialize-rebase-recheck-merge loop that `merge-train.sh` does by hand; the
+  script would remain useful for the audit comment and the ownership/reconcile
+  workflow, but the queue may replace the core loop.

--- a/scripts/merge-train.sh
+++ b/scripts/merge-train.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# merge-train.sh — merge a sequence of PRs safely, in order, with an audit trail.
+#
+# Usage:
+#   scripts/merge-train.sh [--dry-run] <pr> [<pr>...]
+#
+# For each PR, in order:
+#   1. Wait out GitHub's UNKNOWN mergeability recompute.
+#   2. Stop immediately on CONFLICTING with a reconcile instruction.
+#   3. `gh pr checks --watch` until checks settle.
+#   4. Gate STRICTLY on check *conclusions*: every completed check must have
+#      conclusion SUCCESS / NEUTRAL / SKIPPED. Any FAILURE, CANCELLED,
+#      TIMED_OUT, ACTION_REQUIRED, or STARTUP_FAILURE stops the train with the
+#      failing check named. We never merge on mergeability alone — MERGEABLE
+#      only means "no conflicts", not "checks passed".
+#   5. Post a review comment with a verification summary (checks table +
+#      merge rationale) BEFORE merging, so an audit artifact lives on GitHub.
+#   6. `gh pr merge --merge --admin`.
+#
+# --dry-run performs steps 1-4 read-only and prints what steps 5-6 would do.
+#
+# Requirements: gh (authenticated), jq.
+
+set -euo pipefail
+
+DRY_RUN=0
+PRS=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "unknown flag: $arg" >&2; exit 2 ;;
+    *) PRS+=("$arg") ;;
+  esac
+done
+
+if [ "${#PRS[@]}" -eq 0 ]; then
+  echo "usage: scripts/merge-train.sh [--dry-run] <pr> [<pr>...]" >&2
+  exit 2
+fi
+
+command -v gh >/dev/null || { echo "error: gh not found" >&2; exit 2; }
+command -v jq >/dev/null || { echo "error: jq not found" >&2; exit 2; }
+
+MERGEABLE_TIMEOUT="${MERGE_TRAIN_MERGEABLE_TIMEOUT:-120}"   # seconds
+MERGEABLE_POLL="${MERGE_TRAIN_MERGEABLE_POLL:-5}"           # seconds
+
+log() { printf '[merge-train] %s\n' "$*"; }
+fail() { printf '[merge-train] STOP: %s\n' "$*" >&2; exit 1; }
+
+# Wait until mergeable state is no longer UNKNOWN. GitHub recomputes
+# mergeability asynchronously after every base-branch update, so right after
+# a previous merge the next PR often reports UNKNOWN for a while.
+wait_mergeable() {
+  local pr="$1" elapsed=0 state
+  while :; do
+    state="$(gh pr view "$pr" --json mergeable --jq '.mergeable')"
+    if [ "$state" != "UNKNOWN" ]; then
+      printf '%s' "$state"
+      return 0
+    fi
+    if [ "$elapsed" -ge "$MERGEABLE_TIMEOUT" ]; then
+      printf 'UNKNOWN'
+      return 0
+    fi
+    log "PR #$pr mergeability UNKNOWN — waiting for GitHub to recompute (${elapsed}s/${MERGEABLE_TIMEOUT}s)…" >&2
+    sleep "$MERGEABLE_POLL"
+    elapsed=$((elapsed + MERGEABLE_POLL))
+  done
+}
+
+# Returns the statusCheckRollup as JSON.
+get_checks() {
+  gh pr view "$1" --json statusCheckRollup --jq '.statusCheckRollup // []'
+}
+
+for pr in "${PRS[@]}"; do
+  log "=== PR #$pr ==="
+
+  meta="$(gh pr view "$pr" --json number,title,state,url,headRefName,baseRefName)"
+  state="$(jq -r '.state' <<<"$meta")"
+  title="$(jq -r '.title' <<<"$meta")"
+  url="$(jq -r '.url' <<<"$meta")"
+  log "#$pr \"$title\" [$state] $url"
+
+  if [ "$state" != "OPEN" ]; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+      log "PR #$pr is $state (not OPEN) — dry-run continues read-only."
+    else
+      fail "PR #$pr is $state, not OPEN. Refusing to continue the train."
+    fi
+  fi
+
+  # 1. Mergeability (conflicts only — never a merge gate by itself).
+  # GitHub never recomputes mergeability for closed/merged PRs, so skip the
+  # wait in that case (only reachable in dry-run).
+  if [ "$state" != "OPEN" ]; then
+    mergeable="N/A (PR $state)"
+  else
+    mergeable="$(wait_mergeable "$pr")"
+  fi
+  log "PR #$pr mergeable=$mergeable"
+  if [ "$mergeable" = "CONFLICTING" ]; then
+    fail "PR #$pr CONFLICTS with its base. Reconcile before resuming: check out the branch, merge the base branch into it, resolve as a semantic union of both sides (do not blindly take either side — see docs/merge-train.md), push, then re-run: scripts/merge-train.sh $pr <remaining PRs>"
+  fi
+  if [ "$mergeable" = "UNKNOWN" ]; then
+    fail "PR #$pr mergeability still UNKNOWN after ${MERGEABLE_TIMEOUT}s. GitHub has not finished recomputing; retry shortly."
+  fi
+
+  # 2. Wait for checks to settle. `gh pr checks --watch` exits nonzero on
+  # failing checks; we do our own strict gating below, so tolerate that.
+  log "PR #$pr watching checks…"
+  gh pr checks "$pr" --watch || true
+
+  # 3. Strict gate on check CONCLUSIONS.
+  checks="$(get_checks "$pr")"
+  count="$(jq 'length' <<<"$checks")"
+  if [ "$count" -eq 0 ]; then
+    log "PR #$pr has no checks reported — treating as pass (repo has no required checks)."
+  fi
+
+  pending="$(jq -r '[.[] | select(.status? and .status != "COMPLETED")] | length' <<<"$checks")"
+  if [ "$pending" -ne 0 ]; then
+    fail "PR #$pr still has $pending check(s) not COMPLETED after watch. Refusing to merge."
+  fi
+
+  bad="$(jq -r '[.[] | select((.conclusion // "SUCCESS") as $c | ($c != "SUCCESS" and $c != "NEUTRAL" and $c != "SKIPPED"))] | map("\(.name // .context): \(.conclusion)") | join(", ")' <<<"$checks")"
+  if [ -n "$bad" ]; then
+    fail "PR #$pr has failing check(s): $bad. Never merge on mergeability alone — fix the checks first."
+  fi
+
+  # 4. Build the audit comment: checks table + merge rationale.
+  table="$(jq -r '
+    if length == 0 then "_no checks reported_"
+    else
+      "| check | conclusion |\n|---|---|\n" +
+      (map("| \(.name // .context) | \(.conclusion // .state) |") | join("\n"))
+    end' <<<"$checks")"
+
+  body="$(printf '%s\n\n%s\n\n%s\n' \
+    "**Merge-train verification** (scripts/merge-train.sh)" \
+    "$table" \
+    "Rationale: mergeable=$mergeable; all $count check(s) completed with passing conclusions (SUCCESS/NEUTRAL/SKIPPED). Merging via \`gh pr merge --merge --admin\` per the merge-train convention (docs/merge-train.md).")"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "PR #$pr DRY RUN — would post review comment:"
+    printf '%s\n' "$body" | sed 's/^/    /'
+    log "PR #$pr DRY RUN — would run: gh pr merge $pr --merge --admin"
+    continue
+  fi
+
+  # 5. Audit artifact first, then merge.
+  log "PR #$pr posting verification comment…"
+  gh pr comment "$pr" --body "$body"
+
+  log "PR #$pr merging…"
+  gh pr merge "$pr" --merge --admin
+  log "PR #$pr merged."
+done
+
+log "Train complete."

--- a/scripts/wave-ownership.mjs
+++ b/scripts/wave-ownership.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// wave-ownership.mjs — check a branch's changed files against a wave.json
+// ownership manifest. Formalizes per-wave file-ownership contracts so two
+// agents don't silently extend the same file in one wave.
+//
+// wave.json shape:
+//   {
+//     "agents": [
+//       { "branch": "anthro/foo", "owns": ["src/foo/**"], "forbidden": ["src/run-executor.ts"] }
+//     ]
+//   }
+//
+// Usage:
+//   node scripts/wave-ownership.mjs --wave wave.json --branch anthro/foo --pr 123
+//   node scripts/wave-ownership.mjs --wave wave.json --branch anthro/foo --base origin/main
+//   git diff --name-only origin/main | node scripts/wave-ownership.mjs --wave wave.json --branch anthro/foo --stdin
+//
+// Changed files come from `gh pr diff <pr> --name-only`, `git diff --name-only <base>...HEAD`,
+// or stdin. Violations:
+//   - a changed file matches the agent's `forbidden` globs
+//   - a changed file matches another agent's `owns` globs (unless this agent also owns it)
+// Exits nonzero on any violation. No dependencies.
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+function usageExit(msg) {
+  if (msg) console.error(`error: ${msg}`);
+  console.error(
+    "usage: wave-ownership.mjs --wave <wave.json> --branch <branch> (--pr <n> | --base <ref> | --stdin)"
+  );
+  process.exit(2);
+}
+
+const args = process.argv.slice(2);
+const opts = {};
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a === "--stdin") opts.stdin = true;
+  else if (a === "--wave" || a === "--branch" || a === "--pr" || a === "--base") {
+    opts[a.slice(2)] = args[++i] ?? usageExit(`missing value for ${a}`);
+  } else usageExit(`unknown arg ${a}`);
+}
+if (!opts.wave || !opts.branch) usageExit("--wave and --branch are required");
+
+// Minimal glob matcher: supports **, *, ?. Anchored to the whole path.
+function globToRegExp(glob) {
+  let re = "";
+  let i = 0;
+  while (i < glob.length) {
+    if (glob.startsWith("**/", i)) {
+      re += "(?:.*/)?"; // zero or more directories
+      i += 3;
+    } else if (glob.startsWith("**", i)) {
+      re += ".*";
+      i += 2;
+    } else if (glob[i] === "*") {
+      re += "[^/]*";
+      i += 1;
+    } else if (glob[i] === "?") {
+      re += "[^/]";
+      i += 1;
+    } else {
+      re += glob[i].replace(/[.+^${}()|[\]\\]/g, "\\$&");
+      i += 1;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+const matches = (file, globs = []) => globs.some((g) => globToRegExp(g).test(file));
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(opts.wave, "utf8"));
+} catch (e) {
+  usageExit(`cannot read manifest ${opts.wave}: ${e.message}`);
+}
+if (!Array.isArray(manifest.agents)) usageExit("wave.json must have an `agents` array");
+
+const me = manifest.agents.find((a) => a.branch === opts.branch);
+if (!me) usageExit(`branch ${opts.branch} not found in ${opts.wave}`);
+const others = manifest.agents.filter((a) => a !== me);
+
+let files;
+if (opts.stdin) {
+  files = readFileSync(0, "utf8").split("\n");
+} else if (opts.pr) {
+  files = execFileSync("gh", ["pr", "diff", opts.pr, "--name-only"], { encoding: "utf8" }).split("\n");
+} else if (opts.base) {
+  files = execFileSync("git", ["diff", "--name-only", `${opts.base}...HEAD`], { encoding: "utf8" }).split("\n");
+} else {
+  usageExit("provide one of --pr, --base, or --stdin");
+}
+files = files.map((f) => f.trim()).filter(Boolean);
+
+const violations = [];
+for (const file of files) {
+  if (matches(file, me.forbidden)) {
+    violations.push(`${file}: FORBIDDEN for ${me.branch}`);
+    continue;
+  }
+  if (matches(file, me.owns)) continue; // explicitly owned — fine
+  for (const other of others) {
+    if (matches(file, other.owns)) {
+      violations.push(`${file}: owned by ${other.branch}, changed by ${me.branch}`);
+    }
+  }
+}
+
+console.log(`wave-ownership: branch=${me.branch} files=${files.length}`);
+if (violations.length === 0) {
+  console.log("OK — no ownership violations.");
+  process.exit(0);
+}
+console.error(`\n${violations.length} violation(s):`);
+for (const v of violations) console.error(`  - ${v}`);
+process.exit(1);


### PR DESCRIPTION
Codifies the merge-night learnings (27 agent PRs merged in 24h with ad-hoc bash) as small, dependency-light repo tooling.

## What's in here

- **`scripts/merge-train.sh <pr> [<pr>...]`** — serial PR merge train (bash + gh + jq, `--dry-run` supported). Per PR: waits out GitHub's asynchronous UNKNOWN mergeability recompute; stops on CONFLICTING with a semantic-union reconcile instruction; `gh pr checks --watch`; then gates **strictly on check conclusions** (SUCCESS/NEUTRAL/SKIPPED only — never on mergeability alone, which caused the one red-main incident); posts a verification comment (checks table + rationale) on the PR **before** merging so an audit artifact lives on GitHub; then `gh pr merge --merge --admin`.
- **`scripts/wave-ownership.mjs`** — zero-dependency ownership-manifest checker. Reads a `wave.json` (`{agents: [{branch, owns: [globs], forbidden: [globs]}]}`), gets changed files from `gh pr diff --name-only`, `git diff --name-only <base>...HEAD`, or stdin, and exits nonzero on any file that is forbidden or owned by another agent. Formalizes the per-wave verbal ownership contracts after two near-misses (multiple agents extending `src/benchmark-artifacts.ts`; three touching `run-executor.ts` in one wave).
- **`docs/merge-train.md`** — the distilled retro: worktree isolation + explicit ownership, the check-conclusions rule, the admin-merge audit-comment convention, reconcile-agents-doing-semantic-unions, and a follow-up note to evaluate GitHub's native merge queue.

## Testing (read-only)

- `scripts/merge-train.sh --dry-run 351 350` against merged PRs: correct state/mergeability handling, checks tables rendered, would-merge steps printed, no writes.
- `wave-ownership.mjs` against PR #350's real diff with a synthetic manifest: correctly flagged the `src/run-executor.ts` forbidden hit and cross-agent ownership violations (exit 1), and passed a clean stdin file list (exit 0).
- `npm run skills:validate` green (37 skills). `npm test`: 283 pass / 174 fail — identical counts on a clean origin/main tree, so the failures pre-exist and are unrelated (this PR adds only new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->