### PR TITLE
Wire the embedded Pi chat to the benchmark/experiment spine

### DIFF
--- a/src/runtime/conversation/benchmark-extension.ts
+++ b/src/runtime/conversation/benchmark-extension.ts
@@ -1,0 +1,263 @@
+// Benchmark-lab operator tools for the embedded Pi conversation runtime.
+//
+// The desktop app's in-app chat becomes the self-service operator over the
+// same file-based benchmark/experiment spine the 13-tool benchmarks MCP
+// server exposes to external coding agents. Every tool here delegates to
+// `callBenchmarksTool` — the exact dispatcher behind `understudy benchmarks
+// mcp` — so validation, append-only ledger discipline, and queue-not-execute
+// semantics are shared byte for byte, never forked. Schemas are cloned from
+// BENCHMARKS_TOOLS so the two surfaces cannot drift silently.
+//
+// Safety posture mirrors src/runtime/conversation/command-guard.ts: a
+// classifier decides allow/block, the extension enforces it at the Pi
+// `tool_call` boundary, and the execute path enforces it again so the guard
+// holds even if the tool is invoked outside an extension-loaded session.
+// Queueing a run only writes a runs/queue/<run_id>.json file (the executor
+// daemon spends); spend-adjacent shapes (multi-arm or multi-rollout runs,
+// implicit all-task runs, experiment approval/verdict updates) additionally
+// require an explicit `confirm: true` argument, which the model may only set
+// after the user consented in chat.
+//
+// These tools are Pi-only by design: the Vercel runtime twin builds its tool
+// set purely from the request's tool definitions and has no extension
+// mechanism, so the parity contract (frozen conformance fixtures) never
+// references them. The conformance suite validates emitted event traces, not
+// tool inventories, so registering additional never-called tools keeps every
+// frozen scenario inside the contract.
+//
+// Benchmark root resolution is the shared data-core contract: the
+// colon-separated BENCHMARK_HUB_DATA_DIR env var when set, otherwise
+// ~/.understudy/benchmarks.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+
+import { BENCHMARKS_TOOLS, callBenchmarksTool } from "../../benchmarks-mcp.js";
+import { getEntry } from "../../benchmark-hub-core.js";
+import { deriveRigorReport } from "../../rigor-report.js";
+
+/**
+ * Explicit allowlist of MCP-shared operator tools exposed in the embedded
+ * chat. Deliberately smaller than the full MCP surface: rollout-forensics
+ * tools (read_rollout, diff_rollouts) and bulk review application
+ * (apply_auto_accepts) stay on the external-agent surface until the desktop
+ * chat has a reviewed UX for them.
+ */
+export const PI_BENCHMARK_SHARED_TOOLS = [
+  "list_benchmarks",
+  "read_benchmark",
+  "read_task",
+  "run_status",
+  "queue_run",
+  "submit_review",
+  "submit_feedback",
+  "list_experiments",
+  "create_experiment",
+  "update_experiment",
+] as const;
+
+/** Pi-only read tool over the shared rigor derivation (not an MCP tool). */
+export const PI_BENCHMARK_RIGOR_TOOL = "read_rigor_report" as const;
+
+export const PI_BENCHMARK_TOOL_NAMES: readonly string[] = [
+  ...PI_BENCHMARK_SHARED_TOOLS,
+  PI_BENCHMARK_RIGOR_TOOL,
+];
+
+export function benchmarkHubRoots(): string {
+  return process.env.BENCHMARK_HUB_DATA_DIR ?? join(homedir(), ".understudy", "benchmarks");
+}
+
+/* ---------------- spend-adjacent gating (command-guard pattern) ---------------- */
+
+export type BenchmarkGuardDecision =
+  | { decision: "allow" }
+  | { decision: "block"; rule_id: string; reason: string; severity: "high" };
+
+type Obj = Record<string, unknown>;
+
+function asObject(value: unknown): Obj {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Obj)
+    : {};
+}
+
+/**
+ * A trivial queue_run — exactly one candidate arm, one rollout per task, an
+ * explicit task list, and no incumbent arm — is a cheap targeted probe and is
+ * allowed without confirmation. Anything wider is spend-adjacent once an
+ * executor picks it up.
+ */
+export function queueRunIsTrivial(args: Obj): boolean {
+  const models = Array.isArray(args.models) ? args.models : [];
+  const incumbents = Array.isArray(args.incumbent_models) ? args.incumbent_models : [];
+  const rollouts =
+    args.rollouts_per_task === undefined ? 1 : Number(args.rollouts_per_task);
+  return (
+    models.length === 1 &&
+    incumbents.length === 0 &&
+    rollouts === 1 &&
+    Array.isArray(args.tasks) &&
+    args.tasks.length > 0
+  );
+}
+
+/** Fields on an update_experiment patch that adjust approval/spend state. */
+const EXPERIMENT_APPROVAL_FIELDS = ["status", "verdict"] as const;
+
+function experimentPatchTouchesApprovals(patch: Obj): boolean {
+  if (EXPERIMENT_APPROVAL_FIELDS.some((field) => field in patch)) return true;
+  const training = asObject(patch.training);
+  return "approvals" in training;
+}
+
+export function classifyBenchmarkToolCall(
+  toolName: string,
+  input: unknown,
+): BenchmarkGuardDecision {
+  if (!PI_BENCHMARK_TOOL_NAMES.includes(toolName)) return { decision: "allow" };
+  const args = asObject(input);
+  if (args.confirm === true) return { decision: "allow" };
+  if (toolName === "queue_run" && !queueRunIsTrivial(args)) {
+    return {
+      decision: "block",
+      rule_id: "benchmark.queue-run-unconfirmed",
+      reason:
+        "This run request is spend-adjacent (multiple model arms, an incumbent arm, repeated rollouts, or an implicit all-task run) and an executor will spend money or compute the moment it picks the queued file up.",
+      severity: "high",
+    };
+  }
+  if (toolName === "update_experiment" && experimentPatchTouchesApprovals(asObject(args.patch))) {
+    return {
+      decision: "block",
+      rule_id: "benchmark.experiment-approval-unconfirmed",
+      reason:
+        "This experiment patch changes approval, status, or verdict state that downstream tooling treats as cleared spend gates.",
+      severity: "high",
+    };
+  }
+  return { decision: "allow" };
+}
+
+export function benchmarkGuardBlockMessage(
+  decision: Exclude<BenchmarkGuardDecision, { decision: "allow" }>,
+): string {
+  return `Blocked by Understudy benchmark guard [${decision.rule_id}]: ${decision.reason} Ask the user for explicit consent in chat, then retry the same call with confirm: true.`;
+}
+
+export function enforceBenchmarkToolCall(toolName: string, input: unknown): void {
+  const decision = classifyBenchmarkToolCall(toolName, input);
+  if (decision.decision === "block") {
+    throw new Error(benchmarkGuardBlockMessage(decision));
+  }
+}
+
+/* ---------------- tool definitions ---------------- */
+
+const CONFIRM_PROPERTY = {
+  confirm: {
+    type: "boolean",
+    description:
+      "Required true for spend-adjacent shapes. Set only after the user explicitly consented in this conversation.",
+  },
+} as const;
+
+/** Tools whose schema gains the guard's `confirm` escape hatch. */
+const CONFIRMABLE_TOOLS = new Set(["queue_run", "update_experiment"]);
+
+function sharedToolSchema(name: string): Record<string, unknown> {
+  const source = BENCHMARKS_TOOLS.find((tool) => tool.name === name);
+  if (!source) throw new Error(`benchmarks MCP no longer exposes tool ${name}`);
+  const schema = JSON.parse(JSON.stringify(source.inputSchema)) as {
+    type: string;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  if (CONFIRMABLE_TOOLS.has(name)) {
+    schema.properties = { ...(schema.properties ?? {}), ...CONFIRM_PROPERTY };
+  }
+  return schema;
+}
+
+function sharedToolDescription(name: string): string {
+  const source = BENCHMARKS_TOOLS.find((tool) => tool.name === name);
+  if (!source) throw new Error(`benchmarks MCP no longer exposes tool ${name}`);
+  return CONFIRMABLE_TOOLS.has(name)
+    ? `${source.description} Spend-adjacent shapes are blocked unless confirm: true is passed after explicit user consent.`
+    : source.description;
+}
+
+function toolResult(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+    details: value,
+  };
+}
+
+function readRigorReport(input: unknown): unknown {
+  const args = asObject(input);
+  const slug = typeof args.slug === "string" ? args.slug : "";
+  if (!slug) throw new Error("slug (string) is required");
+  const entry = getEntry(slug);
+  if (!entry) throw new Error(`unknown benchmark slug: ${slug} (use list_benchmarks)`);
+  if (entry.kind === "invalid") {
+    throw new Error(`benchmark dir is invalid: ${entry.errors.join("; ")}`);
+  }
+  // Same shared derivation as `understudy benchmarks rigor`; promoted dirs
+  // only (it throws a legible error on a proposed dir's missing benchmark.json).
+  return deriveRigorReport(entry.dir);
+}
+
+export function benchmarkToolDefinitions() {
+  const shared = PI_BENCHMARK_SHARED_TOOLS.map((name) =>
+    defineTool({
+      name,
+      label: `Benchmark lab: ${name}`,
+      description: sharedToolDescription(name),
+      parameters: Type.Unsafe(sharedToolSchema(name)),
+      async execute(_toolCallId, parameters) {
+        enforceBenchmarkToolCall(name, parameters);
+        // Strip the pi-layer confirm flag before delegating: the shared MCP
+        // dispatcher's argument surface stays byte-identical to the hub API.
+        const { confirm: _confirm, ...args } = asObject(parameters);
+        return toolResult(callBenchmarksTool(name, args));
+      },
+    }),
+  );
+  const rigor = defineTool({
+    name: PI_BENCHMARK_RIGOR_TOOL,
+    label: "Benchmark lab: read_rigor_report",
+    description:
+      "Derive the ABC rigor report for one PROMOTED benchmark (same shared derivation as `understudy benchmarks rigor` and the checked-in rigor-report.md): per-item PASS/FLAG/UNKNOWN with evidence. Read-only.",
+    parameters: Type.Unsafe(({
+      type: "object",
+      properties: { slug: { type: "string", description: "Slug from list_benchmarks (promoted stage)." } },
+      required: ["slug"],
+    }) as Record<string, unknown>),
+    async execute(_toolCallId, parameters) {
+      return toolResult(readRigorReport(parameters));
+    },
+  });
+  return [...shared, rigor];
+}
+
+/**
+ * Inline runtime extension (registered in pi-runtime's extensionFactories,
+ * same pattern as understudy-command-guard): registers the operator tools and
+ * enforces the spend-adjacent guard at the tool_call boundary.
+ */
+export function piBenchmarkLabExtension(pi: ExtensionAPI): void {
+  for (const tool of benchmarkToolDefinitions()) {
+    pi.registerTool(tool);
+  }
+  pi.on("tool_call", (event) => {
+    const decision = classifyBenchmarkToolCall(event.toolName, event.input);
+    if (decision.decision === "block") {
+      return { block: true, reason: benchmarkGuardBlockMessage(decision) };
+    }
+  });
+}

--- a/src/runtime/conversation/pi-runtime.ts
+++ b/src/runtime/conversation/pi-runtime.ts
@@ -35,7 +35,25 @@ import {
   enforceShellToolCall,
   piCommandGuardExtension,
 } from "./command-guard.js";
+import {
+  PI_BENCHMARK_TOOL_NAMES,
+  piBenchmarkLabExtension,
+} from "./benchmark-extension.js";
 import { packagePath } from "../../internal/package-root.js";
+
+/**
+ * The explicit, deliberately small preinstall allowlist of packaged skills.
+ * `noSkills` keeps user/project skills disabled; only these load. The
+ * orchestrator (skills/understudy) routes benchmark-lab requests to
+ * skills/operate-benchmark-lab via a relative link, so the lab skill must be
+ * preinstalled alongside it for that route to resolve in the embedded chat.
+ */
+export function piPreinstalledSkillPaths(): string[] {
+  return [
+    packagePath("skills", "understudy", "SKILL.md"),
+    packagePath("skills", "operate-benchmark-lab", "SKILL.md"),
+  ];
+}
 
 function runtimeHome(): string {
   return resolve(
@@ -547,8 +565,10 @@ async function createPiRuntimeSession(options: {
   persistent: boolean;
   maxTokens?: number;
   toolsEnabled?: boolean;
+  benchmarkLab?: boolean;
 }) {
   const { request, target, root, messages, persistent } = options;
+  const benchmarkLab = options.benchmarkLab === true;
   const providerUrl = requireSafeProviderTargetUrl(target, request.allow_remote);
   const cwd = join(root, "cwd");
   const sessionDir = join(root, "sessions");
@@ -598,13 +618,18 @@ async function createPiRuntimeSession(options: {
       .filter(Boolean)
       .join("\n\n") ||
     "You are the Understudy conversation runtime. Use only explicitly provided tools.";
-  const understudyRootSkill = packagePath("skills", "understudy", "SKILL.md");
   const resourceLoader = new DefaultResourceLoader({
     cwd,
     agentDir: join(root, "agent"),
     settingsManager,
     extensionFactories: [
       { name: "understudy-command-guard", factory: piCommandGuardExtension },
+      // The benchmark-lab operator tools load only for primary (persistent
+      // desktop-chat) sessions — never for supervised student/teacher
+      // segments, whose tool surfaces are frozen by the supervision contract.
+      ...(benchmarkLab
+        ? [{ name: "understudy-benchmark-lab", factory: piBenchmarkLabExtension }]
+        : []),
       ...(request.conformance_deterministic_compaction
         ? [
             {
@@ -617,11 +642,11 @@ async function createPiRuntimeSession(options: {
     // Keep user/project extensions disabled. Inline runtime extensions above
     // still load, so the safety boundary is deterministic and app-owned.
     noExtensions: true,
-    // The packaged Understudy orchestrator is the one preinstalled skill.
+    // Preinstalled packaged skills only (explicit allowlist above).
     // `noSkills` keeps project/user skills disabled while additional paths
     // remain loadable by Pi. The app-owned system prompt tells the model to
     // disclose specialist instructions through the restricted CLI tool.
-    additionalSkillPaths: [understudyRootSkill],
+    additionalSkillPaths: piPreinstalledSkillPaths(),
     noSkills: true,
     noPromptTemplates: true,
     noThemes: true,
@@ -639,7 +664,10 @@ async function createPiRuntimeSession(options: {
     agentDir: join(root, "agent"),
     model: selectedModel,
     thinkingLevel: request.provider_kind === "anthropic" ? "medium" : "off",
-    tools: tools.map((tool) => tool.name),
+    tools: [
+      ...tools.map((tool) => tool.name),
+      ...(benchmarkLab ? PI_BENCHMARK_TOOL_NAMES : []),
+    ],
     noTools: "all",
     customTools: tools,
     resourceLoader,
@@ -1334,6 +1362,7 @@ export async function runPiConversation(
     root,
     messages: request.messages,
     persistent: true,
+    benchmarkLab: true,
   });
   let lengthContinuationAttempts = 0;
   let lengthContinuationFailure: unknown;

--- a/tests/benchmark-extension.test.mjs
+++ b/tests/benchmark-extension.test.mjs
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+// The Pi benchmark-lab extension is exercised through the compiled dist,
+// same as tests/benchmarks-mcp.test.mjs and conversation-runtime.test.mjs.
+import {
+  PI_BENCHMARK_SHARED_TOOLS,
+  PI_BENCHMARK_TOOL_NAMES,
+  benchmarkGuardBlockMessage,
+  benchmarkHubRoots,
+  benchmarkToolDefinitions,
+  classifyBenchmarkToolCall,
+  piBenchmarkLabExtension,
+  queueRunIsTrivial,
+} from "../dist/runtime/conversation/benchmark-extension.js";
+import { piPreinstalledSkillPaths } from "../dist/runtime/conversation/pi-runtime.js";
+import { BENCHMARKS_TOOLS, callBenchmarksTool } from "../dist/benchmarks-mcp.js";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-benchmark-extension-"));
+process.env.BENCHMARK_HUB_DATA_DIR = tmp;
+delete process.env.BENCHMARK_HUB_DEMO;
+after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+/* ---------------- fixture: one promoted benchmark ---------------- */
+
+const promotedDir = path.join(tmp, "promoted");
+fs.mkdirSync(path.join(promotedDir, "runs", "live"), { recursive: true });
+fs.writeFileSync(
+  path.join(promotedDir, "benchmark.json"),
+  JSON.stringify({
+    schema_version: "understudy.benchmark.v1",
+    benchmark_id: "promoted-bench",
+    name: "Promoted bench",
+    provenance: { origin: "authored" },
+    taxonomy: [{ category_id: "cat-a" }],
+    tasks: [
+      { task_id: "t1", category_id: "cat-a", genesis: "synthesized", split: "holdout" },
+      { task_id: "t2", category_id: "cat-a", genesis: "synthesized", split: "dev" },
+    ],
+    environment: { format: "verifiers.v1", package_ref: "pkg" },
+    verifier: { kind: "reward-fns", strict_metric: "strict" },
+  }),
+);
+// Slug derivation is data-core's concern; discover it via the shared loader.
+function discoveredSlug() {
+  const out = callBenchmarksTool("list_benchmarks", {});
+  const entry = out.benchmarks.find((b) => b.dir === promotedDir);
+  assert.ok(entry, "fixture benchmark discovered through the shared loader");
+  return entry.slug;
+}
+
+async function execute(name, args) {
+  const tool = benchmarkToolDefinitions().find((t) => t.name === name);
+  assert.ok(tool, `tool ${name} is defined`);
+  return tool.execute("call-1", args, undefined, undefined, {});
+}
+
+/* ---------------- registration + schema parity ---------------- */
+
+describe("tool registration", () => {
+  it("exposes exactly the explicit allowlist", () => {
+    const names = benchmarkToolDefinitions().map((t) => t.name);
+    assert.deepEqual(names, [...PI_BENCHMARK_TOOL_NAMES]);
+    assert.equal(names.length, PI_BENCHMARK_SHARED_TOOLS.length + 1);
+  });
+
+  it("clones MCP schemas verbatim, adding only the confirm gate", () => {
+    for (const name of PI_BENCHMARK_SHARED_TOOLS) {
+      const source = BENCHMARKS_TOOLS.find((t) => t.name === name);
+      const tool = benchmarkToolDefinitions().find((t) => t.name === name);
+      const cloned = JSON.parse(JSON.stringify(tool.parameters));
+      if (["queue_run", "update_experiment"].includes(name)) {
+        assert.equal(cloned.properties.confirm.type, "boolean");
+        delete cloned.properties.confirm;
+      } else {
+        assert.equal(cloned.properties?.confirm, undefined);
+      }
+      assert.deepEqual(cloned, JSON.parse(JSON.stringify(source.inputSchema)));
+    }
+  });
+
+  it("registers every tool plus a tool_call guard through the extension API", () => {
+    const registered = [];
+    const handlers = new Map();
+    piBenchmarkLabExtension({
+      registerTool: (tool) => registered.push(tool.name),
+      on: (event, handler) => handlers.set(event, handler),
+    });
+    assert.deepEqual(registered, [...PI_BENCHMARK_TOOL_NAMES]);
+    const guard = handlers.get("tool_call");
+    assert.equal(typeof guard, "function");
+    const blocked = guard({ toolName: "queue_run", input: { slug: "x", models: ["a", "b"] } });
+    assert.equal(blocked.block, true);
+    assert.match(blocked.reason, /benchmark\.queue-run-unconfirmed/);
+    assert.equal(guard({ toolName: "read_benchmark", input: { slug: "x" } }), undefined);
+    // Shell tools remain the command guard's concern, not this guard's.
+    assert.equal(guard({ toolName: "bash", input: { command: "rm -rf /" } }), undefined);
+  });
+
+  it("defaults the hub root to ~/.understudy/benchmarks with env override", () => {
+    assert.equal(benchmarkHubRoots(), tmp);
+    const saved = process.env.BENCHMARK_HUB_DATA_DIR;
+    delete process.env.BENCHMARK_HUB_DATA_DIR;
+    assert.equal(benchmarkHubRoots(), path.join(os.homedir(), ".understudy", "benchmarks"));
+    process.env.BENCHMARK_HUB_DATA_DIR = saved;
+  });
+});
+
+/* ---------------- spend-adjacent gating ---------------- */
+
+describe("spend-adjacent gating", () => {
+  it("allows trivial single-arm targeted queue_run without confirm", () => {
+    const args = { slug: "s", models: ["m"], tasks: ["t1"], rollouts_per_task: 1 };
+    assert.equal(queueRunIsTrivial(args), true);
+    assert.deepEqual(classifyBenchmarkToolCall("queue_run", args), { decision: "allow" });
+  });
+
+  it("blocks non-trivial queue_run shapes unless confirmed", () => {
+    for (const args of [
+      { slug: "s", models: ["a", "b"], tasks: ["t1"] },
+      { slug: "s", models: ["a"], tasks: ["t1"], rollouts_per_task: 5 },
+      { slug: "s", models: ["a"] }, // implicit all-task run
+      { slug: "s", models: ["a"], tasks: ["t1"], incumbent_models: ["a"] },
+    ]) {
+      const decision = classifyBenchmarkToolCall("queue_run", args);
+      assert.equal(decision.decision, "block");
+      assert.equal(decision.rule_id, "benchmark.queue-run-unconfirmed");
+      assert.match(benchmarkGuardBlockMessage(decision), /confirm: true/);
+      assert.deepEqual(
+        classifyBenchmarkToolCall("queue_run", { ...args, confirm: true }),
+        { decision: "allow" },
+      );
+    }
+  });
+
+  it("blocks experiment approval/status/verdict patches unless confirmed", () => {
+    for (const patch of [
+      { status: "approved" },
+      { verdict: { decision: "promote", summary: "s", decided_at: "now" } },
+      { training: { approvals: [{ gate: "spend", approved_by: "me", at: "now" }] } },
+    ]) {
+      const decision = classifyBenchmarkToolCall("update_experiment", {
+        slug: "s",
+        experiment_id: "e",
+        patch,
+      });
+      assert.equal(decision.decision, "block");
+      assert.equal(decision.rule_id, "benchmark.experiment-approval-unconfirmed");
+    }
+    assert.deepEqual(
+      classifyBenchmarkToolCall("update_experiment", {
+        slug: "s",
+        experiment_id: "e",
+        patch: { produced_artifact: { kind: "adapter", ref: "r", sha256: "x" } },
+      }),
+      { decision: "allow" },
+    );
+  });
+
+  it("enforces the guard on execute, not just at the extension boundary", async () => {
+    await assert.rejects(
+      execute("queue_run", { slug: discoveredSlug(), models: ["a", "b"] }),
+      /benchmark\.queue-run-unconfirmed/,
+    );
+  });
+});
+
+/* ---------------- shared-function delegation ---------------- */
+
+describe("shared-function delegation", () => {
+  it("read tools return exactly what the MCP dispatcher returns", async () => {
+    const slug = discoveredSlug();
+    for (const [name, args] of [
+      ["list_benchmarks", {}],
+      ["read_benchmark", { slug }],
+      ["read_task", { slug, task_id: "t1" }],
+      ["list_experiments", { slug }],
+    ]) {
+      const viaPi = await execute(name, args);
+      assert.deepEqual(viaPi.details, callBenchmarksTool(name, args));
+      assert.deepEqual(JSON.parse(viaPi.content[0].text), viaPi.details);
+    }
+  });
+
+  it("queue_run writes the shared run_request file and strips confirm", async () => {
+    const slug = discoveredSlug();
+    const result = await execute("queue_run", {
+      slug,
+      models: ["model-a", "model-b"],
+      tasks: ["t1"],
+      split: "holdout",
+      confirm: true,
+    });
+    const runId = result.details.run_id;
+    const file = path.join(promotedDir, "runs", "queue", `${runId}.json`);
+    assert.ok(fs.existsSync(file), "run request queued through shared writer");
+    const queued = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.equal(queued.schema_version, "understudy.run_request.v1");
+    assert.deepEqual(queued.models, ["model-a", "model-b"]);
+    assert.equal("confirm" in queued, false);
+    // Status readable back through the same shared loader.
+    const status = await execute("run_status", { slug, run_id: runId });
+    assert.equal(status.details.status, "queued");
+  });
+
+  it("surfaces the shared validation errors unforked", async () => {
+    await assert.rejects(execute("read_benchmark", { slug: "nope" }), /unknown benchmark slug/);
+    await assert.rejects(
+      execute("submit_review", { slug: discoveredSlug(), task_id: "t1", decision: "accept" }),
+      /proposed/i,
+    );
+  });
+
+  it("derives the rigor report for a promoted benchmark", async () => {
+    const result = await execute("read_rigor_report", { slug: discoveredSlug() });
+    assert.equal(result.details.benchmark_id, "promoted-bench");
+    assert.ok(Array.isArray(result.details.items) || typeof result.details === "object");
+    await assert.rejects(execute("read_rigor_report", {}), /slug/);
+  });
+});
+
+/* ---------------- skill preinstall ---------------- */
+
+describe("skill preinstall list", () => {
+  it("preinstalls exactly the orchestrator and the benchmark-lab skill", () => {
+    const paths = piPreinstalledSkillPaths();
+    assert.equal(paths.length, 2);
+    assert.match(paths[0], /skills[\\/]understudy[\\/]SKILL\.md$/);
+    assert.match(paths[1], /skills[\\/]operate-benchmark-lab[\\/]SKILL\.md$/);
+    for (const p of paths) assert.ok(fs.existsSync(p), `${p} exists`);
+  });
+
+  it("the orchestrator's routing can reach the preinstalled lab skill", () => {
+    const [orchestrator, lab] = piPreinstalledSkillPaths();
+    const routed = fs
+      .readFileSync(orchestrator, "utf8")
+      .includes("../operate-benchmark-lab/SKILL.md");
+    assert.ok(routed, "understudy SKILL.md routes to operate-benchmark-lab");
+    assert.equal(path.basename(path.dirname(lab)), "operate-benchmark-lab");
+  });
+});


### PR DESCRIPTION
## What

Makes the desktop app's in-app chat (the embedded Pi agent session spawned by `conversation_sidecar.rs`) a self-service operator over the local benchmark/experiment spine.

### Benchmark extension (`src/runtime/conversation/benchmark-extension.ts`)

- New inline runtime extension `understudy-benchmark-lab`, registered in `pi-runtime`'s `extensionFactories` next to `understudy-command-guard`, following the same pattern.
- Exposes 11 tools via `defineTool`: `list_benchmarks`, `read_benchmark`, `read_task`, `run_status`, `queue_run`, `submit_review`, `submit_feedback`, `list_experiments`, `create_experiment`, `update_experiment` (all delegating to `callBenchmarksTool` — the exact dispatcher behind the 13-tool benchmarks MCP, so validation and append-only semantics are shared, never forked; schemas are cloned from `BENCHMARKS_TOOLS` so the surfaces cannot drift), plus a Pi-only read-only `read_rigor_report` over the shared `deriveRigorReport`. Calibration summaries ride on `read_benchmark`/`run_status` as they do on the MCP.
- Deliberately smaller than the full MCP surface: `read_rollout`/`diff_rollouts`/`apply_auto_accepts` stay external-agent-only for now.
- **Gating** mirrors command-guard: a classifier (`classifyBenchmarkToolCall`) blocks at the Pi `tool_call` boundary **and** in the execute path. Queueing stays write-only (executor executes), but spend-adjacent shapes — multi-arm or incumbent-arm runs, `rollouts_per_task > 1`, implicit all-task runs, and `update_experiment` patches touching `status`/`verdict`/`training.approvals` — are blocked unless the call carries `confirm: true`, which the schema documents as requiring explicit user consent in chat. The `confirm` flag is stripped before delegation so the shared dispatcher's argument surface stays identical to the hub API.
- Benchmark root: shared data-core contract — `BENCHMARK_HUB_DATA_DIR` env override, default `~/.understudy/benchmarks` (`benchmarkHubRoots()`).
- Loaded only for primary persistent desktop-chat sessions (`benchmarkLab: true` on the main `runPiConversation` path) — never for supervised student/teacher segments, whose tool surfaces are frozen by the supervision contract.

### Skills preinstall

`additionalSkillPaths` (verified against `DefaultResourceLoaderOptions` typings: `string[]`) grows from one path to an explicit two-item allowlist exported as `piPreinstalledSkillPaths()`: `skills/understudy/SKILL.md` (orchestrator) + `skills/operate-benchmark-lab/SKILL.md`. The orchestrator already routes benchmark-lab requests via `../operate-benchmark-lab/SKILL.md`, so preinstalling the lab skill makes that route resolvable in-app. `noSkills` still disables user/project skills.

### Conformance findings

- `conformance.ts` freezes input fixtures and validates **emitted event traces** (required events, message identity, attachment ordering, per-scenario evidence) — not tool inventories. Registering additional never-called tools keeps every frozen scenario inside the contract; root `npm test` (which replays the suite) is green.
- The Vercel twin (`vercel-runtime.ts`) builds its tool set purely from the request's tool definitions and has no extension mechanism, so these tools are **gated to Pi only**, documented in the extension header. `release-gate.ts` requires the offline, loopback, `adapter_id: "pi"` conformance report — the new tools are filesystem-only and don't touch that posture.

### Tests (`tests/benchmark-extension.test.mjs`)

Compiled-dist idiom like `benchmarks-mcp.test.mjs` / `conversation-runtime.test.mjs`, against a fixture promoted-benchmark dir: registration allowlist + schema-clone parity, extension `registerTool`/`tool_call`-guard wiring, spend-adjacent gating matrix (trivial allow, non-trivial block, confirm unblocks; experiment approval patches), shared-function delegation (pi results byte-equal to `callBenchmarksTool`, queued `understudy.run_request.v1` file with `confirm` stripped, unforked validation errors, rigor report), and the skill preinstall list + orchestrator routing.

## Verification

- root `npm test`: 921 pass / 0 fail
- `tsc --noEmit`: clean
- `apps/benchmark-hub`: `npm test` 161 pass, `next build` clean
- `npm run skills:validate`: ok 37 public skills

Not touched (ownership): `apps/homescreen`, `benchmarks-mcp.ts` internals, `benchmark-hub-core.ts`, `run-executor.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->