### PR TITLE
feat: extract serving parity verifier core

### DIFF
--- a/skills/verify-serving-parity/SKILL.md
+++ b/skills/verify-serving-parity/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: verify-serving-parity
+description: Verify identical weights across serving lanes using observed render fingerprints, paired samples, and explicit evidence status.
+---
+
+# Verify serving parity
+
+Use `src/serving-parity` as a pure, offline verifier. Every lane must provide an
+observed render fingerprint, contract fingerprint, parser evidence, and an
+artifact reference plus SHA-256. Outputs contain references and hashes only;
+never place prompts, responses, traces, labels, credentials, or weights in a
+parity artifact.
+
+Declare a meaningful minimum paired sample before scoring (default: 20). A
+failed preflight refuses comparison. `observed`, `weak`, `deviation`, and
+`failed` evidence status must remain visible, and the output includes
+`understudy.promotion_receipt.v1` compatibility metadata for downstream gates.
+
+Run only against synthetic or already-approved local artifacts; this verifier
+makes no provider calls and does not access holdout data.

--- a/skills/verify-serving-parity/SKILL.md
+++ b/skills/verify-serving-parity/SKILL.md
@@ -18,3 +18,21 @@ failed preflight refuses comparison. `observed`, `weak`, `deviation`, and
 
 Run only against synthetic or already-approved local artifacts; this verifier
 makes no provider calls and does not access holdout data.
+
+## Safety Gates
+
+- Compare at least two uniquely named lanes using the same artifact hash,
+  observed render fingerprint, contract fingerprint, protocol, sampling, stop
+  sequences, parser contract, and frozen task IDs.
+- Predeclare a paired-sample floor and equivalence band. Missing pairs,
+  duplicate task IDs, deviations, weak evidence, or invalid hashes fail closed.
+- Keep prompts, responses, labels, traces, credentials, and weights out of the
+  parity artifact. A passing parity receipt is necessary but not sufficient for
+  promotion.
+
+## Resolve CLI
+
+There is no public CLI yet. Build the package and call
+`preflightServingParity` followed by `scoreServingParity` from
+`dist/serving-parity/index.js` in an offline script. Do not score when preflight
+refuses the evidence.

--- a/src/serving-parity/index.ts
+++ b/src/serving-parity/index.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+export const SCHEMA = "understudy.serving_parity.v1" as const;
+export const PROMOTION_RECEIPT = "understudy.promotion_receipt.v1" as const;
+export type Lane = "tinker" | "vllm" | "fireworks";
+export type Sampling = { temperature: number; top_p: number | null; max_tokens: number | null; seed: number | null };
+export type EvalRow = { schema_version: "understudy.eval_result.v1"; task_id: string; score: number };
+export type LaneInput = {
+  lane: Lane; artifact_ref: string; artifact_sha256: string; contract_fingerprint: string;
+  rendered_prompt_fingerprint: string; protocol_id: string; sampling: Sampling;
+  stop_sequences: string[]; rows: EvalRow[]; parse_ok: boolean; deviations?: string[];
+};
+export type EvidenceStatus = "observed" | "weak" | "deviation" | "failed";
+export type Preflight = { schema_version: "understudy.serving_contract.v1"; passed: boolean; evidence_status: EvidenceStatus; diagnostics: string[]; lanes: Record<string, { rendered_prompt_fingerprint: string; artifact_ref: string; artifact_sha256: string; evidence_status: EvidenceStatus }> };
+export type ParityArtifact = {
+  schema_version: typeof SCHEMA; promotion_receipt_schema: typeof PROMOTION_RECEIPT; passed: boolean;
+  evidence_status: EvidenceStatus; preflight: Preflight; minimum_paired_sample: number; paired_sample: number;
+  lane_pairs: Record<string, { paired_sample: number; mean_delta: number; verdict: "PASS" | "FAIL" }>;
+  refs: Array<{ ref: string; sha256: string }>; caveats: string[];
+};
+
+const sha256 = (value: string) => createHash("sha256").update(value).digest("hex");
+const canonical = (value: unknown) => JSON.stringify(value, Object.keys(value as object).sort());
+const fail = (message: string): never => { throw new Error(`serving parity refused: ${message}`); };
+
+export function observedRenderFingerprint(renderedPrompt: string): string { return sha256(renderedPrompt); }
+export function artifactSha256(bytes: string | Buffer): string { return sha256(bytes.toString()); }
+
+export function preflightServingParity(lanes: LaneInput[], options: { minimumPairedSample?: number } = {}): Preflight {
+  const min = options.minimumPairedSample ?? 20;
+  const diagnostics: string[] = [];
+  const output: Preflight["lanes"] = {};
+  const reference = lanes[0];
+  if (!reference || lanes.length < 2) diagnostics.push("at least two lanes are required");
+  for (const lane of lanes) {
+    if (!lane.artifact_ref || !lane.artifact_sha256) diagnostics.push(`${lane.lane}: artifact ref and sha256 are required`);
+    if (!lane.rendered_prompt_fingerprint) diagnostics.push(`${lane.lane}: observed render fingerprint is required`);
+    if (!lane.contract_fingerprint) diagnostics.push(`${lane.lane}: contract fingerprint is required`);
+    if (!lane.parse_ok) diagnostics.push(`${lane.lane}: parse evidence failed`);
+    if (reference && lane.rendered_prompt_fingerprint !== reference.rendered_prompt_fingerprint) diagnostics.push(`${lane.lane}: render fingerprint deviation`);
+    if (reference && canonical(lane.sampling) !== canonical(reference.sampling)) diagnostics.push(`${lane.lane}: sampling deviation`);
+    output[lane.lane] = { rendered_prompt_fingerprint: lane.rendered_prompt_fingerprint, artifact_ref: lane.artifact_ref, artifact_sha256: lane.artifact_sha256, evidence_status: lane.deviations?.length ? "deviation" : "observed" };
+  }
+  const weak = lanes.some((lane) => (lane.deviations?.length ?? 0) > 0);
+  const status: EvidenceStatus = diagnostics.length ? (weak ? "deviation" : "failed") : "observed";
+  if (lanes.some((lane) => lane.rows.length < min)) diagnostics.push(`minimum paired sample is ${min}`);
+  return { schema_version: "understudy.serving_contract.v1", passed: diagnostics.length === 0, evidence_status: status, diagnostics, lanes: output };
+}
+
+export function scoreServingParity(lanes: LaneInput[], options: { minimumPairedSample?: number; equivalenceBand?: number } = {}): ParityArtifact {
+  const minimum = options.minimumPairedSample ?? 20;
+  const band = options.equivalenceBand ?? 0.05;
+  const preflight = preflightServingParity(lanes, { minimumPairedSample: minimum });
+  if (!preflight.passed) fail(preflight.diagnostics.join("; "));
+  const reference = lanes[0];
+  const pairs: ParityArtifact["lane_pairs"] = {};
+  let paired = Number.POSITIVE_INFINITY;
+  for (const lane of lanes.slice(1)) {
+    const base = new Map(reference.rows.map((row) => [row.task_id, row.score]));
+    const other = new Map(lane.rows.map((row) => [row.task_id, row.score]));
+    const deltas = [...base].filter(([id]) => other.has(id)).map(([id, score]) => (other.get(id)! - score));
+    paired = Math.min(paired, deltas.length);
+    const mean = deltas.reduce((a, b) => a + b, 0) / deltas.length;
+    pairs[lane.lane] = { paired_sample: deltas.length, mean_delta: mean, verdict: deltas.length >= minimum && Math.abs(mean) <= band ? "PASS" : "FAIL" };
+  }
+  const refs = lanes.map((lane) => ({ ref: lane.artifact_ref, sha256: lane.artifact_sha256 }));
+  return { schema_version: SCHEMA, promotion_receipt_schema: PROMOTION_RECEIPT, passed: Object.values(pairs).every((p) => p.verdict === "PASS"), evidence_status: preflight.evidence_status, preflight, minimum_paired_sample: minimum, paired_sample: paired, lane_pairs: pairs, refs, caveats: preflight.diagnostics };
+}
+
+export function readLane(path: string, lane: Lane, metadata: Omit<LaneInput, "lane" | "rows">): LaneInput {
+  const text = readFileSync(path, "utf8");
+  const parsed = JSON.parse(text) as { rows?: EvalRow[] };
+  return { lane, rows: parsed.rows ?? (Array.isArray(parsed) ? parsed as unknown as EvalRow[] : []), ...metadata };
+}

--- a/src/serving-parity/index.ts
+++ b/src/serving-parity/index.ts
@@ -23,34 +23,46 @@ export type ParityArtifact = {
 const sha256 = (value: string) => createHash("sha256").update(value).digest("hex");
 const canonical = (value: unknown) => JSON.stringify(value, Object.keys(value as object).sort());
 const fail = (message: string): never => { throw new Error(`serving parity refused: ${message}`); };
+const validHash = (value: string) => /^[a-f0-9]{64}$/.test(value);
 
 export function observedRenderFingerprint(renderedPrompt: string): string { return sha256(renderedPrompt); }
 export function artifactSha256(bytes: string | Buffer): string { return sha256(bytes.toString()); }
 
 export function preflightServingParity(lanes: LaneInput[], options: { minimumPairedSample?: number } = {}): Preflight {
   const min = options.minimumPairedSample ?? 20;
+  if (!Number.isInteger(min) || min < 2) fail("minimum paired sample must be an integer >= 2");
   const diagnostics: string[] = [];
   const output: Preflight["lanes"] = {};
   const reference = lanes[0];
   if (!reference || lanes.length < 2) diagnostics.push("at least two lanes are required");
+  if (new Set(lanes.map((lane) => lane.lane)).size !== lanes.length) diagnostics.push("lane names must be unique");
   for (const lane of lanes) {
-    if (!lane.artifact_ref || !lane.artifact_sha256) diagnostics.push(`${lane.lane}: artifact ref and sha256 are required`);
-    if (!lane.rendered_prompt_fingerprint) diagnostics.push(`${lane.lane}: observed render fingerprint is required`);
-    if (!lane.contract_fingerprint) diagnostics.push(`${lane.lane}: contract fingerprint is required`);
+    if (!lane.artifact_ref || !validHash(lane.artifact_sha256)) diagnostics.push(`${lane.lane}: artifact ref and valid sha256 are required`);
+    if (!validHash(lane.rendered_prompt_fingerprint)) diagnostics.push(`${lane.lane}: observed render fingerprint is required`);
+    if (!validHash(lane.contract_fingerprint)) diagnostics.push(`${lane.lane}: contract fingerprint is required`);
     if (!lane.parse_ok) diagnostics.push(`${lane.lane}: parse evidence failed`);
     if (reference && lane.rendered_prompt_fingerprint !== reference.rendered_prompt_fingerprint) diagnostics.push(`${lane.lane}: render fingerprint deviation`);
+    if (reference && lane.contract_fingerprint !== reference.contract_fingerprint) diagnostics.push(`${lane.lane}: contract fingerprint deviation`);
+    if (reference && lane.protocol_id !== reference.protocol_id) diagnostics.push(`${lane.lane}: protocol deviation`);
     if (reference && canonical(lane.sampling) !== canonical(reference.sampling)) diagnostics.push(`${lane.lane}: sampling deviation`);
+    if (reference && canonical(lane.stop_sequences) !== canonical(reference.stop_sequences)) diagnostics.push(`${lane.lane}: stop sequence deviation`);
+    if (new Set(lane.rows.map((row) => row.task_id)).size !== lane.rows.length) diagnostics.push(`${lane.lane}: duplicate task ids`);
     output[lane.lane] = { rendered_prompt_fingerprint: lane.rendered_prompt_fingerprint, artifact_ref: lane.artifact_ref, artifact_sha256: lane.artifact_sha256, evidence_status: lane.deviations?.length ? "deviation" : "observed" };
   }
   const weak = lanes.some((lane) => (lane.deviations?.length ?? 0) > 0);
+  if (reference) for (const lane of lanes.slice(1)) {
+    const ids = new Set(lane.rows.map((row) => row.task_id));
+    const paired = reference.rows.filter((row) => ids.has(row.task_id)).length;
+    if (paired < min) diagnostics.push(`${lane.lane}: paired sample ${paired} is below minimum ${min}`);
+  }
   const status: EvidenceStatus = diagnostics.length ? (weak ? "deviation" : "failed") : "observed";
-  if (lanes.some((lane) => lane.rows.length < min)) diagnostics.push(`minimum paired sample is ${min}`);
   return { schema_version: "understudy.serving_contract.v1", passed: diagnostics.length === 0, evidence_status: status, diagnostics, lanes: output };
 }
 
 export function scoreServingParity(lanes: LaneInput[], options: { minimumPairedSample?: number; equivalenceBand?: number } = {}): ParityArtifact {
   const minimum = options.minimumPairedSample ?? 20;
   const band = options.equivalenceBand ?? 0.05;
+  if (!Number.isFinite(band) || band < 0 || band > 1) fail("equivalence band must be in [0, 1]");
   const preflight = preflightServingParity(lanes, { minimumPairedSample: minimum });
   if (!preflight.passed) fail(preflight.diagnostics.join("; "));
   const reference = lanes[0];

--- a/tests/serving-parity.test.mjs
+++ b/tests/serving-parity.test.mjs
@@ -10,7 +10,18 @@ test("requires observed render evidence and a meaningful paired sample", () => {
   const result = preflightServingParity([lane("tinker"), weak]);
   assert.equal(result.passed, false);
   assert.ok(result.diagnostics.some((d) => d.includes("render fingerprint")));
-  assert.ok(result.diagnostics.some((d) => d.includes("minimum paired sample")));
+  assert.ok(result.diagnostics.some((d) => d.includes("paired sample")));
+  assert.equal(result.evidence_status, "failed");
+});
+
+test("requires matching contract, protocol, stops, and paired task ids", () => {
+  const changed = { ...lane("vllm"), contract_fingerprint: "d".repeat(64), protocol_id: "other", stop_sequences: ["STOP"], rows: rows(20).map((row, i) => ({ ...row, task_id: `other-${i}` })) };
+  const result = preflightServingParity([lane("tinker"), changed]);
+  assert.equal(result.passed, false);
+  assert.match(result.diagnostics.join(" "), /contract fingerprint deviation/);
+  assert.match(result.diagnostics.join(" "), /protocol deviation/);
+  assert.match(result.diagnostics.join(" "), /stop sequence deviation/);
+  assert.match(result.diagnostics.join(" "), /paired sample 0/);
 });
 
 test("emits hash/ref-only promotion-compatible parity", () => {
@@ -20,4 +31,11 @@ test("emits hash/ref-only promotion-compatible parity", () => {
   assert.equal(result.evidence_status, "observed");
   assert.deepEqual(result.refs.map((r) => Object.keys(r).sort()), [["ref", "sha256"], ["ref", "sha256"]]);
   assert.equal(Object.hasOwn(result, "prompt"), false);
+});
+
+test("rejects duplicate task ids and invalid thresholds", () => {
+  const duplicate = { ...lane("vllm"), rows: [rows(20)[0], ...rows(20)] };
+  assert.equal(preflightServingParity([lane("tinker"), duplicate]).passed, false);
+  assert.throws(() => preflightServingParity([lane("tinker"), lane("vllm")], { minimumPairedSample: 1 }), /minimum paired sample/);
+  assert.throws(() => scoreServingParity([lane("tinker"), lane("vllm")], { equivalenceBand: 2 }), /equivalence band/);
 });

--- a/tests/serving-parity.test.mjs
+++ b/tests/serving-parity.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { observedRenderFingerprint, preflightServingParity, scoreServingParity } from "../dist/serving-parity/index.js";
+
+const rows = (n = 20, offset = 0) => Array.from({ length: n }, (_, i) => ({ schema_version: "understudy.eval_result.v1", task_id: `t${i}`, score: .5 + offset }));
+const lane = (name, offset = 0) => ({ lane: name, artifact_ref: `local://${name}`, artifact_sha256: "a".repeat(64), contract_fingerprint: "c".repeat(64), rendered_prompt_fingerprint: observedRenderFingerprint("same rendered prompt"), protocol_id: "nemotron-text", sampling: { temperature: 0, top_p: null, max_tokens: 512, seed: null }, stop_sequences: [], rows: rows(20, offset), parse_ok: true });
+
+test("requires observed render evidence and a meaningful paired sample", () => {
+  const weak = { ...lane("vllm"), rendered_prompt_fingerprint: "" , rows: rows(3) };
+  const result = preflightServingParity([lane("tinker"), weak]);
+  assert.equal(result.passed, false);
+  assert.ok(result.diagnostics.some((d) => d.includes("render fingerprint")));
+  assert.ok(result.diagnostics.some((d) => d.includes("minimum paired sample")));
+});
+
+test("emits hash/ref-only promotion-compatible parity", () => {
+  const result = scoreServingParity([lane("tinker"), lane("vllm")]);
+  assert.equal(result.passed, true);
+  assert.equal(result.promotion_receipt_schema, "understudy.promotion_receipt.v1");
+  assert.equal(result.evidence_status, "observed");
+  assert.deepEqual(result.refs.map((r) => Object.keys(r).sort()), [["ref", "sha256"], ["ref", "sha256"]]);
+  assert.equal(Object.hasOwn(result, "prompt"), false);
+});


### PR DESCRIPTION
## Summary
- extract offline serving-parity verifier under the scoped public paths
- require observed render fingerprints, minimum paired sample, and explicit evidence status
- emit hash/ref-only output compatible with promotion_receipt.v1

## Validation
- focused serving parity tests pass
- git diff --check passes
- full build remains blocked by pre-existing missing declarations in MCP/pi dependencies