### PR TITLE
Add hosted trace capture exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ uses semantic-ish versioning (minor = new skill or new capability, patch = fixes
 
 ### Added
 
+- **Trace-level hosted capture exports.** `understudy traces export <trace-id>`
+  calls the customer trace request-ID lookup and hands every returned ID to the
+  existing resumable request capture exporter. Explicit `--trace-ids-file`
+  batches are supported; the CLI never scans project capture history and has no
+  unbounded all-traces mode. Full payloads remain file-only behind
+  `--include-payload --yes`, with per-request and per-trace retry manifests.
+- **Hosted trace retrieval skill.** The new `export-trace` worker owns requests
+  such as "get this trace" when the developer supplies a `trace_id`, then hands
+  private local files to `ingest-traces` or the trace viewer. Its intent was
+  checked against `use-understudy-gateway` (auth/routing) and `ingest-traces`
+  (already-local processing) before adding a new top-level skill.
 - **Resumable customer capture batches.** `understudy captures export` now
   accepts `--request-ids-file` for one-request-id-per-line exports using the
   signed-in customer's existing capture access. Batch downloads use bounded

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ live in each skill's `references/` directory:
 | Stage | Skills |
 | --- | --- |
 | **Setup & first run** | install-agent-adapter, compatibility install shims, onboard, ladder (the onboarding "climb") |
-| **Understand & capture** | understand-workload, ingest-traces (incl. the capture-directory profiler), capture-evidence (incl. the public-benchmark on-ramp), design-simulated-environment |
+| **Understand & capture** | understand-workload, export-trace, ingest-traces (incl. the capture-directory profiler), capture-evidence (incl. the public-benchmark on-ramp), design-simulated-environment |
 | **Local models** | manage-local-models, run-local-model-lab, recursive-language-model (incl. RLM pedagogical training) |
 | **Compare & diagnose** | compare-model-sweep, compare-trajectories |
 | **Plan hosted runs** | plan-hosted-run (provider routing + cost estimation) |
@@ -597,6 +597,8 @@ understudy workloads create classify --capture
 understudy gateway probe --provider anthropic --project rehearsal --workload classify
 understudy captures list --project rehearsal --workload classify
 understudy captures export --request-ids-file request-ids.txt --project rehearsal --out .understudy/capture-batch --include-payload --yes
+understudy traces export <trace-id> --project rehearsal --out .understudy/trace-exports --include-payload --yes
+understudy traces export --trace-ids-file trace-ids.txt --project rehearsal --out .understudy/trace-exports --include-payload --yes
 understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
 understudy routes show classify --project rehearsal
 understudy routes clear classify --project rehearsal
@@ -630,8 +632,14 @@ file-only, and requires `--include-payload --yes`. For a customer-owned batch,
 put one request id per line in a file and pass `--request-ids-file`; the CLI
 retries transient failures, resumes from completed files, and writes
 `failed-request-ids.txt`. Redacted batch files use `.summary.json`, keeping
-them distinct from full-payload `.payload.json` files. `models list` shows
-public Understudy model IDs and display names only.
+them distinct from full-payload `.payload.json` files. `traces export` resolves
+one explicit `trace_id` through the customer trace request-ID endpoint, then
+reuses that same bounded request exporter for every returned ID. Use a
+positional trace ID or an explicit `--trace-ids-file`; there is no unbounded
+`--all` trace scan. Each trace writes a private `trace.json` membership manifest,
+per-request summary or payload files, `failed-request-ids.txt`, and a batch-level
+`failed-trace-ids.txt`. `models list` shows public Understudy model IDs and
+display names only.
 
 If the coding agent has an approved native email connector, it may complete the
 email-code prompt by reading the fresh Understudy sign-in email directly. The

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -41,6 +41,8 @@ understudy captures list --project rehearsal --workload classify
 understudy captures get <request-id> --project rehearsal --workload classify
 understudy captures export <request-id> --out .understudy/captures/<request-id>.json
 understudy captures export --request-ids-file request-ids.txt --project rehearsal --out .understudy/capture-batch --include-payload --yes
+understudy traces export <trace-id> --project rehearsal --out .understudy/trace-exports --include-payload --yes
+understudy traces export --trace-ids-file trace-ids.txt --project rehearsal --out .understudy/trace-exports --include-payload --yes
 understudy routes show classify --project rehearsal
 understudy routes set classify --project rehearsal --model-id glm-5.1 --traffic-pct 10
 understudy routes clear classify --project rehearsal
@@ -133,7 +135,11 @@ model and what remains passthrough/frontier.
 Hosted capture commands are metadata-first. `captures list` and `captures get`
 redact prompt/completion-bearing fields into presence booleans. Full capture
 export is opt-in with `--include-payload --yes`, writes only to a file, and never
-prints raw payloads to stdout.
+prints raw payloads to stdout. `traces export` calls the customer trace
+request-ID lookup for one explicit `trace_id`, then passes the returned IDs to
+the existing request capture batch exporter. It never walks the project capture
+catalog. Full per-request captures require the same explicit payload opt-in;
+there is no unbounded all-traces operation.
 
 `optimize-workload check` reads `.understudy/capture-evidence/`
 artifacts, fails closed on missing files, invalid JSON, stale baseline hashes,

--- a/docs/privacy-and-data-boundaries.md
+++ b/docs/privacy-and-data-boundaries.md
@@ -74,6 +74,17 @@ only to local files (mode `600` on Unix), redacted `.summary.json` files cannot
 be mistaken for full-payload `.payload.json` files during resume, and stdout
 contains counts and paths rather than capture content.
 
+`understudy traces export` applies the same rule to one explicit hosted
+`trace_id` or a private file of explicit trace IDs. The CLI resolves membership
+through the customer trace request-ID endpoint and passes the returned IDs to
+the existing bounded capture batch exporter; it never scans project capture
+history and exposes no unbounded `--all` operation. A private `trace.json`
+records membership and counts without raw bodies. Full per-request files require
+`--include-payload --yes`, and stdout still contains only counts and paths.
+Owner-private files, disjoint summary/payload suffixes, bounded concurrency,
+retries, resume, `failed-request-ids.txt`, and `failed-trace-ids.txt` preserve
+the request-export boundary.
+
 Gateway probes are explicit live calls. BYOK provider keys are read only from an
 environment variable named by `--byok-env`; they are not requested in chat, not
 persisted, and not printed.

--- a/skills/README.md
+++ b/skills/README.md
@@ -76,6 +76,11 @@ group it belongs to.
   local sanity check), and hands off to `ingest-traces`/`capture-evidence`
   once traces exist. Per-SDK env-var behavior and fallback paths in its
   [`reference.md`](instrument/reference.md).
+- [`export-trace`](export-trace/SKILL.md) retrieves one supplied hosted
+  `trace_id` (or an explicit private list), resolves its ordered request IDs
+  through the customer trace lookup API, and reuses the request capture batch
+  exporter to write private local files. It never scans project capture history
+  or exposes an unbounded all-traces operation.
 - [`ingest-traces`](ingest-traces/SKILL.md) is the front door for developers
   who arrive with data instead of a harness: it turns existing production
   traces (an object-store bucket, provider log exports, or a gateway capture

--- a/skills/export-trace/SKILL.md
+++ b/skills/export-trace/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: export-trace
+description: Use when a developer provides a hosted Understudy trace_id or asks "get this trace", "download this trace", "show every request in this trace", or "export these trace IDs". Resolves trace membership through the customer trace lookup API, exports linked captures privately, and hands local files to the trace viewer or ingest-traces.
+---
+
+# Export Trace
+
+Retrieve one explicit hosted trace without scanning the capture catalog. Resolve
+its request IDs through the customer trace lookup endpoint, then reuse the
+bounded request capture exporter.
+
+## Safety Gates
+
+- Treat a bare `trace_id` as authorization for a redacted local summary export,
+  not for raw prompts or completions.
+- Use `--include-payload --yes` only when the developer explicitly asks for the
+  full, raw, or complete trace/captures. Announce that the files may contain
+  prompts, completions, and tool payloads before running it.
+- Keep outputs under `.understudy/`; never print, paste, commit, or upload trace
+  bodies.
+- Never ask for API keys in chat. Use existing Understudy credentials and report
+  only auth presence or errors.
+- Never replace the trace lookup with project-wide capture pagination. If the
+  lookup endpoint is unavailable, stop and report the backend dependency.
+
+## Resolve CLI
+
+Prefer the installed `understudy` binary. In this repository checkout:
+
+```sh
+npm run build
+node dist/bin.js status --json
+```
+
+Use `node dist/bin.js` in place of `understudy` below when necessary.
+
+## Flow
+
+1. Resolve the project from repo config or an explicit `--project` /
+   `--project-id`. Resolve `--workload` only when the developer supplied or
+   requested that narrower scope.
+2. For redacted metadata, run:
+
+   ```sh
+   understudy traces export <trace-id> \
+     --project <project> \
+     --out .understudy/traces/<trace-id>
+   ```
+
+3. For an explicitly requested full trace, run:
+
+   ```sh
+   understudy traces export <trace-id> \
+     --project <project> \
+     --out .understudy/traces/<trace-id> \
+     --include-payload --yes
+   ```
+
+   For several explicit IDs, put one per line in a private local file and use
+   `--trace-ids-file <path>`. Do not use or recreate an unbounded `--all`
+   operation.
+4. Inspect only metadata artifacts:
+
+   - `trace.json` — `trace_id`, ordered `request_ids`, and export counts;
+   - `failed-request-ids.txt` — request captures to retry;
+   - `failed-trace-ids.txt` — trace lookups or trace exports to retry;
+   - `*.summary.json` or `*.payload.json` — private per-request files.
+
+   Do not print payload file contents. Rerun the same command to resume; completed
+   request files are skipped.
+5. When the developer asks to inspect the conversation locally, build the
+   private viewer:
+
+   ```sh
+   understudy traces build-viewer \
+     --source .understudy/traces/<trace-id> \
+     --trace-id <trace-id> \
+     --output .understudy/trace-viewer/<trace-id>
+   ```
+
+6. When the developer wants an eval, cost profile, or benchmark from the local
+   files, hand off to [`../ingest-traces/SKILL.md`](../ingest-traces/SKILL.md).
+
+## Failure Handling
+
+- `404` for one trace: report that the trace is absent from the authorized
+  project/workload or that the platform trace lookup has not deployed. Do not
+  scan capture history as a fallback.
+- `401`/`403`: stop and route auth/project readiness to
+  [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
+- A non-empty `failed-request-ids.txt`: report a partial export and rerun the
+  same command; do not claim the trace is complete.
+- A response with no request IDs or a mismatched `trace_id`: fail closed and
+  report the contract violation.
+
+## Output Standard
+
+End with the trace ID, project/workload scope, redacted or full mode, request
+count, complete/partial status, private output directory, and one next action:
+open the local viewer, retry failures, or route to `ingest-traces`.

--- a/skills/export-trace/agents/openai.yaml
+++ b/skills/export-trace/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Export Hosted Trace"
+  short_description: "Fetch a hosted trace into private local files"
+  default_prompt: "Use $export-trace to retrieve this hosted trace ID and export its captures privately."

--- a/skills/ingest-traces/SKILL.md
+++ b/skills/ingest-traces/SKILL.md
@@ -18,6 +18,11 @@ local evidence artifacts without leaking anything. This worker does that
 transformation: local source → normalized captures → source-history DAG →
 machine-proposed benchmark → human judgment, all on the local machine.
 
+When the developer has only a hosted `trace_id`, acquire its private local
+files first with [`../export-trace/SKILL.md`](../export-trace/SKILL.md). This
+skill begins after capture files exist locally and does not recreate the hosted
+trace-to-request lookup.
+
 ## OSS filesystem boundary
 
 This public skill starts with files already present in `.understudy/captures/`

--- a/skills/understudy/SKILL.md
+++ b/skills/understudy/SKILL.md
@@ -156,6 +156,11 @@ Identify the developer's current stage and load exactly one:
   capturing my LLM calls") → [`../instrument/SKILL.md`](../instrument/SKILL.md)
   (env-var redirect through the gateway, verified test call, then hands off
   to `ingest-traces`).
+- **Hosted trace ID supplied** — the developer provides a `trace_id` or says
+  "get this trace", "download the full trace", or "show every request in this
+  trace" → [`../export-trace/SKILL.md`](../export-trace/SKILL.md). It resolves
+  request membership through the customer trace lookup API, exports captures
+  privately, and hands the local files to `ingest-traces` or the trace viewer.
 - **Traces already exist** — a bucket of captures, a provider log export, or
   gateway capture files are in hand and the developer wants them turned into
   local eval sets, profiled for where the spend goes, or triaged in bulk by

--- a/src/commands/captures.ts
+++ b/src/commands/captures.ts
@@ -64,8 +64,38 @@ interface BatchExportResult {
   status: BatchExportStatus;
 }
 
+export interface CaptureBatchExportInput {
+  requestIds: string[];
+  inputCount?: number;
+  outputDirectory: string;
+  includePayload: boolean;
+  concurrency: number;
+  retries: number;
+  resume: boolean;
+  orgId: string;
+  projectId: string;
+  workloadId?: string;
+  onProgress?: (completed: number, total: number) => void;
+}
+
+export interface CaptureBatchExportSummary {
+  ok: boolean;
+  input_count: number;
+  unique_count: number;
+  written: number;
+  skipped: number;
+  failed: number;
+  failed_request_ids: string[];
+  output_directory: string;
+  failure_manifest: string;
+  output_suffix: ".payload.json" | ".summary.json";
+  include_payload: boolean;
+  warning: string | null;
+}
+
 export interface CaptureSummary {
   request_id: string | null;
+  trace_id: string | null;
   schema_version: string | null;
   ts: string | null;
   project_id: string | null;
@@ -232,38 +262,83 @@ async function runBatchExport(
     MAX_EXPORT_RETRIES,
     DEFAULT_EXPORT_RETRIES,
   );
-  const outputDirectory = resolveBatchOutputDirectory(opts.out);
-  const failureManifest = join(outputDirectory, "failed-request-ids.txt");
-  const resume = opts.resume !== false;
   const { project, workload } = await resolveCaptureContext(opts);
+  const payload = await exportCapturesByRequestIds({
+    requestIds,
+    inputCount,
+    outputDirectory: opts.out,
+    includePayload: Boolean(opts.includePayload),
+    concurrency,
+    retries,
+    resume: opts.resume !== false,
+    orgId: project.auth.orgId,
+    projectId: project.projectId,
+    workloadId: workload?.id,
+    onProgress: isJsonMode(cmd)
+      ? undefined
+      : (completed, total) => {
+        if (completed % 100 === 0) {
+          process.stderr.write(`Exported ${completed}/${total} captures...\n`);
+        }
+      },
+  });
+
+  if (isJsonMode(cmd)) {
+    const { failed_request_ids: _, ...publicPayload } = payload;
+    process.stdout.write(`${JSON.stringify(publicPayload)}\n`);
+  } else {
+    process.stdout.write(
+      `${payload.failed === 0 ? kleur.green("✓") : kleur.yellow("!")} ` +
+      `Capture batch complete: ${payload.written} written, ${payload.skipped} skipped, ` +
+      `${payload.failed} failed -> ${payload.output_directory}\n`,
+    );
+    process.stdout.write(`Failure manifest: ${payload.failure_manifest}\n`);
+    if (opts.includePayload) {
+      process.stdout.write(
+        `${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`,
+      );
+    }
+  }
+
+  if (payload.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+export async function exportCapturesByRequestIds(
+  input: CaptureBatchExportInput,
+): Promise<CaptureBatchExportSummary> {
+  const requestIds = normalizeRequestIds(input.requestIds);
+  const outputDirectory = resolveBatchOutputDirectory(input.outputDirectory);
+  const failureManifest = join(outputDirectory, "failed-request-ids.txt");
   const results: BatchExportResult[] = new Array(requestIds.length);
   let completed = 0;
   let fatalError: unknown;
 
   await runWithConcurrency(
     requestIds,
-    concurrency,
+    input.concurrency,
     async (requestId, index) => {
       const outputPath = join(
         outputDirectory,
-        batchCaptureFilename(requestId, Boolean(opts.includePayload)),
+        batchCaptureFilename(requestId, input.includePayload),
       );
-      if (resume && isCompletedExport(outputPath)) {
+      if (input.resume && isCompletedExport(outputPath)) {
         results[index] = { requestId, status: "skipped" };
       } else {
         try {
-          if (!resume) {
+          if (!input.resume) {
             quarantineExistingExport(outputPath);
           }
           const capture = await fetchCaptureWithRetry(
-            project.auth.orgId,
-            project.projectId,
+            input.orgId,
+            input.projectId,
             requestId,
-            workload?.id,
-            retries,
+            input.workloadId,
+            input.retries,
           );
           if (fatalError) return;
-          const value = opts.includePayload
+          const value = input.includePayload
             ? capture
             : summarizeCapture(capture);
           writePrivateText(outputPath, `${JSON.stringify(value, null, 2)}\n`);
@@ -279,9 +354,7 @@ async function runBatchExport(
       }
 
       completed += 1;
-      if (!isJsonMode(cmd) && completed % 100 === 0) {
-        process.stderr.write(`Exported ${completed}/${requestIds.length} captures...\n`);
-      }
+      input.onProgress?.(completed, requestIds.length);
     },
     () => fatalError !== undefined,
   );
@@ -298,41 +371,22 @@ async function runBatchExport(
     failedIds.length > 0 ? `${failedIds.join("\n")}\n` : "",
   );
 
-  const payload = {
+  return {
     ok: failedIds.length === 0,
-    input_count: inputCount,
+    input_count: input.inputCount ?? input.requestIds.length,
     unique_count: requestIds.length,
     written,
     skipped,
     failed: failedIds.length,
+    failed_request_ids: failedIds,
     output_directory: outputDirectory,
     failure_manifest: failureManifest,
-    output_suffix: opts.includePayload ? ".payload.json" : ".summary.json",
-    include_payload: Boolean(opts.includePayload),
-    warning: opts.includePayload
+    output_suffix: input.includePayload ? ".payload.json" : ".summary.json",
+    include_payload: input.includePayload,
+    warning: input.includePayload
       ? "files may contain prompts, completions, or tool payloads"
       : null,
   };
-
-  if (isJsonMode(cmd)) {
-    process.stdout.write(`${JSON.stringify(payload)}\n`);
-  } else {
-    process.stdout.write(
-      `${failedIds.length === 0 ? kleur.green("✓") : kleur.yellow("!")} ` +
-      `Capture batch complete: ${written} written, ${skipped} skipped, ` +
-      `${failedIds.length} failed -> ${outputDirectory}\n`,
-    );
-    process.stdout.write(`Failure manifest: ${failureManifest}\n`);
-    if (opts.includePayload) {
-      process.stdout.write(
-        `${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`,
-      );
-    }
-  }
-
-  if (failedIds.length > 0) {
-    process.exitCode = 1;
-  }
 }
 
 async function resolveCaptureContext(opts: CaptureOpts) {
@@ -373,6 +427,7 @@ export function summarizeCapture(input: unknown): CaptureSummary {
   const tags = isObject(capture.tags) ? capture.tags : {};
   return {
     request_id: stringField(capture, "request_id"),
+    trace_id: stringField(capture, "trace_id") ?? stringField(capture, "traceId"),
     schema_version: stringField(capture, "schema_version"),
     ts: stringField(capture, "ts") ?? stringField(capture, "created_at"),
     project_id: stringField(capture, "project_id"),
@@ -434,20 +489,33 @@ function readRequestIds(path: string): {
       `Request-id file contains more than ${MAX_BATCH_REQUEST_IDS} rows.`,
     );
   }
+  return { requestIds: normalizeRequestIds(rows), inputCount: rows.length };
+}
+
+function normalizeRequestIds(rows: string[]): string[] {
+  if (rows.length === 0) {
+    throw new Error("At least one request id is required.");
+  }
+  if (rows.length > MAX_BATCH_REQUEST_IDS) {
+    throw new Error(
+      `Request-id batch contains more than ${MAX_BATCH_REQUEST_IDS} rows.`,
+    );
+  }
   const invalid = rows.find(
     (requestId) =>
-      requestId.length > 512 || /[\u0000-\u001f\u007f]/.test(requestId),
+      requestId.length === 0 ||
+      requestId.length > 512 ||
+      /[\u0000-\u001f\u007f]/.test(requestId),
   );
   if (invalid) {
     throw new Error(
-      "Request ids must be at most 512 characters and contain no control characters.",
+      "Request ids must be non-empty, at most 512 characters, and contain no control characters.",
     );
   }
-  const requestIds = [...new Set(rows)];
-  return { requestIds, inputCount: rows.length };
+  return [...new Set(rows)];
 }
 
-function resolveBatchOutputDirectory(out: string): string {
+export function resolveBatchOutputDirectory(out: string): string {
   if (existsSync(out) && !statSync(out).isDirectory()) {
     throw new Error(`Batch --out must be a directory: ${out}`);
   }
@@ -551,7 +619,7 @@ function isRetryableCaptureError(error: unknown): boolean {
   return error instanceof TypeError;
 }
 
-function isBatchFatalError(error: unknown): boolean {
+export function isBatchFatalError(error: unknown): boolean {
   return error instanceof UnderstudyApiError &&
     (error.status === 401 || error.status === 403);
 }

--- a/src/commands/trace-exports.ts
+++ b/src/commands/trace-exports.ts
@@ -31,7 +31,7 @@ const MAX_TRACE_REQUEST_IDS = 100_000;
 const TraceRequestIdsResponseSchema = z.object({
   trace_id: z.string(),
   request_ids: z.array(z.string()),
-}).strict();
+}).passthrough();
 
 interface TraceExportOpts extends ProjectResolutionOptions {
   workload?: string;
@@ -376,8 +376,10 @@ function validateTraceId(traceId: string): void {
 
 function traceDirectoryName(traceId: string): string {
   const encoded = encodeURIComponent(traceId);
-  if (Buffer.byteLength(encoded, "utf8") <= 180) return encoded;
-  return `${encoded.slice(0, 80)}--${createHash("sha256").update(traceId).digest("hex").slice(0, 20)}`;
+  const safeName = Buffer.byteLength(encoded, "utf8") <= 180
+    ? encoded
+    : `${encoded.slice(0, 80)}--${createHash("sha256").update(traceId).digest("hex").slice(0, 20)}`;
+  return `trace-${safeName}`;
 }
 
 function parseBoundedInteger(

--- a/src/commands/trace-exports.ts
+++ b/src/commands/trace-exports.ts
@@ -1,0 +1,411 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+import { Command } from "commander";
+import kleur from "kleur";
+import { z } from "zod";
+
+import {
+  exportCapturesByRequestIds,
+  isBatchFatalError,
+  resolveBatchOutputDirectory,
+  writePrivateText,
+  type CaptureBatchExportSummary,
+} from "./captures.js";
+import { request, UnderstudyApiError } from "../internal/http.js";
+import { isJsonMode, runAction } from "../internal/output.js";
+import {
+  resolveProject,
+  type ProjectResolutionOptions,
+} from "../internal/projects.js";
+import { resolveWorkload } from "../internal/workloads.js";
+
+const TRACE_EXPORT_SCHEMA = "understudy.trace_export.v1";
+const DEFAULT_EXPORT_CONCURRENCY = 4;
+const MAX_EXPORT_CONCURRENCY = 16;
+const DEFAULT_EXPORT_RETRIES = 2;
+const MAX_EXPORT_RETRIES = 5;
+const MAX_BATCH_TRACE_IDS = 100_000;
+const MAX_TRACE_REQUEST_IDS = 100_000;
+
+const TraceRequestIdsResponseSchema = z.object({
+  trace_id: z.string(),
+  request_ids: z.array(z.string()),
+}).strict();
+
+interface TraceExportOpts extends ProjectResolutionOptions {
+  workload?: string;
+  out: string;
+  traceIdsFile?: string;
+  includePayload?: boolean;
+  yes?: boolean;
+  concurrency?: string;
+  retries?: string;
+  resume?: boolean;
+}
+
+interface TraceExportResult {
+  traceId: string;
+  status: "written" | "partial" | "failed";
+  requestCount: number;
+  batch?: CaptureBatchExportSummary;
+  outputDirectory?: string;
+}
+
+export function registerHostedTraceExportCommand(traces: Command): void {
+  traces.command("export [trace-id]")
+    .description("Resolve hosted trace request ids and export their captures privately.")
+    .requiredOption("--out <directory>", "Private output directory.")
+    .option("--trace-ids-file <path>", "Batch export: one explicit trace id per line.")
+    .option("--project-id <id>", "Project id from `understudy projects list --json`.")
+    .option("--project <slug>", "Project slug to resolve to an id.")
+    .option("--workload <name-or-id>", "Optional workload name or id.")
+    .option("--org <id>", "Org id to use (default: local config or only org in credentials).")
+    .option("--concurrency <n>", `Capture-fetch concurrency, max ${MAX_EXPORT_CONCURRENCY}.`, String(DEFAULT_EXPORT_CONCURRENCY))
+    .option("--retries <n>", `Retries for transient lookup or capture failures, max ${MAX_EXPORT_RETRIES}.`, String(DEFAULT_EXPORT_RETRIES))
+    .option("--no-resume", "Re-download capture files that already exist.")
+    .option("--include-payload", "Write full captures, including prompt/completion payloads.")
+    .option("--yes", "Confirm full payload export without prompting.")
+    .action(async function (this: Command, traceId: string | undefined, opts: TraceExportOpts) {
+      await runAction(this, () => runTraceExport(this, traceId, opts));
+    });
+}
+
+async function runTraceExport(
+  cmd: Command,
+  traceIdInput: string | undefined,
+  opts: TraceExportOpts,
+): Promise<void> {
+  const traceId = traceIdInput?.trim();
+  const traceIdsFile = opts.traceIdsFile?.trim();
+  if (Boolean(traceId) === Boolean(traceIdsFile)) {
+    throw new Error(
+      "Provide exactly one of <trace-id> or --trace-ids-file <path>.",
+    );
+  }
+  if (traceId) validateTraceId(traceId);
+  if (opts.includePayload && !opts.yes) {
+    throw new Error(
+      "Full trace export may contain prompts/completions. Re-run with --include-payload --yes to write it to files.",
+    );
+  }
+
+  const concurrency = parseBoundedInteger(
+    opts.concurrency,
+    "--concurrency",
+    1,
+    MAX_EXPORT_CONCURRENCY,
+    DEFAULT_EXPORT_CONCURRENCY,
+  );
+  const retries = parseBoundedInteger(
+    opts.retries,
+    "--retries",
+    0,
+    MAX_EXPORT_RETRIES,
+    DEFAULT_EXPORT_RETRIES,
+  );
+  const requested = traceIdsFile
+    ? readTraceIds(traceIdsFile)
+    : { traceIds: [traceId!], inputCount: 1 };
+  const project = await resolveProject(opts);
+  const workload = opts.workload
+    ? await resolveWorkload(project, opts.workload)
+    : null;
+  const outputDirectory = resolveBatchOutputDirectory(opts.out);
+  const failureManifest = join(outputDirectory, "failed-trace-ids.txt");
+  const results: TraceExportResult[] = [];
+  const batchMode = Boolean(traceIdsFile);
+
+  for (const selectedTraceId of requested.traceIds) {
+    try {
+      const requestIds = await fetchTraceRequestIdsWithRetry(
+        project.auth.orgId,
+        project.projectId,
+        selectedTraceId,
+        workload?.id,
+        retries,
+      );
+      const traceOutputDirectory = batchMode
+        ? join(outputDirectory, traceDirectoryName(selectedTraceId))
+        : outputDirectory;
+      const batch = await exportCapturesByRequestIds({
+        requestIds,
+        inputCount: requestIds.length,
+        outputDirectory: traceOutputDirectory,
+        includePayload: Boolean(opts.includePayload),
+        concurrency,
+        retries,
+        resume: opts.resume !== false,
+        orgId: project.auth.orgId,
+        projectId: project.projectId,
+        workloadId: workload?.id,
+        onProgress: isJsonMode(cmd)
+          ? undefined
+          : (completed, total) => {
+            if (completed % 100 === 0) {
+              process.stderr.write(
+                `Exported ${completed}/${total} captures for trace ${selectedTraceId}...\n`,
+              );
+            }
+          },
+      });
+      writeTraceManifest(
+        traceOutputDirectory,
+        selectedTraceId,
+        project.projectId,
+        workload?.id,
+        requestIds,
+        batch,
+      );
+      results.push({
+        traceId: selectedTraceId,
+        status: batch.failed === 0 ? "written" : "partial",
+        requestCount: requestIds.length,
+        batch,
+        outputDirectory: traceOutputDirectory,
+      });
+    } catch (error) {
+      if (isBatchFatalError(error) || !batchMode) throw error;
+      results.push({
+        traceId: selectedTraceId,
+        status: "failed",
+        requestCount: 0,
+      });
+    }
+  }
+
+  const complete = results.filter((result) => result.status === "written").length;
+  const partial = results.filter((result) => result.status === "partial").length;
+  const failed = results.filter((result) => result.status === "failed").length;
+  const retryTraceIds = results
+    .filter((result) => result.status !== "written")
+    .map((result) => result.traceId);
+  const requestCount = results.reduce(
+    (sum, result) => sum + result.requestCount,
+    0,
+  );
+  const capturesWritten = results.reduce(
+    (sum, result) => sum + (result.batch?.written ?? 0),
+    0,
+  );
+  const capturesSkipped = results.reduce(
+    (sum, result) => sum + (result.batch?.skipped ?? 0),
+    0,
+  );
+  const capturesFailed = results.reduce(
+    (sum, result) => sum + (result.batch?.failed ?? 0),
+    0,
+  );
+  writePrivateText(
+    failureManifest,
+    retryTraceIds.length > 0 ? `${retryTraceIds.join("\n")}\n` : "",
+  );
+
+  const payload = {
+    ok: retryTraceIds.length === 0,
+    input_count: requested.inputCount,
+    unique_count: requested.traceIds.length,
+    complete,
+    partial,
+    failed,
+    request_count: requestCount,
+    captures_written: capturesWritten,
+    captures_skipped: capturesSkipped,
+    captures_failed: capturesFailed,
+    output_directory: outputDirectory,
+    failure_manifest: failureManifest,
+    include_payload: Boolean(opts.includePayload),
+    warning: opts.includePayload
+      ? "files may contain prompts, completions, or tool payloads"
+      : null,
+  };
+
+  if (isJsonMode(cmd)) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+  } else {
+    process.stdout.write(
+      `${retryTraceIds.length === 0 ? kleur.green("✓") : kleur.yellow("!")} ` +
+      `Trace export complete: ${complete} complete, ${partial} partial, ` +
+      `${failed} failed -> ${outputDirectory}\n`,
+    );
+    process.stdout.write(
+      `Captures: ${capturesWritten} written, ${capturesSkipped} skipped, ${capturesFailed} failed\n`,
+    );
+    process.stdout.write(`Failure manifest: ${failureManifest}\n`);
+    if (opts.includePayload) {
+      process.stdout.write(
+        `${kleur.yellow("warning")}: files may contain prompts, completions, or tool payloads\n`,
+      );
+    }
+  }
+
+  if (retryTraceIds.length > 0) process.exitCode = 1;
+}
+
+async function fetchTraceRequestIdsWithRetry(
+  orgId: string,
+  projectId: string,
+  traceId: string,
+  workloadId: string | undefined,
+  retries: number,
+): Promise<string[]> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fetchTraceRequestIds(
+        orgId,
+        projectId,
+        traceId,
+        workloadId,
+      );
+    } catch (error) {
+      if (attempt >= retries || !isRetryableTraceLookupError(error)) {
+        throw error;
+      }
+      await delay(250 * 2 ** attempt);
+    }
+  }
+}
+
+async function fetchTraceRequestIds(
+  orgId: string,
+  projectId: string,
+  traceId: string,
+  workloadId?: string,
+): Promise<string[]> {
+  const base =
+    `/admin/v1/orgs/${orgId}/projects/${encodeURIComponent(projectId)}` +
+    `/traces/${encodeURIComponent(traceId)}/request-ids`;
+  const params = new URLSearchParams();
+  if (workloadId) params.set("workload_id", workloadId);
+  const url = params.size > 0 ? `${base}?${params}` : base;
+  const res = await request({ url, orgId }, TraceRequestIdsResponseSchema);
+  if (res.data.trace_id !== traceId) {
+    throw new Error(
+      `Trace lookup returned trace_id=${res.data.trace_id} for requested trace_id=${traceId}.`,
+    );
+  }
+  return normalizeTraceRequestIds(res.data.request_ids);
+}
+
+function writeTraceManifest(
+  outputDirectory: string,
+  traceId: string,
+  projectId: string,
+  workloadId: string | undefined,
+  requestIds: string[],
+  batch: CaptureBatchExportSummary,
+): void {
+  writePrivateText(
+    join(outputDirectory, "trace.json"),
+    `${JSON.stringify({
+      schema_version: TRACE_EXPORT_SCHEMA,
+      trace_id: traceId,
+      project_id: projectId,
+      workload_id: workloadId ?? null,
+      request_ids: requestIds,
+      capture_export: {
+        complete: batch.failed === 0,
+        written: batch.written,
+        skipped: batch.skipped,
+        failed: batch.failed,
+        output_suffix: batch.output_suffix,
+        failure_manifest: basename(batch.failure_manifest),
+        include_payload: batch.include_payload,
+      },
+    }, null, 2)}\n`,
+  );
+}
+
+function readTraceIds(path: string): {
+  traceIds: string[];
+  inputCount: number;
+} {
+  if (!existsSync(path) || !statSync(path).isFile()) {
+    throw new Error(`Trace-id file not found: ${path}`);
+  }
+  const rows = readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((row) => row.trim())
+    .filter((row) => row.length > 0 && !row.startsWith("#"));
+  if (rows.length === 0) {
+    throw new Error(`Trace-id file is empty: ${path}`);
+  }
+  if (rows.length > MAX_BATCH_TRACE_IDS) {
+    throw new Error(
+      `Trace-id file contains more than ${MAX_BATCH_TRACE_IDS} rows.`,
+    );
+  }
+  for (const traceId of rows) validateTraceId(traceId);
+  return { traceIds: [...new Set(rows)], inputCount: rows.length };
+}
+
+function normalizeTraceRequestIds(requestIds: string[]): string[] {
+  if (requestIds.length === 0) {
+    throw new Error("Trace lookup returned no request ids.");
+  }
+  if (requestIds.length > MAX_TRACE_REQUEST_IDS) {
+    throw new Error(
+      `Trace lookup returned more than ${MAX_TRACE_REQUEST_IDS} request ids.`,
+    );
+  }
+  const invalid = requestIds.find(
+    (requestId) =>
+      requestId.length === 0 ||
+      requestId.length > 512 ||
+      /[\u0000-\u001f\u007f]/.test(requestId),
+  );
+  if (invalid) {
+    throw new Error(
+      "Trace lookup returned an invalid request id.",
+    );
+  }
+  return [...new Set(requestIds)];
+}
+
+function validateTraceId(traceId: string): void {
+  if (
+    traceId.length === 0 ||
+    traceId.length > 512 ||
+    /[\u0000-\u001f\u007f]/.test(traceId)
+  ) {
+    throw new Error(
+      "Trace ids must be non-empty, at most 512 characters, and contain no control characters.",
+    );
+  }
+}
+
+function traceDirectoryName(traceId: string): string {
+  const encoded = encodeURIComponent(traceId);
+  if (Buffer.byteLength(encoded, "utf8") <= 180) return encoded;
+  return `${encoded.slice(0, 80)}--${createHash("sha256").update(traceId).digest("hex").slice(0, 20)}`;
+}
+
+function parseBoundedInteger(
+  value: string | undefined,
+  option: string,
+  minimum: number,
+  maximum: number,
+  fallback: number,
+): number {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(
+      `Expected ${option} between ${minimum} and ${maximum}, got: ${value}`,
+    );
+  }
+  return parsed;
+}
+
+function isRetryableTraceLookupError(error: unknown): boolean {
+  if (error instanceof UnderstudyApiError) {
+    return error.status === 408 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500;
+  }
+  return error instanceof TypeError;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/commands/traces.ts
+++ b/src/commands/traces.ts
@@ -4,9 +4,11 @@ import { compileTraceFoundry, createTraceReplayPlan, importTraceReviews, promote
 import { serveTraceFoundry } from "../trace-foundry-server.js";
 import { authorOverview, authorTasks, compareAuthoringModels, gatewayClient, resolveDefaultModel, resolveEscalationModel, resolveGatewayAuth } from "../trace-author.js";
 import { renderTraceViewer } from "../trace-viewer.js";
+import { registerHostedTraceExportCommand } from "./trace-exports.js";
 
 export function registerTracesCommand(program: Command): void {
-  const traces = program.command("traces").description("Inspect local trace captures and compile benchmark environments");
+  const traces = program.command("traces").description("Inspect local traces, export hosted captures, and compile benchmark environments");
+  registerHostedTraceExportCommand(traces);
   traces.command("build-viewer")
     .description("Build a private local viewer for one trace's model calls, prompts, and tools")
     .option("--source <path>", "Local capture file or directory", ".understudy/captures")

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -235,7 +235,11 @@ async function withHostedFixture(fn) {
         )
         .map((capture) => capture.request_id);
       return requestIds.length > 0
-        ? send(200, { trace_id: traceId, request_ids: requestIds })
+        ? send(200, {
+          trace_id: traceId,
+          request_ids: requestIds,
+          observability_id: "obs_fixture",
+        })
         : send(404, {
           type: "invalid_request_error",
           message: "Synthetic trace not found.",
@@ -3269,26 +3273,41 @@ class ScoreWithFeedback:
         },
       );
       const alphaManifest = JSON.parse(
-        readFileSync(join(payloadDirectory, "trace_alpha", "trace.json"), "utf8"),
+        readFileSync(
+          join(payloadDirectory, "trace-trace_alpha", "trace.json"),
+          "utf8",
+        ),
       );
       assert.deepEqual(alphaManifest.request_ids, ["req_123", "req_456"]);
       assert.equal(alphaManifest.capture_export.complete, false);
       assert.match(
         readFileSync(
-          join(payloadDirectory, "trace_alpha", "req_123.payload.json"),
+          join(
+            payloadDirectory,
+            "trace-trace_alpha",
+            "req_123.payload.json",
+          ),
           "utf8",
         ),
         /SECRET_PROMPT/,
       );
       assert.equal(
         existsSync(
-          join(payloadDirectory, "trace_alpha", "req_456.payload.json"),
+          join(
+            payloadDirectory,
+            "trace-trace_alpha",
+            "req_456.payload.json",
+          ),
         ),
         false,
       );
       assert.match(
         readFileSync(
-          join(payloadDirectory, "trace_beta", "req_retry.payload.json"),
+          join(
+            payloadDirectory,
+            "trace-trace_beta",
+            "req_retry.payload.json",
+          ),
           "utf8",
         ),
         /SECRET_RETRY_PROMPT/,
@@ -3299,7 +3318,11 @@ class ScoreWithFeedback:
       );
       assert.equal(
         readFileSync(
-          join(payloadDirectory, "trace_alpha", "failed-request-ids.txt"),
+          join(
+            payloadDirectory,
+            "trace-trace_alpha",
+            "failed-request-ids.txt",
+          ),
           "utf8",
         ),
         "req_456\n",
@@ -3307,7 +3330,11 @@ class ScoreWithFeedback:
       if (process.platform !== "win32") {
         assert.equal(
           statSync(
-            join(payloadDirectory, "trace_alpha", "req_123.payload.json"),
+            join(
+              payloadDirectory,
+              "trace-trace_alpha",
+              "req_123.payload.json",
+            ),
           ).mode & 0o777,
           0o600,
         );
@@ -3329,6 +3356,39 @@ class ScoreWithFeedback:
         ),
         false,
         "trace exports must never paginate the capture catalog",
+      );
+
+      const retryCapture = state.captures.find(
+        (capture) => capture.request_id === "req_retry",
+      );
+      assert.ok(retryCapture);
+      retryCapture.trace_id = "failed-trace-ids.txt";
+      const reservedTraceIdsPath = join(repo, "reserved-trace-ids.txt");
+      writeFileSync(reservedTraceIdsPath, "failed-trace-ids.txt\n");
+      const reservedDirectory = join(repo, "reserved-trace-export");
+      const reservedExport = await runWithEnvAsync([
+        "--json", "traces", "export",
+        "--trace-ids-file", reservedTraceIdsPath,
+        "--project", "rehearsal",
+        "--out", reservedDirectory,
+      ], env, repo);
+      assert.equal(reservedExport.status, 0, reservedExport.stderr);
+      assert.equal(
+        readFileSync(join(reservedDirectory, "failed-trace-ids.txt"), "utf8"),
+        "",
+      );
+      assert.equal(
+        JSON.parse(
+          readFileSync(
+            join(
+              reservedDirectory,
+              "trace-failed-trace-ids.txt",
+              "trace.json",
+            ),
+            "utf8",
+          ),
+        ).trace_id,
+        "failed-trace-ids.txt",
       );
     });
   });

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -112,6 +112,7 @@ async function withHostedFixture(fn) {
     captures: [
       {
         request_id: "req_123",
+        trace_id: "trace_alpha",
         schema_version: "understudy.capture.v1",
         ts: "2026-06-07T00:00:00Z",
         project_id: "proj_1",
@@ -130,6 +131,7 @@ async function withHostedFixture(fn) {
       },
       {
         request_id: "req_456",
+        trace_id: "trace_alpha",
         schema_version: "understudy.capture.v1",
         ts: "2026-06-07T00:01:00Z",
         project_id: "proj_1",
@@ -148,6 +150,7 @@ async function withHostedFixture(fn) {
       },
       {
         request_id: "req_retry",
+        trace_id: "trace_beta",
         schema_version: "understudy.capture.v1",
         ts: "2026-06-07T00:02:00Z",
         project_id: "proj_1",
@@ -166,6 +169,7 @@ async function withHostedFixture(fn) {
       },
     ],
     transientCaptureFailures: new Map([["req_retry", 1]]),
+    unavailableCaptureIds: new Set(),
     captureAuthorizationFailure: false,
   };
 
@@ -185,7 +189,6 @@ async function withHostedFixture(fn) {
       res.writeHead(status, { "content-type": "application/x-ndjson", ...headers });
       res.end(value);
     };
-
     if (req.method === "GET" && url.pathname === "/healthz") return send(200, { ok: true });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects") return send(200, { projects: state.projects, cursor: null });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/api_keys") return send(200, { keys: [{ id: "key_1", name: "default", obfuscated_value: "sk_...test", last_used_at: null, permissions: [], created_at: "2026-06-01T00:00:00Z" }] });
@@ -212,6 +215,33 @@ async function withHostedFixture(fn) {
       workload.route_traffic_pct = body.model_id === null ? null : body.route_traffic_pct;
       return send(200, { workload_id: workload.id, project_id: "proj_1", model_id: body.model_id, route_model_id: body.model_id, route_traffic_pct: workload.route_traffic_pct });
     }
+    const traceRequestIds = url.pathname.match(
+      /^\/admin\/v1\/orgs\/org_1\/projects\/proj_1\/traces\/([^/]+)\/request-ids$/,
+    );
+    if (req.method === "GET" && traceRequestIds) {
+      const traceId = decodeURIComponent(traceRequestIds[1]);
+      const workloadId = url.searchParams.get("workload_id");
+      if (workloadId && workloadId !== "usp_classify") {
+        return send(404, {
+          type: "invalid_request_error",
+          message: "Synthetic workload trace not found.",
+          request_id: "req_fixture",
+        });
+      }
+      const requestIds = state.captures
+        .filter((capture) =>
+          capture.trace_id === traceId &&
+          (!workloadId || capture.workload_id === workloadId)
+        )
+        .map((capture) => capture.request_id);
+      return requestIds.length > 0
+        ? send(200, { trace_id: traceId, request_ids: requestIds })
+        : send(404, {
+          type: "invalid_request_error",
+          message: "Synthetic trace not found.",
+          request_id: "req_fixture",
+        });
+    }
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/captures") return send(200, { captures: state.captures, truncated: false, cursor: null });
     if (req.method === "GET" && url.pathname === "/admin/v1/orgs/org_1/projects/proj_1/workloads/usp_classify/captures") return send(200, { captures: state.captures, truncated: false, cursor: null });
     const projectCapture = url.pathname.match(/^\/admin\/v1\/orgs\/org_1\/projects\/proj_1\/captures\/([^/]+)$/);
@@ -226,6 +256,13 @@ async function withHostedFixture(fn) {
         });
       }
       const requestId = decodeURIComponent(captureMatch[1]);
+      if (state.unavailableCaptureIds.has(requestId)) {
+        return send(404, {
+          type: "invalid_request_error",
+          message: "Synthetic capture body is unavailable.",
+          request_id: "req_fixture",
+        });
+      }
       const transientFailures = state.transientCaptureFailures.get(requestId) ?? 0;
       if (transientFailures > 0) {
         state.transientCaptureFailures.set(requestId, transientFailures - 1);
@@ -3107,6 +3144,191 @@ class ScoreWithFeedback:
       assert.equal(
         readFileSync(join(outputDirectory, "failed-request-ids.txt"), "utf8"),
         "",
+      );
+    });
+  });
+
+  it("resolves trace request ids and reuses the capture batch exporter", async () => {
+    await withHostedFixture(async ({ home, repo, requests, state }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const blockedDirectory = join(repo, "blocked-trace-export");
+      const blocked = await runWithEnvAsync([
+        "traces", "export", "trace_alpha",
+        "--out", blockedDirectory,
+        "--include-payload",
+      ], env, repo);
+      assert.notEqual(blocked.status, 0);
+      assert.match(blocked.stderr, /may contain prompts\/completions/);
+      assert.equal(existsSync(blockedDirectory), false);
+
+      const summaryDirectory = join(repo, "trace-summaries");
+      const requestCountBeforeSummary = requests.length;
+      const summaryExport = await runWithEnvAsync([
+        "--json", "traces", "export", "trace_alpha",
+        "--project", "rehearsal",
+        "--workload", "classify",
+        "--out", summaryDirectory,
+      ], env, repo);
+      assert.equal(summaryExport.status, 0, summaryExport.stderr);
+      assert.doesNotMatch(
+        `${summaryExport.stdout}${summaryExport.stderr}`,
+        /SECRET_(?:BATCH_)?(?:PROMPT|COMPLETION)/,
+      );
+      const summaryResult = JSON.parse(summaryExport.stdout);
+      assert.deepEqual(
+        {
+          complete: summaryResult.complete,
+          partial: summaryResult.partial,
+          failed: summaryResult.failed,
+          request_count: summaryResult.request_count,
+          captures_written: summaryResult.captures_written,
+        },
+        {
+          complete: 1,
+          partial: 0,
+          failed: 0,
+          request_count: 2,
+          captures_written: 2,
+        },
+      );
+      const summaryManifest = JSON.parse(
+        readFileSync(join(summaryDirectory, "trace.json"), "utf8"),
+      );
+      assert.equal(summaryManifest.schema_version, "understudy.trace_export.v1");
+      assert.deepEqual(summaryManifest.request_ids, ["req_123", "req_456"]);
+      assert.equal(summaryManifest.capture_export.complete, true);
+      assert.equal(summaryManifest.capture_export.output_suffix, ".summary.json");
+      assert.doesNotMatch(
+        readFileSync(join(summaryDirectory, "req_123.summary.json"), "utf8"),
+        /SECRET_(?:BATCH_)?(?:PROMPT|COMPLETION)/,
+      );
+      assert.equal(
+        JSON.parse(
+          readFileSync(join(summaryDirectory, "req_456.summary.json"), "utf8"),
+        ).trace_id,
+        "trace_alpha",
+      );
+      const summaryRequests = requests.slice(requestCountBeforeSummary);
+      const lookup = summaryRequests.find((entry) =>
+        entry.path ===
+          "/admin/v1/orgs/org_1/projects/proj_1/traces/trace_alpha/request-ids"
+      );
+      assert.ok(lookup, "trace export should call the trace request-id endpoint");
+      assert.equal(lookup.search, "?workload_id=usp_classify");
+      assert.equal(
+        summaryRequests.some((entry) =>
+          entry.path === "/admin/v1/orgs/org_1/projects/proj_1/captures"
+        ),
+        false,
+        "trace export must not scan the capture catalog",
+      );
+
+      state.unavailableCaptureIds.add("req_456");
+      const traceIdsPath = join(repo, "trace-ids.txt");
+      writeFileSync(
+        traceIdsPath,
+        "trace_alpha\ntrace_beta\ntrace_alpha\ntrace_missing\n",
+      );
+      const payloadDirectory = join(repo, "trace-payloads");
+      const batchExport = await runWithEnvAsync([
+        "--json", "traces", "export",
+        "--trace-ids-file", traceIdsPath,
+        "--project", "rehearsal",
+        "--out", payloadDirectory,
+        "--include-payload",
+        "--yes",
+        "--concurrency", "2",
+        "--retries", "1",
+      ], env, repo);
+      assert.equal(batchExport.status, 1, batchExport.stderr);
+      assert.doesNotMatch(
+        `${batchExport.stdout}${batchExport.stderr}`,
+        /SECRET_(?:BATCH_|RETRY_)?(?:PROMPT|COMPLETION)/,
+      );
+      const batchResult = JSON.parse(batchExport.stdout);
+      assert.deepEqual(
+        {
+          input_count: batchResult.input_count,
+          unique_count: batchResult.unique_count,
+          complete: batchResult.complete,
+          partial: batchResult.partial,
+          failed: batchResult.failed,
+          request_count: batchResult.request_count,
+          captures_written: batchResult.captures_written,
+          captures_failed: batchResult.captures_failed,
+        },
+        {
+          input_count: 4,
+          unique_count: 3,
+          complete: 1,
+          partial: 1,
+          failed: 1,
+          request_count: 3,
+          captures_written: 2,
+          captures_failed: 1,
+        },
+      );
+      const alphaManifest = JSON.parse(
+        readFileSync(join(payloadDirectory, "trace_alpha", "trace.json"), "utf8"),
+      );
+      assert.deepEqual(alphaManifest.request_ids, ["req_123", "req_456"]);
+      assert.equal(alphaManifest.capture_export.complete, false);
+      assert.match(
+        readFileSync(
+          join(payloadDirectory, "trace_alpha", "req_123.payload.json"),
+          "utf8",
+        ),
+        /SECRET_PROMPT/,
+      );
+      assert.equal(
+        existsSync(
+          join(payloadDirectory, "trace_alpha", "req_456.payload.json"),
+        ),
+        false,
+      );
+      assert.match(
+        readFileSync(
+          join(payloadDirectory, "trace_beta", "req_retry.payload.json"),
+          "utf8",
+        ),
+        /SECRET_RETRY_PROMPT/,
+      );
+      assert.equal(
+        readFileSync(join(payloadDirectory, "failed-trace-ids.txt"), "utf8"),
+        "trace_alpha\ntrace_missing\n",
+      );
+      assert.equal(
+        readFileSync(
+          join(payloadDirectory, "trace_alpha", "failed-request-ids.txt"),
+          "utf8",
+        ),
+        "req_456\n",
+      );
+      if (process.platform !== "win32") {
+        assert.equal(
+          statSync(
+            join(payloadDirectory, "trace_alpha", "req_123.payload.json"),
+          ).mode & 0o777,
+          0o600,
+        );
+      }
+
+      const unbounded = await runWithEnvAsync([
+        "traces", "export",
+        "--all",
+        "--project", "rehearsal",
+        "--out", join(repo, "unbounded"),
+      ], env, repo);
+      assert.notEqual(unbounded.status, 0);
+      assert.match(unbounded.stderr, /unknown option '--all'/);
+      assert.equal(
+        requests.some((entry) =>
+          entry.method === "GET" &&
+          entry.path === "/admin/v1/orgs/org_1/projects/proj_1/captures" &&
+          entry.search.includes("cursor=")
+        ),
+        false,
+        "trace exports must never paginate the capture catalog",
       );
     });
   });


### PR DESCRIPTION
## What changed

- add `understudy traces export <trace-id>` backed by the customer trace-membership endpoint
- resolve ordered request IDs for one trace and reuse the existing bounded capture batch exporter
- support batches of explicit trace IDs with retry/resume manifests, while deliberately omitting an unbounded `--all` mode and capture-catalog fallback
- add the `export-trace` skill and route hosted trace-ID requests through the public Understudy skill catalog
- document the API dependency, privacy boundary, commands, and artifacts

## Why

Gateway captures now carry `trace_id`, but the agent tools had no safe customer workflow for turning a supplied trace ID into its linked request captures. Agents would otherwise have to guess at an unavailable API or scan the capture catalog. This adds the client-side workflow for the intended platform contract: resolve trace membership first, then fetch each capture through the existing request-ID export path.

## User impact

A developer can provide one hosted trace ID—or a bounded file of explicit trace IDs—and receive private local redacted summaries by default, or full payload files only with explicit confirmation. Partial failures remain resumable through per-request and per-trace manifests.

## Skill catalog rationale

This introduces a distinct hosted-trace acquisition intent. It was checked against `use-understudy-gateway`, which owns authentication and routing readiness, and `ingest-traces`, which starts after capture files are already local.

## Platform dependency

The live command requires:

`GET /admin/v1/orgs/:orgId/projects/:projectId/traces/:traceId/request-ids`

with optional `workload_id`, returning only `{ "trace_id": "...", "request_ids": [...] }` in stable execution order.

## Validation

- `npm run check`
  - build passed
  - typecheck passed
  - 992 tests passed
  - 38 public skills validated
  - npm package dry-run passed
- `git diff --check` passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/understudylabs/understudy-agent-tools/pull/376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->