### PR TITLE
feat: add watch mode for training doctor

### DIFF
--- a/src/commands/training.ts
+++ b/src/commands/training.ts
@@ -20,7 +20,9 @@ import {
 import {
   renderTrainingDoctorReport,
   runTrainingDoctor,
+  runTrainingDoctorWatch,
 } from "../training-doctor/index.js";
+import type { WatchEvent } from "../training-doctor/index.js";
 import { isJsonMode, runAction } from "../internal/output.js";
 
 type LocalSftOptions = {
@@ -66,15 +68,39 @@ export function registerTrainingCommand(program: Command): void {
     .option("--workload <path>", "Capture-import artifact root (workload-card.json lives here).")
     .option("--plan <path>", "Start mid-chain at a remote-training plan.json.")
     .option("--expect-run", "Treat a missing run.json as a broken link.")
+    .option("--watch", "Follow the remote training run to completion.")
+    .option("--interval <ms>", "Poll interval in milliseconds (requires --watch).")
+    .option("--max-wait <seconds>", "Maximum wait time in seconds (requires --watch).")
     .action(async function (this: Command, options: {
       workload?: string;
       plan?: string;
       expectRun?: boolean;
+      watch?: boolean;
+      interval?: string;
+      maxWait?: string;
     }) {
       await runAction(this, async () => {
         if (Boolean(options.workload) === Boolean(options.plan)) {
           throw new Error("Pass exactly one of --workload <artifact_root> or --plan <plan.json>.");
         }
+        if (!options.watch && (options.interval !== undefined || options.maxWait !== undefined)) {
+          throw new Error("--interval and --max-wait are only valid with --watch.");
+        }
+        let intervalMs = 5000;
+        let maxWaitSeconds: number | undefined;
+        if (options.watch) {
+          intervalMs = parseInt(options.interval ?? "5000", 10);
+          if (!Number.isInteger(intervalMs) || intervalMs < 250) {
+            throw new Error("--interval must be an integer >= 250.");
+          }
+          if (options.maxWait !== undefined) {
+            maxWaitSeconds = parseInt(options.maxWait, 10);
+            if (!Number.isInteger(maxWaitSeconds) || maxWaitSeconds <= 0) {
+              throw new Error("--max-wait must be a positive integer.");
+            }
+          }
+        }
+
         const report = await runTrainingDoctor({
           workloadRoot: options.workload,
           planPath: options.plan,
@@ -86,6 +112,74 @@ export function registerTrainingCommand(program: Command): void {
           process.stdout.write(renderTrainingDoctorReport(report));
         }
         if (!report.healthy) process.exitCode = 1;
+
+        if (!options.watch) return;
+
+        if (!report.plan_root) {
+          // No plan root resolved — nothing to watch.
+          return;
+        }
+
+        const json = isJsonMode(this);
+
+        const formatElapsed = (ms: number): string => {
+          const seconds = Math.floor(ms / 1000);
+          const minutes = Math.floor(seconds / 60);
+          const remainingSeconds = seconds % 60;
+          if (minutes > 0) return `${minutes}m${remainingSeconds}s`;
+          return `${seconds}s`;
+        };
+
+        const emitWatch = (event: WatchEvent): void => {
+          if (json) {
+            process.stdout.write(`${JSON.stringify(event)}\n`);
+            return;
+          }
+          switch (event.event) {
+            case "waiting_for_run":
+              process.stdout.write(
+                `waiting for run.json ... (${formatElapsed(event.elapsed_ms)} elapsed)\n`,
+              );
+              break;
+            case "status_change":
+              process.stdout.write(
+                `run is ${event.workflow_status} (${formatElapsed(event.elapsed_ms)} elapsed)\n`,
+              );
+              break;
+            case "timeout":
+              process.stdout.write(
+                `gave up waiting after ${formatElapsed(event.elapsed_ms)}\n`,
+              );
+              break;
+            case "lost_contact":
+              process.stdout.write(
+                "lost contact with the training service\n",
+              );
+              break;
+            case "done":
+              process.stdout.write(
+                `run ${event.workflow_status} after ${formatElapsed(event.elapsed_ms)} (${event.poll_count} polls)\n`,
+              );
+              break;
+          }
+        };
+
+        const finalEvent = await runTrainingDoctorWatch({
+          report,
+          planRoot: report.plan_root,
+          intervalMs,
+          maxWaitSeconds,
+          onEvent: emitWatch,
+        });
+
+        // Set exit code from the final event.
+        if (finalEvent.event === "done") {
+          process.exitCode = finalEvent.ok ? 0 : 1;
+        } else if (finalEvent.event === "timeout") {
+          process.exitCode = 2;
+        } else if (finalEvent.event === "lost_contact") {
+          process.exitCode = 1;
+        }
       });
     });
 

--- a/src/training-doctor/index.ts
+++ b/src/training-doctor/index.ts
@@ -46,6 +46,7 @@ export type TrainingDoctorReport = {
   healthy: boolean;
   first_failure: string | null;
   checks: DoctorCheck[];
+  plan_root: string | null;
 };
 
 export type TrainingDoctorOptions = {
@@ -192,6 +193,68 @@ async function fetchJson(
   }
   return { status: response.status, body: body as Record<string, unknown> };
 }
+
+/**
+ * States known to mean "still going" — keep polling.
+ * Anything outside this set is terminal.
+ */
+const ACTIVE_WORKFLOW_STATUSES = new Set(["queued", "running"]);
+
+/**
+ * Terminal states that count as failure. A terminal status is ok (success)
+ * unless it appears here. This avoids hardcoding a success string — the
+ * remote service's actual value isn't verifiable from this codebase.
+ */
+const FAILED_WORKFLOW_STATUSES = new Set(["failed", "cancelled"]);
+
+export type RunStatusResult = {
+  workflow_status: string;
+  duration_ms: number;
+};
+
+/**
+ * Poll the live run status exactly once. Extracted from the main chain so
+ * watch mode can call it repeatedly without re-verifying the full chain.
+ *
+ * Privacy: never surfaces the API key, run token, or full status URL.
+ */
+export async function pollRunStatus(context: {
+  run: { run_id: string; status_url: string; run_token: string };
+  base: URL;
+  apiKey: string;
+  fetchImpl: typeof fetch;
+}): Promise<RunStatusResult> {
+  assertControlPlaneUrl(context.run.status_url, context.base);
+  const start = Date.now();
+  const { status, body } = await fetchJson(context.fetchImpl, context.run.status_url, {
+    authorization: `Bearer ${context.apiKey}`,
+    "x-understudy-train-run-token": context.run.run_token,
+  });
+  const duration_ms = Date.now() - start;
+  if (status < 200 || status >= 300) {
+    throw new Error(`the training service rejected the run status request (HTTP ${status})`);
+  }
+  const workflow_status = typeof body.workflow_status === "string"
+    ? body.workflow_status
+    : "unknown";
+  return { workflow_status, duration_ms };
+}
+
+export type WatchEvent =
+  | { event: "waiting_for_run"; elapsed_ms: number }
+  | { event: "status_change"; elapsed_ms: number; workflow_status: string }
+  | { event: "timeout"; elapsed_ms: number }
+  | { event: "lost_contact"; elapsed_ms: number }
+  | { event: "done"; workflow_status: string; ok: boolean; elapsed_ms: number; poll_count: number };
+
+export type TrainingDoctorWatchOptions = {
+  report: TrainingDoctorReport;
+  planRoot: string;
+  intervalMs: number;
+  maxWaitSeconds?: number;
+  fetchImpl?: typeof fetch;
+  onEvent: (event: WatchEvent) => void;
+};
 
 type ChainState = {
   checks: DoctorCheck[];
@@ -508,7 +571,7 @@ export async function runTrainingDoctor(
   if (broken()) {
     skip(state, "server_capabilities", "training service capabilities", "blocked by earlier failure");
     skip(state, "run_status", "live run status", "blocked by earlier failure");
-    return finish(state, mode);
+    return finish(state, mode, planRoot);
   }
 
   let base: URL;
@@ -523,7 +586,7 @@ export async function runTrainingDoctor(
       next: "Fix UNDERSTUDY_TRAIN_API_BASE (or unset it to use the default endpoint).",
     });
     skip(state, "run_status", "live run status", "blocked by earlier failure");
-    return finish(state, mode);
+    return finish(state, mode, planRoot);
   }
 
   const apiKey = resolveApiKey();
@@ -536,7 +599,7 @@ export async function runTrainingDoctor(
       next: "Run `understudy login` to create ~/.understudy/credentials.json.",
     });
     skip(state, "run_status", "live run status", "blocked by earlier failure");
-    return finish(state, mode);
+    return finish(state, mode, planRoot);
   }
 
   try {
@@ -575,32 +638,22 @@ export async function runTrainingDoctor(
       next: "Check network access and credentials, then retry (`understudy login` refreshes the key).",
     });
     skip(state, "run_status", "live run status", "blocked by earlier failure");
-    return finish(state, mode);
+    return finish(state, mode, planRoot);
   }
 
   // 8. live run status
   if (!run) {
     skip(state, "run_status", "live run status", "no run started yet");
-    return finish(state, mode);
+    return finish(state, mode, planRoot);
   }
   try {
-    assertControlPlaneUrl(run.status_url, base);
-    const { status, body } = await fetchJson(fetchImpl, run.status_url, {
-      authorization: `Bearer ${apiKey}`,
-      "x-understudy-train-run-token": run.run_token,
-    });
-    if (status < 200 || status >= 300) {
-      throw new Error(`the training service rejected the run status request (HTTP ${status})`);
-    }
-    const workflowStatus = typeof body.workflow_status === "string"
-      ? body.workflow_status
-      : "unknown";
-    if (workflowStatus === "failed" || workflowStatus === "cancelled") {
+    const result = await pollRunStatus({ run, base, apiKey, fetchImpl });
+    if (FAILED_WORKFLOW_STATUSES.has(result.workflow_status)) {
       record(state, {
         id: "run_status",
         label: "live run status",
         status: "fail",
-        detail: `run ${run.run_id} is ${workflowStatus}`,
+        detail: `run ${run.run_id} is ${result.workflow_status}`,
         next: "Inspect the run result in Understudy Desktop and start a fresh run.",
       });
     } else {
@@ -608,7 +661,7 @@ export async function runTrainingDoctor(
         id: "run_status",
         label: "live run status",
         status: "pass",
-        detail: `run ${run.run_id} is ${workflowStatus}`,
+        detail: `run ${run.run_id} is ${result.workflow_status}`,
       });
     }
   } catch (error) {
@@ -621,16 +674,21 @@ export async function runTrainingDoctor(
     });
   }
 
-  return finish(state, mode);
+  return finish(state, mode, planRoot);
 }
 
-function finish(state: ChainState, mode: TrainingDoctorReport["mode"]): TrainingDoctorReport {
+function finish(
+  state: ChainState,
+  mode: TrainingDoctorReport["mode"],
+  planRoot: string | null,
+): TrainingDoctorReport {
   return {
     schema_version: TRAINING_DOCTOR_SCHEMA,
     mode,
     healthy: state.firstFailure === null,
     first_failure: state.firstFailure,
     checks: state.checks,
+    plan_root: planRoot,
   };
 }
 
@@ -655,4 +713,164 @@ export function renderTrainingDoctorReport(report: TrainingDoctorReport): string
       : `training chain: broken at ${report.first_failure}`,
   );
   return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Watch a remote training run to completion. Emits WatchEvent objects via
+ * onEvent as the run progresses. Returns the final event (done/timeout/
+ * lost_contact) so the caller can set process.exitCode.
+ *
+ * Never throws for expected failure modes (timeout, lost contact, run
+ * failed/cancelled) — those are all normal returns via WatchEvent.
+ */
+export async function runTrainingDoctorWatch(
+  options: TrainingDoctorWatchOptions,
+): Promise<WatchEvent> {
+  const { report, planRoot, intervalMs, maxWaitSeconds, onEvent } = options;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const watchStart = Date.now();
+
+  const elapsed = (): number => Date.now() - watchStart;
+  const maxWaitMs = maxWaitSeconds !== undefined ? maxWaitSeconds * 1000 : Infinity;
+  const timedOut = (): boolean => elapsed() >= maxWaitMs;
+
+  // Determine which chain checks exist and where the failure is.
+  // The chain order for the run-relevant checks.
+  const RUN_CHECK_IDS = new Set(["run_manifest", "run_status"]);
+  if (report.first_failure !== null) {
+    // If the chain is broken at or before the run checks, don't watch.
+    // Check if the failure is a run check itself, or an earlier check.
+    const failureIndex = report.checks.findIndex(
+      (check) => check.id === report.first_failure,
+    );
+    const firstRunIndex = report.checks.findIndex(
+      (check) => RUN_CHECK_IDS.has(check.id),
+    );
+    if (failureIndex <= firstRunIndex || firstRunIndex === -1) {
+      // Broken chain before or at the run checks — nothing to watch.
+      const done: WatchEvent = {
+        event: "done",
+        workflow_status: "unknown",
+        ok: false,
+        elapsed_ms: elapsed(),
+        poll_count: 0,
+      };
+      return done;
+    }
+  }
+
+  // Find the run_manifest check to see if we need to wait for run.json.
+  const runManifestCheck = report.checks.find(
+    (check) => check.id === "run_manifest",
+  );
+  const needsRunJson = runManifestCheck?.status === "pending";
+
+  // Wait for run.json to appear if it doesn't exist yet.
+  const runPath = join(planRoot, "run.json");
+  if (needsRunJson) {
+    while (!existsSync(runPath)) {
+      if (timedOut()) {
+        const ev: WatchEvent = { event: "timeout", elapsed_ms: elapsed() };
+        onEvent(ev);
+        return ev;
+      }
+      const ev: WatchEvent = { event: "waiting_for_run", elapsed_ms: elapsed() };
+      onEvent(ev);
+      await sleep(intervalMs);
+    }
+  }
+
+  // Read and validate run.json — same logic as section 6.
+  const RUN_SCHEMA_LOCAL = "understudy.remote_training.run.v1";
+  let run: { run_id: string; status_url: string; run_token: string };
+  try {
+    const manifest = readJson(runPath);
+    if (
+      manifest.schema_version !== RUN_SCHEMA_LOCAL
+      || typeof manifest.run_id !== "string"
+      || typeof manifest.status_url !== "string"
+      || typeof manifest.run_token !== "string"
+    ) {
+      throw new Error("run receipt is missing required fields");
+    }
+    run = {
+      run_id: manifest.run_id as string,
+      status_url: manifest.status_url as string,
+      run_token: manifest.run_token as string,
+    };
+  } catch {
+    // run.json appeared but is corrupt — treat as lost contact.
+    const ev: WatchEvent = { event: "lost_contact", elapsed_ms: elapsed() };
+    onEvent(ev);
+    return ev;
+  }
+
+  // Resolve credentials and base URL.
+  let base: URL;
+  let apiKey: string;
+  try {
+    base = trainApiBase();
+    const resolved = resolveApiKey();
+    if (!resolved) throw new Error("no credentials");
+    apiKey = resolved;
+  } catch {
+    const ev: WatchEvent = { event: "lost_contact", elapsed_ms: elapsed() };
+    onEvent(ev);
+    return ev;
+  }
+
+  // Poll loop.
+  let previousStatus: string | null = null;
+  let consecutiveErrors = 0;
+  let pollCount = 0;
+
+  while (!timedOut()) {
+    pollCount++;
+    try {
+      const result = await pollRunStatus({ run, base, apiKey, fetchImpl });
+      consecutiveErrors = 0;
+
+      if (result.workflow_status !== previousStatus) {
+        const ev: WatchEvent = {
+          event: "status_change",
+          elapsed_ms: elapsed(),
+          workflow_status: result.workflow_status,
+        };
+        onEvent(ev);
+        previousStatus = result.workflow_status;
+      }
+
+      // Terminal?
+      if (!ACTIVE_WORKFLOW_STATUSES.has(result.workflow_status)) {
+        const ok = !FAILED_WORKFLOW_STATUSES.has(result.workflow_status);
+        const done: WatchEvent = {
+          event: "done",
+          workflow_status: result.workflow_status,
+          ok,
+          elapsed_ms: elapsed(),
+          poll_count: pollCount,
+        };
+        onEvent(done);
+        return done;
+      }
+    } catch {
+      consecutiveErrors++;
+      if (consecutiveErrors >= 3) {
+        const ev: WatchEvent = { event: "lost_contact", elapsed_ms: elapsed() };
+        onEvent(ev);
+        return ev;
+      }
+    }
+
+    await sleep(intervalMs);
+  }
+
+  // max-wait exceeded without reaching a terminal status.
+  const ev: WatchEvent = { event: "timeout", elapsed_ms: elapsed() };
+  onEvent(ev);
+  return ev;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/training-doctor.test.mjs
+++ b/tests/training-doctor.test.mjs
@@ -412,3 +412,453 @@ describe("understudy training doctor", () => {
     assert.equal(both.status, 1);
   });
 });
+
+describe("understudy training doctor --watch", () => {
+  // Helper: parse stdout into JSON Lines (one object per line, skip blanks).
+  function parseJsonLines(stdout) {
+    return stdout
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+  }
+
+  // Helper: write a run.json pointing at the fake server.
+  function writeRunJson(planRoot, planPath, base, runId = "run-w1") {
+    writeFileSync(join(planRoot, "run.json"), JSON.stringify({
+      schema_version: "understudy.remote_training.run.v1",
+      run_id: runId,
+      plan_path: planPath,
+      status_url: `${base}/runs/${runId}`,
+      events_url: `${base}/runs/${runId}/events`,
+      run_token: "run-token-secret",
+      next_after: -1,
+      run_manifest_path: join(planRoot, "run.json"),
+    }));
+  }
+
+  // Privacy pattern reused across all tests.
+  const PRIVACY_RE = /sk_test_fixture|run-token-secret|run-token-|runs\/run-w/;
+
+  it("rejects --interval without --watch", async () => {
+    const fixture = writeWorkloadFixture();
+    const result = await runDoctorAsync(["--workload", fixture.root, "--interval", "5000"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--interval and --max-wait are only valid with --watch/);
+  });
+
+  it("rejects --max-wait without --watch", async () => {
+    const fixture = writeWorkloadFixture();
+    const result = await runDoctorAsync(["--workload", fixture.root, "--max-wait", "10"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--interval and --max-wait are only valid with --watch/);
+  });
+
+  it("rejects --watch --interval below 250", async () => {
+    const fixture = writeWorkloadFixture();
+    const result = await runDoctorAsync(["--workload", fixture.root, "--watch", "--interval", "100"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--interval must be an integer >= 250/);
+  });
+
+  it("rejects --watch --max-wait with a non-positive value", async () => {
+    const fixture = writeWorkloadFixture();
+    const result = await runDoctorAsync(["--workload", fixture.root, "--watch", "--max-wait", "-5"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--max-wait must be a positive integer/);
+  });
+
+  it("does not enter watch mode on a broken chain", async () => {
+    const fixture = writeWorkloadFixture();
+    // Break the chain by removing the dataset manifest.
+    rmSync(join(fixture.datasetRoot, "dataset-manifest.json"));
+    const result = await runDoctorAsync([
+      "--workload", fixture.root,
+      "--watch", "--interval", "250",
+    ]);
+    assert.equal(result.status, 1);
+    // The initial report is emitted as a pretty-printed JSON object (--json is
+    // always appended by runDoctorAsync). Parse it as a single object.
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.first_failure, "dataset_manifest");
+    // No watch events should appear — stdout is ONLY the initial report.
+    assert.doesNotMatch(result.stdout, /waiting_for_run|status_change|timeout|lost_contact/);
+    assert.doesNotMatch(result.stdout, PRIVACY_RE);
+  });
+
+  it("emits waiting_for_run heartbeats then timeout when run.json never appears", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+    });
+    try {
+      const result = await runDoctorAsync([
+        "--workload", fixture.root,
+        "--watch", "--interval", "250", "--max-wait", "1",
+      ], {
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TRAIN_API_BASE: base,
+      });
+      assert.equal(result.status, 2, `expected exit 2, got ${result.status}: ${result.stderr}`);
+      // stdout is: initial pretty-printed JSON report, then JSON Lines for watch events.
+      // The initial report ends with "}\n", watch events follow as single-line JSON.
+      // Split by finding lines that parse as objects with an "event" key.
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {
+          // Part of the pretty-printed initial report — skip.
+        }
+      }
+      assert.ok(watchEvents.length >= 2, `expected at least 2 watch events, got ${watchEvents.length}`);
+      const waitingEvents = watchEvents.filter((e) => e.event === "waiting_for_run");
+      assert.ok(waitingEvents.length >= 1, "expected at least one waiting_for_run event");
+      for (const ev of waitingEvents) {
+        assert.equal(typeof ev.elapsed_ms, "number");
+      }
+      const last = watchEvents[watchEvents.length - 1];
+      assert.equal(last.event, "timeout");
+      assert.equal(typeof last.elapsed_ms, "number");
+      assert.doesNotMatch(result.stdout, PRIVACY_RE);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("watches running -> completed and reports ok: true (exit 0)", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    let statusCallCount = 0;
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+      "/api/train/v1/runs/run-w1": () => {
+        statusCallCount++;
+        const status = statusCallCount <= 2 ? "running" : "completed";
+        return { body: { workflow_status: status } };
+      },
+    });
+    try {
+      writeRunJson(fixture.planRoot, fixture.planPath, base);
+      const result = await runDoctorAsync([
+        "--plan", fixture.planPath,
+        "--watch", "--interval", "250", "--max-wait", "5",
+      ], {
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TRAIN_API_BASE: base,
+      });
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}\n${result.stdout}`);
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {
+          // Part of pretty-printed initial report.
+        }
+      }
+      const statusChanges = watchEvents.filter((e) => e.event === "status_change");
+      assert.ok(statusChanges.some((e) => e.workflow_status === "running"), "expected a running status_change");
+      const doneEvents = watchEvents.filter((e) => e.event === "done");
+      assert.equal(doneEvents.length, 1);
+      assert.equal(doneEvents[0].ok, true);
+      assert.equal(doneEvents[0].workflow_status, "completed");
+      assert.ok(doneEvents[0].poll_count >= 2);
+      assert.doesNotMatch(result.stdout, PRIVACY_RE);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("watches running -> succeeded and reports ok: true (proves no hardcoded success string)", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    let statusCallCount = 0;
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+      "/api/train/v1/runs/run-w1": () => {
+        statusCallCount++;
+        const status = statusCallCount <= 2 ? "running" : "succeeded";
+        return { body: { workflow_status: status } };
+      },
+    });
+    try {
+      writeRunJson(fixture.planRoot, fixture.planPath, base);
+      const result = await runDoctorAsync([
+        "--plan", fixture.planPath,
+        "--watch", "--interval", "250", "--max-wait", "5",
+      ], {
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TRAIN_API_BASE: base,
+      });
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}\n${result.stdout}`);
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {
+          // Part of pretty-printed initial report.
+        }
+      }
+      const doneEvents = watchEvents.filter((e) => e.event === "done");
+      assert.equal(doneEvents.length, 1);
+      assert.equal(doneEvents[0].ok, true);
+      assert.equal(doneEvents[0].workflow_status, "succeeded");
+      assert.doesNotMatch(result.stdout, PRIVACY_RE);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("run.json appears mid-watch, then run completes", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    let statusCallCount = 0;
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+      "/api/train/v1/runs/run-w1": () => {
+        statusCallCount++;
+        const status = statusCallCount <= 2 ? "running" : "completed";
+        return { body: { workflow_status: status } };
+      },
+    });
+    try {
+      // Start watch BEFORE run.json exists. We spawn directly to stream stdout
+      // and wait for the precise 'waiting_for_run' signal instead of guessing a delay.
+      const resultPromise = new Promise((resolveRun) => {
+        const child = spawn("node", [resolve("dist/bin.js"), "training", "doctor", "--workload", fixture.root, "--watch", "--interval", "250", "--max-wait", "5", "--json"], {
+          encoding: "utf8",
+          env: { ...baseEnv, UNDERSTUDY_TELEMETRY: "0", HOME: home, USERPROFILE: home, UNDERSTUDY_TRAIN_API_BASE: base },
+        });
+        let stdout = "";
+        let stderr = "";
+        let runJsonWritten = false;
+        child.stdout.setEncoding("utf8");
+        child.stderr.setEncoding("utf8");
+        
+        child.stdout.on("data", (chunk) => { 
+          stdout += chunk; 
+          // If we haven't written the file yet, check if waiting_for_run was emitted.
+          if (!runJsonWritten && stdout.includes('"event":"waiting_for_run"')) {
+            writeRunJson(fixture.planRoot, fixture.planPath, base);
+            runJsonWritten = true;
+          }
+        });
+        child.stderr.on("data", (chunk) => { stderr += chunk; });
+        child.on("close", (status) => resolveRun({ status, stdout, stderr }));
+      });
+      
+      const result = await resultPromise;
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}\n${result.stdout}`);
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {
+          // Part of pretty-printed initial report.
+        }
+      }
+      // Should have at least one waiting_for_run heartbeat.
+      assert.ok(
+        watchEvents.some((e) => e.event === "waiting_for_run"),
+        "expected at least one waiting_for_run event",
+      );
+      assert.ok(
+        watchEvents.some((e) => e.event === "status_change" && e.workflow_status === "running"),
+        "expected a running status_change",
+      );
+      const doneEvents = watchEvents.filter((e) => e.event === "done");
+      assert.equal(doneEvents.length, 1);
+      assert.equal(doneEvents[0].ok, true);
+      assert.equal(doneEvents[0].workflow_status, "completed");
+      assert.doesNotMatch(result.stdout, PRIVACY_RE);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("watches running -> failed and reports ok: false (exit 1)", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    let statusCallCount = 0;
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+      "/api/train/v1/runs/run-w1": () => {
+        statusCallCount++;
+        const status = statusCallCount <= 2 ? "running" : "failed";
+        return { body: { workflow_status: status } };
+      },
+    });
+    try {
+      writeRunJson(fixture.planRoot, fixture.planPath, base);
+      const result = await runDoctorAsync([
+        "--plan", fixture.planPath,
+        "--watch", "--interval", "250", "--max-wait", "5",
+      ], {
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TRAIN_API_BASE: base,
+      });
+      assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.stderr}\n${result.stdout}`);
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {
+          // Part of pretty-printed initial report.
+        }
+      }
+      const doneEvents = watchEvents.filter((e) => e.event === "done");
+      assert.equal(doneEvents.length, 1);
+      assert.equal(doneEvents[0].ok, false);
+      assert.equal(doneEvents[0].workflow_status, "failed");
+      assert.doesNotMatch(result.stdout, PRIVACY_RE);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("watches running -> cancelled and reports ok: false (exit 1)", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    let statusCallCount = 0;
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+      "/api/train/v1/runs/run-w1": () => {
+        statusCallCount++;
+        const status = statusCallCount <= 2 ? "running" : "cancelled";
+        return { body: { workflow_status: status } };
+      },
+    });
+    try {
+      writeRunJson(fixture.planRoot, fixture.planPath, base);
+      const result = await runDoctorAsync([
+        "--plan", fixture.planPath,
+        "--watch", "--interval", "250", "--max-wait", "5",
+      ], {
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TRAIN_API_BASE: base,
+      });
+      assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.stderr}\n${result.stdout}`);
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {
+          // Part of pretty-printed initial report.
+        }
+      }
+      const doneEvents = watchEvents.filter((e) => e.event === "done");
+      assert.equal(doneEvents.length, 1);
+      assert.equal(doneEvents[0].ok, false);
+      assert.equal(doneEvents[0].workflow_status, "cancelled");
+      assert.doesNotMatch(result.stdout, PRIVACY_RE);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("reports lost_contact after 3 consecutive poll errors (exit 1)", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+      "/api/train/v1/runs/run-w1": () => ({
+        status: 500,
+        body: { error: "internal server error" },
+      }),
+    });
+    try {
+      writeRunJson(fixture.planRoot, fixture.planPath, base);
+      const result = await runDoctorAsync([
+        "--plan", fixture.planPath,
+        "--watch", "--interval", "250", "--max-wait", "10",
+      ], {
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TRAIN_API_BASE: base,
+      });
+      assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.stderr}\n${result.stdout}`);
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {
+          // Part of pretty-printed initial report.
+        }
+      }
+      const lostEvents = watchEvents.filter((e) => e.event === "lost_contact");
+      assert.equal(lostEvents.length, 1, "expected exactly one lost_contact event");
+      assert.equal(typeof lostEvents[0].elapsed_ms, "number");
+      assert.doesNotMatch(result.stdout, PRIVACY_RE);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("resets the 3-consecutive-errors counter after a successful poll", async () => {
+    const fixture = writeWorkloadFixture();
+    const home = fakeHome();
+    let statusCallCount = 0;
+    const { server, base } = await startTrainServer({
+      "/api/train/v1/capabilities": () => ({ body: capabilitiesBody }),
+      "/api/train/v1/runs/run-w1": () => {
+        statusCallCount++;
+        // The first call is from the initial chain verification.
+        // Watch loop polls start at statusCallCount = 2.
+        // We want: fail twice, succeed once, then complete.
+        if (statusCallCount === 2 || statusCallCount === 3) {
+          return { status: 500, body: { error: "internal error" } };
+        }
+        if (statusCallCount === 4) {
+          return { body: { workflow_status: "running" } };
+        }
+        return { body: { workflow_status: "completed" } };
+      },
+    });
+    try {
+      writeRunJson(fixture.planRoot, fixture.planPath, base);
+      const result = await runDoctorAsync([
+        "--plan", fixture.planPath,
+        "--watch", "--interval", "250", "--max-wait", "10",
+      ], {
+        HOME: home,
+        USERPROFILE: home,
+        UNDERSTUDY_TRAIN_API_BASE: base,
+      });
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}\n${result.stdout}`);
+      const lines = result.stdout.split("\n").filter((l) => l.trim().length > 0);
+      const watchEvents = [];
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.event) watchEvents.push(obj);
+        } catch {}
+      }
+      const lostEvents = watchEvents.filter((e) => e.event === "lost_contact");
+      assert.equal(lostEvents.length, 0, "expected NO lost_contact event since counter should reset");
+      const doneEvents = watchEvents.filter((e) => e.event === "done");
+      assert.equal(doneEvents.length, 1);
+      assert.equal(doneEvents[0].workflow_status, "completed");
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
training doctor today reports run status once and exits. if a run takes an hour, you're stuck manually re-running the command every few minutes to check if it's done. watch mode follows it to completion.

it polls only the live run-status endpoint once a run exists, printing only on status transitions, and exits 0/1/2 depending on the outcome.

the workflow_status actual enum isn't defined anywhere in this repo — it's owned by the live train service. rather than guess a specific success string, watch mode treats anything outside of {queued, running} as terminal, and only {failed, cancelled} as failures. it degrades correctly regardless of what the real success value turns out to be. flag if the actual contract is documented somewhere i didn't find; happy to tighten this if there's a real enum to match against.

pollRunStatus() was extracted from the existing status check to support this. non-watch behavior is completely unchanged. also adds plan_root to the json report output (additive, doesn't change existing fields) so callers can locate run.json without re-deriving the path.

new flags:
- --watch
- --interval <ms> (default 5000, min 250)
- --max-wait <seconds> (optional)

testing covers validation errors, ensuring a broken chain doesn't enter watch mode, waiting for run.json before a run starts, verifying both "completed" and "succeeded" terminal values to prove no hardcoded success string, failed/cancelled transitions, lost-contact recovery (3 consecutive errors resets on a successful poll), and privacy assertions (no tokens or urls are ever printed).