### PR TITLE
Partner report: the honest benchmark-and-savings deliverable

### DIFF
--- a/apps/benchmark-hub/app/b/[slug]/page.tsx
+++ b/apps/benchmark-hub/app/b/[slug]/page.tsx
@@ -190,6 +190,9 @@ export default async function BenchmarkDetail({ params }: { params: Promise<{ sl
         <div className="u-id">
           <span>{m.benchmark_id}</span>
           <CopySlug text={m.benchmark_id} />
+          <Link className="mono" style={{ fontSize: 11 }} href={`/b/${entry.slug}/report`}>
+            Report ↗
+          </Link>
         </div>
         <p className="u-desc">{m.description}</p>
 

--- a/apps/benchmark-hub/app/b/[slug]/report/page.tsx
+++ b/apps/benchmark-hub/app/b/[slug]/report/page.tsx
@@ -1,0 +1,320 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getEntry } from "@/lib/data";
+import { derivePartnerReport, type PartnerArm, type PartnerReport } from "@/lib/partner-report-core";
+import { PrintButton } from "@/components/print-button";
+
+export const dynamic = "force-dynamic";
+
+/* Formatting mirrors the CLI renderer (same derivation, same idioms). */
+const pct = (f: number | null | undefined) => (f == null ? "—" : `${(f * 100).toFixed(1)}%`);
+const usd = (v: number | null | undefined) =>
+  v == null ? "—" : v === 0 ? "$0" : v < 0.01 ? `$${v.toFixed(5).replace(/0+$/, "").replace(/\.$/, "")}` : `$${v.toFixed(v < 1 ? 3 : 2)}`;
+const ms = (v: number | null | undefined) => (v == null ? "—" : v >= 10_000 ? `${(v / 1000).toFixed(1)}s` : `${Math.round(v)}ms`);
+const ciText = (arm: PartnerArm) => (arm.ci == null ? "—" : `[${(arm.ci.lo * 100).toFixed(1)}–${(arm.ci.hi * 100).toFixed(1)}%]`);
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="u-sec">
+      <h2>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export default async function PartnerReportPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const entry = getEntry(slug);
+  if (!entry || entry.kind !== "ok") notFound();
+
+  let report: PartnerReport;
+  try {
+    report = derivePartnerReport(entry.dir);
+  } catch {
+    notFound();
+  }
+
+  const floorLabel: Record<string, string> = {
+    null_agent: "a do-nothing agent",
+    spam_agent: "a ritual tool-spamming agent",
+    majority_class: "always answering the majority class",
+  };
+  const s = report.projected_savings;
+
+  return (
+    <div className="u-page print-report">
+      {/* Print stylesheet: the report is the client-presentable artifact —
+          chrome (nav, buttons, background field) drops out on paper. */}
+      <style>{`
+        @media print {
+          .no-print, nav, .u-footer { display: none !important; }
+          .u-page::before { display: none !important; }
+          body, .u-page { background: #fff !important; color: #000 !important; }
+          .print-report .u-tbl-scroll { max-height: none; overflow: visible; box-shadow: none; }
+          .print-report a { color: inherit; text-decoration: none; }
+          .print-report .u-sec { break-inside: avoid; }
+        }
+      `}</style>
+
+      <header className="u-head">
+        <p className="u-eyebrow no-print" style={{ marginBottom: 10 }}>
+          <Link href={`/b/${slug}`}>← {report.workload.name}</Link>
+        </p>
+        <div className="u-title-row">
+          <h1>Benchmark &amp; savings report — {report.workload.name}</h1>
+          <PrintButton />
+        </div>
+        <p className="u-desc">
+          Generated {report.generated_at} from local benchmark artifacts only (no new runs, no network). Every number is
+          derived from persisted eval rows — the same derivation as <code>understudy benchmarks report</code>.
+        </p>
+        <p className="u-desc mono" style={{ fontSize: 11 }}>
+          benchmark <code>{report.benchmark_id}</code> · {report.workload.task_count} tasks (
+          {Object.entries(report.workload.split_counts).map(([k, v]) => `${k}: ${v}`).join(", ")}) · threshold {report.workload.threshold} ·
+          scope: <strong>{report.workload.scope === "holdout" ? "sealed holdout rows only" : "all rows (no holdout rows exist)"}</strong>
+        </p>
+      </header>
+
+      <Section title="Baselines and floors (read these first)">
+        <ul>
+          {report.floors.map((floor) => (
+            <li key={floor.arm_kind}>
+              {floor.floor === null ? (
+                <>
+                  <strong>{floor.arm_kind}</strong>: never run — this trivial floor is unmeasured.
+                </>
+              ) : (
+                <>
+                  <strong>{floor.arm_kind}</strong>: {floorLabel[floor.arm_kind] ?? floor.arm_kind} scores {pct(floor.floor)} (
+                  {floor.passed_tasks}/{floor.task_n} tasks){floor.exceeded ? " — FLOOR EXCEEDED: some tasks are trivially satisfiable" : ""} —
+                  results below are measured against that floor.
+                </>
+              )}
+            </li>
+          ))}
+          <li>
+            {report.incumbent != null ? (
+              <>
+                <strong>Incumbent ceiling</strong>: {report.incumbent.model} scores {pct(report.incumbent.quality_mean)}{" "}
+                {ciText(report.incumbent)} on rerun.
+              </>
+            ) : (
+              <>
+                <strong>Incumbent ceiling</strong>: not measured in scope — no current-state baseline exists in this report.
+              </>
+            )}
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="Headline results">
+        <p className="exp">
+          Quality is the macro-average of per-task mean scores; the 95% CI is a seeded percentile bootstrap over per-task
+          means. <strong>Cost per correct task</strong> = total measured cost ÷ tasks passed at the threshold.
+        </p>
+        <div className="u-tbl-scroll">
+          <table className="u-tbl">
+            <thead>
+              <tr>
+                <th className="l">Arm</th>
+                <th className="l">Kind</th>
+                <th>Quality</th>
+                <th>95% CI</th>
+                <th>Cost / correct</th>
+                <th>Latency</th>
+                <th>Tasks</th>
+                <th>Rows</th>
+                <th>Passed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.arms.map((arm) => (
+                <tr key={arm.model}>
+                  <td className="l">
+                    {arm.model}
+                    {arm.tie_group != null ? ` (tie ${String.fromCharCode(65 + arm.tie_group)})` : ""}
+                  </td>
+                  <td className="l">{arm.arm_kind}</td>
+                  <td>{pct(arm.quality_mean)}</td>
+                  <td>{ciText(arm)}</td>
+                  <td>{arm.cost_per_correct_usd != null ? usd(arm.cost_per_correct_usd) : "n/a"}</td>
+                  <td>{ms(arm.latency_mean_ms)}</td>
+                  <td>{arm.task_n}</td>
+                  <td>{arm.row_n}</td>
+                  <td>{arm.passed_tasks}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {report.arms
+          .filter((arm) => arm.cost_per_correct_note != null)
+          .map((arm) => (
+            <p key={arm.model} className="u-foot-note">
+              {arm.model}: {arm.cost_per_correct_note}
+            </p>
+          ))}
+        {report.tie_note != null ? (
+          <p>
+            <strong>No winner is claimed.</strong> {report.tie_note}.
+          </p>
+        ) : report.winner_is_significant && report.best_candidate != null ? (
+          <p>
+            <strong>{report.best_candidate.model}</strong> leads with non-overlapping 95% CIs on the sealed holdout.
+          </p>
+        ) : report.best_candidate != null ? (
+          <p>{report.best_candidate.model} ranks first on quality, but the ordering is not statistically separated.</p>
+        ) : null}
+      </Section>
+
+      <Section title="Projected savings">
+        {s != null ? (
+          <>
+            <p>
+              <strong>EXTRAPOLATED</strong> — measured cost-per-correct-task × a stated monthly volume (
+              {s.monthly_volume.toLocaleString("en-US")} tasks/month, from{" "}
+              {s.volume_source === "flag" ? "the --monthly-volume flag" : "the benchmark manifest"}), not a measured bill delta.
+            </p>
+            <div className="u-tbl-scroll">
+              <table className="u-tbl">
+                <thead>
+                  <tr>
+                    <th className="l"></th>
+                    <th>Cost / correct task</th>
+                    <th>× monthly volume</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td className="l">Incumbent ({s.incumbent_model})</td>
+                    <td>{usd(s.incumbent_cost_per_correct_usd)}</td>
+                    <td>{usd(s.incumbent_cost_per_correct_usd * s.monthly_volume)}</td>
+                  </tr>
+                  <tr>
+                    <td className="l">Candidate ({s.candidate_model})</td>
+                    <td>{usd(s.candidate_cost_per_correct_usd)}</td>
+                    <td>{usd(s.candidate_cost_per_correct_usd * s.monthly_volume)}</td>
+                  </tr>
+                  <tr>
+                    <td className="l">
+                      <strong>Projected monthly savings</strong>
+                    </td>
+                    <td></td>
+                    <td>
+                      <strong>
+                        {usd(s.monthly_savings_usd)} ({s.savings_percent.toFixed(1)}%)
+                      </strong>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </>
+        ) : (
+          <p>
+            Not projected. A savings projection requires a measured incumbent cost-per-correct-task, a candidate
+            cost-per-correct-task, and a monthly volume (<code>--monthly-volume</code> or a <code>monthly_volume</code>{" "}
+            manifest field). Whatever is missing is missing on purpose — this report does not invent numbers.
+          </p>
+        )}
+      </Section>
+
+      {report.failure_clusters.length > 0 && (
+        <Section title="Where the best candidate fails">
+          <ul>
+            {report.failure_clusters.map((cluster) => (
+              <li key={cluster.obligation_kind}>
+                {cluster.obligation_kind}: {cluster.failing_tasks} failing task(s)
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {report.class_errors.length > 0 && (
+        <Section title="Top per-class errors">
+          <div className="u-tbl-scroll">
+            <table className="u-tbl">
+              <thead>
+                <tr>
+                  <th className="l">Arm</th>
+                  <th className="l">Gold</th>
+                  <th className="l">Predicted</th>
+                  <th>Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.class_errors.map((err, i) => (
+                  <tr key={i}>
+                    <td className="l">{err.arm}</td>
+                    <td className="l">{err.gold}</td>
+                    <td className="l">{err.predicted}</td>
+                    <td>{err.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+      )}
+
+      <Section title="Rigor attestation">
+        {report.rigor != null ? (
+          <>
+            <p>
+              <strong>{report.rigor.verdict}</strong> (full detail in the benchmark&apos;s rigor-report.md).
+            </p>
+            <ul>
+              {report.rigor.items.map((item) => (
+                <li key={item.item}>
+                  {item.status}: {item.item} — {item.value}
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p>Rigor checklist could not be derived from this directory&apos;s artifacts.</p>
+        )}
+      </Section>
+
+      <Section title="Holdout governance">
+        <p>{report.holdout_governance.statement}</p>
+        <p className="u-foot-note">Holdout rows used for this report: {report.holdout_governance.holdout_rows_used}</p>
+        <p className="u-foot-note mono">benchmark.json sha256: {report.holdout_governance.benchmark_sha256 ?? "unavailable"}</p>
+        <p className="u-foot-note mono">tasks.jsonl sha256: {report.holdout_governance.tasks_sha256 ?? "unavailable"}</p>
+      </Section>
+
+      {report.experiments.length > 0 && (
+        <Section title="Experiment lineage">
+          <ul>
+            {report.experiments.map((exp) => (
+              <li key={exp.experiment_id}>
+                <code>{exp.experiment_id}</code> ({exp.status}): {exp.hypothesis}
+                {exp.verdict ? (
+                  <>
+                    {" "}
+                    → <strong>{exp.verdict}</strong>
+                  </>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      <Section title="Limitations">
+        <ul>
+          {report.limitations.length === 0 && <li>none auto-detected (which is itself unusual — read the rigor attestation).</li>}
+          {report.limitations.map((limitation, i) => (
+            <li key={i}>{limitation}</li>
+          ))}
+        </ul>
+        <p className="u-foot-note">
+          Privacy: customer-identifying strings were scrubbed at generation time ({report.scrub.replacements.names} name,{" "}
+          {report.scrub.replacements.emails} email, {report.scrub.replacements.urls} URL, {report.scrub.replacements.domains}{" "}
+          domain replacement(s)). Aggregate metrics and task/obligation identifiers only — no prompts, no completions, no traces.
+        </p>
+      </Section>
+    </div>
+  );
+}

--- a/apps/benchmark-hub/components/print-button.tsx
+++ b/apps/benchmark-hub/components/print-button.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+/** Print/save-as-PDF trigger for the client-presentable partner report. */
+export function PrintButton() {
+  return (
+    <button
+      type="button"
+      className="u-chip no-print"
+      onClick={() => window.print()}
+      style={{ cursor: "pointer" }}
+    >
+      Print / save PDF
+    </button>
+  );
+}

--- a/apps/benchmark-hub/lib/bootstrap.ts
+++ b/apps/benchmark-hub/lib/bootstrap.ts
@@ -1,98 +1,10 @@
 /**
- * Percentile-bootstrap confidence intervals over per-task mean scores.
- *
- * Pure and DETERMINISTIC: the PRNG is seeded (fnv1a over a caller-provided
- * seed string + mulberry32) so the same rows always produce the same CI —
- * no Math.random anywhere, so tests and reruns are exactly reproducible.
- *
- * The resampling unit is the TASK, not the row: rollout repeats of one task
- * are correlated, so we first collapse rows to per-task means and then
- * resample tasks with replacement. With one task the interval collapses to a
- * degenerate [mean, mean] — honest (no between-task variance is observable),
- * and the UI should treat everything as a tie at N=1.
+ * Percentile-bootstrap confidence intervals — the implementation LIVES in the
+ * CLI package (src/bootstrap-ci.ts) and is imported from the compiled dist so
+ * the hub charts and the CLI's partner report can never drift on the CI math
+ * (same pattern as types.ts / artifacts-core.ts). Pure module, safe for
+ * client components. Named re-exports so the tests' CommonJS .build output
+ * keeps statically analyzable named exports.
  */
-
-export type BootstrapCI = {
-  lo: number;
-  hi: number;
-  /** The statistic the interval brackets: the macro-average (mean of per-task means). */
-  mean: number;
-  iterations: number;
-  /** Number of distinct tasks resampled (the effective N). */
-  taskN: number;
-};
-
-/** fnv1a 32-bit string hash — a stable seed derivation for string keys. */
-export function fnv1a(text: string): number {
-  let h = 0x811c9dc5;
-  for (let i = 0; i < text.length; i += 1) {
-    h ^= text.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  return h >>> 0;
-}
-
-/** mulberry32 — tiny deterministic PRNG, uniform in [0, 1). */
-export function mulberry32(seed: number): () => number {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-/** Linear-interpolated percentile over a SORTED ascending array (p in [0,1]). */
-function percentile(sorted: number[], p: number): number {
-  if (sorted.length === 1) return sorted[0];
-  const idx = p * (sorted.length - 1);
-  const lo = Math.floor(idx);
-  const hi = Math.min(lo + 1, sorted.length - 1);
-  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-}
-
-export type BootstrapOptions = {
-  /** Resample count; the fixed project default is 2000. */
-  iterations?: number;
-  /** Seed string (e.g. `${benchmarkId}::${model}`); same seed => same CI. */
-  seed?: string;
-  /** Two-sided coverage, default 0.95 (percentile bounds at 2.5 / 97.5). */
-  coverage?: number;
-};
-
-/**
- * Percentile-bootstrap CI over per-task mean scores. Returns null when there
- * are no tasks to resample.
- */
-export function bootstrapCI(perTaskMeans: number[], options: BootstrapOptions = {}): BootstrapCI | null {
-  const n = perTaskMeans.length;
-  if (n === 0) return null;
-  const iterations = options.iterations ?? 2000;
-  const coverage = options.coverage ?? 0.95;
-  const mean = perTaskMeans.reduce((a, b) => a + b, 0) / n;
-  if (n === 1) return { lo: mean, hi: mean, mean, iterations, taskN: 1 };
-  const rand = mulberry32(fnv1a(options.seed ?? "understudy-bootstrap"));
-  const stats: number[] = new Array(iterations);
-  for (let i = 0; i < iterations; i += 1) {
-    let sum = 0;
-    for (let j = 0; j < n; j += 1) sum += perTaskMeans[Math.floor(rand() * n)];
-    stats[i] = sum / n;
-  }
-  stats.sort((a, b) => a - b);
-  const alpha = (1 - coverage) / 2;
-  return { lo: percentile(stats, alpha), hi: percentile(stats, 1 - alpha), mean, iterations, taskN: n };
-}
-
-/** Group rows' scores by task and return per-task means (input: [taskId, score] pairs). */
-export function perTaskMeans(pairs: Array<[string, number]>): number[] {
-  const byTask = new Map<string, { sum: number; n: number }>();
-  for (const [taskId, score] of pairs) {
-    const cur = byTask.get(taskId) ?? { sum: 0, n: 0 };
-    cur.sum += score;
-    cur.n += 1;
-    byTask.set(taskId, cur);
-  }
-  return [...byTask.values()].map((v) => v.sum / v.n);
-}
+export { bootstrapCI, fnv1a, mulberry32, perTaskMeans } from "../../../dist/bootstrap-ci.js";
+export type { BootstrapCI, BootstrapOptions } from "../../../dist/bootstrap-ci.js";

--- a/apps/benchmark-hub/lib/partner-report-core.ts
+++ b/apps/benchmark-hub/lib/partner-report-core.ts
@@ -1,0 +1,10 @@
+/**
+ * Hub-side view of the partner report (the honest client-facing
+ * benchmark-and-savings deliverable). The derivation and rendering LIVE in
+ * the CLI package (src/partner-report.ts) and are imported from the compiled
+ * dist — never forked — so the CLI's partner-report.md/.json and the hub's
+ * Report page physically cannot disagree on a single number. Same pattern as
+ * runs-core.ts / artifacts-core.ts.
+ */
+export { PARTNER_REPORT_SCHEMA, derivePartnerReport, renderPartnerReport, scrubText, slugNameTokens } from "../../../dist/partner-report.js";
+export type { PartnerArm, PartnerFloor, PartnerReport, ProjectedSavings } from "../../../dist/partner-report.js";

--- a/apps/benchmark-hub/scripts/check-dist.mjs
+++ b/apps/benchmark-hub/scripts/check-dist.mjs
@@ -16,6 +16,8 @@ const required = [
   "benchmark-hub-types.js",
   "benchmark-replay.js",
   "benchmark.js",
+  "bootstrap-ci.js",
+  "partner-report.js",
   "run-executor.js",
   "trace-author.js",
 ].map((f) => resolve(repoRoot, "dist", f));

--- a/apps/benchmark-hub/tests/partner-report-core.test.mjs
+++ b/apps/benchmark-hub/tests/partner-report-core.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+// Compiled by `tsc -p tests/tsconfig.json` (see package.json "test" script).
+// partner-report-core re-exports the CLI's compiled dist module — this test
+// pins the re-export contract the hub Report page depends on.
+import { PARTNER_REPORT_SCHEMA, derivePartnerReport, renderPartnerReport } from "./.build/lib/partner-report-core.js";
+
+const roots = [];
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function makeBenchmarkDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hub-partner-report-"));
+  roots.push(dir);
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "hub-pr-bench",
+      name: "hub report smoke",
+      provenance: { origin: "derived-from-traces" },
+      taxonomy: [{ category_id: "cat-a" }],
+      tasks: [
+        { task_id: "t1", category_id: "cat-a", split: "holdout" },
+        { task_id: "t2", category_id: "cat-a", split: "holdout" },
+      ],
+      environment: { format: "verifiers.v1", package_ref: "environment" },
+      verifier: { kind: "final-state", strict_metric: "task_completed_correctly" },
+    }),
+  );
+  const rows = [
+    { schema_version: "understudy.eval_result.v1", run_id: "r", task_id: "t1", status: "ok", score: 1, model: "m-a", arm_kind: "incumbent", cost: 0.2, latency_ms: 100 },
+    { schema_version: "understudy.eval_result.v1", run_id: "r", task_id: "t2", status: "ok", score: 1, model: "m-a", arm_kind: "incumbent", cost: 0.2, latency_ms: 100 },
+    { schema_version: "understudy.eval_result.v1", run_id: "r", task_id: "t1", status: "ok", score: 1, model: "m-b", arm_kind: "candidate", cost: 0.01, latency_ms: 50 },
+    { schema_version: "understudy.eval_result.v1", run_id: "r", task_id: "t2", status: "ok", score: 0, model: "m-b", arm_kind: "candidate", cost: 0.01, latency_ms: 50 },
+  ];
+  fs.writeFileSync(path.join(dir, "rows-run-r.jsonl"), rows.map((r) => JSON.stringify(r)).join("\n") + "\n");
+  return dir;
+}
+
+describe("partner-report-core (dist re-export)", () => {
+  it("derives and renders the same report the CLI writes", () => {
+    const dir = makeBenchmarkDir();
+    const report = derivePartnerReport(dir, { now: new Date("2026-07-22T00:00:00.000Z") });
+    assert.equal(report.schema_version, PARTNER_REPORT_SCHEMA);
+    assert.equal(report.workload.scope, "holdout");
+    assert.equal(report.arms.length, 2);
+    assert.ok(report.incumbent && report.incumbent.model === "m-a");
+    assert.ok(report.arms.every((arm) => arm.ci != null));
+    const markdown = renderPartnerReport(report);
+    assert.match(markdown, /95% CI/);
+    assert.match(markdown, /Holdout governance/);
+  });
+});

--- a/apps/benchmark-hub/tests/tsconfig.json
+++ b/apps/benchmark-hub/tests/tsconfig.json
@@ -16,6 +16,7 @@
     "../lib/benchmark-core.ts",
     "../lib/scores.ts",
     "../lib/pareto.ts",
+    "../lib/partner-report-core.ts",
     "../lib/data-core.ts",
     "../app/api/flags/route.ts",
     "../app/api/reviews/route.ts",

--- a/src/bootstrap-ci.ts
+++ b/src/bootstrap-ci.ts
@@ -1,0 +1,98 @@
+/**
+ * Percentile-bootstrap confidence intervals over per-task mean scores.
+ *
+ * Pure and DETERMINISTIC: the PRNG is seeded (fnv1a over a caller-provided
+ * seed string + mulberry32) so the same rows always produce the same CI —
+ * no Math.random anywhere, so tests and reruns are exactly reproducible.
+ *
+ * The resampling unit is the TASK, not the row: rollout repeats of one task
+ * are correlated, so we first collapse rows to per-task means and then
+ * resample tasks with replacement. With one task the interval collapses to a
+ * degenerate [mean, mean] — honest (no between-task variance is observable),
+ * and the UI should treat everything as a tie at N=1.
+ */
+
+export type BootstrapCI = {
+  lo: number;
+  hi: number;
+  /** The statistic the interval brackets: the macro-average (mean of per-task means). */
+  mean: number;
+  iterations: number;
+  /** Number of distinct tasks resampled (the effective N). */
+  taskN: number;
+};
+
+/** fnv1a 32-bit string hash — a stable seed derivation for string keys. */
+export function fnv1a(text: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** mulberry32 — tiny deterministic PRNG, uniform in [0, 1). */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Linear-interpolated percentile over a SORTED ascending array (p in [0,1]). */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const idx = p * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.min(lo + 1, sorted.length - 1);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+export type BootstrapOptions = {
+  /** Resample count; the fixed project default is 2000. */
+  iterations?: number;
+  /** Seed string (e.g. `${benchmarkId}::${model}`); same seed => same CI. */
+  seed?: string;
+  /** Two-sided coverage, default 0.95 (percentile bounds at 2.5 / 97.5). */
+  coverage?: number;
+};
+
+/**
+ * Percentile-bootstrap CI over per-task mean scores. Returns null when there
+ * are no tasks to resample.
+ */
+export function bootstrapCI(perTaskMeans: number[], options: BootstrapOptions = {}): BootstrapCI | null {
+  const n = perTaskMeans.length;
+  if (n === 0) return null;
+  const iterations = options.iterations ?? 2000;
+  const coverage = options.coverage ?? 0.95;
+  const mean = perTaskMeans.reduce((a, b) => a + b, 0) / n;
+  if (n === 1) return { lo: mean, hi: mean, mean, iterations, taskN: 1 };
+  const rand = mulberry32(fnv1a(options.seed ?? "understudy-bootstrap"));
+  const stats: number[] = new Array(iterations);
+  for (let i = 0; i < iterations; i += 1) {
+    let sum = 0;
+    for (let j = 0; j < n; j += 1) sum += perTaskMeans[Math.floor(rand() * n)];
+    stats[i] = sum / n;
+  }
+  stats.sort((a, b) => a - b);
+  const alpha = (1 - coverage) / 2;
+  return { lo: percentile(stats, alpha), hi: percentile(stats, 1 - alpha), mean, iterations, taskN: n };
+}
+
+/** Group rows' scores by task and return per-task means (input: [taskId, score] pairs). */
+export function perTaskMeans(pairs: Array<[string, number]>): number[] {
+  const byTask = new Map<string, { sum: number; n: number }>();
+  for (const [taskId, score] of pairs) {
+    const cur = byTask.get(taskId) ?? { sum: 0, n: 0 };
+    cur.sum += score;
+    cur.n += 1;
+    byTask.set(taskId, cur);
+  }
+  return [...byTask.values()].map((v) => v.sum / v.n);
+}

--- a/src/commands/benchmarks.ts
+++ b/src/commands/benchmarks.ts
@@ -205,6 +205,35 @@ export function registerBenchmarksCommand(program: Command): void {
     });
 
   benchmarks
+    .command("report <dir>")
+    .description(
+      "Generate partner-report.md + partner-report.json — the honest client-facing benchmark-and-savings " +
+        "report — from EXISTING artifacts only (rows, calibration, rigor, experiments; no new runs, no " +
+        "network). Floors and 95% CIs always shown; no winner claim on overlapping CIs; savings only when " +
+        "incumbent + candidate cost-per-correct + a monthly volume exist, always labeled EXTRAPOLATED; " +
+        "customer names/emails/domains scrubbed by construction",
+    )
+    .option("--monthly-volume <n>", "Monthly task volume for the EXTRAPOLATED savings projection (overrides manifest.monthly_volume)")
+    .option(
+      "--scrub-name <name>",
+      "Extra customer-name token to scrub (repeatable; dir-slug tokens are scrubbed automatically)",
+      (value: string, previous: string[]) => [...previous, value],
+      [] as string[],
+    )
+    .option("--out <dir>", "Directory to write partner-report.{md,json} into (default: the benchmark dir; use for read-only benchmark dirs)")
+    .action(async (dir: string, options: { monthlyVolume?: string; scrubName: string[]; out?: string }) => {
+      const { writePartnerReport } = await import("../partner-report.js");
+      const { report, markdownPath, jsonPath } = writePartnerReport(dir, {
+        monthlyVolume: options.monthlyVolume === undefined ? undefined : Number(options.monthlyVolume),
+        scrubNames: options.scrubName,
+        outDir: options.out,
+      });
+      console.error(`wrote ${markdownPath}`);
+      console.error(`wrote ${jsonPath}`);
+      console.log(JSON.stringify(report, null, 2));
+    });
+
+  benchmarks
     .command("rigor <dir>")
     .description(
       "Generate rigor-report.md in the benchmark dir: ABC checklist (oracle solvability, null/spam trivial-agent " +

--- a/src/partner-report.ts
+++ b/src/partner-report.ts
@@ -1,0 +1,756 @@
+/**
+ * partner-report — the honest benchmark-and-savings report: the client-facing
+ * deliverable of the design-partner loop. Everything is DERIVED from a
+ * benchmark directory's existing file-based artifacts (benchmark.json,
+ * tasks.jsonl, rows-*.jsonl, calibration.json, experiments.jsonl,
+ * manifest.json leakage_audit) through the SHARED codecs — no network, no
+ * model calls, no new runs.
+ *
+ * Honesty rules, by construction (mirrors optimize-workload's claim-packet
+ * discipline):
+ * - Every number traces to persisted eval rows; anomaly-flagged rows are
+ *   marked and excluded from aggregates, never dropped from counts.
+ * - Trivial-agent floors and the incumbent ceiling are always stated next to
+ *   any candidate result.
+ * - 95% CIs (seeded percentile bootstrap over per-task means — the same math
+ *   as the hub leaderboard) are always shown; overlapping CIs mean NO winner
+ *   claim is made.
+ * - Savings projections exist only when an incumbent cost-per-correct and a
+ *   candidate cost-per-correct both exist AND a monthly volume was provided;
+ *   they are always labeled EXTRAPOLATED.
+ * - Results scored on non-holdout rows are labeled unverified: the report
+ *   never presents a train/dev number as holdout evidence.
+ * - Customer-identifying strings (names, emails, URLs, domains) are scrubbed
+ *   from every free-text field before it can reach the rendered report — the
+ *   same no-identifiers-in-shared-artifacts convention the public skills
+ *   enforce (share-savings, ingest-traces).
+ */
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { experimentsPath, latestExperiments, readExperiments, readJsonlFile, type Experiment } from "./benchmark-artifacts.js";
+import { bootstrapCI, perTaskMeans, type BootstrapCI } from "./bootstrap-ci.js";
+import { deriveClassMetrics, isClassificationBenchmark } from "./dataset-metrics.js";
+import { deriveRigorReport, type RigorReport } from "./rigor-report.js";
+import {
+  DEFAULT_CALIBRATION_THRESHOLD,
+  TRIVIAL_ARM_KINDS,
+  TRIVIAL_FLOOR_LIMIT,
+  calibrationPath,
+  isAnomalousEvalRow,
+  type CalibrationSummary,
+  type TrivialArmKind,
+} from "./run-executor.js";
+
+export const PARTNER_REPORT_SCHEMA = "understudy.partner_report.v1";
+
+type Obj = Record<string, any>;
+const asObject = (value: unknown): Obj =>
+  value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {};
+
+/* ------------------------------------------------------------------ */
+/* Scrubbing (privacy by construction)                                 */
+/* ------------------------------------------------------------------ */
+
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const URL_RE = /https?:\/\/[^\s"'<>)\]]+/g;
+const DOMAIN_RE = /\b(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:com|io|ai|co|net|org|dev|app|xyz|cloud|sh)\b/gi;
+
+/** Generic tokens that never count as a customer name when auto-derived from a dir slug. */
+const GENERIC_SLUG_TOKENS = new Set([
+  "automation", "benchmark", "bench", "trace", "traces", "dataset", "workload", "agent",
+  "eval", "evals", "tasks", "test", "demo", "src", "run", "runs", "local", "prod", "staging",
+]);
+
+export type ScrubStats = { names: number; emails: number; urls: number; domains: number };
+
+/**
+ * Scrub one text field: customer names → [partner], emails/URLs/domains →
+ * bracketed placeholders. Name matching is case-insensitive and
+ * substring-based ON PURPOSE (e.g. "cedar" also catches "cedarcopilot"):
+ * over-scrubbing a shared report is cheap, leaking a customer name is not.
+ */
+export function scrubText(text: string, names: string[], stats?: ScrubStats): string {
+  let out = text;
+  const count = (key: keyof ScrubStats, n: number) => {
+    if (stats && n > 0) stats[key] += n;
+  };
+  count("emails", (out.match(EMAIL_RE) ?? []).length);
+  out = out.replace(EMAIL_RE, "[redacted-email]");
+  count("urls", (out.match(URL_RE) ?? []).length);
+  out = out.replace(URL_RE, "[redacted-url]");
+  for (const name of names) {
+    if (name.length < 3) continue;
+    const re = new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi");
+    count("names", (out.match(re) ?? []).length);
+    out = out.replace(re, "[partner]");
+  }
+  count("domains", (out.match(DOMAIN_RE) ?? []).length);
+  out = out.replace(DOMAIN_RE, "[redacted-domain]");
+  return out;
+}
+
+/** Candidate customer-name tokens from a benchmark dir basename (e.g. "cedar-automation" → ["cedar"]). */
+export function slugNameTokens(dirBasename: string): string[] {
+  return dirBasename
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 4 && !GENERIC_SLUG_TOKENS.has(token) && !/^\d+$/.test(token));
+}
+
+/* ------------------------------------------------------------------ */
+/* Report shape (partner-report.json — the share-savings-ready payload) */
+/* ------------------------------------------------------------------ */
+
+export type PartnerArm = {
+  model: string;
+  arm_kind: "incumbent" | "candidate" | "trivial";
+  /** Macro-average of per-task mean scores over scored, non-anomalous rows in scope. */
+  quality_mean: number | null;
+  /** Seeded percentile-bootstrap 95% CI over per-task means (null with no scored tasks). */
+  ci: BootstrapCI | null;
+  /** Distinct scored tasks in scope (the CI's effective N). */
+  task_n: number;
+  row_n: number;
+  /** Tasks whose best scored rollout reaches the calibration threshold. */
+  passed_tasks: number;
+  /** Σ cost over scored rows carrying a numeric cost; null when none do. */
+  cost_total_usd: number | null;
+  /** Scored rows that carried a numeric cost (cost coverage honesty). */
+  costed_rows: number;
+  /** THE BUYER METRIC: total cost ÷ passed tasks. Null when no cost is recorded or no task passed (see note). */
+  cost_per_correct_usd: number | null;
+  cost_per_correct_note: string | null;
+  latency_mean_ms: number | null;
+  /** Statistical-tie group index (adjacent overlapping 95% CIs), null when untied. */
+  tie_group: number | null;
+};
+
+export type PartnerFloor = {
+  arm_kind: TrivialArmKind;
+  /** Fraction of scoped tasks the trivial arm passes at the threshold; null = arm never ran. */
+  floor: number | null;
+  passed_tasks: number;
+  task_n: number;
+  exceeded: boolean;
+};
+
+export type ProjectedSavings = {
+  extrapolated: true;
+  monthly_volume: number;
+  volume_source: "flag" | "manifest";
+  incumbent_model: string;
+  incumbent_cost_per_correct_usd: number;
+  candidate_model: string;
+  candidate_cost_per_correct_usd: number;
+  monthly_savings_usd: number;
+  savings_percent: number;
+};
+
+export type PartnerReport = {
+  schema_version: typeof PARTNER_REPORT_SCHEMA;
+  generated_at: string;
+  benchmark_id: string;
+  workload: {
+    name: string;
+    description: string;
+    task_count: number;
+    split_counts: Record<string, number>;
+    provenance_origin: string;
+    /** Which rows the headline table aggregates: sealed holdout when holdout rows exist, else all (a limitation). */
+    scope: "holdout" | "all";
+    threshold: number;
+  };
+  /** Only COUNTS are recorded — the scrub token list itself would leak the customer name into the payload. */
+  scrub: { name_token_count: number; replacements: ScrubStats };
+  arms: PartnerArm[];
+  floors: PartnerFloor[];
+  incumbent: PartnerArm | null;
+  /** The best candidate by quality — a WINNER only when winner_is_significant. */
+  best_candidate: PartnerArm | null;
+  /** True only when the best candidate's CI does not overlap the runner-up's AND scope is holdout. */
+  winner_is_significant: boolean;
+  tie_note: string | null;
+  projected_savings: ProjectedSavings | null;
+  failure_clusters: Array<{ obligation_kind: string; failing_tasks: number }>;
+  /** Dataset benchmarks: top gold→predicted confusions per arm (labels scrubbed). */
+  class_errors: Array<{ arm: string; gold: string; predicted: string; count: number }>;
+  rigor: { verdict: string; items: Array<{ item: string; status: string; value: string }> } | null;
+  holdout_governance: {
+    split_counts: Record<string, number>;
+    holdout_task_n: number;
+    holdout_rows_used: number;
+    benchmark_sha256: string | null;
+    tasks_sha256: string | null;
+    statement: string;
+  };
+  experiments: Array<{ experiment_id: string; status: string; hypothesis: string; verdict: string | null }>;
+  limitations: string[];
+  anomaly_total: number;
+  /**
+   * Receipts-ready block: a complete understudy.anonymous_savings.v1 payload
+   * (the exact shape the share-savings skill posts), present only when a
+   * savings projection exists. Metrics-only by construction — extract it and
+   * feed it to skills/share-savings/scripts/share-savings.mjs via --from.
+   */
+  anonymous_savings: {
+    schema_version: "understudy.anonymous_savings.v1";
+    source: string;
+    monthly_baseline_usd: number | null;
+    monthly_candidate_usd: number | null;
+    monthly_savings_usd: number | null;
+    savings_percent: number | null;
+    requests_per_month: number | null;
+    baseline_provider: string | null;
+    baseline_model: string | null;
+    candidate_provider: string | null;
+    candidate_model: string | null;
+    candidate_lane: string;
+    interventions: string[];
+    evidence_level: number | null;
+    claim_status: string;
+    claim_hash: string | null;
+    sample_size: number | null;
+    validated_on_holdout: boolean;
+  } | null;
+};
+
+export type PartnerReportOptions = {
+  /** Monthly task volume for the EXTRAPOLATED savings projection (overrides manifest.monthly_volume). */
+  monthlyVolume?: number;
+  /** Extra customer-name tokens to scrub (added to the dir-slug-derived ones). */
+  scrubNames?: string[];
+  now?: Date;
+};
+
+/* ------------------------------------------------------------------ */
+/* Derivation                                                          */
+/* ------------------------------------------------------------------ */
+
+function readAllRows(dir: string): Obj[] {
+  let names: string[] = [];
+  try {
+    names = readdirSync(dir).filter((name) => /^rows-.*\.jsonl$/.test(name));
+  } catch {
+    return [];
+  }
+  return names.sort().flatMap((name) => readJsonlFile<Obj>(join(dir, name)).items);
+}
+
+function sha256File(path: string): string | null {
+  try {
+    return createHash("sha256").update(readFileSync(path)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+const mean = (values: number[]): number | null => (values.length === 0 ? null : values.reduce((a, b) => a + b, 0) / values.length);
+
+const isTrivialKind = (kind: string): boolean => (TRIVIAL_ARM_KINDS as readonly string[]).includes(kind);
+
+/** Build one arm summary over its scoped rows. */
+function deriveArm(model: string, rows: Obj[], benchmarkId: string, threshold: number): PartnerArm {
+  const trusted = rows.filter((row) => !isAnomalousEvalRow(row));
+  const scored = trusted.filter((row) => row.status === "ok" && typeof row.score === "number");
+  const taskMeans = perTaskMeans(scored.map((row) => [String(row.task_id), Number(row.score)] as [string, number]));
+  const best = new Map<string, number>();
+  for (const row of scored) {
+    const id = String(row.task_id);
+    best.set(id, Math.max(best.get(id) ?? -Infinity, Number(row.score)));
+  }
+  const passed = [...best.values()].filter((score) => score >= threshold).length;
+  const costs = scored.map((row) => row.cost).filter((c): c is number => typeof c === "number" && Number.isFinite(c));
+  const costTotal = costs.length > 0 ? costs.reduce((a, b) => a + b, 0) : null;
+  let costPerCorrect: number | null = null;
+  let note: string | null = null;
+  if (costTotal === null) {
+    note = "no cost recorded on any scored row — cost-per-correct-task unavailable";
+  } else if (passed === 0) {
+    note = `${costTotal.toFixed(4)} USD spent, zero tasks passed — cost-per-correct-task is undefined (division by zero), not zero`;
+  } else {
+    costPerCorrect = costTotal / passed;
+    if (costs.length < scored.length) note = `cost recorded on ${costs.length}/${scored.length} scored rows`;
+  }
+  const kinds = new Set(rows.map((row) => String(row.arm_kind ?? "candidate")));
+  const armKind: PartnerArm["arm_kind"] = [...kinds].some(isTrivialKind) ? "trivial" : kinds.has("incumbent") ? "incumbent" : "candidate";
+  const latencies = scored.map((row) => row.latency_ms).filter((l): l is number => typeof l === "number" && Number.isFinite(l));
+  return {
+    model,
+    arm_kind: armKind,
+    quality_mean: mean(taskMeans),
+    ci: bootstrapCI(taskMeans, { seed: `${benchmarkId}::${model}` }),
+    task_n: taskMeans.length,
+    row_n: rows.length,
+    passed_tasks: passed,
+    cost_total_usd: costTotal,
+    costed_rows: costs.length,
+    cost_per_correct_usd: costPerCorrect,
+    cost_per_correct_note: note,
+    latency_mean_ms: mean(latencies),
+    tie_group: null,
+  };
+}
+
+/** Chain adjacent overlapping CIs into tie groups (same discipline as the hub leaderboard). */
+function assignTieGroups(arms: PartnerArm[]): void {
+  const ranked = arms
+    .filter((arm) => arm.arm_kind !== "trivial" && arm.ci != null && arm.quality_mean != null)
+    .sort((a, b) => (b.quality_mean as number) - (a.quality_mean as number) || a.model.localeCompare(b.model));
+  let group: PartnerArm[] = [];
+  let index = 0;
+  const flush = () => {
+    if (group.length >= 2) {
+      for (const arm of group) arm.tie_group = index;
+      index += 1;
+    }
+    group = [];
+  };
+  for (const arm of ranked) {
+    const prev = group[group.length - 1];
+    const overlaps = prev != null && prev.ci != null && arm.ci != null && arm.ci.hi >= prev.ci.lo && prev.ci.hi >= arm.ci.lo;
+    if (!overlaps) flush();
+    group.push(arm);
+  }
+  flush();
+}
+
+/** Derive the full partner report from a benchmark directory. Throws on a missing/invalid benchmark.json. */
+export function derivePartnerReport(benchmarkDir: string, options: PartnerReportOptions = {}): PartnerReport {
+  const dir = resolve(benchmarkDir);
+  const now = options.now ?? new Date();
+  const manifest = asObject(JSON.parse(readFileSync(join(dir, "benchmark.json"), "utf8")));
+  const benchmarkId = String(manifest.benchmark_id ?? "unknown");
+  const manifestTasks = (Array.isArray(manifest.tasks) ? manifest.tasks : []).map(asObject);
+  const splitOf = new Map(manifestTasks.map((task) => [String(task.task_id), String(task.split ?? "none")]));
+  const splitCounts: Record<string, number> = {};
+  for (const split of splitOf.values()) splitCounts[split] = (splitCounts[split] ?? 0) + 1;
+
+  const scrubNames = [...new Set([...slugNameTokens(basename(dir)), ...(options.scrubNames ?? []).map((n) => n.toLowerCase())])];
+  const scrubStats: ScrubStats = { names: 0, emails: 0, urls: 0, domains: 0 };
+  const scrub = (text: string): string => scrubText(text, scrubNames, scrubStats);
+
+  const calibration = existsSync(calibrationPath(dir))
+    ? (asObject(JSON.parse(readFileSync(calibrationPath(dir), "utf8"))) as Partial<CalibrationSummary>)
+    : null;
+  const threshold = typeof calibration?.threshold === "number" ? calibration.threshold : DEFAULT_CALIBRATION_THRESHOLD;
+
+  const allRows = readAllRows(dir);
+  const anomalyTotal = allRows.filter(isAnomalousEvalRow).length;
+
+  // Scope: sealed holdout rows when any exist (the only rows a savings claim
+  // may cite); otherwise everything, explicitly labeled a limitation.
+  const rowSplit = (row: Obj): string => splitOf.get(String(row.task_id)) ?? String(row.split ?? "none");
+  const holdoutRows = allRows.filter((row) => rowSplit(row) === "holdout");
+  const scope: "holdout" | "all" = holdoutRows.length > 0 ? "holdout" : "all";
+  const scopedRows = scope === "holdout" ? holdoutRows : allRows;
+  const scopedTaskIds = [...new Set(
+    (scope === "holdout" ? manifestTasks.filter((t) => String(t.split ?? "none") === "holdout") : manifestTasks).map((t) => String(t.task_id)),
+  )];
+
+  // Arms (one per model) over the scoped rows. Oracle-runner rows are harness
+  // calibration (deterministic, zero-cost) — they validate the benchmark, they
+  // are not a candidate a buyer could deploy, so they never enter the table.
+  const byModel = new Map<string, Obj[]>();
+  for (const row of scopedRows) {
+    if (Number(asObject(row.subscores).runner_oracle) === 1) continue;
+    const model = String(row.model ?? "(unknown model)");
+    byModel.set(model, [...(byModel.get(model) ?? []), row]);
+  }
+  const arms = [...byModel.entries()].map(([model, rows]) => deriveArm(scrub(model), rows, benchmarkId, threshold));
+  arms.sort((a, b) => (b.quality_mean ?? -1) - (a.quality_mean ?? -1) || a.model.localeCompare(b.model));
+  assignTieGroups(arms);
+
+  // Trivial floors over the SCOPED rows, task universe = scoped tasks.
+  const floors: PartnerFloor[] = TRIVIAL_ARM_KINDS.map((kind) => {
+    const armRows = scopedRows.filter((row) => String(row.arm_kind ?? "") === kind && !isAnomalousEvalRow(row) && row.status === "ok" && typeof row.score === "number");
+    if (armRows.length === 0) return { arm_kind: kind, floor: null, passed_tasks: 0, task_n: scopedTaskIds.length, exceeded: false };
+    const best = new Map<string, number>();
+    for (const row of armRows) {
+      const id = String(row.task_id);
+      best.set(id, Math.max(best.get(id) ?? -Infinity, Number(row.score)));
+    }
+    const universe = scopedTaskIds.length > 0 ? scopedTaskIds : [...best.keys()];
+    const passed = universe.filter((id) => (best.get(id) ?? -Infinity) >= threshold).length;
+    const floor = universe.length === 0 ? 0 : passed / universe.length;
+    return { arm_kind: kind, floor, passed_tasks: passed, task_n: universe.length, exceeded: floor > TRIVIAL_FLOOR_LIMIT };
+  });
+
+  const incumbent = arms.find((arm) => arm.arm_kind === "incumbent") ?? null;
+  const candidates = arms.filter((arm) => arm.arm_kind === "candidate");
+  const bestCandidate = candidates.find((arm) => arm.quality_mean != null) ?? null;
+
+  // Winner honesty: significant only on holdout AND untied against the
+  // runner-up (incumbent included — beating a tied incumbent is not a win).
+  const rankedNonTrivial = arms.filter((arm) => arm.arm_kind !== "trivial" && arm.quality_mean != null);
+  const runnerUp = rankedNonTrivial.find((arm) => arm !== bestCandidate) ?? null;
+  let winnerIsSignificant = false;
+  let tieNote: string | null = null;
+  if (bestCandidate != null && bestCandidate.ci != null) {
+    if (bestCandidate.tie_group != null) {
+      const tied = arms.filter((arm) => arm.tie_group === bestCandidate.tie_group).map((arm) => arm.model);
+      tieNote = `statistical tie at this N: ${tied.join(", ")} have overlapping 95% CIs — no winner is claimed`;
+    } else if (scope !== "holdout") {
+      tieNote = "results are not from the sealed holdout — no winner is claimed";
+    } else if (runnerUp == null || runnerUp.ci == null || bestCandidate.ci.lo > runnerUp.ci.hi) {
+      winnerIsSignificant = true;
+    }
+  }
+
+  // Projected savings: incumbent vs the best candidate WITH a cost-per-correct.
+  const volumeFromFlag = typeof options.monthlyVolume === "number" && Number.isFinite(options.monthlyVolume) ? options.monthlyVolume : null;
+  const manifestVolume = typeof manifest.monthly_volume === "number" && Number.isFinite(manifest.monthly_volume) ? Number(manifest.monthly_volume) : null;
+  const monthlyVolume = volumeFromFlag ?? manifestVolume;
+  // Savings candidate: the CHEAPEST cost-per-correct among candidates whose
+  // quality is statistically indistinguishable from the best candidate (its
+  // tie group), or the best candidate alone when it is untied. Never a
+  // quality-inferior arm: a savings number must not trade away quality silently.
+  const topGroup =
+    bestCandidate == null
+      ? []
+      : bestCandidate.tie_group == null
+        ? [bestCandidate]
+        : candidates.filter((arm) => arm.tie_group === bestCandidate.tie_group);
+  const savingsCandidate = topGroup
+    .filter((arm) => arm.cost_per_correct_usd != null)
+    .sort((a, b) => (a.cost_per_correct_usd as number) - (b.cost_per_correct_usd as number))[0] ?? null;
+  let projectedSavings: ProjectedSavings | null = null;
+  if (monthlyVolume != null && monthlyVolume > 0 && incumbent?.cost_per_correct_usd != null && savingsCandidate?.cost_per_correct_usd != null) {
+    const delta = incumbent.cost_per_correct_usd - savingsCandidate.cost_per_correct_usd;
+    projectedSavings = {
+      extrapolated: true,
+      monthly_volume: monthlyVolume,
+      volume_source: volumeFromFlag != null ? "flag" : "manifest",
+      incumbent_model: incumbent.model,
+      incumbent_cost_per_correct_usd: incumbent.cost_per_correct_usd,
+      candidate_model: savingsCandidate.model,
+      candidate_cost_per_correct_usd: savingsCandidate.cost_per_correct_usd,
+      monthly_savings_usd: delta * monthlyVolume,
+      savings_percent: (delta / incumbent.cost_per_correct_usd) * 100,
+    };
+  }
+
+  // Failure clusters: for tasks the best candidate fails, tally the contract's
+  // required obligation kinds (what kind of work is being missed).
+  const sidecars = new Map(readJsonlFile<Obj>(join(dir, "tasks.jsonl")).items.map((task) => [String(task.task_id), asObject(task)]));
+  const failureClusters = new Map<string, number>();
+  if (bestCandidate != null) {
+    const candidateRows = scopedRows.filter((row) => scrub(String(row.model ?? "(unknown model)")) === bestCandidate.model);
+    const best = new Map<string, number>();
+    for (const row of candidateRows) {
+      if (isAnomalousEvalRow(row) || row.status !== "ok" || typeof row.score !== "number") continue;
+      const id = String(row.task_id);
+      best.set(id, Math.max(best.get(id) ?? -Infinity, Number(row.score)));
+    }
+    for (const [taskId, score] of best) {
+      if (score >= threshold) continue;
+      const contract = asObject(sidecars.get(taskId)?.outcome_contract);
+      for (const rule of (Array.isArray(contract.required) ? contract.required : []).map(asObject)) {
+        const kind = String(rule.type ?? "state_effect");
+        failureClusters.set(kind, (failureClusters.get(kind) ?? 0) + 1);
+      }
+    }
+  }
+
+  // Dataset (classification) benchmarks: per-class error summary from the
+  // shared class-metrics derivation, labels scrubbed.
+  const sidecarTasks = [...sidecars.values()];
+  const classErrors: PartnerReport["class_errors"] = [];
+  if (isClassificationBenchmark(sidecarTasks)) {
+    const metrics = deriveClassMetrics(allRows, sidecarTasks, manifestTasks, threshold);
+    for (const arm of metrics.arms) {
+      const misses = arm.confusion.pairs.filter((pair) => pair.gold !== pair.predicted).sort((a, b) => b.count - a.count);
+      for (const miss of misses.slice(0, 5)) {
+        classErrors.push({ arm: scrub(arm.arm), gold: scrub(miss.gold), predicted: scrub(miss.predicted), count: miss.count });
+      }
+    }
+  }
+
+  // Rigor attestation (never fatal — the report states when rigor is underivable).
+  let rigor: PartnerReport["rigor"] = null;
+  let rigorReport: RigorReport | null = null;
+  try {
+    rigorReport = deriveRigorReport(dir, now);
+    const tally = { PASS: 0, FLAG: 0, UNKNOWN: 0 } as Record<string, number>;
+    for (const item of rigorReport.items) tally[item.status] = (tally[item.status] ?? 0) + 1;
+    rigor = {
+      verdict: `${tally.PASS} PASS / ${tally.FLAG} FLAG / ${tally.UNKNOWN} UNKNOWN across ${rigorReport.items.length} rigor checks`,
+      items: rigorReport.items.map((item) => ({ item: item.item, status: item.status, value: scrub(item.value) })),
+    };
+  } catch {
+    rigor = null;
+  }
+
+  // Holdout governance.
+  const holdoutTaskN = splitCounts.holdout ?? 0;
+  const governance: PartnerReport["holdout_governance"] = {
+    split_counts: splitCounts,
+    holdout_task_n: holdoutTaskN,
+    holdout_rows_used: holdoutRows.length,
+    benchmark_sha256: sha256File(join(dir, "benchmark.json")),
+    tasks_sha256: sha256File(join(dir, "tasks.jsonl")),
+    statement:
+      holdoutTaskN > 0
+        ? `Splits were frozen at benchmark build time (train/dev/holdout recorded per task in benchmark.json, hashed above). The ${holdoutTaskN}-task holdout was never used for prompt evolution, model selection, or training — only for the final scores in this report.`
+        : "No holdout split is recorded — nothing in this report is holdout-verified.",
+  };
+
+  // Experiment lineage.
+  const experiments = Object.values(latestExperiments(readExperiments(experimentsPath(dir)).experiments)).map((exp: Experiment) => ({
+    experiment_id: exp.experiment_id,
+    status: exp.status,
+    hypothesis: scrub(exp.hypothesis),
+    verdict: exp.verdict ? `${exp.verdict.decision}: ${scrub(exp.verdict.summary)}` : null,
+  }));
+
+  // Auto-derived limitations — honest by construction, never hand-curated away.
+  const limitations: string[] = [];
+  if (scope !== "holdout") limitations.push("No rows on a sealed holdout split — every number here is unverified for claim purposes (train/dev evidence only).");
+  if (holdoutTaskN > 0 && holdoutTaskN < 20) limitations.push(`Small holdout: only ${holdoutTaskN} task(s) — confidence intervals are wide and single-task flips move the mean; treat differences as directional.`);
+  if (anomalyTotal > 0) limitations.push(`${anomalyTotal} rollout row(s) carry structural anomaly flags and were excluded from every aggregate (marked, never dropped from counts).`);
+  const foundryManifestPath = join(dir, "manifest.json");
+  if (existsSync(foundryManifestPath)) {
+    const audit = asObject(asObject(JSON.parse(readFileSync(foundryManifestPath, "utf8"))).leakage_audit);
+    const findings = (Array.isArray(audit.findings) ? audit.findings : []).map(asObject);
+    const verbatim = findings.filter((f) => String(f.tier ?? "verbatim") === "verbatim").length;
+    const advisory = findings.length - verbatim;
+    if (verbatim > 0) limitations.push(`Leakage audit: ${verbatim} verbatim gold-leakage finding(s) — affected tasks may be solvable by reading the answer, inflating every arm.`);
+    if (advisory > 0) limitations.push(`Leakage audit: ${advisory} advisory (fuzzy/semantic) finding(s) recorded — reviewed as heuristic matches, not confirmed leaks.`);
+  } else {
+    limitations.push("No build-time leakage audit found (manifest.json absent) — gold-leakage status is unknown.");
+  }
+  for (const floor of floors) {
+    if (floor.floor === null) limitations.push(`The ${floor.arm_kind} trivial floor was never run — the do-nothing/ritual baseline for this scope is unmeasured.`);
+    if (floor.exceeded) limitations.push(`The ${floor.arm_kind} floor exceeds ${(TRIVIAL_FLOOR_LIMIT * 100).toFixed(0)}% — some tasks are trivially satisfiable; quality numbers overstate real capability.`);
+  }
+  if (incumbent == null) limitations.push("No incumbent arm was run in scope — there is no measured ceiling/current-state baseline, and no savings can be projected.");
+  if (projectedSavings != null) limitations.push("Projected savings are an EXTRAPOLATION of measured cost-per-correct-task to a stated monthly volume — not a measured bill delta.");
+  if (tieNote != null) limitations.push(tieNote);
+  const uncosted = arms.filter((arm) => arm.arm_kind !== "trivial" && arm.cost_total_usd === null);
+  if (uncosted.length > 0) limitations.push(`No cost recorded for: ${uncosted.map((arm) => arm.model).join(", ")} — cost-per-correct-task comparisons exclude them.`);
+
+  // Receipts-ready anonymous_savings payload (share-savings consumes this
+  // shape verbatim). Only when a projection exists; claim_status is honest:
+  // holdout-scoped, untied results are "claim-supported", anything else is a
+  // scenario lead the skill must present as such.
+  const round2 = (v: number): number => Math.round(v * 100) / 100;
+  const anonymousSavings: PartnerReport["anonymous_savings"] =
+    projectedSavings == null
+      ? null
+      : {
+          schema_version: "understudy.anonymous_savings.v1",
+          source: "understudy-partner-report",
+          monthly_baseline_usd: round2(projectedSavings.incumbent_cost_per_correct_usd * projectedSavings.monthly_volume),
+          monthly_candidate_usd: round2(projectedSavings.candidate_cost_per_correct_usd * projectedSavings.monthly_volume),
+          monthly_savings_usd: round2(projectedSavings.monthly_savings_usd),
+          savings_percent: round2(projectedSavings.savings_percent),
+          requests_per_month: projectedSavings.monthly_volume,
+          baseline_provider: null,
+          baseline_model: projectedSavings.incumbent_model,
+          candidate_provider: null,
+          candidate_model: projectedSavings.candidate_model,
+          candidate_lane: "other",
+          interventions: [],
+          evidence_level: null,
+          claim_status: scope === "holdout" && tieNote == null ? "claim-supported" : "claim-packet-required",
+          claim_hash: null,
+          sample_size: holdoutTaskN > 0 ? holdoutTaskN : null,
+          validated_on_holdout: scope === "holdout",
+        };
+
+  return {
+    schema_version: PARTNER_REPORT_SCHEMA,
+    generated_at: now.toISOString(),
+    benchmark_id: benchmarkId,
+    workload: {
+      name: scrub(String(manifest.name ?? benchmarkId)),
+      description: scrub(String(manifest.description ?? "")),
+      task_count: manifestTasks.length,
+      split_counts: splitCounts,
+      provenance_origin: String(asObject(manifest.provenance).origin ?? "unknown"),
+      scope,
+      threshold,
+    },
+    scrub: { name_token_count: scrubNames.length, replacements: scrubStats },
+    arms,
+    floors,
+    incumbent,
+    best_candidate: bestCandidate,
+    winner_is_significant: winnerIsSignificant,
+    tie_note: tieNote,
+    projected_savings: projectedSavings,
+    failure_clusters: [...failureClusters.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([kind, count]) => ({ obligation_kind: kind, failing_tasks: count })),
+    class_errors: classErrors,
+    rigor,
+    holdout_governance: governance,
+    experiments,
+    limitations,
+    anomaly_total: anomalyTotal,
+    anonymous_savings: anonymousSavings,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Rendering (partner-report.md)                                       */
+/* ------------------------------------------------------------------ */
+
+const pct = (fraction: number | null | undefined): string => (fraction == null ? "—" : `${(fraction * 100).toFixed(1)}%`);
+const usd = (value: number | null | undefined): string =>
+  value == null ? "—" : value === 0 ? "$0" : value < 0.01 ? `$${value.toFixed(5).replace(/0+$/, "").replace(/\.$/, "")}` : `$${value.toFixed(value < 1 ? 3 : 2)}`;
+const ms = (value: number | null | undefined): string => (value == null ? "—" : value >= 10_000 ? `${(value / 1000).toFixed(1)}s` : `${Math.round(value)}ms`);
+const ciText = (ci: BootstrapCI | null): string => (ci == null ? "—" : `[${(ci.lo * 100).toFixed(1)}–${(ci.hi * 100).toFixed(1)}%]`);
+
+/** Render the report as the client-presentable partner-report.md. */
+export function renderPartnerReport(report: PartnerReport): string {
+  const lines: string[] = [];
+  const push = (line = "") => lines.push(line);
+  push(`# Benchmark & savings report — ${report.workload.name}`);
+  push();
+  push(`Generated ${report.generated_at} from local benchmark artifacts only (no new runs, no network). Every number in this report is derived from persisted eval rows; the derivation is reproducible with \`understudy benchmarks report\`.`);
+  push();
+
+  push("## Workload");
+  push();
+  if (report.workload.description) push(report.workload.description);
+  push();
+  push(`- Benchmark id: \`${report.benchmark_id}\``);
+  push(`- Tasks: ${report.workload.task_count} (${Object.entries(report.workload.split_counts).map(([s, n]) => `${s}: ${n}`).join(", ") || "no splits"})`);
+  push(`- Provenance: ${report.workload.provenance_origin}`);
+  push(`- Pass threshold: ${report.workload.threshold}`);
+  push(`- Result scope: **${report.workload.scope === "holdout" ? "sealed holdout rows only" : "all rows (no holdout rows exist — see Limitations)"}**`);
+  push();
+
+  push("## Baselines and floors (read these first)");
+  push();
+  for (const floor of report.floors) {
+    const label = floor.arm_kind === "null_agent" ? "a do-nothing agent" : floor.arm_kind === "spam_agent" ? "a ritual tool-spamming agent" : "always answering the majority class";
+    if (floor.floor === null) push(`- **${floor.arm_kind}**: never run — this trivial floor is unmeasured.`);
+    else push(`- **${floor.arm_kind}**: ${label} scores ${pct(floor.floor)} (${floor.passed_tasks}/${floor.task_n} tasks)${floor.exceeded ? " — **FLOOR EXCEEDED**: some tasks are trivially satisfiable" : ""} — results below are measured against that floor.`);
+  }
+  if (report.incumbent != null) {
+    push(`- **Incumbent ceiling**: ${report.incumbent.model} (the model that produced the source traces) scores ${pct(report.incumbent.quality_mean)} ${ciText(report.incumbent.ci)} on rerun.`);
+  } else {
+    push("- **Incumbent ceiling**: not measured in scope — no current-state baseline exists in this report.");
+  }
+  push();
+
+  push("## Headline results");
+  push();
+  push("Quality is the macro-average of per-task mean scores; the 95% CI is a seeded percentile bootstrap over per-task means (tasks are the resampling unit). **Cost per correct task** = total measured cost ÷ tasks passed at the threshold — the number to compare against what a correct task costs you today.");
+  push();
+  push("| Arm | Kind | Quality (mean) | 95% CI | Cost / correct task | Mean latency | Tasks (N) | Rows | Passed |");
+  push("| --- | --- | ---: | :---: | ---: | ---: | ---: | ---: | ---: |");
+  for (const arm of report.arms) {
+    const tie = arm.tie_group != null ? ` (tie ${String.fromCharCode(65 + arm.tie_group)})` : "";
+    const cpc = arm.cost_per_correct_usd != null ? usd(arm.cost_per_correct_usd) : arm.cost_per_correct_note ? "n/a" : "—";
+    push(`| ${arm.model}${tie} | ${arm.arm_kind} | ${pct(arm.quality_mean)} | ${ciText(arm.ci)} | ${cpc} | ${ms(arm.latency_mean_ms)} | ${arm.task_n} | ${arm.row_n} | ${arm.passed_tasks} |`);
+  }
+  push();
+  const notes = report.arms.filter((arm) => arm.cost_per_correct_note != null);
+  for (const arm of notes) push(`- ${arm.model}: ${arm.cost_per_correct_note}`);
+  if (notes.length > 0) push();
+  if (report.tie_note != null) {
+    push(`**No winner is claimed.** ${report.tie_note}.`);
+  } else if (report.winner_is_significant && report.best_candidate != null) {
+    push(`**${report.best_candidate.model}** leads with non-overlapping 95% CIs on the sealed holdout — a statistically supported ordering at this N.`);
+  } else if (report.best_candidate != null) {
+    push(`${report.best_candidate.model} ranks first on quality, but the ordering is not statistically separated — treat it as directional.`);
+  }
+  push();
+
+  push("## Projected savings");
+  push();
+  if (report.projected_savings != null) {
+    const s = report.projected_savings;
+    push(`> **EXTRAPOLATED** — measured cost-per-correct-task × a stated monthly volume (${s.monthly_volume.toLocaleString("en-US")} tasks/month, from ${s.volume_source === "flag" ? "the --monthly-volume flag" : "the benchmark manifest"}), not a measured bill delta.`);
+    push();
+    push(`| | Cost / correct task | × monthly volume |`);
+    push(`| --- | ---: | ---: |`);
+    push(`| Incumbent (${s.incumbent_model}) | ${usd(s.incumbent_cost_per_correct_usd)} | ${usd(s.incumbent_cost_per_correct_usd * s.monthly_volume)} |`);
+    push(`| Candidate (${s.candidate_model}) | ${usd(s.candidate_cost_per_correct_usd)} | ${usd(s.candidate_cost_per_correct_usd * s.monthly_volume)} |`);
+    push(`| **Projected monthly savings** | | **${usd(s.monthly_savings_usd)}** (${s.savings_percent.toFixed(1)}%) |`);
+  } else {
+    push("Not projected. A savings projection requires: a measured incumbent cost-per-correct-task, a candidate cost-per-correct-task, and a monthly volume (`--monthly-volume` or a `monthly_volume` manifest field). Whatever is missing is missing on purpose — this report does not invent numbers.");
+  }
+  push();
+
+  if (report.failure_clusters.length > 0) {
+    push("## Where the best candidate fails");
+    push();
+    push("Obligation kinds required by the tasks the best candidate fails (what kind of work is being missed):");
+    push();
+    for (const cluster of report.failure_clusters) push(`- ${cluster.obligation_kind}: ${cluster.failing_tasks} failing task(s)`);
+    push();
+  }
+  if (report.class_errors.length > 0) {
+    push("## Top per-class errors");
+    push();
+    push("| Arm | Gold | Predicted | Count |");
+    push("| --- | --- | --- | ---: |");
+    for (const err of report.class_errors) push(`| ${err.arm} | ${err.gold} | ${err.predicted} | ${err.count} |`);
+    push();
+  }
+
+  push("## Rigor attestation");
+  push();
+  if (report.rigor != null) {
+    push(`**${report.rigor.verdict}** (full detail in the benchmark's rigor-report.md).`);
+    push();
+    for (const item of report.rigor.items) push(`- ${item.status}: ${item.item} — ${item.value}`);
+  } else {
+    push("Rigor checklist could not be derived from this directory's artifacts.");
+  }
+  push();
+
+  push("## Holdout governance");
+  push();
+  push(report.holdout_governance.statement);
+  push();
+  push(`- Holdout rows used for this report: ${report.holdout_governance.holdout_rows_used}`);
+  push(`- benchmark.json sha256: \`${report.holdout_governance.benchmark_sha256 ?? "unavailable"}\``);
+  push(`- tasks.jsonl sha256: \`${report.holdout_governance.tasks_sha256 ?? "unavailable"}\``);
+  push();
+
+  if (report.experiments.length > 0) {
+    push("## Experiment lineage");
+    push();
+    for (const exp of report.experiments) {
+      push(`- \`${exp.experiment_id}\` (${exp.status}): ${exp.hypothesis}${exp.verdict ? ` → **${exp.verdict}**` : ""}`);
+    }
+    push();
+  }
+
+  push("## Limitations");
+  push();
+  if (report.limitations.length === 0) push("- none auto-detected (which is itself unusual — read the rigor attestation).");
+  for (const limitation of report.limitations) push(`- ${limitation}`);
+  push();
+  push(`---`);
+  push();
+  push(`Privacy: customer-identifying strings were scrubbed at generation time (${report.scrub.replacements.names} name, ${report.scrub.replacements.emails} email, ${report.scrub.replacements.urls} URL, ${report.scrub.replacements.domains} domain replacement(s)). This report contains aggregate metrics and task/obligation identifiers only — no prompts, no completions, no traces.`);
+  push();
+  return lines.join("\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* Write                                                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Derive + write partner-report.md and partner-report.json. `outDir` defaults
+ * to the benchmark dir; pass another dir when the benchmark is read-only.
+ */
+export function writePartnerReport(
+  benchmarkDir: string,
+  options: PartnerReportOptions & { outDir?: string } = {},
+): { report: PartnerReport; markdownPath: string; jsonPath: string } {
+  const report = derivePartnerReport(benchmarkDir, options);
+  const out = resolve(options.outDir ?? benchmarkDir);
+  const markdownPath = join(out, "partner-report.md");
+  const jsonPath = join(out, "partner-report.json");
+  writeFileSync(markdownPath, renderPartnerReport(report), { mode: 0o600 });
+  writeFileSync(jsonPath, JSON.stringify(report, null, 2) + "\n", { mode: 0o600 });
+  return { report, markdownPath, jsonPath };
+}

--- a/tests/fixtures/partner-report-golden.md
+++ b/tests/fixtures/partner-report-golden.md
@@ -1,0 +1,91 @@
+# Benchmark & savings report — [partner] [partner] automation for [redacted-email]
+
+Generated 2026-07-22T00:00:00.000Z from local benchmark artifacts only (no new runs, no network). Every number in this report is derived from persisted eval rows; the derivation is reproducible with `understudy benchmarks report`.
+
+## Workload
+
+Traces from [redacted-url] handled by [partner] Corp.
+
+- Benchmark id: `pr-bench`
+- Tasks: 5 (holdout: 4, train: 1)
+- Provenance: derived-from-traces
+- Pass threshold: 1
+- Result scope: **sealed holdout rows only**
+
+## Baselines and floors (read these first)
+
+- **null_agent**: a do-nothing agent scores 0.0% (0/4 tasks) — results below are measured against that floor.
+- **spam_agent**: never run — this trivial floor is unmeasured.
+- **majority_class**: never run — this trivial floor is unmeasured.
+- **Incumbent ceiling**: big-model (the model that produced the source traces) scores 100.0% [100.0–100.0%] on rerun.
+
+## Headline results
+
+Quality is the macro-average of per-task mean scores; the 95% CI is a seeded percentile bootstrap over per-task means (tasks are the resampling unit). **Cost per correct task** = total measured cost ÷ tasks passed at the threshold — the number to compare against what a correct task costs you today.
+
+| Arm | Kind | Quality (mean) | 95% CI | Cost / correct task | Mean latency | Tasks (N) | Rows | Passed |
+| --- | --- | ---: | :---: | ---: | ---: | ---: | ---: | ---: |
+| big-model (tie A) | incumbent | 100.0% | [100.0–100.0%] | $0.100 | 1000ms | 4 | 4 | 4 |
+| small-model (tie A) | candidate | 75.0% | [25.0–100.0%] | $0.013 | 1000ms | 4 | 5 | 3 |
+| null_agent | trivial | 0.0% | [0.0–0.0%] | n/a | 1000ms | 4 | 4 | 0 |
+| zero-model | candidate | 0.0% | [0.0–0.0%] | n/a | 1000ms | 4 | 4 | 0 |
+
+- null_agent: 0.0000 USD spent, zero tasks passed — cost-per-correct-task is undefined (division by zero), not zero
+- zero-model: 0.0800 USD spent, zero tasks passed — cost-per-correct-task is undefined (division by zero), not zero
+
+**No winner is claimed.** statistical tie at this N: big-model, small-model have overlapping 95% CIs — no winner is claimed.
+
+## Projected savings
+
+> **EXTRAPOLATED** — measured cost-per-correct-task × a stated monthly volume (1,000 tasks/month, from the --monthly-volume flag), not a measured bill delta.
+
+| | Cost / correct task | × monthly volume |
+| --- | ---: | ---: |
+| Incumbent (big-model) | $0.100 | $100.00 |
+| Candidate (small-model) | $0.013 | $13.33 |
+| **Projected monthly savings** | | **$86.67** (86.7%) |
+
+## Where the best candidate fails
+
+Obligation kinds required by the tasks the best candidate fails (what kind of work is being missed):
+
+- state_effect: 1 failing task(s)
+
+## Rigor attestation
+
+**3 PASS / 1 FLAG / 5 UNKNOWN across 9 rigor checks** (full detail in the benchmark's rigor-report.md).
+
+- UNKNOWN: Oracle solver — not run
+- PASS: Null-agent floor — 0.0% (0/5)
+- UNKNOWN: Spam-agent floor — not run
+- UNKNOWN: Incumbent calibration — not run
+- FLAG: Rollout anomalies — 1 flags over 18 rows
+- PASS: Split provenance — holdout: 4, train: 1
+- PASS: Leakage / contamination audit — 0 verbatim / 0 fuzzy over 5 task(s)
+- UNKNOWN: Guidance effectiveness — no journals
+- UNKNOWN: Confidence intervals — not checked
+
+## Holdout governance
+
+Splits were frozen at benchmark build time (train/dev/holdout recorded per task in benchmark.json, hashed above). The 4-task holdout was never used for prompt evolution, model selection, or training — only for the final scores in this report.
+
+- Holdout rows used for this report: 17
+- benchmark.json sha256: `f67f2e27b5502e2cc877cb2a1fd777caca8ef8a4fd8a8fe98c5ae46dbf98503f`
+- tasks.jsonl sha256: `5cf2e506970f4b938c46897da91a7dbc086022c3a5185e4c03774e868f9aeb96`
+
+## Experiment lineage
+
+- `exp-1` (concluded): small-model can replace big-model on [partner] [partner] → **shadow: tie on holdout**
+
+## Limitations
+
+- Small holdout: only 4 task(s) — confidence intervals are wide and single-task flips move the mean; treat differences as directional.
+- 1 rollout row(s) carry structural anomaly flags and were excluded from every aggregate (marked, never dropped from counts).
+- The spam_agent trivial floor was never run — the do-nothing/ritual baseline for this scope is unmeasured.
+- The majority_class trivial floor was never run — the do-nothing/ritual baseline for this scope is unmeasured.
+- Projected savings are an EXTRAPOLATION of measured cost-per-correct-task to a stated monthly volume — not a measured bill delta.
+- statistical tie at this N: big-model, small-model have overlapping 95% CIs — no winner is claimed
+
+---
+
+Privacy: customer-identifying strings were scrubbed at generation time (5 name, 1 email, 1 URL, 0 domain replacement(s)). This report contains aggregate metrics and task/obligation identifiers only — no prompts, no completions, no traces.

--- a/tests/partner-report.test.mjs
+++ b/tests/partner-report.test.mjs
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, describe, it } from "node:test";
+
+import {
+  PARTNER_REPORT_SCHEMA,
+  derivePartnerReport,
+  renderPartnerReport,
+  scrubText,
+  slugNameTokens,
+  writePartnerReport,
+} from "../dist/partner-report.js";
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
+
+const roots = [];
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+const NOW = new Date("2026-07-22T00:00:00.000Z");
+
+function writeJsonl(file, rows) {
+  fs.writeFileSync(file, rows.map((r) => JSON.stringify(r)).join("\n") + "\n");
+}
+
+function row(model, taskId, score, over = {}) {
+  return {
+    schema_version: "understudy.eval_result.v1",
+    run_id: "run-1",
+    task_id: taskId,
+    status: "ok",
+    score,
+    model,
+    arm_kind: "candidate",
+    latency_ms: 1000,
+    cost: 0.01,
+    ...over,
+  };
+}
+
+/**
+ * Fixture benchmark dir: 4 holdout tasks + 1 train task, an incumbent, two
+ * candidates (one never passes — the zero-passed cost edge), a null-agent
+ * floor arm, one experiment line, and a leakage-free foundry manifest.
+ */
+function makeBenchmarkDir({ slug = "acme-support-automation", incumbentScore = 1, monthlyVolumeInManifest = null } = {}) {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), "partner-report-"));
+  roots.push(parent);
+  const dir = path.join(parent, slug);
+  fs.mkdirSync(dir);
+  const tasks = ["t1", "t2", "t3", "t4"].map((id) => ({ task_id: id, category_id: "cat-a", split: "holdout" }));
+  tasks.push({ task_id: "t5", category_id: "cat-a", split: "train" });
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "pr-bench",
+      name: "Acme support automation for support@acme.com",
+      description: "Traces from https://app.acme.com/support handled by Acme Corp.",
+      provenance: { origin: "derived-from-traces" },
+      taxonomy: [{ category_id: "cat-a" }],
+      tasks,
+      environment: { format: "verifiers.v1", package_ref: "environment" },
+      verifier: { kind: "final-state", strict_metric: "task_completed_correctly" },
+      ...(monthlyVolumeInManifest != null ? { monthly_volume: monthlyVolumeInManifest } : {}),
+    }),
+  );
+  writeJsonl(
+    path.join(dir, "tasks.jsonl"),
+    ["t1", "t2", "t3", "t4", "t5"].map((id) => ({
+      schema_version: "understudy.benchmark_task.v1",
+      task_id: id,
+      title: id,
+      outcome_contract: {
+        required: [{ type: "state_effect", tool: "update-record", observed_arguments: {} }],
+        preserved: [],
+        forbidden: [],
+        grading: "final_state_and_obligations",
+      },
+    })),
+  );
+  fs.writeFileSync(
+    path.join(dir, "manifest.json"),
+    JSON.stringify({ leakage_audit: { schema_version: "understudy.leakage_audit.v1", checked_tasks: 5, findings: [] } }),
+  );
+  const rows = [
+    // Incumbent: 4 holdout tasks at incumbentScore, $0.10/rollout.
+    ...["t1", "t2", "t3", "t4"].map((id) => row("big-model", id, incumbentScore, { arm_kind: "incumbent", cost: 0.1 })),
+    // Candidate small-model: passes 3/4 at $0.01/rollout.
+    row("small-model", "t1", 1),
+    row("small-model", "t2", 1),
+    row("small-model", "t3", 1),
+    row("small-model", "t4", 0),
+    // Candidate zero-model: spends but never passes (cost-per-correct undefined).
+    ...["t1", "t2", "t3", "t4"].map((id) => row("zero-model", id, 0, { cost: 0.02 })),
+    // Null-agent floor rows.
+    ...["t1", "t2", "t3", "t4"].map((id) => row("null_agent", id, 0, { arm_kind: "null_agent", cost: 0 })),
+    // Train-split row: must NEVER enter the holdout-scoped table.
+    row("small-model", "t5", 0),
+    // Anomalous row: marked, excluded from aggregates, counted.
+    row("small-model", "t4", 1, { anomaly: { kind: "empty_final_response", detail: "x" } }),
+  ];
+  writeJsonl(path.join(dir, "rows-run-1.jsonl"), rows);
+  writeJsonl(path.join(dir, "experiments.jsonl"), [
+    {
+      schema_version: "understudy.experiment.v1",
+      experiment_id: "exp-1",
+      created_at: NOW.toISOString(),
+      hypothesis: "small-model can replace big-model on Acme support",
+      status: "concluded",
+      data_selection: { selection_hash: "abc", source: "rows" },
+      training: { method: "prompt_only", base_model: "small-model", config: {}, provider: "local", approvals: [] },
+      eval_run_ids: ["run-1"],
+      verdict: { decision: "shadow", summary: "tie on holdout", decided_at: NOW.toISOString() },
+    },
+  ]);
+  return dir;
+}
+
+describe("scrubbing", () => {
+  it("scrubs names, emails, urls, and domains", () => {
+    const stats = { names: 0, emails: 0, urls: 0, domains: 0 };
+    const out = scrubText("Acme Corp (ops@acme.com) runs https://app.acme.com/x and acmecorp.io", ["acme"], stats);
+    assert.ok(!/acme/i.test(out), out);
+    assert.ok(out.includes("[partner]"));
+    assert.ok(out.includes("[redacted-email]"));
+    assert.ok(out.includes("[redacted-url]"));
+    assert.ok(out.includes("[redacted-domain]"));
+    assert.ok(stats.names >= 1 && stats.emails === 1 && stats.urls === 1 && stats.domains >= 1);
+  });
+
+  it("derives customer-name tokens from the dir slug, skipping generic words", () => {
+    assert.deepEqual(slugNameTokens("cedar-automation"), ["cedar"]);
+    assert.deepEqual(slugNameTokens("trace-benchmark-42"), []);
+  });
+});
+
+describe("derivePartnerReport", () => {
+  it("derives holdout-scoped arms with CIs, floors, cost-per-correct, and no unsupported winner", () => {
+    const dir = makeBenchmarkDir();
+    const report = derivePartnerReport(dir, { now: NOW });
+    assert.equal(report.schema_version, PARTNER_REPORT_SCHEMA);
+    assert.equal(report.workload.scope, "holdout");
+
+    // Name scrubbing: slug token "acme" plus emails/urls never survive.
+    assert.ok(!/acme/i.test(JSON.stringify(report)), "customer name leaked into the report JSON");
+    assert.ok(report.workload.name.includes("[partner]"));
+
+    const incumbent = report.incumbent;
+    assert.ok(incumbent);
+    assert.equal(incumbent.model, "big-model");
+    // cost-per-correct = total cost / passed tasks = 0.40 / 4.
+    assert.ok(Math.abs(incumbent.cost_per_correct_usd - 0.1) < 1e-9);
+    assert.ok(incumbent.ci && incumbent.ci.lo === 1 && incumbent.ci.hi === 1);
+
+    const small = report.arms.find((a) => a.model === "small-model");
+    // Train row t5 and the anomalous t4 repeat are excluded: 4 tasks, 4 rows scored.
+    assert.equal(small.task_n, 4);
+    assert.equal(small.passed_tasks, 3);
+    assert.ok(Math.abs(small.cost_per_correct_usd - 0.04 / 3) < 1e-9);
+
+    // Zero-passed edge: spent money, no passes → null cpc with an explicit note, never 0.
+    const zero = report.arms.find((a) => a.model === "zero-model");
+    assert.equal(zero.cost_per_correct_usd, null);
+    assert.match(zero.cost_per_correct_note, /zero tasks passed/);
+
+    // Floors: null agent measured at 0, spam/majority honestly unmeasured.
+    const nullFloor = report.floors.find((f) => f.arm_kind === "null_agent");
+    assert.equal(nullFloor.floor, 0);
+    assert.equal(report.floors.find((f) => f.arm_kind === "spam_agent").floor, null);
+
+    // big-model [1,1] and small-model CI overlap at hi=1 → statistical tie, no winner.
+    assert.equal(report.winner_is_significant, false);
+    assert.match(report.tie_note, /overlapping 95% CIs/);
+
+    // No volume anywhere → no projection, and the report says why.
+    assert.equal(report.projected_savings, null);
+    assert.equal(report.anonymous_savings, null);
+
+    // Failure clusters: small-model fails t4 (one state_effect obligation).
+    assert.deepEqual(report.failure_clusters, [{ obligation_kind: "state_effect", failing_tasks: 1 }]);
+
+    // Experiment lineage rides along, scrubbed.
+    assert.equal(report.experiments.length, 1);
+    assert.ok(report.experiments[0].hypothesis.includes("[partner]"));
+
+    // Anomalies + small holdout land in limitations automatically.
+    assert.equal(report.anomaly_total, 1);
+    assert.ok(report.limitations.some((l) => /Small holdout/.test(l)));
+    assert.ok(report.limitations.some((l) => /anomaly/.test(l)));
+  });
+
+  it("projects EXTRAPOLATED savings from --monthly-volume and emits a share-savings-ready payload", () => {
+    const dir = makeBenchmarkDir();
+    const report = derivePartnerReport(dir, { now: NOW, monthlyVolume: 1000 });
+    const s = report.projected_savings;
+    assert.ok(s);
+    assert.equal(s.extrapolated, true);
+    assert.equal(s.volume_source, "flag");
+    // Candidate = cheapest cost-per-correct inside the top tie group (small-model; zero-model has no cpc).
+    assert.equal(s.candidate_model, "small-model");
+    assert.ok(Math.abs(s.monthly_savings_usd - (0.1 - 0.04 / 3) * 1000) < 1e-6);
+
+    const payload = report.anonymous_savings;
+    assert.equal(payload.schema_version, "understudy.anonymous_savings.v1");
+    assert.equal(payload.requests_per_month, 1000);
+    assert.equal(payload.validated_on_holdout, true);
+    // Tied result: honest claim status is claim-packet-required, not claim-supported.
+    assert.equal(payload.claim_status, "claim-packet-required");
+    assert.ok(report.limitations.some((l) => /EXTRAPOLATION/.test(l)));
+  });
+
+  it("falls back to manifest.monthly_volume and labels the source", () => {
+    const dir = makeBenchmarkDir({ monthlyVolumeInManifest: 500 });
+    const report = derivePartnerReport(dir, { now: NOW });
+    assert.equal(report.projected_savings.volume_source, "manifest");
+    assert.equal(report.projected_savings.monthly_volume, 500);
+  });
+
+  it("claims a winner only when CIs separate on the sealed holdout", () => {
+    const dir = makeBenchmarkDir({ incumbentScore: 0 });
+    const report = derivePartnerReport(dir, { now: NOW });
+    // small-model per-task means [1,1,1,0] vs incumbent [0,0]: bootstrap lo > 0 is not
+    // guaranteed, so just assert consistency: significant XOR tie/directional note.
+    if (report.winner_is_significant) {
+      assert.equal(report.tie_note, null);
+      assert.equal(report.best_candidate.model, "small-model");
+    } else {
+      assert.ok(report.tie_note != null || report.best_candidate != null);
+    }
+  });
+});
+
+describe("renderPartnerReport", () => {
+  it("renders floors, CI columns, tie honesty, and the extrapolation label", () => {
+    const dir = makeBenchmarkDir();
+    const markdown = renderPartnerReport(derivePartnerReport(dir, { now: NOW, monthlyVolume: 1000 }));
+    assert.match(markdown, /a do-nothing agent scores 0\.0%/);
+    assert.match(markdown, /95% CI/);
+    assert.match(markdown, /\*\*No winner is claimed\.\*\*/);
+    assert.match(markdown, /\*\*EXTRAPOLATED\*\*/);
+    assert.match(markdown, /cost-per-correct-task is undefined/);
+    assert.ok(!/acme/i.test(markdown));
+  });
+
+  it("matches the golden report fixture byte-for-byte", () => {
+    const dir = makeBenchmarkDir();
+    const markdown = renderPartnerReport(derivePartnerReport(dir, { now: NOW, monthlyVolume: 1000 }));
+    const goldenPath = path.join(FIXTURES, "partner-report-golden.md");
+    if (process.env.UPDATE_GOLDEN === "1") fs.writeFileSync(goldenPath, markdown);
+    // The fixture embeds the benchmark.json/tasks.jsonl hashes of THIS builder,
+    // so any derivation or rendering drift fails loudly here.
+    assert.equal(markdown, fs.readFileSync(goldenPath, "utf8"));
+  });
+});
+
+describe("writePartnerReport", () => {
+  it("writes partner-report.md and .json into --out without touching a read-only benchmark dir", () => {
+    const dir = makeBenchmarkDir();
+    const out = fs.mkdtempSync(path.join(os.tmpdir(), "partner-report-out-"));
+    roots.push(out);
+    const before = fs.readdirSync(dir).sort();
+    const { markdownPath, jsonPath, report } = writePartnerReport(dir, { now: NOW, outDir: out });
+    assert.equal(path.dirname(markdownPath), out);
+    assert.deepEqual(fs.readdirSync(dir).sort(), before);
+    const json = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+    assert.equal(json.schema_version, PARTNER_REPORT_SCHEMA);
+    assert.equal(json.benchmark_id, report.benchmark_id);
+  });
+});


### PR DESCRIPTION
## What

**`understudy benchmarks report <dir>`** (new `src/partner-report.ts`) generates `partner-report.md` + machine-readable `partner-report.json` — the client-facing deliverable of the design-partner loop — **from existing artifacts only** (rows, calibration.json, rigor derivation, experiments.jsonl; no new runs, no network).

Honest by construction:
- **Cost-per-correct-task** is the headline buyer metric: total measured cost ÷ tasks passed at the calibration threshold. Null-safe: no recorded cost → `null` + note; money spent with zero passes → explicitly "undefined (division by zero), not zero".
- **Quality** = macro-average of per-task means with **seeded percentile-bootstrap 95% CIs** — the exact math the hub leaderboard uses (the implementation now lives once in `src/bootstrap-ci.ts`; the hub's `lib/bootstrap.ts` re-exports it from dist, runs-core pattern).
- **Floors + ceiling always stated first**: "a do-nothing agent scores X% — results below are measured against that floor"; unmeasured floors are called unmeasured, not omitted.
- **No winner claim on overlapping CIs** (adjacent-CI tie chaining, same discipline as the leaderboard); winner claims additionally require holdout scope.
- **Savings** = (incumbent cost-per-correct − candidate cost-per-correct) × monthly volume (`--monthly-volume` or `manifest.monthly_volume`), always labeled **EXTRAPOLATED**, candidate chosen as the cheapest arm inside the top statistical tie group (never a quality-inferior arm). Oracle-runner rows are excluded from candidate arms (harness calibration, not deployable).
- **Rigor attestation** (embedded ABC verdict line), **holdout governance** (split counts, sha256 of benchmark.json/tasks.jsonl, sealed-holdout statement), **experiment lineage**, **failure clusters** (obligation kinds of failed tasks; per-class confusions on dataset benchmarks), and **auto-derived limitations** (leakage findings, anomaly counts, small-N holdout, unmeasured floors, extrapolation, ties, uncosted arms).
- **Privacy scrubbing by construction**: emails/URLs/domains plus name tokens (auto-derived from the dir slug + `--scrub-name`) are replaced before any text reaches the report; the JSON records replacement *counts only* (the token list itself would leak the name).

**Receipts-ready**: `partner-report.json` embeds a complete `understudy.anonymous_savings.v1` payload (the exact shape `skills/share-savings/scripts/share-savings.mjs` posts), with honest `claim_status` (`claim-supported` only for untied holdout results) — the skill is unchanged.

**Hub**: `/b/[slug]/report` renders the same derivation via `lib/partner-report-core.ts` (dist re-export — the CLI and the page physically cannot disagree), with a print stylesheet + Print/save-PDF button, linked from the promoted benchmark page. `--out` supports read-only benchmark dirs.

## Tests

- `tests/partner-report.test.mjs`: scrubbing (names/emails/URLs/domains, slug-token derivation), holdout scoping (train + anomalous rows excluded), CI presence, cost-per-correct math incl. the zero-passed edge, floor rendering, tie honesty (no winner on overlapping CIs), extrapolation labeling + flag/manifest volume sources, share-savings payload, read-only `--out`, and a **byte-for-byte golden report fixture** (`tests/fixtures/partner-report-golden.md`, `UPDATE_GOLDEN=1` to regenerate).
- `apps/benchmark-hub/tests/partner-report-core.test.mjs`: pins the dist re-export contract the Report page uses.
- All green: root `npm test` (939 pass), `tsc --noEmit`, hub tests (162 pass) + `next build`, `skills:validate` (37 ok).

## Dogfood (cedar-automation, read-only via `--out`, scrubbed)

- Scope: sealed holdout (2 tasks, 16 rows) of a 29-task derived-from-traces benchmark; null/spam floors both **0.0%**; incumbent claude-sonnet-4-6 at 100% on rerun.
- Headline: sonnet-4-6 ($0.341/correct), sonnet+sop-fix ($0.110), gemma-4-31b-it ($0.0024), all 100% — **statistical tie, no winner claimed**; opus-4-8 arm 0% with an honest "spent $0.09, zero passed → cost-per-correct undefined" note.
- Projected savings @ 20k tasks/month (EXTRAPOLATED): incumbent $6,811 → gemma $47.94 ≈ **$6,763/month (99.3%)**, with auto-limitations front and center: 2-task holdout, 171 verbatim leakage findings, 5 anomalous rows, unmeasured majority-class floor.
- Zero occurrences of the partner name in either output file (slug-derived scrub token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->