### PR TITLE
Smart defaults: one-time trust posture replaces per-call approval gates

### DIFF
--- a/docs/agent-operator-surface.md
+++ b/docs/agent-operator-surface.md
@@ -104,6 +104,42 @@ the same frozen tasks (see [`app-harness.md`](app-harness.md)):
 6. Regression verdict = compare the app-replay rows on the frozen task set
    before vs after the code edit.
 
+## Trust posture (one-time, not per-call)
+
+Autonomy is governed by the **one-time trust posture** in
+`~/.understudy/trust.json` (`understudy.trust_posture.v1`,
+`src/config/trust.ts`) instead of per-action approval dialogs:
+
+```bash
+understudy trust show                          # posture + resolved boundaries
+understudy trust set bounded_experiments       # one action, visible, reversible
+understudy trust set hosted_ops --spend-stop-loss 25
+```
+
+Levels: `local_sandbox` (default) < `bounded_experiments` < `hosted_ops`,
+with per-boundary overrides (`allow_provider_upload`,
+`allow_spend_usd_per_run`, `allow_traffic_changes`). The embedded Pi chat's
+benchmark-lab tools consult it: spend-adjacent `queue_run` shapes and
+experiment approval/verdict patches **proceed with a visible one-line notice**
+(arm count, rough cost estimate) at `bounded_experiments`+, and below that
+return the single-action guidance to raise the posture (`confirm: true` after
+explicit in-chat consent remains a per-call escape hatch). The run executor
+reads the same posture for the spend stop-loss: **no default cap at any
+level**; when `allow_spend_usd_per_run` is set it warns-and-records at 1x
+(`spend_warning` event, run continues) and stops only at 2x (`spend_stop`
+event; completed rows kept) — never a mid-run hard-kill below 2x.
+
+Local trained-artifact arms are machine-aware by default: the executor
+predicts fit from the onboarding profile (`~/.understudy/profile.json`) or an
+OS memory probe, and on predicted OOM or a real serve failure falls back to
+the gateway on the artifact's base model — recorded as an `arm_fallback`
+event and a `fallback_reason` field on every affected row, never a silent
+swap.
+
+Follow-up: the desktop app's upload-approval dialog is the natural ONE-TIME
+posture UI — it should read/write `trust.json` (`allow_provider_upload`)
+instead of asking per upload.
+
 ## Guardrails
 
 - Reviews are append-only; the newest line per `task_id` wins. Decisions:

--- a/skills/operate-benchmark-lab/SKILL.md
+++ b/skills/operate-benchmark-lab/SKILL.md
@@ -37,6 +37,23 @@ MCP registration (Claude Code `~/.claude.json` → `mcpServers`):
 - **Queueing is not executing.** `queue_run` / `understudy runs queue` only
   writes a request file. Model rollouts spend gateway money only when an
   executor picks the request up; say which executor will, before queueing.
+- **Trust posture, not per-call dialogs.** Spend-adjacent shapes (multi-arm
+  or multi-rollout runs, implicit all-task runs, experiment
+  approval/verdict patches) consult the one-time posture in
+  `~/.understudy/trust.json` (`understudy trust set`, levels `local_sandbox`
+  < `bounded_experiments` < `hosted_ops`). At `bounded_experiments`+ they
+  proceed with a visible one-line notice (arm count, rough cost) — surface
+  that notice to the user, then keep moving. Below that, the guard returns
+  the one action to offer (`understudy trust set bounded_experiments`);
+  `confirm: true` after explicit in-chat consent stays a per-call escape
+  hatch. There is NO default spend cap: the posture's
+  `allow_spend_usd_per_run` is an opt-in generous stop-loss (warn at 1x with
+  a recorded `spend_warning`; hard stop only at 2x with `spend_stop`).
+- **Local arms are machine-aware.** On predicted OOM (onboarding profile /
+  memory probe) or a serve failure, the executor runs the arm on the gateway
+  base model and records it — `arm_fallback` event plus `fallback_reason` on
+  every row. Report the fallback; never present a fallen-back arm as a local
+  measurement.
 - **One executor per benchmark dir.** Before starting `runs execute --watch`,
   check for a live claim (`claimed_by` on the request, `executor_version` on
   events) — a stale watcher built before a feature landed is the classic

--- a/src/commands/trust.ts
+++ b/src/commands/trust.ts
@@ -1,0 +1,90 @@
+/**
+ * `understudy trust` — the one-time autonomy posture (~/.understudy/trust.json).
+ *
+ * Smart defaults instead of per-action approval dialogs: set the posture
+ * once, and every spend/upload/traffic gate consults it instead of
+ * prompting. Visible (`trust show`) and reversible (`trust set`).
+ */
+import type { Command } from "commander";
+
+import {
+  TRUST_LEVELS,
+  readTrustPosture,
+  resolveTrustBoundaries,
+  trustPosturePath,
+  writeTrustPosture,
+  type TrustLevel,
+} from "../config/trust.js";
+
+export function registerTrustCommand(program: Command): void {
+  const trust = program
+    .command("trust")
+    .description(
+      "One-time autonomy posture (trust.json): smart defaults instead of per-action approval dialogs. " +
+        `Levels: ${TRUST_LEVELS.join(" < ")}. Visible and reversible — set it once, change it any time.`,
+    );
+
+  trust
+    .command("show")
+    .description("Print the posture in force plus the resolved boundaries (defaults apply when the file is absent)")
+    .action(() => {
+      const posture = readTrustPosture();
+      console.log(
+        JSON.stringify(
+          { file: trustPosturePath(), posture, resolved: resolveTrustBoundaries(posture) },
+          null,
+          2,
+        ),
+      );
+    });
+
+  trust
+    .command("set <level>")
+    .description(
+      "Set the posture level (local_sandbox | bounded_experiments | hosted_ops) and optional per-boundary overrides. " +
+        "There is NO default spend cap at any level; --spend-stop-loss opts into a generous per-run stop-loss (warn at 1x, never mid-run hard-kill below 2x).",
+    )
+    .option("--spend-stop-loss <usd>", "Opt-in generous per-run spend stop-loss in USD (omit for unlimited)")
+    .option("--clear-spend-stop-loss", "Remove the spend stop-loss (back to unlimited)")
+    .option("--allow-provider-upload", "Override: allow data uploads to providers regardless of level")
+    .option("--forbid-provider-upload", "Override: forbid provider uploads regardless of level")
+    .option("--allow-traffic-changes", "Override: allow live traffic changes regardless of level")
+    .option("--forbid-traffic-changes", "Override: forbid live traffic changes regardless of level")
+    .action(
+      (
+        level: string,
+        options: {
+          spendStopLoss?: string;
+          clearSpendStopLoss?: boolean;
+          allowProviderUpload?: boolean;
+          forbidProviderUpload?: boolean;
+          allowTrafficChanges?: boolean;
+          forbidTrafficChanges?: boolean;
+        },
+      ) => {
+        if (!(TRUST_LEVELS as readonly string[]).includes(level)) {
+          console.error(`trust set: unknown level "${level}" (expected one of: ${TRUST_LEVELS.join(", ")})`);
+          process.exitCode = 1;
+          return;
+        }
+        const overrides: Record<string, boolean | number | null> = {};
+        if (options.clearSpendStopLoss) overrides.allow_spend_usd_per_run = null;
+        else if (options.spendStopLoss !== undefined) {
+          const usd = Number(options.spendStopLoss);
+          if (!Number.isFinite(usd) || usd <= 0) {
+            console.error("trust set: --spend-stop-loss must be a positive USD number");
+            process.exitCode = 1;
+            return;
+          }
+          overrides.allow_spend_usd_per_run = usd;
+        }
+        if (options.allowProviderUpload) overrides.allow_provider_upload = true;
+        if (options.forbidProviderUpload) overrides.allow_provider_upload = false;
+        if (options.allowTrafficChanges) overrides.allow_traffic_changes = true;
+        if (options.forbidTrafficChanges) overrides.allow_traffic_changes = false;
+        const posture = writeTrustPosture({ level: level as TrustLevel, overrides });
+        console.error(`trust: posture set to ${posture.level} (${trustPosturePath()})`);
+        console.log(JSON.stringify({ posture, resolved: resolveTrustBoundaries(posture) }, null, 2));
+      },
+    );
+}

--- a/src/config/trust.ts
+++ b/src/config/trust.ts
@@ -1,0 +1,187 @@
+/**
+ * Trust posture — the ONE-TIME autonomy choice that replaces per-action
+ * approval dialogs (`~/.understudy/trust.json`).
+ *
+ * Doctrine: per-action confirmation dialogs die; smart defaults everywhere.
+ * The few genuinely consequential boundaries — data leaving the machine,
+ * money being spent, production traffic changing — become a single visible,
+ * reversible posture choice instead of a recurring interruption. Every gate
+ * in the toolchain consults this file instead of prompting; raising or
+ * lowering the posture is one explicit action (`understudy trust set`).
+ *
+ * The schema id lives HERE, not in src/benchmark-artifacts.ts: that module's
+ * charter is the codecs of files inside a benchmark directory, while
+ * trust.json is global per-user config next to profile.json/credentials.json
+ * (see src/config/paths.ts).
+ *
+ * Levels (orderable, lowest first):
+ * - `local_sandbox` (default) — everything local and free proceeds; gates
+ *   that spend money, upload data, or touch traffic return one-action
+ *   guidance to raise the posture (never a per-call dialog).
+ * - `bounded_experiments` — spend-adjacent experiment operations (multi-arm
+ *   benchmark runs, experiment approval/verdict updates) proceed with a
+ *   visible one-line notice instead of blocking.
+ * - `hosted_ops` — hosted operations (provider upload, traffic changes)
+ *   are additionally allowed by default.
+ *
+ * Per-boundary overrides always win over the level defaults. There is NO
+ * default spend cap at any level (caps default unlimited — warn, don't
+ * kill): `allow_spend_usd_per_run` is an opt-in generous stop-loss, not a
+ * budget.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const TRUST_POSTURE_SCHEMA = "understudy.trust_posture.v1";
+
+export const TRUST_LEVELS = ["local_sandbox", "bounded_experiments", "hosted_ops"] as const;
+export type TrustLevel = (typeof TRUST_LEVELS)[number];
+
+export type TrustOverrides = {
+  /** Data may leave the machine to a provider (uploads). Level default: hosted_ops+. */
+  allow_provider_upload?: boolean;
+  /**
+   * Opt-in generous stop-loss per run, in USD. NO cap by default at any
+   * level: absent = unlimited. Consumers warn-and-record at the threshold
+   * and never hard-kill a run below 2x this value (stop-loss, not budget).
+   */
+  allow_spend_usd_per_run?: number;
+  /** Live/production traffic changes (ramp dial). Level default: hosted_ops. */
+  allow_traffic_changes?: boolean;
+};
+
+export type TrustPosture = {
+  schema_version: typeof TRUST_POSTURE_SCHEMA;
+  level: TrustLevel;
+  /** ISO timestamp of the last explicit `understudy trust set`. */
+  set_at: string | null;
+  overrides: TrustOverrides;
+};
+
+export const DEFAULT_TRUST_POSTURE: TrustPosture = {
+  schema_version: TRUST_POSTURE_SCHEMA,
+  level: "local_sandbox",
+  set_at: null,
+  overrides: {},
+};
+
+type Obj = Record<string, unknown>;
+const asObject = (value: unknown): Obj =>
+  value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {};
+
+/** `UNDERSTUDY_TRUST_FILE` overrides for tests/sandboxes; default is the global config dir. */
+export function trustPosturePath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.UNDERSTUDY_TRUST_FILE?.trim();
+  return override ? override : join(homedir(), ".understudy", "trust.json");
+}
+
+const isTrustLevel = (value: unknown): value is TrustLevel =>
+  typeof value === "string" && (TRUST_LEVELS as readonly string[]).includes(value);
+
+/**
+ * Read the posture in force. TOLERANT: a missing/unreadable/wrong-schema
+ * file yields the default (`local_sandbox`, no overrides) — a typo'd file
+ * must never silently widen autonomy. Recognized fields apply individually.
+ */
+export function readTrustPosture(env: NodeJS.ProcessEnv = process.env): TrustPosture {
+  let parsed: Obj;
+  try {
+    parsed = asObject(JSON.parse(readFileSync(trustPosturePath(env), "utf8")));
+  } catch {
+    return { ...DEFAULT_TRUST_POSTURE, overrides: {} };
+  }
+  if (parsed.schema_version !== TRUST_POSTURE_SCHEMA) return { ...DEFAULT_TRUST_POSTURE, overrides: {} };
+  const rawOverrides = asObject(parsed.overrides);
+  const overrides: TrustOverrides = {
+    ...(typeof rawOverrides.allow_provider_upload === "boolean"
+      ? { allow_provider_upload: rawOverrides.allow_provider_upload }
+      : {}),
+    ...(typeof rawOverrides.allow_spend_usd_per_run === "number" &&
+    Number.isFinite(rawOverrides.allow_spend_usd_per_run) &&
+    rawOverrides.allow_spend_usd_per_run > 0
+      ? { allow_spend_usd_per_run: rawOverrides.allow_spend_usd_per_run }
+      : {}),
+    ...(typeof rawOverrides.allow_traffic_changes === "boolean"
+      ? { allow_traffic_changes: rawOverrides.allow_traffic_changes }
+      : {}),
+  };
+  return {
+    schema_version: TRUST_POSTURE_SCHEMA,
+    level: isTrustLevel(parsed.level) ? parsed.level : "local_sandbox",
+    set_at: typeof parsed.set_at === "string" ? parsed.set_at : null,
+    overrides,
+  };
+}
+
+/**
+ * Merge-write the posture (the ONE write path — `understudy trust set` and
+ * the desktop app's posture UI both land here). Level and each override are
+ * updated individually; `null` on an override key clears it back to the
+ * level default.
+ */
+export function writeTrustPosture(
+  patch: {
+    level?: TrustLevel;
+    overrides?: { [K in keyof TrustOverrides]?: TrustOverrides[K] | null };
+  },
+  env: NodeJS.ProcessEnv = process.env,
+  now: () => Date = () => new Date(),
+): TrustPosture {
+  const current = readTrustPosture(env);
+  const overrides: TrustOverrides = { ...current.overrides };
+  for (const key of ["allow_provider_upload", "allow_spend_usd_per_run", "allow_traffic_changes"] as const) {
+    if (!patch.overrides || !(key in patch.overrides)) continue;
+    const value = patch.overrides[key];
+    if (value === null || value === undefined) delete overrides[key];
+    else (overrides as Obj)[key] = value;
+  }
+  const next: TrustPosture = {
+    schema_version: TRUST_POSTURE_SCHEMA,
+    level: patch.level ?? current.level,
+    set_at: now().toISOString(),
+    overrides,
+  };
+  const file = trustPosturePath(env);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  return next;
+}
+
+/** True when the posture's level is at least `level` (local_sandbox < bounded_experiments < hosted_ops). */
+export function trustAtLeast(posture: TrustPosture, level: TrustLevel): boolean {
+  return TRUST_LEVELS.indexOf(posture.level) >= TRUST_LEVELS.indexOf(level);
+}
+
+export type ResolvedTrustBoundaries = {
+  /** Data may leave the machine to a provider. */
+  allow_provider_upload: boolean;
+  /** Live/production traffic changes allowed. */
+  allow_traffic_changes: boolean;
+  /** Generous per-run spend stop-loss in USD; null = unlimited (the default at EVERY level). */
+  spend_stop_loss_usd: number | null;
+};
+
+/**
+ * The posture resolution matrix: explicit per-boundary overrides always win;
+ * otherwise the level decides. Spend has NO level default — unlimited unless
+ * the user opted into a stop-loss.
+ */
+export function resolveTrustBoundaries(posture: TrustPosture): ResolvedTrustBoundaries {
+  const hosted = trustAtLeast(posture, "hosted_ops");
+  return {
+    allow_provider_upload: posture.overrides.allow_provider_upload ?? hosted,
+    allow_traffic_changes: posture.overrides.allow_traffic_changes ?? hosted,
+    spend_stop_loss_usd: posture.overrides.allow_spend_usd_per_run ?? null,
+  };
+}
+
+/** The one-action fix a below-posture gate offers instead of a per-call dialog. */
+export function raiseTrustHint(level: TrustLevel): string {
+  return `understudy trust set ${level}`;
+}
+
+/** True when the trust file exists at all (posture explicitly chosen at least once). */
+export function trustPostureChosen(env: NodeJS.ProcessEnv = process.env): boolean {
+  return existsSync(trustPosturePath(env));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { registerRunCommand } from "./commands/run.js";
 import { registerRunsCommand } from "./commands/runs.js";
 import { registerBenchmarksCommand } from "./commands/benchmarks.js";
 import { registerRuntimeCommand } from "./commands/runtime.js";
+import { registerTrustCommand } from "./commands/trust.js";
 import { registerTrainingCommand } from "./commands/training.js";
 import { registerSetupCodeCommand } from "./commands/setup-code.js";
 import { registerSetupCommand } from "./commands/setup.js";
@@ -868,6 +869,7 @@ export function buildProgram(): Command {
   registerRunsCommand(program);
   registerBenchmarksCommand(program);
   registerRuntimeCommand(program);
+  registerTrustCommand(program);
   registerTrainingCommand(program);
 
   const understand = program

--- a/src/local-serving.ts
+++ b/src/local-serving.ts
@@ -28,7 +28,7 @@ import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { createServer } from "node:net";
-import { homedir } from "node:os";
+import { homedir, totalmem } from "node:os";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 
 import { mlxVlmRuntimeStatus } from "./runtime/mlx-vlm/lifecycle.js";
@@ -151,6 +151,135 @@ export function resolveLocalArm(spec: { ref: string; label?: string; serving?: O
     },
     serving: asObject(spec.serving),
   };
+}
+
+/* ------------------------------------------------------------------ */
+/* Machine-aware sizing (batteries included, no OOM surprises)         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The local-model sizing ladder, encoding the heuristics that already live
+ * in skills/manage-local-models/reference.md ("what fits in RAM") and
+ * skills/run-local-model-lab/reference.md: approx resident footprint of the
+ * certified rungs, and the machine memory tier each is comfortable on
+ * (weights + KV cache + OS headroom). Used to pick an OOM-safe DEFAULT and
+ * to predict fit for known ids — never to block an artifact we cannot size.
+ */
+export const LOCAL_MODEL_LADDER: readonly { id: string; approx_gb: number; min_memory_gb: number }[] = [
+  { id: "gemma-4-e2b-it-qat-mlx-vlm-understudy", approx_gb: 3.6, min_memory_gb: 8 },
+  { id: "gemma-4-e4b-it-qat-mlx-vlm-understudy", approx_gb: 5.6, min_memory_gb: 12 },
+  { id: "gemma-4-12b-it-qat-mlx-vlm-understudy", approx_gb: 7.5, min_memory_gb: 16 },
+  { id: "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy", approx_gb: 16, min_memory_gb: 32 },
+];
+
+export type MachineMemory = { memory_gb: number | null; source: "profile" | "os_probe" | "unknown" };
+
+/**
+ * Machine memory for sizing decisions: the onboarding profile
+ * (~/.understudy/profile.json, machine.memory_gb — override the path with
+ * UNDERSTUDY_PROFILE_FILE for tests) when present, else an os.totalmem()
+ * probe. Unknown only when both fail.
+ */
+export function readMachineMemoryGb(env: NodeJS.ProcessEnv = process.env): MachineMemory {
+  const file = env.UNDERSTUDY_PROFILE_FILE?.trim() || join(homedir(), ".understudy", "profile.json");
+  const profile = readJsonIfPresent(file);
+  const fromProfile = Number(asObject(profile?.machine).memory_gb);
+  if (Number.isFinite(fromProfile) && fromProfile > 0) return { memory_gb: fromProfile, source: "profile" };
+  const probed = totalmem() / 1024 ** 3;
+  if (Number.isFinite(probed) && probed > 0) return { memory_gb: Number(probed.toFixed(1)), source: "os_probe" };
+  return { memory_gb: null, source: "unknown" };
+}
+
+/** The largest ladder rung that comfortably fits `memoryGb`; the smallest rung when memory is unknown (safe default, never a failure). */
+export function defaultLocalModelForMemory(memoryGb: number | null): { id: string; approx_gb: number; min_memory_gb: number } {
+  if (memoryGb === null) return LOCAL_MODEL_LADDER[0];
+  const fitting = LOCAL_MODEL_LADDER.filter((rung) => memoryGb >= rung.min_memory_gb);
+  return fitting.length > 0 ? fitting[fitting.length - 1] : LOCAL_MODEL_LADDER[0];
+}
+
+const WEIGHT_FILE = /\.(safetensors|gguf|npz|bin)$/;
+
+function weightBytes(root: string): number {
+  let weights = 0;
+  let total = 0;
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const path = join(dir, name);
+      const st = statSync(path);
+      if (st.isDirectory()) walk(path);
+      else if (st.isFile()) {
+        total += st.size;
+        if (WEIGHT_FILE.test(name)) weights += st.size;
+      }
+    }
+  };
+  walk(root);
+  return weights > 0 ? weights : total;
+}
+
+/**
+ * Estimated resident footprint (GB) of serving an artifact: a ladder rung's
+ * published footprint when the id matches, else measured weight bytes with
+ * the skill's rule-of-thumb overhead (KV cache + runtime, roughly +20% and
+ * +1 GB). Adapter bundles size the cached base weights when present; null =
+ * honestly unknown (never a guess that blocks serving).
+ */
+export function estimateArtifactMemoryGb(ref: string): number | null {
+  const root = resolve(ref);
+  const names = [basename(root.replace(/\/+$/, "")), artifactBaseModel(root)];
+  for (const rung of LOCAL_MODEL_LADDER) {
+    if (names.some((n) => n === rung.id)) return rung.approx_gb;
+  }
+  try {
+    if (!statSync(root).isDirectory()) return null;
+    let bytes = weightBytes(root);
+    if (artifactHasAdapter(root)) {
+      const base = artifactBaseModel(root);
+      const rung = LOCAL_MODEL_LADDER.find((r) => r.id === base);
+      if (rung) return rung.approx_gb + bytes / 1024 ** 3;
+      const cached = join(homedir(), ".understudy", "models", base);
+      if (existsSync(cached)) bytes += weightBytes(cached);
+      else return null; // base weights not measurable locally — unknown, not unfit
+    }
+    const gb = bytes / 1024 ** 3;
+    return gb > 0 ? Number((gb * 1.2 + 1).toFixed(2)) : null;
+  } catch {
+    return null;
+  }
+}
+
+export type LocalFitPrediction = {
+  fits: boolean;
+  /** Human-readable reason when fits=false; null otherwise. */
+  reason: string | null;
+  estimated_gb: number | null;
+  memory_gb: number | null;
+};
+
+/** Fraction of machine memory a local model server may plan to occupy (OS + app headroom). */
+export const LOCAL_FIT_MEMORY_FRACTION = 0.85;
+
+/**
+ * Predict whether serving `ref` fits this machine. Predicts OOM only when
+ * BOTH the artifact estimate and machine memory are known and the estimate
+ * exceeds the usable fraction — unknowns always "fit" (we never refuse to
+ * try on ignorance; a real serve failure still triggers the recorded
+ * gateway fallback in the executor).
+ */
+export function predictLocalFit(ref: string, env: NodeJS.ProcessEnv = process.env): LocalFitPrediction {
+  const estimated = estimateArtifactMemoryGb(ref);
+  const { memory_gb } = readMachineMemoryGb(env);
+  if (estimated === null || memory_gb === null) return { fits: true, reason: null, estimated_gb: estimated, memory_gb };
+  const usable = memory_gb * LOCAL_FIT_MEMORY_FRACTION;
+  if (estimated > usable) {
+    return {
+      fits: false,
+      reason: `estimated ~${estimated.toFixed(1)} GB resident exceeds ~${usable.toFixed(1)} GB usable of ${memory_gb} GB machine memory`,
+      estimated_gb: estimated,
+      memory_gb,
+    };
+  }
+  return { fits: true, reason: null, estimated_gb: estimated, memory_gb };
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -23,7 +23,8 @@ import { spawnSync } from "node:child_process";
 import { buildReplayInvocation, goldFinalResponseFor, isMutatingTool, oracleEventsFor, readCapturesByKey, responseJudgedRequired, scoreContract } from "./trace-foundry.js";
 import { COST_PER_MTOKEN, resolveGatewayAuth } from "./trace-author.js";
 import { BENCHMARK_PROPOSAL_SCHEMA, BENCHMARK_SCHEMA, CALIBRATION_SCHEMA, EVAL_RESULT_SCHEMA, RUN_EVENT_SCHEMA, appendJournalEntry, readJsonlFile, serializeJsonlLine, serializeRunEvent } from "./benchmark-artifacts.js";
-import { resolveLocalArm, type LocalServerHandle, type LocalServingRig, type ResolvedLocalArm } from "./local-serving.js";
+import { predictLocalFit, resolveLocalArm, type LocalServerHandle, type LocalServingRig, type ResolvedLocalArm } from "./local-serving.js";
+import { readTrustPosture, resolveTrustBoundaries, type TrustPosture } from "./config/trust.js";
 
 type Obj = Record<string, any>;
 const asObject = (value: unknown): Obj => (value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {});
@@ -207,6 +208,13 @@ export type RunRequest = {
   claimed_by?: RunClaim | null;
   /** Additive: recorded when an executor skipped this request because it lacks a required capability. */
   unsupported?: { executor_version: string; missing: string[]; at: string } | null;
+  /**
+   * Additive (present only when the trust posture opted into a per-run spend
+   * stop-loss): recorded spend vs the stop-loss. warned = crossed 1x
+   * (recorded, run continued); stopped = reached 2x (remaining rollouts
+   * stopped; completed rows kept as evidence).
+   */
+  spend?: { recorded_usd: number; stop_loss_usd: number; warned: boolean; stopped: boolean } | null;
 };
 
 /* ------------------------------------------------------------------ */
@@ -720,7 +728,7 @@ export type RunEvent = {
   schema_version: typeof RUN_EVENT_SCHEMA;
   ts: string;
   run_id: string;
-  type: "run_started" | "arm_started" | "rollout" | "rollout_error" | "arm_finished" | "run_finished" | "run_cancelled" | "run_failed" | "cap_warning" | "run_unsupported";
+  type: "run_started" | "arm_started" | "rollout" | "rollout_error" | "arm_finished" | "run_finished" | "run_cancelled" | "run_failed" | "cap_warning" | "run_unsupported" | "arm_fallback" | "spend_warning" | "spend_stop";
   model?: string;
   task_id?: string;
   rollout?: number;
@@ -781,6 +789,13 @@ export type ExecuteOptions = {
    * with the ref silently dropped.
    */
   localServing?: LocalServingRig;
+  /**
+   * Test seam: the trust posture consulted for the spend stop-loss (default:
+   * readTrustPosture() — ~/.understudy/trust.json). There is NO default cap:
+   * the stop-loss engages only when the posture opts into
+   * allow_spend_usd_per_run.
+   */
+  trustPosture?: TrustPosture;
   /** Rollouts in flight per arm (the concurrency flag). */
   concurrency?: number;
   /** Per-rollout wall-clock budget in seconds; the request's rollout_timeout_seconds wins when present. */
@@ -912,6 +927,28 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
   } catch { /* no generated environment — prompt sentinels skipped */ }
 
   const cancelled = (): boolean => readRunRequest(file)?.status === "cancelled";
+  // Spend stop-loss (stop-loss doctrine, src/config/trust.ts): NO default cap
+  // anywhere — the posture's opt-in allow_spend_usd_per_run acts as a
+  // generous stop-loss. Warn-and-record at 1x (the run continues), hard-stop
+  // only at 2x (so a run is never mid-run hard-killed below 2x the user's
+  // own estimate-scale bound). Recorded costs only; unknown costs never trip it.
+  const spendStopLossUsd = resolveTrustBoundaries(options.trustPosture ?? readTrustPosture()).spend_stop_loss_usd;
+  let spentUsd = 0;
+  let spendWarned = false;
+  let spendStopped = false;
+  const recordSpend = (cost: number | null | undefined): void => {
+    if (typeof cost !== "number" || !Number.isFinite(cost) || cost <= 0) return;
+    spentUsd += cost;
+    if (spendStopLossUsd === null) return;
+    if (!spendWarned && spentUsd >= spendStopLossUsd) {
+      spendWarned = true;
+      appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "spend_warning", warning: `recorded spend $${spentUsd.toFixed(2)} crossed the posture stop-loss threshold of $${spendStopLossUsd.toFixed(2)} (allow_spend_usd_per_run); the run continues — hard stop only at 2x ($${(2 * spendStopLossUsd).toFixed(2)})` }, options.onEvent);
+    }
+    if (!spendStopped && spentUsd >= 2 * spendStopLossUsd) {
+      spendStopped = true;
+      appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "spend_stop", error: `recorded spend $${spentUsd.toFixed(2)} reached 2x the posture stop-loss ($${spendStopLossUsd.toFixed(2)}/run); remaining rollouts stopped — completed rows are kept as evidence` }, options.onEvent);
+    }
+  };
   let completed = 0;
   const persistProgress = () => {
     // Re-read before writing so an external cancel flip is never clobbered.
@@ -928,8 +965,32 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
       // Local arm: stand the artifact's server up for the WHOLE arm (or reuse
       // a running one the spec points at) and tear it down after — the runner
       // gets the endpoint instead of the gateway.
+      // Machine-aware smart default: predict fit against the onboarding
+      // profile (or an OS memory probe) BEFORE spawning; on predicted OOM or
+      // a real serve failure, fall back to the gateway arm on the artifact's
+      // base model — WITH a recorded event and a fallback_reason on every
+      // row. Never a silent swap, never a dead run because the laptop is
+      // smaller than the artifact.
       let localServer: LocalServerHandle | null = null;
-      if (arm.local) localServer = await options.localServing!.start(arm.local);
+      let fallbackReason: string | null = null;
+      if (arm.local) {
+        // A reuse arm (serving.base_url) points at an ALREADY-RUNNING server —
+        // nothing to size; prediction applies only when we would spawn.
+        const reusesServer = typeof arm.local.serving.base_url === "string" && arm.local.serving.base_url.trim().length > 0;
+        const fit = reusesServer ? { fits: true, reason: null } : predictLocalFit(arm.local.ref);
+        if (!fit.fits) {
+          fallbackReason = `predicted_oom: ${fit.reason}`;
+        } else {
+          try {
+            localServer = await options.localServing!.start(arm.local);
+          } catch (err) {
+            fallbackReason = `serve_failed: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+        if (fallbackReason) {
+          appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "arm_fallback", model, warning: `local arm "${model}" fell back to the gateway on ${arm.local.artifact.base_model} (${fallbackReason}); rows carry fallback_reason` }, options.onEvent);
+        }
+      }
       try {
       const rowsFile = rowsFilePath(dir, runId, model);
       // Live journal for this arm: the world/runner appends tool events the
@@ -945,7 +1006,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
       let armCancelled = false;
       const worker = async (): Promise<void> => {
         for (;;) {
-          if (armCancelled || cancelled()) {
+          if (armCancelled || spendStopped || cancelled()) {
             armCancelled = true;
             return;
           }
@@ -970,7 +1031,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
           try {
             // Override arms invoke the BASE model; the arm label only labels
             // rows/files. The suffix + label ride the additive runner args.
-            const attempt = arm.runner({ benchmarkDir: dir, model: arm.override?.model ?? model, task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)), journalPath, runId, rolloutTimeoutSeconds: timeoutSeconds, ...(arm.override ? { armLabel: arm.override.arm_label, systemPromptSuffix: arm.override.system_prompt_suffix } : {}), ...(localServer ? { local: { baseUrl: localServer.baseUrl, modelId: localServer.modelId } } : {}) });
+            const attempt = arm.runner({ benchmarkDir: dir, model: arm.override?.model ?? (arm.local && fallbackReason ? arm.local.artifact.base_model : model), task: sidecar, rollout: item.rollout, selectedTaskIds: selected.map((t) => String(t.task_id)), journalPath, runId, rolloutTimeoutSeconds: timeoutSeconds, ...(arm.override ? { armLabel: arm.override.arm_label, systemPromptSuffix: arm.override.system_prompt_suffix } : {}), ...(localServer ? { local: { baseUrl: localServer.baseUrl, modelId: localServer.modelId } } : {}) });
             const raced = await Promise.race([attempt, new Promise<typeof TIMED_OUT>((res) => { timer = setTimeout(() => res(TIMED_OUT), Math.max(1, Math.round(timeoutSeconds * 1000))); })]);
             if (raced === TIMED_OUT) {
               attempt.catch(() => { /* late settle of the abandoned rollout is irrelevant */ });
@@ -1029,7 +1090,10 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
             arm_kind: arm.kind,
             // Additive attribution stamp: which executor build produced this row.
             executor_version: EXECUTOR_VERSION,
-            route: arm.local ? "local" : "gateway",
+            route: arm.local && !fallbackReason ? "local" : "gateway",
+            // Additive: the gateway-fallback provenance (predicted OOM or a
+            // real serve failure) — a swapped arm is always visible on the row.
+            ...(fallbackReason ? { fallback_reason: fallbackReason } : {}),
             latency_ms: result.latency_ms,
             cost: result.cost,
             created_at: now().toISOString(),
@@ -1060,6 +1124,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
             ...(result.error ? { error: result.error } : {}),
           };
           appendFileSync(rowsFile, serializeJsonlLine(row), { mode: 0o600 });
+          recordSpend(result.cost);
           completed += 1;
           appendEvent(
             dir,
@@ -1084,7 +1149,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
       };
       await Promise.all(Array.from({ length: Math.min(concurrency, queue.length) }, () => worker()));
       appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "arm_finished", model, progress: { completed, total } }, options.onEvent);
-      if (armCancelled) break;
+      if (armCancelled || spendStopped) break;
       } finally {
         // Teardown after the arm — a server the rig REUSED is never ours to stop.
         if (localServer && !localServer.reused) await localServer.stop();
@@ -1108,7 +1173,7 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
     return request;
   }
 
-  request = { ...(readRunRequest(file) ?? request), status: "done", finished_at: now().toISOString(), progress: { completed, total }, live: null };
+  request = { ...(readRunRequest(file) ?? request), status: "done", finished_at: now().toISOString(), progress: { completed, total }, live: null, ...(spendStopLossUsd !== null ? { spend: { recorded_usd: Number(spentUsd.toFixed(4)), stop_loss_usd: spendStopLossUsd, warned: spendWarned, stopped: spendStopped } } : {}) };
   writeRunRequest(dir, request);
   appendEvent(dir, { schema_version: RUN_EVENT_SCHEMA, ts: now().toISOString(), run_id: runId, type: "run_finished", progress: { completed, total } }, options.onEvent);
   // Calibration gate: a finished run with an incumbent arm and/or trivial

--- a/src/runtime/conversation/benchmark-extension.ts
+++ b/src/runtime/conversation/benchmark-extension.ts
@@ -9,14 +9,18 @@
 // BENCHMARKS_TOOLS so the two surfaces cannot drift silently.
 //
 // Safety posture mirrors src/runtime/conversation/command-guard.ts: a
-// classifier decides allow/block, the extension enforces it at the Pi
+// classifier decides allow/notice/block, the extension enforces it at the Pi
 // `tool_call` boundary, and the execute path enforces it again so the guard
 // holds even if the tool is invoked outside an extension-loaded session.
 // Queueing a run only writes a runs/queue/<run_id>.json file (the executor
-// daemon spends); spend-adjacent shapes (multi-arm or multi-rollout runs,
-// implicit all-task runs, experiment approval/verdict updates) additionally
-// require an explicit `confirm: true` argument, which the model may only set
-// after the user consented in chat.
+// daemon spends). Spend-adjacent shapes (multi-arm or multi-rollout runs,
+// implicit all-task runs, experiment approval/verdict updates) consult the
+// ONE-TIME trust posture (~/.understudy/trust.json, src/config/trust.ts)
+// instead of demanding a per-call dialog: at `bounded_experiments`+ they
+// proceed with a visible one-line notice (arm count, rough cost estimate);
+// below that they return the single-action guidance to raise the posture.
+// `confirm: true` (set only after explicit user consent in chat) remains a
+// per-call escape hatch that works at any posture.
 //
 // These tools are Pi-only by design: the Vercel runtime twin builds its tool
 // set purely from the request's tool definitions and has no extension
@@ -39,6 +43,8 @@ import { Type } from "@earendil-works/pi-ai";
 import { BENCHMARKS_TOOLS, callBenchmarksTool } from "../../benchmarks-mcp.js";
 import { getEntry } from "../../benchmark-hub-core.js";
 import { deriveRigorReport } from "../../rigor-report.js";
+import { COST_PER_MTOKEN } from "../../trace-author.js";
+import { raiseTrustHint, readTrustPosture, trustAtLeast, type TrustPosture } from "../../config/trust.js";
 
 /**
  * Explicit allowlist of MCP-shared operator tools exposed in the embedded
@@ -75,7 +81,8 @@ export function benchmarkHubRoots(): string {
 /* ---------------- spend-adjacent gating (command-guard pattern) ---------------- */
 
 export type BenchmarkGuardDecision =
-  | { decision: "allow" }
+  /** `notice`, when present, is the visible one-line posture notice that MUST surface with the result. */
+  | { decision: "allow"; notice?: string }
   | { decision: "block"; rule_id: string; reason: string; severity: "high" };
 
 type Obj = Record<string, unknown>;
@@ -115,26 +122,80 @@ function experimentPatchTouchesApprovals(patch: Obj): boolean {
   return "approvals" in training;
 }
 
+/** Rough per-rollout token assumption for the visible spend notice (an estimate label, never billing). */
+const NOTICE_TOKENS = { input: 8_000, output: 2_000 } as const;
+
+/**
+ * Visible one-line notice for a spend-adjacent queue_run allowed by posture:
+ * arm count, rollout volume, and a rough cost estimate from the shared
+ * gateway rate table. Task count comes from the hub loader when the shape is
+ * an implicit all-task run; "?" when the benchmark cannot be resolved.
+ */
+export function queueRunSpendNotice(args: Obj, posture: TrustPosture): string {
+  const models = Array.isArray(args.models) ? args.models : [];
+  const incumbents = Array.isArray(args.incumbent_models) ? args.incumbent_models : [];
+  const armCount = models.length + (Array.isArray(args.prompt_overrides) ? args.prompt_overrides.length : 0);
+  const rollouts = args.rollouts_per_task === undefined ? 1 : Number(args.rollouts_per_task);
+  let taskCount: number | null = Array.isArray(args.tasks) ? args.tasks.length : null;
+  if (taskCount === null && typeof args.slug === "string") {
+    try {
+      const entry = getEntry(args.slug);
+      if (entry && entry.kind === "ok") taskCount = entry.manifest.tasks.length;
+      else if (entry && entry.kind === "proposed") taskCount = entry.tasks.length;
+    } catch {
+      /* unresolvable benchmark — task count stays unknown */
+    }
+  }
+  const totalRollouts = taskCount === null ? null : armCount * taskCount * (Number.isFinite(rollouts) ? rollouts : 1);
+  // Rough estimate: gateway (string) arms at the shared rate table; local {ref} arms are $0.
+  let estimate: number | null = null;
+  if (taskCount !== null) {
+    estimate = 0;
+    const gatewayArms = models.filter((m) => typeof m === "string") as string[];
+    for (const model of gatewayArms) {
+      const rate = COST_PER_MTOKEN[model] ?? COST_PER_MTOKEN.default;
+      estimate += (taskCount * rollouts * (NOTICE_TOKENS.input * rate.input + NOTICE_TOKENS.output * rate.output)) / 1_000_000;
+    }
+  }
+  const est = estimate === null ? "est. cost unknown (task count unresolved)" : `~$${estimate.toFixed(2)} est. gateway cost (rough)`;
+  return (
+    `Trust posture ${posture.level}: queueing spend-adjacent run — ${armCount} arm(s)` +
+    `${incumbents.length > 0 ? ` (incl. ${incumbents.length} incumbent)` : ""} x ` +
+    `${taskCount ?? "?"} task(s) x ${rollouts} rollout(s)` +
+    `${totalRollouts === null ? "" : ` = ${totalRollouts} rollout(s)`}; ${est}. ` +
+    `Recorded, reversible: cancel via run_status/cancel; lower autonomy any time with \`understudy trust set local_sandbox\`.`
+  );
+}
+
 export function classifyBenchmarkToolCall(
   toolName: string,
   input: unknown,
+  posture: TrustPosture = readTrustPosture(),
 ): BenchmarkGuardDecision {
   if (!PI_BENCHMARK_TOOL_NAMES.includes(toolName)) return { decision: "allow" };
   const args = asObject(input);
   if (args.confirm === true) return { decision: "allow" };
+  const postureAllows = trustAtLeast(posture, "bounded_experiments");
   if (toolName === "queue_run" && !queueRunIsTrivial(args)) {
+    if (postureAllows) return { decision: "allow", notice: queueRunSpendNotice(args, posture) };
     return {
       decision: "block",
-      rule_id: "benchmark.queue-run-unconfirmed",
+      rule_id: "benchmark.queue-run-below-posture",
       reason:
         "This run request is spend-adjacent (multiple model arms, an incumbent arm, repeated rollouts, or an implicit all-task run) and an executor will spend money or compute the moment it picks the queued file up.",
       severity: "high",
     };
   }
   if (toolName === "update_experiment" && experimentPatchTouchesApprovals(asObject(args.patch))) {
+    if (postureAllows) {
+      return {
+        decision: "allow",
+        notice: `Trust posture ${posture.level}: updating experiment approval/status/verdict state (spend-gate-adjacent). Recorded in experiments.jsonl (append-only, reversible with a later line).`,
+      };
+    }
     return {
       decision: "block",
-      rule_id: "benchmark.experiment-approval-unconfirmed",
+      rule_id: "benchmark.experiment-approval-below-posture",
       reason:
         "This experiment patch changes approval, status, or verdict state that downstream tooling treats as cleared spend gates.",
       severity: "high",
@@ -146,14 +207,24 @@ export function classifyBenchmarkToolCall(
 export function benchmarkGuardBlockMessage(
   decision: Exclude<BenchmarkGuardDecision, { decision: "allow" }>,
 ): string {
-  return `Blocked by Understudy benchmark guard [${decision.rule_id}]: ${decision.reason} Ask the user for explicit consent in chat, then retry the same call with confirm: true.`;
+  return (
+    `Blocked by Understudy benchmark guard [${decision.rule_id}]: ${decision.reason} ` +
+    `The current trust posture is below "bounded_experiments". ONE action fixes this for every future call ` +
+    `(no per-call dialogs): have the user run \`${raiseTrustHint("bounded_experiments")}\` once — visible and ` +
+    `reversible. Alternatively, for this single call only, retry with confirm: true after the user explicitly consented in chat.`
+  );
 }
 
-export function enforceBenchmarkToolCall(toolName: string, input: unknown): void {
-  const decision = classifyBenchmarkToolCall(toolName, input);
+export function enforceBenchmarkToolCall(
+  toolName: string,
+  input: unknown,
+  posture?: TrustPosture,
+): { notice?: string } {
+  const decision = classifyBenchmarkToolCall(toolName, input, posture);
   if (decision.decision === "block") {
     throw new Error(benchmarkGuardBlockMessage(decision));
   }
+  return decision.notice ? { notice: decision.notice } : {};
 }
 
 /* ---------------- tool definitions ---------------- */
@@ -162,7 +233,7 @@ const CONFIRM_PROPERTY = {
   confirm: {
     type: "boolean",
     description:
-      "Required true for spend-adjacent shapes. Set only after the user explicitly consented in this conversation.",
+      "Per-call escape hatch for spend-adjacent shapes when the trust posture is below bounded_experiments. Set only after the user explicitly consented in this conversation.",
   },
 } as const;
 
@@ -187,7 +258,7 @@ function sharedToolDescription(name: string): string {
   const source = BENCHMARKS_TOOLS.find((tool) => tool.name === name);
   if (!source) throw new Error(`benchmarks MCP no longer exposes tool ${name}`);
   return CONFIRMABLE_TOOLS.has(name)
-    ? `${source.description} Spend-adjacent shapes are blocked unless confirm: true is passed after explicit user consent.`
+    ? `${source.description} Spend-adjacent shapes consult the one-time trust posture (~/.understudy/trust.json): at bounded_experiments+ they proceed with a visible spend notice; below that they are blocked with guidance to raise the posture once (or pass confirm: true after explicit user consent).`
     : source.description;
 }
 
@@ -220,11 +291,14 @@ export function benchmarkToolDefinitions() {
       description: sharedToolDescription(name),
       parameters: Type.Unsafe(sharedToolSchema(name)),
       async execute(_toolCallId, parameters) {
-        enforceBenchmarkToolCall(name, parameters);
+        const { notice } = enforceBenchmarkToolCall(name, parameters);
         // Strip the pi-layer confirm flag before delegating: the shared MCP
         // dispatcher's argument surface stays byte-identical to the hub API.
         const { confirm: _confirm, ...args } = asObject(parameters);
-        return toolResult(callBenchmarksTool(name, args));
+        const result = toolResult(callBenchmarksTool(name, args));
+        // Posture notices are VISIBLE by contract: the one-line notice rides
+        // ahead of the payload so the model must surface it to the user.
+        return notice ? { ...result, content: [{ type: "text" as const, text: notice }, ...result.content] } : result;
       },
     }),
   );

--- a/tests/benchmark-extension.test.mjs
+++ b/tests/benchmark-extension.test.mjs
@@ -22,6 +22,10 @@ import { BENCHMARKS_TOOLS, callBenchmarksTool } from "../dist/benchmarks-mcp.js"
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-benchmark-extension-"));
 process.env.BENCHMARK_HUB_DATA_DIR = tmp;
 delete process.env.BENCHMARK_HUB_DEMO;
+// Pin the trust posture to the absent-file default (local_sandbox) so a
+// developer machine's real ~/.understudy/trust.json never flips these tests.
+process.env.UNDERSTUDY_TRUST_FILE = path.join(tmp, "trust.json");
+const postureAt = (level) => ({ schema_version: "understudy.trust_posture.v1", level, set_at: null, overrides: {} });
 after(() => fs.rmSync(tmp, { recursive: true, force: true }));
 
 /* ---------------- fixture: one promoted benchmark ---------------- */
@@ -94,7 +98,7 @@ describe("tool registration", () => {
     assert.equal(typeof guard, "function");
     const blocked = guard({ toolName: "queue_run", input: { slug: "x", models: ["a", "b"] } });
     assert.equal(blocked.block, true);
-    assert.match(blocked.reason, /benchmark\.queue-run-unconfirmed/);
+    assert.match(blocked.reason, /benchmark\.queue-run-below-posture/);
     assert.equal(guard({ toolName: "read_benchmark", input: { slug: "x" } }), undefined);
     // Shell tools remain the command guard's concern, not this guard's.
     assert.equal(guard({ toolName: "bash", input: { command: "rm -rf /" } }), undefined);
@@ -127,7 +131,7 @@ describe("spend-adjacent gating", () => {
     ]) {
       const decision = classifyBenchmarkToolCall("queue_run", args);
       assert.equal(decision.decision, "block");
-      assert.equal(decision.rule_id, "benchmark.queue-run-unconfirmed");
+      assert.equal(decision.rule_id, "benchmark.queue-run-below-posture");
       assert.match(benchmarkGuardBlockMessage(decision), /confirm: true/);
       assert.deepEqual(
         classifyBenchmarkToolCall("queue_run", { ...args, confirm: true }),
@@ -148,7 +152,7 @@ describe("spend-adjacent gating", () => {
         patch,
       });
       assert.equal(decision.decision, "block");
-      assert.equal(decision.rule_id, "benchmark.experiment-approval-unconfirmed");
+      assert.equal(decision.rule_id, "benchmark.experiment-approval-below-posture");
     }
     assert.deepEqual(
       classifyBenchmarkToolCall("update_experiment", {
@@ -160,10 +164,51 @@ describe("spend-adjacent gating", () => {
     );
   });
 
+  it("posture matrix: blocks below bounded_experiments, proceeds WITH a visible notice at bounded_experiments+", () => {
+    const spendy = { slug: "s", models: ["glm-5.2", "gemma-4-31b-it"], tasks: ["t1", "t2"], rollouts_per_task: 3 };
+    const blocked = classifyBenchmarkToolCall("queue_run", spendy, postureAt("local_sandbox"));
+    assert.equal(blocked.decision, "block");
+    assert.match(benchmarkGuardBlockMessage(blocked), /understudy trust set bounded_experiments/, "ONE action, not a per-call dialog");
+    for (const level of ["bounded_experiments", "hosted_ops"]) {
+      const allowed = classifyBenchmarkToolCall("queue_run", spendy, postureAt(level));
+      assert.equal(allowed.decision, "allow");
+      assert.match(allowed.notice, /2 arm\(s\)/, "notice carries the arm count");
+      assert.match(allowed.notice, /est\. gateway cost|est\. cost/, "notice carries a cost estimate");
+      assert.match(allowed.notice, /2 task\(s\) x 3 rollout\(s\)/);
+    }
+    // Trivial probes stay notice-free at every level.
+    for (const level of ["local_sandbox", "bounded_experiments", "hosted_ops"]) {
+      assert.deepEqual(
+        classifyBenchmarkToolCall("queue_run", { slug: "s", models: ["m"], tasks: ["t1"] }, postureAt(level)),
+        { decision: "allow" },
+      );
+    }
+    // Experiment approval patches follow the same matrix.
+    const patchArgs = { slug: "s", experiment_id: "e", patch: { status: "approved" } };
+    assert.equal(classifyBenchmarkToolCall("update_experiment", patchArgs, postureAt("local_sandbox")).decision, "block");
+    const noticed = classifyBenchmarkToolCall("update_experiment", patchArgs, postureAt("bounded_experiments"));
+    assert.equal(noticed.decision, "allow");
+    assert.match(noticed.notice, /approval\/status\/verdict/);
+  });
+
+  it("execute surfaces the posture notice ahead of the payload (never a silent proceed)", async () => {
+    fs.writeFileSync(
+      process.env.UNDERSTUDY_TRUST_FILE,
+      JSON.stringify({ schema_version: "understudy.trust_posture.v1", level: "bounded_experiments", set_at: null, overrides: {} }),
+    );
+    try {
+      const result = await execute("queue_run", { slug: discoveredSlug(), models: ["model-a", "model-b"], tasks: ["t1"], split: "holdout" });
+      assert.match(result.content[0].text, /Trust posture bounded_experiments/, "first content block is the notice");
+      assert.ok(result.details.run_id, "the run still queues through the shared writer");
+    } finally {
+      fs.rmSync(process.env.UNDERSTUDY_TRUST_FILE, { force: true });
+    }
+  });
+
   it("enforces the guard on execute, not just at the extension boundary", async () => {
     await assert.rejects(
       execute("queue_run", { slug: discoveredSlug(), models: ["a", "b"] }),
-      /benchmark\.queue-run-unconfirmed/,
+      /benchmark\.queue-run-below-posture/,
     );
   });
 });

--- a/tests/local-arms.test.mjs
+++ b/tests/local-arms.test.mjs
@@ -19,7 +19,19 @@ import {
   runRequestPath,
   validateRunRequestInput,
 } from "../dist/run-executor.js";
-import { artifactBaseModel, artifactHasAdapter, bundleSha256, renderServeCommand, resolveLocalArm, servingModelPath } from "../dist/local-serving.js";
+import {
+  LOCAL_MODEL_LADDER,
+  artifactBaseModel,
+  artifactHasAdapter,
+  bundleSha256,
+  defaultLocalModelForMemory,
+  estimateArtifactMemoryGb,
+  predictLocalFit,
+  readMachineMemoryGb,
+  renderServeCommand,
+  resolveLocalArm,
+  servingModelPath,
+} from "../dist/local-serving.js";
 
 const roots = [];
 after(() => {
@@ -446,5 +458,111 @@ describe("majority-class arm", () => {
     assert.equal(summary.majority_floor.floor_exceeded, true);
     const without = deriveCalibrationSummary({ benchmarkId: "b", runId: "r", incumbentModels: [], selectedTaskIds: ["a"], rows: [], events: [] });
     assert.ok(!("majority_floor" in without));
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* 4. Machine-aware sizing + recorded gateway fallback                 */
+/* ------------------------------------------------------------------ */
+
+const fakeProfile = (memoryGb) => {
+  const file = path.join(tmpdir("profile-"), "profile.json");
+  fs.writeFileSync(file, JSON.stringify({ schema_version: "understudy.profile.v1", machine: { memory_gb: memoryGb } }));
+  return { UNDERSTUDY_PROFILE_FILE: file };
+};
+
+/** A plain (adapterless) model dir named after a ladder rung, so sizing uses the published footprint. */
+function makeLadderModelDir(rungId) {
+  const dir = path.join(tmpdir("ladder-model-"), rungId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "weights.safetensors"), "tiny");
+  return dir;
+}
+
+describe("machine-aware local sizing", () => {
+  it("reads memory from a fake onboarding profile, falling back to an OS probe", () => {
+    assert.deepEqual(readMachineMemoryGb(fakeProfile(32)), { memory_gb: 32, source: "profile" });
+    const probed = readMachineMemoryGb({ UNDERSTUDY_PROFILE_FILE: path.join(tmpdir("no-profile-"), "missing.json") });
+    assert.equal(probed.source, "os_probe");
+    assert.ok(probed.memory_gb > 0);
+  });
+
+  it("defaultLocalModelForMemory picks the largest OOM-safe rung, smallest when memory is unknown", () => {
+    assert.equal(defaultLocalModelForMemory(null).id, LOCAL_MODEL_LADDER[0].id);
+    assert.equal(defaultLocalModelForMemory(8).id, "gemma-4-e2b-it-qat-mlx-vlm-understudy");
+    assert.equal(defaultLocalModelForMemory(16).id, "gemma-4-12b-it-qat-mlx-vlm-understudy");
+    assert.equal(defaultLocalModelForMemory(64).id, "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy");
+    assert.equal(defaultLocalModelForMemory(4).id, LOCAL_MODEL_LADDER[0].id, "tiny machines still get a default, never a failure");
+  });
+
+  it("estimates ladder rungs by published footprint and unknown artifacts by measured weights", () => {
+    const rung = makeLadderModelDir("gemma-4-26b-a4b-it-qat-mlx-vlm-understudy");
+    assert.equal(estimateArtifactMemoryGb(rung), 16);
+    const tiny = makeBundle({ adapter: false });
+    const est = estimateArtifactMemoryGb(tiny);
+    assert.ok(est !== null && est < 2, "tiny measured dir estimates small (weights*1.2 + 1GB overhead)");
+  });
+
+  it("predictLocalFit: OOM only when BOTH sides are known and exceeded; unknowns always fit", () => {
+    const rung = makeLadderModelDir("gemma-4-26b-a4b-it-qat-mlx-vlm-understudy");
+    const oom = predictLocalFit(rung, fakeProfile(8));
+    assert.equal(oom.fits, false);
+    assert.match(oom.reason, /16\.0 GB.*8 GB/s);
+    assert.equal(predictLocalFit(rung, fakeProfile(64)).fits, true);
+    // Adapter bundle over an unknown, uncached base: unknown estimate -> fits.
+    const adapterBundle = makeBundle({ base: "some-uncached-base" });
+    assert.equal(predictLocalFit(adapterBundle, fakeProfile(1)).fits, true, "never refuse to try on ignorance");
+  });
+});
+
+describe("executor gateway fallback (recorded, never silent)", () => {
+  const runnerSeeing = (seen) => async ({ model, local, journalPath }) => {
+    seen.push({ model, local: local ?? null });
+    if (journalPath) fs.appendFileSync(journalPath, JSON.stringify({ kind: "call", tool: "update-record", status: "ok" }) + "\n");
+    return { score: 1, subscores: null, status: "ok", latency_ms: 1, cost: 0.001, writes: [{ tool: "update-record", arguments: { id: "r-1" } }] };
+  };
+
+  it("predicted OOM: the arm runs on the gateway base model with fallback_reason on rows and an arm_fallback event", async () => {
+    const dir = makeAgenticBenchmark();
+    const ref = makeLadderModelDir("gemma-4-26b-a4b-it-qat-mlx-vlm-understudy");
+    const run = createRunRequest(dir, { benchmark_id: "local-arms-bench", models: [{ ref, label: "big-local" }], split: "all", tasks: "all", rollouts_per_task: 1 });
+    const saved = process.env.UNDERSTUDY_PROFILE_FILE;
+    process.env.UNDERSTUDY_PROFILE_FILE = fakeProfile(8).UNDERSTUDY_PROFILE_FILE;
+    let rigStarted = false;
+    const seen = [];
+    try {
+      const result = await executeRunRequest(dir, run.run_id, { runner: runnerSeeing(seen), localServing: { start: async () => { rigStarted = true; throw new Error("must not start"); } } });
+      assert.equal(result.status, "done");
+    } finally {
+      if (saved === undefined) delete process.env.UNDERSTUDY_PROFILE_FILE;
+      else process.env.UNDERSTUDY_PROFILE_FILE = saved;
+    }
+    assert.equal(rigStarted, false, "predicted OOM never spawns the server");
+    assert.equal(seen[0].local, null, "runner gets no local endpoint");
+    assert.equal(seen[0].model, "gemma-4-26b-a4b-it-qat-mlx-vlm-understudy", "gateway arm runs the artifact's base model");
+    const row = readRows(dir)[0];
+    assert.equal(row.route, "gateway");
+    assert.match(row.fallback_reason, /^predicted_oom:/);
+    assert.equal(row.model, "big-local", "the arm label is preserved");
+    const fallbackEvent = readEvents(dir).find((e) => e.type === "arm_fallback");
+    assert.ok(fallbackEvent, "fallback recorded as a run event");
+    assert.match(fallbackEvent.warning, /fell back to the gateway/);
+  });
+
+  it("serve failure: falls back to the gateway with fallback_reason serve_failed", async () => {
+    const dir = makeAgenticBenchmark();
+    const bundle = makeBundle({ adapter: false });
+    const run = createRunRequest(dir, { benchmark_id: "local-arms-bench", models: [{ ref: bundle, label: "flaky-local" }], split: "all", tasks: "all", rollouts_per_task: 1 });
+    const seen = [];
+    const result = await executeRunRequest(dir, run.run_id, {
+      runner: runnerSeeing(seen),
+      localServing: { start: async () => { throw new Error("mlx server exited with 137 before becoming ready"); } },
+    });
+    assert.equal(result.status, "done", "a serve failure degrades to the gateway, never kills the run");
+    const row = readRows(dir)[0];
+    assert.equal(row.route, "gateway");
+    assert.match(row.fallback_reason, /^serve_failed: mlx server exited with 137/);
+    assert.equal(seen[0].model, "gemma-4-e2b-it", "bundle base model becomes the gateway arm");
+    assert.ok(readEvents(dir).some((e) => e.type === "arm_fallback"));
   });
 });

--- a/tests/spend-stop-loss.test.mjs
+++ b/tests/spend-stop-loss.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import { createRunRequest, executeRunRequest, runEventsPath } from "../dist/run-executor.js";
+
+const roots = [];
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+const tmpdir = (prefix) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  roots.push(dir);
+  return dir;
+};
+
+function makeBenchmark(taskCount) {
+  const dir = tmpdir("spend-bench-");
+  const ids = Array.from({ length: taskCount }, (_, i) => `t${i + 1}`);
+  fs.writeFileSync(
+    path.join(dir, "benchmark.json"),
+    JSON.stringify({
+      schema_version: "understudy.benchmark.v1",
+      benchmark_id: "spend-bench",
+      tasks: ids.map((task_id) => ({ task_id, category_id: "cat", split: "train" })),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(dir, "tasks.jsonl"),
+    ids
+      .map((task_id) =>
+        JSON.stringify({
+          schema_version: "understudy.benchmark_task.v1",
+          task_id,
+          title: `task ${task_id}`,
+          outcome_contract: { required: [{ type: "state_effect", tool: "update-record", observed_arguments: { id: "r-1" } }], preserved: [], forbidden: [], grading: "final_state_and_obligations" },
+        }),
+      )
+      .join("\n") + "\n",
+  );
+  return dir;
+}
+
+const posture = (overrides) => ({ schema_version: "understudy.trust_posture.v1", level: "bounded_experiments", set_at: null, overrides });
+
+const costingRunner = (usdPerRollout) => async ({ journalPath }) => {
+  if (journalPath) fs.appendFileSync(journalPath, JSON.stringify({ kind: "call", tool: "update-record", status: "ok" }) + "\n");
+  return { score: 1, subscores: null, status: "ok", latency_ms: 1, cost: usdPerRollout, writes: [{ tool: "update-record", arguments: { id: "r-1" } }] };
+};
+
+const events = (dir) => fs.readFileSync(runEventsPath(dir), "utf8").trim().split("\n").map((l) => JSON.parse(l));
+
+describe("posture spend stop-loss (stop-loss doctrine: warn, don't kill)", () => {
+  it("no posture stop-loss = no cap: nothing warns, nothing stops, no spend stamp", async () => {
+    const dir = makeBenchmark(3);
+    const run = createRunRequest(dir, { benchmark_id: "spend-bench", models: ["gw"], split: "all", tasks: "all", rollouts_per_task: 1 });
+    const result = await executeRunRequest(dir, run.run_id, { runner: costingRunner(100), trustPosture: posture({}) });
+    assert.equal(result.status, "done");
+    assert.equal(result.progress.completed, 3, "every rollout ran despite huge recorded costs");
+    assert.ok(!("spend" in result), "no stop-loss, no spend stamp");
+    assert.ok(!events(dir).some((e) => e.type === "spend_warning" || e.type === "spend_stop"));
+  });
+
+  it("warn path: crossing 1x records a spend_warning and the run CONTINUES to completion", async () => {
+    const dir = makeBenchmark(4);
+    const run = createRunRequest(dir, { benchmark_id: "spend-bench", models: ["gw"], split: "all", tasks: "all", rollouts_per_task: 1 });
+    // 4 x $1 = $4 total; stop-loss $3: warned at the 3rd rollout, 2x ($6) never reached.
+    const result = await executeRunRequest(dir, run.run_id, { runner: costingRunner(1), trustPosture: posture({ allow_spend_usd_per_run: 3 }), concurrency: 1 });
+    assert.equal(result.status, "done");
+    assert.equal(result.progress.completed, 4, "warn-at-threshold never kills the run");
+    const warnings = events(dir).filter((e) => e.type === "spend_warning");
+    assert.equal(warnings.length, 1, "warned exactly once");
+    assert.match(warnings[0].warning, /stop-loss threshold of \$3\.00/);
+    assert.match(warnings[0].warning, /run continues/);
+    assert.ok(!events(dir).some((e) => e.type === "spend_stop"));
+    assert.deepEqual(result.spend, { recorded_usd: 4, stop_loss_usd: 3, warned: true, stopped: false });
+  });
+
+  it("hard stop only at 2x: remaining rollouts stop, completed rows are kept, everything is recorded", async () => {
+    const dir = makeBenchmark(10);
+    const run = createRunRequest(dir, { benchmark_id: "spend-bench", models: ["gw"], split: "all", tasks: "all", rollouts_per_task: 1 });
+    // $1/rollout, stop-loss $2: warn at $2, stop at $4 — never a mid-run kill below 2x.
+    const result = await executeRunRequest(dir, run.run_id, { runner: costingRunner(1), trustPosture: posture({ allow_spend_usd_per_run: 2 }), concurrency: 1 });
+    assert.equal(result.status, "done", "a spend stop is a recorded early finish, not a failure");
+    assert.equal(result.progress.completed, 4, "stopped exactly at 2x the stop-loss");
+    assert.ok(events(dir).some((e) => e.type === "spend_warning"));
+    const stop = events(dir).find((e) => e.type === "spend_stop");
+    assert.match(stop.error, /2x the posture stop-loss/);
+    assert.deepEqual(result.spend, { recorded_usd: 4, stop_loss_usd: 2, warned: true, stopped: true });
+  });
+});

--- a/tests/trust-posture.test.mjs
+++ b/tests/trust-posture.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import {
+  DEFAULT_TRUST_POSTURE,
+  TRUST_LEVELS,
+  TRUST_POSTURE_SCHEMA,
+  raiseTrustHint,
+  readTrustPosture,
+  resolveTrustBoundaries,
+  trustAtLeast,
+  trustPosturePath,
+  writeTrustPosture,
+} from "../dist/config/trust.js";
+import { DEFAULT_REVIEW_POLICY, readReviewPolicy } from "../dist/benchmark-artifacts.js";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trust-posture-"));
+after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+const envWith = (name) => ({ UNDERSTUDY_TRUST_FILE: path.join(tmp, name) });
+
+describe("trust posture file", () => {
+  it("defaults to local_sandbox with NO overrides when the file is absent", () => {
+    const posture = readTrustPosture(envWith("absent.json"));
+    assert.deepEqual(posture, { ...DEFAULT_TRUST_POSTURE, overrides: {} });
+  });
+
+  it("is tolerant: unreadable / wrong-schema / junk fields never widen autonomy", () => {
+    const env = envWith("junk.json");
+    fs.writeFileSync(trustPosturePath(env), "not json");
+    assert.equal(readTrustPosture(env).level, "local_sandbox");
+    fs.writeFileSync(trustPosturePath(env), JSON.stringify({ schema_version: "wrong", level: "hosted_ops" }));
+    assert.equal(readTrustPosture(env).level, "local_sandbox");
+    fs.writeFileSync(
+      trustPosturePath(env),
+      JSON.stringify({
+        schema_version: TRUST_POSTURE_SCHEMA,
+        level: "yolo_mode",
+        overrides: { allow_spend_usd_per_run: -5, allow_provider_upload: "yes" },
+      }),
+    );
+    const posture = readTrustPosture(env);
+    assert.equal(posture.level, "local_sandbox");
+    assert.deepEqual(posture.overrides, {});
+  });
+
+  it("writeTrustPosture merge-writes and round-trips; null clears an override", () => {
+    const env = envWith("write.json");
+    writeTrustPosture({ level: "bounded_experiments", overrides: { allow_spend_usd_per_run: 25 } }, env);
+    let posture = readTrustPosture(env);
+    assert.equal(posture.level, "bounded_experiments");
+    assert.equal(posture.overrides.allow_spend_usd_per_run, 25);
+    assert.ok(posture.set_at, "set_at stamped");
+    writeTrustPosture({ overrides: { allow_provider_upload: true } }, env);
+    posture = readTrustPosture(env);
+    assert.equal(posture.level, "bounded_experiments", "level preserved on override-only write");
+    assert.equal(posture.overrides.allow_spend_usd_per_run, 25, "existing override preserved");
+    assert.equal(posture.overrides.allow_provider_upload, true);
+    writeTrustPosture({ overrides: { allow_spend_usd_per_run: null } }, env);
+    assert.equal(readTrustPosture(env).overrides.allow_spend_usd_per_run, undefined, "null clears back to default");
+  });
+});
+
+describe("posture resolution matrix", () => {
+  const at = (level, overrides = {}) => ({ schema_version: TRUST_POSTURE_SCHEMA, level, set_at: null, overrides });
+
+  it("levels order local_sandbox < bounded_experiments < hosted_ops", () => {
+    assert.deepEqual(TRUST_LEVELS, ["local_sandbox", "bounded_experiments", "hosted_ops"]);
+    assert.equal(trustAtLeast(at("local_sandbox"), "bounded_experiments"), false);
+    assert.equal(trustAtLeast(at("bounded_experiments"), "bounded_experiments"), true);
+    assert.equal(trustAtLeast(at("hosted_ops"), "bounded_experiments"), true);
+    assert.equal(trustAtLeast(at("bounded_experiments"), "hosted_ops"), false);
+  });
+
+  it("level defaults: upload/traffic open only at hosted_ops; spend has NO cap at ANY level", () => {
+    for (const [level, expected] of [
+      ["local_sandbox", false],
+      ["bounded_experiments", false],
+      ["hosted_ops", true],
+    ]) {
+      const resolved = resolveTrustBoundaries(at(level));
+      assert.equal(resolved.allow_provider_upload, expected, `${level} upload`);
+      assert.equal(resolved.allow_traffic_changes, expected, `${level} traffic`);
+      assert.equal(resolved.spend_stop_loss_usd, null, `${level} has no default spend cap`);
+    }
+  });
+
+  it("explicit per-boundary overrides always win over the level default", () => {
+    const widened = resolveTrustBoundaries(at("local_sandbox", { allow_provider_upload: true, allow_spend_usd_per_run: 10 }));
+    assert.equal(widened.allow_provider_upload, true);
+    assert.equal(widened.spend_stop_loss_usd, 10);
+    const narrowed = resolveTrustBoundaries(at("hosted_ops", { allow_traffic_changes: false, allow_provider_upload: false }));
+    assert.equal(narrowed.allow_traffic_changes, false);
+    assert.equal(narrowed.allow_provider_upload, false);
+  });
+
+  it("raiseTrustHint is the ONE action a blocked gate offers", () => {
+    assert.equal(raiseTrustHint("bounded_experiments"), "understudy trust set bounded_experiments");
+  });
+});
+
+describe("born-accepted review default (no pending-first path)", () => {
+  it("default_decision is accept by default and for any absent/invalid sidecar", () => {
+    assert.equal(DEFAULT_REVIEW_POLICY.default_decision, "accept");
+    assert.equal(readReviewPolicy(tmp).default_decision, "accept", "absent sidecar → accept");
+    fs.writeFileSync(path.join(tmp, "review-policy.json"), JSON.stringify({ schema_version: "understudy.review_policy.v1", default_decision: "sometimes" }));
+    assert.equal(readReviewPolicy(tmp).default_decision, "accept", "unrecognized value → accept");
+    fs.writeFileSync(path.join(tmp, "review-policy.json"), JSON.stringify({ schema_version: "understudy.review_policy.v1", default_decision: "pending" }));
+    assert.equal(readReviewPolicy(tmp).default_decision, "pending", "pending remains available ONLY as explicit config");
+  });
+
+  it("no code path writes a pending-first review policy (explicit config only)", () => {
+    // The writer surface: grep-equivalent — reviewPolicyPath is read-only in src.
+    const srcFiles = fs
+      .readdirSync("src", { recursive: true })
+      .filter((f) => String(f).endsWith(".ts"))
+      .map((f) => fs.readFileSync(path.join("src", String(f)), "utf8"))
+      .join("\n");
+    assert.doesNotMatch(srcFiles, /default_decision"?\s*:\s*"pending"/, "nothing ships a pending-first policy");
+  });
+});


### PR DESCRIPTION
Implements the founder autonomy directive ("remove approval gates and have smart defaults") reconciled with the trust-ladder principle: per-action dialogs die; the few consequential boundaries — data leaves the machine, money spent, prod traffic — become **one-time posture choices**, visible and reversible.

## Trust posture (new)
- `src/config/trust.ts` — `understudy.trust_posture.v1` at `~/.understudy/trust.json`. Levels `local_sandbox` (default) < `bounded_experiments` < `hosted_ops`, plus per-boundary overrides `allow_provider_upload`, `allow_spend_usd_per_run`, `allow_traffic_changes`. Tolerant reads (junk never widens autonomy); explicit overrides beat level defaults; upload/traffic open only at `hosted_ops`; **spend has NO cap at any level** unless opted in.
- CLI: `understudy trust set <level> [--spend-stop-loss usd | --clear-spend-stop-loss | --allow/forbid-provider-upload | --allow/forbid-traffic-changes]` and `understudy trust show` (`src/commands/trust.ts`). Readable by app/MCP/Pi via the shared module. `UNDERSTUDY_TRUST_FILE` env seam for tests.

## Gates converted (before → after)
| Gate | Before | After |
| --- | --- | --- |
| Pi `queue_run` (spend-adjacent shapes) | blocked, per-call `confirm: true` dialog | posture check: at `bounded_experiments`+ proceeds with a **visible one-line notice** (arm count, task×rollout volume, rough est. cost); below, one-action guidance (`understudy trust set bounded_experiments`); `confirm: true` stays a per-call escape hatch |
| Pi `update_experiment` (approval/status/verdict) | blocked unless confirmed | same posture matrix, notice records the approval-adjacent change |
| Local trained-artifact arms | serve failure/OOM killed the run | machine-aware: `predictLocalFit` (onboarding `profile.json` / OS memory probe + the manage-local-models sizing ladder, `LOCAL_MODEL_LADDER` + `defaultLocalModelForMemory`); predicted OOM or serve failure → automatic gateway fallback on the artifact's base model, recorded (`arm_fallback` event + `fallback_reason` on every row) — never silent, unknowns always try |
| Spend | no cap code at all | still **no default caps**; posture's opt-in `allow_spend_usd_per_run` is a generous stop-loss: `spend_warning` at 1x (run continues), hard stop only at 2x (`spend_stop`, completed rows kept, additive `spend` stamp on the request) |
| Review policy | (verify) | verified born-accepted `default_decision:"accept"` is the only shipped default (hub, MCP, from-dataset writes no sidecar); `"pending"` remains explicit config only, with a regression test that nothing in `src/` ships a pending-first policy |

## Docs
- `docs/agent-operator-surface.md` + `skills/operate-benchmark-lab/SKILL.md` now describe the posture flow instead of the old confirm flow.
- `apps/homescreen` Rust untouched by design; docs note the app's upload-approval dialog as the natural one-time posture UI that should read `trust.json` (`allow_provider_upload`) in a follow-up.
- `docs/app-benchmark-bridge.md` does not exist on main (no stale confirm text found elsewhere).

## Tests
- `tests/trust-posture.test.mjs` — posture resolution matrix, tolerant reads, merge writes, born-accepted verification.
- `tests/benchmark-extension.test.mjs` — gate behavior at each level, notice surfacing on execute, block guidance.
- `tests/local-arms.test.mjs` — sizing helpers, predicted-OOM fallback with a fake profile, serve-failure fallback.
- `tests/spend-stop-loss.test.mjs` — no-cap default, warn path, 2x stop path.

All green: root `npm test` (950 pass), `tsc --noEmit`, hub tests (161) + `next build`, `skills:validate` (37 skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->