### PR TITLE
fix(trace-foundry): add fault-tolerant JSONL parsing for trace files (#381)

### DIFF
--- a/src/trace-foundry.ts
+++ b/src/trace-foundry.ts
@@ -452,7 +452,19 @@ function writeJsonl(path: string, rows: Obj[]): void {
   writeFileSync(path, "", { mode: 0o600 });
   for (let i = 0; i < rows.length; i += 200) appendFileSync(path, rows.slice(i, i + 200).map((row) => JSON.stringify(row)).join("\n") + "\n");
 }
-function readJsonl(path: string): Obj[] { return existsSync(path) ? readFileSync(path, "utf8").split(/\r?\n/).filter(Boolean).map((line) => asObject(JSON.parse(line))) : []; }
+function readJsonl(path: string): Obj[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [asObject(JSON.parse(line))];
+      } catch {
+        return [];
+      }
+    });
+}
 function appendJsonl(path: string, rows: Obj[]): void { if (rows.length === 0) return; mkdirSync(resolve(path, ".."), { recursive: true }); appendFileSync(path, rows.map((row) => JSON.stringify(row)).join("\n") + "\n", { mode: 0o600 }); }
 const pyName = (value: string): string => { const clean = value.replace(/[^A-Za-z0-9_]/g, "_"); return /^[A-Za-z_]/.test(clean) ? clean : `tool_${clean}`; };
 


### PR DESCRIPTION
Fixes #381 
## Summary

Fixes an unhandled exception crash in `src/trace-foundry.ts` when reading `.jsonl` trace and event files containing malformed, truncated, or incomplete lines.

## Problem

In `src/trace-foundry.ts`, the inline `readJsonl` helper executed `JSON.parse(line)` directly inside Array `.map()` without error handling. When processing trace log files, event streams, or replay captures where a file contains an incomplete trailing line (e.g., from an interrupted background execution or partial disk flush), `JSON.parse` threw an unhandled `SyntaxError`, crashing the entire trace foundry analysis and benchmark orchard pipeline.

## Solution

Updated `readJsonl` in `src/trace-foundry.ts` to use a `flatMap` with `try...catch` error handling. Corrupted or partially written lines are now safely skipped, aligning with the fault-tolerant design of `readJsonlFile` in `benchmark-artifacts.ts`.

## Changes Made

- **`src/trace-foundry.ts`**: Wrapped `JSON.parse` line parsing inside a `try...catch` block within `flatMap` to ignore parse errors and return valid parsed objects.