### PR TITLE
Continuous benchmarks fast-follow: hash-based staleness, ledger snapshots, regrade events

### DIFF
--- a/apps/benchmark-hub/components/leaderboard.tsx
+++ b/apps/benchmark-hub/components/leaderboard.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useMemo, useState } from "react";
 import { computeLeaderboard, formatCI, formatCost, formatLatency, formatScore, hasSplits, isAnomalousRow, statisticalTieGroups } from "@/lib/scores";
-import { isRowStale, latestBreakingBumps, staleRowSummary } from "@/lib/benchmark-core";
+import { isRowStale, latestBreakingBumps, staleRowSummary, tasksByIdForStaleness } from "@/lib/benchmark-core";
 import type { BenchmarkManifest, BenchmarkVersion, EvalRow, TaskSplit } from "@/lib/types";
 import { Badge, RouteBadge } from "@/components/badges";
 import { cn } from "@/lib/utils";
@@ -34,10 +34,13 @@ export function Leaderboard({
   // silently dropped — counts stay visible as chips below.
   const [includeStale, setIncludeStale] = useState(false);
   const breakingBumps = useMemo(() => latestBreakingBumps(versions), [versions]);
-  const staleSummary = useMemo(() => staleRowSummary(rows, breakingBumps), [rows, breakingBumps]);
+  // Current-task version/hash stamps: rows stamped at write time get an EXACT
+  // staleness verdict against these; unstamped rows keep the timestamp gate.
+  const currentTasks = useMemo(() => tasksByIdForStaleness(manifest.tasks ?? []), [manifest]);
+  const staleSummary = useMemo(() => staleRowSummary(rows, breakingBumps, currentTasks), [rows, breakingBumps, currentTasks]);
   const effectiveRows = useMemo(
-    () => (includeStale || staleSummary.staleCount === 0 ? rows : rows.filter((r) => !isRowStale(r, breakingBumps))),
-    [rows, includeStale, staleSummary, breakingBumps],
+    () => (includeStale || staleSummary.staleCount === 0 ? rows : rows.filter((r) => !isRowStale(r, breakingBumps, currentTasks))),
+    [rows, includeStale, staleSummary, breakingBumps, currentTasks],
   );
   const [localOnly, setLocalOnly] = useState(false);
   const [showRoute, setShowRoute] = useState(true);

--- a/apps/benchmark-hub/lib/benchmark-core.ts
+++ b/apps/benchmark-hub/lib/benchmark-core.ts
@@ -16,5 +16,5 @@ export type { Branch, ProjectionOptions, TraceNode } from "../../../dist/benchma
 // Leaderboard staleness gating (versions.jsonl task bumps → stale-row math):
 // same anti-drift pattern, re-exported from the dependency-free dist module
 // so client components can bundle it (no node builtins in its graph).
-export { isRowStale, latestBreakingBumps, staleRowSummary } from "../../../dist/benchmark-staleness.js";
+export { isRowStale, latestBreakingBumps, staleRowSummary, stampStaleness, tasksByIdForStaleness } from "../../../dist/benchmark-staleness.js";
 export type { BreakingBump, StaleRowSummary } from "../../../dist/benchmark-staleness.js";

--- a/apps/benchmark-hub/tests/staleness.test.mjs
+++ b/apps/benchmark-hub/tests/staleness.test.mjs
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 // Compiled by `tsc -p tests/tsconfig.json` (see package.json "test" script).
 // benchmark-core re-exports the staleness math from the repo's dist —
 // this exercises the exact functions the Leaderboard client component uses.
-import { isRowStale, latestBreakingBumps, staleRowSummary } from "./.build/lib/benchmark-core.js";
+import { isRowStale, latestBreakingBumps, staleRowSummary, tasksByIdForStaleness } from "./.build/lib/benchmark-core.js";
 import { computeLeaderboard } from "./.build/lib/scores.js";
 
 const manifest = {
@@ -83,5 +83,65 @@ describe("leaderboard stale-row exclusion math", () => {
   it("no versions.jsonl task bumps => nothing stale", () => {
     const legacyOnly = latestBreakingBumps([versions[0]]);
     assert.equal(staleRowSummary(rows, legacyOnly).staleCount, 0);
+  });
+});
+
+describe("hash/version row stamps (preferred over created_at when both sides carry them)", () => {
+  const hashes = { env_sha256: "a".repeat(64), verifier_sha256: "b".repeat(64), meta_sha256: "c".repeat(64) };
+  // Current task definitions as the leaderboard sees them (manifest tasks
+  // carrying version + content_hashes stamps).
+  const currentTasks = tasksByIdForStaleness([
+    { task_id: "t1", version: "2.0.0", content_hashes: hashes },
+    { task_id: "t2", version: "1.0.1" },
+  ]);
+  const bumps = latestBreakingBumps(versions); // t1 has a major bump at 2026-02-01
+
+  it("env/verifier hash mismatch is decisive stale even for post-bump rows", () => {
+    const mismatch = row({
+      created_at: "2026-03-01T00:00:00Z", // after the bump — timestamp gate would say fresh
+      provenance: { task_content_hashes: { ...hashes, env_sha256: "d".repeat(64) } },
+    });
+    assert.equal(isRowStale(mismatch, bumps, currentTasks), true);
+    const verifierMoved = row({
+      created_at: "2026-03-01T00:00:00Z",
+      provenance: { task_content_hashes: { ...hashes, verifier_sha256: "d".repeat(64) } },
+    });
+    assert.equal(isRowStale(verifierMoved, bumps, currentTasks), true);
+  });
+
+  it("meta-only hash drift never stales a row", () => {
+    const metaOnly = row({
+      created_at: "2026-03-01T00:00:00Z",
+      provenance: { task_content_hashes: { ...hashes, meta_sha256: "d".repeat(64) } },
+    });
+    assert.equal(isRowStale(metaOnly, bumps, currentTasks), false);
+  });
+
+  it("a matching stamp rescues rows without created_at (conservatively stale before stamping)", () => {
+    const undatedStamped = row({ created_at: null, provenance: { task_content_hashes: hashes } });
+    assert.equal(isRowStale(undatedStamped, bumps, currentTasks), false);
+    const undatedUnstamped = row({ created_at: null });
+    assert.equal(isRowStale(undatedUnstamped, bumps, currentTasks), true);
+  });
+
+  it("a matching stamp does NOT rescue rows predating a breaking bump (regrade supersession)", () => {
+    // A regrade appends a MINOR bump without changing task content: the
+    // superseded rows stamp-match the current task but must stay stale.
+    const preBumpMatch = row({ created_at: "2026-01-10T00:00:00Z", provenance: { task_content_hashes: hashes } });
+    assert.equal(isRowStale(preBumpMatch, bumps, currentTasks), true);
+  });
+
+  it("version stamps fall back to major.minor comparison when hashes are absent", () => {
+    const patchOnly = row({ task_id: "t2", created_at: null, provenance: { task_version: "1.0.0" } });
+    assert.equal(isRowStale(patchOnly, bumps, currentTasks), false); // 1.0.x == 1.0.x
+    const minorBehind = row({ task_id: "t2", created_at: "2026-03-01T00:00:00Z", provenance: { task_version: "0.9.0" } });
+    assert.equal(isRowStale(minorBehind, bumps, currentTasks), true);
+  });
+
+  it("staleRowSummary threads currentTasks and reports the current version on chips", () => {
+    const staleRows = [row({ created_at: "2026-03-01T00:00:00Z", provenance: { task_content_hashes: { ...hashes, env_sha256: "d".repeat(64) } } })];
+    const summary = staleRowSummary(staleRows, bumps, currentTasks);
+    assert.equal(summary.staleCount, 1);
+    assert.deepEqual(summary.byTask, [{ task_id: "t1", count: 1, version: "2.0.0" }]);
   });
 });

--- a/docs/benchmark-rigor.md
+++ b/docs/benchmark-rigor.md
@@ -116,7 +116,33 @@ surface fields (conservatively, unknown => env).
 `understudy runs regrade` participates in the same ledger: writing regraded
 rows appends one MINOR `versions.jsonl` line covering the regraded tasks, so
 the superseded source rows go stale in leaderboard aggregates rather than
-double-counting alongside their regrades.
+double-counting alongside their regrades. Regrades are also first-class in
+the run journal: each written regrade run appends `type: "regrade"`
+claimed/completed lines to `runs/events.jsonl` (additive — readers that
+switch on known event types ignore the new member).
+
+### Row stamps and hash-based staleness
+
+The run executor and `runs regrade` stamp every eval row at write time with
+`provenance.task_version` and `provenance.task_content_hashes` — the exact
+semver and env/verifier/meta hashes of the task the row ran against
+(additive on `understudy.eval_result.v1`; unstamped legacy tasks produce no
+stamp, never an invented one). The leaderboard staleness gate
+(`isRowStale` in `src/benchmark-staleness.ts`) prefers this stamp when both
+the row and the current task carry one: an env or verifier hash mismatch is
+decisively stale regardless of timestamps, meta-only drift never stales, and
+a matching stamp rescues rows missing `created_at`. A matching stamp does
+NOT rescue rows predating a breaking bump — a regrade bumps `versions.jsonl`
+without changing task content, and its superseded source rows must stay
+stale. Rows without stamps keep the created_at-vs-breaking-bump fallback.
+
+`versions.jsonl` entries written by `benchmarks upgrade` and `runs regrade`
+additionally snapshot every task's `{task_id, version, content_hashes}`
+under `tasks` (additive on `understudy.benchmark_version.v1`), which lets
+`benchmarks upgrade --against-version <version|index>` diff the current
+manifest against the ledger itself; legacy snapshot-less lines still require
+`--against` with the archived manifest (a bare entry cannot reproduce old
+content hashes).
 
 ## Current gaps (in progress)
 

--- a/schemas/understudy.benchmark_version.v1.schema.json
+++ b/schemas/understudy.benchmark_version.v1.schema.json
@@ -55,6 +55,32 @@
         }
       },
       "description": "Per-task version changes recorded in this line. Absent/empty for legacy split-freeze-only lines."
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["task_id"],
+        "additionalProperties": true,
+        "properties": {
+          "task_id": { "type": "string", "minLength": 1 },
+          "version": {
+            "type": ["string", "null"],
+            "description": "The task's semantic version as of this line."
+          },
+          "content_hashes": {
+            "type": ["object", "null"],
+            "properties": {
+              "env_sha256": { "type": ["string", "null"] },
+              "verifier_sha256": { "type": ["string", "null"] },
+              "meta_sha256": { "type": ["string", "null"] }
+            },
+            "additionalProperties": true,
+            "description": "The task's stamped content hashes as of this line; null when the task was unstamped."
+          }
+        }
+      },
+      "description": "Additive, optional: per-task version/hash snapshot as of this entry, enabling `benchmarks upgrade --against-version` to diff against the ledger itself without the archived manifest. Absent on legacy lines (which still require the archived manifest)."
     }
   }
 }

--- a/schemas/understudy.eval_result.v1.schema.json
+++ b/schemas/understudy.eval_result.v1.schema.json
@@ -108,6 +108,20 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Paths or ids of supporting artifacts (fixtures, trace files, packet paths)."
+        },
+        "task_version": {
+          "type": ["string", "null"],
+          "description": "Additive: the task's semantic version (MAJOR.MINOR.PATCH) at the moment this row was written — leaderboard staleness prefers a version/hash mismatch against the current task over created_at-vs-bump inference."
+        },
+        "task_content_hashes": {
+          "type": ["object", "null"],
+          "properties": {
+            "env_sha256": { "type": ["string", "null"] },
+            "verifier_sha256": { "type": ["string", "null"] },
+            "meta_sha256": { "type": ["string", "null"] }
+          },
+          "additionalProperties": true,
+          "description": "Additive: the task's stamped content hashes (env/verifier/meta canonical-JSON sha256) at row-write time. A row whose env or verifier sha no longer matches the current task is stale exactly; meta-only drift never stales."
         }
       },
       "additionalProperties": true

--- a/skills/operate-benchmark-lab/reference.md
+++ b/skills/operate-benchmark-lab/reference.md
@@ -120,12 +120,24 @@ in `src/benchmark.ts`; full table in `docs/benchmark-rigor.md`):
 
 `version` and `content_hashes` themselves are excluded from hashing.
 Benchmark-level version = max bump across tasks; added tasks count MAJOR,
-removed MINOR. Leaderboard staleness is currently computed from each row's
-`created_at` against the newest breaking (MAJOR/MINOR) bump per task in
-`versions.jsonl` — rows older than the bump are stale (excluded from
-headline aggregates, counted and named, restorable via the include toggle);
-rows missing `created_at` are conservatively stale. Stamping rows with the
-exact task version/content hash they ran against is the planned tightening.
+removed MINOR. Eval rows are now stamped at write time (run executor and
+`runs regrade`) with `provenance.task_version` + `provenance.task_content_hashes`
+— the exact task semver and env/verifier/meta hashes the row ran against.
+Leaderboard staleness prefers that stamp when both the row and the current
+task carry one: an env/verifier hash mismatch is decisively stale (meta-only
+drift never stales); a matching stamp rescues rows missing `created_at` but
+never rows predating a breaking bump (a regrade bumps `versions.jsonl`
+without changing task content — its superseded source rows must stay stale).
+Unstamped rows keep the fallback: `created_at` against the newest breaking
+(MAJOR/MINOR) bump per task in `versions.jsonl`, rows missing `created_at`
+conservatively stale. Stale rows are excluded from headline aggregates,
+counted and named, restorable via the include toggle. `versions.jsonl`
+entries written by `benchmarks upgrade` and `runs regrade` also snapshot
+per-task `tasks: [{task_id, version, content_hashes}]`, so
+`benchmarks upgrade --against-version <version|index>` can diff against the
+ledger itself (legacy snapshot-less lines still need `--against` with the
+archived manifest). Regrades journal first-class `type: "regrade"`
+claimed/completed lines into `runs/events.jsonl`.
 
 ## Executor daemon details
 

--- a/src/benchmark-hub-types.ts
+++ b/src/benchmark-hub-types.ts
@@ -29,6 +29,10 @@ export type ManifestTask = {
   gold?: { kind: "final-state" | "rubric" | "reference"; ref: string } | null;
   /** Per-task incumbent (additive; null/absent on pre-incumbent builds). */
   incumbent?: IncumbentInfo | null;
+  /** Additive: the task's semantic version (born-versioned foundry builds). */
+  version?: string | null;
+  /** Additive: stamped env/verifier/meta content hashes (drives exact leaderboard staleness). */
+  content_hashes?: { env_sha256?: string | null; verifier_sha256?: string | null; meta_sha256?: string | null } | null;
 };
 
 export type TaxonomyCategory = {

--- a/src/benchmark-staleness.ts
+++ b/src/benchmark-staleness.ts
@@ -12,6 +12,54 @@
 
 type JsonObject = Record<string, unknown>;
 
+const asObject = (value: unknown): JsonObject | null =>
+  value !== null && typeof value === "object" && !Array.isArray(value) ? (value as JsonObject) : null;
+
+/**
+ * The row-provenance stamp the run executor / regrade writes at row-write
+ * time: the exact task semver + content hashes the row ran against
+ * (additive fields under understudy.eval_result.v1 `provenance`).
+ */
+export type RowTaskStamp = {
+  task_version?: string;
+  task_content_hashes?: { env_sha256: string; verifier_sha256: string; meta_sha256: string };
+};
+
+/**
+ * Build the provenance stamp for a task at row-write time: `task_version`
+ * from the task's semver, `task_content_hashes` from its stamped
+ * content_hashes (only when all three shas are present). Null when the task
+ * carries neither (legacy unstamped tasks — rows stay unstamped, staleness
+ * falls back to created_at-vs-bump).
+ */
+export function taskProvenanceStamp(task: unknown): RowTaskStamp | null {
+  const t = asObject(task);
+  if (!t) return null;
+  const out: RowTaskStamp = {};
+  if (typeof t.version === "string" && t.version.trim()) out.task_version = t.version;
+  const hashes = stampedHashes(t.content_hashes);
+  if (hashes) out.task_content_hashes = hashes;
+  return out.task_version || out.task_content_hashes ? out : null;
+}
+
+function stampedHashes(value: unknown): { env_sha256: string; verifier_sha256: string; meta_sha256: string } | null {
+  const h = asObject(value);
+  if (!h) return null;
+  const env = h.env_sha256;
+  const verifier = h.verifier_sha256;
+  const meta = h.meta_sha256;
+  return typeof env === "string" && typeof verifier === "string" && typeof meta === "string"
+    ? { env_sha256: env, verifier_sha256: verifier, meta_sha256: meta }
+    : null;
+}
+
+/** "major.minor" prefix of a semver string, or null when not semver-shaped. */
+function majorMinor(version: unknown): string | null {
+  if (typeof version !== "string") return null;
+  const match = /^(\d+)\.(\d+)\.\d+$/.exec(version.trim());
+  return match ? `${match[1]}.${match[2]}` : null;
+}
+
 export type BreakingBump = {
   /** Task semver in force after the bump (chip text: "task vX"); null when unknown. */
   version: string | null;
@@ -50,18 +98,58 @@ export function latestBreakingBumps(versions: unknown[]): Record<string, Breakin
   return out;
 }
 
+/** A row shape the staleness gate can judge (provenance is the additive stamp). */
+export type StalenessRow = { task_id: string; created_at?: string | null; provenance?: unknown };
+
 /**
- * True when a MAJOR/MINOR bump postdates this row's provenance. Rows
- * without a created_at under a bumped task are conservatively stale (their
- * provenance cannot prove they postdate the change).
+ * Hash/version verdict for a stamped row against the CURRENT task definition.
+ * Returns true/false when BOTH sides carry stamps (content hashes preferred:
+ * stale iff env or verifier sha moved — meta-only churn never stales; version
+ * fallback compares major.minor, so PATCH bumps never stale). Returns null
+ * when either side is unstamped — no verdict, caller falls back to
+ * created_at-vs-breaking-bump.
+ */
+export function stampStaleness(row: StalenessRow, currentTask: unknown): boolean | null {
+  const provenance = asObject(row.provenance);
+  const task = asObject(currentTask);
+  if (!provenance || !task) return null;
+  const rowHashes = stampedHashes(provenance.task_content_hashes);
+  const taskHashes = stampedHashes(task.content_hashes);
+  if (rowHashes && taskHashes) {
+    return rowHashes.env_sha256 !== taskHashes.env_sha256 || rowHashes.verifier_sha256 !== taskHashes.verifier_sha256;
+  }
+  const rowVersion = majorMinor(provenance.task_version);
+  const taskVersion = majorMinor(task.version);
+  if (rowVersion && taskVersion) return rowVersion !== taskVersion;
+  return null;
+}
+
+/**
+ * True when this row's provenance no longer matches the benchmark. When both
+ * the row and the current task carry version/hash stamps, a stamp MISMATCH
+ * is decisive stale (exact — timestamps cannot rescue a row that provably ran
+ * against different content). A stamp MATCH rescues rows the timestamp gate
+ * would have staled only conservatively (missing created_at); it deliberately
+ * does NOT rescue rows whose created_at predates a breaking bump, because a
+ * regrade appends a MINOR bump WITHOUT changing task content — the superseded
+ * source rows carry stamps equal to the current task and must still go stale
+ * (otherwise leaderboards double-count old-verdict rows next to their
+ * regrades). Unstamped rows keep the created_at-vs-bump fallback.
  */
 export function isRowStale(
-  row: { task_id: string; created_at?: string | null },
+  row: StalenessRow,
   bumps: Record<string, BreakingBump>,
+  /** Optional: current task definitions by task_id (manifest/tasks.jsonl tasks carrying `version` + `content_hashes`). */
+  currentTasks?: Record<string, unknown>,
 ): boolean {
+  const stamped = stampStaleness(row, currentTasks?.[row.task_id]);
+  if (stamped === true) return true;
   const bump = bumps[row.task_id];
   if (!bump) return false;
-  return typeof row.created_at !== "string" || row.created_at < bump.created_at;
+  if (typeof row.created_at === "string") return row.created_at < bump.created_at;
+  // No created_at: matching stamps prove current provenance; unstamped rows
+  // under a bumped task stay conservatively stale.
+  return stamped !== false;
 }
 
 export type StaleRowSummary = {
@@ -72,15 +160,31 @@ export type StaleRowSummary = {
 
 /** Never silently drop: the visible-count side of the staleness gate. */
 export function staleRowSummary(
-  rows: { task_id: string; created_at?: string | null }[],
+  rows: StalenessRow[],
   bumps: Record<string, BreakingBump>,
+  currentTasks?: Record<string, unknown>,
 ): StaleRowSummary {
   const counts = new Map<string, number>();
   for (const row of rows) {
-    if (isRowStale(row, bumps)) counts.set(row.task_id, (counts.get(row.task_id) ?? 0) + 1);
+    if (isRowStale(row, bumps, currentTasks)) counts.set(row.task_id, (counts.get(row.task_id) ?? 0) + 1);
   }
   const byTask = [...counts.entries()]
-    .map(([task_id, count]) => ({ task_id, count, version: bumps[task_id]?.version ?? null }))
+    .map(([task_id, count]) => {
+      const current = asObject(currentTasks?.[task_id]);
+      const currentVersion = typeof current?.version === "string" && current.version.trim() ? current.version : null;
+      return { task_id, count, version: currentVersion ?? bumps[task_id]?.version ?? null };
+    })
     .sort((a, b) => a.task_id.localeCompare(b.task_id));
   return { staleCount: byTask.reduce((n, t) => n + t.count, 0), byTask };
+}
+
+/** Convenience: manifest/tasks.jsonl tasks keyed by task_id for the currentTasks argument. */
+export function tasksByIdForStaleness(tasks: unknown[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const task of tasks) {
+    const t = asObject(task);
+    const id = t?.task_id;
+    if (typeof id === "string" && !(id in out)) out[id] = t;
+  }
+  return out;
 }

--- a/src/benchmark-upgrade.ts
+++ b/src/benchmark-upgrade.ts
@@ -31,6 +31,18 @@ export type VersionTaskBump = {
   reason: string | null;
 };
 
+/**
+ * One tasks[] element of an understudy.benchmark_version.v1 line: the
+ * per-task snapshot (semver + stamped content hashes) as of the entry, so a
+ * later `benchmarks upgrade --against-version` can diff against the ledger
+ * itself without the archived manifest.
+ */
+export type VersionTaskSnapshot = {
+  task_id: string;
+  version: string | null;
+  content_hashes: { env_sha256: string; verifier_sha256: string; meta_sha256: string } | null;
+};
+
 /** One versions.jsonl line (understudy.benchmark_version.v1; additive). */
 export type BenchmarkVersionEntry = {
   schema_version: "understudy.benchmark_version.v1";
@@ -40,7 +52,27 @@ export type BenchmarkVersionEntry = {
   contamination: "clean" | "contaminated" | "unknown" | null;
   note: string | null;
   task_bumps: VersionTaskBump[];
+  /** Additive, optional: per-task version/hash snapshot as of this entry. Absent on legacy lines. */
+  tasks?: VersionTaskSnapshot[];
 };
+
+/** Snapshot every task's version + stamped content hashes (sorted by task_id). */
+export function versionTaskSnapshots(tasks: unknown[]): VersionTaskSnapshot[] {
+  const out: VersionTaskSnapshot[] = [];
+  for (const raw of tasks) {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const task = raw as JsonObject;
+    if (typeof task.task_id !== "string") continue;
+    const hashes = task.content_hashes;
+    const h = hashes !== null && typeof hashes === "object" && !Array.isArray(hashes) ? (hashes as JsonObject) : null;
+    const stamped =
+      h && typeof h.env_sha256 === "string" && typeof h.verifier_sha256 === "string" && typeof h.meta_sha256 === "string"
+        ? { env_sha256: h.env_sha256, verifier_sha256: h.verifier_sha256, meta_sha256: h.meta_sha256 }
+        : null;
+    out.push({ task_id: task.task_id, version: taskVersion(task), content_hashes: stamped });
+  }
+  return out.sort((a, b) => a.task_id.localeCompare(b.task_id));
+}
 
 export type UpgradePlanOptions = ComputeTaskContentHashesOptions & {
   /** Benchmark-level semver before the upgrade (default "1.0.0"). */
@@ -166,6 +198,9 @@ export function planBenchmarkUpgrade(
     contamination: splits.contamination,
     note: note ?? null,
     task_bumps,
+    // Additive: snapshot of the NEW manifest's per-task version/hash stamps,
+    // so future upgrades can diff --against-version this ledger line.
+    tasks: versionTaskSnapshots(Array.isArray(newManifest.tasks) ? newManifest.tasks : []),
   };
 
   return { diff, benchmark_version: { from, to, bump: diff.benchmarkBump }, entry, counts, cost_note };
@@ -178,5 +213,5 @@ export function serializeVersionEntryLine(entry: BenchmarkVersionEntry): string 
 
 // Staleness gating lives in ./benchmark-staleness.ts (dependency-free so the
 // hub can bundle it into client components); re-exported here for src users.
-export { latestBreakingBumps, isRowStale, staleRowSummary } from "./benchmark-staleness.js";
-export type { BreakingBump, StaleRowSummary } from "./benchmark-staleness.js";
+export { latestBreakingBumps, isRowStale, staleRowSummary, stampStaleness, taskProvenanceStamp, tasksByIdForStaleness } from "./benchmark-staleness.js";
+export type { BreakingBump, StaleRowSummary, RowTaskStamp, StalenessRow } from "./benchmark-staleness.js";

--- a/src/commands/benchmarks.ts
+++ b/src/commands/benchmarks.ts
@@ -196,10 +196,16 @@ export function registerBenchmarksCommand(program: Command): void {
         "run_request files for the rerun set. Queue-only, never executes: `understudy runs execute --watch` " +
         "picks requests up, same trust posture as the hub Run panel",
     )
-    .requiredOption(
+    .option(
       "--against <file>",
-      "The PREVIOUS benchmark manifest (old benchmark.json) to diff against. A bare versions.jsonl entry is not " +
-        "enough to recompute content hashes — pass the archived manifest",
+      "The PREVIOUS benchmark manifest (old benchmark.json) to diff against. A legacy versions.jsonl entry " +
+        "without a tasks[] snapshot is not enough to recompute content hashes — pass the archived manifest",
+    )
+    .option(
+      "--against-version <version|index>",
+      "Diff against a versions.jsonl entry's tasks[] snapshot instead of an archived manifest: a benchmark " +
+        "version string (e.g. 1.2.0) or a 0-based entry index. Only entries written with per-task snapshots " +
+        "(version + content_hashes) qualify; legacy lines still need --against",
     )
     .option("--note <text>", "Note recorded on the appended versions.jsonl line")
     .option("--dry-run", "Print the plan without appending to versions.jsonl (and never queue)", false)
@@ -211,14 +217,52 @@ export function registerBenchmarksCommand(program: Command): void {
       [] as string[],
     )
     .option("--rollouts <n>", "Rollouts per task for the queued rerun", "1")
-    .action(async (dir: string, options: { against: string; note?: string; dryRun: boolean; queue: boolean; model: string[]; rollouts: string }) => {
+    .action(async (dir: string, options: { against?: string; againstVersion?: string; note?: string; dryRun: boolean; queue: boolean; model: string[]; rollouts: string }) => {
       const fs = await import("node:fs");
       const path = await import("node:path");
       const { planBenchmarkUpgrade, serializeVersionEntryLine } = await import("../benchmark-upgrade.js");
       const entry = await loadDirEntry(dir);
       if (entry.kind !== "ok") throw new Error(`upgrade needs a promoted benchmark dir (understudy.benchmark.v1); this dir is stage "${entry.kind}"`);
+      if ((options.against ? 1 : 0) + (options.againstVersion ? 1 : 0) !== 1) {
+        throw new Error("pass exactly one of --against <old-manifest.json> or --against-version <version|index>");
+      }
 
-      const againstRaw = JSON.parse(readFileSync(options.against, "utf8"));
+      let againstRaw: unknown;
+      if (options.againstVersion) {
+        // Ledger-backed baseline: a versions.jsonl entry with a per-task
+        // snapshot (tasks[]: version + content_hashes) stands in for the
+        // archived manifest — classifyTaskChange compares stamped hashes.
+        const wanted = options.againstVersion;
+        const versionLines = entry.versions as Record<string, unknown>[];
+        const byVersion = versionLines.filter((line) => typeof line.version === "string" && line.version === wanted);
+        const line = byVersion.length > 0
+          ? byVersion[byVersion.length - 1]
+          : /^\d+$/.test(wanted) && Number(wanted) < versionLines.length
+            ? versionLines[Number(wanted)]
+            : null;
+        if (!line) {
+          const known = versionLines.map((l, i) => `${i}:${typeof l.version === "string" ? l.version : "(no version)"}`).join(", ");
+          throw new Error(`--against-version ${wanted} matches no versions.jsonl entry (have: ${known || "none"})`);
+        }
+        const snapshots = Array.isArray(line.tasks) ? line.tasks : null;
+        if (!snapshots || snapshots.length === 0) {
+          throw new Error(
+            `versions.jsonl entry ${typeof line.version === "string" ? line.version : wanted} carries no tasks[] snapshot ` +
+              "(written before snapshot support) — a bare entry cannot reproduce the old content hashes; pass the " +
+              "archived manifest with --against instead",
+          );
+        }
+        const unstamped = snapshots.filter((s) => !(s as { content_hashes?: unknown }).content_hashes);
+        if (unstamped.length > 0) {
+          throw new Error(
+            `versions.jsonl snapshot for entry ${typeof line.version === "string" ? line.version : wanted} has ` +
+              `${unstamped.length} task(s) without content_hashes — cannot diff exactly; pass the archived manifest with --against`,
+          );
+        }
+        againstRaw = { version: line.version ?? null, tasks: snapshots };
+      } else {
+        againstRaw = JSON.parse(readFileSync(options.against!, "utf8"));
+      }
       if (againstRaw === null || typeof againstRaw !== "object" || !Array.isArray((againstRaw as { tasks?: unknown }).tasks)) {
         throw new Error(
           "--against must be a previous benchmark manifest (an object with a tasks[] array); a versions.jsonl " +

--- a/src/regrade.ts
+++ b/src/regrade.ts
@@ -14,13 +14,36 @@
  * regrade re-judges, it never re-spends). Non-replayable or trace-missing
  * rows are skipped with an explicit reason, never silently dropped.
  */
-import { appendFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
-import { EVAL_RESULT_SCHEMA, appendJsonlRows, readJsonlFile } from "./benchmark-artifacts.js";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { EVAL_RESULT_SCHEMA, RUN_EVENT_SCHEMA, appendJsonlRows, readJsonlFile, serializeRunEvent } from "./benchmark-artifacts.js";
 import { accumulateReplay, type ReplayCall } from "./benchmark-replay.js";
 import { bumpVersion } from "./benchmark.js";
-import { serializeVersionEntryLine, type BenchmarkVersionEntry, type VersionTaskBump } from "./benchmark-upgrade.js";
-import { newOutputFiles, rowsFilePath, verifiersWorkDir } from "./run-executor.js";
+import { taskProvenanceStamp } from "./benchmark-staleness.js";
+import { serializeVersionEntryLine, versionTaskSnapshots, type BenchmarkVersionEntry, type VersionTaskBump } from "./benchmark-upgrade.js";
+import { EXECUTOR_VERSION, newOutputFiles, rowsFilePath, runEventsPath, verifiersWorkDir } from "./run-executor.js";
+
+/**
+ * First-class journal presence: writing a regrade run appends a claimed +
+ * completed `type: "regrade"` pair to runs/events.jsonl (same
+ * understudy.run_event.v1 lines the executor writes — old readers that
+ * switch on known types simply ignore the new member). The completed event's
+ * progress counts regraded rows over rows considered.
+ */
+function appendRegradeEvents(
+  benchmarkDir: string,
+  args: { newRunId: string; sourceRunId: string; regraded: number; considered: number; skipped: number; ts: string },
+): void {
+  const file = runEventsPath(benchmarkDir);
+  mkdirSync(dirname(file), { recursive: true });
+  const base = { schema_version: RUN_EVENT_SCHEMA, run_id: args.newRunId, type: "regrade" as const, executor_version: EXECUTOR_VERSION, source_run_id: args.sourceRunId };
+  appendFileSync(file, serializeRunEvent({ ...base, ts: args.ts, status: "claimed", progress: { completed: 0, total: args.regraded } }), { mode: 0o600 });
+  appendFileSync(
+    file,
+    serializeRunEvent({ ...base, ts: args.ts, status: "completed", progress: { completed: args.regraded, total: args.regraded }, rows_considered: args.considered, skipped: args.skipped }),
+    { mode: 0o600 },
+  );
+}
 
 type Obj = Record<string, unknown>;
 const asObject = (value: unknown): Obj =>
@@ -203,6 +226,8 @@ export function regradeVersionEntry(
   taskBumps: VersionTaskBump[],
   createdAt: string,
   note: string,
+  /** Additive: current task definitions (tasks.jsonl) snapshotted onto the entry as tasks[] (version + content hashes). */
+  currentTasks?: Obj[],
 ): BenchmarkVersionEntry {
   const lastLine = priorVersionLines.length > 0 ? asObject(priorVersionLines[priorVersionLines.length - 1]) : null;
   const lastVersion = typeof lastLine?.version === "string" && lastLine.version.trim() ? lastLine.version : null;
@@ -218,6 +243,7 @@ export function regradeVersionEntry(
       contamination === "clean" || contamination === "contaminated" || contamination === "unknown" ? contamination : null,
     note,
     task_bumps: taskBumps,
+    ...(currentTasks ? { tasks: versionTaskSnapshots(currentTasks) } : {}),
   };
 }
 
@@ -313,6 +339,9 @@ export function regradeRuns(benchmarkDir: string, options: RegradeOptions = {}):
         created_at: now().toISOString(),
         provenance: {
           ...asObject(row.provenance),
+          // Additive hash-based staleness stamp: the CURRENT task's semver +
+          // content hashes — the definition this regrade actually judged under.
+          ...(taskProvenanceStamp(task) ?? {}),
           source_run: { action: "regrade", run_id: runId, row_ref: rowRef },
         },
       });
@@ -333,6 +362,7 @@ export function regradeRuns(benchmarkDir: string, options: RegradeOptions = {}):
         byModel.set(model, [...(byModel.get(model) ?? []), row]);
       }
       for (const [model, rows] of byModel) appendJsonlRows(rowsFilePath(dir, newRunId, model), rows);
+      appendRegradeEvents(dir, { newRunId, sourceRunId: runId, regraded: regraded.length, considered: sourceRows.length, skipped: skipped.length, ts: now().toISOString() });
       // Every regraded task gets a MINOR bump on the invocation's single
       // versions.jsonl entry (appended once, below). from is null — the
       // verifier edit that motivated the regrade was not necessarily
@@ -377,6 +407,7 @@ export function regradeRuns(benchmarkDir: string, options: RegradeOptions = {}):
       taskBumps,
       versionStampedAt,
       `runs regrade: rescored ${rescored} row(s) across ${summaries.filter((s) => s.new_run_id !== null).length} run(s) under the current verifier`,
+      [...sidecarTasks.values()],
     );
     appendFileSync(join(dir, "versions.jsonl"), serializeVersionEntryLine(entry), "utf8");
     for (const summary of summaries) summary.version_entry = entry;

--- a/src/run-executor.ts
+++ b/src/run-executor.ts
@@ -25,6 +25,7 @@ import { COST_PER_MTOKEN, resolveGatewayAuth } from "./trace-author.js";
 import { BENCHMARK_PROPOSAL_SCHEMA, BENCHMARK_SCHEMA, CALIBRATION_SCHEMA, EVAL_RESULT_SCHEMA, RUN_EVENT_SCHEMA, appendJournalEntry, readJsonlFile, serializeJsonlLine, serializeRunEvent } from "./benchmark-artifacts.js";
 import { predictLocalFit, resolveLocalArm, type LocalServerHandle, type LocalServingRig, type ResolvedLocalArm } from "./local-serving.js";
 import { readTrustPosture, resolveTrustBoundaries, type TrustPosture } from "./config/trust.js";
+import { taskProvenanceStamp } from "./benchmark-staleness.js";
 
 type Obj = Record<string, any>;
 const asObject = (value: unknown): Obj => (value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Obj) : {});
@@ -728,7 +729,7 @@ export type RunEvent = {
   schema_version: typeof RUN_EVENT_SCHEMA;
   ts: string;
   run_id: string;
-  type: "run_started" | "arm_started" | "rollout" | "rollout_error" | "arm_finished" | "run_finished" | "run_cancelled" | "run_failed" | "cap_warning" | "run_unsupported" | "arm_fallback" | "spend_warning" | "spend_stop";
+  type: "run_started" | "arm_started" | "rollout" | "rollout_error" | "arm_finished" | "run_finished" | "run_cancelled" | "run_failed" | "cap_warning" | "run_unsupported" | "arm_fallback" | "spend_warning" | "spend_stop" | "regrade";
   model?: string;
   task_id?: string;
   rollout?: number;
@@ -1123,6 +1124,12 @@ export async function executeRunRequest(benchmarkDir: string, runId: string, opt
             ...(anomalies.length > 0 ? { anomaly: anomalies[0], anomalies } : {}),
             ...(result.error ? { error: result.error } : {}),
           };
+          // Additive provenance stamp: the exact task semver + content hashes
+          // this row ran against (sidecar task first — the foundry stamps the
+          // full tasks.jsonl content — else the manifest task's copy). The
+          // leaderboard staleness gate prefers this over created_at-vs-bump.
+          const taskStamp = taskProvenanceStamp(sidecar) ?? taskProvenanceStamp(manifestTasks.get(taskId));
+          if (taskStamp) row.provenance = { ...asObject(row.provenance), ...taskStamp };
           appendFileSync(rowsFile, serializeJsonlLine(row), { mode: 0o600 });
           recordSpend(result.cost);
           completed += 1;

--- a/tests/benchmark-upgrade.test.mjs
+++ b/tests/benchmark-upgrade.test.mjs
@@ -255,6 +255,69 @@ describe("understudy benchmarks upgrade (CLI)", () => {
     assert.equal(fs.readdirSync(queueDir).length, 1);
   });
 
+  it("snapshots the NEW manifest's per-task version/hash stamps onto the entry", () => {
+    const stamps = { env_sha256: "e".repeat(64), verifier_sha256: "v".repeat(64), meta_sha256: "m".repeat(64) };
+    const oldM = manifest([task("t1", { version: "1.0.0", content_hashes: stamps })]);
+    const newM = manifest([task("t1", { version: "1.1.0", content_hashes: { ...stamps, verifier_sha256: "w".repeat(64) } }), task("t2")]);
+    const plan = planBenchmarkUpgrade(oldM, newM, { previousBenchmarkVersion: "1.0.0" });
+    assert.deepEqual(plan.entry.tasks, [
+      { task_id: "t1", version: "1.1.0", content_hashes: { ...stamps, verifier_sha256: "w".repeat(64) } },
+      { task_id: "t2", version: null, content_hashes: null }, // unstamped: honest nulls
+    ]);
+  });
+
+  it("--against-version diffs against a ledger snapshot (and errors clearly without one)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "us-upgrade-snap-"));
+    const stamps = { env_sha256: "e".repeat(64), verifier_sha256: "v".repeat(64), meta_sha256: "m".repeat(64) };
+    const v1 = manifest([task("t1", { version: "1.0.0", content_hashes: stamps })]);
+    fs.writeFileSync(path.join(dir, "benchmark.json"), JSON.stringify(v1, null, 2));
+    // First upgrade (identity diff against itself) just records the snapshot line.
+    const againstPath = path.join(dir, "old.json");
+    fs.writeFileSync(againstPath, JSON.stringify(v1, null, 2));
+    execFileSync(process.execPath, [bin, "benchmarks", "upgrade", dir, "--against", againstPath], { encoding: "utf8" });
+    const entry1 = JSON.parse(fs.readFileSync(path.join(dir, "versions.jsonl"), "utf8").split("\n").filter(Boolean)[0]);
+    assert.deepEqual(entry1.tasks, [{ task_id: "t1", version: "1.0.0", content_hashes: stamps }]);
+
+    // Verifier edit lands in the manifest; diff against the LEDGER entry by version.
+    const v2 = manifest([task("t1", { version: "1.1.0", content_hashes: { ...stamps, verifier_sha256: "w".repeat(64) } })]);
+    fs.writeFileSync(path.join(dir, "benchmark.json"), JSON.stringify(v2, null, 2));
+    const out = JSON.parse(
+      execFileSync(process.execPath, [bin, "benchmarks", "upgrade", dir, "--against-version", entry1.version, "--dry-run"], { encoding: "utf8" }),
+    );
+    assert.deepEqual(out.diff.plan.regrade, ["t1"]);
+    assert.equal(out.benchmark_version.bump, "minor");
+    // Same entry addressable by 0-based index.
+    const byIndex = JSON.parse(
+      execFileSync(process.execPath, [bin, "benchmarks", "upgrade", dir, "--against-version", "0", "--dry-run"], { encoding: "utf8" }),
+    );
+    assert.deepEqual(byIndex.diff.plan.regrade, ["t1"]);
+
+    // A legacy line without tasks[] keeps the clear error.
+    const legacyDir = fs.mkdtempSync(path.join(os.tmpdir(), "us-upgrade-legacy-"));
+    fs.writeFileSync(path.join(legacyDir, "benchmark.json"), JSON.stringify(v2, null, 2));
+    fs.writeFileSync(
+      path.join(legacyDir, "versions.jsonl"),
+      JSON.stringify({ schema_version: "understudy.benchmark_version.v1", created_at: "2026-01-01T00:00:00Z", version: "1.0.0", task_bumps: [] }) + "\n",
+    );
+    assert.throws(
+      () => execFileSync(process.execPath, [bin, "benchmarks", "upgrade", legacyDir, "--against-version", "1.0.0"], { encoding: "utf8", stdio: "pipe" }),
+      /no tasks\[\] snapshot/,
+    );
+    // Unknown version, and mutually exclusive flags.
+    assert.throws(
+      () => execFileSync(process.execPath, [bin, "benchmarks", "upgrade", dir, "--against-version", "9.9.9"], { encoding: "utf8", stdio: "pipe" }),
+      /matches no versions\.jsonl entry/,
+    );
+    assert.throws(
+      () => execFileSync(process.execPath, [bin, "benchmarks", "upgrade", dir], { encoding: "utf8", stdio: "pipe" }),
+      /exactly one of --against/,
+    );
+    assert.throws(
+      () => execFileSync(process.execPath, [bin, "benchmarks", "upgrade", dir, "--against", againstPath, "--against-version", "0"], { encoding: "utf8", stdio: "pipe" }),
+      /exactly one of --against/,
+    );
+  });
+
   it("rejects a versions-entry file as --against (needs the archived manifest)", () => {
     const { dir, againstPath } = setup();
     const entryPath = path.join(dir, "entry.json");

--- a/tests/benchmarks-mcp.test.mjs
+++ b/tests/benchmarks-mcp.test.mjs
@@ -551,6 +551,25 @@ describe("from_dataset", () => {
     // The proposed benchmark is immediately visible to the operator surface.
     const listed = callBenchmarksTool("list_benchmarks");
     assert.ok(listed.benchmarks.some((b) => b.slug === "data--spam-intake" && b.stage === "proposed"));
+    // Born-versioned via the MCP path too: every generated task is stamped
+    // 1.0.0 with env/verifier/meta content hashes (same stamping helper the
+    // trace foundry uses), on both the sidecar and the manifest tasks.
+    const sidecarTasks = fs
+      .readFileSync(path.join(out.dir, "tasks.jsonl"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    assert.ok(sidecarTasks.length > 0);
+    for (const task of sidecarTasks) {
+      assert.equal(task.version, "1.0.0");
+      assert.match(task.content_hashes.env_sha256, /^[0-9a-f]{64}$/);
+      assert.match(task.content_hashes.verifier_sha256, /^[0-9a-f]{64}$/);
+      assert.match(task.content_hashes.meta_sha256, /^[0-9a-f]{64}$/);
+    }
+    for (const task of manifest.tasks) {
+      assert.equal(task.version, "1.0.0");
+      assert.match(task.content_hashes.env_sha256, /^[0-9a-f]{64}$/);
+    }
   });
 
   it("refuses an existing dir, a bad slug, and a missing source", () => {

--- a/tests/run-executor.test.mjs
+++ b/tests/run-executor.test.mjs
@@ -45,6 +45,9 @@ function makeBenchmarkDir() {
     {
       schema_version: "understudy.benchmark_task.v1",
       task_id: "t1",
+      // Born-versioned task: rows must carry the version/hash provenance stamp.
+      version: "1.2.0",
+      content_hashes: { env_sha256: "e".repeat(64), verifier_sha256: "v".repeat(64), meta_sha256: "m".repeat(64) },
       outcome_contract: { required: [{ tool: "update-record", observed_arguments: { id: "r1" } }], preserved: [], forbidden: [], grading: "final_state_and_obligations" },
     },
     {
@@ -126,6 +129,16 @@ describe("executeRunRequest state machine", () => {
       assert.equal(row.run_id, run.run_id);
       assert.equal(row.category_id, "cat-a");
       assert.ok(Array.isArray(row.writes));
+      // Hash-based staleness stamp: stamped sidecar tasks (t1) put their
+      // version + content hashes on row provenance; unstamped tasks (t2)
+      // write no stamp — never an invented one.
+      if (row.task_id === "t1") {
+        assert.equal(row.provenance.task_version, "1.2.0");
+        assert.equal(row.provenance.task_content_hashes.env_sha256, "e".repeat(64));
+        assert.equal(row.provenance.task_content_hashes.verifier_sha256, "v".repeat(64));
+      } else {
+        assert.equal(row.provenance?.task_version, undefined);
+      }
     }
     // Per-model rows files (the hub's rows-*.jsonl glob).
     const files = fs.readdirSync(dir).filter((f) => /^rows-.*\.jsonl$/.test(f));

--- a/tests/runs-regrade.test.mjs
+++ b/tests/runs-regrade.test.mjs
@@ -39,7 +39,9 @@ function makeFixture({ replayable = true } = {}) {
   writeFileSync(
     join(dir, "tasks.jsonl"),
     jsonl([
-      { task_id: "t1", outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "blue" }], forbidden: [] } },
+      // t1 is born-versioned (foundry-stamped): regraded rows must carry its
+      // CURRENT version + content hashes in provenance.
+      { task_id: "t1", version: "1.1.0", content_hashes: { env_sha256: "a".repeat(64), verifier_sha256: "b".repeat(64), meta_sha256: "c".repeat(64) }, outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "blue" }], forbidden: [] } },
       { task_id: "t2", outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "red" }], forbidden: [] } },
       { task_id: "t3", outcome_contract: { required: [{ type: "response_obligation", kind: "contains_category", expected: "green" }], forbidden: [] } },
     ]),
@@ -232,6 +234,75 @@ describe("regradeRuns", () => {
     const { dir, runId } = makeFixture();
     writeFileSync(join(dir, `rows-${runId}-regrade-1-whatever.jsonl`), "");
     assert.equal(allocateRegradeRunId(dir, runId, new Set([`${runId}-regrade-2`])), `${runId}-regrade-3`);
+  });
+
+  it("stamps regraded rows with the CURRENT task version + content hashes (stamped tasks only)", () => {
+    const { dir, runId, model } = makeFixture();
+    regradeRuns(dir, { now: () => new Date("2026-07-23T00:00:00.000Z") });
+    const rows = readFileSync(rowsFilePath(dir, `${runId}-regrade-1`, model), "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    const rowT1 = rows.find((r) => r.task_id === "t1");
+    assert.equal(rowT1.provenance.task_version, "1.1.0");
+    assert.deepEqual(rowT1.provenance.task_content_hashes, {
+      env_sha256: "a".repeat(64),
+      verifier_sha256: "b".repeat(64),
+      meta_sha256: "c".repeat(64),
+    });
+    // t2's sidecar task is unstamped — its regraded row carries no stamp
+    // (staleness falls back to created_at for such rows), never a fake one.
+    const rowT2 = rows.find((r) => r.task_id === "t2");
+    assert.equal(rowT2.provenance.task_version, undefined);
+    assert.equal(rowT2.provenance.task_content_hashes, undefined);
+    // A stamped row matching the current task stays fresh through the
+    // hash-preferred gate even though a MINOR bump was just appended.
+    const lines = readFileSync(join(dir, "versions.jsonl"), "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    const bumps = latestBreakingBumps(lines);
+    const currentTasks = { t1: { version: "1.1.0", content_hashes: rowT1.provenance.task_content_hashes } };
+    assert.equal(isRowStale(rowT1, bumps, currentTasks), false);
+    // A row stamped with DIFFERENT env hashes is stale regardless of created_at.
+    const oldStamped = { task_id: "t1", created_at: "2027-01-01T00:00:00.000Z", provenance: { task_content_hashes: { env_sha256: "d".repeat(64), verifier_sha256: "b".repeat(64), meta_sha256: "c".repeat(64) } } };
+    assert.equal(isRowStale(oldStamped, bumps, currentTasks), true);
+  });
+
+  it("snapshots per-task version/hash stamps onto the appended versions.jsonl entry", () => {
+    const { dir } = makeFixture();
+    const [summary] = regradeRuns(dir, { now: () => new Date("2026-07-23T00:00:00.000Z") });
+    const entry = summary.version_entry;
+    assert.ok(Array.isArray(entry.tasks));
+    assert.deepEqual(entry.tasks.map((t) => t.task_id), ["t1", "t2", "t3"]);
+    const t1 = entry.tasks.find((t) => t.task_id === "t1");
+    assert.equal(t1.version, "1.1.0");
+    assert.equal(t1.content_hashes.env_sha256, "a".repeat(64));
+    // Unstamped tasks snapshot honestly as nulls (no invented hashes).
+    const t2 = entry.tasks.find((t) => t.task_id === "t2");
+    assert.equal(t2.version, null);
+    assert.equal(t2.content_hashes, null);
+  });
+
+  it("appends first-class regrade events to runs/events.jsonl (claimed + completed)", () => {
+    const { dir, runId } = makeFixture();
+    regradeRuns(dir, { now: () => new Date("2026-07-23T00:00:00.000Z") });
+    const eventsFile = join(dir, "runs", "events.jsonl");
+    assert.ok(existsSync(eventsFile));
+    const events = readFileSync(eventsFile, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    assert.equal(events.length, 2);
+    for (const event of events) {
+      assert.equal(event.schema_version, "understudy.run_event.v1");
+      assert.equal(event.type, "regrade");
+      assert.equal(event.run_id, `${runId}-regrade-1`);
+      assert.equal(event.source_run_id, runId);
+      assert.equal(event.ts, "2026-07-23T00:00:00.000Z");
+      assert.equal(typeof event.executor_version, "string");
+    }
+    assert.deepEqual(events[0].progress, { completed: 0, total: 2 });
+    assert.equal(events[0].status, "claimed");
+    assert.equal(events[1].status, "completed");
+    assert.deepEqual(events[1].progress, { completed: 2, total: 2 });
+    assert.equal(events[1].rows_considered, 4);
+    assert.equal(events[1].skipped, 2);
+    // Dry runs journal nothing.
+    const { dir: dryDir } = makeFixture();
+    regradeRuns(dryDir, { dryRun: true });
+    assert.ok(!existsSync(join(dryDir, "runs", "events.jsonl")));
   });
 
   it("loadRetainedTraces is empty for an arm without a structural work dir", () => {


### PR DESCRIPTION
Fast-follow to #374:

- **Hash-based row staleness**: executor and regrade rows stamp `provenance.task_version` + `provenance.task_content_hashes` at write time (additive `eval_result.v1` fields); `isRowStale` prefers the stamp verdict, with a deliberate asymmetry — mismatch is decisively stale, but a matching stamp does not rescue rows predating a breaking bump (a regrade appends a MINOR bump without changing task content, so "stamp match wins" would double-count superseded source rows). All four cases covered in hub tests.
- **Ledger snapshots**: `benchmark_version.v1` entries from `benchmarks upgrade` and `runs regrade` snapshot per-task `{task_id, version, content_hashes}`; new `benchmarks upgrade --against-version <version|index>` diffs against the ledger without needing archived manifests.
- **Regrade as first-class run events**: `RunEvent` gains `"regrade"`; regrade appends claimed/completed lines to `runs/events.jsonl`; old readers tolerate unknown types.
- **`from_dataset` born-versioning**: verified already stamped via `stampTaskVersions` on the base branch; locked in with explicit sidecar+manifest assertions.

`npm run check` 1064/1064; hub suite 172/172; schemas additive; ledgers append-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->