### PR TITLE
Speed up CI with parallel, path-aware jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Cache Next.js
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: apps/homescreen/.next/cache
           key: next-${{ runner.os }}-${{ hashFiles('apps/homescreen/bun.lock') }}-${{ hashFiles('apps/homescreen/app/**', 'apps/homescreen/public/**', 'apps/homescreen/next.config.mjs') }}
@@ -149,6 +149,7 @@ jobs:
       - test_core
       - test_cli
       - desktop_web
+      - rust
     runs-on: ubuntu-latest
     steps:
       - name: Require successful Node and Desktop checks
@@ -158,15 +159,19 @@ jobs:
           TEST_CORE_RESULT: ${{ needs.test_core.result }}
           TEST_CLI_RESULT: ${{ needs.test_cli.result }}
           DESKTOP_WEB_RESULT: ${{ needs.desktop_web.result }}
+          RUST_RESULT: ${{ needs.rust.result }}
         run: |
           for result in "$CHANGES_RESULT" "$STATIC_RESULT" "$TEST_CORE_RESULT" "$TEST_CLI_RESULT"; do
             [[ "$result" == "success" ]] || exit 1
           done
           [[ "$DESKTOP_WEB_RESULT" == "success" || "$DESKTOP_WEB_RESULT" == "skipped" ]]
+          [[ "$RUST_RESULT" == "success" || "$RUST_RESULT" == "skipped" ]]
 
   rust:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    # Desktop releases require a successful Rust check for the exact main
+    # commit, even when the commit itself did not touch native sources.
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     runs-on: macos-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,42 @@ on:
     branches: [main]
 
 jobs:
-  gates:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      desktop_web: ${{ steps.paths.outputs.desktop_web }}
+      rust: ${{ steps.paths.outputs.rust }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Desktop changes
+        id: paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            changed_files="$(git ls-files)"
+          else
+            changed_files="$(git diff --name-only "$BASE_SHA" "$GITHUB_SHA")"
+          fi
+
+          desktop_web=false
+          rust=false
+          if grep -Eq '^apps/homescreen/' <<<"$changed_files" ||
+             grep -Fxq '.github/workflows/ci.yml' <<<"$changed_files"; then
+            desktop_web=true
+          fi
+          if grep -Eq '^apps/homescreen/src-tauri/' <<<"$changed_files" ||
+             grep -Fxq '.github/workflows/ci.yml' <<<"$changed_files"; then
+            rust=true
+          fi
+
+          echo "desktop_web=$desktop_web" >> "$GITHUB_OUTPUT"
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+
+  static:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -20,13 +55,85 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Node checks
-        run: npm run check
+      - name: Build and typecheck
+        run: |
+          npm run build
+          npm run typecheck
+
+      - name: Validate skills
+        run: npm run skills:validate
+
+      - name: Check package contents
+        run: npm run package:smoke
+
+  test_core:
+    name: test-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run core Node tests
+        # cli.test.mjs launches a fresh Node process for most assertions.
+        # Isolate it below so those subprocesses do not contend with the
+        # rest of the test suite on one small runner.
+        run: |
+          find tests -maxdepth 1 -name '*.test.mjs' ! -name 'cli.test.mjs' -print0 \
+            | sort -z \
+            | xargs -0 node --test
+
+  test_cli:
+    name: test-cli
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run CLI integration tests
+        run: node --test --test-concurrency=1 tests/cli.test.mjs
+
+  desktop_web:
+    name: desktop-web
+    needs: changes
+    if: needs.changes.outputs.desktop_web == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Bun 1.3.14
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
+
+      - name: Cache Next.js
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: apps/homescreen/.next/cache
+          key: next-${{ runner.os }}-${{ hashFiles('apps/homescreen/bun.lock') }}-${{ hashFiles('apps/homescreen/app/**', 'apps/homescreen/public/**', 'apps/homescreen/next.config.mjs') }}
+          restore-keys: |
+            next-${{ runner.os }}-${{ hashFiles('apps/homescreen/bun.lock') }}-
 
       - name: Desktop web build
         working-directory: apps/homescreen
@@ -34,7 +141,32 @@ jobs:
           bun install --frozen-lockfile
           bun run build
 
+  gates:
+    if: always()
+    needs:
+      - changes
+      - static
+      - test_core
+      - test_cli
+      - desktop_web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful Node and Desktop checks
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          STATIC_RESULT: ${{ needs.static.result }}
+          TEST_CORE_RESULT: ${{ needs.test_core.result }}
+          TEST_CLI_RESULT: ${{ needs.test_cli.result }}
+          DESKTOP_WEB_RESULT: ${{ needs.desktop_web.result }}
+        run: |
+          for result in "$CHANGES_RESULT" "$STATIC_RESULT" "$TEST_CORE_RESULT" "$TEST_CLI_RESULT"; do
+            [[ "$result" == "success" ]] || exit 1
+          done
+          [[ "$DESKTOP_WEB_RESULT" == "success" || "$DESKTOP_WEB_RESULT" == "skipped" ]]
+
   rust:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: macos-latest
     defaults:
       run:


### PR DESCRIPTION
## What changed

- split static checks, core Node tests, CLI integration tests, and the Desktop web build into parallel jobs
- keep `gates` as the stable aggregate pass/fail check, including Rust outcomes
- isolate `cli.test.mjs`, whose child processes previously contended with the rest of the Node suite
- skip Desktop web and Rust jobs on unrelated pull requests; Rust still runs on every push so Desktop releases retain an exact-commit success check
- cache the Next.js build cache between relevant runs

## Why

The previous workflow serialized all Node checks and the Desktop build. In the latest baseline run, `gates` took 6m52s: Node checks consumed 5m02s, including 4m26s for tests, followed by another 1m14s for Desktop. The subprocess-heavy CLI suite reported 248s while sharing the runner; isolated locally, the same suite completes in about 65s.

## Impact

Coverage and release safety are preserved. Both full PR runs exercised every job and completed in 3m53s and 3m04s, a 43–55% reduction from the 6m52s baseline. Ordinary CLI-only changes should be faster again because the Desktop jobs are skipped.

## Validation

- latest GitHub Actions run: all seven checks passed with zero annotations
- static build, typecheck, skill validation, and package smoke: passed (12.87s locally)
- core Node slice: 905 tests passed (19.29s locally)
- CLI integration slice: 81 tests passed (64.61s locally)
- Desktop `bun install --frozen-lockfile && bun run build`: passed
- `git diff --check`: passed

## Review follow-up

- Rust is enforced by the aggregate gate
- Rust runs on every push to preserve Desktop release validation
- all automated review findings are addressed and resolved