### PR TITLE
Workload intake: drop a folder, Pi profiles it and proposes a benchmark

### DIFF
--- a/apps/homescreen/app/components/ChatPane.tsx
+++ b/apps/homescreen/app/components/ChatPane.tsx
@@ -76,6 +76,7 @@ import {
   isWorkloadDropBusy,
   shouldInspectDroppedTable,
   shouldInspectStructuredDataset,
+  workloadHandoffPrompt,
   workloadDropPersonaState,
   workloadDropReducer,
   workloadDropStatus,
@@ -1369,6 +1370,9 @@ export function ChatPane({
   const wasTrainingActive = useRef(false);
   const dropInFlight = useRef(false);
   const dropRequestGeneration = useRef(0);
+  // Fresh `send` for the drag-drop effect (its dep array is deliberately
+  // narrow, so calling `send` directly from there would capture stale state).
+  const sendRef = useRef<((text: string) => Promise<void>) | null>(null);
   const environmentArchitectAttempted = useRef<string | null>(null);
   const customCompileAttempted = useRef<string | null>(null);
   const environmentArchitectDraftRef = useRef("");
@@ -1998,14 +2002,29 @@ export function ChatPane({
       })
         .then(async (result) => {
           if (disposed || dropRequestGeneration.current !== requestGeneration) return;
+          const inspectTable = shouldInspectDroppedTable(result);
+          const inspectStructured = shouldInspectStructuredDataset(result);
+          if (!inspectTable && !inspectStructured) {
+            // Directories and non-table files have no deterministic training
+            // flow — handing them to the in-chat agent (which carries the
+            // benchmark-lab profile_workload/from_dataset tools) instead of
+            // opening a training thread that nothing would ever advance.
+            dispatchDrop({ type: "succeeded" });
+            dispatchDrop({ type: "reset" });
+            const handoff = sendRef.current;
+            if (handoff) {
+              void handoff(workloadHandoffPrompt(result));
+            } else {
+              setNotice("Workload draft created locally; ask in chat to profile it.");
+            }
+            return;
+          }
           setDroppedWorkload(result);
           // Dropping data creates the thread immediately (status active) so
           // a mid-flow restart can resume this flow from the nav.
           const threadId = crypto.randomUUID();
           setTrainingThreadId(threadId);
           void persistTrainingThread(threadId, result, null, "active");
-          const inspectTable = shouldInspectDroppedTable(result);
-          const inspectStructured = shouldInspectStructuredDataset(result);
           if (inspectStructured) {
             dispatchDrop({ type: "inspection_started" });
             try {
@@ -2020,7 +2039,7 @@ export function ChatPane({
                 throw error;
               }
             }
-          } else if (inspectTable) {
+          } else {
             dispatchDrop({ type: "inspection_started" });
             try {
               await inspectCsvWorkload(result, requestGeneration);
@@ -2030,13 +2049,6 @@ export function ChatPane({
               dispatchDrop({ type: "succeeded" });
               setNotice("Workload draft created locally; this file is not a supported table.");
             }
-          } else {
-            dispatchDrop({ type: "succeeded" });
-            setNotice(
-              result.truncated
-                ? "Workload draft created at the safety limit; no file contents were read."
-                : "Workload draft created locally; no file contents were read.",
-            );
           }
         })
         .catch((error) => {
@@ -2842,6 +2854,7 @@ export function ChatPane({
       setAssistantSpeaking(false);
     }
   };
+  sendRef.current = (text: string) => send(text);
 
   const connectAnthropic = async () => {
     const key = window.prompt(

--- a/apps/homescreen/app/lib/workload-drop-state.d.mts
+++ b/apps/homescreen/app/lib/workload-drop-state.d.mts
@@ -40,6 +40,12 @@ export function shouldInspectStructuredDataset(workload: {
   source_name?: string | null;
 } | null): boolean;
 
+export function workloadHandoffPrompt(workload: {
+  source_path?: string | null;
+  source_type?: string | null;
+  scanned_file_count?: number | null;
+} | null): string;
+
 export function workloadDropReducer(
   phase: WorkloadDropPhase,
   action: WorkloadDropAction,

--- a/apps/homescreen/app/lib/workload-drop-state.mjs
+++ b/apps/homescreen/app/lib/workload-drop-state.mjs
@@ -44,6 +44,26 @@ export function shouldInspectStructuredDataset(workload) {
 // Compatibility alias for older Desktop lineage checks and integrations.
 export const shouldInspectTrainingRecipe = shouldInspectStructuredDataset;
 
+/**
+ * The chat message that hands a non-inspectable drop (a directory, or a file
+ * with no deterministic training flow) to the in-chat agent, which carries
+ * the benchmark-lab profile_workload / from_dataset tools. The prompt states
+ * the contract explicitly: profile → discuss → user confirms → proposed
+ * benchmark in the review inbox — the agent never queues a run from a drop.
+ */
+export function workloadHandoffPrompt(workload) {
+  const path = String(workload?.source_path ?? "").trim();
+  const kind = workload?.source_type === "directory" ? "folder" : "file";
+  const scanned = Number(workload?.scanned_file_count ?? 0);
+  const scannedNote = scanned > 0 ? ` (${scanned} file${scanned === 1 ? "" : "s"} scanned locally, contents unread)` : "";
+  return (
+    `I dropped the ${kind} \`${path}\` into the chat${scannedNote}. ` +
+    "Profile it with profile_workload and tell me what this workload appears to be and which labeled dataset files you found. " +
+    "Then help me pick the right dataset and columns, and once I confirm, compile it with from_dataset into a proposed benchmark " +
+    "so I can review its tasks and start a benchmark run. Don't queue any runs until I've reviewed the proposal."
+  );
+}
+
 const BUSY_PHASES = new Set(["validating", "compiling", "inspecting", "preparing_dataset"]);
 
 /**

--- a/apps/homescreen/src-tauri/src/db.rs
+++ b/apps/homescreen/src-tauri/src/db.rs
@@ -1339,6 +1339,25 @@ impl Db {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
+    /// Startup reconcile: an "active" thread nobody has touched in
+    /// `stale_after_hours` is an abandoned or crashed flow, not live work —
+    /// mark it dismissed in the store instead of leaving the sidebar to hide
+    /// it cosmetically forever. Returns how many threads transitioned.
+    pub fn reconcile_stale_training_threads(&self, stale_after_hours: i64) -> Result<usize> {
+        let conn = self.conn()?;
+        let cutoff = chrono::Utc::now() - chrono::Duration::hours(stale_after_hours.max(1));
+        let changed = conn.execute(
+            "UPDATE training_threads
+             SET status='dismissed', updated_at=?2
+             WHERE status='active' AND updated_at < ?1",
+            rusqlite::params![
+                cutoff.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+                now_iso()
+            ],
+        )?;
+        Ok(changed)
+    }
+
     /// Archive = mark dismissed. Completed threads keep their audit-trail
     /// status; only active threads transition.
     pub fn archive_training_thread(&self, thread_id: &str) -> Result<bool> {
@@ -1610,6 +1629,33 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let db = Db::open(dir.clone()).expect("open temp db");
         (dir, db)
+    }
+
+    #[test]
+    fn reconcile_dismisses_only_stale_active_threads() {
+        let (dir, db) = temp_db("reconcile-stale");
+        db.save_training_thread("fresh", "fresh", "/tmp/a", "{}", "null", "active")
+            .unwrap();
+        db.save_training_thread("stale", "stale", "/tmp/b", "{}", "null", "active")
+            .unwrap();
+        db.save_training_thread("done", "done", "/tmp/c", "{}", "null", "completed")
+            .unwrap();
+        // Backdate the stale-active and the completed thread past the cutoff.
+        let conn = db.conn().unwrap();
+        conn.execute(
+            "UPDATE training_threads SET updated_at='2020-01-01T00:00:00Z' WHERE thread_id IN ('stale','done')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert_eq!(db.reconcile_stale_training_threads(24).unwrap(), 1);
+        assert_eq!(db.training_thread("stale").unwrap().unwrap().status, "dismissed");
+        assert_eq!(db.training_thread("fresh").unwrap().unwrap().status, "active");
+        assert_eq!(db.training_thread("done").unwrap().unwrap().status, "completed");
+        // Idempotent on the second pass.
+        assert_eq!(db.reconcile_stale_training_threads(24).unwrap(), 0);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -132,6 +132,15 @@ pub fn run() {
             let db_started = Instant::now();
             let db = db::Db::open(data_dir).expect("understudy database opened");
             let db_ms = db_started.elapsed().as_millis();
+            // Abandoned/crashed training flows must not stay "active" forever:
+            // reconcile them to dismissed in the store (the sidebar previously
+            // only hid them cosmetically). 24h comfortably exceeds any real
+            // local training or review session.
+            match db.reconcile_stale_training_threads(24) {
+                Ok(0) => {}
+                Ok(n) => eprintln!("understudy: reconciled {n} stale active training thread(s) to dismissed"),
+                Err(e) => eprintln!("understudy: training-thread reconcile skipped: {e}"),
+            }
             app.manage(db);
             app.manage(metrics::MetricsReader::new());
             app.manage(machine);

--- a/skills/operate-benchmark-lab/SKILL.md
+++ b/skills/operate-benchmark-lab/SKILL.md
@@ -71,6 +71,14 @@ MCP registration (Claude Code `~/.claude.json` → `mcpServers`):
 
 ## The lifecycle
 
+0. **Intake (dropped workloads).** When the user drops a folder or file into
+   the chat (or names a local path), `profile_workload` scans it locally
+   (payloads unread, nothing leaves the machine) and lists
+   foundry-consumable dataset candidates. Discuss what the workload is,
+   confirm the dataset and label/input columns with the user, then
+   `from_dataset` compiles it into a PROPOSED benchmark (review-pending,
+   `executable: false`) whose tasks land in the review inbox. Never queue a
+   run from an intake — the user reviews the proposal first (step 2).
 1. **Build.** Captured traces → `understudy traces build-benchmark`, then
    `understudy traces author-tasks` (gateway) for legible task definitions.
    The generated environment already ships the fixtures pre/post split

--- a/src/benchmark-artifacts.ts
+++ b/src/benchmark-artifacts.ts
@@ -35,6 +35,8 @@ const asObject = (value: unknown): Obj =>
 /* ------------------------------------------------------------------ */
 
 export const TRACE_FOUNDRY_SCHEMA = "understudy.trace_foundry.v1";
+/** Sibling foundry manifest for dataset-derived benchmarks (see dataset-foundry.ts SCHEMA DECISION). */
+export const DATASET_FOUNDRY_SCHEMA = "understudy.dataset_foundry.v1";
 export const BENCHMARK_SCHEMA = "understudy.benchmark.v1";
 /** Pre-promotion machine proposal (post schema-name-collision rename). */
 export const BENCHMARK_PROPOSAL_SCHEMA = "understudy.benchmark_proposal.v1";

--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -17,6 +17,7 @@ import {
   BENCHMARK_FLAG_SCHEMA,
   BENCHMARK_TASK_SCHEMA,
   CALIBRATION_SCHEMA,
+  DATASET_FOUNDRY_SCHEMA,
   EVAL_RESULT_SCHEMA,
   PROMOTION_RECORD_SCHEMA,
   SOURCE_DAG_SCHEMA,
@@ -266,7 +267,12 @@ export function loadProposedEntryFromDir(
   } catch {
     return null;
   }
-  if (foundry?.schema_version !== TRACE_FOUNDRY_SCHEMA) return null;
+  // Both foundry entrances land on the same proposed spine: trace-derived
+  // dirs carry understudy.trace_foundry.v1, dataset-derived dirs the sibling
+  // understudy.dataset_foundry.v1 (see dataset-foundry.ts SCHEMA DECISION).
+  if (foundry?.schema_version !== TRACE_FOUNDRY_SCHEMA && foundry?.schema_version !== DATASET_FOUNDRY_SCHEMA) {
+    return null;
+  }
   const tasksPath = path.join(dir, "tasks.jsonl");
   if (!fs.existsSync(tasksPath)) return null;
 

--- a/src/benchmarks-mcp.ts
+++ b/src/benchmarks-mcp.ts
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, extname, join, resolve } from "node:path";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -38,6 +38,8 @@ import type { AnyHubEntry, CalibrationSummary, EvalRow, FoundryTask, ProposedHub
 import { REVIEW_DECISIONS, taskDisplayName } from "./benchmark-hub-types.js";
 import { isAnomalousEvalRow, liveJournalPath, readRunRequest, runRequestPath, RUN_SPLITS } from "./run-executor.js";
 import { accumulateReplay, type OracleReplay, type ReplayCall } from "./benchmark-replay.js";
+import { compileCaptureImport } from "./capture-import.js";
+import { compileDatasetFoundry, type DatasetFoundryOptions } from "./dataset-foundry.js";
 
 type Obj = Record<string, unknown>;
 const asObject = (v: unknown): Obj => (v !== null && typeof v === "object" && !Array.isArray(v) ? (v as Obj) : {});
@@ -606,6 +608,126 @@ function toolListExperiments(args: Obj): unknown {
   return listExperiments(entry.dir);
 }
 
+/* ---------------- workload intake: profile + dataset foundry ---------------- */
+
+/** Extensions dataset-foundry can load (mirrors its DATA_EXTENSIONS). */
+const DATASET_EXTENSIONS = new Set([".jsonl", ".ndjson", ".csv", ".tsv", ".xlsx"]);
+const MAX_DATASET_CANDIDATES = 50;
+const MAX_CANDIDATE_SCAN_DEPTH = 3;
+const SKIPPED_SCAN_DIRS = new Set(["node_modules", ".git", ".venv", "__pycache__", "dist", "build"]);
+
+function datasetCandidates(root: string, depth = 0, found: string[] = []): string[] {
+  if (depth > MAX_CANDIDATE_SCAN_DEPTH || found.length >= MAX_DATASET_CANDIDATES) return found;
+  let names: string[];
+  try {
+    names = readdirSync(root).sort();
+  } catch {
+    return found;
+  }
+  for (const name of names) {
+    if (found.length >= MAX_DATASET_CANDIDATES) break;
+    if (name.startsWith(".") || SKIPPED_SCAN_DIRS.has(name)) continue;
+    const full = join(root, name);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) datasetCandidates(full, depth + 1, found);
+    else if (stat.isFile() && DATASET_EXTENSIONS.has(extname(name).toLowerCase())) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Profile a dropped file or directory with the SAME local-only scanner the
+ * desktop drop path uses (`understudy capture-import compile`): writes
+ * workload-card.json / capture-sources.json under ~/.understudy/capture-imports
+ * and returns the compile summary plus any dataset files the foundry could
+ * consume. Payloads are never read; nothing leaves the machine.
+ */
+function toolProfileWorkload(args: Obj): unknown {
+  const path = resolve(requireString(args, "path"));
+  if (!existsSync(path)) throw new ToolError(`path does not exist: ${path}`);
+  const stat = statSync(path);
+  if (!stat.isFile() && !stat.isDirectory()) throw new ToolError(`path must be a file or directory: ${path}`);
+  const outputRoot = optionalString(args, "output_root");
+  const compiled = outputRoot
+    ? compileCaptureImport(path, new Date(), resolve(outputRoot))
+    : compileCaptureImport(path);
+  const candidates = stat.isDirectory()
+    ? datasetCandidates(path)
+    : DATASET_EXTENSIONS.has(extname(path).toLowerCase())
+      ? [path]
+      : [];
+  return {
+    ...compiled,
+    dataset_candidates: candidates,
+    dataset_candidates_truncated: candidates.length >= MAX_DATASET_CANDIDATES,
+    next:
+      candidates.length > 0
+        ? "Inspect the workload card, confirm the labeled dataset with the user, then call from_dataset to compile a proposed benchmark (tasks land in the review inbox — nothing runs)."
+        : "No foundry-consumable dataset files (.jsonl/.csv/.tsv/.xlsx) found; discuss with the user what the workload's ground truth is before proposing a benchmark.",
+  };
+}
+
+const SLUG_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+function hubPrimaryRoot(): string {
+  const roots = (process.env.BENCHMARK_HUB_DATA_DIR ?? join(homedir(), ".understudy", "benchmarks"))
+    .split(":")
+    .filter(Boolean);
+  return roots[0] ?? join(homedir(), ".understudy", "benchmarks");
+}
+
+function optionalString(args: Obj, key: string): string | undefined {
+  const v = args[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== "string" || v.length === 0) throw new ToolError(`${key} must be a non-empty string when provided`);
+  return v;
+}
+
+/**
+ * `understudy benchmarks from-dataset` behind the tool codec: compile a
+ * labeled dataset into a PROPOSED benchmark under the primary hub root. The
+ * output is machine_compiled_review_pending with executable:false and
+ * human_final_judgment among its promotion blockers — creating it queues
+ * nothing and spends nothing; the user confirms via the task inbox.
+ */
+function toolFromDataset(args: Obj): unknown {
+  const source = resolve(requireString(args, "source"));
+  if (!existsSync(source)) throw new ToolError(`source does not exist: ${source}`);
+  const slug = requireString(args, "slug");
+  if (!SLUG_RE.test(slug)) {
+    throw new ToolError("slug must be lowercase [a-z0-9._-], start alphanumeric, max 64 chars");
+  }
+  const dir = join(hubPrimaryRoot(), slug);
+  if (existsSync(dir)) throw new ToolError(`benchmark dir already exists: ${dir} (pick a new slug)`);
+  const options: DatasetFoundryOptions = {};
+  const name = optionalString(args, "name");
+  if (name) options.name = name;
+  const labelColumn = optionalString(args, "label_column");
+  if (labelColumn) options.labelColumn = labelColumn;
+  if (args.input_columns !== undefined) {
+    if (!Array.isArray(args.input_columns) || args.input_columns.some((c) => typeof c !== "string" || c.length === 0)) {
+      throw new ToolError("input_columns must be an array of non-empty strings when provided");
+    }
+    options.inputColumns = args.input_columns as string[];
+  }
+  const groupColumn = optionalString(args, "group_column");
+  if (groupColumn) options.groupColumn = groupColumn;
+  const systemPrompt = optionalString(args, "system_prompt");
+  if (systemPrompt) options.systemPrompt = systemPrompt;
+  const result = compileDatasetFoundry(source, dir, options);
+  // Hub slugs are <root-prefix>--<dir-name>: the first BENCHMARK_HUB_DATA_DIR
+  // root gets prefix "data"; the ~/.understudy/benchmarks default gets "local"
+  // (benchmark-hub-core slugRoots). Return the resolvable slug so the caller
+  // can read_benchmark / read_task immediately.
+  const prefix = process.env.BENCHMARK_HUB_DATA_DIR ? "data" : "local";
+  return { ok: true, slug: `${prefix}--${slug}`, dir, result };
+}
+
 /* ---------------- MCP wiring ---------------- */
 
 export const BENCHMARKS_TOOLS = [
@@ -819,6 +941,44 @@ export const BENCHMARKS_TOOLS = [
     },
   },
   {
+    name: "profile_workload",
+    description:
+      "Profile a dropped file or directory with the local-only capture-import scanner (same as the desktop " +
+      "drop path): classifies every file, writes workload-card.json + capture-sources.json under " +
+      "~/.understudy/capture-imports, and lists dataset files (.jsonl/.csv/.tsv/.xlsx) the foundry could " +
+      "consume. Payload bytes are never read as model input and nothing leaves the machine.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "Absolute path to the dropped file or directory." },
+        output_root: { type: "string", description: "Override artifact root (default ~/.understudy/capture-imports)." },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "from_dataset",
+    description:
+      "Compile one labeled dataset (file, or directory containing exactly one data file) into a PROPOSED " +
+      "benchmark under the primary hub root — the same `understudy benchmarks from-dataset` foundry: curated " +
+      "normalized captures, grouped train/dev/holdout splits, a verifiers environment, and machine_proposed " +
+      "tasks awaiting the user's review in the task inbox. Creates review-pending artifacts only: " +
+      "executable:false, human_final_judgment blocked — never queues a run, never spends.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source: { type: "string", description: "Absolute path to the dataset file or its directory." },
+        slug: { type: "string", description: "New benchmark slug (lowercase [a-z0-9._-]); becomes the dir name under the hub root." },
+        name: { type: "string", description: "Human benchmark name; defaults from the source filename." },
+        label_column: { type: "string", description: "Label/target column; inferred when omitted." },
+        input_columns: { type: "array", items: { type: "string" }, description: "Input columns; inferred when omitted." },
+        group_column: { type: "string", description: "Leakage-group column; defaults to the normalized input text." },
+        system_prompt: { type: "string", description: "Literal system prompt recorded for the workload." },
+      },
+      required: ["source", "slug"],
+    },
+  },
+  {
     name: "run_status",
     description:
       "Status of a queued/running/finished run request plus a row summary (per model and per task) as " +
@@ -843,6 +1003,8 @@ export function callBenchmarksTool(name: string, args: Obj): unknown {
     case "apply_auto_accepts": return toolApplyAutoAccepts(args);
     case "submit_feedback": return toolSubmitFeedback(args);
     case "queue_run": return toolQueueRun(args);
+    case "profile_workload": return toolProfileWorkload(args);
+    case "from_dataset": return toolFromDataset(args);
     case "run_status": return toolRunStatus(args);
     case "create_experiment": return toolCreateExperiment(args);
     case "update_experiment": return toolUpdateExperiment(args);

--- a/src/dataset-foundry.ts
+++ b/src/dataset-foundry.ts
@@ -42,7 +42,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSy
 import { createHash } from "node:crypto";
 import { basename, extname, join, resolve } from "node:path";
 import { readCaptureDelimitedTable, inferTableMapping } from "./capture-import.js";
-import { parseJsonlText, toPortablePath } from "./benchmark-artifacts.js";
+import { DATASET_FOUNDRY_SCHEMA, parseJsonlText, toPortablePath } from "./benchmark-artifacts.js";
 import { benchmarkManifestFrom, runFoundrySelfCheck, writeVerifiersEnvironment } from "./trace-foundry.js";
 import { validateBenchmarkManifest } from "./benchmark.js";
 
@@ -52,7 +52,9 @@ const hash = (value: unknown): string => createHash("sha256").update(JSON.string
 function writeJson(path: string, value: unknown): void { mkdirSync(resolve(path, ".."), { recursive: true }); writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 }); }
 function writeJsonl(path: string, rows: unknown[]): void { mkdirSync(resolve(path, ".."), { recursive: true }); writeFileSync(path, rows.map((row) => JSON.stringify(row)).join("\n") + (rows.length > 0 ? "\n" : ""), { mode: 0o600 }); }
 
-export const DATASET_FOUNDRY_SCHEMA = "understudy.dataset_foundry.v1";
+// Schema id lives in benchmark-artifacts.ts (the single home for schema
+// literals); re-exported here so existing importers keep working.
+export { DATASET_FOUNDRY_SCHEMA } from "./benchmark-artifacts.js";
 export const DATASET_CURATION_SCHEMA = "understudy.dataset_curation.v1";
 
 /** Verifiers commit the generated environment pins (same as the trace foundry). */

--- a/src/runtime/conversation/benchmark-extension.ts
+++ b/src/runtime/conversation/benchmark-extension.ts
@@ -1,8 +1,8 @@
 // Benchmark-lab operator tools for the embedded Pi conversation runtime.
 //
 // The desktop app's in-app chat becomes the self-service operator over the
-// same file-based benchmark/experiment spine the 13-tool benchmarks MCP
-// server exposes to external coding agents. Every tool here delegates to
+// same file-based benchmark/experiment spine the benchmarks MCP server
+// exposes to external coding agents. Every tool here delegates to
 // `callBenchmarksTool` — the exact dispatcher behind `understudy benchmarks
 // mcp` — so validation, append-only ledger discipline, and queue-not-execute
 // semantics are shared byte for byte, never forked. Schemas are cloned from
@@ -64,6 +64,12 @@ export const PI_BENCHMARK_SHARED_TOOLS = [
   "list_experiments",
   "create_experiment",
   "update_experiment",
+  // Workload intake: profile a dropped file/dir and compile a labeled dataset
+  // into a PROPOSED (review-pending, never-executing) benchmark. Both are
+  // local-artifact writers, not spend-adjacent — the executor only ever picks
+  // up runs queued through the guarded queue_run above.
+  "profile_workload",
+  "from_dataset",
 ] as const;
 
 /** Pi-only read tool over the shared rigor derivation (not an MCP tool). */

--- a/tests/benchmarks-mcp.test.mjs
+++ b/tests/benchmarks-mcp.test.mjs
@@ -474,6 +474,71 @@ describe("floors in read_benchmark / run_status (additive)", () => {
 
 /* ---------------- roots + stdio protocol ---------------- */
 
+/* ---------------- workload intake: profile_workload + from_dataset ---------------- */
+
+describe("profile_workload", () => {
+  const dropDir = path.join(tmp, "drop-src");
+  fs.mkdirSync(path.join(dropDir, "data"), { recursive: true });
+  fs.writeFileSync(path.join(dropDir, "README.md"), "# demo\n");
+  fs.writeFileSync(
+    path.join(dropDir, "data", "labeled.csv"),
+    "text,label\nhello there,ham\nWIN A PRIZE,spam\nsee you at 5,ham\nFREE CASH NOW,spam\n",
+  );
+  const outputRoot = path.join(tmp, "capture-imports");
+
+  it("profiles a directory and lists foundry-consumable dataset candidates", () => {
+    const out = callBenchmarksTool("profile_workload", { path: dropDir, output_root: outputRoot });
+    assert.equal(out.source_type, "directory");
+    assert.equal(out.local_only, true);
+    assert.deepEqual(out.dataset_candidates, [path.join(dropDir, "data", "labeled.csv")]);
+    assert.equal(out.dataset_candidates_truncated, false);
+    assert.ok(fs.existsSync(path.join(out.artifact_root, "workload-card.json")));
+    assert.match(out.next, /from_dataset/);
+  });
+
+  it("profiles a single dataset file as its own candidate", () => {
+    const out = callBenchmarksTool("profile_workload", {
+      path: path.join(dropDir, "data", "labeled.csv"),
+      output_root: outputRoot,
+    });
+    assert.equal(out.source_type, "file");
+    assert.deepEqual(out.dataset_candidates, [path.join(dropDir, "data", "labeled.csv")]);
+  });
+
+  it("rejects a missing path", () => {
+    assert.throws(() => callBenchmarksTool("profile_workload", { path: path.join(tmp, "nope") }), /does not exist/);
+    assert.throws(() => callBenchmarksTool("profile_workload", {}), /path \(string\) is required/);
+  });
+});
+
+describe("from_dataset", () => {
+  const dataFile = path.join(tmp, "spam.csv");
+  const rows = [["text", "label"]];
+  for (let i = 0; i < 12; i += 1) rows.push([`ham message number ${i}`, "ham"], [`spam offer number ${i}`, "spam"]);
+  fs.writeFileSync(dataFile, rows.map((r) => r.join(",")).join("\n") + "\n");
+
+  it("compiles a labeled dataset into a proposed benchmark under the hub root", () => {
+    const out = callBenchmarksTool("from_dataset", { source: dataFile, slug: "spam-intake", label_column: "label" });
+    assert.equal(out.ok, true);
+    assert.equal(out.slug, "data--spam-intake");
+    assert.equal(out.dir, path.join(tmp, "spam-intake"));
+    const manifest = JSON.parse(fs.readFileSync(path.join(out.dir, "benchmark.json"), "utf8"));
+    assert.equal(manifest.schema_version, "understudy.benchmark_proposal.v1");
+    assert.equal(manifest.status, "machine_compiled_review_pending");
+    assert.equal(manifest.executable, false);
+    assert.ok(manifest.promotion_blockers.includes("human_final_judgment"));
+    // The proposed benchmark is immediately visible to the operator surface.
+    const listed = callBenchmarksTool("list_benchmarks");
+    assert.ok(listed.benchmarks.some((b) => b.slug === "data--spam-intake" && b.stage === "proposed"));
+  });
+
+  it("refuses an existing dir, a bad slug, and a missing source", () => {
+    assert.throws(() => callBenchmarksTool("from_dataset", { source: dataFile, slug: "spam-intake" }), /already exists/);
+    assert.throws(() => callBenchmarksTool("from_dataset", { source: dataFile, slug: "Bad Slug!" }), /slug must be/);
+    assert.throws(() => callBenchmarksTool("from_dataset", { source: path.join(tmp, "nope.csv"), slug: "x" }), /does not exist/);
+  });
+});
+
 describe("server wiring", () => {
   it("configureBenchmarksMcpRoots appends extra roots after the defaults", () => {
     const saved = process.env.BENCHMARK_HUB_DATA_DIR;
@@ -501,8 +566,10 @@ describe("server wiring", () => {
         "apply_auto_accepts",
         "create_experiment",
         "diff_rollouts",
+        "from_dataset",
         "list_benchmarks",
         "list_experiments",
+        "profile_workload",
         "queue_run",
         "read_benchmark",
         "read_rollout",


### PR DESCRIPTION
## What

Wires the "drop anything into the chat and the agent takes it from there" flow:

- **Two new shared operator tools** on the benchmarks codec (MCP + embedded Pi chat, cloned schemas, zero forked logic):
  - `profile_workload(path)` — local-only capture-import scan of a dropped file/dir; returns the workload card plus foundry-consumable dataset candidates. Payloads unread, nothing leaves the machine.
  - `from_dataset(source, slug, …)` — `understudy benchmarks from-dataset` behind the tool codec: compiles a labeled dataset into a PROPOSED benchmark (review-pending, `executable: false`) under the primary hub root and returns the resolvable hub slug.
  - Neither is spend-adjacent; runs still only enter through the guarded `queue_run`.
- **Pi allowlist + skill**: both tools join `PI_BENCHMARK_SHARED_TOOLS`; `operate-benchmark-lab` gains an intake step 0 stating profile → confirm → propose → review, never queue-from-intake.
- **Desktop drop handoff**: non-inspectable drops (directories, non-table files) no longer strand a training thread with `flow_json: null` (the forever-"In progress" orphan) — they auto-send a handoff prompt into the Pi chat, which now owns the profiling conversation.
- **Orphan reconcile**: startup marks `active` training threads untouched for 24h as `dismissed` in the store (the sidebar previously only hid them cosmetically).

## Bug fixed en route

`from-dataset` output dirs were invisible to the hub: `loadProposedEntryFromDir` only accepted `understudy.trace_foundry.v1`, so dataset-derived benchmarks listed as stage **invalid**, contradicting the #354 design ("all unchanged downstream"). Hub-core now accepts the sibling `understudy.dataset_foundry.v1`; the schema literal moved to `benchmark-artifacts.ts` where schema ids live.

## Tests

- 5 new node tests (profile_workload candidates/errors, from_dataset happy path + hub visibility + refusals); full TS suite green.
- New Rust test for the stale-thread reconcile; 307 lib tests green; clippy clean; 37 skills validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->