### PR TITLE
feat: add generic verifier trust gate

### DIFF
--- a/skills/audit-verifier-reliability/SKILL.md
+++ b/skills/audit-verifier-reliability/SKILL.md
@@ -15,3 +15,18 @@ failure; missing natural coverage is `insufficient-evidence`.
 Use `evaluateTrustGate` from `src/verifier-trust/`. Keep raw trajectories out of
 receipts and retain the resulting hash-bound receipt with the calibration
 artifact (`understudy.verifier_calibration.v1`).
+
+## Safety Gates
+
+- Operate only on already-approved local calibration summaries; never read a
+  holdout, call a provider, upload trajectories, or include customer content.
+- Require valid source-binding, verifier, and fixture SHA-256 values plus both
+  natural and adversarial arms. Missing evidence is never trusted.
+- Treat the receipt as verifier-calibration evidence, not model-quality or
+  promotion evidence.
+
+## Resolve CLI
+
+No CLI command is required. Build the package and call `evaluateTrustGate` from
+`dist/verifier-trust/index.js` in an offline script or test. Preserve only the
+hash-bound receipt; keep raw probes in their approved local evidence store.

--- a/skills/audit-verifier-reliability/SKILL.md
+++ b/skills/audit-verifier-reliability/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: audit-verifier-reliability
+description: Use when deciding whether a verifier reward is trustworthy for optimization.
+---
+# Audit verifier reliability
+
+Trust requires two independent, offline arms: deterministic adversarial probes
+and replayed natural trajectories. The receipt is trusted only when both meet
+the predeclared gate and carries source, verifier, and fixture SHA-256 bindings.
+
+Never read holdout data, call providers, upload traces, include customer data,
+or spend money in this audit. Natural evidence cannot override an adversarial
+failure; missing natural coverage is `insufficient-evidence`.
+
+Use `evaluateTrustGate` from `src/verifier-trust/`. Keep raw trajectories out of
+receipts and retain the resulting hash-bound receipt with the calibration
+artifact (`understudy.verifier_calibration.v1`).

--- a/src/verifier-trust/index.ts
+++ b/src/verifier-trust/index.ts
@@ -18,6 +18,6 @@ export function evaluateTrustGate(binding: TrustBinding, natural: ArmEvidence, a
   const reasons: string[] = [];
   if (!passes(adversarial, TRUST_GATE.min_probes)) reasons.push("adversarial_arm_failed");
   if (!passes(natural, TRUST_GATE.min_natural_probes)) reasons.push("natural_arm_failed_or_insufficient");
-  if (!binding.source_binding_sha256 || !binding.verifier_sha256 || !binding.fixture_sha256) reasons.push("missing_provenance_binding");
+  if (![binding.source_binding_sha256, binding.verifier_sha256, binding.fixture_sha256].every((value) => /^[a-f0-9]{64}$/.test(value))) reasons.push("missing_or_invalid_provenance_binding");
   return { schema_version: VERIFIER_TRUST_VERSION, gate_version: "verifier-reliability-gate-v1", ...binding, natural, adversarial, verdict: reasons.length === 0 ? "trusted" : (natural.probes < TRUST_GATE.min_natural_probes ? "insufficient-evidence" : "untrusted"), reasons, idempotency_key: trustIdempotencyKey(binding, natural, adversarial) };
 }

--- a/src/verifier-trust/index.ts
+++ b/src/verifier-trust/index.ts
@@ -1,0 +1,23 @@
+import { createHash } from "node:crypto";
+
+export const VERIFIER_TRUST_VERSION = "understudy.verifier_trust.v1" as const;
+export type ArmEvidence = { probes: number; false_positive_rate: number | null; false_negative_rate: number | null; mcc: number | null; reward_hacked_probes: number; replay_fidelity_mismatches?: number };
+export type TrustBinding = { source_binding_sha256: string; verifier_sha256: string; fixture_sha256: string };
+export type TrustReceipt = TrustBinding & { schema_version: typeof VERIFIER_TRUST_VERSION; gate_version: "verifier-reliability-gate-v1"; natural: ArmEvidence; adversarial: ArmEvidence; verdict: "trusted" | "untrusted" | "insufficient-evidence"; reasons: string[]; idempotency_key: string };
+
+export const TRUST_GATE = Object.freeze({ min_probes: 24, min_natural_probes: 8, max_false_positive_rate: 0, max_false_negative_rate: 0.05, min_mcc: 0.9, max_reward_hacked_probes: 0 });
+
+function canonical(value: unknown): string { return JSON.stringify(value, (_k, v) => v && typeof v === "object" && !Array.isArray(v) ? Object.fromEntries(Object.entries(v).sort(([a], [b]) => a.localeCompare(b))) : v); }
+export function trustIdempotencyKey(binding: TrustBinding, natural: ArmEvidence, adversarial: ArmEvidence): string {
+  return createHash("sha256").update(canonical({ binding, gate: TRUST_GATE, natural, adversarial })).digest("hex");
+}
+function passes(e: ArmEvidence, min: number): boolean {
+  return e.probes >= min && e.false_positive_rate === 0 && e.false_negative_rate !== null && e.false_negative_rate <= TRUST_GATE.max_false_negative_rate && e.mcc !== null && e.mcc >= TRUST_GATE.min_mcc && e.reward_hacked_probes === 0 && (e.replay_fidelity_mismatches ?? 0) === 0;
+}
+export function evaluateTrustGate(binding: TrustBinding, natural: ArmEvidence, adversarial: ArmEvidence): TrustReceipt {
+  const reasons: string[] = [];
+  if (!passes(adversarial, TRUST_GATE.min_probes)) reasons.push("adversarial_arm_failed");
+  if (!passes(natural, TRUST_GATE.min_natural_probes)) reasons.push("natural_arm_failed_or_insufficient");
+  if (!binding.source_binding_sha256 || !binding.verifier_sha256 || !binding.fixture_sha256) reasons.push("missing_provenance_binding");
+  return { schema_version: VERIFIER_TRUST_VERSION, gate_version: "verifier-reliability-gate-v1", ...binding, natural, adversarial, verdict: reasons.length === 0 ? "trusted" : (natural.probes < TRUST_GATE.min_natural_probes ? "insufficient-evidence" : "untrusted"), reasons, idempotency_key: trustIdempotencyKey(binding, natural, adversarial) };
+}

--- a/tests/verifier-trust.test.mjs
+++ b/tests/verifier-trust.test.mjs
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { evaluateTrustGate, TRUST_GATE } from "../dist/verifier-trust/index.js";
+const binding = { source_binding_sha256: "a".repeat(64), verifier_sha256: "b".repeat(64), fixture_sha256: "c".repeat(64) };
+const arm = (probes) => ({ probes, false_positive_rate: 0, false_negative_rate: 0, mcc: 1, reward_hacked_probes: 0 });
+test("requires both arms and binds the receipt", () => { const r = evaluateTrustGate(binding, arm(8), arm(24)); assert.equal(r.verdict, "trusted"); assert.equal(r.source_binding_sha256, binding.source_binding_sha256); assert.equal(r.schema_version, "understudy.verifier_trust.v1"); });
+test("natural evidence is mandatory and adversarial failure is never trusted", () => { assert.equal(evaluateTrustGate(binding, arm(7), arm(24)).verdict, "insufficient-evidence"); assert.equal(evaluateTrustGate(binding, arm(8), { ...arm(24), reward_hacked_probes: 1 }).verdict, "untrusted"); });
+test("provenance is required", () => { const r = evaluateTrustGate({ ...binding, verifier_sha256: "" }, arm(8), arm(24)); assert.equal(r.verdict, "untrusted"); assert.match(r.reasons.join(" "), /provenance/); });
+assert.equal(TRUST_GATE.max_false_positive_rate, 0);

--- a/tests/verifier-trust.test.mjs
+++ b/tests/verifier-trust.test.mjs
@@ -5,5 +5,5 @@ const binding = { source_binding_sha256: "a".repeat(64), verifier_sha256: "b".re
 const arm = (probes) => ({ probes, false_positive_rate: 0, false_negative_rate: 0, mcc: 1, reward_hacked_probes: 0 });
 test("requires both arms and binds the receipt", () => { const r = evaluateTrustGate(binding, arm(8), arm(24)); assert.equal(r.verdict, "trusted"); assert.equal(r.source_binding_sha256, binding.source_binding_sha256); assert.equal(r.schema_version, "understudy.verifier_trust.v1"); });
 test("natural evidence is mandatory and adversarial failure is never trusted", () => { assert.equal(evaluateTrustGate(binding, arm(7), arm(24)).verdict, "insufficient-evidence"); assert.equal(evaluateTrustGate(binding, arm(8), { ...arm(24), reward_hacked_probes: 1 }).verdict, "untrusted"); });
-test("provenance is required", () => { const r = evaluateTrustGate({ ...binding, verifier_sha256: "" }, arm(8), arm(24)); assert.equal(r.verdict, "untrusted"); assert.match(r.reasons.join(" "), /provenance/); });
+test("valid SHA-256 provenance is required", () => { for (const verifier_sha256 of ["", "not-a-hash", "A".repeat(64)]) { const r = evaluateTrustGate({ ...binding, verifier_sha256 }, arm(8), arm(24)); assert.equal(r.verdict, "untrusted"); assert.match(r.reasons.join(" "), /provenance/); } });
 assert.equal(TRUST_GATE.max_false_positive_rate, 0);


### PR DESCRIPTION
## Summary
- extract a generic offline dual-arm verifier trust gate
- require source/verifier/fixture hash bindings and calibration-compatible receipt fields
- add focused tests and reliability skill guidance

## Validation
- npm run build
- node --test tests/verifier-trust.test.mjs
- git diff --check

## Scope
Only src/verifier-trust/**, tests/verifier-trust.test.mjs, and skills/audit-verifier-reliability/** were changed. No holdout reads, provider calls, customer data, or paid work.