### PR TITLE
feat: add fail-closed outcome method ladder

### DIFF
--- a/skills/operate-benchmark-lab/references/method-ladder.md
+++ b/skills/operate-benchmark-lab/references/method-ladder.md
@@ -1,0 +1,19 @@
+# Outcome-first method ladder
+
+This planner chooses the next intervention from canonical, hash-bound **dev**
+evidence. It has no provider, execution, holdout, or promotion path. Its only
+outcomes are `target_met`, `continue_gepa`, `escalate_sft`, `escalate_dpo`,
+`escalate_grpo`, and `blocked`.
+
+Every baseline, optimized, verifier-trust, difficulty, arm-evidence, and
+serving-parity receipt must bind the same source, verifier, benchmark, and split
+manifest hashes. Unknown fields and any holdout-shaped input are rejected.
+Protected-family targets and allowed regression are evaluated from explicit
+per-family baseline and optimized scores.
+
+Each rung supplies its own availability, exhaustion state, estimated cost, and
+estimated gain. The planner walks GEPA, SFT, DPO, then GRPO and selects the first
+available, unexhausted rung whose estimates fit the remaining dev gap and
+budget. This lets a documented GEPA plateau advance to training without
+pretending that a hard-coded gain is measured evidence. All returned estimates
+remain labelled estimates, and `target_met` is not a promotion decision.

--- a/src/method-ladder/index.ts
+++ b/src/method-ladder/index.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+export const METHOD_LADDER_INPUT_SCHEMA = "understudy.method_ladder.input.v2" as const;
+export const METHOD_LADDER_RECOMMENDATION_SCHEMA = "understudy.method_ladder.recommendation.v2" as const;
+export const OUTCOMES = ["target_met", "continue_gepa", "escalate_sft", "escalate_dpo", "escalate_grpo", "blocked"] as const;
+export type Outcome = (typeof OUTCOMES)[number];
+
+const Hash = z.string().regex(/^[0-9a-f]{64}$/);
+const Score = z.number().min(0).max(1);
+
+const Binding = z.object({
+  source_binding_sha256: Hash,
+  verifier_sha256: Hash,
+  benchmark_sha256: Hash,
+  split_manifest_sha256: Hash,
+}).strict();
+
+const DevReceipt = Binding.extend({
+  receipt_sha256: Hash,
+  split: z.literal("dev"),
+  aggregate_score: Score,
+  family_scores: z.record(z.string().min(1), Score),
+}).strict();
+
+const BoundStatus = Binding.extend({
+  receipt_sha256: Hash,
+  status: z.enum(["pass", "fail"]),
+}).strict();
+
+const VerifierTrust = BoundStatus.extend({
+  trusted: z.boolean(),
+}).strict();
+
+const Difficulty = Binding.extend({
+  receipt_sha256: Hash,
+  status: z.enum(["sufficient", "insufficient", "blocked"]),
+  headroom_rows: z.number().int().nonnegative(),
+  frontier_also_fails: z.boolean(),
+}).strict();
+
+const ProtectedFamily = z.object({
+  family: z.string().min(1),
+  target_score: Score,
+  max_regression: z.number().min(0).max(1),
+}).strict();
+
+const Rung = z.object({
+  available: z.boolean(),
+  exhausted: z.boolean(),
+  cost_usd: z.number().nonnegative(),
+  expected_gain: z.number().min(0).max(1),
+}).strict();
+
+const Input = z.object({
+  schema_version: z.literal(METHOD_LADDER_INPUT_SCHEMA),
+  target_score: Score,
+  baseline: DevReceipt,
+  optimized: DevReceipt,
+  expected_receipt_hashes: z.object({ baseline: Hash, optimized: Hash }).strict(),
+  verifier_trust: VerifierTrust,
+  difficulty: Difficulty,
+  arm_evidence: BoundStatus,
+  serving_parity: BoundStatus,
+  protected_families: z.array(ProtectedFamily),
+  budget: z.object({
+    remaining_usd: z.number().nonnegative(),
+    rungs: z.object({
+      gepa: Rung,
+      sft: Rung,
+      dpo: Rung,
+      grpo: Rung,
+    }).strict(),
+  }).strict(),
+}).strict();
+
+export type MethodLadderInput = z.infer<typeof Input>;
+export type Recommendation = {
+  schema_version: typeof METHOD_LADDER_RECOMMENDATION_SCHEMA;
+  outcome: Outcome;
+  rationale: string[];
+  estimates_are_estimates: true;
+  input_sha256: string;
+};
+
+function canonical(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, child]) => `${JSON.stringify(key)}:${canonical(child)}`)
+    .join(",")}}`;
+}
+
+export function sha256(value: unknown): string {
+  return createHash("sha256").update(canonical(value)).digest("hex");
+}
+
+function sameBinding(expected: z.infer<typeof Binding>, actual: z.infer<typeof Binding>): boolean {
+  return expected.source_binding_sha256 === actual.source_binding_sha256
+    && expected.verifier_sha256 === actual.verifier_sha256
+    && expected.benchmark_sha256 === actual.benchmark_sha256
+    && expected.split_manifest_sha256 === actual.split_manifest_sha256;
+}
+
+function bindingOf(value: z.infer<typeof Binding>): z.infer<typeof Binding> {
+  return {
+    source_binding_sha256: value.source_binding_sha256,
+    verifier_sha256: value.verifier_sha256,
+    benchmark_sha256: value.benchmark_sha256,
+    split_manifest_sha256: value.split_manifest_sha256,
+  };
+}
+
+export function recommendMethod(input: unknown): Recommendation {
+  const parsed = Input.parse(input);
+  const input_sha256 = sha256(parsed);
+  const result = (outcome: Outcome, rationale: string[]): Recommendation => ({
+    schema_version: METHOD_LADDER_RECOMMENDATION_SCHEMA,
+    outcome,
+    rationale,
+    estimates_are_estimates: true,
+    input_sha256,
+  });
+  const blocked = (reason: string): Recommendation => result("blocked", [reason]);
+
+  if (parsed.baseline.receipt_sha256 !== parsed.expected_receipt_hashes.baseline
+      || parsed.optimized.receipt_sha256 !== parsed.expected_receipt_hashes.optimized) {
+    return blocked("receipt hash mismatch");
+  }
+
+  const expectedBinding = bindingOf(parsed.baseline);
+  const boundEvidence = [parsed.optimized, parsed.verifier_trust, parsed.difficulty, parsed.arm_evidence, parsed.serving_parity];
+  if (boundEvidence.some((evidence) => !sameBinding(expectedBinding, bindingOf(evidence)))) {
+    return blocked("source, verifier, benchmark, or split binding mismatch");
+  }
+  if (!parsed.verifier_trust.trusted || parsed.verifier_trust.status !== "pass") {
+    return blocked("verifier trust is not established");
+  }
+  if (parsed.difficulty.status !== "sufficient" || parsed.difficulty.headroom_rows === 0) {
+    return blocked("difficulty calibration does not prove usable headroom");
+  }
+  if (parsed.difficulty.frontier_also_fails) {
+    return blocked("frontier also fails the same dev rows; repair or re-scope the task");
+  }
+  if (parsed.arm_evidence.status !== "pass") return blocked("arm evidence gate did not pass");
+  if (parsed.serving_parity.status !== "pass") return blocked("serving parity did not pass");
+  if (parsed.optimized.aggregate_score < parsed.baseline.aggregate_score) {
+    return blocked("optimized aggregate dev score regressed");
+  }
+
+  for (const gate of parsed.protected_families) {
+    const baseline = parsed.baseline.family_scores[gate.family];
+    const optimized = parsed.optimized.family_scores[gate.family];
+    if (baseline === undefined || optimized === undefined) {
+      return blocked(`protected family ${gate.family} is missing from a receipt`);
+    }
+    if (baseline - optimized > gate.max_regression) {
+      return blocked(`protected family ${gate.family} regressed beyond its allowance`);
+    }
+  }
+
+  const protectedTargetsMet = parsed.protected_families.every(
+    (gate) => (parsed.optimized.family_scores[gate.family] ?? -1) >= gate.target_score,
+  );
+  if (parsed.optimized.aggregate_score >= parsed.target_score && protectedTargetsMet) {
+    return result("target_met", ["optimized canonical dev target and protected-family gates are met"]);
+  }
+
+  const gap = Math.max(0, parsed.target_score - parsed.optimized.aggregate_score);
+  const choices: Array<[Exclude<Outcome, "target_met" | "blocked">, keyof MethodLadderInput["budget"]["rungs"]]> = [
+    ["continue_gepa", "gepa"],
+    ["escalate_sft", "sft"],
+    ["escalate_dpo", "dpo"],
+    ["escalate_grpo", "grpo"],
+  ];
+  for (const [outcome, name] of choices) {
+    const rung = parsed.budget.rungs[name];
+    if (!rung.available || rung.exhausted) continue;
+    if (rung.cost_usd > parsed.budget.remaining_usd) continue;
+    if (rung.expected_gain < gap) continue;
+    return result(outcome, [`${name} is the first available, unexhausted rung whose estimates fit the dev gap and budget`]);
+  }
+
+  return blocked("no available unexhausted rung has sufficient estimated gain within budget");
+}

--- a/tests/method-ladder.test.mjs
+++ b/tests/method-ladder.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { METHOD_LADDER_INPUT_SCHEMA, recommendMethod, sha256 } from "../dist/method-ladder/index.js";
+
+const a = "a".repeat(64);
+const b = "b".repeat(64);
+const binding = {
+  source_binding_sha256: a,
+  verifier_sha256: a,
+  benchmark_sha256: a,
+  split_manifest_sha256: a,
+};
+
+function input(overrides = {}) {
+  return {
+    schema_version: METHOD_LADDER_INPUT_SCHEMA,
+    target_score: 0.9,
+    baseline: { ...binding, receipt_sha256: a, split: "dev", aggregate_score: 0.7, family_scores: { direct: 0.8, unmatched: 1 } },
+    optimized: { ...binding, receipt_sha256: b, split: "dev", aggregate_score: 0.8, family_scores: { direct: 0.85, unmatched: 1 } },
+    expected_receipt_hashes: { baseline: a, optimized: b },
+    verifier_trust: { ...binding, receipt_sha256: a, status: "pass", trusted: true },
+    difficulty: { ...binding, receipt_sha256: a, status: "sufficient", headroom_rows: 20, frontier_also_fails: false },
+    arm_evidence: { ...binding, receipt_sha256: a, status: "pass" },
+    serving_parity: { ...binding, receipt_sha256: a, status: "pass" },
+    protected_families: [
+      { family: "direct", target_score: 0.85, max_regression: 0 },
+      { family: "unmatched", target_score: 1, max_regression: 0 },
+    ],
+    budget: {
+      remaining_usd: 100,
+      rungs: {
+        gepa: { available: true, exhausted: false, cost_usd: 20, expected_gain: 0.15 },
+        sft: { available: true, exhausted: false, cost_usd: 60, expected_gain: 0.25 },
+        dpo: { available: true, exhausted: false, cost_usd: 70, expected_gain: 0.2 },
+        grpo: { available: true, exhausted: false, cost_usd: 90, expected_gain: 0.3 },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("generic outcome-first method ladder", () => {
+  it("continues GEPA when it is the first plausible rung", () => {
+    assert.equal(recommendMethod(input()).outcome, "continue_gepa");
+  });
+
+  it("escalates to SFT after GEPA is explicitly exhausted", () => {
+    const value = input();
+    value.budget.rungs.gepa.exhausted = true;
+    assert.equal(recommendMethod(value).outcome, "escalate_sft");
+  });
+
+  it("reports target_met without promotion vocabulary", () => {
+    const value = input({ target_score: 0.8 });
+    const recommendation = recommendMethod(value);
+    assert.equal(recommendation.outcome, "target_met");
+    assert.ok(!JSON.stringify(recommendation).includes("promot"));
+  });
+
+  it("rejects unknown and holdout-shaped input", () => {
+    assert.throws(() => recommendMethod({ ...input(), unknown: true }));
+    assert.throws(() => recommendMethod({ ...input(), holdout: { status: "sealed_not_run" } }));
+    assert.throws(() => recommendMethod({ ...input(), optimized: { ...input().optimized, split: "holdout" } }));
+  });
+
+  it("fails closed on every binding mismatch", () => {
+    for (const key of Object.keys(binding)) {
+      const value = input();
+      value.serving_parity = { ...value.serving_parity, [key]: b };
+      assert.equal(recommendMethod(value).outcome, "blocked", key);
+    }
+  });
+
+  it("fails closed on trust, parity, arm, and difficulty gates", () => {
+    for (const mutate of [
+      (value) => { value.verifier_trust.trusted = false; },
+      (value) => { value.serving_parity.status = "fail"; },
+      (value) => { value.arm_evidence.status = "fail"; },
+      (value) => { value.difficulty.status = "insufficient"; },
+    ]) {
+      const value = input();
+      mutate(value);
+      assert.equal(recommendMethod(value).outcome, "blocked");
+    }
+  });
+
+  it("requires every protected family and refuses regression", () => {
+    const missing = input();
+    delete missing.optimized.family_scores.unmatched;
+    assert.equal(recommendMethod(missing).outcome, "blocked");
+
+    const regressed = input();
+    regressed.optimized.family_scores.direct = 0.7;
+    assert.equal(recommendMethod(regressed).outcome, "blocked");
+  });
+
+  it("blocks when every rung is exhausted, unavailable, underpowered, or over budget", () => {
+    const value = input({ budget: {
+      remaining_usd: 10,
+      rungs: {
+        gepa: { available: true, exhausted: true, cost_usd: 1, expected_gain: 1 },
+        sft: { available: false, exhausted: false, cost_usd: 1, expected_gain: 1 },
+        dpo: { available: true, exhausted: false, cost_usd: 20, expected_gain: 1 },
+        grpo: { available: true, exhausted: false, cost_usd: 1, expected_gain: 0.01 },
+      },
+    } });
+    assert.equal(recommendMethod(value).outcome, "blocked");
+  });
+
+  it("uses canonical hashes independent of key order", () => {
+    assert.equal(sha256({ b: 2, a: 1 }), sha256({ a: 1, b: 2 }));
+  });
+});


### PR DESCRIPTION
## Summary
- add generic outcome-first planner over hash-bound dev receipts
- fail closed on trust, parity, arm, protected-family, hash, and regression gates
- add synthetic tests and operator reference

## Validation
- npm run build
- node --test tests/method-ladder.test.mjs
- npm run skills:validate
- git diff --check

Planner has no provider calls or holdout access and emits only the permitted outcomes.