### PR TITLE
fix(local-classifier): guard accuracy and macro_f1 against division by zero (#383)

### DIFF
--- a/src/local-classifier/frontier.ts
+++ b/src/local-classifier/frontier.ts
@@ -563,8 +563,8 @@ function computeHeldout(
     return { label, precision, recall, f1, support: count.support };
   });
   return {
-    accuracy: correct / rows.length,
-    macro_f1: perClass.reduce((sum, row) => sum + row.f1, 0) / perClass.length,
+    accuracy: rows.length > 0 ? correct / rows.length : 0,
+    macro_f1: perClass.length > 0 ? perClass.reduce((sum, row) => sum + row.f1, 0) / perClass.length : 0,
     latency_ms_p50: latencyMsP50,
     per_class: perClass,
     weakest_classes: [...perClass]


### PR DESCRIPTION
Fixes #383 
## Summary
Fixes a division-by-zero bug in `src/local-classifier/frontier.ts` that produces `NaN` evaluation metrics when processing empty datasets or zero-label evaluation splits.

## Problem
In `src/local-classifier/frontier.ts`, `accuracy` and `macro_f1` were computed without guarding against zero-length arrays:

```typescript
accuracy: correct / rows.length,
macro_f1: perClass.reduce((sum, row) => sum + row.f1, 0) / perClass.length,
```

When `rows` is empty (`rows.length === 0`) or `orderedLabels` contains no active classes (`perClass.length === 0`), these expressions evaluate to `0 / 0`, resulting in `NaN`.

Since `NaN` is not a valid JSON value, serializing evaluation reports with `JSON.stringify()` converts it to `null`, which can also trigger downstream schema validation failures in Zod schemas expecting numeric metric values.

## Solution
Added zero-length guards to both metric calculations:

```typescript
accuracy: rows.length > 0 ? correct / rows.length : 0,
macro_f1:
  perClass.length > 0
    ? perClass.reduce((sum, row) => sum + row.f1, 0) / perClass.length
    : 0,
```

## Changes Made
- **`src/local-classifier/frontier.ts`**
  - Guarded `accuracy` with `rows.length > 0` to prevent division by zero.
  - Guarded `macro_f1` with `perClass.length > 0` to prevent division by zero.
  - Ensured evaluation metrics remain valid numeric values for JSON serialization and downstream schema validation.