### PR TITLE
Desktop app → benchmark/experiment spine bridge (lineage, approval gate, benchmark linkage)

### DIFF
--- a/apps/homescreen/app/components/BenchmarkLinkagePane.tsx
+++ b/apps/homescreen/app/components/BenchmarkLinkagePane.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  benchmarkLinkageState,
+  relevantRunRequest,
+  type BenchmarkBridgeStatus,
+} from "../lib/experiment-bridge.mjs";
+
+type ArtifactRef = { kind: string; ref: string; sha256: string };
+
+type Props = {
+  /** The dropped workload's artifact root (owns <root>/benchmark by convention). */
+  artifactRoot: string;
+  /** Completed training run manifest — the source of the local-arm artifact. */
+  runManifestPath: string;
+  /** Where the experiment record lives (dataset/plan dir), for run linkage. */
+  lineageDir: string | null;
+  experimentId: string | null;
+  /** Incumbent gateway model for the calibration arm. */
+  incumbentModel?: string;
+  armLabel: string;
+};
+
+/**
+ * Benchmark linkage for a completed training run. Feature-detected end to
+ * end: if `<artifactRoot>/benchmark` exists, "Compare on benchmark" queues a
+ * run request (trained artifact as a local arm + the incumbent + the
+ * majority-class floor) through the existing file queue and shows its status;
+ * if the CLI has grown `benchmarks from-dataset`, the benchmark can be built
+ * right here; otherwise this renders the honest entrance-landing state. The
+ * app never executes benchmark runs — `understudy runs execute --watch` does.
+ */
+export function BenchmarkLinkagePane({
+  artifactRoot,
+  runManifestPath,
+  lineageDir,
+  experimentId,
+  incumbentModel = "glm-5.2",
+  armLabel,
+}: Props) {
+  const [bridge, setBridge] = useState<BenchmarkBridgeStatus | null>(null);
+  const [artifact, setArtifact] = useState<ArtifactRef | null>(null);
+  const [probeDone, setProbeDone] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [queuedRun, setQueuedRun] = useState<Record<string, unknown> | null>(null);
+  const [runStatus, setRunStatus] = useState<Record<string, unknown> | null>(null);
+
+  const probe = useCallback(() => {
+    let cancelled = false;
+    void Promise.allSettled([
+      invoke<BenchmarkBridgeStatus>("benchmark_bridge_status", { artifactRoot }),
+      invoke<ArtifactRef>("training_artifact_ref", { runManifestPath }),
+    ]).then(([bridgeResult, artifactResult]) => {
+      if (cancelled) return;
+      setBridge(bridgeResult.status === "fulfilled" ? bridgeResult.value : null);
+      setArtifact(artifactResult.status === "fulfilled" ? artifactResult.value : null);
+      setProbeDone(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [artifactRoot, runManifestPath]);
+
+  useEffect(() => probe(), [probe]);
+
+  // Poll the queue-file status while a run request is in flight.
+  useEffect(() => {
+    if (!queuedRun || !bridge?.benchmark_dir) return;
+    const runId = String(queuedRun.run_id ?? "");
+    const read = () => {
+      void invoke<Record<string, unknown>[]>("benchmark_run_requests", {
+        benchmarkDir: bridge.benchmark_dir,
+      })
+        .then((requests) => {
+          const mine = (Array.isArray(requests) ? requests : []).find(
+            (request) => request.run_id === runId,
+          );
+          setRunStatus(mine ?? relevantRunRequest(requests, experimentId));
+        })
+        .catch(() => {
+          // Status is read-only context; the queued request file still stands.
+        });
+    };
+    read();
+    const timer = window.setInterval(read, 5_000);
+    return () => window.clearInterval(timer);
+  }, [bridge, experimentId, queuedRun]);
+
+  const buildBenchmark = () => {
+    setBusy(true);
+    setError(null);
+    void invoke("create_benchmark_from_dataset", { artifactRoot })
+      .then(() => probe())
+      .catch((cause) => setError(String(cause)))
+      .finally(() => setBusy(false));
+  };
+
+  const queueComparison = () => {
+    if (!bridge?.benchmark_dir || !artifact) return;
+    setBusy(true);
+    setError(null);
+    void invoke<Record<string, unknown>>("queue_benchmark_comparison_run", {
+      benchmarkDir: bridge.benchmark_dir,
+      localArmLabel: armLabel,
+      localArmRef: artifact.ref,
+      incumbentModel,
+      experimentId,
+      lineageDir,
+    })
+      .then(setQueuedRun)
+      .catch((cause) => setError(String(cause)))
+      .finally(() => setBusy(false));
+  };
+
+  if (!probeDone) return null;
+  const state = benchmarkLinkageState(bridge, artifact);
+
+  if (queuedRun) {
+    const status = String(runStatus?.status ?? queuedRun.status ?? "queued");
+    return (
+      <div className="benchmark-linkage" aria-live="polite">
+        <header>
+          <span>Benchmark comparison</span>
+          <strong>Run {String(queuedRun.run_id ?? "")} · {status}</strong>
+        </header>
+        <small>
+          Arms: {armLabel} (your trained model, served locally) vs {incumbentModel} (incumbent) vs the
+          majority-class floor. Execute with <code>understudy runs execute --benchmark {bridge?.benchmark_dir} --watch</code>.
+        </small>
+        {error && <p role="alert">{error}</p>}
+      </div>
+    );
+  }
+
+  if (state.kind === "ready") {
+    return (
+      <div className="benchmark-linkage">
+        <header>
+          <span>Benchmark</span>
+          <strong>Compare this model where it counts</strong>
+        </header>
+        <small>
+          Queues your trained model as a local arm next to {incumbentModel} and the majority-class
+          floor on this dataset&apos;s benchmark. Nothing runs in the app; the request lands in the
+          benchmark&apos;s file queue.
+        </small>
+        <div className="remote-training-actions">
+          <button type="button" className="btn primary" onClick={queueComparison} disabled={busy}>
+            {busy ? "Queueing…" : "Compare on benchmark"}
+          </button>
+        </div>
+        {error && <p role="alert">{error}</p>}
+      </div>
+    );
+  }
+
+  if (state.kind === "no_artifact") {
+    return (
+      <div className="benchmark-linkage is-landing">
+        <header>
+          <span>Benchmark</span>
+          <strong>This run can&apos;t take a benchmark arm yet</strong>
+        </header>
+        <small>
+          A benchmark exists for this dataset, but this training run produced no locally servable
+          model artifact. Local SFT runs (LoRA adapters) can enter as an arm.
+        </small>
+      </div>
+    );
+  }
+
+  if (state.kind === "buildable") {
+    return (
+      <div className="benchmark-linkage is-landing">
+        <header>
+          <span>Benchmark</span>
+          <strong>No benchmark for this dataset yet</strong>
+        </header>
+        <small>Your CLI can build one from the prepared dataset — frozen splits and all.</small>
+        <div className="remote-training-actions">
+          <button type="button" className="btn secondary" onClick={buildBenchmark} disabled={busy}>
+            {busy ? "Building…" : "Build benchmark from this dataset"}
+          </button>
+        </div>
+        {error && <p role="alert">{error}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="benchmark-linkage is-landing">
+      <header>
+        <span>Benchmark</span>
+        <strong>No benchmark for this dataset yet</strong>
+      </header>
+      <small>
+        When this dataset gets a benchmark (an upcoming <code>understudy benchmarks from-dataset</code>{" "}
+        can build one), trained models will be comparable here against the incumbent and a
+        majority-class floor — same splits, same scoring.
+      </small>
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/ExperimentLineageCard.tsx
+++ b/apps/homescreen/app/components/ExperimentLineageCard.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { lineageSummary, type ExperimentRecord } from "../lib/experiment-bridge.mjs";
+
+type Props = {
+  experiment: ExperimentRecord | null;
+  /** A lineage write that failed — surfaced honestly, never hidden. */
+  error?: string | null;
+};
+
+/**
+ * Compact experiment-lineage strip for a training run view: the
+ * understudy.experiment.v1 identity (id, status, data hash, provider,
+ * cleared gates, verdict) that the app recorded through the CLI. Everything
+ * shown here comes from the append-only experiments.jsonl record — the same
+ * file the benchmark run queue cross-links via run_request.experiment_id.
+ */
+export function ExperimentLineageCard({ experiment, error }: Props) {
+  if (error) {
+    return (
+      <p className="experiment-lineage-card is-error" role="status">
+        <strong>Experiment lineage was not recorded</strong>
+        <small>{error}</small>
+      </p>
+    );
+  }
+  const summary = lineageSummary(experiment);
+  if (!summary) return null;
+  return (
+    <div className="experiment-lineage-card" aria-label="Experiment lineage">
+      <header>
+        <span>Experiment</span>
+        <code>{summary.experimentId}</code>
+        <em data-status={summary.status}>{summary.status}</em>
+      </header>
+      <ul>
+        <li>
+          Data <code>{summary.dataHash}</code>
+        </li>
+        <li>Provider {summary.provider}</li>
+        {summary.approvals.length > 0 && (
+          <li>Gates cleared: {summary.approvals.join(", ")}</li>
+        )}
+      </ul>
+      {summary.verdict && <small>Verdict · {summary.verdict}</small>}
+    </div>
+  );
+}

--- a/apps/homescreen/app/components/LocalSftTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalSftTrainingPanel.tsx
@@ -3,6 +3,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
 
+import {
+  abandonedPatch,
+  concludedPatch,
+  sftVerdict,
+  trainingExperimentInput,
+  type ExperimentDataSelection,
+  type ExperimentRecord,
+} from "../lib/experiment-bridge.mjs";
+import { BenchmarkLinkagePane } from "./BenchmarkLinkagePane";
+import { ExperimentLineageCard } from "./ExperimentLineageCard";
 import type { RemotePlan } from "./RemoteTrainingPanel";
 import type { TrainingHaloVisual } from "./TrainingHalo";
 
@@ -49,9 +59,32 @@ export function LocalSftTrainingPanel({ plan, modelName, onTrainRemote, onActive
   const [result, setResult] = useState<LocalSftResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(true);
+  const [experiment, setExperiment] = useState<ExperimentRecord | null>(null);
+  const [lineageError, setLineageError] = useState<string | null>(null);
   const runId = useRef(crypto.randomUUID());
   const generation = useRef(0);
   const startedKey = useRef("");
+  const lineage = useRef<{ dir: string; experimentId: string } | null>(null);
+
+  /** Append the terminal status/verdict (+ produced adapter) to the record. */
+  const concludeExperiment = useCallback(
+    (currentGeneration: number, patch: Record<string, unknown>) => {
+      const target = lineage.current;
+      if (!target) return;
+      void invoke<ExperimentRecord>("update_training_experiment", {
+        lineageDir: target.dir,
+        experimentId: target.experimentId,
+        patch,
+      })
+        .then((record) => {
+          if (generation.current === currentGeneration) setExperiment(record);
+        })
+        .catch((cause) => {
+          if (generation.current === currentGeneration) setLineageError(String(cause));
+        });
+    },
+    [],
+  );
 
   const start = useCallback(() => {
     const currentGeneration = generation.current + 1;
@@ -61,6 +94,39 @@ export function LocalSftTrainingPanel({ plan, modelName, onTrainRemote, onActive
     setResult(null);
     setError(null);
     setRunning(true);
+    // Experiment lineage from the prepared plan's own hashes (see
+    // LocalTrainingPanel): evidence for local runs, never a gate.
+    setExperiment(null);
+    setLineageError(null);
+    lineage.current = null;
+    void invoke<{ lineage_dir: string; data_selection: ExperimentDataSelection }>(
+      "plan_lineage_context",
+      { planPath: plan.plan_path },
+    )
+      .then((context) =>
+        invoke<ExperimentRecord>("record_training_experiment", {
+          lineageDir: context.lineage_dir,
+          input: trainingExperimentInput({
+            method: "lora",
+            baseModel: plan.recipe_id,
+            provider: "local",
+            dataSelection: context.data_selection,
+            config: {
+              task_kind: plan.task_kind,
+              epochs: plan.epochs,
+              output_model_name: plan.output_model_name,
+              run_id: runId.current,
+            },
+          }),
+        }).then((record) => {
+          if (generation.current !== currentGeneration) return;
+          lineage.current = { dir: context.lineage_dir, experimentId: record.experiment_id };
+          setExperiment(record);
+        }),
+      )
+      .catch((cause) => {
+        if (generation.current === currentGeneration) setLineageError(String(cause));
+      });
     const channel = new Channel<LocalSftPhaseEvent>();
     channel.onmessage = (event) => {
       if (generation.current === currentGeneration) setPhase(event);
@@ -74,13 +140,24 @@ export function LocalSftTrainingPanel({ plan, modelName, onTrainRemote, onActive
         if (generation.current !== currentGeneration) return;
         setResult(receipt);
         setRunning(false);
+        // Attach the produced adapter (when complete evidence exists) so the
+        // benchmark local arm and the experiment record cite the same artifact.
+        void invoke<{ kind: string; ref: string; sha256: string }>("training_artifact_ref", {
+          runManifestPath: receipt.manifest_path,
+        })
+          .catch(() => null)
+          .then((artifact) => {
+            const complete = artifact && artifact.ref && artifact.sha256 ? artifact : null;
+            concludeExperiment(currentGeneration, concludedPatch(sftVerdict(receipt), complete));
+          });
       })
       .catch((cause) => {
         if (generation.current !== currentGeneration) return;
         setError(String(cause));
         setRunning(false);
+        concludeExperiment(currentGeneration, abandonedPatch(`local SFT run failed: ${String(cause)}`));
       });
-  }, [plan.plan_path]);
+  }, [concludeExperiment, plan.plan_path]);
 
   useEffect(() => {
     const key = `${plan.plan_path}:${attempt}`;
@@ -163,6 +240,16 @@ export function LocalSftTrainingPanel({ plan, modelName, onTrainRemote, onActive
           <small>Promotion: {result.promotion.status === "promoted" ? "ready" : "needs another run"}</small>
           <small>Offline · no upload · receipt {result.manifest_path}</small>
         </details>
+        <ExperimentLineageCard experiment={experiment} error={lineageError} />
+        {lineage.current && (
+          <BenchmarkLinkagePane
+            artifactRoot={lineage.current.dir}
+            runManifestPath={result.manifest_path}
+            lineageDir={lineage.current.dir}
+            experimentId={lineage.current.experimentId}
+            armLabel={plan.output_model_name}
+          />
+        )}
         <div className="remote-training-actions">
           {onTrainRemote && <button type="button" className="btn primary" onClick={onTrainRemote}>Try cloud</button>}
           <button type="button" className="btn ghost" onClick={() => setAttempt((value) => value + 1)}>Run again</button>

--- a/apps/homescreen/app/components/LocalTrainingPanel.tsx
+++ b/apps/homescreen/app/components/LocalTrainingPanel.tsx
@@ -14,7 +14,17 @@ import {
   type LocalTrainingEvent,
   type LocalTrainingState,
 } from "../lib/local-training-state.mjs";
+import {
+  abandonedPatch,
+  classificationVerdict,
+  concludedPatch,
+  trainingExperimentInput,
+  type ExperimentDataSelection,
+  type ExperimentRecord,
+} from "../lib/experiment-bridge.mjs";
+import { BenchmarkLinkagePane } from "./BenchmarkLinkagePane";
 import { EvaluationRadar } from "./EvaluationRadar";
+import { ExperimentLineageCard } from "./ExperimentLineageCard";
 import {
   RemoteTrainingPanel,
   type RemoteTrainingCapabilities,
@@ -176,6 +186,12 @@ type Props = {
   onVisualChange?: (visual: TrainingHaloVisual | null) => void;
 };
 
+type LineageContext = {
+  schema_version: "understudy.desktop.lineage_context.v1";
+  lineage_dir: string;
+  data_selection: ExperimentDataSelection;
+};
+
 type RemoteCapabilitiesEnvelope = {
   schema_version: "understudy.remote_training.capabilities.v1";
   enabled: boolean;
@@ -234,6 +250,9 @@ export function LocalTrainingPanel({
   const [remoteActive, setRemoteActive] = useState(false);
   const [remoteVisual, setRemoteVisual] = useState<TrainingHaloVisual | null>(null);
   const [forceLocal, setForceLocal] = useState(false);
+  const [experiment, setExperiment] = useState<ExperimentRecord | null>(null);
+  const [lineageError, setLineageError] = useState<string | null>(null);
+  const lineage = useRef<{ dir: string; experimentId: string } | null>(null);
   const [clockMs, setClockMs] = useState(() => Date.now());
   const generation = useRef(0);
   const activeRunId = useRef<string | null>(null);
@@ -310,6 +329,9 @@ export function LocalTrainingPanel({
     setRemoteActive(false);
     setRemoteVisual(null);
     setForceLocal(false);
+    setExperiment(null);
+    setLineageError(null);
+    lineage.current = null;
     runStartedAt.current = null;
     trainingStartedAt.current = null;
     lastEpochCompletedAt.current = null;
@@ -379,6 +401,23 @@ export function LocalTrainingPanel({
     };
   }, [active, state.phase, trainingPreview]);
 
+  /** Append the terminal status/verdict to this run's experiment record. */
+  const concludeExperiment = useCallback((requestGeneration: number, patch: Record<string, unknown>) => {
+    const target = lineage.current;
+    if (!target) return;
+    void invoke<ExperimentRecord>("update_training_experiment", {
+      lineageDir: target.dir,
+      experimentId: target.experimentId,
+      patch,
+    })
+      .then((record) => {
+        if (generation.current === requestGeneration) setExperiment(record);
+      })
+      .catch((cause) => {
+        if (generation.current === requestGeneration) setLineageError(String(cause));
+      });
+  }, []);
+
   const startTraining = useCallback(() => {
     if (active) return;
     const id = runId();
@@ -403,6 +442,36 @@ export function LocalTrainingPanel({
     lastEpochCompletedAt.current = null;
     setClockMs(startedAt);
     dispatch({ type: "start", runId: id });
+    // Experiment lineage: one understudy.experiment.v1 record per training
+    // run, written through the CLI next to the prepared dataset. The data
+    // hashes come from the manifest the drop flow already verified. Lineage
+    // is evidence, never a gate for LOCAL training — failures are shown, not
+    // blocking.
+    setExperiment(null);
+    setLineageError(null);
+    lineage.current = null;
+    void invoke<LineageContext>("dataset_lineage_context", {
+      datasetManifestPath,
+    })
+      .then((context) =>
+        invoke<ExperimentRecord>("record_training_experiment", {
+          lineageDir: context.lineage_dir,
+          input: trainingExperimentInput({
+            method: "sft",
+            baseModel: MODERN_BERT_MODEL,
+            provider: "local",
+            dataSelection: context.data_selection,
+            config: { task: "text_classification", run_id: id },
+          }),
+        }).then((record) => {
+          if (generation.current !== requestGeneration) return;
+          lineage.current = { dir: context.lineage_dir, experimentId: record.experiment_id };
+          setExperiment(record);
+        }),
+      )
+      .catch((cause) => {
+        if (generation.current === requestGeneration) setLineageError(String(cause));
+      });
     void invoke<ClassificationTrainingPreview>("local_classification_training_examples", {
       manifestPath: datasetManifestPath,
     })
@@ -449,19 +518,31 @@ export function LocalTrainingPanel({
       .then((result) => {
         if (generation.current !== requestGeneration) return;
         activeRunId.current = null;
-        dispatch(cancellationRequested.current
+        const cancelled = cancellationRequested.current;
+        dispatch(cancelled
           ? { type: "cancelled" }
           : { type: "succeeded", result });
+        concludeExperiment(
+          requestGeneration,
+          cancelled
+            ? abandonedPatch("training run cancelled before completion")
+            : concludedPatch(classificationVerdict(result)),
+        );
       })
       .catch((error) => {
         if (generation.current !== requestGeneration) return;
         activeRunId.current = null;
         const message = String(error);
-        dispatch(cancellationRequested.current || message.toLowerCase().includes("cancel")
+        const cancelled = cancellationRequested.current || message.toLowerCase().includes("cancel");
+        dispatch(cancelled
           ? { type: "cancelled" }
           : { type: "failed", error: message });
+        concludeExperiment(
+          requestGeneration,
+          abandonedPatch(cancelled ? "training run cancelled before completion" : `training run failed: ${message}`),
+        );
       });
-  }, [active, datasetManifestPath]);
+  }, [active, concludeExperiment, datasetManifestPath]);
 
   useEffect(() => {
     if (
@@ -665,6 +746,16 @@ export function LocalTrainingPanel({
         <strong>{verdict.title}</strong>
         <small>{verdict.detail}</small>
       </div>
+      <ExperimentLineageCard experiment={experiment} error={lineageError} />
+      {lineage.current && (
+        <BenchmarkLinkagePane
+          artifactRoot={lineage.current.dir}
+          runManifestPath={state.result.manifest_path}
+          lineageDir={lineage.current.dir}
+          experimentId={lineage.current.experimentId}
+          armLabel={`classifier.${state.result.run_id}`}
+        />
+      )}
       {!frontierComparison && (
         <div className="frontier-comparison-prompt" aria-live="polite" aria-busy={comparingFrontier}>
           <div>

--- a/apps/homescreen/app/components/RemoteTrainingPanel.tsx
+++ b/apps/homescreen/app/components/RemoteTrainingPanel.tsx
@@ -2,6 +2,16 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Channel, invoke } from "@tauri-apps/api/core";
+import {
+  abandonedPatch,
+  concludedPatch,
+  providerSpendApproval,
+  remoteVerdict,
+  trainingExperimentInput,
+  type ExperimentDataSelection,
+  type ExperimentRecord,
+} from "../lib/experiment-bridge.mjs";
+import { ExperimentLineageCard } from "./ExperimentLineageCard";
 import type { TrainingHaloVisual } from "./TrainingHalo";
 import { TrainingRunStatus } from "./TrainingRunStatus";
 import {
@@ -373,8 +383,11 @@ export function RemoteTrainingPanel(props: Props) {
   const [submitted, setSubmitted] = useState(false);
   const [, setBackendCompatibility] = useState<BackendCompatibility | null>(null);
   const [backendCompatibilityError, setBackendCompatibilityError] = useState<string | null>(null);
+  const [experiment, setExperiment] = useState<ExperimentRecord | null>(null);
   const polling = useRef(false);
   const stopped = useRef(false);
+  const lineage = useRef<{ dir: string; experimentId: string } | null>(null);
+  const experimentConcluded = useRef(false);
   const provider = providers.find((candidate) => candidate.id === providerId) ?? providers[0];
   const profile = provider?.model_profiles.find((candidate) => candidate.id === profileId)
     ?? (provider ? profileDefault(provider) : undefined);
@@ -479,6 +492,9 @@ export function RemoteTrainingPanel(props: Props) {
     setRunStartedAt(null);
     setError(null);
     setSubmitted(false);
+    setExperiment(null);
+    lineage.current = null;
+    experimentConcluded.current = false;
     stopped.current = false;
     const recovery = preparedPlan
       ? invoke<RemoteRunReceipt | null>("existing_remote_training", {
@@ -533,6 +549,25 @@ export function RemoteTrainingPanel(props: Props) {
       });
   }, [capabilities, datasetManifestPath, profile, provider, stage]);
 
+  /** Append the terminal status/verdict to this run's experiment record (once). */
+  const concludeExperiment = useCallback((patch: Record<string, unknown>) => {
+    const target = lineage.current;
+    if (!target || experimentConcluded.current) return;
+    experimentConcluded.current = true;
+    void invoke<ExperimentRecord>("update_training_experiment", {
+      lineageDir: target.dir,
+      experimentId: target.experimentId,
+      patch,
+    })
+      .then((record) => {
+        if (!stopped.current) setExperiment(record);
+      })
+      .catch(() => {
+        // Lineage conclusion is evidence; the run outcome is already shown.
+        experimentConcluded.current = false;
+      });
+  }, []);
+
   const poll = useCallback(async (receipt: RemoteRunReceipt) => {
     if (polling.current || stopped.current) return;
     polling.current = true;
@@ -550,17 +585,23 @@ export function RemoteTrainingPanel(props: Props) {
       if (update.status.workflow_status === "completed" && update.status.result) {
         setResult(update.status.result);
         setStage("terminal");
+        concludeExperiment(concludedPatch(remoteVerdict(update.status.result)));
       } else if (update.status.workflow_status === "failed" || update.status.workflow_status === "cancelled") {
         setResult(update.status.result ?? null);
         setError(update.status.workflow_status === "cancelled" ? "Remote training stopped safely." : "The remote workflow did not finish.");
         setStage(update.status.workflow_status === "cancelled" ? "terminal" : "failed");
+        concludeExperiment(abandonedPatch(
+          update.status.workflow_status === "cancelled"
+            ? "remote training cancelled before completion"
+            : "remote training workflow failed",
+        ));
       }
     } catch (cause) {
       setError(`Connection interrupted: ${String(cause)}. The durable job is still safe; retrying.`);
     } finally {
       polling.current = false;
     }
-  }, []);
+  }, [concludeExperiment]);
 
   useEffect(() => {
     if (stage !== "running" || !run) return;
@@ -580,13 +621,60 @@ export function RemoteTrainingPanel(props: Props) {
     setLossPoints([]);
     const channel = new Channel<UploadEvent>();
     channel.onmessage = setUploadEvent;
-    void invoke<RemoteRunReceipt>("start_remote_training", {
-      planPath: plan.plan_path,
-      confirmUpload: true,
-      confirmSpend: true,
-      confirmTemporaryDeployment: true,
-      onEvent: channel,
-    })
+    // The approval gate is a HARD boundary, not prose: the cleared
+    // provider_training_spend entry (approved_by = this app's identity) is
+    // appended to the understudy.experiment.v1 record FIRST, and
+    // start_remote_training refuses to upload unless that record carries the
+    // gate. If lineage cannot be written, nothing is submitted.
+    void (async () => {
+      const [{ approved_by }, context] = await Promise.all([
+        invoke<{ approved_by: string }>("experiment_approver_identity"),
+        invoke<{ lineage_dir: string; data_selection: ExperimentDataSelection }>(
+          "plan_lineage_context",
+          { planPath: plan.plan_path },
+        ),
+      ]);
+      const approval = providerSpendApproval(approved_by);
+      let target = lineage.current;
+      if (!target) {
+        const record = await invoke<ExperimentRecord>("record_training_experiment", {
+          lineageDir: context.lineage_dir,
+          input: trainingExperimentInput({
+            method: "sft",
+            baseModel: plan.model_profile,
+            provider: providerId,
+            dataSelection: context.data_selection,
+            config: {
+              task_kind: plan.task_kind,
+              epochs: plan.epochs,
+              output_model_name: plan.output_model_name,
+              recipe_id: plan.recipe_id,
+            },
+            costEstimate: plan.maximum_spend_usd,
+            approvals: [approval],
+          }),
+        });
+        target = { dir: context.lineage_dir, experimentId: record.experiment_id };
+        lineage.current = target;
+        setExperiment(record);
+      } else {
+        const record = await invoke<ExperimentRecord>("update_training_experiment", {
+          lineageDir: target.dir,
+          experimentId: target.experimentId,
+          patch: { status: "training", training: { approvals: [approval] } },
+        });
+        setExperiment(record);
+      }
+      return invoke<RemoteRunReceipt>("start_remote_training", {
+        planPath: plan.plan_path,
+        confirmUpload: true,
+        confirmSpend: true,
+        confirmTemporaryDeployment: true,
+        approvalLineageDir: target.dir,
+        approvalExperimentId: target.experimentId,
+        onEvent: channel,
+      });
+    })()
       .then((receipt) => {
         setRun(receipt);
         setUploadEvent(null);
@@ -656,11 +744,20 @@ export function RemoteTrainingPanel(props: Props) {
 
   if (stage === "confirm" && plan) {
     return (
-      <div className="remote-training-confirm">
+      <div className="remote-training-confirm" role="group" aria-label="Provider training approval gate">
         {backendCompatibilityError && <p className="remote-training-warning">Portable backend check failed: {backendCompatibilityError}</p>}
         <ConsentReceipts plan={plan} />
+        <section className="remote-training-approval-gate" aria-label="What approving records">
+          <strong>Approval gate · provider_training_spend</strong>
+          <small>
+            Provider: {provider?.label ?? "Understudy managed training"} · estimated cost up to{" "}
+            {plan.maximum_spend_usd.toLocaleString(undefined, { style: "currency", currency: "USD" })} · the listed
+            training data leaves this Mac. Approving appends a signed gate entry to this dataset&apos;s experiment
+            record before anything uploads — without it, remote training refuses to start.
+          </small>
+        </section>
         <div className="remote-training-actions" style={{ justifyContent: "flex-end" }}>
-          <button type="button" className="btn primary" onClick={start}>Upload & train</button>
+          <button type="button" className="btn primary" onClick={start}>Approve upload & train</button>
         </div>
       </div>
     );
@@ -693,6 +790,7 @@ export function RemoteTrainingPanel(props: Props) {
           {run && <button type="button" className="btn ghost" onClick={cancel}>Cancel</button>}
         </header>
         <TrainingRunStatus events={events} lossPoints={lossPoints} />
+        <ExperimentLineageCard experiment={experiment} />
         {examples.length > 0 && (
           <div className="remote-training-example-window" aria-label="Actual prepared training examples">
             <header>
@@ -745,6 +843,7 @@ export function RemoteTrainingPanel(props: Props) {
       <div className={`remote-training-result ${result.outcome}`}>
         <div><span>{terminalCopy.eyebrow}</span><strong>{terminalCopy.title}</strong><small>{result.reconciled_spend_usd != null ? "Provider spend" : "Budget accounted"}: ${result.spend_usd.toFixed(2)}</small></div>
         {diagnostic && <p className="remote-training-diagnostic"><strong>{diagnostic.title}</strong><small>{diagnostic.message}</small></p>}
+        <ExperimentLineageCard experiment={experiment} />
         {primaryMetric && <div className="remote-training-metrics"><article><span>{primaryMetric.label}</span><strong>{primaryMetric.display_value}</strong></article></div>}
         {(secondaryMetrics.length > 0 || result.failures.length > 0 || result.output_model || result.provider_error || hasSpendBreakdown || hasCleanupDetails) && (
           <details className="remote-training-details">

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -8985,3 +8985,143 @@ select,
 .settings-danger-btn:hover:not(:disabled) {
   background: color-mix(in srgb, var(--c-bad) 10%, transparent);
 }
+
+/* Experiment lineage + benchmark linkage (app → benchmark spine bridge) */
+.experiment-lineage-card {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  padding: 10px 14px 11px;
+  border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--c-window) 94%, transparent);
+  text-align: left;
+  font-size: 12px;
+}
+.experiment-lineage-card > header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.experiment-lineage-card > header > span {
+  color: var(--text-3);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.experiment-lineage-card > header > code {
+  color: var(--c-ink);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+.experiment-lineage-card > header > em {
+  margin-left: auto;
+  padding: 1px 8px;
+  border: 1px solid color-mix(in srgb, var(--text) 14%, transparent);
+  border-radius: 999px;
+  color: var(--text-2);
+  font-size: 11px;
+  font-style: normal;
+}
+.experiment-lineage-card > header > em[data-status="concluded"] {
+  border-color: color-mix(in srgb, #9edbd3 45%, transparent);
+  color: color-mix(in srgb, #9edbd3 80%, var(--text-2));
+}
+.experiment-lineage-card > header > em[data-status="abandoned"] {
+  border-color: color-mix(in srgb, var(--c-bad) 40%, transparent);
+  color: var(--c-bad);
+}
+.experiment-lineage-card > ul {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--text-3);
+  font-size: 11px;
+}
+.experiment-lineage-card > ul code {
+  font-family: var(--mono);
+  font-size: 11px;
+}
+.experiment-lineage-card > small {
+  color: var(--text-2);
+  font-size: 11px;
+}
+.experiment-lineage-card.is-error {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  border-color: color-mix(in srgb, var(--c-bad) 35%, transparent);
+}
+.experiment-lineage-card.is-error strong {
+  color: var(--c-bad);
+  font-size: 12px;
+}
+.experiment-lineage-card.is-error small {
+  color: var(--text-3);
+  font-size: 11px;
+}
+.benchmark-linkage {
+  display: grid;
+  gap: 7px;
+  width: 100%;
+  padding: 12px 16px 13px;
+  border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--c-window) 94%, transparent);
+  text-align: left;
+}
+.benchmark-linkage > header {
+  display: grid;
+  gap: 2px;
+}
+.benchmark-linkage > header > span {
+  color: var(--text-3);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.benchmark-linkage > header > strong {
+  color: var(--c-ink);
+  font-size: 13px;
+  font-weight: 500;
+}
+.benchmark-linkage > small {
+  color: var(--text-3);
+  font-size: 11px;
+  line-height: 1.5;
+}
+.benchmark-linkage > small code {
+  font-family: var(--mono);
+  font-size: 10px;
+}
+.benchmark-linkage.is-landing {
+  border-style: dashed;
+}
+.benchmark-linkage p[role="alert"] {
+  margin: 0;
+  color: var(--c-bad);
+  font-size: 11px;
+}
+.remote-training-approval-gate {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, #f2b34c 38%, var(--border));
+  border-radius: 10px;
+  background: color-mix(in srgb, #f2b34c 5%, transparent);
+}
+.remote-training-approval-gate strong {
+  color: var(--c-ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+}
+.remote-training-approval-gate small {
+  color: var(--text-2);
+  font-size: 11px;
+  line-height: 1.5;
+}

--- a/apps/homescreen/app/lib/experiment-bridge.d.mts
+++ b/apps/homescreen/app/lib/experiment-bridge.d.mts
@@ -1,0 +1,94 @@
+export const PROVIDER_TRAINING_SPEND_GATE: "provider_training_spend";
+
+export type ExperimentApproval = { gate: string; approved_by: string; at: string };
+
+export type ExperimentDataSelection = {
+  selection_hash: string;
+  source: string;
+  splits_sha256?: string;
+};
+
+export type ExperimentRecord = {
+  schema_version: "understudy.experiment.v1";
+  experiment_id: string;
+  created_at: string;
+  hypothesis: string;
+  status: "draft" | "training" | "evaluating" | "concluded" | "abandoned";
+  data_selection: ExperimentDataSelection;
+  training: {
+    method: "sft" | "lora" | "distill" | "rl" | "prompt_only" | "none";
+    base_model: string;
+    config: Record<string, unknown>;
+    provider: string;
+    cost_estimate?: number | Record<string, unknown>;
+    approvals: ExperimentApproval[];
+  };
+  produced_artifact?: { kind: string; ref: string; sha256: string };
+  baseline_run_id?: string;
+  eval_run_ids: string[];
+  verdict?: { decision: "promote" | "shadow" | "collect" | "stop"; summary: string; decided_at: string };
+};
+
+export type ExperimentVerdict = { decision: "promote" | "shadow" | "collect" | "stop"; summary: string };
+
+export function draftHypothesis(input: {
+  method: string;
+  baseModel: string;
+  provider: string;
+  source: string;
+}): string;
+
+export function trainingExperimentInput(input: {
+  method: string;
+  baseModel: string;
+  provider: string;
+  dataSelection: ExperimentDataSelection;
+  config?: Record<string, unknown>;
+  costEstimate?: number | Record<string, unknown>;
+  approvals?: ExperimentApproval[];
+}): Record<string, unknown>;
+
+export function providerSpendApproval(approvedBy: string, at?: string): ExperimentApproval;
+
+export function classificationVerdict(result: unknown): ExperimentVerdict;
+export function sftVerdict(result: unknown): ExperimentVerdict;
+export function remoteVerdict(result: unknown): ExperimentVerdict;
+
+export function concludedPatch(
+  verdict: ExperimentVerdict,
+  producedArtifact?: { kind: string; ref: string; sha256: string } | null,
+): Record<string, unknown>;
+export function abandonedPatch(reason: string): Record<string, unknown>;
+
+export type LineageSummary = {
+  experimentId: string;
+  status: string;
+  dataHash: string;
+  provider: string;
+  approvals: string[];
+  verdict: string | null;
+};
+export function lineageSummary(experiment: unknown): LineageSummary | null;
+
+export type BenchmarkBridgeStatus = {
+  schema_version: "understudy.desktop.benchmark_bridge.v1";
+  benchmark_dir: string;
+  benchmark_exists: boolean;
+  from_dataset_available: boolean;
+};
+
+export type BenchmarkLinkageState =
+  | { kind: "ready"; benchmarkDir: string }
+  | { kind: "no_artifact"; benchmarkDir: string }
+  | { kind: "buildable" }
+  | { kind: "landing" };
+
+export function benchmarkLinkageState(
+  bridge: BenchmarkBridgeStatus | null | undefined,
+  artifactRef: unknown,
+): BenchmarkLinkageState;
+
+export function relevantRunRequest(
+  requests: unknown,
+  experimentId?: string | null,
+): Record<string, unknown> | null;

--- a/apps/homescreen/app/lib/experiment-bridge.mjs
+++ b/apps/homescreen/app/lib/experiment-bridge.mjs
@@ -1,0 +1,165 @@
+/**
+ * Pure logic for the app → benchmark/experiment-spine bridge.
+ *
+ * The drag-drop training flow already computes verified dataset hashes and
+ * training configs; these helpers turn that evidence into
+ * understudy.experiment.v1 inputs (written through the CLI, never directly),
+ * map training outcomes onto the experiment verdict vocabulary, and derive
+ * the honest UI states for the benchmark linkage pane. Kept as an .mjs module
+ * so the node test suite exercises it directly (same pattern as
+ * training-run-view.mjs).
+ */
+
+export const PROVIDER_TRAINING_SPEND_GATE = "provider_training_spend";
+
+/** Auto-drafted falsifiable hypothesis from the training config. */
+export function draftHypothesis({ method, baseModel, provider, source }) {
+  const where = provider === "local" ? "on this Mac" : `on ${provider}`;
+  return (
+    `${method} training of ${baseModel} ${where} on dataset ${source} ` +
+    "beats its measured baseline on the frozen held-out split"
+  );
+}
+
+/**
+ * Build the experiment.v1 create input for a training run that is starting
+ * now. `dataSelection` comes verbatim from the Rust lineage-context command
+ * (hashes the drop flow already computed — never re-derived here).
+ */
+export function trainingExperimentInput({
+  method,
+  baseModel,
+  provider,
+  dataSelection,
+  config = {},
+  costEstimate,
+  approvals = [],
+}) {
+  if (!dataSelection || typeof dataSelection.selection_hash !== "string") {
+    throw new Error("trainingExperimentInput requires a data_selection with a selection_hash");
+  }
+  return {
+    hypothesis: draftHypothesis({ method, baseModel, provider, source: dataSelection.source }),
+    status: "training",
+    data_selection: dataSelection,
+    training: {
+      method,
+      base_model: baseModel,
+      provider,
+      config,
+      ...(costEstimate !== undefined ? { cost_estimate: costEstimate } : {}),
+      approvals,
+    },
+  };
+}
+
+/** One cleared provider_training_spend gate entry (the und-289 shape). */
+export function providerSpendApproval(approvedBy, at = new Date().toISOString()) {
+  if (typeof approvedBy !== "string" || approvedBy.trim() === "") {
+    throw new Error("an approval needs a non-empty approved_by identity");
+  }
+  return { gate: PROVIDER_TRAINING_SPEND_GATE, approved_by: approvedBy, at };
+}
+
+/**
+ * Map a local classification run verdict onto the experiment decision
+ * vocabulary. Deliberately conservative: the app never auto-"promote"s from a
+ * single local run — the strongest local outcome is "shadow" (worth running
+ * against the benchmark / live traffic before adoption).
+ */
+export function classificationVerdict(result) {
+  const status = result?.verdict?.status;
+  const decision =
+    status === "promising" ? "shadow" : status === "improved_not_ready" ? "collect" : "stop";
+  return {
+    decision,
+    summary:
+      result?.verdict?.reason ??
+      `local classification run finished with verdict "${status ?? "unknown"}"`,
+  };
+}
+
+/** Same conservative mapping for a local SFT run. */
+export function sftVerdict(result) {
+  const promoted = result?.promotion?.status === "promoted";
+  const improved = result?.improvement?.improved === true;
+  return {
+    decision: promoted ? "shadow" : improved ? "collect" : "stop",
+    summary: `local SFT ${result?.outcome ?? "unknown"}: ${result?.baseline?.score ?? "?"} → ${result?.heldout?.score ?? "?"} on the frozen heldout (promotion: ${result?.promotion?.status ?? "unknown"})`,
+  };
+}
+
+/** And for a remote (provider) run terminal result. */
+export function remoteVerdict(result) {
+  const outcome = result?.outcome;
+  const decision =
+    outcome === "promoted" ? "shadow" : outcome === "needs_work" ? "collect" : "stop";
+  return {
+    decision,
+    summary: `remote training finished "${outcome ?? "unknown"}" (provider spend $${(result?.spend_usd ?? 0).toFixed(2)})`,
+  };
+}
+
+/** The status-patch for an experiment when its training run ends. */
+export function concludedPatch(verdict, producedArtifact) {
+  return {
+    status: "concluded",
+    verdict: { ...verdict, decided_at: new Date().toISOString() },
+    ...(producedArtifact ? { produced_artifact: producedArtifact } : {}),
+  };
+}
+
+export function abandonedPatch(reason) {
+  return {
+    status: "abandoned",
+    verdict: { decision: "stop", summary: reason, decided_at: new Date().toISOString() },
+  };
+}
+
+const short = (hash) => (typeof hash === "string" && hash.length > 12 ? `${hash.slice(0, 12)}…` : hash ?? "—");
+
+/** Compact projection of the newest experiment record for the lineage card. */
+export function lineageSummary(experiment) {
+  if (!experiment || typeof experiment.experiment_id !== "string") return null;
+  return {
+    experimentId: experiment.experiment_id,
+    status: experiment.status ?? "draft",
+    dataHash: short(experiment.data_selection?.selection_hash),
+    provider: experiment.training?.provider ?? "—",
+    approvals: Array.isArray(experiment.training?.approvals)
+      ? experiment.training.approvals.map((approval) => approval.gate)
+      : [],
+    verdict: experiment.verdict
+      ? `${experiment.verdict.decision} — ${experiment.verdict.summary}`
+      : null,
+  };
+}
+
+/**
+ * Honest benchmark-linkage state from the Rust bridge probe + the artifact
+ * check. Exactly one of four states, never an optimistic fabrication:
+ * - "ready": a benchmark dir exists and this run has a servable artifact;
+ * - "no_artifact": a benchmark exists but this run cannot serve as an arm;
+ * - "buildable": no benchmark yet, but the CLI can build one from the dataset;
+ * - "landing": no benchmark and no from-dataset verb — show the entrance copy.
+ */
+export function benchmarkLinkageState(bridge, artifactRef) {
+  if (bridge?.benchmark_exists) {
+    return artifactRef
+      ? { kind: "ready", benchmarkDir: bridge.benchmark_dir }
+      : { kind: "no_artifact", benchmarkDir: bridge.benchmark_dir };
+  }
+  return bridge?.from_dataset_available ? { kind: "buildable" } : { kind: "landing" };
+}
+
+/** Newest run request touching this experiment (or the newest overall). */
+export function relevantRunRequest(requests, experimentId) {
+  const rows = Array.isArray(requests) ? requests : [];
+  const mine = experimentId
+    ? rows.filter((request) => request.experiment_id === experimentId)
+    : rows;
+  const pool = mine.length > 0 ? mine : rows;
+  return (
+    [...pool].sort((a, b) => String(a.created_at ?? "").localeCompare(String(b.created_at ?? ""))).at(-1) ?? null
+  );
+}

--- a/apps/homescreen/src-tauri/src/experiment_lineage.rs
+++ b/apps/homescreen/src-tauri/src/experiment_lineage.rs
@@ -350,11 +350,10 @@ fn latest_experiment_record(dir: &Path, experiment_id: &str) -> Option<Value> {
     content
         .lines()
         .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
-        .filter(|row| {
+        .rfind(|row| {
             row.get("schema_version").and_then(Value::as_str) == Some(EXPERIMENT_SCHEMA)
                 && row.get("experiment_id").and_then(Value::as_str) == Some(experiment_id)
         })
-        .next_back()
 }
 
 fn record_has_provider_spend_approval(record: &Value) -> bool {

--- a/apps/homescreen/src-tauri/src/experiment_lineage.rs
+++ b/apps/homescreen/src-tauri/src/experiment_lineage.rs
@@ -1,0 +1,705 @@
+//! Bridge between the desktop drag-drop training flow and the benchmark /
+//! experiment spine in the Understudy CLI.
+//!
+//! Everything here shells to the bundled `understudy` CLI (the same pattern
+//! as workload_drop.rs) so the app never re-implements lineage semantics:
+//! - experiment.v1 records live in `experiments.jsonl` (append-only,
+//!   newest-per-id wins) next to the prepared dataset (`--plain-dir`) and,
+//!   once a benchmark dir exists, inside that benchmark dir;
+//! - the und-289 approval discipline is enforced HERE as a hard boundary:
+//!   remote training refuses to submit unless the experiment record carries a
+//!   cleared `provider_training_spend` gate (see
+//!   `verify_provider_training_spend_approval`);
+//! - benchmark comparison runs go through the existing file queue
+//!   (`understudy runs queue` → `<benchmark>/runs/queue/*.json`), never by
+//!   executing models in-app.
+//!
+//! `understudy benchmarks from-dataset` is feature-detected at runtime via
+//! `understudy benchmarks --help` — the app degrades to an honest
+//! "benchmark entrance landing" state when the verb does not exist yet.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+const EXPERIMENT_SCHEMA: &str = "understudy.experiment.v1";
+const PROVIDER_TRAINING_SPEND_GATE: &str = "provider_training_spend";
+
+fn bounded_detail(stderr: &[u8]) -> String {
+    let detail = String::from_utf8_lossy(stderr).trim().to_string();
+    if detail.is_empty() {
+        "No diagnostic was returned.".to_string()
+    } else {
+        detail.chars().take(800).collect()
+    }
+}
+
+fn cli_json(args: &[&str]) -> Result<Value, String> {
+    let output = crate::bin::command("understudy")
+        .args(args)
+        .output()
+        .map_err(|error| {
+            format!(
+                "Could not run the Understudy CLI ({error}). Open Status to repair the CLI, then retry."
+            )
+        })?;
+    if !output.status.success() {
+        return Err(bounded_detail(&output.stderr));
+    }
+    serde_json::from_slice::<Value>(&output.stdout)
+        .map_err(|_| "The Understudy CLI returned malformed JSON.".to_string())
+}
+
+fn canonical_dir(path: &str, name: &str) -> Result<PathBuf, String> {
+    let canonical = PathBuf::from(path.trim())
+        .canonicalize()
+        .map_err(|error| format!("The {name} is unavailable: {error}"))?;
+    if !canonical.is_dir() {
+        return Err(format!("The {name} must be a directory."));
+    }
+    Ok(canonical)
+}
+
+fn valid_experiment_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+/// Who cleared an approval gate, from the app's own identity: the signed-in
+/// org when known, otherwise the local machine account. Never empty.
+pub(crate) fn approver_identity() -> String {
+    if let Some(resolved) = crate::creds::resolve() {
+        if let Some(org_id) = resolved.org_id.as_deref() {
+            if !org_id.trim().is_empty() {
+                return format!("desktop-app:org:{org_id}");
+            }
+        }
+        return format!("desktop-app:key:{}", resolved.api_key_suffix());
+    }
+    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
+    format!("desktop-app:local:{user}")
+}
+
+#[tauri::command]
+pub fn experiment_approver_identity() -> Result<Value, String> {
+    Ok(json!({ "approved_by": approver_identity() }))
+}
+
+/* ------------------------------------------------------------------ */
+/* Lineage context: where the records live + what data hash they cite  */
+/* ------------------------------------------------------------------ */
+
+/// Read the prepared classification dataset manifest the drop flow already
+/// produced and derive the experiment's data_selection from the hashes the
+/// preparation step computed (never re-hashing rows here).
+#[tauri::command]
+pub async fn dataset_lineage_context(dataset_manifest_path: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let manifest_path = PathBuf::from(dataset_manifest_path.trim())
+            .canonicalize()
+            .map_err(|error| format!("The dataset manifest is unavailable: {error}"))?;
+        let manifest = std::fs::read(&manifest_path)
+            .map_err(|error| format!("The dataset manifest could not be read: {error}"))?;
+        let manifest = serde_json::from_slice::<Value>(&manifest)
+            .map_err(|_| "The dataset manifest is malformed.".to_string())?;
+        lineage_context_from_dataset_manifest(&manifest, &manifest_path)
+    })
+    .await
+    .map_err(|error| format!("The lineage reader stopped unexpectedly: {error}"))?
+}
+
+fn lineage_context_from_dataset_manifest(
+    manifest: &Value,
+    manifest_path: &Path,
+) -> Result<Value, String> {
+    let dataset_id = manifest
+        .get("dataset_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "The dataset manifest omitted its dataset id.".to_string())?;
+    let splits = manifest
+        .get("splits")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "The dataset manifest omitted its verified splits.".to_string())?;
+    let split_sha = |name: &str| -> Result<String, String> {
+        splits
+            .get(name)
+            .and_then(|split| split.get("sha256"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| format!("The dataset manifest omitted the {name} split hash."))
+    };
+    let train = split_sha("train")?;
+    let dev = split_sha("dev")?;
+    let holdout = split_sha("holdout")?;
+    // One stable digest over the three frozen split hashes — the same
+    // "hash of the frozen split artifact" slot experiment.v1 defines.
+    let splits_sha256 = format!(
+        "{:x}",
+        Sha256::digest(format!("train:{train}\ndev:{dev}\nholdout:{holdout}\n").as_bytes())
+    );
+    let lineage_dir = manifest
+        .get("artifact_root")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .filter(|root| root.is_dir())
+        .or_else(|| manifest_path.parent().map(Path::to_path_buf))
+        .ok_or_else(|| "The dataset manifest has no usable artifact root.".to_string())?;
+    Ok(json!({
+        "schema_version": "understudy.desktop.lineage_context.v1",
+        "lineage_dir": lineage_dir,
+        "data_selection": {
+            "selection_hash": train,
+            "source": dataset_id,
+            "splits_sha256": splits_sha256,
+        }
+    }))
+}
+
+/// Same derivation for a prepared training plan (SFT / remote recipes): the
+/// plan already carries a split_hash plus per-artifact sha256 receipts.
+#[tauri::command]
+pub async fn plan_lineage_context(plan_path: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let plan_file = PathBuf::from(plan_path.trim())
+            .canonicalize()
+            .map_err(|error| format!("The training plan is unavailable: {error}"))?;
+        let plan = std::fs::read(&plan_file)
+            .map_err(|error| format!("The training plan could not be read: {error}"))?;
+        let plan = serde_json::from_slice::<Value>(&plan)
+            .map_err(|_| "The training plan is malformed.".to_string())?;
+        lineage_context_from_plan(&plan, &plan_file)
+    })
+    .await
+    .map_err(|error| format!("The lineage reader stopped unexpectedly: {error}"))?
+}
+
+fn lineage_context_from_plan(plan: &Value, plan_file: &Path) -> Result<Value, String> {
+    let split_hash = plan
+        .get("split_hash")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "The training plan omitted its split hash.".to_string())?;
+    let source = plan
+        .get("source_dataset_id")
+        .or_else(|| plan.get("workload_name"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "The training plan omitted its source dataset.".to_string())?;
+    let lineage_dir = plan_file
+        .parent()
+        .ok_or_else(|| "The training plan has no parent directory.".to_string())?;
+    Ok(json!({
+        "schema_version": "understudy.desktop.lineage_context.v1",
+        "lineage_dir": lineage_dir,
+        "data_selection": {
+            "selection_hash": split_hash,
+            "source": source,
+        }
+    }))
+}
+
+/* ------------------------------------------------------------------ */
+/* experiment.v1 writes/reads — always through the CLI                 */
+/* ------------------------------------------------------------------ */
+
+fn validate_experiment_envelope(value: &Value) -> Result<Value, String> {
+    if value.get("schema_version").and_then(Value::as_str) != Some(EXPERIMENT_SCHEMA)
+        || value
+            .get("experiment_id")
+            .and_then(Value::as_str)
+            .is_none_or(|id| !valid_experiment_id(id))
+    {
+        return Err("The Understudy CLI returned an invalid experiment record.".into());
+    }
+    Ok(value.clone())
+}
+
+#[tauri::command]
+pub async fn record_training_experiment(
+    lineage_dir: String,
+    input: Value,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let dir = canonical_dir(&lineage_dir, "experiment lineage directory")?;
+        if !input.is_object() {
+            return Err("The experiment record must be a JSON object.".into());
+        }
+        let payload = serde_json::to_string(&input)
+            .map_err(|_| "The experiment record could not be serialized.".to_string())?;
+        let value = cli_json(&[
+            "benchmarks",
+            "experiment",
+            "create",
+            &dir.to_string_lossy(),
+            "--plain-dir",
+            "--input",
+            &payload,
+        ])?;
+        validate_experiment_envelope(&value)
+    })
+    .await
+    .map_err(|error| format!("The experiment recorder stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+pub async fn update_training_experiment(
+    lineage_dir: String,
+    experiment_id: String,
+    patch: Value,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let dir = canonical_dir(&lineage_dir, "experiment lineage directory")?;
+        if !valid_experiment_id(&experiment_id) {
+            return Err("The experiment id is invalid.".into());
+        }
+        if !patch.is_object() {
+            return Err("The experiment patch must be a JSON object.".into());
+        }
+        let payload = serde_json::to_string(&patch)
+            .map_err(|_| "The experiment patch could not be serialized.".to_string())?;
+        let value = cli_json(&[
+            "benchmarks",
+            "experiment",
+            "update",
+            &dir.to_string_lossy(),
+            &experiment_id,
+            "--plain-dir",
+            "--input",
+            &payload,
+        ])?;
+        validate_experiment_envelope(&value)
+    })
+    .await
+    .map_err(|error| format!("The experiment recorder stopped unexpectedly: {error}"))?
+}
+
+#[tauri::command]
+pub async fn training_experiment_lineage(lineage_dir: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let dir = canonical_dir(&lineage_dir, "experiment lineage directory")?;
+        cli_json(&["benchmarks", "experiment", "list", &dir.to_string_lossy()])
+    })
+    .await
+    .map_err(|error| format!("The lineage reader stopped unexpectedly: {error}"))?
+}
+
+/// The benchmark-servable artifact a completed training run produced, read
+/// from the run manifest the trainer already wrote. Today that is the local
+/// SFT LoRA adapter (`model.adapter_path`, servable by the MLX rig as a
+/// `runs queue --local-arm` ref). Runs without a servable artifact (e.g. the
+/// ModernBERT classifier) return an honest error instead of a fake ref.
+#[tauri::command]
+pub async fn training_artifact_ref(run_manifest_path: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let manifest_path = PathBuf::from(run_manifest_path.trim())
+            .canonicalize()
+            .map_err(|error| format!("The training run manifest is unavailable: {error}"))?;
+        let manifest = std::fs::read(&manifest_path)
+            .map_err(|error| format!("The training run manifest could not be read: {error}"))?;
+        let manifest = serde_json::from_slice::<Value>(&manifest)
+            .map_err(|_| "The training run manifest is malformed.".to_string())?;
+        artifact_ref_from_run_manifest(&manifest)
+    })
+    .await
+    .map_err(|error| format!("The artifact reader stopped unexpectedly: {error}"))?
+}
+
+fn artifact_ref_from_run_manifest(manifest: &Value) -> Result<Value, String> {
+    if manifest.get("schema_version").and_then(Value::as_str)
+        == Some("understudy.local_sft.run.v1")
+    {
+        let model = manifest
+            .get("model")
+            .and_then(Value::as_object)
+            .ok_or_else(|| "The training run manifest omitted its model.".to_string())?;
+        let adapter_path = model
+            .get("adapter_path")
+            .and_then(Value::as_str)
+            .filter(|path| !path.is_empty())
+            .ok_or_else(|| "The training run manifest omitted its adapter path.".to_string())?;
+        let sha256 = model
+            .get("adapter_sha256")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        return Ok(json!({
+            "kind": "lora_adapter",
+            "ref": adapter_path,
+            "sha256": sha256,
+        }));
+    }
+    Err(
+        "This training run has no benchmark-servable artifact yet (only local SFT adapters can run as a local benchmark arm)."
+            .into(),
+    )
+}
+
+/* ------------------------------------------------------------------ */
+/* und-289 hard boundary: no provider upload without a recorded gate   */
+/* ------------------------------------------------------------------ */
+
+/// Newest experiments.jsonl record for one experiment_id (append-only file,
+/// newest line wins — same superseding rule as the CLI/hub).
+fn latest_experiment_record(dir: &Path, experiment_id: &str) -> Option<Value> {
+    let content = std::fs::read_to_string(dir.join("experiments.jsonl")).ok()?;
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
+        .filter(|row| {
+            row.get("schema_version").and_then(Value::as_str) == Some(EXPERIMENT_SCHEMA)
+                && row.get("experiment_id").and_then(Value::as_str) == Some(experiment_id)
+        })
+        .next_back()
+}
+
+fn record_has_provider_spend_approval(record: &Value) -> bool {
+    record
+        .get("training")
+        .and_then(|training| training.get("approvals"))
+        .and_then(Value::as_array)
+        .is_some_and(|approvals| {
+            approvals.iter().any(|approval| {
+                approval.get("gate").and_then(Value::as_str) == Some(PROVIDER_TRAINING_SPEND_GATE)
+                    && approval
+                        .get("approved_by")
+                        .and_then(Value::as_str)
+                        .is_some_and(|by| !by.trim().is_empty())
+                    && approval
+                        .get("at")
+                        .and_then(Value::as_str)
+                        .is_some_and(|at| !at.trim().is_empty())
+            })
+        })
+}
+
+/// The hard boundary remote training submission stands behind: the newest
+/// experiment record must carry a cleared `provider_training_spend` approval.
+/// "Not approved for provider upload" is an error, not prose.
+pub(crate) fn verify_provider_training_spend_approval(
+    lineage_dir: &str,
+    experiment_id: &str,
+) -> Result<(), String> {
+    let dir = canonical_dir(lineage_dir, "experiment lineage directory")?;
+    if !valid_experiment_id(experiment_id) {
+        return Err("The experiment id is invalid.".into());
+    }
+    let record = latest_experiment_record(&dir, experiment_id).ok_or_else(|| {
+        "This dataset is not approved for provider upload: no experiment record exists yet."
+            .to_string()
+    })?;
+    if !record_has_provider_spend_approval(&record) {
+        return Err(
+            "This dataset is not approved for provider upload: the experiment record has no cleared provider_training_spend gate."
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+/* ------------------------------------------------------------------ */
+/* Benchmark linkage: feature detection + queue-file run requests      */
+/* ------------------------------------------------------------------ */
+
+/// Conventional benchmark home for a dropped dataset's artifact root.
+fn benchmark_dir_for(artifact_root: &Path) -> PathBuf {
+    artifact_root.join("benchmark")
+}
+
+fn is_benchmark_dir(dir: &Path) -> bool {
+    dir.join("benchmark.json").is_file() || dir.join("manifest.json").is_file()
+}
+
+fn help_mentions_from_dataset(help_text: &str) -> bool {
+    help_text
+        .lines()
+        .any(|line| line.trim_start().starts_with("from-dataset"))
+}
+
+/// Feature-detect the benchmark bridge: does this dataset already have a
+/// benchmark dir, and does the installed CLI know `benchmarks from-dataset`?
+/// The from-dataset verb is being built on a separate branch; this app must
+/// work (with an honest landing state) whether or not it exists.
+#[tauri::command]
+pub async fn benchmark_bridge_status(artifact_root: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = canonical_dir(&artifact_root, "workload artifact root")?;
+        let benchmark_dir = benchmark_dir_for(&root);
+        let benchmark_exists = is_benchmark_dir(&benchmark_dir);
+        let from_dataset_available = crate::bin::command("understudy")
+            .args(["benchmarks", "--help"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| {
+                help_mentions_from_dataset(&String::from_utf8_lossy(&output.stdout))
+            })
+            .unwrap_or(false);
+        Ok(json!({
+            "schema_version": "understudy.desktop.benchmark_bridge.v1",
+            "benchmark_dir": benchmark_dir,
+            "benchmark_exists": benchmark_exists,
+            "from_dataset_available": from_dataset_available,
+        }))
+    })
+    .await
+    .map_err(|error| format!("The benchmark bridge probe stopped unexpectedly: {error}"))?
+}
+
+/// Best-effort compile hook onto `understudy benchmarks from-dataset` once the
+/// verb ships. Refuses (honestly) when the installed CLI does not have it.
+#[tauri::command]
+pub async fn create_benchmark_from_dataset(artifact_root: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = canonical_dir(&artifact_root, "workload artifact root")?;
+        let status = crate::bin::command("understudy")
+            .args(["benchmarks", "--help"])
+            .output()
+            .map_err(|error| format!("Could not run the Understudy CLI ({error})."))?;
+        if !status.status.success()
+            || !help_mentions_from_dataset(&String::from_utf8_lossy(&status.stdout))
+        {
+            return Err(
+                "This Understudy CLI cannot build a benchmark from a dataset yet (no `benchmarks from-dataset` verb)."
+                    .into(),
+            );
+        }
+        let benchmark_dir = benchmark_dir_for(&root);
+        cli_json(&[
+            "benchmarks",
+            "from-dataset",
+            &root.to_string_lossy(),
+            "--out",
+            &benchmark_dir.to_string_lossy(),
+            "--json",
+        ])
+    })
+    .await
+    .map_err(|error| format!("The benchmark builder stopped unexpectedly: {error}"))?
+}
+
+/// Queue one comparison run through the existing file-based queue contract:
+/// the trained bundle as a local arm + the incumbent gateway model
+/// (calibration arm) + the majority-class floor. Never executes models —
+/// `understudy runs execute --watch` picks the request up.
+#[tauri::command]
+pub async fn queue_benchmark_comparison_run(
+    benchmark_dir: String,
+    local_arm_label: String,
+    local_arm_ref: String,
+    incumbent_model: String,
+    experiment_id: Option<String>,
+    lineage_dir: Option<String>,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let benchmark = canonical_dir(&benchmark_dir, "benchmark directory")?;
+        if !is_benchmark_dir(&benchmark) {
+            return Err("Compare on a real benchmark directory (benchmark.json missing).".into());
+        }
+        let label = local_arm_label.trim();
+        if label.is_empty()
+            || label.len() > 128
+            || label.contains('=')
+            || label.contains(',')
+        {
+            return Err("The trained model arm label is invalid.".into());
+        }
+        let arm_ref = PathBuf::from(local_arm_ref.trim())
+            .canonicalize()
+            .map_err(|error| format!("The trained model artifact is unavailable: {error}"))?;
+        let incumbent = incumbent_model.trim();
+        if incumbent.is_empty() || incumbent.len() > 128 || incumbent.contains(',') {
+            return Err("The incumbent model id is invalid.".into());
+        }
+        // Experiment linkage: the run request's experiment_id must already
+        // exist in the BENCHMARK dir's experiments.jsonl. Lineage written next
+        // to the dataset is carried over on first use.
+        if let Some(experiment_id) = experiment_id.as_deref() {
+            if !valid_experiment_id(experiment_id) {
+                return Err("The experiment id is invalid.".into());
+            }
+            if latest_experiment_record(&benchmark, experiment_id).is_none() {
+                let source_dir = lineage_dir
+                    .as_deref()
+                    .ok_or_else(|| "The experiment record is not in the benchmark yet and no lineage directory was provided.".to_string())
+                    .and_then(|dir| canonical_dir(dir, "experiment lineage directory"))?;
+                let record = latest_experiment_record(&source_dir, experiment_id).ok_or_else(
+                    || "The experiment record could not be found in the lineage directory.".to_string(),
+                )?;
+                let payload = serde_json::to_string(&record)
+                    .map_err(|_| "The experiment record could not be serialized.".to_string())?;
+                cli_json(&[
+                    "benchmarks",
+                    "experiment",
+                    "create",
+                    &benchmark.to_string_lossy(),
+                    "--input",
+                    &payload,
+                ])?;
+            }
+        }
+        let benchmark_arg = benchmark.to_string_lossy().into_owned();
+        let local_arm = format!("{label}={}", arm_ref.to_string_lossy());
+        let mut args: Vec<String> = vec![
+            "runs".into(),
+            "queue".into(),
+            "--benchmark".into(),
+            benchmark_arg,
+            "--local-arm".into(),
+            local_arm,
+            "--models".into(),
+            incumbent.into(),
+            "--incumbent".into(),
+            incumbent.into(),
+            "--trivial-arms".into(),
+            "majority_class".into(),
+        ];
+        if let Some(experiment_id) = experiment_id.as_deref() {
+            args.push("--experiment".into());
+            args.push(experiment_id.into());
+        }
+        let args: Vec<&str> = args.iter().map(String::as_str).collect();
+        let run = cli_json(&args)?;
+        if run.get("run_id").and_then(Value::as_str).is_none() {
+            return Err("The Understudy CLI queued a run without a run id.".into());
+        }
+        Ok(run)
+    })
+    .await
+    .map_err(|error| format!("The run queue stopped unexpectedly: {error}"))?
+}
+
+/// Read-only status over `<benchmark>/runs/queue/` via `understudy runs list`.
+#[tauri::command]
+pub async fn benchmark_run_requests(benchmark_dir: String) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let benchmark = canonical_dir(&benchmark_dir, "benchmark directory")?;
+        cli_json(&["runs", "list", "--benchmark", &benchmark.to_string_lossy()])
+    })
+    .await
+    .map_err(|error| format!("The run status reader stopped unexpectedly: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(approvals: Value) -> Value {
+        json!({
+            "schema_version": EXPERIMENT_SCHEMA,
+            "experiment_id": "exp-1",
+            "training": { "approvals": approvals }
+        })
+    }
+
+    #[test]
+    fn provider_spend_gate_requires_a_complete_entry() {
+        assert!(!record_has_provider_spend_approval(&record(json!([]))));
+        assert!(!record_has_provider_spend_approval(&record(json!([
+            { "gate": "consensus_audit", "approved_by": "a", "at": "t" }
+        ]))));
+        assert!(!record_has_provider_spend_approval(&record(json!([
+            { "gate": "provider_training_spend", "approved_by": "", "at": "t" }
+        ]))));
+        assert!(!record_has_provider_spend_approval(&record(json!([
+            { "gate": "provider_training_spend", "approved_by": "a" }
+        ]))));
+        assert!(record_has_provider_spend_approval(&record(json!([
+            { "gate": "consensus_audit", "approved_by": "a", "at": "t" },
+            { "gate": "provider_training_spend", "approved_by": "desktop-app:org:o1", "at": "2026-07-22T00:00:00Z" }
+        ]))));
+    }
+
+    #[test]
+    fn newest_line_per_experiment_wins() {
+        let dir = std::env::temp_dir().join(format!("lineage-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("experiments.jsonl");
+        let older = record(json!([]));
+        let newer = record(json!([
+            { "gate": "provider_training_spend", "approved_by": "a", "at": "t" }
+        ]));
+        std::fs::write(&file, format!("{older}\n{newer}\n")).unwrap();
+        let latest = latest_experiment_record(&dir, "exp-1").unwrap();
+        assert!(record_has_provider_spend_approval(&latest));
+        assert!(latest_experiment_record(&dir, "exp-2").is_none());
+        assert!(verify_provider_training_spend_approval(
+            dir.to_string_lossy().as_ref(),
+            "exp-1"
+        )
+        .is_ok());
+        assert!(verify_provider_training_spend_approval(
+            dir.to_string_lossy().as_ref(),
+            "exp-2"
+        )
+        .is_err());
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn dataset_lineage_context_uses_prepared_hashes() {
+        let dir = std::env::temp_dir().join(format!("lineage-ctx-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest_path = dir.join("manifest.json");
+        let manifest = json!({
+            "dataset_id": "ds-1",
+            "artifact_root": dir,
+            "splits": {
+                "train": { "sha256": "a".repeat(64) },
+                "dev": { "sha256": "b".repeat(64) },
+                "holdout": { "sha256": "c".repeat(64) }
+            }
+        });
+        let context = lineage_context_from_dataset_manifest(&manifest, &manifest_path).unwrap();
+        assert_eq!(
+            context["data_selection"]["selection_hash"],
+            json!("a".repeat(64))
+        );
+        assert_eq!(context["data_selection"]["source"], json!("ds-1"));
+        assert_eq!(
+            context["lineage_dir"],
+            json!(dir)
+        );
+        // Deterministic split digest: same input, same hash.
+        let again = lineage_context_from_dataset_manifest(&manifest, &manifest_path).unwrap();
+        assert_eq!(
+            context["data_selection"]["splits_sha256"],
+            again["data_selection"]["splits_sha256"]
+        );
+        // Missing split hash is an error, never a silent placeholder.
+        let broken = json!({ "dataset_id": "ds-1", "splits": { "train": {} } });
+        assert!(lineage_context_from_dataset_manifest(&broken, &manifest_path).is_err());
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn artifact_ref_reads_sft_adapters_and_refuses_the_rest() {
+        let sft = json!({
+            "schema_version": "understudy.local_sft.run.v1",
+            "model": { "adapter_path": "/tmp/adapter", "adapter_sha256": "abc" }
+        });
+        let artifact = artifact_ref_from_run_manifest(&sft).unwrap();
+        assert_eq!(artifact["kind"], json!("lora_adapter"));
+        assert_eq!(artifact["ref"], json!("/tmp/adapter"));
+        let classifier = json!({
+            "schema_version": "understudy.capture_import.classification_run.v1",
+            "model": { "path": "/tmp/classifier" }
+        });
+        assert!(artifact_ref_from_run_manifest(&classifier).is_err());
+    }
+
+    #[test]
+    fn from_dataset_detection_reads_subcommand_listings_only() {
+        assert!(help_mentions_from_dataset(
+            "Commands:\n  mcp\n  from-dataset <dir>  Build a benchmark\n"
+        ));
+        assert!(!help_mentions_from_dataset(
+            "Commands:\n  mcp   reads rows from-dataset caches\n"
+        ));
+        assert!(!help_mentions_from_dataset("Commands:\n  experiment\n"));
+    }
+}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod conversation_sidecar;
 mod creds;
 mod custom_evals;
 mod db;
+mod experiment_lineage;
 mod explore;
 mod gepa;
 mod knowledge;
@@ -378,6 +379,17 @@ pub fn run() {
             workload_drop::update_local_classification_run,
             workload_drop::repeat_local_classification_evaluation,
             workload_drop::export_local_classification_predictions,
+            experiment_lineage::experiment_approver_identity,
+            experiment_lineage::dataset_lineage_context,
+            experiment_lineage::plan_lineage_context,
+            experiment_lineage::record_training_experiment,
+            experiment_lineage::update_training_experiment,
+            experiment_lineage::training_experiment_lineage,
+            experiment_lineage::benchmark_bridge_status,
+            experiment_lineage::create_benchmark_from_dataset,
+            experiment_lineage::queue_benchmark_comparison_run,
+            experiment_lineage::benchmark_run_requests,
+            experiment_lineage::training_artifact_ref,
             remote_training::remote_training_capabilities,
             remote_training::inspect_remote_training_recipe,
             remote_training::automatic_training_goal_card,

--- a/apps/homescreen/src-tauri/src/remote_training.rs
+++ b/apps/homescreen/src-tauri/src/remote_training.rs
@@ -3873,14 +3873,26 @@ fn verify_split(
     Ok(rows)
 }
 
+/// The desktop UI's remote-training entry point. Beyond the boolean consent
+/// flags, it enforces the und-289 approval discipline as a HARD boundary:
+/// the caller must name an understudy.experiment.v1 record whose newest line
+/// carries a cleared `provider_training_spend` gate, or nothing is uploaded.
+/// The approval-gate dialog in RemoteTrainingPanel appends that gate entry
+/// (approved_by = the app identity) BEFORE calling this command.
 #[tauri::command]
 pub async fn start_remote_training(
     plan_path: String,
     confirm_upload: bool,
     confirm_spend: bool,
     confirm_temporary_deployment: bool,
+    approval_lineage_dir: String,
+    approval_experiment_id: String,
     on_event: Channel<Value>,
 ) -> Result<Value, String> {
+    crate::experiment_lineage::verify_provider_training_spend_approval(
+        &approval_lineage_dir,
+        &approval_experiment_id,
+    )?;
     start_remote_classification_training(
         plan_path,
         confirm_upload,

--- a/docs/app-benchmark-bridge.md
+++ b/docs/app-benchmark-bridge.md
@@ -1,0 +1,69 @@
+# Desktop app → benchmark/experiment spine bridge
+
+The desktop drag-drop training flow (CSV/JSONL → prepared dataset → local
+classification / local SFT / remote training) now feeds the same
+machine-readable spine the CLI and benchmark hub use. A self-service user gets
+lineage, approval gates, and benchmark comparison from the flow that already
+exists — no new workflow to learn.
+
+## What the app records
+
+**Experiment lineage (`understudy.experiment.v1`).** Every training start
+creates one record via `understudy benchmarks experiment create <dir>
+--plain-dir` (a small additive CLI mode that writes `experiments.jsonl` next
+to the prepared dataset, before any benchmark exists):
+
+- `hypothesis` — auto-drafted from the training config;
+- `data_selection` — the split hashes the drop flow already verified
+  (train-split sha256 as the selection hash, plus a digest over the frozen
+  train/dev/holdout hashes);
+- `status` transitions `training → concluded/abandoned`, with a conservative
+  verdict mapping (the app never auto-`promote`s; the strongest outcome of a
+  single run is `shadow`);
+- local SFT runs attach the produced LoRA adapter as `produced_artifact`.
+
+The compact lineage card (`ExperimentLineageCard`) renders the record —
+experiment id, status, data hash, provider, cleared gates, verdict — in each
+training run view.
+
+## The approval gate (und-289 discipline, as a hard boundary)
+
+Before any REMOTE submission the confirm screen is an explicit approval gate:
+provider, estimated maximum cost, and the fact that the listed artifacts leave
+the machine. Approving appends
+`{gate: "provider_training_spend", approved_by: <app identity>, at}` to the
+experiment record FIRST; only then is `start_remote_training` invoked — and
+that Tauri command independently re-reads `experiments.jsonl` and **refuses to
+upload** unless the newest record carries the cleared gate
+(`verify_provider_training_spend_approval` in
+`apps/homescreen/src-tauri/src/experiment_lineage.rs`). Local training needs
+no gate.
+
+## Benchmark linkage
+
+Where a dropped dataset has a benchmark dir (`<artifact_root>/benchmark` by
+convention), the training result view offers **Compare on benchmark**: it
+queues one `understudy.run_request.v1` through the existing file queue
+(`understudy runs queue --local-arm <label>=<adapter> --models <incumbent>
+--incumbent <incumbent> --trivial-arms majority_class --experiment <id>`) and
+polls `runs list` for status. The app never executes models; `understudy runs
+execute --watch` does.
+
+Feature detection, honestly surfaced (`BenchmarkLinkagePane`):
+
+- benchmark exists + servable artifact → "Compare on benchmark";
+- benchmark exists, no servable artifact (e.g. the ModernBERT classifier) →
+  an honest "can't take an arm yet" state;
+- no benchmark, but the CLI has `benchmarks from-dataset` (detected at runtime
+  via `understudy benchmarks --help`; the verb ships separately) → "Build
+  benchmark from this dataset";
+- neither → the benchmark entrance landing state.
+
+## Additive CLI surface
+
+- `understudy benchmarks experiment create|update … --plain-dir` — lineage in
+  a plain directory (validation unchanged; `list`/`show` already work there).
+- `understudy runs queue --experiment <id>` — cross-links a queued run to an
+  experiment, with the same must-already-exist check the hub/MCP queue path
+  enforces. When queueing against a benchmark whose `experiments.jsonl` lacks
+  the record, the app copies the dataset-side record in first.

--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -1169,7 +1169,17 @@ function experimentWriteGate(entry: AnyHubEntry | null): WriteFailure | null {
 export function createExperiment(entry: AnyHubEntry | null, input: ExperimentInput): ExperimentWriteResult {
   const gate = experimentWriteGate(entry);
   if (gate) return gate;
-  const dir = (entry as HubEntry | ProposedHubEntry).dir;
+  return createExperimentInDir((entry as HubEntry | ProposedHubEntry).dir, input);
+}
+
+/**
+ * Dir-addressed variant of createExperiment (additive). Used by the CLI's
+ * `--plain-dir` mode so the desktop app can keep experiment lineage next to a
+ * prepared dataset BEFORE a benchmark dir exists (benchmark.json absent).
+ * Same validation, same append-only file; only the hub-entry write gate is
+ * skipped (the caller owns the dir).
+ */
+export function createExperimentInDir(dir: string, input: ExperimentInput): ExperimentWriteResult {
   let experiment: Experiment;
   try {
     experiment = makeExperiment(input);
@@ -1198,7 +1208,15 @@ export function updateExperiment(
 ): ExperimentWriteResult {
   const gate = experimentWriteGate(entry);
   if (gate) return gate;
-  const dir = (entry as HubEntry | ProposedHubEntry).dir;
+  return updateExperimentInDir((entry as HubEntry | ProposedHubEntry).dir, experimentId, patch);
+}
+
+/** Dir-addressed variant of updateExperiment (additive; see createExperimentInDir). */
+export function updateExperimentInDir(
+  dir: string,
+  experimentId: unknown,
+  patch: Record<string, unknown>,
+): ExperimentWriteResult {
   if (typeof experimentId !== "string" || experimentId.length === 0) {
     return { ok: false, error: "experiment_id (string) is required", status: 400 };
   }

--- a/src/commands/benchmarks.ts
+++ b/src/commands/benchmarks.ts
@@ -54,13 +54,21 @@ export function registerBenchmarksCommand(program: Command): void {
     return entry;
   };
 
+  const plainDirHelp =
+    "Write lineage into a plain directory (no benchmark.json required) — the desktop app keeps experiment records next to a prepared dataset before a benchmark exists";
+
   experiment
     .command("create <dir>")
     .description("Append one NEW understudy.experiment.v1 line to <dir>/experiments.jsonl (validated; JSON out)")
     .requiredOption("--input <json>", "Experiment record as inline JSON or @file (hypothesis, data_selection, training, ...)")
-    .action(async (dir: string, options: { input: string }) => {
-      const { createExperiment } = await import("../benchmark-hub-core.js");
-      const result = createExperiment(await loadDirEntry(dir), parseJsonOption(options.input) as never);
+    .option("--plain-dir", plainDirHelp, false)
+    .action(async (dir: string, options: { input: string; plainDir: boolean }) => {
+      const path = await import("node:path");
+      const { createExperiment, createExperimentInDir } = await import("../benchmark-hub-core.js");
+      const input = parseJsonOption(options.input) as never;
+      const result = options.plainDir
+        ? createExperimentInDir(path.resolve(dir), input)
+        : createExperiment(await loadDirEntry(dir), input);
       if (!result.ok) throw new Error(result.error);
       console.error(`appended ${result.file}`);
       console.log(JSON.stringify(result.experiment, null, 2));
@@ -70,9 +78,14 @@ export function registerBenchmarksCommand(program: Command): void {
     .command("update <dir> <experiment_id>")
     .description("Supersede one experiment: merge --input over its newest record and append the full merged record (approvals + eval_run_ids append; JSON out)")
     .requiredOption("--input <json>", "Partial understudy.experiment.v1 fields as inline JSON or @file")
-    .action(async (dir: string, experimentId: string, options: { input: string }) => {
-      const { updateExperiment } = await import("../benchmark-hub-core.js");
-      const result = updateExperiment(await loadDirEntry(dir), experimentId, parseJsonOption(options.input));
+    .option("--plain-dir", plainDirHelp, false)
+    .action(async (dir: string, experimentId: string, options: { input: string; plainDir: boolean }) => {
+      const path = await import("node:path");
+      const { updateExperiment, updateExperimentInDir } = await import("../benchmark-hub-core.js");
+      const patch = parseJsonOption(options.input);
+      const result = options.plainDir
+        ? updateExperimentInDir(path.resolve(dir), experimentId, patch)
+        : updateExperiment(await loadDirEntry(dir), experimentId, patch);
       if (!result.ok) throw new Error(result.error);
       console.error(`appended ${result.file}`);
       console.log(JSON.stringify(result.experiment, null, 2));

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -57,6 +57,7 @@ export function registerRunsCommand(program: Command): void {
     .option("--tasks <ids>", 'Comma-separated task ids (default "all")')
     .option("--rollouts <count>", "Rollouts per task", "1")
     .option("--incumbent <ids>", "Comma-separated subset of --models labeled as the incumbent calibration arm")
+    .option("--experiment <id>", "experiments.jsonl experiment_id this run evaluates (must already exist in <benchmark>/experiments.jsonl)")
     .option("--rollout-timeout <seconds>", "Per-rollout wall-clock budget written onto the request")
     .option(
       "--prompt-override <label=model=file...>",
@@ -67,7 +68,7 @@ export function registerRunsCommand(program: Command): void {
         return [...prior, { arm_label: match[1], model: match[2], system_prompt_suffix: readFileSync(resolve(match[3]), "utf8").trim() }];
       },
     )
-    .action((options: { benchmark: string; models?: string; localArm?: { ref: string; label?: string }[]; trivialArms?: string; split: string; tasks?: string; rollouts: string; incumbent?: string; rolloutTimeout?: string; promptOverride?: PromptOverride[] }) => {
+    .action(async (options: { benchmark: string; models?: string; localArm?: { ref: string; label?: string }[]; trivialArms?: string; split: string; tasks?: string; rollouts: string; incumbent?: string; experiment?: string; rolloutTimeout?: string; promptOverride?: PromptOverride[] }) => {
       const benchmark = resolve(options.benchmark);
       const manifest = JSON.parse(readFileSync(join(benchmark, "benchmark.json"), "utf8")) as Record<string, unknown>;
       const knownTaskIds = (Array.isArray(manifest.tasks) ? (manifest.tasks as Record<string, unknown>[]) : []).map((t) => String(t.task_id));
@@ -86,7 +87,17 @@ export function registerRunsCommand(program: Command): void {
         rollout_timeout_seconds: options.rolloutTimeout !== undefined ? Number(options.rolloutTimeout) : undefined,
         prompt_overrides: options.promptOverride,
         trivial_arms: options.trivialArms ? (options.trivialArms.split(",").map((t) => t.trim()).filter(Boolean) as Parameters<typeof createRunRequest>[1]["trivial_arms"]) : undefined,
+        experiment_id: options.experiment,
       };
+      // Same cross-link discipline as the hub/MCP queue path: a declared
+      // experiment must already exist in the benchmark's experiments.jsonl.
+      if (options.experiment !== undefined) {
+        const { readExperiments, latestExperiments, experimentsPath } = await import("../benchmark-artifacts.js");
+        const { experiments } = readExperiments(experimentsPath(benchmark));
+        if (!latestExperiments(experiments)[options.experiment]) {
+          throw new Error(`unknown experiment_id: ${options.experiment} (understudy benchmarks experiment create first)`);
+        }
+      }
       const errors = validateRunRequestInput(input, knownTaskIds);
       if (errors.length > 0) throw new Error(`invalid run request: ${errors.join("; ")}`);
       if (selectTasks(manifest, { split: input.split, tasks: input.tasks }).length === 0) throw new Error(`no tasks match split=${input.split}`);

--- a/tests/app-benchmark-bridge.test.mjs
+++ b/tests/app-benchmark-bridge.test.mjs
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+// The desktop app → benchmark spine bridge:
+// 1. the CLI's additive `--plain-dir` experiment mode (lineage next to a
+//    prepared dataset, before any benchmark exists) and the additive
+//    `runs queue --experiment` cross-link;
+// 2. the app-side pure logic in apps/homescreen/app/lib/experiment-bridge.mjs.
+import {
+  PROVIDER_TRAINING_SPEND_GATE,
+  abandonedPatch,
+  benchmarkLinkageState,
+  classificationVerdict,
+  concludedPatch,
+  draftHypothesis,
+  lineageSummary,
+  providerSpendApproval,
+  relevantRunRequest,
+  remoteVerdict,
+  sftVerdict,
+  trainingExperimentInput,
+} from "../apps/homescreen/app/lib/experiment-bridge.mjs";
+
+const bin = path.resolve("dist/bin.js");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "app-benchmark-bridge-"));
+after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+const cli = (...args) => {
+  const result = spawnSync(process.execPath, [bin, ...args], { encoding: "utf8" });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+};
+
+const dataSelection = {
+  selection_hash: "a".repeat(64),
+  source: "support-tickets.csv",
+  splits_sha256: "b".repeat(64),
+};
+
+const createInput = () =>
+  trainingExperimentInput({
+    method: "sft",
+    baseModel: "answerdotai/ModernBERT-base",
+    provider: "local",
+    dataSelection,
+    config: { task: "text_classification" },
+  });
+
+describe("CLI --plain-dir experiment lineage (dataset dir, no benchmark.json)", () => {
+  const datasetDir = path.join(tmp, "dataset");
+  fs.mkdirSync(datasetDir, { recursive: true });
+
+  it("refuses a bare dir without --plain-dir (unchanged behavior)", () => {
+    const result = cli("benchmarks", "experiment", "create", datasetDir, "--input", JSON.stringify(createInput()));
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /not a benchmark dir/);
+  });
+
+  it("creates, updates (approvals append), and lists in a plain dir", () => {
+    const created = cli(
+      "benchmarks", "experiment", "create", datasetDir,
+      "--plain-dir", "--input", JSON.stringify(createInput()),
+    );
+    assert.equal(created.status, 0, created.stderr);
+    const experiment = JSON.parse(created.stdout);
+    assert.equal(experiment.schema_version, "understudy.experiment.v1");
+    assert.equal(experiment.status, "training");
+    assert.equal(experiment.data_selection.selection_hash, dataSelection.selection_hash);
+    assert.ok(fs.existsSync(path.join(datasetDir, "experiments.jsonl")));
+
+    // The und-289 gate entry appends (never replaces) on update.
+    const approval = providerSpendApproval("desktop-app:org:org_1", "2026-07-22T00:00:00Z");
+    const updated = cli(
+      "benchmarks", "experiment", "update", datasetDir, experiment.experiment_id,
+      "--plain-dir", "--input", JSON.stringify({ training: { approvals: [approval] } }),
+    );
+    assert.equal(updated.status, 0, updated.stderr);
+    const patched = JSON.parse(updated.stdout);
+    assert.deepEqual(patched.training.approvals, [approval]);
+    assert.equal(patched.training.base_model, "answerdotai/ModernBERT-base");
+
+    // Conclude with the app's concludedPatch shape.
+    const concluded = cli(
+      "benchmarks", "experiment", "update", datasetDir, experiment.experiment_id,
+      "--plain-dir", "--input", JSON.stringify(concludedPatch({ decision: "shadow", summary: "beats tf-idf" })),
+    );
+    assert.equal(concluded.status, 0, concluded.stderr);
+    const final = JSON.parse(concluded.stdout);
+    assert.equal(final.status, "concluded");
+    assert.equal(final.verdict.decision, "shadow");
+    // Approvals cleared earlier are never dropped by a later patch.
+    assert.deepEqual(final.training.approvals, [approval]);
+
+    const listed = cli("benchmarks", "experiment", "list", datasetDir);
+    assert.equal(listed.status, 0, listed.stderr);
+    const { experiments, total_lines } = JSON.parse(listed.stdout);
+    assert.equal(experiments.length, 1);
+    assert.equal(total_lines, 3);
+    assert.equal(experiments[0].status, "concluded");
+  });
+
+  it("still validates records in plain-dir mode", () => {
+    const result = cli(
+      "benchmarks", "experiment", "create", datasetDir,
+      "--plain-dir", "--input", JSON.stringify({ hypothesis: "" }),
+    );
+    assert.notEqual(result.status, 0);
+  });
+});
+
+describe("runs queue --experiment cross-link", () => {
+  const benchDir = path.join(tmp, "bench");
+  fs.mkdirSync(benchDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(benchDir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "bridge-bench",
+      name: "Bridge bench",
+      provenance: { origin: "authored" },
+      taxonomy: [{ category_id: "cat-a" }],
+      tasks: [{ task_id: "t1", category_id: "cat-a", genesis: "synthesized", split: "holdout" }],
+      environment: { format: "verifiers.v1", package_ref: "pkg" },
+      verifier: { kind: "reward-fns", strict_metric: "strict" },
+    }),
+  );
+
+  it("rejects an experiment_id that is not in the benchmark's experiments.jsonl", () => {
+    const result = cli(
+      "runs", "queue", "--benchmark", benchDir,
+      "--models", "glm-5.2", "--incumbent", "glm-5.2",
+      "--experiment", "exp-missing",
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown experiment_id/);
+  });
+
+  it("queues the app's comparison shape once the experiment exists", () => {
+    const created = cli(
+      "benchmarks", "experiment", "create", benchDir,
+      "--input", JSON.stringify({ ...createInput(), experiment_id: "exp-bridge-1" }),
+    );
+    assert.equal(created.status, 0, created.stderr);
+
+    const armDir = path.join(tmp, "adapter");
+    fs.mkdirSync(armDir, { recursive: true });
+    const queued = cli(
+      "runs", "queue", "--benchmark", benchDir,
+      "--local-arm", `my-tuned-model=${armDir}`,
+      "--models", "glm-5.2", "--incumbent", "glm-5.2",
+      "--trivial-arms", "majority_class",
+      "--experiment", "exp-bridge-1",
+    );
+    assert.equal(queued.status, 0, queued.stderr);
+    const run = JSON.parse(queued.stdout);
+    assert.equal(run.experiment_id, "exp-bridge-1");
+    assert.equal(run.status, "queued");
+    assert.ok(run.models.some((m) => typeof m === "object" && m.label === "my-tuned-model"));
+    assert.deepEqual(run.incumbent_models, ["glm-5.2"]);
+    assert.deepEqual(run.trivial_arms, ["majority_class"]);
+    // The request landed in the file queue the executor watches.
+    const queue = fs.readdirSync(path.join(benchDir, "runs", "queue"));
+    assert.equal(queue.length, 1);
+  });
+});
+
+describe("experiment-bridge app logic", () => {
+  it("drafts a falsifiable hypothesis from the training config", () => {
+    const local = draftHypothesis({ method: "sft", baseModel: "m", provider: "local", source: "ds" });
+    assert.match(local, /on this Mac/);
+    assert.match(local, /dataset ds/);
+    assert.match(
+      draftHypothesis({ method: "sft", baseModel: "m", provider: "managed", source: "ds" }),
+      /on managed/,
+    );
+  });
+
+  it("builds a create input and refuses a missing selection hash", () => {
+    const input = createInput();
+    assert.equal(input.status, "training");
+    assert.deepEqual(input.training.approvals, []);
+    assert.throws(() =>
+      trainingExperimentInput({ method: "sft", baseModel: "m", provider: "local", dataSelection: {} }),
+    );
+  });
+
+  it("providerSpendApproval demands an identity", () => {
+    assert.equal(providerSpendApproval("me", "t").gate, PROVIDER_TRAINING_SPEND_GATE);
+    assert.throws(() => providerSpendApproval(""));
+    assert.throws(() => providerSpendApproval("   "));
+  });
+
+  it("maps outcomes conservatively (never auto-promote)", () => {
+    assert.equal(classificationVerdict({ verdict: { status: "promising", reason: "r" } }).decision, "shadow");
+    assert.equal(classificationVerdict({ verdict: { status: "improved_not_ready" } }).decision, "collect");
+    assert.equal(classificationVerdict({ verdict: { status: "not_better" } }).decision, "stop");
+    assert.equal(sftVerdict({ promotion: { status: "promoted" }, improvement: { improved: true } }).decision, "shadow");
+    assert.equal(sftVerdict({ promotion: { status: "needs_work" }, improvement: { improved: true } }).decision, "collect");
+    assert.equal(sftVerdict({ promotion: { status: "needs_work" }, improvement: { improved: false } }).decision, "stop");
+    assert.equal(remoteVerdict({ outcome: "promoted", spend_usd: 3 }).decision, "shadow");
+    assert.equal(remoteVerdict({ outcome: "needs_work", spend_usd: 3 }).decision, "collect");
+    assert.equal(remoteVerdict({ outcome: "failed", spend_usd: 0 }).decision, "stop");
+    assert.equal(abandonedPatch("why").verdict.decision, "stop");
+  });
+
+  it("summarizes a record compactly for the lineage card", () => {
+    const summary = lineageSummary({
+      experiment_id: "exp-1",
+      status: "concluded",
+      data_selection: { selection_hash: "c".repeat(64) },
+      training: { provider: "local", approvals: [{ gate: "provider_training_spend" }] },
+      verdict: { decision: "shadow", summary: "s" },
+    });
+    assert.equal(summary.dataHash, `${"c".repeat(12)}…`);
+    assert.deepEqual(summary.approvals, ["provider_training_spend"]);
+    assert.match(summary.verdict, /^shadow — /);
+    assert.equal(lineageSummary(null), null);
+  });
+
+  it("derives the four honest benchmark linkage states", () => {
+    const bridge = (exists, verb) => ({
+      benchmark_dir: "/x/benchmark",
+      benchmark_exists: exists,
+      from_dataset_available: verb,
+    });
+    assert.equal(benchmarkLinkageState(bridge(true, false), { ref: "/a" }).kind, "ready");
+    assert.equal(benchmarkLinkageState(bridge(true, true), null).kind, "no_artifact");
+    assert.equal(benchmarkLinkageState(bridge(false, true), { ref: "/a" }).kind, "buildable");
+    assert.equal(benchmarkLinkageState(bridge(false, false), { ref: "/a" }).kind, "landing");
+    assert.equal(benchmarkLinkageState(null, null).kind, "landing");
+  });
+
+  it("picks the newest run request for the experiment", () => {
+    const rows = [
+      { run_id: "r1", created_at: "2026-01-01", experiment_id: "e1" },
+      { run_id: "r2", created_at: "2026-01-03", experiment_id: "e2" },
+      { run_id: "r3", created_at: "2026-01-02", experiment_id: "e1" },
+    ];
+    assert.equal(relevantRunRequest(rows, "e1").run_id, "r3");
+    assert.equal(relevantRunRequest(rows, "missing").run_id, "r2");
+    assert.equal(relevantRunRequest([], "e1"), null);
+    assert.equal(relevantRunRequest(undefined, null), null);
+  });
+});

--- a/tests/remote-training-desktop.test.mjs
+++ b/tests/remote-training-desktop.test.mjs
@@ -109,7 +109,10 @@ test("remote training uses live capabilities with explicit upload and spend cons
   assert.match(panel, /existing_remote_training/);
   assert.match(panel, /compile_remote_training_backends/);
   assert.match(panel, /preparedPlan/);
-  assert.match(panel, /Upload & train/);
+  // The confirm action IS the approval gate (und-289): approving appends the
+  // provider_training_spend entry to the experiment record before upload.
+  assert.match(panel, /Approve upload & train/);
+  assert.match(panel, /provider_training_spend/);
   assert.doesNotMatch(panel, /Upload & train · \$/);
   assert.match(panel, /remote-training-example-track/);
   assert.match(panel, /trainingExamples/);


### PR DESCRIPTION
Bridges the desktop app's existing drag-drop training flow to the benchmark/experiment spine so a self-service user gets lineage + benchmarks + approval gates from the flow that already exists.

## 1. Experiment lineage from the app
- Every training start (local classification, local SFT, remote) creates an `understudy.experiment.v1` record via the CLI (`benchmarks experiment create --plain-dir`, written next to the prepared dataset).
- Hypothesis auto-drafted from the training config; `data_selection` from the hashes the drop flow already computed (train-split sha256 + a digest over the frozen train/dev/holdout hashes, derived in `dataset_lineage_context` / `plan_lineage_context` — never re-hashed rows).
- Status transitions `training → concluded/abandoned`; verdicts map conservatively (a single run's best outcome is `shadow`, never auto-`promote`). SFT runs attach the produced LoRA adapter as `produced_artifact`.
- Compact lineage card (`ExperimentLineageCard`: id, status, data hash, provider, cleared gates, verdict) renders in all three run views.

## 2. Approval gate as UI (und-289 as a hard boundary)
- The remote confirm screen is now an explicit gate: provider, estimated max cost, and that the listed artifacts leave the Mac; button is "Approve upload & train".
- On approve, the app appends `{gate: provider_training_spend, approved_by: <app identity>, at}` to the experiment record FIRST, then submits.
- `start_remote_training` (Rust) independently re-reads `experiments.jsonl` and **refuses to upload** unless the newest record carries the cleared gate (`verify_provider_training_spend_approval`) — not prose. Local training needs no gate.

## 3. Benchmark linkage pane
- When `<artifact_root>/benchmark` exists, "Compare on benchmark" queues one run request through the existing file queue (`runs queue --local-arm <adapter> --models <incumbent> --incumbent <incumbent> --trivial-arms majority_class --experiment <id>`) and polls `runs list` for status. The app never executes models.
- `benchmarks from-dataset` is **feature-detected at runtime** via `understudy benchmarks --help` (it's being built on `anthro/dataset-foundry`; nothing here depends on unmerged code). Four honest states: ready / no servable artifact (e.g. the ModernBERT classifier) / buildable / entrance landing.

## Additive CLI surface (minimal src diffs)
- `benchmarks experiment create|update … --plain-dir` (dir-addressed cores `createExperimentInDir`/`updateExperimentInDir`; same validation, entry write-gate skipped for caller-owned dirs).
- `runs queue --experiment <id>` with the same must-already-exist cross-link check the hub/MCP queue path enforces. Run-executor internals, trace-foundry, and hub components untouched.

## Tests
- Rust: `cargo check` + `cargo test` green (306 passed; 6 new unit tests in `experiment_lineage.rs` covering the gate check, newest-line-wins, lineage hashing, artifact refs, from-dataset detection).
- Node: `npm test` green (919 tests) incl. new `tests/app-benchmark-bridge.test.mjs` (CLI plain-dir lifecycle, approvals-append, `runs queue --experiment` reject/accept, bridge lib logic); `remote-training-desktop.test.mjs` consent assertions updated for the new gate label.
- `npm run typecheck`, app `tsc --noEmit`, `skills:validate` green.

## Known gaps
- Local classification runs have no MLX-servable artifact, so they get the honest "can't take a benchmark arm yet" state rather than a comparison.
- `create_benchmark_from_dataset` assumes `from-dataset <dir> --out <dir> --json`; if the foundry branch ships different flags, only that one Rust arg list needs adjusting (failures surface verbatim in the pane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->