### PR TITLE
Fail closed on historical holdout state

### DIFF
--- a/experiments/domain-identification-repair/gepa/WAVE8-DPO-RESULT-20260803.md
+++ b/experiments/domain-identification-repair/gepa/WAVE8-DPO-RESULT-20260803.md
@@ -1,0 +1,61 @@
+# Wave 8 DPO repaired-dev result
+
+Status: **dev promotion eligible**. This is not production-replacement or
+holdout evidence.
+
+## Result
+
+Run `wave8-dpo-20260803T073222Z` improved the Nemotron student from `0.854167`
+to `0.958333` on the same repaired canonical dev protocol (`k=3`, temperature
+0). The protected-family scores are direct `1.0`, lookalike `1.0`, parent
+`1.0`, and unmatched `0.833333`. The confirmation recorded zero forbidden
+writes and zero runtime errors.
+
+The winning checkpoint is
+`tinker://3f538eaa-22a5-5c9b-ad65-d0e82e865fd1:train:0/sampler_weights/final`.
+Training used 44 validated train-only DPO pairs, rank 32, beta `0.1`, three
+epochs, batch size 4, and learning rate `1e-5`. Training wall time was 374.5
+seconds.
+
+## Provenance
+
+- Source commit: `33ce4f396fe4c8be0ccbc02bf38179262b8e5d6f`
+- Fixture SHA-256: `3b996e126603f4200f6fa1b01e0d084c3c3a7e694246f77687b76ff15d863de2`
+- Train split SHA-256: `b358c36f429303d64bb9309a685f78ddfd03bd1602cbf415e8dd1e977ac93017`
+- Dev split SHA-256: `3934011a2182ac6d4b32e7016b705cb908e21c2c1ae469f3b0e116ed7bc345a2`
+- System prompt SHA-256: `cd718da1b0189d2153c24dabd78e00bd0b99ae3779c433cf2c7de47246dc1493`
+- Validated normalized-pairs SHA-256: `a9e2cf5cc61ce34a47750eb76daf4eb22a4c44be11d199c15a181c4f6bc00f36`
+
+The immutable receipt bundle and `SHA256SUMS.txt` are on Spark Alpha at
+`/home/understudy/services/gepa-viz/runs/wave8-dpo-20260803T073222Z/`.
+Local and Alpha checksum verification passed for the pair manifest, validator
+receipt, training receipt, baseline and optimized canonical evaluations,
+promotion receipt, and experiment manifest.
+
+## Serving decision
+
+Across 4,075 observed rollout samples, the Tinker lane measured p50 `5.099s`
+and p95 `13.394s`, with no service-pressure failure cluster in the terminal
+manifest. That is materially faster than the earlier 42.72s/71.01s lane and
+does not currently justify standing up Modal or GCP solely for wall-clock
+acceleration. Revisit deployment only if a future diversity-capable wave shows
+sustained queueing, 429/5xx/timeouts, or serving latency again dominates the
+parallel optimizer.
+
+Tinker billing usage is eventually consistent and returned no rows on the
+first reconciliation query. The dashboard therefore reports `cost_usd=null`
+and `cost_coverage=tinker receipt pending`; no dollar total is inferred.
+
+## Holdout boundary
+
+Wave 8 did not construct or execute a fresh holdout. The historical holdout
+was already observed, so it is not sealed promotion evidence. The authoritative
+manifest reports `holdout_untouched=false`,
+`holdout_status=historical_holdout_observed`, and
+`totals.holdout_executed=false`. A production replacement decision requires a
+new, separately authorized, hash-bound holdout and serving-parity evidence.
+
+## Live view
+
+The unified monitor is available to the tailnet at
+`http://spark-246e.taila24722.ts.net:5151/monitor/index.html`.

--- a/experiments/domain-identification-repair/gepa/experiment_manifest.py
+++ b/experiments/domain-identification-repair/gepa/experiment_manifest.py
@@ -22,8 +22,9 @@ Methodology guards (critical):
     k=1 reference (e.g. the incumbent) is a reference line, not rank-comparable
     to canonical k=3.
 
-The manifest is hash-bound to the dev split provenance and always declares that
-the holdout is untouched.
+The manifest is hash-bound to the dev split provenance. Holdout state is
+explicit and fail-closed: a run can truthfully declare that it did not execute
+holdout without implying that an unobserved promotion holdout exists.
 """
 import copy
 import hashlib
@@ -154,7 +155,7 @@ def rank_nodes(nodes, rank_protocol):
 
 def build_manifest(*, experiment, dev_split_sha256, rank_protocol, nodes,
                    reference_lines=None, totals=None, holdout_untouched=True,
-                   generated_ts=None):
+                   holdout_status=None, generated_ts=None):
     """Assemble the combined manifest. The headline high-score is computed ONLY
     from rank-eligible nodes matching rank_protocol, so an in-progress node, a
     gepa_observed metadata node, or a canonical k=1 reference can never become
@@ -164,12 +165,15 @@ def build_manifest(*, experiment, dev_split_sha256, rank_protocol, nodes,
     ranked = rank_nodes(nodes, rank_protocol)
     high = ranked[0]["score"] if ranked else None
     high_node = ranked[0]["node_id"] if ranked else None
+    if holdout_status is None:
+        holdout_status = "untouched" if holdout_untouched else "unverified"
     manifest = {
         "schema_version": SCHEMA_VERSION,
         "experiment": experiment,
         "generated_ts": generated_ts if generated_ts is not None else time.time(),
         "dev_split_sha256": dev_split_sha256,
         "holdout_untouched": bool(holdout_untouched),
+        "holdout_status": holdout_status,
         "rank_protocol": dict(rank_protocol),
         "headline": {
             "high_score": high,
@@ -191,8 +195,16 @@ def validate_manifest(manifest):
         raise ValueError("bad schema_version")
     if not manifest.get("dev_split_sha256"):
         raise ValueError("manifest must be hash-bound to dev provenance")
-    if manifest.get("holdout_untouched") is not True:
-        raise ValueError("manifest must declare holdout untouched")
+    if not isinstance(manifest.get("holdout_untouched"), bool):
+        raise ValueError("manifest must explicitly declare holdout_untouched")
+    holdout_status = manifest.get("holdout_status")
+    if holdout_status not in {
+            "untouched", "historical_holdout_observed", "unverified", "executed"}:
+        raise ValueError("manifest must declare a recognized holdout_status")
+    if manifest["holdout_untouched"] and holdout_status != "untouched":
+        raise ValueError("holdout_untouched=true requires holdout_status=untouched")
+    if not manifest["holdout_untouched"] and holdout_status == "untouched":
+        raise ValueError("holdout_status=untouched contradicts holdout_untouched=false")
     rank_protocol = manifest.get("rank_protocol")
     if not rank_protocol or rank_protocol.get("method") not in RANKABLE_METHODS:
         raise ValueError("rank_protocol must be a canonical (rank-eligible) protocol")

--- a/experiments/domain-identification-repair/gepa/viz/index.html
+++ b/experiments/domain-identification-repair/gepa/viz/index.html
@@ -185,7 +185,11 @@
       document.getElementById("elapsed").textContent = duration(manifest.totals?.wall_clock_s);
       document.getElementById("budget").textContent = cap ? `${completed}/${cap} episodes` : `${completed} episodes`;
       const holdout = document.getElementById("holdout");
-      holdout.textContent = manifest.holdout_untouched === true ? "GEPA holdout not run" : "GEPA holdout unverified";
+      holdout.textContent = manifest.holdout_untouched === true
+        ? "holdout untouched"
+        : manifest.holdout_status === "historical_holdout_observed"
+          ? "historical holdout observed · dev evidence only"
+          : "holdout status unverified";
       holdout.style.color = manifest.holdout_untouched === true ? "#4ade80" : "#f87171";
       document.getElementById("started").textContent = pct(baseline?.score);
       document.getElementById("current").textContent = pct(best?.score);

--- a/experiments/domain-identification-repair/gepa/viz/monitor-panel.mjs
+++ b/experiments/domain-identification-repair/gepa/viz/monitor-panel.mjs
@@ -126,6 +126,7 @@ export function summarizeManifest(manifest) {
     holdoutUntouched: manifest?.holdout_untouched === undefined
       ? null
       : manifest.holdout_untouched === true,
+    holdoutStatus: manifest?.holdout_status ?? "unverified",
     evidenceState,
     isPreview: evidenceState === "preview",
   };
@@ -156,7 +157,9 @@ export function renderSummaryHTML(summary) {
     : "";
   const holdout = summary.holdoutUntouched === true
     ? '<span class="monitor-panel__holdout-ok">holdout untouched</span>'
-    : '<span class="monitor-panel__holdout-fail">HOLDOUT UNTOUCHED: UNVERIFIED — FAIL CLOSED</span>';
+    : summary.holdoutStatus === "historical_holdout_observed"
+      ? '<span class="monitor-panel__holdout-fail">historical holdout observed — not promotion evidence</span>'
+      : '<span class="monitor-panel__holdout-fail">HOLDOUT UNTOUCHED: UNVERIFIED — FAIL CLOSED</span>';
   return `<div class="monitor-panel__inner">
     <div class="monitor-panel__title">Overall experiment</div>
     ${preview}

--- a/experiments/domain-identification-repair/gepa/viz/monitor-panel.test.mjs
+++ b/experiments/domain-identification-repair/gepa/viz/monitor-panel.test.mjs
@@ -170,4 +170,13 @@ test("holdout status is fail-closed unless explicitly true", () => {
   assert.equal(trueSummary.holdoutUntouched, true);
   assert.match(renderSummaryHTML(trueSummary), /holdout untouched/);
   assert.doesNotMatch(renderSummaryHTML(trueSummary), /FAIL CLOSED/);
+
+  const observedSummary = summarizeManifest({
+    ...manifest(),
+    holdout_untouched: false,
+    holdout_status: "historical_holdout_observed",
+  });
+  assert.equal(observedSummary.holdoutUntouched, false);
+  assert.match(renderSummaryHTML(observedSummary), /historical holdout observed/);
+  assert.match(renderSummaryHTML(observedSummary), /not promotion evidence/);
 });


### PR DESCRIPTION
## Summary
- distinguishes a dev-only run from an actually untouched promotion holdout
- renders historical holdout exposure explicitly in the unified monitor
- adds regression coverage for the observed-holdout state

## Evidence
- `python3 experiments/domain-identification-repair/gepa/test_island_race.py` (43 tests)
- `node experiments/domain-identification-repair/gepa/viz/monitor-panel.test.mjs` (10 tests)
- deployed Alpha snapshot reports `holdout_untouched=false`, `holdout_status=historical_holdout_observed`, and `holdout_executed=false`

No holdout was constructed or executed.