### PR TITLE
Make agentic optimization evidence-driven

### DIFF
--- a/skills/compare-model-sweep/SKILL.md
+++ b/skills/compare-model-sweep/SKILL.md
@@ -122,21 +122,43 @@ comparison.
    free-text wording, scorer/rubric errors, labels, and harness/parser failures.
    Scope conclusions to represented coverage strata.
 
-6. **Quantify uncertainty before ranking.** Point estimates on a small N are
-   not a ranking. For each candidate, compute a bootstrap confidence interval
-   over per-task scores: resample the task rows with replacement (≥1,000
-   resamples), recompute the aggregate, take the 2.5/97.5 percentiles. Report
-   N, the CI, and per-task variance in `summary.csv` alongside the pass rate.
-   **Refuse to declare a winner when the top candidates' CIs overlap** — call
-   it a statistical tie and either expand the frozen row set or pick on the
-   secondary axes (cost, latency) while saying quality is tied. This is the
-   Agentic Benchmark Checklist's reporting bar
+6. **Quantify uncertainty against a prespecified decision rule.** Point
+   estimates on a small N are not a ranking. For each candidate, report N,
+   per-task variance, and a bootstrap confidence interval over its aggregate
+   score. When candidates ran on the same rows, make the decision from the
+   paired per-row deltas: bootstrap the row-aligned deltas (≥1,000 resamples)
+   and report their 2.5/97.5 percentiles. Marginal candidate intervals remain
+   descriptive; their overlap or non-overlap is not a hypothesis test of the
+   difference.
+
+   Prespecify the decision that matches the workload:
+
+   - **superiority:** the paired-delta interval clears the superiority threshold;
+   - **non-inferiority:** its lower bound clears the workload's maximum
+     acceptable quality regression;
+   - **equivalence:** the full interval lies inside the prespecified equivalence
+     band;
+   - **multi-objective route decision:** the candidate satisfies every hard
+     contract/safety constraint and maximizes the prespecified utility or
+     lexicographic objective across quality, cost, latency, and reliability.
+
+   If rows are not pairable, state that limitation and use an appropriate
+   independent-sample interval/test or gather paired rows. Never relabel an
+   inconclusive superiority result as quality improvement. A route may still be
+   selected on cost/latency after demonstrated quality non-inferiority, or by a
+   prespecified multi-objective utility rule, with that basis stated explicitly.
+   This follows the Agentic Benchmark Checklist's reporting bar
    ([uiuc-kang-lab/agentic-benchmarks](https://github.com/uiuc-kang-lab/agentic-benchmarks));
    see [`../../docs/benchmark-rigor.md`](../../docs/benchmark-rigor.md).
 
-7. **Compute the frontier.** A candidate is dominated when another candidate has
-   equal or better quality and equal or lower cost and latency, with no worse
-   error rate or safety result. Write `pareto.json` with dominated reasons.
+7. **Compute the decision frontier.** Record workload-specific
+   acceptable-regression/non-inferiority bands and mark developer-specified
+   contract and safety requirements as hard constraints. Exclude candidates
+   that violate a hard constraint. Among eligible candidates, a route is
+   dominated when another has decision-supported equal or better quality and
+   equal or lower cost and latency, with no worse error rate or safety result.
+   Write `pareto.json` with bands, hard-constraint outcomes, decision rule, and
+   dominated reasons.
 
 8. **Report the decision.** Write `report.md` with the top frontier candidates,
    the best route for the agreed objective and constraints, and the next action:
@@ -183,8 +205,9 @@ When the sweep informs a real route decision, also write the report as a
 **decision memo** the developer can paste to their team unedited:
 
 - a results table: candidate, pass rate against the production validator
-  (with its bootstrap CI and N — a "winner" whose CI overlaps the runner-up
-  is reported as a tie),
+  (with its bootstrap CI and N), paired quality delta against the decision
+  baseline with its interval, and the prespecified superiority,
+  non-inferiority, equivalence, or utility verdict,
   total cost, cost per unit of work the business counts (per deal, per ticket,
   per call — not per token), and the cost ratio vs the incumbent;
 - caching basis per row (see step 5) and any other comparability caveats;

--- a/skills/optimize-agentic-workload/SKILL.md
+++ b/skills/optimize-agentic-workload/SKILL.md
@@ -1,22 +1,25 @@
 ---
 name: optimize-agentic-workload
-description: Use when a developer's agent — a multi-turn tool-calling loop — should get cheaper, faster, or better without retraining. "My agent is too slow", "this workflow costs too much", "test a cheaper model in my tool-calling loop", "A/B the policy model". Covers read-only search loops and state-mutating API workflows alike.
+description: Use when a developer's agent — a multi-turn tool-calling loop — should get cheaper, faster, or better. "My agent is too slow", "this workflow costs too much", "test a cheaper model in my tool-calling loop", "A/B the policy model". Covers read-only search loops and state-mutating API workflows alike.
 metadata:
   understudy:
     mode: interactive
     safety: approval-required
-    cli_required: true
+    cli_required: false
 ---
 
 # Optimize Agentic Workload
 
 Use this worker when the workload is an **agentic loop**: an LLM that plans over
 multiple turns and calls tools (web search, retrieval, REST/SDK calls, code
-execution) before finishing. The model's policy is the variable; the tools are
-held fixed. The goal is to pick the policy model you would ship on a
+execution) before finishing. Freeze every non-target variable within each
+experiment; model/route comparisons hold the tools fixed, while a named
+implementation arm may isolate one deployable tool, app, or harness change. The
+goal is to pick the route and implementation you would ship on a
 **multi-objective** basis — quality and latency and cost (and, for workflows
-that write, side-effect safety) — using only skills and the public CLI, with no
-new product code.
+that write, side-effect safety). The route is backend-agnostic: use the existing
+harness, provider-native evaluation or training, the public CLI, or a small
+versioned app/harness change when the measured failure calls for it.
 
 **The one discriminator that changes the playbook** is whether the loop
 *mutates state*:
@@ -32,14 +35,16 @@ new product code.
   Harness specifics:
   [`references/state-mutating-workflows.md`](references/state-mutating-workflows.md).
 
-Everything else — the artifact contract, the baseline gate, model A/B as the
-primary lever, prompt optimization as the secondary one, and the three-gate RL
-escalation — is shared.
+Everything else — the artifact contract, measured baseline, workload-specific
+decision contract, evidence-driven intervention choice, and stronger RL gates —
+is shared.
 
-This is not the handoff skill. Reach for
+This is not the RL handoff skill. Reach for
 [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md)
-only after model A/B and prompt optimization are exhausted and the evidence
-shows the agent must *learn stateful behavior*.
+only when the evidence shows the residual requires reinforcement learning of
+stateful behavior and its reward and renderer gates pass. Supervised
+fine-tuning or distillation is a separate intervention and can be selected
+earlier when correction labels or deterministic verifier targets support it.
 
 ## Safety Gates
 
@@ -62,7 +67,7 @@ secrets. Do not print or commit `sk_*` values; let
 [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md)
 inject them into the child process only.
 
-## Resolve CLI
+## Resolve CLI When Using An Understudy Route
 
 Prefer the installed `understudy` binary. If it is unavailable inside a
 checkout:
@@ -79,7 +84,8 @@ Use this skill when **all** of these hold:
 - the workload runs a tool-calling loop, not a single prompt-in/answer-out call;
 - success depends on *how the agent acts* (turn count, which tools, in what
   order, what it writes), not just the final string;
-- the tools are fixed and available to every candidate model;
+- the tool contract can be frozen for model comparisons, and any implementation
+  change can be isolated as its own named arm;
 - the developer wants to compare candidate policy models, or shrink a frontier
   model down to a cheaper one without losing quality.
 
@@ -91,18 +97,23 @@ single-output optimization does not need a tool environment.
 ## Flow
 
 1. **Confirm it is agentic and pick the lens.** Inspect the workload for a
-   multi-turn loop and tool calls. State the fixed tool set and the policy
-   model that varies. Then classify: do any tools **mutate state**? Read-only →
+   multi-turn loop and tool calls. State the fixed tool set and policy model for
+   route comparisons, plus any separately isolated implementation variable.
+   Then classify: do any tools **mutate state**? Read-only →
    [`references/read-only-search.md`](references/read-only-search.md);
    state-mutating →
    [`references/state-mutating-workflows.md`](references/state-mutating-workflows.md).
    If it is single-output, hand back to `capture-evidence`.
 
 2. **Adopt a runnable harness.** Read-only loops use a verifiers environment
-   (`vf.Environment` + `Rubric`; the `vf-eval` command is the harness).
-   State-mutating workflows use the existing benchmark/sandbox runner with a
+   (`vf.Environment` + `Rubric`; the `vf-eval` command is one supported
+   harness) or another replayable provider-native/application runner.
+   State-mutating workflows use an existing benchmark/sandbox runner with a
    deterministic reset (seeded state, fixed API schemas, fixed policy docs,
-   final-state validator). Either way, capture it into the
+   final-state validator). A small deployable app or harness change is allowed
+   when it directly addresses a measured failure; version it and evaluate it as
+   a distinct arm instead of silently changing the comparison. Either way,
+   capture the runnable contract into the
    `.understudy/capture-evidence/` artifact contract — each reference documents
    the env → artifact bridge for its shape.
 
@@ -126,7 +137,10 @@ single-output optimization does not need a tool environment.
    (turn counts, tool/API call counts, timing, token usage) — read those
    instead of inventing a meter. State-mutating workflows add a
    **side-effect-safety** axis (forbidden writes, invalid requests, retries).
-   Record the axes and an acceptable-regression band in `metric.json`.
+   Record the axes, workload-specific acceptable-regression/non-inferiority
+   bands, and any hard constraints in `metric.json`. Contract requirements and
+   safety requirements marked hard by the developer remain zero-tolerance;
+   statistical or multi-objective tradeoffs cannot waive them.
 
 4. **Freeze determinism.** Read-only: live tool calls are non-deterministic, so
    freeze the query set and **snapshot/cache the tool outputs** so the harness
@@ -157,12 +171,16 @@ single-output optimization does not need a tool environment.
    the running environment. Let the attribution pick the **highest-leverage rung
    likely to close the gap**: output-contract repair (prefill / format / parser /
    schema), tool-access or endpoint-catalog repair, model A/B, prompt / GEPA
-   (automatic prompt evolution), distillation, or RL. Use the cheaper rung first
-   only when evidence says it can solve the attributed failure; skip directly to
-   a stronger model or broader intervention when weak iterations would only
-   delay the answer.
+   (automatic prompt evolution), supervised fine-tuning/distillation, or RL.
+   Rank the eligible rungs by expected objective gain, confidence, time, spend,
+   and reversibility; start with the highest expected value rather than a fixed
+   sequence. Use a cheaper rung first only when evidence says it can solve the
+   attributed failure.
 
-7. **PRIMARY intervention — model A/B via the CLI.** This is the main move:
+7. **Candidate intervention — compare models and routes.** When attribution
+   points to model capability or provider/runtime behavior, compare deployable
+   candidates through any backend that can honor the frozen contract. The
+   Understudy CLI is one route:
 
    ```sh
    understudy models list --json
@@ -172,22 +190,29 @@ single-output optimization does not need a tool environment.
    ```
 
    List public model options, route the project workload to a chosen model,
-   then run the frozen harness through the gateway with `understudy run`.
+   then run the frozen harness through the gateway with `understudy run`; a
+   provider-native or existing application runner is equally valid when it
+   preserves the same rows, prompt, tools, metric, seed/reset, and data
+   boundary.
    Compare quality vs latency vs cost (vs side-effect safety) across candidates
-   and pick the model you would ship. For keyless accounts, prefer a
-   managed-catalog sweep on a cleared/no-route workload before traffic-split
-   A/B. Prerequisite for a traffic split: the non-routed passthrough share
-   needs a configured managed provider credential or BYO key so untouched
-   traffic still completes. Clear a route with `--clear`. Routing detail lives in
+   under the decision contract and pick the route you would ship. For keyless
+   accounts, prefer a managed-catalog sweep on a cleared/no-route workload
+   before traffic-split A/B. Prerequisite for a traffic split: the non-routed
+   passthrough share needs a configured managed provider credential or BYO key
+   so untouched traffic still completes. Clear a route with `--clear`. Routing
+   detail lives in
    [`../use-understudy-gateway/SKILL.md`](../use-understudy-gateway/SKILL.md).
    For state-mutating workflows, A/B is often simpler: run the same harness
    rows twice with only the model changed (see the reference).
 
-8. **SECONDARY intervention — optimize the cheap model's prompt.** If a cheaper
-   model wins on latency and cost but trails on quality, close the gap with a
-   train/dev-only GEPA pass against the feedback-rich rubric, keeping the
-   latency/cost win. When the workload already lives in a promoted benchmark
-   dir with frozen splits, run the automatic loop directly:
+8. **Candidate intervention — repair prompt, tools, contract, or harness.** When
+   the attributed gap is instructional or structural, test the smallest
+   deployable correction: prompt/GEPA, output parser or schema, tool
+   descriptions/retrieval, retry policy, or a versioned app/harness change.
+   If a cheaper model wins on latency and cost but trails on quality, a
+   train/dev-only GEPA pass against the feedback-rich rubric may close the gap
+   while keeping the latency/cost win. When the workload already lives in a
+   promoted benchmark dir with frozen splits, run the automatic loop directly:
 
    ```sh
    # terminal 1 — the only thing that executes models
@@ -206,10 +231,12 @@ single-output optimization does not need a tool environment.
    loop and budget guidance. **Claim rules** mirror
    [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md): it evolves
    on train, selects the champion on dev, touches the sealed holdout exactly
-   once for the final champion-vs-bare run, and reports a win only when that
-   holdout run's paired 95% CI excludes zero — a `no_win`/`unverified`/
-   `inconclusive` verdict must never be presented as an improvement. For
-   single-output workloads, hand off to
+   once for the final champion-vs-bare run, and reports quality improvement only
+   when that holdout run's paired 95% CI clears the prespecified superiority
+   threshold. A route may still be selected after demonstrated quality
+   non-inferiority or by a prespecified multi-objective rule, but a `no_win`/
+   `unverified`/`inconclusive` superiority verdict must never be presented as an
+   improvement. For single-output workloads, hand off to
    [`../optimize-workload/SKILL.md`](../optimize-workload/SKILL.md) instead;
    never tune on holdout.
 
@@ -226,12 +253,23 @@ single-output optimization does not need a tool environment.
    one run, same scorer, per-arm rows. Operating detail in
    [`../operate-benchmark-lab/SKILL.md`](../operate-benchmark-lab/SKILL.md).
 
-9. **Escalate to RL only as a true handoff, behind three gates.** If model swap
-   and prompt/distillation stall while real headroom remains and the residual
-   is genuinely *stateful* multi-step behavior, route to
+9. **Candidate intervention — supervised fine-tuning or distillation.** Select
+   this early when the failure evidence supplies learnable correction pairs,
+   teacher trajectories, or deterministic verifier labels and a trained
+   candidate can be evaluated in the same end-to-end harness. Do not require
+   model A/B or prompt optimization to fail first. Freeze the dataset lineage,
+   keep holdout sealed, declare provider/data/retention/spend bounds, and compare
+   the trained route against the incumbent under the same hard safety and
+   contract constraints. Treat next-action imitation as diagnostic unless the
+   end-to-end rollout also validates result propagation, recovery, termination,
+   and final state.
+
+10. **Escalate to RL only as a true handoff, behind three gates.** When the
+   residual is genuinely *stateful* multi-step behavior, route to
    [`../prepare-verifier-handoff/SKILL.md`](../prepare-verifier-handoff/SKILL.md).
    First confirm: (a) the attribution in step 6 shows **cross-turn reasoning**
-   is the residual, not format/argument-value (which are cheaper to fix); (b)
+   is the residual, not format/argument-value (which supervised or deterministic
+   repairs can address); (b)
    the reward is **dense, not strict** — a binary/strict reward can be constant
    within a group, giving zero advantage and no gradient (paid-for, wasted
    steps); and (c) the model has a first-class multi-turn GRPO **trainer and
@@ -248,22 +286,25 @@ must rest on a measured baseline, and any savings statement needs the
 End with:
 
 - whether the workload was confirmed agentic, which lens applied (read-only vs
-  state-mutating), and the fixed tool set named;
+  state-mutating), and the fixed tool set plus any isolated implementation
+  variable named;
 - the harness id/command used (verifiers env or workflow runner);
 - the objective axes (quality / latency / cost / side-effect safety where
-  applicable) and the baseline numbers;
+  applicable), hard constraints, acceptable-regression/non-inferiority bands,
+  and the baseline numbers;
 - whether determinism was frozen (tool snapshot or seeded reset) and the
   holdout stayed clean;
-- the model A/B result and the model you would ship;
+- the interventions considered, the evidence-driven first choice, its result,
+  and the route you would ship;
 - result type: evidence-capture, evaluation, optimization-lead, heldout, or
   handoff;
 - one recommended next command or local action.
 
 ## References
 
-- [`references/read-only-search.md`](references/read-only-search.md) — verifiers
-  ToolEnv harness, tool-output snapshotting, the env → artifact bridge, and the
-  CLI A/B procedure for read-only loops.
+- [`references/read-only-search.md`](references/read-only-search.md) — replayable
+  agent harnesses, tool-output snapshotting, the env → artifact bridge, and
+  backend-agnostic model/route comparison for read-only loops.
 - [`references/state-mutating-workflows.md`](references/state-mutating-workflows.md)
   — resettable sandbox harness, final-state/policy rubric, tool-access
   reporting, failure-mode table, and the GEPA bridge for multi-step rollouts.

--- a/skills/optimize-agentic-workload/references/read-only-search.md
+++ b/skills/optimize-agentic-workload/references/read-only-search.md
@@ -29,13 +29,15 @@ again, and eventually answers. Three consequences shape the whole playbook:
   minute to minute. That fights the hash-stable artifact contract unless you
   snapshot tool outputs (see Determinism, below).
 
-## Harness: A Verifiers Environment
+## Harness: A Replayable Agent Environment
 
-Use a Prime Intellect `verifiers` environment as the eval harness. The
-environment is a `vf.Environment` (for tool loops, a `ToolEnv`) plus a `Rubric`.
-The runnable command — conceptually `vf-eval <env-id> --model <model> -n <N>` —
-is what the agent executes; the environment supplies the dataset, the fixed
-tools, and the scoring rubric.
+Use an existing replayable agent runner that supplies the dataset, fixed tools,
+and scoring rubric. A Prime Intellect `verifiers` environment is one supported
+option: the environment is a `vf.Environment` (for tool loops, a `ToolEnv`) plus
+a `Rubric`, and the runnable command is conceptually
+`vf-eval <env-id> --model <model> -n <N>`. An existing application harness or
+provider-native evaluator is equally valid when it emits equivalent per-rollout
+evidence and honors the same snapshot, split, metric, and data boundary.
 
 Public docs:
 
@@ -99,9 +101,13 @@ shape:
     "latency": { "source": "toolenv", "fields": ["num_turns", "wall_clock_s"] },
     "cost":    { "source": "toolenv", "fields": ["prompt_tokens", "completion_tokens", "tool_calls"], "price_assumption": "synthetic" }
   },
-  "acceptable_regression": { "quality": -0.0, "latency_s": 0.5, "cost_pct": 0 }
+  "acceptable_regression": { "quality": -0.02, "latency_s": 0.5, "cost_pct": 5 }
 }
 ```
+
+The numeric bands above are synthetic examples, not universal promotion gates;
+derive them from the workload's utility and risk. Mark any developer-required
+contract or safety criterion as hard instead of averaging it into the tradeoff.
 
 Debias the LLM-judge with a swapped two-pass score; never single-pass. Bare
 pass/fail feedback wastes a later GEPA pass — see
@@ -184,9 +190,12 @@ deliberately (and re-baseline) rather than letting live drift in. Treat the
 cache as local artifact data subject to the same public boundary — do not commit
 scraped third-party content or anything proprietary.
 
-## Primary Intervention: Model A/B
+## Candidate Intervention: Model And Route Comparison
 
-The main lever is swapping the policy model with tools held fixed. Procedure:
+Use this intervention when the attributed gap is model capability or
+provider/runtime behavior. Swap the policy model with tools held fixed; a
+provider-native or application runner may replace the Understudy commands below
+when it preserves the same comparison contract. Procedure:
 
 1. `understudy models list --json` — enumerate public model options.
 2. For each candidate, route the workload to it and run the frozen harness
@@ -201,9 +210,11 @@ The main lever is swapping the policy model with tools held fixed. Procedure:
 3. Read quality from the rubric and latency/cost from the `ToolEnv` rollout
    metadata. Tabulate quality vs latency vs cost across candidates.
 4. Pick the model you would ship for the named objective under the
-   `acceptable_regression` band. Compare expected quality, latency, spend, and
-   confidence explicitly; do not make the lowest-cost model the default when a
-   stronger or faster model would materially improve the outcome.
+   workload-specific acceptable-regression/non-inferiority bands and hard
+   constraints. Compare expected quality, latency, spend, and confidence
+   explicitly; do not make the lowest-cost model the default when a stronger or
+   faster model would materially improve the outcome. Contract and safety
+   requirements marked hard remain zero-tolerance.
 5. Clear routes you are done with:
 
    ```sh
@@ -219,15 +230,18 @@ during the experiment. Configure it through the normal gateway/project setup in
 [`../../use-understudy-gateway/SKILL.md`](../../use-understudy-gateway/SKILL.md);
 this skill does not describe the internal plumbing.
 
-Inference defaults to Understudy within the activated workflow via
-`understudy login --email <developer-email>`; BYO provider keys are a fallback if
-the developer prefers. Keep provider, model, budget, and data class in the run
-artifact.
+The selected backend is part of the activated workflow. Understudy managed
+routing, provider-native runs, and BYO provider routes are all eligible when
+they fit the declared destination, spend, retention, and data-class envelope.
+Keep provider, model, budget, and data class in the run artifact.
 
-## Secondary Intervention: GEPA a Promising Model's Prompt
+## Candidate Intervention: Prompt Or Implementation Repair
 
-If a cheaper model wins latency/cost but trails on quality, optimize its prompt
-to close the gap while keeping the win. GEPA is train/dev-only and feeds on the
+Use prompt/GEPA when the attributed gap is instructional. If a cheaper model
+wins latency/cost but trails on quality, optimizing its prompt can close the gap
+while keeping the win. A small versioned app/harness change is also eligible
+when the measured cause is a parser, schema, tool-access, or retry-policy
+defect; evaluate it as a separate arm. GEPA is train/dev-only and feeds on the
 rubric's natural-language feedback, so a feedback-rich `metric.json` is the
 precondition. Hand the actual run to
 [`../../optimize-workload/SKILL.md`](../../optimize-workload/SKILL.md):
@@ -242,18 +256,28 @@ For an agentic loop, useful prompt targets are: when to stop searching (turn
 budget), how to phrase tool queries, and how to cite retrieved sources. Each maps
 to a rubric criterion, so the feedback is actionable.
 
-## When To Escalate To The Handoff
+## Candidate Intervention: Supervised Fine-Tuning Or Distillation
 
-Escalate to
+Select supervised training early when correction pairs, teacher trajectories,
+or deterministic verifier labels directly cover the attributed failures. It
+does not require model A/B or GEPA to fail first. Keep dataset lineage explicit,
+holdout sealed, and provider/data/retention/spend bounds declared. Evaluate the
+trained candidate in the same full loop; next-action imitation alone does not
+establish result propagation, recovery, termination, or replacement readiness.
+
+## When To Escalate To The RL Handoff
+
+Use
 [`../../prepare-verifier-handoff/SKILL.md`](../../prepare-verifier-handoff/SKILL.md)
-only when **all** of these hold:
+only for reinforcement learning and only when **all** of these hold:
 
-- model A/B found no shippable model within the regression band;
-- train/dev GEPA stalled with real headroom remaining;
-- the failure is *stateful* — the agent must learn multi-step behavior (when to
-  branch, backtrack, or re-plan) that a single-output reward cannot teach.
+- the failure is *stateful* — the agent must learn multi-step behavior such as
+  branching, backtracking, or re-planning;
+- the reward has enough within-group variation to train the behavior rather
+  than collapsing to a constant strict/binary signal;
+- the target model has a compatible first-class multi-turn trainer and renderer.
 
-That is the RL / policy-training rung. This OSS repo never runs it; the handoff
+That is the RL rung. This OSS repo never runs it; the handoff
 skill prepares the evidence packet and refers to Prime Intellect Verifiers.
 
 ## Capture-Evidence And Claim Discipline

--- a/skills/optimize-agentic-workload/references/state-mutating-workflows.md
+++ b/skills/optimize-agentic-workload/references/state-mutating-workflows.md
@@ -333,10 +333,13 @@ workflow semantics before registering or routing it:
 Keep `baseline.model` factual. If the incumbent is unknown, write
 `"unknown-pending-baseline"` and do not claim an optimization result.
 
-## Model A/B Procedure
+## Candidate Model/Route Procedure
 
-For API workflows, A/B is simpler than live traffic routing: run the same
-harness rows twice with only the candidate route changed.
+Use this intervention when the attributed gap is model capability or
+provider/runtime behavior. For API workflows, the comparison is simpler than
+live traffic routing: run the same harness rows twice with only the candidate
+route changed. Understudy, provider-native, and existing application runners
+are all eligible when they preserve the frozen comparison and data contract.
 
 ```sh
 understudy run -- "$HARNESS_CMD" \
@@ -360,10 +363,12 @@ Compare:
 - API call count and retry count
 
 Pick the model with the best expected outcome under the approved regression,
-latency, spend, and safety constraints. Show the tradeoff rather than silently
-optimizing for the lowest price. If both models fail the same invariant, the
-next intervention is prompt/tool-description repair, not another blind model
-swap.
+latency, spend, and safety constraints. Make acceptable-regression or
+non-inferiority bands workload-specific, and keep developer-marked contract and
+safety requirements hard. Show the tradeoff rather than silently optimizing for
+the lowest price. If both models fail the same invariant, use attribution to
+select a prompt/tool-description repair, supervised fine-tuning, or another
+supported intervention instead of another blind model swap.
 
 ## GEPA Bridge For Multi-Step Rollouts
 
@@ -431,9 +436,16 @@ an equivalent per-suite override.
 | Bad recovery | transient error causes abandoned task | retry policy and error-specific feedback |
 | State drift | same row yields different result after reset | fix reset/seed harness before optimizing |
 
-Only escalate to verifier handoff when model A/B and train/dev prompt/tool
-optimization stall with real headroom on stateful decisions that cannot be fixed
-by clearer instructions, schemas, routing, or retry policy.
+Supervised fine-tuning or distillation may be selected before model/prompt
+experiments when correction pairs, teacher trajectories, or deterministic
+verifier labels directly cover the failure. Keep training lineage, holdout,
+provider/data/retention/spend bounds, and end-to-end rollout validation intact.
+
+Escalate to the RL verifier handoff only when the residual requires stateful
+cross-turn learning, the reward has enough within-group variation, and the
+target has a compatible first-class multi-turn trainer and renderer. Do not use
+RL to repair format, schema, or argument-value failures that supervised or
+deterministic interventions can address.
 
 ## Claim Discipline
 

--- a/tests/evaluation-evidence-gates.test.mjs
+++ b/tests/evaluation-evidence-gates.test.mjs
@@ -38,6 +38,38 @@ test("decision skills enforce the shared evaluation evidence gates", () => {
   }
 });
 
+test("agentic optimization is backend-agnostic and evidence-driven", () => {
+  const skill = read("skills/optimize-agentic-workload/SKILL.md");
+  const references = [
+    "skills/optimize-agentic-workload/references/read-only-search.md",
+    "skills/optimize-agentic-workload/references/state-mutating-workflows.md",
+  ].map(read).join("\n");
+
+  assert.match(skill, /route is backend-agnostic/i);
+  assert.match(skill, /cli_required: false/i);
+  assert.match(skill, /start with the highest expected value rather than a fixed\s+sequence/i);
+  assert.match(skill, /Supervised fine-tuning or distillation/i);
+  assert.match(skill, /Do not require\s+model A\/B or prompt optimization to fail first/i);
+  assert.match(skill, /Contract requirements and\s+safety requirements marked hard.*zero-tolerance/is);
+  assert.doesNotMatch(skill, /using only skills and the public CLI/i);
+  assert.doesNotMatch(skill, /PRIMARY intervention|SECONDARY intervention/);
+
+  assert.match(references, /provider-native/i);
+  assert.match(references, /Supervised fine-tuning or distillation/i);
+  assert.match(references, /compatible first-class multi-turn trainer and renderer/i);
+});
+
+test("model sweeps use paired uncertainty and prespecified decision rules", () => {
+  const skill = read("skills/compare-model-sweep/SKILL.md");
+
+  assert.match(skill, /paired per-row deltas/i);
+  assert.match(skill, /superiority:[\s\S]*non-inferiority:[\s\S]*equivalence:/i);
+  assert.match(skill, /multi-objective route decision/i);
+  assert.match(skill, /Never relabel an\s+inconclusive superiority result as quality improvement/i);
+  assert.match(skill, /contract and safety requirements as hard constraints/i);
+  assert.doesNotMatch(skill, /Refuse to declare a winner when the top candidates' CIs overlap/i);
+});
+
 test("cost audits prioritize concentration and keep value classification human-guided", () => {
   const skill = read("skills/lower-anthropic-bill/SKILL.md");
 


### PR DESCRIPTION
## What changed

- Make `optimize-agentic-workload` backend-agnostic and allow a provider-native run or a small, versioned app/harness change when attribution supports it.
- Replace the fixed model-swap → prompt → training sequence with an expected-value intervention choice.
- Treat supervised fine-tuning/distillation as an independent rung that may run early when correction pairs or deterministic verifier labels exist, while retaining stronger rewardability and multi-turn renderer/trainer gates for RL.
- Replace marginal-CI overlap as a model-sweep winner veto with paired-delta uncertainty and prespecified superiority, non-inferiority, equivalence, or multi-objective utility decisions.
- Preserve workload-specific hard contract/safety constraints, privacy and secret handling, bounded spend/retention/destination envelopes, production-write separation, holdout integrity, and conservative evidence labels.
- Add skill-content tests that lock in the new decision rules.

## Why

The prior guidance encoded implementation choices as universal policy: it required the public CLI, prohibited small product changes, prioritized model A/B and prompt work before training, conflated supervised training with RL escalation, and treated overlap between marginal confidence intervals as proof of a statistical tie. Those constraints can delay the highest-value experiment and the CI-overlap rule is not a valid test of the paired difference.

## User impact

Agents can now choose the intervention most likely to produce a deployable replacement for the measured workload—across providers, prompt/tooling repairs, small implementation changes, or supervised training—without weakening the privacy, spend, production-write, holdout, or hard safety boundaries. Route recommendations state whether they rely on superiority, non-inferiority, equivalence, or an explicit multi-objective rule and never relabel inconclusive superiority as improvement.

## Validation

- `npm run check` (build, typecheck, 1,071 tests, 37 public-skill validations, package smoke)
- `git diff --check`