### PR TITLE
Desktop sidebar cleanup: unnest New chat, fix clipping, remove artifacts

### DIFF
--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { invoke, isTauri } from "@tauri-apps/api/core";
-import { PlusIcon } from "lucide-react";
+import { SquarePenIcon, UserRoundIcon } from "lucide-react";
 import { TooltipProvider } from "@/app/components/base-ui/tooltip";
 import { NAV_ITEMS, paneToNavId, type NavGroupId, type Scope } from "../lib/nav";
 import { NavGroup } from "./sidebar/NavGroup";
@@ -41,16 +41,8 @@ export type PaneId =
   | "training-rl"
   | "training-jobs";
 
-const AccountIcon = () => (
-  <svg viewBox="0 0 16 16" fill="none" className="nav-icon" aria-hidden="true">
-    <circle cx="8" cy="5.5" r="2.5" stroke="currentColor" strokeWidth="1.3" />
-    <path d="M3 14c.7-2.5 2.7-4 5-4s4.3 1.5 5 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-  </svg>
-);
-
 const GROUP_LABELS: Record<NavGroupId, string> = {
   organization: "Capture",
-  workload: "Workload",
   training: "Training",
   sessions: "Chats",
   manage: "Manage",
@@ -101,7 +93,7 @@ export function Sidebar({
   onSelectThread: (threadId: string) => void;
   onArchiveThread: (threadId: string) => Promise<boolean>;
 }) {
-  const activeNavId = paneToNavId(active, activeSessionId, activeThreadId);
+  const activeNavId = paneToNavId(active);
 
   // Bottom-left identity: prefer a real org name when the gateway exposes
   // one; fall back to a shortened org id ("org_ABCD…WXYZ"), then "Account".
@@ -146,53 +138,60 @@ export function Sidebar({
           onWorkloadSelected={() => onSelect("workload-config")}
         />
 
-        <NavGroup group="organization" label={GROUP_LABELS.organization}>
-          {itemsFor("organization")}
-        </NavGroup>
+        <button type="button" className="sidebar-new-chat" onClick={onNewChat}>
+          <SquarePenIcon className="nav-icon" aria-hidden="true" size={15} strokeWidth={1.8} />
+          New chat
+        </button>
 
-        <NavGroup group="training" label={GROUP_LABELS.training}>
-          {itemsFor("training")}
-          <TrainingThreadList
-            active={active}
-            trainingThreads={trainingThreads}
-            activeThreadId={activeThreadId}
-            archiveBusy={archiveBusy}
-            onSelectThread={onSelectThread}
-            onArchiveThread={onArchiveThread}
-          />
-        </NavGroup>
+        <div className="sidebar-nav">
+          <NavGroup group="organization" label={GROUP_LABELS.organization}>
+            {itemsFor("organization")}
+          </NavGroup>
 
-        <NavGroup group="sessions" label={GROUP_LABELS.sessions}>
-          <NavItem label="New chat" icon={PlusIcon} active={false} onSelect={onNewChat} />
-          <ChatSessionList
-            active={active}
-            sessions={sessions}
-            archivedSessions={archivedSessions}
-            activeSessionId={activeSessionId}
-            historyLoading={historyLoading}
-            historyError={historyError}
-            archiveBusy={archiveBusy}
-            archiveActiveDisabled={archiveActiveDisabled}
-            onSelectSession={onSelectSession}
-            onArchiveSession={onArchiveSession}
-            onRestoreSession={onRestoreSession}
-            onArchiveAll={onArchiveAll}
-          />
-          {itemsFor("sessions")}
-        </NavGroup>
+          <NavGroup group="training" label={GROUP_LABELS.training}>
+            {itemsFor("training")}
+            <TrainingThreadList
+              active={active}
+              trainingThreads={trainingThreads}
+              activeThreadId={activeThreadId}
+              archiveBusy={archiveBusy}
+              onSelectThread={onSelectThread}
+              onArchiveThread={onArchiveThread}
+            />
+          </NavGroup>
 
-        <NavGroup group="manage" label={GROUP_LABELS.manage}>
-          {itemsFor("manage")}
-        </NavGroup>
+          <NavGroup group="sessions" label={GROUP_LABELS.sessions}>
+            <ChatSessionList
+              active={active}
+              sessions={sessions}
+              archivedSessions={archivedSessions}
+              activeSessionId={activeSessionId}
+              historyLoading={historyLoading}
+              historyError={historyError}
+              archiveBusy={archiveBusy}
+              archiveActiveDisabled={archiveActiveDisabled}
+              onSelectSession={onSelectSession}
+              onArchiveSession={onArchiveSession}
+              onRestoreSession={onRestoreSession}
+              onArchiveAll={onArchiveAll}
+            />
+            {itemsFor("sessions")}
+          </NavGroup>
 
-        <div className="nav-spacer" />
+          <NavGroup group="manage" label={GROUP_LABELS.manage}>
+            {itemsFor("manage")}
+          </NavGroup>
+        </div>
+
         <button
           className={"nav-account" + (active === "account" ? " active" : "")}
           onClick={() => onSelect("account")}
         >
-          <AccountIcon />
+          <UserRoundIcon className="nav-icon" aria-hidden="true" size={16} strokeWidth={1.6} />
           <span className="nav-account-copy">
-            <span>{orgLabel ?? "Account"}</span>
+            <span className="nav-account-name" title={orgLabel ?? undefined}>
+              {orgLabel ?? "Account"}
+            </span>
             <span className="nav-account-status">
               <span className={"dot" + (connected ? " running" : "")} />
               {connected ? "Connected" : "Disconnected"}

--- a/apps/homescreen/app/components/sidebar/ChatSessionList.tsx
+++ b/apps/homescreen/app/components/sidebar/ChatSessionList.tsx
@@ -47,26 +47,31 @@ export function ChatSessionList({
   const [showArchived, setShowArchived] = useState(false);
   const [archiveAllOpen, setArchiveAllOpen] = useState(false);
   const visibleSessions = showArchived ? archivedSessions : sessions;
+  // Nothing to list or toggle: skip the heading entirely instead of leaving
+  // a stray archive button floating under the group label.
+  const showHeading = showArchived || sessions.length > 0 || archivedSessions.length > 0;
 
   return (
     <>
-      <div className="chat-nav-heading">
-        <div className="nav-section">{showArchived ? "Archived" : ""}</div>
-        <button
-          type="button"
-          className="chat-nav-view-toggle"
-          onClick={() => setShowArchived((value) => !value)}
-          aria-label={showArchived ? "Back to chats" : "View archived chats"}
-          title={showArchived ? "Back to chats" : "View archived chats"}
-        >
-          {showArchived ? (
-            <ArrowLeftIcon aria-hidden="true" size={14} strokeWidth={1.8} />
-          ) : (
-            <ArchiveIcon aria-hidden="true" size={14} strokeWidth={1.8} />
-          )}
-          <span>{showArchived ? "Chats" : archivedSessions.length || ""}</span>
-        </button>
-      </div>
+      {showHeading && (
+        <div className="chat-nav-heading">
+          <div className="nav-section">{showArchived ? "Archived" : "Recent"}</div>
+          <button
+            type="button"
+            className="chat-nav-view-toggle"
+            onClick={() => setShowArchived((value) => !value)}
+            aria-label={showArchived ? "Back to chats" : "View archived chats"}
+            title={showArchived ? "Back to chats" : "View archived chats"}
+          >
+            {showArchived ? (
+              <ArrowLeftIcon aria-hidden="true" size={14} strokeWidth={1.8} />
+            ) : (
+              <ArchiveIcon aria-hidden="true" size={14} strokeWidth={1.8} />
+            )}
+            <span>{showArchived ? "Chats" : archivedSessions.length || ""}</span>
+          </button>
+        </div>
+      )}
 
       {historyError && (
         <div className="chat-nav-error" role="alert">

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -347,8 +347,8 @@ select,
 .sidebar {
   background: var(--surface);
   border-right: 1px solid var(--border);
-  display: flex;
   flex-direction: column;
+  min-height: 0;
   padding: calc(var(--titlebar-h) + 10px) 10px 14px;
   gap: 4px;
   display: none;
@@ -357,9 +357,50 @@ select,
   display: flex;
 }
 
-.chat-nav-heading {
+/* Primary action: always visible at the top of the rail, never nested. */
+.sidebar-new-chat {
   display: flex;
   align-items: center;
+  gap: 8px;
+  flex: none;
+  min-height: 32px;
+  margin: 2px 8px 4px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--model-mint) 26%, var(--border));
+  border-radius: var(--r-control);
+  background: color-mix(in srgb, var(--model-mint) 8%, transparent);
+  color: var(--model-mint);
+  font-size: 12.5px;
+  cursor: pointer;
+  text-align: left;
+}
+.sidebar-new-chat:hover,
+.sidebar-new-chat:focus-visible {
+  background: color-mix(in srgb, var(--model-mint) 15%, transparent);
+  outline: none;
+}
+
+/* The nav groups scroll as one region so the account footer stays pinned
+   and nothing overlaps or clips when the window is short. */
+.sidebar-nav {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  scrollbar-width: none;
+}
+.sidebar-nav::-webkit-scrollbar {
+  display: none;
+}
+.sidebar-nav .nav-group {
+  flex: none;
+}
+
+.chat-nav-heading {
+  display: flex;
+  align-items: flex-end;
   justify-content: space-between;
   gap: 8px;
   padding-right: 4px;
@@ -379,7 +420,6 @@ select,
   gap: 4px;
   min-width: 28px;
   height: 26px;
-  margin-top: 8px;
   border: 0;
   border-radius: 7px;
   background: transparent;
@@ -642,11 +682,8 @@ select,
   opacity: 0.9;
 }
 
-.nav-spacer {
-  flex: 1;
-}
-
 .nav-account {
+  flex: none;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -674,6 +711,11 @@ select,
   min-width: 0;
   display: grid;
   gap: 2px;
+}
+.nav-account-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .nav-account-status {
   display: flex;

--- a/apps/homescreen/app/lib/nav.ts
+++ b/apps/homescreen/app/lib/nav.ts
@@ -19,7 +19,6 @@ export type Scope = { projectId: string | null; workloadId: string | null };
 
 export type NavGroupId =
   | "organization"
-  | "workload"
   | "training"
   | "sessions"
   | "manage";
@@ -60,8 +59,9 @@ export const NAV_ITEMS: NavItemDef[] = [
   { id: "workload-captures", group: "organization", label: "Captures", icon: Inbox, pane: "captures", requiresWorkload: true },
   // Training
   { id: "training-overview", group: "training", label: "Overview", icon: FlaskConical, pane: "training-jobs" },
-  // Chats (Explore is an ordinary row; New chat is rendered separately)
-  { id: "chats-explore", group: "sessions", label: "Explore Data", icon: Compass, pane: "explore" },
+  // Chats (Explore is an ordinary row; New chat is the sidebar's primary
+  // action, rendered at the top of the rail rather than inside this group)
+  { id: "chats-explore", group: "sessions", label: "Explore data", icon: Compass, pane: "explore" },
   // Manage
   // "Models" is Aamir's catalog surface (web /models). The desktop-native
   // local model library pane still exists but is reachable only via deep-link.
@@ -79,15 +79,9 @@ export const NAV_ITEMS: NavItemDef[] = [
  * Chat sessions and training threads keep their own compound active checks
  * inside ChatSessionList / TrainingThreadList (deliberately not generalized).
  */
-export function paneToNavId(
-  pane: PaneId,
-  activeSessionId: string | null,
-  activeThreadId: string | null,
-): string | null {
+export function paneToNavId(pane: PaneId): string | null {
   if (pane === "chat") {
     // Session/thread rows own the active state when one is selected.
-    void activeSessionId;
-    void activeThreadId;
     return null;
   }
   const item = NAV_ITEMS.find((entry) => entry.pane === pane);

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -200,12 +200,12 @@ export default function Page() {
     storeScope(next);
   }, []);
 
-  const newChat = () => {
-    if (pane !== "chat") return;
+  const newChat = useCallback(() => {
+    setPane("chat");
     setRequestedChatSession(null);
     setActiveChatSessionId(null);
     setChatResetToken((token) => token + 1);
-  };
+  }, []);
 
   const openFirstRunSignIn = useCallback((downloadAfterSignIn: boolean) => {
     setSignInIntent({ returnToChat: true, downloadAfterSignIn });
@@ -278,13 +278,12 @@ export default function Page() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!event.metaKey || event.shiftKey || event.altKey || event.ctrlKey) return;
       if (event.key.toLowerCase() !== "n") return;
-      if (pane !== "chat") return;
       event.preventDefault();
       newChat();
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [pane]);
+  }, [newChat]);
 
   return (
     <div className={"shell" + (railOpen ? " rail-open" : "")}>
@@ -299,17 +298,15 @@ export default function Page() {
         <PanelLeftIcon aria-hidden="true" size={16} strokeWidth={2} />
       </button>
       {pane === "chat" && (
-        <>
-          <button
-            type="button"
-            className="titlebar-new-chat"
-            aria-label="New chat"
-            title="New chat (Cmd+N)"
-            onClick={newChat}
-          >
-            <SquarePenIcon aria-hidden="true" size={15} strokeWidth={2} />
-          </button>
-        </>
+        <button
+          type="button"
+          className="titlebar-new-chat"
+          aria-label="New chat"
+          title="New chat (Cmd+N)"
+          onClick={newChat}
+        >
+          <SquarePenIcon aria-hidden="true" size={15} strokeWidth={2} />
+        </button>
       )}
       <DownloadQrButton />
       <div className="operation-notice-stack">
@@ -328,12 +325,7 @@ export default function Page() {
         connected={connected}
         scope={scope}
         onScopeChange={handleScopeChange}
-        onNewChat={() => {
-          setPane("chat");
-          setRequestedChatSession(null);
-          setActiveChatSessionId(null);
-          setChatResetToken((token) => token + 1);
-        }}
+        onNewChat={newChat}
         sessions={chatHistory}
         archivedSessions={archivedChatHistory}
         activeSessionId={activeChatSessionId}

--- a/tests/desktop-ui-lineage.test.mjs
+++ b/tests/desktop-ui-lineage.test.mjs
@@ -240,9 +240,9 @@ test("public desktop preserves the reviewed Train interaction language", async (
   );
   assert.match(chat, /msg\.stage === "cloud_fallback_local"/);
 
-  // "Chats" is now the nav group label; the heading only flips to "Archived".
+  // "Chats" is now the nav group label; the heading flips Recent/Archived.
   assert.match(sidebar, /sessions: "Chats"/);
-  assert.match(sidebar, /<div className="nav-section">\{showArchived \? "Archived" : ""\}<\/div>/);
+  assert.match(sidebar, /<div className="nav-section">\{showArchived \? "Archived" : "Recent"\}<\/div>/);
   assert.match(sidebar, /aria-label=\{showArchived \? "Archived chats" : "Recent chats"\}/);
   assert.match(sidebar, /visibleSessions\.map\(\(session\) =>/);
   assert.match(sidebar, /onSelectSession\(session\.session_id\)/);


### PR DESCRIPTION
Founder feedback before release: "its a huge mess right now. we need to unnest new chat, avoid clipping, and overall it has a ton of artifacts and all."

Diagnosed against the rendered app (`next dev` + headless Chrome; Tauri invokes stubbed out, so lists render empty but layout/overflow behavior is real).

## Unnest New chat
- New chat was a row buried inside the collapsible **Chats** group. It is now a top-level primary action (mint accent, `SquarePen` icon) pinned directly under the scope switcher — always visible, never collapsed away.
- Cmd+N previously only worked while already on the chat pane; it now starts a new chat from any pane. Sidebar button, titlebar button, and shortcut share one `newChat` handler.

## Clipping / overlap
- The sidebar column had no overflow handling: in short windows the collapsible groups compressed **on top of each other** (group labels rendered over item rows), and the account footer overlapped/clipped the last Manage rows ("Setup" was half-hidden at 800px height). Nav groups now live in a scrollable `.sidebar-nav` region (`flex:1; min-height:0; overflow-y:auto`, groups `flex:none`), with the account footer pinned below it.
- Long org names in the account footer now truncate with ellipsis + `title` tooltip.

## Artifacts removed
- Stray floating archive icon: with zero chats, the Chats group rendered an empty `nav-section` div plus an unlabeled archive toggle hanging in space. The heading is now hidden when there is nothing to list, and labeled **Recent**/**Archived** otherwise (removed the `margin-top: 8px` alignment hack too).
- Duplicate `display: flex` / `display: none` declarations in the `.sidebar` rule.
- Dead `"workload"` nav group id + `GROUP_LABELS.workload` (no NAV_ITEMS ever used it).
- `.nav-spacer` element/rule (obsolete once the nav region scrolls).
- Hand-rolled inline account SVG — the only non-lucide icon in the rail; replaced with lucide `UserRound`.
- Vestigial `paneToNavId(pane, activeSessionId, activeThreadId)` params that were immediately `void`ed.
- Empty `<>…</>` fragment around the titlebar new-chat button in `page.tsx`.
- Casing inconsistency: "Explore Data" → "Explore data" (all other items are sentence case).

IA untouched (same groups, same order, same panes); design-language v2.0 respected (mint operational accent for the primary action, IBM Plex mono group labels unchanged). Existing a11y affordances (aria-labels, focus-visible rings, tooltips) preserved.

## Verification
- `tsc --noEmit` (homescreen + root): clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: pass
- root `npm test`: 971/971 (one lineage test intentionally updated — it pinned the old empty-heading markup)
- `npm run skills:validate`: ok 37 skills
- Before/after screenshots taken at 1200x800 and 1200x540; the 540px "before" shows the group-overlap mess, the "after" scrolls cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->