### PR TITLE
Add resumable customer capture batch exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
   remains file-only and requires `--include-payload --yes`. Shared
   authorization failures stop the batch immediately, and failed forced
   refreshes quarantine the previous file so a later resume cannot trust it.
+  Temporary files are randomized and created exclusively before replacement.
 - **The benchmark lab comes to the Desktop.** Desktop/runtime 0.3.41 and CLI
   0.6.38 bridge the app to the benchmark/experiment spine: experiment lineage
   cards trace every result back to the run, dataset, and prompt that produced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
   signed-in customer's existing capture access. Batch downloads use bounded
   concurrency, retry transient failures, skip completed files by default, and
   write `failed-request-ids.txt` for a clean retry handoff. Payload export
-  remains file-only and requires `--include-payload --yes`.
+  remains file-only and requires `--include-payload --yes`. Shared
+  authorization failures stop the batch immediately, and failed forced
+  refreshes quarantine the previous file so a later resume cannot trust it.
 - **The benchmark lab comes to the Desktop.** Desktop/runtime 0.3.41 and CLI
   0.6.38 bridge the app to the benchmark/experiment spine: experiment lineage
   cards trace every result back to the run, dataset, and prompt that produced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Added
 
+- **Resumable customer capture batches.** `understudy captures export` now
+  accepts `--request-ids-file` for one-request-id-per-line exports using the
+  signed-in customer's existing capture access. Batch downloads use bounded
+  concurrency, retry transient failures, skip completed files by default, and
+  write `failed-request-ids.txt` for a clean retry handoff. Payload export
+  remains file-only and requires `--include-payload --yes`.
 - **The benchmark lab comes to the Desktop.** Desktop/runtime 0.3.41 and CLI
   0.6.38 bridge the app to the benchmark/experiment spine: experiment lineage
   cards trace every result back to the run, dataset, and prompt that produced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
   remains file-only and requires `--include-payload --yes`. Shared
   authorization failures stop the batch immediately, and failed forced
   refreshes quarantine the previous file so a later resume cannot trust it.
-  Temporary files are randomized and created exclusively before replacement.
+  Summary and payload modes use disjoint filename suffixes. Temporary files are
+  randomized and created exclusively before replacement.
 - **The benchmark lab comes to the Desktop.** Desktop/runtime 0.3.41 and CLI
   0.6.38 bridge the app to the benchmark/experiment spine: experiment lineage
   cards trace every result back to the run, dataset, and prompt that produced

--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ understudy workloads list
 understudy workloads create classify --capture
 understudy gateway probe --provider anthropic --project rehearsal --workload classify
 understudy captures list --project rehearsal --workload classify
+understudy captures export --request-ids-file request-ids.txt --project rehearsal --out .understudy/capture-batch --include-payload --yes
 understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
 understudy routes show classify --project rehearsal
 understudy routes clear classify --project rehearsal
@@ -625,7 +626,11 @@ call and prints request metadata, not the completion text. If you need BYOK for
 the probe, pass `--byok-env ENV_NAME`; the CLI reads the key from the
 environment and never persists or prints it. `captures list/get` are
 metadata-first and redacted by default. Full capture export is opt-in,
-file-only, and requires `--include-payload --yes`. `models list` shows public
+file-only, and requires `--include-payload --yes`. For a customer-owned batch,
+put one request id per line in a file and pass `--request-ids-file`; the CLI
+retries transient failures, resumes from completed files, and writes
+`failed-request-ids.txt`. Redacted batch files use `.summary.json`, keeping
+them distinct from full-payload `.json` files. `models list` shows public
 Understudy model IDs and display names only.
 
 If the coding agent has an approved native email connector, it may complete the

--- a/README.md
+++ b/README.md
@@ -630,8 +630,8 @@ file-only, and requires `--include-payload --yes`. For a customer-owned batch,
 put one request id per line in a file and pass `--request-ids-file`; the CLI
 retries transient failures, resumes from completed files, and writes
 `failed-request-ids.txt`. Redacted batch files use `.summary.json`, keeping
-them distinct from full-payload `.json` files. `models list` shows public
-Understudy model IDs and display names only.
+them distinct from full-payload `.payload.json` files. `models list` shows
+public Understudy model IDs and display names only.
 
 If the coding agent has an approved native email connector, it may complete the
 email-code prompt by reading the fresh Understudy sign-in email directly. The

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -40,6 +40,7 @@ understudy gateway probe --provider anthropic --project rehearsal --workload cla
 understudy captures list --project rehearsal --workload classify
 understudy captures get <request-id> --project rehearsal --workload classify
 understudy captures export <request-id> --out .understudy/captures/<request-id>.json
+understudy captures export --request-ids-file request-ids.txt --project rehearsal --out .understudy/capture-batch --include-payload --yes
 understudy routes show classify --project rehearsal
 understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
 understudy routes clear classify --project rehearsal

--- a/docs/privacy-and-data-boundaries.md
+++ b/docs/privacy-and-data-boundaries.md
@@ -68,7 +68,11 @@ and `understudy captures get` print redacted summaries only: payload-bearing
 fields are represented as present/absent booleans. `understudy captures export`
 writes redacted metadata by default. Full capture export requires
 `--include-payload --yes`, writes to a file, and must not print raw prompts,
-completions, or tool payloads to stdout.
+completions, or tool payloads to stdout. The same boundary applies to
+`--request-ids-file` batches: request ids are read locally, payloads are written
+only to local files (mode `600` on Unix), redacted `.summary.json` files cannot
+be mistaken for full-payload `.json` files during resume, and stdout contains
+counts and paths rather than capture content.
 
 Gateway probes are explicit live calls. BYOK provider keys are read only from an
 environment variable named by `--byok-env`; they are not requested in chat, not

--- a/docs/privacy-and-data-boundaries.md
+++ b/docs/privacy-and-data-boundaries.md
@@ -71,8 +71,8 @@ writes redacted metadata by default. Full capture export requires
 completions, or tool payloads to stdout. The same boundary applies to
 `--request-ids-file` batches: request ids are read locally, payloads are written
 only to local files (mode `600` on Unix), redacted `.summary.json` files cannot
-be mistaken for full-payload `.json` files during resume, and stdout contains
-counts and paths rather than capture content.
+be mistaken for full-payload `.payload.json` files during resume, and stdout
+contains counts and paths rather than capture content.
 
 Gateway probes are explicit live calls. BYOK provider keys are read only from an
 environment variable named by `--byok-env`; they are not requested in chat, not

--- a/src/commands/captures.ts
+++ b/src/commands/captures.ts
@@ -307,7 +307,7 @@ async function runBatchExport(
     failed: failedIds.length,
     output_directory: outputDirectory,
     failure_manifest: failureManifest,
-    output_suffix: opts.includePayload ? ".json" : ".summary.json",
+    output_suffix: opts.includePayload ? ".payload.json" : ".summary.json",
     include_payload: Boolean(opts.includePayload),
     warning: opts.includePayload
       ? "files may contain prompts, completions, or tool payloads"
@@ -473,7 +473,7 @@ function batchCaptureFilename(
   requestId: string,
   includePayload: boolean,
 ): string {
-  return `${captureFilename(requestId)}${includePayload ? "" : ".summary"}.json`;
+  return `${captureFilename(requestId)}${includePayload ? ".payload" : ".summary"}.json`;
 }
 
 function isCompletedExport(path: string): boolean {

--- a/src/commands/captures.ts
+++ b/src/commands/captures.ts
@@ -1,14 +1,28 @@
-import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { Command } from "commander";
 import kleur from "kleur";
 import { z } from "zod";
 
 import { findProjectRoot } from "../config/paths.js";
-import { request } from "../internal/http.js";
+import { request, UnderstudyApiError } from "../internal/http.js";
 import { isJsonMode, runAction } from "../internal/output.js";
 import { resolveProject, type ProjectResolutionOptions } from "../internal/projects.js";
 import { resolveWorkload } from "../internal/workloads.js";
+
+const DEFAULT_EXPORT_CONCURRENCY = 4;
+const MAX_EXPORT_CONCURRENCY = 16;
+const DEFAULT_EXPORT_RETRIES = 2;
+const MAX_EXPORT_RETRIES = 5;
+const MAX_BATCH_REQUEST_IDS = 100_000;
 
 const CaptureEnvelopeSchema = z.object({
   capture: z.unknown().optional(),
@@ -33,9 +47,19 @@ interface ExportOpts extends CaptureOpts {
   out: string;
   includePayload?: boolean;
   yes?: boolean;
+  requestIdsFile?: string;
+  concurrency?: string;
+  retries?: string;
+  resume?: boolean;
 }
 
 type JsonObject = Record<string, unknown>;
+type BatchExportStatus = "written" | "skipped" | "failed";
+
+interface BatchExportResult {
+  requestId: string;
+  status: BatchExportStatus;
+}
 
 export interface CaptureSummary {
   request_id: string | null;
@@ -75,12 +99,16 @@ export function registerCapturesCommand(program: Command): void {
       await runAction(this, () => runGet(this, requestId, opts));
     });
 
-  addCaptureOptions(captures.command("export <request-id>")
-    .description("Write a redacted or full capture object to a local file.")
+  addCaptureOptions(captures.command("export [request-id]")
+    .description("Write one or a file-listed batch of capture objects locally.")
     .requiredOption("--out <path>", "Output file or directory.")
+    .option("--request-ids-file <path>", "Batch export: one request id per line.")
+    .option("--concurrency <n>", `Batch export concurrency, max ${MAX_EXPORT_CONCURRENCY}.`, String(DEFAULT_EXPORT_CONCURRENCY))
+    .option("--retries <n>", `Retries for transient batch failures, max ${MAX_EXPORT_RETRIES}.`, String(DEFAULT_EXPORT_RETRIES))
+    .option("--no-resume", "Re-download batch files that already exist.")
     .option("--include-payload", "Write the full capture object, including prompt/completion payloads.")
     .option("--yes", "Confirm full payload export without prompting."))
-    .action(async function (this: Command, requestId: string, opts: ExportOpts) {
+    .action(async function (this: Command, requestId: string | undefined, opts: ExportOpts) {
       await runAction(this, () => runExport(this, requestId, opts));
     });
 }
@@ -130,16 +158,40 @@ async function runGet(cmd: Command, requestId: string, opts: CaptureOpts): Promi
   printCaptureBlock(summary);
 }
 
-async function runExport(cmd: Command, requestId: string, opts: ExportOpts): Promise<void> {
+async function runExport(
+  cmd: Command,
+  requestId: string | undefined,
+  opts: ExportOpts,
+): Promise<void> {
+  const singleRequestId = requestId?.trim();
+  const requestIdsFile = opts.requestIdsFile?.trim();
+  if (Boolean(singleRequestId) === Boolean(requestIdsFile)) {
+    throw new Error(
+      "Provide exactly one of <request-id> or --request-ids-file <path>.",
+    );
+  }
   if (opts.includePayload && !opts.yes) {
     throw new Error("Full capture export may contain prompts/completions. Re-run with --include-payload --yes to write it to a file.");
   }
+
+  if (requestIdsFile) {
+    await runBatchExport(cmd, requestIdsFile, opts);
+    return;
+  }
+
+  await runSingleExport(cmd, singleRequestId!, opts);
+}
+
+async function runSingleExport(
+  cmd: Command,
+  requestId: string,
+  opts: ExportOpts,
+): Promise<void> {
   const { project, workload } = await resolveCaptureContext(opts);
   const capture = await fetchCapture(project.auth.orgId, project.projectId, requestId, workload?.id);
   const outputPath = resolveOutputPath(opts.out, requestId);
-  mkdirSync(dirname(outputPath), { recursive: true });
   const value = opts.includePayload ? capture : summarizeCapture(capture);
-  writeFileSync(outputPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  writePrivateText(outputPath, `${JSON.stringify(value, null, 2)}\n`);
 
   const payload = {
     ok: true,
@@ -157,6 +209,116 @@ async function runExport(cmd: Command, requestId: string, opts: ExportOpts): Pro
   }
 }
 
+async function runBatchExport(
+  cmd: Command,
+  requestIdsFile: string,
+  opts: ExportOpts,
+): Promise<void> {
+  const { requestIds, inputCount } = readRequestIds(requestIdsFile);
+  const concurrency = parseBoundedInteger(
+    opts.concurrency,
+    "--concurrency",
+    1,
+    MAX_EXPORT_CONCURRENCY,
+    DEFAULT_EXPORT_CONCURRENCY,
+  );
+  const retries = parseBoundedInteger(
+    opts.retries,
+    "--retries",
+    0,
+    MAX_EXPORT_RETRIES,
+    DEFAULT_EXPORT_RETRIES,
+  );
+  const outputDirectory = resolveBatchOutputDirectory(opts.out);
+  const failureManifest = join(outputDirectory, "failed-request-ids.txt");
+  const resume = opts.resume !== false;
+  const { project, workload } = await resolveCaptureContext(opts);
+  const results: BatchExportResult[] = new Array(requestIds.length);
+  let completed = 0;
+
+  await runWithConcurrency(
+    requestIds,
+    concurrency,
+    async (requestId, index) => {
+      const outputPath = join(
+        outputDirectory,
+        batchCaptureFilename(requestId, Boolean(opts.includePayload)),
+      );
+      if (resume && isCompletedExport(outputPath)) {
+        results[index] = { requestId, status: "skipped" };
+      } else {
+        try {
+          const capture = await fetchCaptureWithRetry(
+            project.auth.orgId,
+            project.projectId,
+            requestId,
+            workload?.id,
+            retries,
+          );
+          const value = opts.includePayload
+            ? capture
+            : summarizeCapture(capture);
+          writePrivateText(outputPath, `${JSON.stringify(value, null, 2)}\n`);
+          results[index] = { requestId, status: "written" };
+        } catch {
+          results[index] = { requestId, status: "failed" };
+        }
+      }
+
+      completed += 1;
+      if (!isJsonMode(cmd) && completed % 100 === 0) {
+        process.stderr.write(`Exported ${completed}/${requestIds.length} captures...\n`);
+      }
+    },
+  );
+
+  const written = results.filter((result) => result.status === "written").length;
+  const skipped = results.filter((result) => result.status === "skipped").length;
+  const failedIds = results
+    .filter((result) => result.status === "failed")
+    .map((result) => result.requestId);
+  writePrivateText(
+    failureManifest,
+    failedIds.length > 0 ? `${failedIds.join("\n")}\n` : "",
+  );
+
+  const payload = {
+    ok: failedIds.length === 0,
+    input_count: inputCount,
+    unique_count: requestIds.length,
+    written,
+    skipped,
+    failed: failedIds.length,
+    output_directory: outputDirectory,
+    failure_manifest: failureManifest,
+    output_suffix: opts.includePayload ? ".json" : ".summary.json",
+    include_payload: Boolean(opts.includePayload),
+    warning: opts.includePayload
+      ? "files may contain prompts, completions, or tool payloads"
+      : null,
+  };
+
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+  } else {
+    process.stdout.write(
+      `${failedIds.length === 0 ? kleur.green("✓") : kleur.yellow("!")} ` +
+      `Capture batch complete: ${written} written, ${skipped} skipped, ` +
+      `${failedIds.length} failed -> ${outputDirectory}\n`,
+    );
+    process.stdout.write(`Failure manifest: ${failureManifest}\n`);
+    if (opts.includePayload) {
+      process.stdout.write(
+        `${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`,
+      );
+    }
+  }
+
+  if (failedIds.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
 async function resolveCaptureContext(opts: CaptureOpts) {
   const project = await resolveProject(opts);
   const workload = opts.workload ? await resolveWorkload(project, opts.workload) : null;
@@ -169,6 +331,25 @@ async function fetchCapture(orgId: string, projectId: string, requestId: string,
     : `/admin/v1/orgs/${orgId}/projects/${encodeURIComponent(projectId)}/captures/${encodeURIComponent(requestId)}`;
   const res = await request({ url: base, orgId }, CaptureEnvelopeSchema);
   return res.data.capture ?? res.data;
+}
+
+async function fetchCaptureWithRetry(
+  orgId: string,
+  projectId: string,
+  requestId: string,
+  workloadId: string | undefined,
+  retries: number,
+): Promise<unknown> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fetchCapture(orgId, projectId, requestId, workloadId);
+    } catch (error) {
+      if (attempt >= retries || !isRetryableCaptureError(error)) {
+        throw error;
+      }
+      await delay(250 * 2 ** attempt);
+    }
+  }
 }
 
 export function summarizeCapture(input: unknown): CaptureSummary {
@@ -202,14 +383,143 @@ function parseLimit(value: string | undefined): number {
   return parsed;
 }
 
+function parseBoundedInteger(
+  value: string | undefined,
+  option: string,
+  minimum: number,
+  maximum: number,
+  fallback: number,
+): number {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(
+      `Expected ${option} between ${minimum} and ${maximum}, got: ${value}`,
+    );
+  }
+  return parsed;
+}
+
+function readRequestIds(path: string): {
+  requestIds: string[];
+  inputCount: number;
+} {
+  if (!existsSync(path) || !statSync(path).isFile()) {
+    throw new Error(`Request-id file not found: ${path}`);
+  }
+  const rows = readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((row) => row.trim())
+    .filter((row) => row.length > 0 && !row.startsWith("#"));
+  if (rows.length === 0) {
+    throw new Error(`Request-id file is empty: ${path}`);
+  }
+  if (rows.length > MAX_BATCH_REQUEST_IDS) {
+    throw new Error(
+      `Request-id file contains more than ${MAX_BATCH_REQUEST_IDS} rows.`,
+    );
+  }
+  const invalid = rows.find(
+    (requestId) =>
+      requestId.length > 512 || /[\u0000-\u001f\u007f]/.test(requestId),
+  );
+  if (invalid) {
+    throw new Error(
+      "Request ids must be at most 512 characters and contain no control characters.",
+    );
+  }
+  const requestIds = [...new Set(rows)];
+  return { requestIds, inputCount: rows.length };
+}
+
+function resolveBatchOutputDirectory(out: string): string {
+  if (existsSync(out) && !statSync(out).isDirectory()) {
+    throw new Error(`Batch --out must be a directory: ${out}`);
+  }
+  mkdirSync(out, { recursive: true, mode: 0o700 });
+  return out;
+}
+
 function resolveOutputPath(out: string, requestId: string): string {
   if (existsSync(out) && statSync(out).isDirectory()) {
-    return join(out, ".understudy", "captures", `${requestId}.json`);
+    return join(out, ".understudy", "captures", `${captureFilename(requestId)}.json`);
   }
   if (out.endsWith("/") || out.endsWith("\\")) {
-    return join(out, ".understudy", "captures", `${requestId}.json`);
+    return join(out, ".understudy", "captures", `${captureFilename(requestId)}.json`);
   }
   return out || join(findProjectRoot(), ".understudy", "captures", `${requestId}.json`);
+}
+
+function captureFilename(requestId: string): string {
+  return encodeURIComponent(requestId);
+}
+
+function batchCaptureFilename(
+  requestId: string,
+  includePayload: boolean,
+): string {
+  return `${captureFilename(requestId)}${includePayload ? "" : ".summary"}.json`;
+}
+
+function isCompletedExport(path: string): boolean {
+  if (!existsSync(path)) return false;
+  const stat = statSync(path);
+  return stat.isFile() && stat.size > 0;
+}
+
+function writePrivateText(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const partialPath = `${path}.${process.pid}.partial`;
+  try {
+    writeFileSync(partialPath, contents, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    try {
+      renameSync(partialPath, path);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if ((code !== "EEXIST" && code !== "EPERM") || !existsSync(path)) {
+        throw error;
+      }
+      rmSync(path, { force: true });
+      renameSync(partialPath, path);
+    }
+  } finally {
+    rmSync(partialPath, { force: true });
+  }
+}
+
+async function runWithConcurrency<T>(
+  values: T[],
+  concurrency: number,
+  worker: (value: T, index: number) => Promise<void>,
+): Promise<void> {
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        await worker(values[index]!, index);
+      }
+    },
+  );
+  await Promise.all(workers);
+}
+
+function isRetryableCaptureError(error: unknown): boolean {
+  if (error instanceof UnderstudyApiError) {
+    return error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500;
+  }
+  return error instanceof TypeError;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function isObject(value: unknown): value is JsonObject {

--- a/src/commands/captures.ts
+++ b/src/commands/captures.ts
@@ -1,6 +1,9 @@
+import { randomUUID } from "node:crypto";
 import {
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -493,14 +496,15 @@ function quarantineExistingExport(path: string): void {
   renameSync(path, previousPath);
 }
 
-function writePrivateText(path: string, contents: string): void {
+export function writePrivateText(path: string, contents: string): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  const partialPath = `${path}.${process.pid}.partial`;
+  const partialPath = `${path}.${process.pid}.${randomUUID()}.partial`;
+  let descriptor: number | undefined;
   try {
-    writeFileSync(partialPath, contents, {
-      encoding: "utf8",
-      mode: 0o600,
-    });
+    descriptor = openSync(partialPath, "wx", 0o600);
+    writeFileSync(descriptor, contents, { encoding: "utf8" });
+    closeSync(descriptor);
+    descriptor = undefined;
     try {
       renameSync(partialPath, path);
     } catch (error) {
@@ -512,6 +516,7 @@ function writePrivateText(path: string, contents: string): void {
       renameSync(partialPath, path);
     }
   } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
     rmSync(partialPath, { force: true });
   }
 }

--- a/src/commands/captures.ts
+++ b/src/commands/captures.ts
@@ -235,6 +235,7 @@ async function runBatchExport(
   const { project, workload } = await resolveCaptureContext(opts);
   const results: BatchExportResult[] = new Array(requestIds.length);
   let completed = 0;
+  let fatalError: unknown;
 
   await runWithConcurrency(
     requestIds,
@@ -248,6 +249,9 @@ async function runBatchExport(
         results[index] = { requestId, status: "skipped" };
       } else {
         try {
+          if (!resume) {
+            quarantineExistingExport(outputPath);
+          }
           const capture = await fetchCaptureWithRetry(
             project.auth.orgId,
             project.projectId,
@@ -255,12 +259,18 @@ async function runBatchExport(
             workload?.id,
             retries,
           );
+          if (fatalError) return;
           const value = opts.includePayload
             ? capture
             : summarizeCapture(capture);
           writePrivateText(outputPath, `${JSON.stringify(value, null, 2)}\n`);
+          rmSync(previousExportPath(outputPath), { force: true });
           results[index] = { requestId, status: "written" };
-        } catch {
+        } catch (error) {
+          if (isBatchFatalError(error)) {
+            fatalError ??= error;
+            return;
+          }
           results[index] = { requestId, status: "failed" };
         }
       }
@@ -270,7 +280,10 @@ async function runBatchExport(
         process.stderr.write(`Exported ${completed}/${requestIds.length} captures...\n`);
       }
     },
+    () => fatalError !== undefined,
   );
+
+  if (fatalError) throw fatalError;
 
   const written = results.filter((result) => result.status === "written").length;
   const skipped = results.filter((result) => result.status === "skipped").length;
@@ -466,6 +479,20 @@ function isCompletedExport(path: string): boolean {
   return stat.isFile() && stat.size > 0;
 }
 
+function previousExportPath(path: string): string {
+  return `${path}.previous`;
+}
+
+function quarantineExistingExport(path: string): void {
+  if (!existsSync(path)) return;
+  if (!statSync(path).isFile()) {
+    throw new Error(`Cannot replace non-file capture export: ${path}`);
+  }
+  const previousPath = previousExportPath(path);
+  rmSync(previousPath, { force: true });
+  renameSync(path, previousPath);
+}
+
 function writePrivateText(path: string, contents: string): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const partialPath = `${path}.${process.pid}.partial`;
@@ -493,12 +520,13 @@ async function runWithConcurrency<T>(
   values: T[],
   concurrency: number,
   worker: (value: T, index: number) => Promise<void>,
+  shouldStop: () => boolean = () => false,
 ): Promise<void> {
   let nextIndex = 0;
   const workers = Array.from(
     { length: Math.min(concurrency, values.length) },
     async () => {
-      while (nextIndex < values.length) {
+      while (nextIndex < values.length && !shouldStop()) {
         const index = nextIndex;
         nextIndex += 1;
         await worker(values[index]!, index);
@@ -516,6 +544,11 @@ function isRetryableCaptureError(error: unknown): boolean {
       error.status >= 500;
   }
   return error instanceof TypeError;
+}
+
+function isBatchFatalError(error: unknown): boolean {
+  return error instanceof UnderstudyApiError &&
+    (error.status === 401 || error.status === 403);
 }
 
 function delay(ms: number): Promise<void> {

--- a/tests/capture-export-security.test.mjs
+++ b/tests/capture-export-security.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { writePrivateText } from "../dist/commands/captures.js";
+
+test(
+  "capture exports do not follow predictable temporary-file symlinks",
+  { skip: process.platform === "win32" },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "understudy-capture-export-"));
+    try {
+      const outputPath = join(root, "capture.json");
+      const victimPath = join(root, "victim.txt");
+      const predictablePartialPath = `${outputPath}.${process.pid}.partial`;
+      writeFileSync(victimPath, "unchanged\n");
+      symlinkSync(victimPath, predictablePartialPath);
+
+      writePrivateText(outputPath, "private capture\n");
+
+      assert.equal(readFileSync(outputPath, "utf8"), "private capture\n");
+      assert.equal(readFileSync(victimPath, "utf8"), "unchanged\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1910,15 +1910,15 @@ class ScoreWithFeedback:
           include_payload: true,
         },
       );
-      assert.match(readFileSync(join(outputDirectory, "req_123.json"), "utf8"), /SECRET_PROMPT/);
-      assert.match(readFileSync(join(outputDirectory, "req_456.json"), "utf8"), /SECRET_BATCH_PROMPT/);
-      assert.match(readFileSync(join(outputDirectory, "req_retry.json"), "utf8"), /SECRET_RETRY_PROMPT/);
+      assert.match(readFileSync(join(outputDirectory, "req_123.payload.json"), "utf8"), /SECRET_PROMPT/);
+      assert.match(readFileSync(join(outputDirectory, "req_456.payload.json"), "utf8"), /SECRET_BATCH_PROMPT/);
+      assert.match(readFileSync(join(outputDirectory, "req_retry.payload.json"), "utf8"), /SECRET_RETRY_PROMPT/);
       assert.equal(
         readFileSync(join(outputDirectory, "failed-request-ids.txt"), "utf8"),
         "req_missing\n",
       );
       if (process.platform !== "win32") {
-        assert.equal(statSync(join(outputDirectory, "req_123.json")).mode & 0o777, 0o600);
+        assert.equal(statSync(join(outputDirectory, "req_123.payload.json")).mode & 0o777, 0o600);
         assert.equal(statSync(join(outputDirectory, "failed-request-ids.txt")).mode & 0o777, 0o600);
       }
       assert.equal(
@@ -1987,6 +1987,57 @@ class ScoreWithFeedback:
     });
   });
 
+  it("keeps summary and payload batch filenames collision-free", async () => {
+    await withHostedFixture(async ({ home, repo, state }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const requestIdsPath = join(repo, "collision-request-ids.txt");
+      const outputDirectory = join(repo, "collision-batch");
+      const baseCapture = state.captures[0];
+      state.captures.push(
+        { ...baseCapture, request_id: "abc" },
+        { ...baseCapture, request_id: "abc.summary" },
+      );
+      writeFileSync(requestIdsPath, "abc\nabc.summary\n");
+
+      const payloadExport = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+        "--include-payload",
+        "--yes",
+      ], env, repo);
+      assert.equal(payloadExport.status, 0, payloadExport.stderr);
+      assert.equal(JSON.parse(payloadExport.stdout).output_suffix, ".payload.json");
+      assert.equal(JSON.parse(payloadExport.stdout).written, 2);
+      assert.equal(JSON.parse(payloadExport.stdout).skipped, 0);
+
+      const summaryExport = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+      ], env, repo);
+      assert.equal(summaryExport.status, 0, summaryExport.stderr);
+      assert.equal(JSON.parse(summaryExport.stdout).output_suffix, ".summary.json");
+      assert.equal(JSON.parse(summaryExport.stdout).written, 2);
+      assert.equal(JSON.parse(summaryExport.stdout).skipped, 0);
+
+      const expected = new Map([
+        ["abc.payload.json", "abc"],
+        ["abc.summary.payload.json", "abc.summary"],
+        ["abc.summary.json", "abc"],
+        ["abc.summary.summary.json", "abc.summary"],
+      ]);
+      for (const [filename, requestId] of expected) {
+        assert.equal(
+          JSON.parse(readFileSync(join(outputDirectory, filename), "utf8")).request_id,
+          requestId,
+          `${filename} should retain its own request id`,
+        );
+      }
+      assert.equal(expected.size, new Set(expected.keys()).size);
+    });
+  });
+
   it("aborts a capture batch on shared authorization failures", async () => {
     await withHostedFixture(async ({ home, repo, requests, state }) => {
       const env = { HOME: home, USERPROFILE: home };
@@ -2028,7 +2079,7 @@ class ScoreWithFeedback:
       const env = { HOME: home, USERPROFILE: home };
       const requestIdsPath = join(repo, "refresh-request-ids.txt");
       const outputDirectory = join(repo, "refresh-batch");
-      const outputPath = join(outputDirectory, "req_456.json");
+      const outputPath = join(outputDirectory, "req_456.payload.json");
       const previousPath = `${outputPath}.previous`;
       writeFileSync(requestIdsPath, "req_456\n");
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -166,6 +166,7 @@ async function withHostedFixture(fn) {
       },
     ],
     transientCaptureFailures: new Map([["req_retry", 1]]),
+    captureAuthorizationFailure: false,
   };
 
   const server = createServer(async (req, res) => {
@@ -217,6 +218,13 @@ async function withHostedFixture(fn) {
     const workloadCapture = url.pathname.match(/^\/admin\/v1\/orgs\/org_1\/projects\/proj_1\/workloads\/usp_classify\/captures\/([^/]+)$/);
     const captureMatch = projectCapture ?? workloadCapture;
     if (req.method === "GET" && captureMatch) {
+      if (state.captureAuthorizationFailure) {
+        return send(403, {
+          type: "permission_error",
+          message: "Synthetic capture access denied.",
+          request_id: "req_fixture",
+        });
+      }
       const requestId = decodeURIComponent(captureMatch[1]);
       const transientFailures = state.transientCaptureFailures.get(requestId) ?? 0;
       if (transientFailures > 0) {
@@ -1976,6 +1984,102 @@ class ScoreWithFeedback:
       ], env, repo);
       assert.notEqual(ambiguous.status, 0);
       assert.match(ambiguous.stderr, /exactly one/);
+    });
+  });
+
+  it("aborts a capture batch on shared authorization failures", async () => {
+    await withHostedFixture(async ({ home, repo, requests, state }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const requestIdsPath = join(repo, "authorization-request-ids.txt");
+      const outputDirectory = join(repo, "authorization-batch");
+      writeFileSync(
+        requestIdsPath,
+        Array.from({ length: 20 }, (_, index) => `req_auth_${index}`).join("\n"),
+      );
+      state.captureAuthorizationFailure = true;
+
+      const requestCountBefore = requests.length;
+      const exported = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+        "--concurrency", "2",
+      ], env, repo);
+
+      assert.equal(exported.status, 1);
+      assert.match(exported.stderr, /Synthetic capture access denied/);
+      const captureRequests = requests.slice(requestCountBefore).filter((entry) =>
+        entry.path.includes("/captures/")
+      );
+      assert.ok(
+        captureRequests.length > 0 && captureRequests.length <= 2,
+        `authorization failure should stop the pool, got ${captureRequests.length} capture requests`,
+      );
+      assert.equal(
+        existsSync(join(outputDirectory, "failed-request-ids.txt")),
+        false,
+        "a shared authorization error should surface directly, not hide behind an item manifest",
+      );
+    });
+  });
+
+  it("keeps a failed forced capture refresh retryable", async () => {
+    await withHostedFixture(async ({ home, repo, state }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const requestIdsPath = join(repo, "refresh-request-ids.txt");
+      const outputDirectory = join(repo, "refresh-batch");
+      const outputPath = join(outputDirectory, "req_456.json");
+      const previousPath = `${outputPath}.previous`;
+      writeFileSync(requestIdsPath, "req_456\n");
+
+      const initial = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+        "--include-payload",
+        "--yes",
+      ], env, repo);
+      assert.equal(initial.status, 0, initial.stderr);
+      assert.equal(existsSync(outputPath), true);
+
+      state.transientCaptureFailures.set("req_456", 1);
+      const failedRefresh = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+        "--include-payload",
+        "--yes",
+        "--no-resume",
+        "--retries", "0",
+      ], env, repo);
+      assert.equal(failedRefresh.status, 1, failedRefresh.stderr);
+      assert.equal(existsSync(outputPath), false);
+      assert.equal(
+        existsSync(previousPath),
+        true,
+        "the old file should be quarantined where resume cannot trust it",
+      );
+      assert.equal(
+        readFileSync(join(outputDirectory, "failed-request-ids.txt"), "utf8"),
+        "req_456\n",
+      );
+
+      const retried = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+        "--include-payload",
+        "--yes",
+      ], env, repo);
+      assert.equal(retried.status, 0, retried.stderr);
+      assert.equal(JSON.parse(retried.stdout).written, 1);
+      assert.equal(JSON.parse(retried.stdout).skipped, 0);
+      assert.equal(existsSync(outputPath), true);
+      assert.equal(existsSync(previousPath), false);
+      assert.equal(
+        readFileSync(join(outputDirectory, "failed-request-ids.txt"), "utf8"),
+        "",
+      );
     });
   });
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -128,7 +128,44 @@ async function withHostedFixture(fn) {
         upstream_request_body: { messages: [{ role: "user", content: "SECRET_PROMPT" }] },
         response_body: { content: "SECRET_COMPLETION" },
       },
+      {
+        request_id: "req_456",
+        schema_version: "understudy.capture.v1",
+        ts: "2026-06-07T00:01:00Z",
+        project_id: "proj_1",
+        workload_id: "usp_classify",
+        mode: "gateway",
+        provider: "openai",
+        endpoint: "/v1/chat/completions",
+        requested_model: "synthetic-model",
+        upstream_model: "synthetic-model",
+        status_code: 200,
+        latency_ms: 21,
+        tags: { env: "test" },
+        customer_request_body: { messages: [{ role: "user", content: "SECRET_BATCH_PROMPT" }] },
+        upstream_request_body: { messages: [{ role: "user", content: "SECRET_BATCH_PROMPT" }] },
+        response_body: { content: "SECRET_BATCH_COMPLETION" },
+      },
+      {
+        request_id: "req_retry",
+        schema_version: "understudy.capture.v1",
+        ts: "2026-06-07T00:02:00Z",
+        project_id: "proj_1",
+        workload_id: "usp_classify",
+        mode: "gateway",
+        provider: "openai",
+        endpoint: "/v1/chat/completions",
+        requested_model: "synthetic-model",
+        upstream_model: "synthetic-model",
+        status_code: 200,
+        latency_ms: 34,
+        tags: { env: "test" },
+        customer_request_body: { messages: [{ role: "user", content: "SECRET_RETRY_PROMPT" }] },
+        upstream_request_body: { messages: [{ role: "user", content: "SECRET_RETRY_PROMPT" }] },
+        response_body: { content: "SECRET_RETRY_COMPLETION" },
+      },
     ],
+    transientCaptureFailures: new Map([["req_retry", 1]]),
   };
 
   const server = createServer(async (req, res) => {
@@ -176,8 +213,29 @@ async function withHostedFixture(fn) {
     }
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/captures") return send(200, { captures: state.captures, truncated: false, cursor: null });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify/captures") return send(200, { captures: state.captures, truncated: false, cursor: null });
-    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/captures/req_123") return send(200, { capture: state.captures[0] });
-    if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify/captures/req_123") return send(200, { capture: state.captures[0] });
+    const projectCapture = url.pathname.match(/^\/admin\/v1\/orgs\/org_1\/projects\/proj_1\/captures\/([^/]+)$/);
+    const workloadCapture = url.pathname.match(/^\/admin\/v1\/orgs\/org_1\/projects\/proj_1\/workloads\/usp_classify\/captures\/([^/]+)$/);
+    const captureMatch = projectCapture ?? workloadCapture;
+    if (req.method === "GET" && captureMatch) {
+      const requestId = decodeURIComponent(captureMatch[1]);
+      const transientFailures = state.transientCaptureFailures.get(requestId) ?? 0;
+      if (transientFailures > 0) {
+        state.transientCaptureFailures.set(requestId, transientFailures - 1);
+        return send(503, {
+          type: "server_error",
+          message: "Synthetic transient capture failure.",
+          request_id: "req_fixture",
+        });
+      }
+      const capture = state.captures.find((entry) => entry.request_id === requestId);
+      return capture
+        ? send(200, { capture })
+        : send(404, {
+          type: "invalid_request_error",
+          message: "Synthetic capture not found.",
+          request_id: "req_fixture",
+        });
+    }
     const evalBase = "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify";
     const rawCapture = `${JSON.stringify(state.captures[0])}\n`;
     const rawCaptureSha = createHash("sha256").update(rawCapture).digest("hex");
@@ -1778,6 +1836,146 @@ class ScoreWithFeedback:
       const blockedJson = await runWithEnvAsync(["--json", "captures", "export", "req_123", "--out", join(repo, "full-json.json"), "--include-payload"], env, repo);
       assert.notEqual(blockedJson.status, 0, "json mode must still require --yes for payload export");
       assert.match(blockedJson.stderr, /may contain prompts\/completions/);
+    });
+  });
+
+  it("batch-exports customer captures with retries, resume, and a failure manifest", async () => {
+    await withHostedFixture(async ({ home, repo, requests }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const requestIdsPath = join(repo, "request-ids.txt");
+      const outputDirectory = join(repo, "capture-batch");
+      writeFileSync(
+        requestIdsPath,
+        [
+          "# synthetic capture cohort",
+          "req_123",
+          "req_456",
+          "req_123",
+          "req_retry",
+          "req_missing",
+          "",
+        ].join("\n"),
+      );
+
+      const blocked = await runWithEnvAsync([
+        "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+        "--include-payload",
+      ], env, repo);
+      assert.notEqual(blocked.status, 0);
+      assert.match(blocked.stderr, /may contain prompts\/completions/);
+      assert.equal(existsSync(outputDirectory), false);
+
+      const exported = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", requestIdsPath,
+        "--out", outputDirectory,
+        "--include-payload",
+        "--yes",
+        "--concurrency", "2",
+        "--retries", "1",
+      ], env, repo);
+      assert.equal(exported.status, 1, exported.stderr);
+      assert.doesNotMatch(
+        `${exported.stdout}${exported.stderr}`,
+        /SECRET_(?:BATCH_|RETRY_)?(?:PROMPT|COMPLETION)/,
+      );
+      const summary = JSON.parse(exported.stdout);
+      assert.deepEqual(
+        {
+          ok: summary.ok,
+          input_count: summary.input_count,
+          unique_count: summary.unique_count,
+          written: summary.written,
+          skipped: summary.skipped,
+          failed: summary.failed,
+          include_payload: summary.include_payload,
+        },
+        {
+          ok: false,
+          input_count: 5,
+          unique_count: 4,
+          written: 3,
+          skipped: 0,
+          failed: 1,
+          include_payload: true,
+        },
+      );
+      assert.match(readFileSync(join(outputDirectory, "req_123.json"), "utf8"), /SECRET_PROMPT/);
+      assert.match(readFileSync(join(outputDirectory, "req_456.json"), "utf8"), /SECRET_BATCH_PROMPT/);
+      assert.match(readFileSync(join(outputDirectory, "req_retry.json"), "utf8"), /SECRET_RETRY_PROMPT/);
+      assert.equal(
+        readFileSync(join(outputDirectory, "failed-request-ids.txt"), "utf8"),
+        "req_missing\n",
+      );
+      if (process.platform !== "win32") {
+        assert.equal(statSync(join(outputDirectory, "req_123.json")).mode & 0o777, 0o600);
+        assert.equal(statSync(join(outputDirectory, "failed-request-ids.txt")).mode & 0o777, 0o600);
+      }
+      assert.equal(
+        requests.filter((entry) => entry.path.endsWith("/captures/req_retry")).length,
+        2,
+        "transient capture fetch should retry once",
+      );
+
+      const resumeIdsPath = join(repo, "resume-request-ids.txt");
+      writeFileSync(resumeIdsPath, "req_123\nreq_456\n");
+      const fetchesBeforeResume = requests.filter((entry) =>
+        entry.path.endsWith("/captures/req_123") ||
+        entry.path.endsWith("/captures/req_456")
+      ).length;
+      const resumed = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", resumeIdsPath,
+        "--out", outputDirectory,
+        "--include-payload",
+        "--yes",
+      ], env, repo);
+      assert.equal(resumed.status, 0, resumed.stderr);
+      assert.deepEqual(
+        {
+          written: JSON.parse(resumed.stdout).written,
+          skipped: JSON.parse(resumed.stdout).skipped,
+          failed: JSON.parse(resumed.stdout).failed,
+        },
+        { written: 0, skipped: 2, failed: 0 },
+      );
+      assert.equal(
+        requests.filter((entry) =>
+          entry.path.endsWith("/captures/req_123") ||
+          entry.path.endsWith("/captures/req_456")
+        ).length,
+        fetchesBeforeResume,
+        "resume should not fetch completed capture files",
+      );
+      assert.equal(
+        readFileSync(join(outputDirectory, "failed-request-ids.txt"), "utf8"),
+        "",
+        "a clean resumed run should clear stale failures",
+      );
+
+      const redacted = await runWithEnvAsync([
+        "--json", "captures", "export",
+        "--request-ids-file", resumeIdsPath,
+        "--out", outputDirectory,
+      ], env, repo);
+      assert.equal(redacted.status, 0, redacted.stderr);
+      assert.equal(JSON.parse(redacted.stdout).written, 2);
+      assert.equal(JSON.parse(redacted.stdout).output_suffix, ".summary.json");
+      assert.doesNotMatch(
+        readFileSync(join(outputDirectory, "req_123.summary.json"), "utf8"),
+        /SECRET_PROMPT|SECRET_COMPLETION/,
+        "redacted and full-payload resume files must not collide",
+      );
+
+      const ambiguous = await runWithEnvAsync([
+        "captures", "export", "req_123",
+        "--request-ids-file", resumeIdsPath,
+        "--out", outputDirectory,
+      ], env, repo);
+      assert.notEqual(ambiguous.status, 0);
+      assert.match(ambiguous.stderr, /exactly one/);
     });
   });
 


### PR DESCRIPTION
## What changed

- Extend `understudy captures export` with `--request-ids-file` for one-request-id-per-line customer capture batches.
- Download with bounded concurrency, transient retries, duplicate-ID removal, and resume-by-default behavior.
- Write `failed-request-ids.txt` and return a nonzero exit status when any requested capture cannot be retrieved.
- Preserve the existing payload safety gate: full captures remain file-only and require `--include-payload --yes`.
- Keep redacted `.summary.json` files separate from full-payload `.json` files and write private files with mode `600` on Unix.
- Document the public command and privacy behavior.

## Why

The existing customer CLI accepted only one request ID per invocation. Retrieving an analyzed trace cohort therefore required thousands of manual CLI calls or an internal operator path. This adds a customer-owned, resumable workflow on top of the existing customer capture endpoint without adding Super-admin access or changing the gateway.

## User impact

A signed-in customer can now download an exact request-ID cohort with one command and safely resume interrupted exports. Automation receives a deterministic failure manifest and exit code for follow-up retries.

## Validation

- `npm run check`
- Build and TypeScript checks passed.
- 987 tests passed, including new hosted-CLI coverage for payload confirmation, retry, deduplication, failures, redacted/full separation, and resume.
- Public skill validation and package smoke checks passed.
- `git diff --check` passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->