### PR TITLE
feat(desktop): add production health monitor

### DIFF
--- a/apps/homescreen/app/components/MonitorPane.tsx
+++ b/apps/homescreen/app/components/MonitorPane.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  ClipboardCheckIcon,
+  CopyIcon,
+  RefreshCwIcon,
+} from "lucide-react";
+import {
+  buildWorkloadRows,
+  cacheReusePercent,
+  displayModelName,
+  monitoringState,
+  snapshotForSelection,
+  topModelRows,
+} from "../lib/monitoring.mjs";
+
+type RoutingStatusEntry = {
+  workload_id: string;
+  display_name: string;
+  environment: string | null;
+  route_mode: "primary" | "understudy" | "passthrough";
+  active_traffic_pct: number;
+  provider_label: string | null;
+  model: string | null;
+  updated_at: string;
+};
+
+type ProviderHealthEntry = {
+  provider: string;
+  workload: string;
+  model: string;
+  request_count: number;
+  error_5xx_count: number;
+  error_5xx_rate: number;
+  timeout_count: number;
+  fallback_count: number;
+  last_failing_at: string | null;
+  example_request_ids: string[];
+};
+
+type TokenBreakdown = {
+  input_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  output_tokens: number;
+  reasoning_output_tokens: number;
+  total_tokens: number;
+};
+
+type MonitoringSnapshot = {
+  project_id: string;
+  window: string;
+  fetched_at: string;
+  source: string;
+  routing: {
+    project_id: string;
+    workloads: RoutingStatusEntry[];
+    workload_count: number;
+    generated_at: string;
+  };
+  health: {
+    project_id: string;
+    window: string;
+    window_start: string;
+    window_end: string;
+    total_requests: number;
+    total_errors: number;
+    providers: ProviderHealthEntry[];
+    generated_at: string;
+  };
+  billing: {
+    summary: {
+      org_id: string;
+      from: string;
+      to: string;
+      tokens: TokenBreakdown;
+      metered_requests: number;
+      priced_events: number;
+      estimated_cost_usd: number;
+      blended_price_per_mtok: number;
+    };
+  } | null;
+  usage_by_model: {
+    rows: Array<{
+      provider: string;
+      served_model: string;
+      requests: number;
+      tokens: TokenBreakdown;
+      cost_usd: number;
+    }>;
+  } | null;
+  warnings: string[];
+};
+
+const WINDOWS = [
+  ["30m", "30 min"],
+  ["1h", "1 hour"],
+  ["6h", "6 hours"],
+  ["12h", "12 hours"],
+  ["24h", "24 hours"],
+] as const;
+const CACHE_PREFIX = "understudy.monitor.snapshot.v1";
+const WINDOW_KEY = "understudy.monitor.window.v1";
+
+const count = new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 });
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function cacheKey(projectId: string, window: string) {
+  return `${CACHE_PREFIX}.${projectId}.${window}`;
+}
+
+function readCachedSnapshot(projectId: string, window: string): MonitoringSnapshot | null {
+  try {
+    const raw = localStorage.getItem(cacheKey(projectId, window));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as MonitoringSnapshot;
+    return parsed.project_id === projectId && parsed.window === window ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function relativeTime(value: string) {
+  const elapsed = Math.max(0, Date.now() - new Date(value).getTime());
+  if (elapsed < 60_000) return "just now";
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+}
+
+function routeLabel(mode: string, percent: number) {
+  if (mode === "passthrough") return "Direct";
+  if (percent >= 100) return "Understudy · all traffic";
+  return `Understudy · ${percent}%`;
+}
+
+export function MonitorPane({
+  projectId,
+  onOpenAccount,
+}: {
+  projectId: string | null;
+  onOpenAccount: () => void;
+}) {
+  const [window, setWindow] = useState("12h");
+  const [snapshot, setSnapshot] = useState<MonitoringSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const requestSequence = useRef(0);
+
+  const loadSnapshot = useCallback(async (
+    nextProjectId: string,
+    nextWindow: string,
+    options: { preferCache?: boolean; background?: boolean } = {},
+  ) => {
+    if (!nextProjectId || !isTauri()) return;
+    const sequence = ++requestSequence.current;
+    const cached = options.preferCache ? readCachedSnapshot(nextProjectId, nextWindow) : null;
+    if (cached) {
+      setSnapshot(cached);
+      setLoading(false);
+    }
+    if (options.background) setRefreshing(true);
+    else if (!cached) setLoading(true);
+    setError(null);
+    try {
+      const next = await invoke<MonitoringSnapshot>("reporting_snapshot", {
+        projectId: nextProjectId,
+        window: nextWindow,
+      });
+      if (sequence !== requestSequence.current) return;
+      setSnapshot(next);
+      localStorage.setItem(cacheKey(nextProjectId, nextWindow), JSON.stringify(next));
+    } catch (nextError) {
+      if (sequence !== requestSequence.current) return;
+      setError(String(nextError));
+    } finally {
+      if (sequence === requestSequence.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isTauri()) {
+      setLoading(false);
+      setError("Production monitoring is available in the installed Desktop app.");
+      return;
+    }
+    const storedWindow = localStorage.getItem(WINDOW_KEY);
+    const selectedWindow = WINDOWS.some(([value]) => value === storedWindow)
+      ? storedWindow!
+      : "12h";
+    setWindow(selectedWindow);
+    if (!projectId) {
+      requestSequence.current += 1;
+      setSnapshot(null);
+      setError(null);
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+    void loadSnapshot(projectId, selectedWindow, { preferCache: true });
+  }, [loadSnapshot, projectId]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const timer = globalThis.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        void loadSnapshot(projectId, window, { background: true });
+      }
+    }, 60_000);
+    return () => globalThis.clearInterval(timer);
+  }, [loadSnapshot, projectId, window]);
+
+  const visibleSnapshot = snapshotForSelection(snapshot, projectId, window);
+  const state = useMemo(() => monitoringState(visibleSnapshot?.health), [visibleSnapshot]);
+  const workloads = useMemo(
+    () => buildWorkloadRows(visibleSnapshot?.routing.workloads, visibleSnapshot?.health.providers),
+    [visibleSnapshot],
+  );
+  const models = useMemo(
+    () => topModelRows(visibleSnapshot?.usage_by_model?.rows ?? [], 6),
+    [visibleSnapshot],
+  );
+  const reuse = cacheReusePercent(visibleSnapshot?.billing?.summary);
+  const maxModelCost = Math.max(0, ...models.map((model) => model.cost_usd));
+  const copyRequestId = async (requestId: string) => {
+    await navigator.clipboard.writeText(requestId);
+    setCopied(requestId);
+    globalThis.setTimeout(() => setCopied((current) => current === requestId ? null : current), 1800);
+  };
+
+  return (
+    <section className="monitor-pane settle" aria-labelledby="monitor-title">
+      <header className="monitor-topbar">
+        <div>
+          <span className="monitor-kicker">Production monitor</span>
+          <h1 id="monitor-title">Production health</h1>
+          <p>Customer-safe aggregates only. Prompts and responses never load here.</p>
+        </div>
+        <div className="monitor-controls">
+          <label>
+            <span className="sr-only">Time window</span>
+            <select
+              value={window}
+              onChange={(event) => {
+                const next = event.target.value;
+                setWindow(next);
+                localStorage.setItem(WINDOW_KEY, next);
+                if (projectId) void loadSnapshot(projectId, next, { preferCache: true });
+              }}
+            >
+              {WINDOWS.map(([value, label]) => (
+                <option key={value} value={value}>Last {label}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="monitor-refresh"
+            aria-label="Refresh production monitor"
+            disabled={!projectId || refreshing}
+            onClick={() => void loadSnapshot(projectId, window, { background: true })}
+          >
+            <RefreshCwIcon aria-hidden="true" size={15} className={refreshing ? "spinning" : ""} />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      {!projectId ? (
+        <div className="monitor-blocked">
+          <AlertTriangleIcon aria-hidden="true" size={20} />
+          <div>
+            <strong>Choose a project</strong>
+            <p>Select a project above to inspect its live routing and provider health.</p>
+          </div>
+        </div>
+      ) : loading && !visibleSnapshot ? (
+        <div className="monitor-loading" aria-live="polite">
+          <span className="monitor-loading-ring" aria-hidden="true" />
+          <strong>Checking production traffic…</strong>
+          <span>Routing and health first; spend follows independently.</span>
+        </div>
+      ) : error && !visibleSnapshot ? (
+        <div className="monitor-blocked" role="alert">
+          <AlertTriangleIcon aria-hidden="true" size={20} />
+          <div>
+            <strong>Monitoring could not open</strong>
+            <p>{error}</p>
+          </div>
+          {error.toLowerCase().includes("sign in") && (
+            <button type="button" onClick={onOpenAccount}>Sign in</button>
+          )}
+        </div>
+      ) : visibleSnapshot ? (
+        <>
+          <section className={`monitor-verdict ${state.tone}`} aria-live="polite">
+            <div className="monitor-verdict-icon">
+              {state.tone === "healthy" ? (
+                <CheckCircle2Icon aria-hidden="true" size={25} strokeWidth={1.6} />
+              ) : (
+                <AlertTriangleIcon aria-hidden="true" size={25} strokeWidth={1.6} />
+              )}
+            </div>
+            <div>
+              <span>Right now</span>
+              <h2>{state.label}</h2>
+              <p>{state.detail}</p>
+            </div>
+            <time dateTime={visibleSnapshot.fetched_at}>Updated {relativeTime(visibleSnapshot.fetched_at)}</time>
+          </section>
+
+          {error && <div className="monitor-stale" role="status">Showing the last local snapshot. {error}</div>}
+          {visibleSnapshot.warnings.length > 0 && (
+            <div className="monitor-warning" role="status">
+              Traffic health is current. Some spend context is unavailable.
+            </div>
+          )}
+
+          <section className="monitor-metrics" aria-label="Production summary">
+            <article>
+              <span>Requests</span>
+              <strong>{count.format(visibleSnapshot.health.total_requests)}</strong>
+              <small>Selected project</small>
+            </article>
+            <article>
+              <span>Estimated spend</span>
+              <strong>{visibleSnapshot.billing ? money.format(visibleSnapshot.billing.summary.estimated_cost_usd) : "—"}</strong>
+              <small>All org projects</small>
+            </article>
+            <article className={state.errors > 0 ? "attention" : ""}>
+              <span>Provider failures</span>
+              <strong>{count.format(state.errors)}</strong>
+              <small>{state.timeouts} timeouts · {state.fallbacks} fallbacks</small>
+            </article>
+            <article>
+              <span>Input reused</span>
+              <strong>{reuse === null ? "—" : `${reuse.toFixed(1)}%`}</strong>
+              <small>Org-wide prompt cache</small>
+            </article>
+          </section>
+
+          <div className="monitor-grid">
+            <section className="monitor-panel monitor-workloads">
+              <header>
+                <div>
+                  <span className="monitor-kicker">Traffic by workload</span>
+                  <h2>What is live</h2>
+                </div>
+                <span>{workloads.length} workloads</span>
+              </header>
+              <div className="monitor-workload-list">
+                {workloads.length === 0 ? (
+                  <p className="monitor-empty">No workloads are configured yet.</p>
+                ) : workloads.map((workload) => {
+                  const hasProblem = workload.errors > 0 || workload.timeouts > 0;
+                  const hasFallback = workload.fallbacks > 0;
+                  return (
+                    <article key={workload.workloadId} className={hasProblem ? "attention" : hasFallback ? "watch" : ""}>
+                      <div className="monitor-workload-main">
+                        <span className="monitor-health-dot" aria-hidden="true" />
+                        <div>
+                          <strong>{workload.name}</strong>
+                          <small>{routeLabel(workload.routeMode, workload.trafficPercent)}{workload.model ? ` · ${displayModelName(workload.model)}` : ""}</small>
+                        </div>
+                      </div>
+                      <div className="monitor-workload-count">
+                        <strong>{count.format(workload.requests)}</strong>
+                        <span>requests</span>
+                      </div>
+                      <div className="monitor-workload-state">
+                        {hasProblem
+                          ? `${workload.errors} errors · ${workload.timeouts} timeouts`
+                          : hasFallback
+                            ? `${workload.fallbacks} fallbacks`
+                            : workload.requests > 0 ? "Healthy" : "No traffic"}
+                      </div>
+                      {workload.requestIds.length > 0 && (
+                        <div className="monitor-request-ids">
+                          <span>Affected requests</span>
+                          {workload.requestIds.map((requestId) => (
+                            <button key={requestId} type="button" onClick={() => void copyRequestId(requestId)}>
+                              <code>{requestId}</code>
+                              {copied === requestId
+                                ? <ClipboardCheckIcon aria-hidden="true" size={12} />
+                                : <CopyIcon aria-hidden="true" size={12} />}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="monitor-panel monitor-models">
+              <header>
+                <div>
+                  <span className="monitor-kicker">Spend-weighted</span>
+                  <h2>Models used</h2>
+                </div>
+                <span>Org-wide</span>
+              </header>
+              {models.length === 0 ? (
+                <p className="monitor-empty">Model spend is not available for this window.</p>
+              ) : (
+                <div className="monitor-model-list">
+                  {models.map((model) => (
+                    <article key={`${model.provider}:${model.served_model}`}>
+                      <div>
+                        <strong>{displayModelName(model.served_model)}</strong>
+                        <span>{count.format(model.requests)} requests</span>
+                      </div>
+                      <b>{money.format(model.cost_usd)}</b>
+                      <i aria-hidden="true"><span style={{ width: `${maxModelCost > 0 ? (model.cost_usd / maxModelCost) * 100 : 0}%` }} /></i>
+                    </article>
+                  ))}
+                </div>
+              )}
+              <footer>
+                Ranked by spend so the highest-leverage traffic is always first.
+              </footer>
+            </section>
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/homescreen/app/components/MonitorPane.tsx
+++ b/apps/homescreen/app/components/MonitorPane.tsx
@@ -272,7 +272,9 @@ export function MonitorPane({
             className="monitor-refresh"
             aria-label="Refresh production monitor"
             disabled={!projectId || refreshing}
-            onClick={() => void loadSnapshot(projectId, window, { background: true })}
+            onClick={() => {
+              if (projectId) void loadSnapshot(projectId, window, { background: true });
+            }}
           >
             <RefreshCwIcon aria-hidden="true" size={15} className={refreshing ? "spinning" : ""} />
             Refresh

--- a/apps/homescreen/app/components/Sidebar.tsx
+++ b/apps/homescreen/app/components/Sidebar.tsx
@@ -36,6 +36,7 @@ export type PaneId =
   | "workload-config"
   | "project-summary"
   | "project-reporting"
+  | "production-monitor"
   | "settings"
   | "training-evals"
   | "training-optimization"

--- a/apps/homescreen/app/globals.css
+++ b/apps/homescreen/app/globals.css
@@ -9488,3 +9488,94 @@ select,
   font-size: 11px;
   line-height: 1.5;
 }
+/* Customer-safe production monitor */
+.monitor-pane { width: min(1180px, 100%); min-height: 100%; margin: 0 auto; padding-bottom: 24px; }
+.monitor-topbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 18px; }
+.monitor-topbar h1 { margin: 5px 0 3px; font-size: clamp(22px, 3vw, 31px); font-weight: 550; letter-spacing: -.035em; }
+.monitor-topbar p { margin: 0; color: var(--text-3); font-size: 11px; }
+.monitor-kicker { color: var(--mb-cyan); font: 9px/1.2 var(--mono); letter-spacing: .09em; text-transform: uppercase; }
+.monitor-controls { display: flex; align-items: center; gap: 7px; }
+.monitor-controls select, .monitor-refresh { height: 34px; border: 1px solid var(--border-strong); border-radius: 8px; background: var(--surface); color: var(--text-2); font-size: 11px; }
+.monitor-controls select { padding: 0 28px 0 10px; }
+.monitor-refresh { display: inline-flex; align-items: center; gap: 7px; padding: 0 11px; }
+.monitor-refresh:hover:not(:disabled) { border-color: color-mix(in srgb, var(--mb-cyan) 34%, var(--border)); color: var(--text); }
+.monitor-refresh:disabled { opacity: .5; }
+.monitor-refresh .spinning { animation: monitor-spin 900ms linear infinite; }
+@keyframes monitor-spin { to { transform: rotate(360deg); } }
+.monitor-loading, .monitor-blocked { display: flex; align-items: center; justify-content: center; gap: 14px; min-height: 420px; color: var(--text-2); }
+.monitor-loading { flex-direction: column; }
+.monitor-loading strong { color: var(--text); font-size: 14px; font-weight: 500; }
+.monitor-loading > span:last-child { color: var(--text-3); font-size: 11px; }
+.monitor-loading-ring { width: 34px; height: 34px; border: 1px solid color-mix(in srgb, var(--mb-cyan) 18%, transparent); border-top-color: var(--mb-cyan); border-radius: 50%; animation: monitor-spin 1s linear infinite; }
+.monitor-blocked { min-height: 280px; }
+.monitor-blocked > svg { color: var(--c-warn); }
+.monitor-blocked strong { color: var(--text); font-weight: 550; }
+.monitor-blocked p { max-width: 560px; margin: 5px 0 0; font-size: 11px; line-height: 1.5; }
+.monitor-blocked button { min-height: 34px; border: 1px solid color-mix(in srgb, var(--mb-cyan) 40%, var(--border)); border-radius: 8px; background: color-mix(in srgb, var(--mb-cyan) 12%, transparent); padding: 0 12px; color: var(--text); }
+.monitor-verdict { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 14px; min-height: 92px; border: 1px solid color-mix(in srgb, var(--c-ok) 26%, var(--border)); border-radius: 13px; background: linear-gradient(90deg, color-mix(in srgb, var(--c-ok) 7%, transparent), transparent 48%); padding: 15px 18px; }
+.monitor-verdict.attention { border-color: color-mix(in srgb, var(--error) 38%, var(--border)); background: linear-gradient(90deg, color-mix(in srgb, var(--error) 7%, transparent), transparent 48%); }
+.monitor-verdict.watch, .monitor-verdict.quiet { border-color: color-mix(in srgb, var(--c-warn) 30%, var(--border)); background: linear-gradient(90deg, color-mix(in srgb, var(--c-warn) 6%, transparent), transparent 48%); }
+.monitor-verdict-icon { display: grid; width: 45px; height: 45px; place-items: center; border-radius: 50%; background: color-mix(in srgb, var(--c-ok) 11%, transparent); color: var(--c-ok); }
+.monitor-verdict.attention .monitor-verdict-icon { background: color-mix(in srgb, var(--error) 11%, transparent); color: var(--error); }
+.monitor-verdict.watch .monitor-verdict-icon, .monitor-verdict.quiet .monitor-verdict-icon { background: color-mix(in srgb, var(--c-warn) 10%, transparent); color: var(--c-warn); }
+.monitor-verdict span, .monitor-verdict time { color: var(--text-3); font: 9px/1.2 var(--mono); letter-spacing: .04em; text-transform: uppercase; }
+.monitor-verdict h2 { margin: 4px 0 2px; font-size: 19px; font-weight: 550; letter-spacing: -.025em; }
+.monitor-verdict p { margin: 0; color: var(--text-2); font-size: 11px; }
+.monitor-verdict time { align-self: start; padding-top: 3px; }
+.monitor-stale, .monitor-warning { margin-top: 8px; border: 1px solid color-mix(in srgb, var(--c-warn) 26%, var(--border)); border-radius: 8px; background: color-mix(in srgb, var(--c-warn) 5%, transparent); padding: 8px 10px; color: color-mix(in srgb, var(--c-warn) 68%, var(--text)); font-size: 10px; }
+.monitor-metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 12px; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+.monitor-metrics article { display: grid; min-width: 0; gap: 5px; padding: 13px 15px; border-right: 1px solid var(--border); background: color-mix(in srgb, var(--surface) 88%, transparent); }
+.monitor-metrics article:last-child { border-right: 0; }
+.monitor-metrics article.attention { background: color-mix(in srgb, var(--error) 5%, var(--surface)); }
+.monitor-metrics span, .monitor-metrics small { overflow: hidden; color: var(--text-3); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.monitor-metrics span { font-family: var(--mono); letter-spacing: .04em; text-transform: uppercase; }
+.monitor-metrics strong { font: 500 22px/1.05 var(--mono); font-variant-numeric: tabular-nums; }
+.monitor-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(280px, .75fr); gap: 12px; margin-top: 12px; }
+.monitor-panel { min-width: 0; border: 1px solid var(--border); border-radius: 12px; background: color-mix(in srgb, var(--surface) 86%, transparent); overflow: hidden; }
+.monitor-panel > header { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 58px; border-bottom: 1px solid var(--border); padding: 11px 14px; }
+.monitor-panel > header h2 { margin: 4px 0 0; font-size: 14px; font-weight: 550; }
+.monitor-panel > header > span { color: var(--text-3); font: 9px/1.2 var(--mono); }
+.monitor-empty { margin: 0; padding: 26px 15px; color: var(--text-3); font-size: 11px; }
+.monitor-workload-list { display: grid; max-height: 340px; overflow-y: auto; }
+.monitor-workload-list > article { display: grid; grid-template-columns: minmax(0, 1fr) 82px 120px; align-items: center; gap: 12px; min-height: 60px; border-bottom: 1px solid var(--border); padding: 9px 13px; }
+.monitor-workload-list > article:last-child { border-bottom: 0; }
+.monitor-workload-main { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.monitor-workload-main > div { display: grid; min-width: 0; gap: 4px; }
+.monitor-workload-main strong, .monitor-workload-main small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.monitor-workload-main strong { font-size: 11px; font-weight: 550; }
+.monitor-workload-main small { color: var(--text-3); font: 8px/1.2 var(--mono); }
+.monitor-health-dot { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--c-ok); box-shadow: 0 0 8px color-mix(in srgb, var(--c-ok) 46%, transparent); }
+.monitor-workload-list > article.attention .monitor-health-dot { background: var(--error); }
+.monitor-workload-list > article.watch .monitor-health-dot { background: var(--c-warn); }
+.monitor-workload-count { display: grid; gap: 3px; text-align: right; }
+.monitor-workload-count strong { font: 500 12px/1.2 var(--mono); }
+.monitor-workload-count span, .monitor-workload-state { color: var(--text-3); font: 8px/1.2 var(--mono); }
+.monitor-workload-state { text-align: right; }
+.monitor-workload-list > article.attention .monitor-workload-state { color: var(--error); }
+.monitor-workload-list > article.watch .monitor-workload-state { color: var(--c-warn); }
+.monitor-request-ids { grid-column: 1 / -1; display: flex; flex-wrap: wrap; align-items: center; gap: 5px; margin: -1px 0 2px 17px; }
+.monitor-request-ids > span { margin-right: 3px; color: var(--text-3); font: 8px/1.2 var(--mono); text-transform: uppercase; }
+.monitor-request-ids button { display: inline-flex; align-items: center; gap: 5px; max-width: 180px; border: 1px solid var(--border); border-radius: 999px; background: var(--bg); padding: 4px 7px; color: var(--text-3); }
+.monitor-request-ids code { overflow: hidden; font: 8px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.monitor-model-list { display: grid; padding: 5px 13px 9px; }
+.monitor-model-list article { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 5px 10px; padding: 9px 0; border-bottom: 1px solid var(--border); }
+.monitor-model-list article:last-child { border-bottom: 0; }
+.monitor-model-list article > div { display: grid; min-width: 0; gap: 3px; }
+.monitor-model-list strong { overflow: hidden; font: 500 9px/1.2 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.monitor-model-list article span { color: var(--text-3); font: 8px/1.2 var(--mono); }
+.monitor-model-list b { font: 500 10px/1.2 var(--mono); }
+.monitor-model-list i { grid-column: 1 / -1; display: block; height: 2px; overflow: hidden; border-radius: 99px; background: var(--border); }
+.monitor-model-list i span { display: block; height: 100%; border-radius: inherit; background: var(--mb-cyan); }
+.monitor-models footer { border-top: 1px solid var(--border); padding: 9px 13px; color: var(--text-3); font-size: 9px; line-height: 1.4; }
+@media (prefers-reduced-motion: reduce) { .monitor-refresh .spinning, .monitor-loading-ring { animation-duration: 2.5s; } }
+@media (max-width: 900px) {
+  .monitor-topbar { align-items: flex-start; flex-direction: column; }
+  .monitor-controls { width: 100%; }
+  .monitor-controls label { flex: 1; }
+  .monitor-controls select { width: 100%; }
+  .monitor-metrics { grid-template-columns: 1fr 1fr; }
+  .monitor-metrics article:nth-child(2) { border-right: 0; }
+  .monitor-metrics article:nth-child(-n+2) { border-bottom: 1px solid var(--border); }
+  .monitor-grid { grid-template-columns: 1fr; }
+  .monitor-workload-list { max-height: none; }
+}

--- a/apps/homescreen/app/lib/monitoring.d.mts
+++ b/apps/homescreen/app/lib/monitoring.d.mts
@@ -66,6 +66,6 @@ export function displayModelName(value?: unknown): string;
 
 export function snapshotForSelection<T extends { project_id?: string; window?: string }>(
   snapshot: T | null | undefined,
-  projectId: string,
+  projectId: string | null,
   window: string,
 ): T | null;

--- a/apps/homescreen/app/lib/monitoring.d.mts
+++ b/apps/homescreen/app/lib/monitoring.d.mts
@@ -1,0 +1,71 @@
+export type RoutingEntryLike = {
+  workload_id: string;
+  display_name?: string;
+  environment?: string | null;
+  route_mode: string;
+  active_traffic_pct?: number;
+  provider_label?: string | null;
+  model?: string | null;
+};
+
+export type HealthEntryLike = {
+  workload: string;
+  provider?: string;
+  model?: string;
+  request_count?: number;
+  error_5xx_count?: number;
+  timeout_count?: number;
+  fallback_count?: number;
+  example_request_ids?: string[];
+};
+
+export type WorkloadMonitorRow = {
+  workloadId: string;
+  name: string;
+  environment: string | null;
+  routeMode: string;
+  trafficPercent: number;
+  provider: string | null;
+  model: string | null;
+  requests: number;
+  errors: number;
+  timeouts: number;
+  fallbacks: number;
+  requestIds: string[];
+};
+
+export function buildWorkloadRows(
+  routingEntries?: RoutingEntryLike[],
+  healthEntries?: HealthEntryLike[],
+): WorkloadMonitorRow[];
+
+export function monitoringState(health?: {
+  total_requests?: number;
+  total_errors?: number;
+  providers?: HealthEntryLike[];
+}): {
+  tone: "attention" | "watch" | "quiet" | "healthy";
+  label: string;
+  detail: string;
+  errors: number;
+  timeouts: number;
+  fallbacks: number;
+};
+
+export function cacheReusePercent(summary?: {
+  tokens?: {
+    input_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+} | null): number | null;
+
+export function topModelRows<T extends { cost_usd?: number }>(rows?: T[], limit?: number): T[];
+
+export function displayModelName(value?: unknown): string;
+
+export function snapshotForSelection<T extends { project_id?: string; window?: string }>(
+  snapshot: T | null | undefined,
+  projectId: string,
+  window: string,
+): T | null;

--- a/apps/homescreen/app/lib/monitoring.mjs
+++ b/apps/homescreen/app/lib/monitoring.mjs
@@ -1,0 +1,138 @@
+export function buildWorkloadRows(routingEntries = [], healthEntries = []) {
+  const rows = new Map();
+
+  for (const route of routingEntries) {
+    rows.set(route.workload_id, {
+      workloadId: route.workload_id,
+      name: route.display_name || route.workload_id,
+      environment: route.environment ?? null,
+      routeMode: route.route_mode,
+      trafficPercent: Number(route.active_traffic_pct ?? 0),
+      provider: route.provider_label ?? null,
+      model: route.model ?? null,
+      requests: 0,
+      errors: 0,
+      timeouts: 0,
+      fallbacks: 0,
+      requestIds: [],
+    });
+  }
+
+  for (const health of healthEntries) {
+    const existing = rows.get(health.workload) ?? {
+      workloadId: health.workload,
+      name: health.workload,
+      environment: null,
+      routeMode: "unknown",
+      trafficPercent: 0,
+      provider: null,
+      model: null,
+      requests: 0,
+      errors: 0,
+      timeouts: 0,
+      fallbacks: 0,
+      requestIds: [],
+    };
+    existing.requests += Number(health.request_count ?? 0);
+    existing.errors += Number(health.error_5xx_count ?? 0);
+    existing.timeouts += Number(health.timeout_count ?? 0);
+    existing.fallbacks += Number(health.fallback_count ?? 0);
+    existing.provider ||= health.provider || null;
+    existing.model ||= health.model || null;
+    existing.requestIds = [...new Set([
+      ...existing.requestIds,
+      ...(health.example_request_ids ?? []),
+    ])].slice(0, 5);
+    rows.set(health.workload, existing);
+  }
+
+  return [...rows.values()].sort((left, right) => {
+    if (right.requests !== left.requests) return right.requests - left.requests;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function monitoringState(health) {
+  const requests = Number(health?.total_requests ?? 0);
+  const errors = Number(health?.total_errors ?? 0);
+  const timeouts = (health?.providers ?? []).reduce(
+    (sum, provider) => sum + Number(provider.timeout_count ?? 0),
+    0,
+  );
+  const fallbacks = (health?.providers ?? []).reduce(
+    (sum, provider) => sum + Number(provider.fallback_count ?? 0),
+    0,
+  );
+
+  if (errors > 0 || timeouts > 0) {
+    return {
+      tone: "attention",
+      label: "Needs attention",
+      detail: `${errors} errors · ${timeouts} timeouts`,
+      errors,
+      timeouts,
+      fallbacks,
+    };
+  }
+  if (fallbacks > 0) {
+    return {
+      tone: "watch",
+      label: "Healthy with fallbacks",
+      detail: `${fallbacks} requests used a fallback`,
+      errors,
+      timeouts,
+      fallbacks,
+    };
+  }
+  if (requests === 0) {
+    return {
+      tone: "quiet",
+      label: "No traffic yet",
+      detail: "No requests in this window",
+      errors,
+      timeouts,
+      fallbacks,
+    };
+  }
+  return {
+    tone: "healthy",
+    label: "Everything is green",
+    detail: "No provider errors, timeouts, or fallbacks",
+    errors,
+    timeouts,
+    fallbacks,
+  };
+}
+
+export function cacheReusePercent(summary) {
+  const tokens = summary?.tokens;
+  if (!tokens) return null;
+  const cached = Number(tokens.cache_read_input_tokens ?? 0);
+  const totalInput =
+    Number(tokens.input_tokens ?? 0) +
+    cached +
+    Number(tokens.cache_creation_input_tokens ?? 0);
+  if (totalInput <= 0) return null;
+  return Math.max(0, Math.min(100, (cached / totalInput) * 100));
+}
+
+export function topModelRows(rows = [], limit = 6) {
+  return [...rows]
+    .sort((left, right) => Number(right.cost_usd ?? 0) - Number(left.cost_usd ?? 0))
+    .slice(0, limit);
+}
+
+export function displayModelName(value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "Unknown model";
+  const path = raw.split("?")[0].replace(/\/+$/, "");
+  const segments = path.split(/[/:]/).filter(Boolean);
+  return segments.at(-1) || raw;
+}
+
+export function snapshotForSelection(snapshot, projectId, window) {
+  if (!snapshot) return null;
+  return snapshot.project_id === projectId && snapshot.window === window
+    ? snapshot
+    : null;
+}

--- a/apps/homescreen/app/lib/nav.ts
+++ b/apps/homescreen/app/lib/nav.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import {
+  Activity,
   BarChart3,
   Beaker,
   Boxes,
@@ -47,6 +48,7 @@ export const NAV_ITEMS: NavItemDef[] = [
   // The web's project-scoped Analytics (`/p/[project_slug]` reporting view),
   // presented as the per-workload breakdown.
   { id: "org-project-analytics", group: "organization", label: "Workloads", icon: BarChart3, pane: "project-reporting" },
+  { id: "org-production-health", group: "organization", label: "Production health", icon: Activity, pane: "production-monitor" },
   // The Configuration row is folded into the Workloads pane — each workload
   // card expands into its route/capture controls (WorkloadConfigInline). The
   // "workload-config" pane id + WorkloadConfigPane remain reachable for deep

--- a/apps/homescreen/app/page.tsx
+++ b/apps/homescreen/app/page.tsx
@@ -31,6 +31,7 @@ import { SetupPane } from "./components/SetupPane";
 import { SettingsPane } from "./components/SettingsPane";
 import { loadStoredScope, storeScope } from "./components/sidebar/ScopeSwitcher";
 import { ScopeBreadcrumb } from "./components/ScopeBreadcrumb";
+import { MonitorPane } from "./components/MonitorPane";
 import {
   Tooltip,
   TooltipContent,
@@ -266,6 +267,7 @@ export default function Page() {
       "workload-config",
       "project-summary",
       "project-reporting",
+      "production-monitor",
       "settings",
       "training-evals",
       "training-optimization",
@@ -438,6 +440,9 @@ export default function Page() {
         )}
         {pane === "project-reporting" && (
           <WorkloadsPane requestedWorkload={requestedWorkload} />
+        )}
+        {pane === "production-monitor" && (
+          <MonitorPane projectId={scope.projectId} onOpenAccount={() => setPane("account")} />
         )}
         {pane === "setup" && <SetupPane onNavigate={setPane} />}
         {pane === "settings" && <SettingsPane scope={scope} />}

--- a/apps/homescreen/src-tauri/src/lib.rs
+++ b/apps/homescreen/src-tauri/src/lib.rs
@@ -468,6 +468,7 @@ pub fn run() {
             mgmt::mgmt_workload_update,
             reporting::reporting_workload_status,
             reporting::reporting_usage_summary,
+            reporting::reporting_snapshot,
             scope::workload_config_load,
             scope::workload_routing_apply,
             scope::workload_capture_set,

--- a/apps/homescreen/src-tauri/src/reporting.rs
+++ b/apps/homescreen/src-tauri/src/reporting.rs
@@ -192,9 +192,7 @@ pub async fn reporting_snapshot(
     project_id: String,
     window: Option<String>,
 ) -> Result<Value, String> {
-    if let Err(reason) = crate::admin::validate_path_segment(&project_id) {
-        return Err(reason);
-    }
+    crate::admin::validate_path_segment(&project_id)?;
     let window = window.unwrap_or_else(|| "12h".to_string());
     let minutes = monitoring_window_minutes(&window)
         .ok_or_else(|| "Choose a monitoring window between 30 minutes and 24 hours.".to_string())?;

--- a/apps/homescreen/src-tauri/src/reporting.rs
+++ b/apps/homescreen/src-tauri/src/reporting.rs
@@ -13,6 +13,7 @@
 //! carry the admin API's `x-understudy-request-id` support handle when we
 //! have one.
 
+use chrono::{Duration as ChronoDuration, SecondsFormat, Utc};
 use serde_json::{json, Value};
 
 use crate::creds;
@@ -172,6 +173,71 @@ pub async fn reporting_usage_summary(project_id: String, window: String) -> Resu
     })
 }
 
+fn monitoring_window_minutes(window: &str) -> Option<i64> {
+    match window {
+        "30m" => Some(30),
+        "1h" => Some(60),
+        "6h" => Some(360),
+        "12h" => Some(720),
+        "24h" => Some(1_440),
+        _ => None,
+    }
+}
+
+/// Customer-safe production snapshot. Routing and provider health are required;
+/// org-level spend context is best-effort so a billing outage never hides
+/// operational health.
+#[tauri::command]
+pub async fn reporting_snapshot(
+    project_id: String,
+    window: Option<String>,
+) -> Result<Value, String> {
+    if let Err(reason) = crate::admin::validate_path_segment(&project_id) {
+        return Err(reason);
+    }
+    let window = window.unwrap_or_else(|| "12h".to_string());
+    let minutes = monitoring_window_minutes(&window)
+        .ok_or_else(|| "Choose a monitoring window between 30 minutes and 24 hours.".to_string())?;
+    let api = AdminApi::resolve()?;
+    let now = Utc::now();
+    let from = (now - ChronoDuration::minutes(minutes))
+        .to_rfc3339_opts(SecondsFormat::Millis, true);
+    let to = now.to_rfc3339_opts(SecondsFormat::Millis, true);
+
+    let routing_path = format!("projects/{project_id}/routing-status");
+    let health_path = format!("projects/{project_id}/provider-health?window={window}");
+    let billing_path = format!("billing/summary?from={from}&to={to}");
+    let models_path = format!("billing/usage-by-model?from={from}&to={to}");
+    let (routing, health, billing, usage_by_model) = tokio::join!(
+        api.get_json(&routing_path),
+        api.get_json(&health_path),
+        api.get_json(&billing_path),
+        api.get_json(&models_path),
+    );
+
+    let routing = routing.map_err(|error| error.message)?;
+    let health = health.map_err(|error| error.message)?;
+    let mut warnings = Vec::new();
+    let billing = billing
+        .map_err(|error| warnings.push(format!("Spend summary: {}", error.message)))
+        .ok();
+    let usage_by_model = usage_by_model
+        .map_err(|error| warnings.push(format!("Model usage: {}", error.message)))
+        .ok();
+
+    Ok(json!({
+        "project_id": project_id,
+        "window": window,
+        "fetched_at": to,
+        "source": "understudy-admin-api",
+        "routing": routing,
+        "health": health,
+        "billing": billing,
+        "usage_by_model": usage_by_model,
+        "warnings": warnings,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,6 +275,25 @@ mod tests {
                 .await
                 .unwrap();
             assert!(is_rejected(&out), "{bad} should be rejected: {out:?}");
+        }
+    }
+
+    #[test]
+    fn monitoring_windows_are_bounded_and_explicit() {
+        assert_eq!(monitoring_window_minutes("30m"), Some(30));
+        assert_eq!(monitoring_window_minutes("12h"), Some(720));
+        assert_eq!(monitoring_window_minutes("24h"), Some(1_440));
+        assert_eq!(monitoring_window_minutes("25h"), None);
+        assert_eq!(monitoring_window_minutes("all"), None);
+    }
+
+    #[tokio::test]
+    async fn monitoring_snapshot_rejects_path_traversal() {
+        for bad in ["../secrets", "%2e%2e/escape", "proj?x=1", "proj/y"] {
+            let error = reporting_snapshot(bad.to_string(), Some("12h".to_string()))
+                .await
+                .unwrap_err();
+            assert!(error.contains("Path segment"), "{bad} should be rejected: {error}");
         }
     }
 }

--- a/tests/monitoring.test.mjs
+++ b/tests/monitoring.test.mjs
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildWorkloadRows,
+  cacheReusePercent,
+  displayModelName,
+  monitoringState,
+  snapshotForSelection,
+  topModelRows,
+} from "../apps/homescreen/app/lib/monitoring.mjs";
+
+test("workload monitor joins aggregate health to routes and sorts by volume", () => {
+  const rows = buildWorkloadRows(
+    [
+      {
+        workload_id: "workload-a",
+        display_name: "Conversation updater",
+        route_mode: "primary",
+        active_traffic_pct: 100,
+        provider_label: "managed",
+        model: "model-a",
+      },
+      {
+        workload_id: "workload-b",
+        display_name: "Next steps",
+        route_mode: "understudy",
+        active_traffic_pct: 30,
+      },
+    ],
+    [
+      {
+        workload: "workload-b",
+        provider: "managed",
+        model: "model-b",
+        request_count: 80,
+        error_5xx_count: 1,
+        timeout_count: 1,
+        fallback_count: 2,
+        example_request_ids: ["req-1", "req-1", "req-2"],
+      },
+      {
+        workload: "workload-a",
+        request_count: 20,
+        error_5xx_count: 0,
+        timeout_count: 0,
+        fallback_count: 0,
+      },
+    ],
+  );
+
+  assert.equal(rows[0].name, "Next steps");
+  assert.equal(rows[0].requests, 80);
+  assert.equal(rows[0].provider, "managed");
+  assert.deepEqual(rows[0].requestIds, ["req-1", "req-2"]);
+  assert.equal(rows[1].trafficPercent, 100);
+});
+
+test("monitoring state only claims green when the exact health checks are clear", () => {
+  assert.equal(
+    monitoringState({ total_requests: 100, total_errors: 0, providers: [] }).label,
+    "Everything is green",
+  );
+  assert.equal(
+    monitoringState({
+      total_requests: 100,
+      total_errors: 0,
+      providers: [{ workload: "a", fallback_count: 2 }],
+    }).tone,
+    "watch",
+  );
+  assert.equal(
+    monitoringState({ total_requests: 0, total_errors: 0, providers: [] }).tone,
+    "quiet",
+  );
+});
+
+test("cache reuse is based on all input-side token classes", () => {
+  assert.equal(
+    cacheReusePercent({
+      tokens: {
+        input_tokens: 20,
+        cache_read_input_tokens: 70,
+        cache_creation_input_tokens: 10,
+      },
+    }),
+    70,
+  );
+  assert.equal(cacheReusePercent({ tokens: {} }), null);
+});
+
+test("top models are spend-weighted", () => {
+  const rows = topModelRows([
+    { served_model: "small", cost_usd: 1 },
+    { served_model: "large", cost_usd: 20 },
+    { served_model: "medium", cost_usd: 5 },
+  ], 2);
+  assert.deepEqual(rows.map((row) => row.served_model), ["large", "medium"]);
+});
+
+test("model labels hide provider routing namespaces", () => {
+  assert.equal(displayModelName("accounts/vendor/models/glm-5p2"), "glm-5p2");
+  assert.equal(displayModelName("zai-org/glm-5.2"), "glm-5.2");
+  assert.equal(displayModelName("gemma-4-12b-it"), "gemma-4-12b-it");
+});
+
+test("monitor snapshots render only for the selected project and window", () => {
+  const snapshot = { project_id: "project-a", window: "12h", health: "green" };
+  assert.equal(snapshotForSelection(snapshot, "project-a", "12h"), snapshot);
+  assert.equal(snapshotForSelection(snapshot, "project-b", "12h"), null);
+  assert.equal(snapshotForSelection(snapshot, "project-a", "24h"), null);
+});


### PR DESCRIPTION
## Summary
- Ports the useful production-health surface from #275 onto the current Desktop navigation and project-scope architecture.
- Reuses the current authenticated Rust admin client for routing, provider health, and best-effort billing context.
- Preserves project/window snapshot isolation so stale cross-project data never renders.

## Validation
- Root package build passed.
- Focused monitoring tests passed: 6/6.
- Rust reporting tests passed: 4/4.
- Git diff whitespace validation passed.

## Notes
- Customer-safe aggregates only; prompts and responses are never requested.
- Routing and provider health fail closed; billing/model context degrades independently.
- Local Next production build was blocked by stale local Desktop dependencies and sandboxed Google Fonts access; GitHub CI is the authoritative dependency-resolved build.

Supersedes #275.