### PR TITLE
docs: integrate outcome-first replacement workflow

### DIFF
--- a/skills/operate-benchmark-lab/SKILL.md
+++ b/skills/operate-benchmark-lab/SKILL.md
@@ -78,6 +78,35 @@ MCP registration (Claude Code `~/.claude.json` → `mcpServers`):
   never rejected a wrong answer has not been tested; do not regrade or
   calibrate against it.
 
+## Outcome-first replacement loop
+
+When the requested result is “meet or beat the incumbent” rather than merely
+“run this model,” operate one hash-bound decision loop:
+
+1. Bind each task, history, trajectory, final effects, and outcome contract to
+   one authoritative source execution. Do not optimize ambiguous or
+   reconstructed rows.
+2. Calibrate the verifier with a known-valid oracle and plausible wrong
+   sentinels, then calibrate difficulty to prove measurable dev headroom.
+3. Freeze immutable train, dev, and holdout boundaries. Optimize on train,
+   make method decisions from canonical dev receipts, and leave holdout
+   untouched until an explicitly authorized promotion evaluation.
+4. Measure the incumbent and candidate through the same canonical serving
+   contract. Preserve per-family scores, cost, latency, failures, and hashes;
+   aggregate-only evidence is insufficient for regression gates.
+5. Run GEPA only after those gates pass. Feed its canonical dev receipt into
+   the fail-closed method ladder to decide whether to continue GEPA or advance
+   to SFT, DPO, or GRPO within the remaining budget.
+6. Before any promotion claim, require serving parity, strict arm evidence,
+   protected-family no-regression, immutable artifacts, and an authorized
+   fresh holdout receipt. `target_met` on dev is a candidate-selection result,
+   not production evidence.
+
+The exact contracts, failure boundaries, and current executor integration
+status are in [`references/outcome-first-replacement-loop.md`](references/outcome-first-replacement-loop.md).
+The method-ladder decision contract is in
+[`references/method-ladder.md`](references/method-ladder.md).
+
 ## The lifecycle
 
 0. **Intake (dropped workloads).** When the user drops a folder or file into

--- a/skills/operate-benchmark-lab/references/outcome-first-replacement-loop.md
+++ b/skills/operate-benchmark-lab/references/outcome-first-replacement-loop.md
@@ -1,0 +1,60 @@
+# Outcome-first replacement loop
+
+Use this path when the goal is a reproducible workload replacement rather than
+a leaderboard-style model sweep. The unit of progress is a hash-bound evidence
+packet that can support the next decision without weakening provenance,
+serving parity, or holdout boundaries.
+
+## Evidence spine
+
+| Stage | Required evidence | Fail-closed boundary |
+| --- | --- | --- |
+| Source binding | One exact execution binds prompt and history, trajectory, final effects, and outcome contract | Ambiguous parentage, mixed executions, or reconstructed history blocks the row |
+| Verifier calibration | Known-valid oracle passes; plausible wrong sentinels fail; verifier receipt is hash-bound | An untested or permissive verifier blocks scoring and optimization |
+| Immutable splits | Source, benchmark, verifier, and split-manifest hashes; explicit train/dev/holdout membership | Split drift, overlap, or missing hashes blocks comparison |
+| Canonical baseline | Incumbent and candidate use the same serving contract; aggregate and family scores, cost, latency, and failure clusters are retained | Provider/adapter mismatch or aggregate-only evidence blocks a quality claim |
+| GEPA | Train-only mutation plus canonical dev evaluation, bounded by calls, episodes, spend, and wall-clock limits | No mutation may advance from an untrusted minibatch or noncanonical evaluator |
+| Method ladder | Hash-matched baseline and optimized dev receipts plus verifier trust, difficulty, arm evidence, serving parity, protected families, and remaining budget | Any missing/mismatched receipt returns `blocked`; estimates remain estimates |
+| Promotion | Frozen candidate, serving parity, strict arm evidence, no-regression checks, immutable artifacts, and an explicitly authorized fresh holdout | Dev `target_met` never implies promotion; a previously observed holdout cannot be reused as fresh evidence |
+
+## Decision sequence
+
+1. **Repair provenance first.** Quarantine a corpus when its recorded
+   trajectory cannot satisfy its own contract. More rollouts cannot repair a
+   source DAG or execution-binding defect.
+2. **Prove the scorer discriminates.** Run provider-free oracle and sentinel
+   fixtures before spending. Record the verifier hash and calibration receipt.
+3. **Freeze the experiment identity.** Materialize immutable membership and
+   hashes for train, dev, and holdout. Holdout content and scores stay outside
+   optimizer and planner inputs.
+4. **Establish canonical dev truth.** Run baseline and candidate through the
+   serving envelope intended for comparison. Record per-row receipts and derive
+   aggregate and protected-family metrics from them.
+5. **Optimize and checkpoint.** GEPA mutates from train evidence and evaluates
+   candidates on canonical dev. Persist checkpoints before publishing live
+   visualizer state; terminal or spend-incomplete checkpoints are not resumable
+   evidence.
+6. **Choose the next rung.** Call the public `recommendMethod` API from
+   `src/method-ladder/index.ts` (also exported from the package entrypoint).
+   It selects the first available, unexhausted GEPA, SFT, DPO, or GRPO rung
+   whose estimated gain and cost fit the remaining dev gap and budget.
+7. **Promote separately.** Freeze the selected candidate, verify serving parity
+   and arm evidence again, then request explicit authority for a fresh
+   hash-bound holdout evaluation. Report dev and holdout evidence separately.
+
+## Runtime integration status
+
+The method-ladder planner and provider-free baseline/GEPA execution primitives
+are public and merged in PRs #449 and #450. Their schemas, planner/executor
+functions, authority-bound receipt types, checkpoint types, and adapter
+interfaces are exported from the package entrypoint. Baseline fanout operates
+only on canonical dev; GEPA accepts train context and derives scores from a
+complete set of authority-verified canonical-dev row receipts. Both enforce
+bounded calls, episodes, spend, wall-clock execution, durable terminal
+checkpoints, and protected-family gates.
+
+These primitives intentionally supply no provider implementation, holdout
+execution, or promotion path. The planner's `target_met` result means only that
+canonical dev target and protected-family gates are met. Provider adapters and
+any independently authorized fresh-holdout/promotion lane remain separate,
+reviewed integrations.

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,40 @@ export {
   type ExperimentRequest,
   type ExperimentSubmitRequest,
 } from "./experiment-executor.js";
+export {
+  METHOD_LADDER_INPUT_SCHEMA,
+  METHOD_LADDER_RECOMMENDATION_SCHEMA,
+  OUTCOMES,
+  recommendMethod,
+  sha256 as sha256MethodLadderInput,
+  type MethodLadderInput,
+  type Outcome as MethodLadderOutcome,
+  type Recommendation as MethodLadderRecommendation,
+} from "./method-ladder/index.js";
+export {
+  BASELINE_FANOUT_SCHEMA,
+  GEPA_CONTROLLER_SCHEMA,
+  GEPA_VIZ_SCHEMA,
+  executeBaselineFanout,
+  idempotencyKey as outcomeExecutorIdempotencyKey,
+  planBaselineFanout,
+  runGepaHillclimb,
+  sha256 as sha256OutcomeExecutorInput,
+  type BaselineCheckpoint,
+  type BaselineInput,
+  type BaselinePlan,
+  type ExecutionAdapter,
+  type ExecutionResult,
+  type Fuse as OutcomeExecutorFuse,
+  type GepaCheckpoint,
+  type GepaEvaluation,
+  type GepaInput,
+  type GepaProposal,
+  type GepaRowReceipt,
+  type GepaVizManifest,
+  type Hooks as OutcomeExecutorHooks,
+  type StoredCall,
+} from "./outcome-executors/index.js";
 
 export const repoRoot = installedPackageRoot();
 

--- a/tests/outcome-workflow-integration.test.mjs
+++ b/tests/outcome-workflow-integration.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import {
+  BASELINE_FANOUT_SCHEMA,
+  GEPA_CONTROLLER_SCHEMA,
+  METHOD_LADDER_INPUT_SCHEMA,
+  executeBaselineFanout,
+  planBaselineFanout,
+  recommendMethod,
+  runGepaHillclimb,
+  sha256OutcomeExecutorInput,
+} from "../dist/index.js";
+
+const hash = (letter) => letter.repeat(64);
+const binding = {
+  source_binding_sha256: hash("a"),
+  verifier_calibration_sha256: hash("b"),
+  benchmark_sha256: hash("c"),
+  split_manifest_sha256: hash("d"),
+  train_sha256: hash("e"),
+  dev_sha256: hash("f"),
+  holdout_sha256: null,
+};
+const fuse = {
+  max_concurrency: 2,
+  max_metric_calls: 4,
+  max_spend_usd: 4,
+  max_cost_per_call_usd: 1,
+  max_wallclock_ms: 10_000,
+  max_episodes: 4,
+  max_reflections: 4,
+};
+const devRows = [
+  { id: "d1", split: "dev", family: "direct", frozen: false },
+  { id: "d2", split: "dev", family: "unmatched", frozen: false },
+];
+const incumbent = { candidate_id: "incumbent", candidate_sha256: hash("1") };
+const seed = { candidate_id: "student-seed", candidate_sha256: hash("2") };
+
+function receipts(context, direct, unmatched) {
+  return [
+    { row_id: "d1", family: "direct", metric: direct },
+    { row_id: "d2", family: "unmatched", metric: unmatched },
+  ].map((row) => {
+    const body = {
+      controller_sha256: context.controller_sha256,
+      candidate_sha256: context.candidate.candidate_sha256,
+      wave: context.wave,
+      dev_sha256: context.dev_sha256,
+      verifier_calibration_sha256: context.verifier_calibration_sha256,
+      ...row,
+      status: "ok",
+    };
+    return { ...body, receipt_sha256: sha256OutcomeExecutorInput(body) };
+  });
+}
+
+it("runs the provider-free outcome-first dev loop and stops at target without holdout or promotion", async () => {
+  const baselinePlan = planBaselineFanout({
+    schema_version: BASELINE_FANOUT_SCHEMA,
+    run_id: "outcome-audit-baseline",
+    workload_id: "synthetic-outcome",
+    ...binding,
+    rows: devRows,
+    candidates: [seed],
+    incumbent,
+    protected_families: [
+      { family: "direct", target_score: 0.8, max_regression: 0 },
+      { family: "unmatched", target_score: 1, max_regression: 0 },
+    ],
+    target_score: 0.95,
+    fuse,
+  });
+  const baseline = await executeBaselineFanout(baselinePlan, async (candidate, row) => ({
+    status: "ok",
+    metric: candidate.candidate_id === "incumbent" ? (row.family === "direct" ? 0.8 : 1) : (row.family === "direct" ? 0.82 : 1),
+    cost_usd: 0,
+    latency_ms: 1,
+  }));
+  assert.equal(baseline.state, "completed");
+  assert.equal(baseline.target_candidate_id, null);
+
+  const gepa = await runGepaHillclimb({
+    input: {
+      schema_version: GEPA_CONTROLLER_SCHEMA,
+      run_id: "outcome-audit-gepa",
+      workload_id: "synthetic-outcome",
+      ...binding,
+      train_rows: [{ id: "t1", split: "train", family: "direct", frozen: false }],
+      dev_rows: devRows,
+      seed,
+      seed_dev_quality: 0.91,
+      seed_family_scores: { direct: 0.82, unmatched: 1 },
+      protected_families: [
+        { family: "direct", target_score: 0.8, max_regression: 0 },
+        { family: "unmatched", target_score: 1, max_regression: 0 },
+      ],
+      target_score: 0.95,
+      fuse,
+    },
+    verifyEvaluationReceipt: () => true,
+    propose: async () => ({ status: "ok", candidate: { candidate_id: "student-optimized", candidate_sha256: hash("3") }, cost_usd: 0, latency_ms: 1 }),
+    evaluate: async (context) => ({ status: "ok", rows: receipts(context, 0.9, 1), cost_usd: 0, latency_ms: 1 }),
+  });
+  assert.equal(gepa.state, "target_reached");
+  assert.equal(gepa.best_dev_quality, 0.95);
+  assert.equal(gepa.spend_usd, 0);
+
+  const baselineReceipt = hash("4");
+  const optimizedReceipt = hash("5");
+  const ladderBinding = {
+    source_binding_sha256: binding.source_binding_sha256,
+    verifier_sha256: binding.verifier_calibration_sha256,
+    benchmark_sha256: binding.benchmark_sha256,
+    split_manifest_sha256: binding.split_manifest_sha256,
+  };
+  const recommendation = recommendMethod({
+    schema_version: METHOD_LADDER_INPUT_SCHEMA,
+    target_score: 0.95,
+    baseline: { ...ladderBinding, receipt_sha256: baselineReceipt, split: "dev", aggregate_score: 0.91, family_scores: { direct: 0.82, unmatched: 1 } },
+    optimized: { ...ladderBinding, receipt_sha256: optimizedReceipt, split: "dev", aggregate_score: 0.95, family_scores: { direct: 0.9, unmatched: 1 } },
+    expected_receipt_hashes: { baseline: baselineReceipt, optimized: optimizedReceipt },
+    verifier_trust: { ...ladderBinding, receipt_sha256: hash("6"), status: "pass", trusted: true },
+    difficulty: { ...ladderBinding, receipt_sha256: hash("7"), status: "sufficient", headroom_rows: 2, frontier_also_fails: false },
+    arm_evidence: { ...ladderBinding, receipt_sha256: hash("8"), status: "pass" },
+    serving_parity: { ...ladderBinding, receipt_sha256: hash("9"), status: "pass" },
+    protected_families: [
+      { family: "direct", target_score: 0.8, max_regression: 0 },
+      { family: "unmatched", target_score: 1, max_regression: 0 },
+    ],
+    budget: {
+      remaining_usd: 0,
+      rungs: {
+        gepa: { available: true, exhausted: false, cost_usd: 0, expected_gain: 0 },
+        sft: { available: false, exhausted: false, cost_usd: 0, expected_gain: 0 },
+        dpo: { available: false, exhausted: false, cost_usd: 0, expected_gain: 0 },
+        grpo: { available: false, exhausted: false, cost_usd: 0, expected_gain: 0 },
+      },
+    },
+  });
+  assert.equal(recommendation.outcome, "target_met");
+  assert.ok(!JSON.stringify(recommendation).includes("promot"));
+  assert.equal(binding.holdout_sha256, null);
+});


### PR DESCRIPTION
## Summary
- export the merged method-ladder and provider-free baseline/GEPA execution primitives from the package entrypoint
- document the cohesive source-binding -> verifier-calibration -> immutable-split -> canonical-baseline -> GEPA -> method-ladder -> parity/evidence -> separate-promotion workflow
- add a provider-free end-to-end dev audit proving target attainment without holdout execution or promotion vocabulary

## Capability boundary
- no provider implementation
- no holdout execution
- no promotion path
- `target_met` remains canonical-dev evidence only

## Validation
- npm run build
- node --test tests/method-ladder.test.mjs tests/outcome-executors.test.mjs tests/outcome-workflow-integration.test.mjs (33/33)
- npm run skills:validate (40/40)
- git diff --check
