### PR TITLE
feat: add outcome-first evidence contracts

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,6 +3,33 @@
 Versioned JSON Schemas for artifacts that cross surface boundaries (desktop
 app, skills, CLI, ladder). One spine, adopted everywhere.
 
+## Outcome-first replacement contracts
+
+Four draft-2020-12 contracts form the fail-closed evidence boundary for an
+outcome-first replacement run:
+
+- [`understudy.source_binding.v1.schema.json`](understudy.source_binding.v1.schema.json)
+  binds an opaque source id and sanitized fixture to explicit content hashes.
+- [`understudy.verifier_calibration.v1.schema.json`](understudy.verifier_calibration.v1.schema.json)
+  can pass only with hash-bound oracle=1, sentinel=0, replay, and distinct
+  total-versus-consecutive malformed semantics.
+- [`understudy.gepa_viz_manifest.v1.schema.json`](understudy.gepa_viz_manifest.v1.schema.json)
+  exposes redacted live state, aggregate progress, cost, latency, and artifact
+  references; running/completed manifests require source, calibration, train,
+  and dev hashes.
+- [`understudy.promotion_receipt.v1.schema.json`](understudy.promotion_receipt.v1.schema.json)
+  records promotion or a truthful no-promotion terminal. `promoted` requires a
+  freshly executed hash-bound holdout, passing serving parity, scored results,
+  a compiled-policy reference, claim boundary, demotion trigger, and receipts.
+  Dev-only or historically observed holdout evidence can never promote.
+
+Unknown evidence is represented by required nullable fields rather than an
+invented value. These schemas are deliberately closed: prompts, trace bodies,
+source rows, secrets, and other private payloads must stay in referenced,
+content-addressed artifacts. Costs and latency remain null unless a truthful
+basis exists. Focused conformance cases live in
+[`tests/outcome-first-contracts.test.mjs`](../tests/outcome-first-contracts.test.mjs).
+
 ## Portable environment proposals
 
 [`understudy.proposal_environment.v1.schema.json`](understudy.proposal_environment.v1.schema.json)

--- a/schemas/understudy.gepa_viz_manifest.v1.schema.json
+++ b/schemas/understudy.gepa_viz_manifest.v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.gepa_viz_manifest.v1.schema.json",
+  "title": "understudy.gepa_viz_manifest.v1",
+  "description": "Redacted live GEPA visualization manifest. It carries state, aggregate progress, hashes, metrics, and artifact references only; candidate prompts and private rollout bodies are never inlined.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id", "workload_id", "state", "source_binding_sha256", "verifier_calibration_sha256", "splits", "progress", "incumbent", "cost", "latency", "artifact_refs", "updated_at"],
+  "properties": {
+    "schema_version": { "const": "understudy.gepa_viz_manifest.v1" },
+    "run_id": { "type": "string", "minLength": 1 },
+    "workload_id": { "type": "string", "minLength": 1 },
+    "state": { "enum": ["pending", "running", "completed", "failed", "cancelled"] },
+    "source_binding_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "verifier_calibration_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "splits": { "$ref": "#/$defs/splits" },
+    "progress": { "$ref": "#/$defs/progress" },
+    "incumbent": { "$ref": "#/$defs/incumbent" },
+    "cost": { "$ref": "#/$defs/cost" },
+    "latency": { "$ref": "#/$defs/latency" },
+    "artifact_refs": { "$ref": "#/$defs/artifact_refs" },
+    "updated_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "state": { "enum": ["running", "completed"] } }, "required": ["state"] },
+      "then": {
+        "properties": {
+          "source_binding_sha256": { "$ref": "#/$defs/sha256" },
+          "verifier_calibration_sha256": { "$ref": "#/$defs/sha256" },
+          "splits": { "$ref": "#/$defs/runnable_splits" },
+          "artifact_refs": { "$ref": "#/$defs/nonempty_artifact_refs" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "nullable_sha256": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] },
+    "splits": {
+      "type": "object", "additionalProperties": false, "required": ["train_sha256", "dev_sha256", "holdout_sha256"],
+      "properties": { "train_sha256": { "$ref": "#/$defs/nullable_sha256" }, "dev_sha256": { "$ref": "#/$defs/nullable_sha256" }, "holdout_sha256": { "$ref": "#/$defs/nullable_sha256" } }
+    },
+    "runnable_splits": {
+      "type": "object", "additionalProperties": false, "required": ["train_sha256", "dev_sha256", "holdout_sha256"],
+      "properties": { "train_sha256": { "$ref": "#/$defs/sha256" }, "dev_sha256": { "$ref": "#/$defs/sha256" }, "holdout_sha256": { "$ref": "#/$defs/nullable_sha256" } }
+    },
+    "progress": {
+      "type": "object", "additionalProperties": false, "required": ["wave", "candidates_started", "candidates_completed", "candidates_failed", "rollouts_completed", "rollouts_total"],
+      "properties": {
+        "wave": { "type": ["integer", "null"], "minimum": 0 }, "candidates_started": { "type": "integer", "minimum": 0 }, "candidates_completed": { "type": "integer", "minimum": 0 }, "candidates_failed": { "type": "integer", "minimum": 0 }, "rollouts_completed": { "type": "integer", "minimum": 0 }, "rollouts_total": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+    "incumbent": {
+      "type": "object", "additionalProperties": false, "required": ["candidate_id", "candidate_sha256", "dev_quality"],
+      "properties": { "candidate_id": { "type": ["string", "null"], "minLength": 1 }, "candidate_sha256": { "$ref": "#/$defs/nullable_sha256" }, "dev_quality": { "type": ["number", "null"], "minimum": 0, "maximum": 1 } }
+    },
+    "cost": {
+      "type": "object", "additionalProperties": false, "required": ["actual_usd", "budget_usd", "basis"],
+      "properties": { "actual_usd": { "type": ["number", "null"], "minimum": 0 }, "budget_usd": { "type": ["number", "null"], "minimum": 0 }, "basis": { "type": ["string", "null"], "minLength": 1 } }
+    },
+    "latency": {
+      "type": "object", "additionalProperties": false, "required": ["elapsed_ms", "p50_ms", "p95_ms", "basis"],
+      "properties": { "elapsed_ms": { "type": ["number", "null"], "minimum": 0 }, "p50_ms": { "type": ["number", "null"], "minimum": 0 }, "p95_ms": { "type": ["number", "null"], "minimum": 0 }, "basis": { "type": ["string", "null"], "minLength": 1 } }
+    },
+    "artifact_refs": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "nonempty_artifact_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+  }
+}

--- a/schemas/understudy.promotion_receipt.v1.schema.json
+++ b/schemas/understudy.promotion_receipt.v1.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.promotion_receipt.v1.schema.json",
+  "title": "understudy.promotion_receipt.v1",
+  "description": "Canonical fail-closed promotion or no-promotion receipt. Dev-only and historical-holdout evidence can be recorded but can never satisfy the promoted branch. All private evidence remains behind content-addressed references.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "receipt_id", "run_id", "workload_id", "decision", "evidence_scope", "source_binding_sha256", "verifier_calibration_sha256", "splits", "holdout", "baseline", "optimized", "serving_parity", "cost", "latency", "compiled_policy_ref", "claim_boundary", "demotion_trigger", "artifact_refs", "created_at"],
+  "properties": {
+    "schema_version": { "const": "understudy.promotion_receipt.v1" },
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "workload_id": { "type": "string", "minLength": 1 },
+    "decision": { "enum": ["promoted", "not_promoted", "insufficient_evidence"] },
+    "evidence_scope": { "enum": ["unknown", "dev_only", "historical_holdout", "fresh_holdout"] },
+    "source_binding_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "verifier_calibration_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "splits": { "$ref": "#/$defs/splits" },
+    "holdout": { "$ref": "#/$defs/holdout" },
+    "baseline": { "$ref": "#/$defs/result" },
+    "optimized": { "$ref": "#/$defs/result" },
+    "serving_parity": { "$ref": "#/$defs/serving_parity" },
+    "cost": { "$ref": "#/$defs/cost" },
+    "latency": { "$ref": "#/$defs/latency" },
+    "compiled_policy_ref": { "type": ["string", "null"], "minLength": 1 },
+    "claim_boundary": { "type": ["string", "null"], "minLength": 1 },
+    "demotion_trigger": { "type": ["string", "null"], "minLength": 1 },
+    "artifact_refs": { "$ref": "#/$defs/artifact_refs" },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "decision": { "const": "promoted" } }, "required": ["decision"] },
+      "then": {
+        "properties": {
+          "evidence_scope": { "const": "fresh_holdout" },
+          "source_binding_sha256": { "$ref": "#/$defs/sha256" },
+          "verifier_calibration_sha256": { "$ref": "#/$defs/sha256" },
+          "splits": { "$ref": "#/$defs/promotion_splits" },
+          "holdout": { "$ref": "#/$defs/fresh_holdout" },
+          "baseline": { "$ref": "#/$defs/scored_result" },
+          "optimized": { "$ref": "#/$defs/passing_result" },
+          "serving_parity": { "$ref": "#/$defs/passed_parity" },
+          "compiled_policy_ref": { "type": "string", "minLength": 1 },
+          "claim_boundary": { "type": "string", "minLength": 1 },
+          "demotion_trigger": { "type": "string", "minLength": 1 },
+          "artifact_refs": { "$ref": "#/$defs/nonempty_artifact_refs" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "nullable_sha256": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] },
+    "splits": {
+      "type": "object", "additionalProperties": false, "required": ["train_sha256", "dev_sha256", "holdout_sha256"],
+      "properties": { "train_sha256": { "$ref": "#/$defs/nullable_sha256" }, "dev_sha256": { "$ref": "#/$defs/nullable_sha256" }, "holdout_sha256": { "$ref": "#/$defs/nullable_sha256" } }
+    },
+    "promotion_splits": {
+      "type": "object", "additionalProperties": false, "required": ["train_sha256", "dev_sha256", "holdout_sha256"],
+      "properties": { "train_sha256": { "$ref": "#/$defs/sha256" }, "dev_sha256": { "$ref": "#/$defs/sha256" }, "holdout_sha256": { "$ref": "#/$defs/sha256" } }
+    },
+    "holdout": {
+      "type": "object", "additionalProperties": false, "required": ["status", "sha256", "executed_at", "receipt_ref"],
+      "properties": { "status": { "enum": ["unknown", "not_executed", "historical_observed", "executed_fresh"] }, "sha256": { "$ref": "#/$defs/nullable_sha256" }, "executed_at": { "type": ["string", "null"], "format": "date-time" }, "receipt_ref": { "type": ["string", "null"], "minLength": 1 } }
+    },
+    "fresh_holdout": {
+      "type": "object", "additionalProperties": false, "required": ["status", "sha256", "executed_at", "receipt_ref"],
+      "properties": { "status": { "const": "executed_fresh" }, "sha256": { "$ref": "#/$defs/sha256" }, "executed_at": { "type": "string", "format": "date-time" }, "receipt_ref": { "type": "string", "minLength": 1 } }
+    },
+    "result": {
+      "type": "object", "additionalProperties": false, "required": ["run_id", "quality", "passed", "artifact_ref"],
+      "properties": { "run_id": { "type": ["string", "null"], "minLength": 1 }, "quality": { "type": ["number", "null"], "minimum": 0, "maximum": 1 }, "passed": { "type": ["boolean", "null"] }, "artifact_ref": { "type": ["string", "null"], "minLength": 1 } }
+    },
+    "scored_result": {
+      "type": "object", "additionalProperties": false, "required": ["run_id", "quality", "passed", "artifact_ref"],
+      "properties": { "run_id": { "type": "string", "minLength": 1 }, "quality": { "type": "number", "minimum": 0, "maximum": 1 }, "passed": { "type": "boolean" }, "artifact_ref": { "type": "string", "minLength": 1 } }
+    },
+    "passing_result": {
+      "type": "object", "additionalProperties": false, "required": ["run_id", "quality", "passed", "artifact_ref"],
+      "properties": { "run_id": { "type": "string", "minLength": 1 }, "quality": { "type": "number", "minimum": 0, "maximum": 1 }, "passed": { "const": true }, "artifact_ref": { "type": "string", "minLength": 1 } }
+    },
+    "serving_parity": {
+      "type": "object", "additionalProperties": false, "required": ["passed", "receipt_ref"],
+      "properties": { "passed": { "type": ["boolean", "null"] }, "receipt_ref": { "type": ["string", "null"], "minLength": 1 } }
+    },
+    "passed_parity": {
+      "type": "object", "additionalProperties": false, "required": ["passed", "receipt_ref"],
+      "properties": { "passed": { "const": true }, "receipt_ref": { "type": "string", "minLength": 1 } }
+    },
+    "cost": {
+      "type": "object", "additionalProperties": false, "required": ["actual_usd", "budget_usd", "basis"],
+      "properties": { "actual_usd": { "type": ["number", "null"], "minimum": 0 }, "budget_usd": { "type": ["number", "null"], "minimum": 0 }, "basis": { "type": ["string", "null"], "minLength": 1 } }
+    },
+    "latency": {
+      "type": "object", "additionalProperties": false, "required": ["p50_ms", "p95_ms", "basis"],
+      "properties": { "p50_ms": { "type": ["number", "null"], "minimum": 0 }, "p95_ms": { "type": ["number", "null"], "minimum": 0 }, "basis": { "type": ["string", "null"], "minLength": 1 } }
+    },
+    "artifact_refs": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "nonempty_artifact_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+  }
+}

--- a/schemas/understudy.source_binding.v1.schema.json
+++ b/schemas/understudy.source_binding.v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.source_binding.v1.schema.json",
+  "title": "understudy.source_binding.v1",
+  "description": "Content-addressed binding between one workload and its authoritative source and sanitized fixture. References only: prompts, trace bodies, source rows, credentials, and other private payloads must never be inlined.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "binding_id", "workload_id", "state", "source_id", "source_sha256", "fixture_sha256", "artifact_refs", "created_at"],
+  "properties": {
+    "schema_version": { "const": "understudy.source_binding.v1" },
+    "binding_id": { "type": "string", "minLength": 1 },
+    "workload_id": { "type": "string", "minLength": 1 },
+    "state": { "enum": ["unknown", "bound", "invalid"] },
+    "source_id": { "type": ["string", "null"], "minLength": 1, "description": "Opaque source identifier or version pin; never source content." },
+    "source_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "fixture_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "artifact_refs": { "$ref": "#/$defs/artifact_refs" },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "state": { "const": "bound" } }, "required": ["state"] },
+      "then": {
+        "properties": {
+          "source_id": { "type": "string", "minLength": 1 },
+          "source_sha256": { "$ref": "#/$defs/sha256" },
+          "fixture_sha256": { "$ref": "#/$defs/sha256" },
+          "artifact_refs": { "$ref": "#/$defs/nonempty_artifact_refs" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "nullable_sha256": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] },
+    "artifact_refs": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "nonempty_artifact_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+  }
+}

--- a/schemas/understudy.verifier_calibration.v1.schema.json
+++ b/schemas/understudy.verifier_calibration.v1.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://understudylabs.com/schemas/understudy.verifier_calibration.v1.schema.json",
+  "title": "understudy.verifier_calibration.v1",
+  "description": "Fail-closed calibration receipt for a hash-bound verifier. A passed receipt proves oracle, sentinel, replay, and malformed-counter semantics; unknown evidence remains explicitly null. References only, with no inline prompts or traces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "calibration_id", "workload_id", "status", "source_binding_sha256", "fixture_sha256", "verifier_sha256", "oracle", "sentinel", "replay", "malformed_semantics", "artifact_refs", "created_at"],
+  "properties": {
+    "schema_version": { "const": "understudy.verifier_calibration.v1" },
+    "calibration_id": { "type": "string", "minLength": 1 },
+    "workload_id": { "type": "string", "minLength": 1 },
+    "status": { "enum": ["unknown", "passed", "failed"] },
+    "source_binding_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "fixture_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "verifier_sha256": { "$ref": "#/$defs/nullable_sha256" },
+    "oracle": { "$ref": "#/$defs/probe" },
+    "sentinel": { "$ref": "#/$defs/probe" },
+    "replay": { "$ref": "#/$defs/replay_probe" },
+    "malformed_semantics": { "$ref": "#/$defs/malformed_probe" },
+    "artifact_refs": { "$ref": "#/$defs/artifact_refs" },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "passed" } }, "required": ["status"] },
+      "then": {
+        "properties": {
+          "source_binding_sha256": { "$ref": "#/$defs/sha256" },
+          "fixture_sha256": { "$ref": "#/$defs/sha256" },
+          "verifier_sha256": { "$ref": "#/$defs/sha256" },
+          "oracle": { "$ref": "#/$defs/passed_oracle" },
+          "sentinel": { "$ref": "#/$defs/passed_sentinel" },
+          "replay": { "$ref": "#/$defs/passed_replay" },
+          "malformed_semantics": { "$ref": "#/$defs/passed_malformed" },
+          "artifact_refs": { "$ref": "#/$defs/nonempty_artifact_refs" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "nullable_sha256": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] },
+    "nullable_unit_score": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+    "probe": {
+      "type": "object", "additionalProperties": false, "required": ["score", "passed"],
+      "properties": { "score": { "$ref": "#/$defs/nullable_unit_score" }, "passed": { "type": ["boolean", "null"] } }
+    },
+    "passed_oracle": {
+      "type": "object", "additionalProperties": false, "required": ["score", "passed"],
+      "properties": { "score": { "const": 1 }, "passed": { "const": true } }
+    },
+    "passed_sentinel": {
+      "type": "object", "additionalProperties": false, "required": ["score", "passed"],
+      "properties": { "score": { "const": 0 }, "passed": { "const": true } }
+    },
+    "replay_probe": {
+      "type": "object", "additionalProperties": false, "required": ["executed", "passed", "trajectory_count"],
+      "properties": { "executed": { "type": ["boolean", "null"] }, "passed": { "type": ["boolean", "null"] }, "trajectory_count": { "type": ["integer", "null"], "minimum": 0 } }
+    },
+    "passed_replay": {
+      "type": "object", "additionalProperties": false, "required": ["executed", "passed", "trajectory_count"],
+      "properties": { "executed": { "const": true }, "passed": { "const": true }, "trajectory_count": { "type": "integer", "minimum": 1 } }
+    },
+    "malformed_probe": {
+      "type": "object", "additionalProperties": false, "required": ["malformed_total_distinct_from_consecutive", "passed"],
+      "properties": { "malformed_total_distinct_from_consecutive": { "type": ["boolean", "null"] }, "passed": { "type": ["boolean", "null"] } }
+    },
+    "passed_malformed": {
+      "type": "object", "additionalProperties": false, "required": ["malformed_total_distinct_from_consecutive", "passed"],
+      "properties": { "malformed_total_distinct_from_consecutive": { "const": true }, "passed": { "const": true } }
+    },
+    "artifact_refs": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "nonempty_artifact_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+  }
+}

--- a/tests/outcome-first-contracts.test.mjs
+++ b/tests/outcome-first-contracts.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const SHA_C = "c".repeat(64);
+const NOW = "2026-08-03T00:00:00.000Z";
+
+function loadSchema(name) {
+  return JSON.parse(fs.readFileSync(path.resolve("schemas", name), "utf8"));
+}
+
+// Repository tests intentionally avoid a validator dependency. This focused
+// draft-2020-12 subset covers every keyword used by these four contracts,
+// including conditional promotion/calibration gates.
+function makeValidator(root) {
+  function resolve(schema) {
+    if (!schema || typeof schema !== "object" || typeof schema.$ref !== "string") return schema;
+    let node = root;
+    for (const part of schema.$ref.replace(/^#\//, "").split("/")) node = node?.[part];
+    return node ?? {};
+  }
+
+  function errors(schemaIn, value, at = "$") {
+    const schema = resolve(schemaIn);
+    const out = [];
+    if (!schema || typeof schema !== "object") return out;
+
+    if (schema.allOf) for (const branch of schema.allOf) out.push(...errors(branch, value, at));
+    if (schema.anyOf && !schema.anyOf.some((branch) => errors(branch, value, at).length === 0)) out.push(`${at}: no anyOf branch matched`);
+    if (schema.if && errors(schema.if, value, at).length === 0 && schema.then) out.push(...errors(schema.then, value, at));
+    if (Object.hasOwn(schema, "const") && value !== schema.const) out.push(`${at}: expected const ${JSON.stringify(schema.const)}`);
+    if (schema.enum && !schema.enum.includes(value)) out.push(`${at}: not in enum`);
+
+    const types = schema.type == null ? null : Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (types && value !== undefined) {
+      const actual = value === null ? "null" : Array.isArray(value) ? "array" : typeof value === "number" && Number.isInteger(value) ? "integer" : typeof value;
+      if (!types.some((type) => type === actual || (type === "number" && actual === "integer"))) out.push(`${at}: expected ${types.join("|")}, got ${actual}`);
+    }
+    if (typeof value === "string") {
+      if (schema.minLength != null && value.length < schema.minLength) out.push(`${at}: shorter than ${schema.minLength}`);
+      if (schema.pattern && !new RegExp(schema.pattern).test(value)) out.push(`${at}: pattern mismatch`);
+    }
+    if (typeof value === "number") {
+      if (schema.minimum != null && value < schema.minimum) out.push(`${at}: below minimum`);
+      if (schema.maximum != null && value > schema.maximum) out.push(`${at}: above maximum`);
+    }
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const key of schema.required ?? []) if (!Object.hasOwn(value, key)) out.push(`${at}.${key}: required`);
+      for (const [key, child] of Object.entries(schema.properties ?? {})) if (Object.hasOwn(value, key)) out.push(...errors(child, value[key], `${at}.${key}`));
+      if (schema.additionalProperties === false) {
+        for (const key of Object.keys(value)) if (!Object.hasOwn(schema.properties ?? {}, key)) out.push(`${at}.${key}: additional property`);
+      }
+    }
+    if (Array.isArray(value)) {
+      if (schema.minItems != null && value.length < schema.minItems) out.push(`${at}: fewer than ${schema.minItems} items`);
+      if (schema.uniqueItems && new Set(value.map((item) => JSON.stringify(item))).size !== value.length) out.push(`${at}: duplicate items`);
+      if (schema.items) value.forEach((item, index) => out.push(...errors(schema.items, item, `${at}[${index}]`)));
+    }
+    return out;
+  }
+  return (value) => errors(root, value);
+}
+
+const sourceValidate = makeValidator(loadSchema("understudy.source_binding.v1.schema.json"));
+const verifierValidate = makeValidator(loadSchema("understudy.verifier_calibration.v1.schema.json"));
+const vizValidate = makeValidator(loadSchema("understudy.gepa_viz_manifest.v1.schema.json"));
+const promotionValidate = makeValidator(loadSchema("understudy.promotion_receipt.v1.schema.json"));
+
+function unknownSource() {
+  return { schema_version: "understudy.source_binding.v1", binding_id: "bind-1", workload_id: "wl", state: "unknown", source_id: null, source_sha256: null, fixture_sha256: null, artifact_refs: [], created_at: NOW };
+}
+
+function unknownCalibration() {
+  return {
+    schema_version: "understudy.verifier_calibration.v1", calibration_id: "cal-1", workload_id: "wl", status: "unknown",
+    source_binding_sha256: null, fixture_sha256: null, verifier_sha256: null,
+    oracle: { score: null, passed: null }, sentinel: { score: null, passed: null },
+    replay: { executed: null, passed: null, trajectory_count: null },
+    malformed_semantics: { malformed_total_distinct_from_consecutive: null, passed: null }, artifact_refs: [], created_at: NOW,
+  };
+}
+
+function viz(state = "pending") {
+  return {
+    schema_version: "understudy.gepa_viz_manifest.v1", run_id: "run-1", workload_id: "wl", state,
+    source_binding_sha256: null, verifier_calibration_sha256: null,
+    splits: { train_sha256: null, dev_sha256: null, holdout_sha256: null },
+    progress: { wave: null, candidates_started: 0, candidates_completed: 0, candidates_failed: 0, rollouts_completed: 0, rollouts_total: null },
+    incumbent: { candidate_id: null, candidate_sha256: null, dev_quality: null },
+    cost: { actual_usd: null, budget_usd: null, basis: null },
+    latency: { elapsed_ms: null, p50_ms: null, p95_ms: null, basis: null }, artifact_refs: [], updated_at: NOW,
+  };
+}
+
+function receipt(decision = "insufficient_evidence") {
+  return {
+    schema_version: "understudy.promotion_receipt.v1", receipt_id: "receipt-1", run_id: "run-1", workload_id: "wl", decision,
+    evidence_scope: "unknown", source_binding_sha256: null, verifier_calibration_sha256: null,
+    splits: { train_sha256: null, dev_sha256: null, holdout_sha256: null },
+    holdout: { status: "unknown", sha256: null, executed_at: null, receipt_ref: null },
+    baseline: { run_id: null, quality: null, passed: null, artifact_ref: null },
+    optimized: { run_id: null, quality: null, passed: null, artifact_ref: null },
+    serving_parity: { passed: null, receipt_ref: null },
+    cost: { actual_usd: null, budget_usd: null, basis: null },
+    latency: { p50_ms: null, p95_ms: null, basis: null },
+    compiled_policy_ref: null, claim_boundary: "Dev-only; no promotion evidence.", demotion_trigger: null,
+    artifact_refs: [], created_at: NOW,
+  };
+}
+
+describe("understudy.source_binding.v1", () => {
+  it("represents unknown provenance explicitly and requires hashes before bound", () => {
+    assert.deepEqual(sourceValidate(unknownSource()), []);
+    const bound = { ...unknownSource(), state: "bound", source_id: "r2://capture/7", source_sha256: SHA_A, fixture_sha256: SHA_B, artifact_refs: ["artifacts/source-binding.json"] };
+    assert.deepEqual(sourceValidate(bound), []);
+    assert.ok(sourceValidate({ ...bound, fixture_sha256: null }).some((error) => error.includes("fixture_sha256")));
+  });
+});
+
+describe("understudy.verifier_calibration.v1", () => {
+  it("allows unknown probes but passes only exact oracle/sentinel/replay semantics", () => {
+    assert.deepEqual(verifierValidate(unknownCalibration()), []);
+    const passed = {
+      ...unknownCalibration(), status: "passed", source_binding_sha256: SHA_A, fixture_sha256: SHA_B, verifier_sha256: SHA_C,
+      oracle: { score: 1, passed: true }, sentinel: { score: 0, passed: true },
+      replay: { executed: true, passed: true, trajectory_count: 23 },
+      malformed_semantics: { malformed_total_distinct_from_consecutive: true, passed: true }, artifact_refs: ["receipts/calibration.json"],
+    };
+    assert.deepEqual(verifierValidate(passed), []);
+    assert.ok(verifierValidate({ ...passed, sentinel: { score: 0.1, passed: true } }).some((error) => error.includes("sentinel.score")));
+    assert.ok(verifierValidate({ ...passed, replay: { executed: false, passed: true, trajectory_count: 23 } }).some((error) => error.includes("replay.executed")));
+  });
+});
+
+describe("understudy.gepa_viz_manifest.v1", () => {
+  it("keeps pending unknowns nullable but requires provenance and train/dev hashes while live", () => {
+    assert.deepEqual(vizValidate(viz()), []);
+    const running = viz("running");
+    assert.ok(vizValidate(running).some((error) => error.includes("source_binding_sha256")));
+    Object.assign(running, { source_binding_sha256: SHA_A, verifier_calibration_sha256: SHA_B, artifact_refs: ["viz/run-1.json"] });
+    running.splits = { train_sha256: SHA_A, dev_sha256: SHA_B, holdout_sha256: null };
+    assert.deepEqual(vizValidate(running), []);
+  });
+});
+
+describe("understudy.promotion_receipt.v1", () => {
+  it("records dev-only and historical evidence without allowing promotion", () => {
+    const devOnly = receipt();
+    devOnly.evidence_scope = "dev_only";
+    devOnly.holdout.status = "not_executed";
+    assert.deepEqual(promotionValidate(devOnly), []);
+
+    const invalid = { ...devOnly, decision: "promoted" };
+    assert.ok(promotionValidate(invalid).some((error) => error.includes("evidence_scope")));
+
+    const historical = receipt("promoted");
+    historical.evidence_scope = "historical_holdout";
+    historical.holdout = { status: "historical_observed", sha256: SHA_C, executed_at: NOW, receipt_ref: "receipts/old.json" };
+    assert.ok(promotionValidate(historical).some((error) => error.includes("evidence_scope")));
+  });
+
+  it("accepts promotion only with fresh hash-bound holdout, parity, policy, and receipts", () => {
+    const promoted = receipt("promoted");
+    Object.assign(promoted, {
+      evidence_scope: "fresh_holdout", source_binding_sha256: SHA_A, verifier_calibration_sha256: SHA_B,
+      splits: { train_sha256: SHA_A, dev_sha256: SHA_B, holdout_sha256: SHA_C },
+      holdout: { status: "executed_fresh", sha256: SHA_C, executed_at: NOW, receipt_ref: "receipts/holdout.json" },
+      baseline: { run_id: "base", quality: 0.85, passed: true, artifact_ref: "receipts/base.json" },
+      optimized: { run_id: "opt", quality: 1, passed: true, artifact_ref: "receipts/opt.json" },
+      serving_parity: { passed: true, receipt_ref: "receipts/parity.json" },
+      cost: { actual_usd: 12.34, budget_usd: 100, basis: "gateway-metered" },
+      latency: { p50_ms: 120, p95_ms: 350, basis: "canonical-serving-receipt" },
+      compiled_policy_ref: "policies/winner.json", claim_boundary: "Fresh holdout for workload wl only.",
+      demotion_trigger: "Demote on verifier or serving-parity regression.", artifact_refs: ["receipts/promotion.json"],
+    });
+    assert.deepEqual(promotionValidate(promoted), []);
+    assert.ok(promotionValidate({ ...promoted, serving_parity: { passed: null, receipt_ref: null } }).some((error) => error.includes("serving_parity")));
+  });
+
+  it("rejects inline prompt/private payload fields in every contract", () => {
+    for (const [validate, row] of [[sourceValidate, unknownSource()], [verifierValidate, unknownCalibration()], [vizValidate, viz()], [promotionValidate, receipt()]]) {
+      assert.ok(validate({ ...row, prompt: "private" }).some((error) => error.includes("prompt: additional property")));
+    }
+  });
+});


### PR DESCRIPTION
Implements the four reusable OSS contracts identified in the outcome-first architecture audit:\n\n- `understudy.source_binding.v1`\n- `understudy.verifier_calibration.v1`\n- `understudy.gepa_viz_manifest.v1`\n- `understudy.promotion_receipt.v1`\n\nThe schemas fail closed around source/verifier hashes, live GEPA provenance, fresh-vs-historical holdout truth, serving parity, cost/latency, compiled policy references, claim boundaries, and demotion triggers. Private prompts and payloads cannot be inlined.\n\nValidation:\n- `npm run build`\n- `npm test` — 1127 passed, 0 failed\n- focused contract suite — 6 passed\n- `git diff --check`\n\nNo provider calls, paid runs, or holdout execution.