### PR TITLE
Add canonical native-tool trajectory adapter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { installedPackageRoot } from "./internal/package-root.js";
 export { compileTraceFoundry, createTraceReplayPlan, importTraceReviews, runTraceReplays } from "./trace-foundry.js";
 export { serveTraceFoundry } from "./trace-foundry-server.js";
 export { buildRejectionGuidance, classifyRejection, computeRecoveryOverJournals, computeRecoveryRates, loadGuidanceFile, readRolloutJournals, synthesizeMinimalExample } from "./rejection-guidance.js";
+export * from "./protocol-trajectory/index.js";
 export {
   ExecutorCancellationReceiptSchema,
   ExecutorJobRefSchema,

--- a/src/protocol-trajectory/index.ts
+++ b/src/protocol-trajectory/index.ts
@@ -232,12 +232,18 @@ function openAiContent(message: Record<string, unknown>, context: string): Canon
 export function decodeAnthropicRequest(body: unknown): CanonicalTrajectory {
   const request = record(body, "Anthropic request");
   const system = request.system === undefined ? [] : anthropicContent(request.system, "system");
-  const messages = array(request.messages, "messages").map((value, index): CanonicalTurn => {
+  const messages = array(request.messages, "messages").flatMap((value, index): CanonicalTurn[] => {
     const message = record(value, `messages[${index}]`);
     const role = string(message.role, `messages[${index}].role`);
     if (role !== "user" && role !== "assistant") throw new ProtocolTrajectoryError("invalid_role", `Unsupported Anthropic role: ${role}`);
     const parts = anthropicContent(message.content, `messages[${index}].content`);
-    return { role: role === "assistant" ? "assistant" : parts.every((part) => part.type === "tool_result") ? "tool" : "user", parts };
+    if (role === "assistant") return [{ role: "assistant", parts }];
+    const results = parts.filter((part): part is CanonicalToolResultPart => part.type === "tool_result");
+    const text = parts.filter((part): part is CanonicalTextPart => part.type === "text");
+    return [
+      ...(results.length ? [{ role: "tool" as const, parts: results }] : []),
+      ...(text.length ? [{ role: "user" as const, parts: text }] : []),
+    ];
   });
   const tools = (request.tools === undefined ? [] : array(request.tools, "tools")).map((value, index): CanonicalToolDefinition => {
     const tool = record(value, `tools[${index}]`);
@@ -339,4 +345,3 @@ export function decodeOpenAIResponse(body: unknown): CanonicalAssistantResponse 
     return part;
   }), stop_reason: stopReason(choice.finish_reason) };
 }
-

--- a/src/protocol-trajectory/index.ts
+++ b/src/protocol-trajectory/index.ts
@@ -1,0 +1,342 @@
+import { createHash } from "node:crypto";
+
+export type JsonSchema = boolean | { [key: string]: unknown };
+
+export type CanonicalTextPart = { type: "text"; text: string };
+export type CanonicalToolCallPart = {
+  type: "tool_call";
+  id: string;
+  name: string;
+  arguments: unknown;
+  raw_arguments?: string;
+};
+export type CanonicalToolResultPart = {
+  type: "tool_result";
+  call_id: string;
+  name?: string;
+  content: unknown;
+  is_error: boolean;
+};
+export type CanonicalPart = CanonicalTextPart | CanonicalToolCallPart | CanonicalToolResultPart;
+
+export type CanonicalTurn = {
+  role: "user" | "assistant" | "tool";
+  parts: CanonicalPart[];
+};
+
+export type CanonicalToolDefinition = {
+  name: string;
+  description?: string;
+  input_schema: JsonSchema;
+};
+
+export type CanonicalTrajectory = {
+  schema_version: "understudy.tool_trajectory.v1";
+  system: CanonicalPart[];
+  messages: CanonicalTurn[];
+  tools: CanonicalToolDefinition[];
+};
+
+export type CanonicalAssistantResponse = {
+  role: "assistant";
+  parts: Array<CanonicalTextPart | CanonicalToolCallPart>;
+  stop_reason: "tool_calls" | "end_turn" | "length" | "content_filter" | "other" | null;
+};
+
+export class ProtocolTrajectoryError extends Error {
+  readonly code: string;
+  readonly details?: unknown;
+
+  constructor(code: string, message: string, details?: unknown) {
+    super(message);
+    this.name = "ProtocolTrajectoryError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ProtocolTrajectoryError("invalid_shape", `${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new ProtocolTrajectoryError("invalid_shape", `${label} must be an array`);
+  return value;
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string") throw new ProtocolTrajectoryError("invalid_shape", `${label} must be a string`);
+  return value;
+}
+
+function stable(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stable(object[key])}`).join(",")}}`;
+}
+
+function fingerprint(value: unknown): string {
+  return createHash("sha256").update(stable(value)).digest("hex");
+}
+
+export function canonicalToolCatalogFingerprint(tools: CanonicalToolDefinition[]): string {
+  return fingerprint(normalizeTools(tools));
+}
+
+export function canonicalTrajectoryFingerprint(trajectory: CanonicalTrajectory): string {
+  validateTrajectory(trajectory);
+  return fingerprint({ ...trajectory, tools: normalizeTools(trajectory.tools) });
+}
+
+function decodePointerToken(token: string): string {
+  return token.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+function resolvePointer(root: unknown, ref: string): unknown {
+  if (ref === "#") return root;
+  if (!ref.startsWith("#/")) {
+    throw new ProtocolTrajectoryError("external_schema_ref", `Only local JSON Schema refs are supported: ${ref}`);
+  }
+  let current = root;
+  for (const token of ref.slice(2).split("/").map(decodePointerToken)) {
+    if (current === null || typeof current !== "object" || !(token in current)) {
+      throw new ProtocolTrajectoryError("missing_schema_ref", `Unresolved local JSON Schema ref: ${ref}`);
+    }
+    current = (current as Record<string, unknown>)[token];
+  }
+  return current;
+}
+
+export function dereferenceLocalJsonSchema(schema: JsonSchema): JsonSchema {
+  const root = schema;
+  const visit = (value: unknown, refs: Set<string>): unknown => {
+    if (Array.isArray(value)) return value.map((entry) => visit(entry, refs));
+    if (value === null || typeof value !== "object") return value;
+    const source = value as Record<string, unknown>;
+    if ("$ref" in source) {
+      const ref = string(source.$ref, "JSON Schema $ref");
+      if (refs.has(ref)) throw new ProtocolTrajectoryError("cyclic_schema_ref", `Cyclic JSON Schema ref: ${ref}`);
+      const siblings = Object.fromEntries(Object.entries(source).filter(([key]) => key !== "$ref"));
+      const target = visit(resolvePointer(root, ref), new Set([...refs, ref]));
+      if (Object.keys(siblings).length === 0) return target;
+      if (target === null || typeof target !== "object" || Array.isArray(target)) {
+        throw new ProtocolTrajectoryError("invalid_schema_ref", `Cannot merge sibling keywords into ${ref}`);
+      }
+      return { ...(target as Record<string, unknown>), ...(visit(siblings, refs) as Record<string, unknown>) };
+    }
+    return Object.fromEntries(Object.entries(source).map(([key, entry]) => [key, visit(entry, refs)]));
+  };
+  const result = visit(schema, new Set());
+  return result as JsonSchema;
+}
+
+function normalizeTools(tools: CanonicalToolDefinition[]): CanonicalToolDefinition[] {
+  const names = new Set<string>();
+  return tools.map((tool) => {
+    if (!tool.name || names.has(tool.name)) {
+      throw new ProtocolTrajectoryError("invalid_tool_catalog", `Tool names must be non-empty and unique: ${tool.name}`);
+    }
+    names.add(tool.name);
+    return { ...tool, input_schema: dereferenceLocalJsonSchema(tool.input_schema) };
+  });
+}
+
+export function validateTrajectory(trajectory: CanonicalTrajectory): void {
+  if (trajectory.schema_version !== "understudy.tool_trajectory.v1") {
+    throw new ProtocolTrajectoryError("invalid_schema_version", "Unsupported canonical trajectory schema version");
+  }
+  normalizeTools(trajectory.tools);
+  if (trajectory.system.some((part) => part.type !== "text")) {
+    throw new ProtocolTrajectoryError("invalid_system_part", "Canonical system content may contain only text parts");
+  }
+  const seenCalls = new Set<string>();
+  let pending: string[] = [];
+  for (const turn of trajectory.messages) {
+    if (turn.role === "assistant") {
+      if (turn.parts.some((part) => part.type === "tool_result")) throw new ProtocolTrajectoryError("invalid_turn_part", "Assistant turns cannot contain tool results");
+      if (pending.length) throw new ProtocolTrajectoryError("dropped_tool_result", `Missing results for: ${pending.join(", ")}`);
+      pending = turn.parts.filter((part): part is CanonicalToolCallPart => part.type === "tool_call").map((part) => {
+        if (!part.id || seenCalls.has(part.id)) throw new ProtocolTrajectoryError("invalid_call_id", `Tool call id must be non-empty and unique: ${part.id}`);
+        seenCalls.add(part.id);
+        return part.id;
+      });
+    } else {
+      const requiredType = turn.role === "tool" ? "tool_result" : "text";
+      if (turn.parts.some((part) => part.type !== requiredType)) throw new ProtocolTrajectoryError("invalid_turn_part", `${turn.role} turns may contain only ${requiredType} parts`);
+      for (const part of turn.parts) {
+        if (part.type !== "tool_result") continue;
+        const expected = pending.shift();
+        if (!expected) throw new ProtocolTrajectoryError("orphan_tool_result", `No pending tool call for result ${part.call_id}`);
+        if (part.call_id !== expected) {
+          throw new ProtocolTrajectoryError("tool_result_order", `Expected result ${expected}, received ${part.call_id}`);
+        }
+      }
+    }
+  }
+  if (pending.length) throw new ProtocolTrajectoryError("dropped_tool_result", `Missing results for: ${pending.join(", ")}`);
+}
+
+function parseOpenAiArguments(raw: unknown, context: string): { arguments: unknown } {
+  const rawArguments = string(raw, `${context} arguments`);
+  try {
+    return { arguments: JSON.parse(rawArguments) };
+  } catch (cause) {
+    const part: CanonicalToolCallPart = { type: "tool_call", id: "", name: "", arguments: null, raw_arguments: rawArguments };
+    throw new ProtocolTrajectoryError("malformed_tool_arguments", `${context} contains malformed JSON arguments`, { raw_arguments: rawArguments, canonical_part: part, cause: String(cause) });
+  }
+}
+
+function decodeOpenAiToolCall(value: unknown, context: string): CanonicalToolCallPart {
+  const call = record(value, context);
+  const fn = record(call.function, `${context}.function`);
+  try {
+    return { type: "tool_call", id: string(call.id, `${context}.id`), name: string(fn.name, `${context}.function.name`), ...parseOpenAiArguments(fn.arguments, context) };
+  } catch (error) {
+    if (error instanceof ProtocolTrajectoryError && error.code === "malformed_tool_arguments") {
+      const details = record(error.details, "malformed argument details");
+      details.canonical_part = { type: "tool_call", id: call.id, name: fn.name, arguments: null, raw_arguments: details.raw_arguments };
+    }
+    throw error;
+  }
+}
+
+function anthropicContent(value: unknown, context: string): CanonicalPart[] {
+  if (typeof value === "string") return [{ type: "text", text: value }];
+  return array(value, context).map((entry, index) => {
+    const block = record(entry, `${context}[${index}]`);
+    if (block.type === "text") return { type: "text", text: string(block.text, `${context}[${index}].text`) };
+    if (block.type === "tool_use") return { type: "tool_call", id: string(block.id, `${context}[${index}].id`), name: string(block.name, `${context}[${index}].name`), arguments: block.input };
+    if (block.type === "tool_result") return { type: "tool_result", call_id: string(block.tool_use_id, `${context}[${index}].tool_use_id`), content: block.content, is_error: block.is_error === true };
+    throw new ProtocolTrajectoryError("unsupported_content", `Unsupported Anthropic content block: ${String(block.type)}`);
+  });
+}
+
+function openAiContent(message: Record<string, unknown>, context: string): CanonicalPart[] {
+  const parts: CanonicalPart[] = [];
+  if (typeof message.content === "string" && message.content.length) parts.push({ type: "text", text: message.content });
+  if (Array.isArray(message.content)) {
+    for (const [index, value] of message.content.entries()) {
+      const block = record(value, `${context}.content[${index}]`);
+      if (block.type !== "text") throw new ProtocolTrajectoryError("unsupported_content", `Unsupported OpenAI content part: ${String(block.type)}`);
+      parts.push({ type: "text", text: string(block.text, `${context}.content[${index}].text`) });
+    }
+  }
+  if (Array.isArray(message.tool_calls)) message.tool_calls.forEach((call, index) => parts.push(decodeOpenAiToolCall(call, `${context}.tool_calls[${index}]`)));
+  return parts;
+}
+
+export function decodeAnthropicRequest(body: unknown): CanonicalTrajectory {
+  const request = record(body, "Anthropic request");
+  const system = request.system === undefined ? [] : anthropicContent(request.system, "system");
+  const messages = array(request.messages, "messages").map((value, index): CanonicalTurn => {
+    const message = record(value, `messages[${index}]`);
+    const role = string(message.role, `messages[${index}].role`);
+    if (role !== "user" && role !== "assistant") throw new ProtocolTrajectoryError("invalid_role", `Unsupported Anthropic role: ${role}`);
+    const parts = anthropicContent(message.content, `messages[${index}].content`);
+    return { role: role === "assistant" ? "assistant" : parts.every((part) => part.type === "tool_result") ? "tool" : "user", parts };
+  });
+  const tools = (request.tools === undefined ? [] : array(request.tools, "tools")).map((value, index): CanonicalToolDefinition => {
+    const tool = record(value, `tools[${index}]`);
+    return { name: string(tool.name, `tools[${index}].name`), ...(typeof tool.description === "string" ? { description: tool.description } : {}), input_schema: dereferenceLocalJsonSchema(tool.input_schema as JsonSchema) };
+  });
+  const trajectory: CanonicalTrajectory = { schema_version: "understudy.tool_trajectory.v1", system, messages, tools };
+  validateTrajectory(trajectory);
+  return trajectory;
+}
+
+export function decodeOpenAIRequest(body: unknown): CanonicalTrajectory {
+  const request = record(body, "OpenAI request");
+  const system: CanonicalPart[] = [];
+  const messages: CanonicalTurn[] = [];
+  for (const [index, value] of array(request.messages, "messages").entries()) {
+    const message = record(value, `messages[${index}]`);
+    const role = string(message.role, `messages[${index}].role`);
+    if (role === "system") { system.push(...openAiContent(message, `messages[${index}]`)); continue; }
+    if (role === "tool") {
+      const part: CanonicalToolResultPart = { type: "tool_result", call_id: string(message.tool_call_id, `messages[${index}].tool_call_id`), content: message.content, is_error: message.is_error === true };
+      const previous = messages.at(-1);
+      if (previous?.role === "tool") previous.parts.push(part);
+      else messages.push({ role: "tool", parts: [part] });
+      continue;
+    }
+    if (role !== "user" && role !== "assistant") throw new ProtocolTrajectoryError("invalid_role", `Unsupported OpenAI role: ${role}`);
+    messages.push({ role, parts: openAiContent(message, `messages[${index}]`) });
+  }
+  const tools = (request.tools === undefined ? [] : array(request.tools, "tools")).map((value, index): CanonicalToolDefinition => {
+    const wrapper = record(value, `tools[${index}]`);
+    if (wrapper.type !== "function") throw new ProtocolTrajectoryError("invalid_tool_catalog", "Only OpenAI function tools are supported");
+    const fn = record(wrapper.function, `tools[${index}].function`);
+    return { name: string(fn.name, `tools[${index}].function.name`), ...(typeof fn.description === "string" ? { description: fn.description } : {}), input_schema: dereferenceLocalJsonSchema(fn.parameters as JsonSchema) };
+  });
+  const trajectory: CanonicalTrajectory = { schema_version: "understudy.tool_trajectory.v1", system, messages, tools };
+  validateTrajectory(trajectory);
+  return trajectory;
+}
+
+function anthropicBlocks(parts: CanonicalPart[]): unknown[] {
+  return parts.map((part) => part.type === "text" ? { type: "text", text: part.text } : part.type === "tool_call" ? { type: "tool_use", id: part.id, name: part.name, input: part.arguments } : { type: "tool_result", tool_use_id: part.call_id, content: part.content, ...(part.is_error ? { is_error: true } : {}) });
+}
+
+export function encodeAnthropicRequest(trajectory: CanonicalTrajectory, options: Record<string, unknown> = {}): Record<string, unknown> {
+  validateTrajectory(trajectory);
+  return {
+    ...options,
+    system: anthropicBlocks(trajectory.system),
+    messages: trajectory.messages.map((turn) => ({ role: turn.role === "tool" ? "user" : turn.role, content: anthropicBlocks(turn.parts) })),
+    tools: normalizeTools(trajectory.tools).map((tool) => ({ name: tool.name, ...(tool.description ? { description: tool.description } : {}), input_schema: tool.input_schema })),
+  };
+}
+
+function openAiText(parts: CanonicalPart[]): string | Array<{ type: "text"; text: string }> | null {
+  const text = parts.filter((part): part is CanonicalTextPart => part.type === "text");
+  if (text.length === 0) return null;
+  if (text.length === 1) return text[0]!.text;
+  return text.map((part) => ({ type: "text", text: part.text }));
+}
+
+export function encodeOpenAIRequest(trajectory: CanonicalTrajectory, options: Record<string, unknown> = {}): Record<string, unknown> {
+  validateTrajectory(trajectory);
+  const messages: unknown[] = [];
+  if (trajectory.system.length) messages.push({ role: "system", content: openAiText(trajectory.system) });
+  for (const turn of trajectory.messages) {
+    if (turn.role === "tool") {
+      for (const part of turn.parts) if (part.type === "tool_result") messages.push({ role: "tool", tool_call_id: part.call_id, ...(part.name ? { name: part.name } : {}), content: typeof part.content === "string" ? part.content : stable(part.content), ...(part.is_error ? { is_error: true } : {}) });
+      continue;
+    }
+    const calls = turn.parts.filter((part): part is CanonicalToolCallPart => part.type === "tool_call");
+    messages.push({ role: turn.role, content: openAiText(turn.parts), ...(calls.length ? { tool_calls: calls.map((call) => ({ id: call.id, type: "function", function: { name: call.name, arguments: call.raw_arguments ?? stable(call.arguments) } })) } : {}) });
+  }
+  return { ...options, messages, tools: normalizeTools(trajectory.tools).map((tool) => ({ type: "function", function: { name: tool.name, ...(tool.description ? { description: tool.description } : {}), parameters: tool.input_schema } })) };
+}
+
+function stopReason(value: unknown): CanonicalAssistantResponse["stop_reason"] {
+  if (value === null || value === undefined) return null;
+  if (value === "tool_use" || value === "tool_calls") return "tool_calls";
+  if (value === "end_turn" || value === "stop") return "end_turn";
+  if (value === "max_tokens" || value === "length") return "length";
+  if (value === "content_filter") return "content_filter";
+  return "other";
+}
+
+export function decodeAnthropicResponse(body: unknown): CanonicalAssistantResponse {
+  const response = record(body, "Anthropic response");
+  return { role: "assistant", parts: anthropicContent(response.content, "content").map((part) => {
+    if (part.type === "tool_result") throw new ProtocolTrajectoryError("invalid_response", "Assistant response cannot contain tool results");
+    return part;
+  }), stop_reason: stopReason(response.stop_reason) };
+}
+
+export function decodeOpenAIResponse(body: unknown): CanonicalAssistantResponse {
+  const response = record(body, "OpenAI response");
+  const choice = record(array(response.choices, "choices")[0], "choices[0]");
+  const message = record(choice.message, "choices[0].message");
+  return { role: "assistant", parts: openAiContent(message, "choices[0].message").map((part) => {
+    if (part.type === "tool_result") throw new ProtocolTrajectoryError("invalid_response", "Assistant response cannot contain tool results");
+    return part;
+  }), stop_reason: stopReason(choice.finish_reason) };
+}
+

--- a/tests/protocol-trajectory.test.mjs
+++ b/tests/protocol-trajectory.test.mjs
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ProtocolTrajectoryError,
+  canonicalToolCatalogFingerprint,
+  canonicalTrajectoryFingerprint,
+  decodeAnthropicRequest,
+  decodeAnthropicResponse,
+  decodeOpenAIRequest,
+  decodeOpenAIResponse,
+  dereferenceLocalJsonSchema,
+  encodeAnthropicRequest,
+  encodeOpenAIRequest,
+  validateTrajectory,
+} from "../dist/protocol-trajectory/index.js";
+
+const tools = [{
+  name: "lookup",
+  description: "Look up records",
+  input_schema: {
+    $defs: {
+      query: {
+        type: "object",
+        properties: { values: { type: "array", items: {} }, label: { type: ["string", "null"] } },
+        required: ["values", "label"],
+      },
+    },
+    $ref: "#/$defs/query",
+  },
+}];
+
+const canonical = {
+  schema_version: "understudy.tool_trajectory.v1",
+  system: [{ type: "text", text: "Use tools carefully. 世界" }],
+  tools: [{
+    name: "lookup",
+    description: "Look up records",
+    input_schema: {
+      $defs: { query: { type: "object", properties: { values: { type: "array", items: {} }, label: { type: ["string", "null"] } }, required: ["values", "label"] } },
+      type: "object",
+      properties: { values: { type: "array", items: {} }, label: { type: ["string", "null"] } },
+      required: ["values", "label"],
+    },
+  }],
+  messages: [
+    { role: "user", parts: [{ type: "text", text: "Find α and β" }] },
+    { role: "assistant", parts: [
+      { type: "text", text: "Checking. " },
+      { type: "tool_call", id: "call-1", name: "lookup", arguments: { values: ["α", null, [1, 2]], label: null } },
+      { type: "tool_call", id: "call-2", name: "lookup", arguments: ["β", null] },
+    ] },
+    { role: "tool", parts: [
+      { type: "tool_result", call_id: "call-1", content: "found α", is_error: false },
+      { type: "tool_result", call_id: "call-2", content: "timeout", is_error: true },
+    ] },
+    { role: "assistant", parts: [{ type: "tool_call", id: "call-3", name: "lookup", arguments: { values: [], label: "retry" } }] },
+    { role: "tool", parts: [{ type: "tool_result", call_id: "call-3", content: "found β", is_error: false }] },
+    { role: "assistant", parts: [{ type: "text", text: "Done: α, β." }] },
+  ],
+};
+
+function anthropicFixture() {
+  return {
+    system: [{ type: "text", text: "Use tools carefully. 世界" }],
+    tools: tools.map((tool) => ({ name: tool.name, description: tool.description, input_schema: tool.input_schema })),
+    messages: [
+      { role: "user", content: [{ type: "text", text: "Find α and β" }] },
+      { role: "assistant", content: [
+        { type: "text", text: "Checking. " },
+        { type: "tool_use", id: "call-1", name: "lookup", input: { values: ["α", null, [1, 2]], label: null } },
+        { type: "tool_use", id: "call-2", name: "lookup", input: ["β", null] },
+      ] },
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "call-1", content: "found α" },
+        { type: "tool_result", tool_use_id: "call-2", content: "timeout", is_error: true },
+      ] },
+      { role: "assistant", content: [{ type: "tool_use", id: "call-3", name: "lookup", input: { values: [], label: "retry" } }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "call-3", content: "found β" }] },
+      { role: "assistant", content: [{ type: "text", text: "Done: α, β." }] },
+    ],
+  };
+}
+
+function openAiFixture() {
+  return {
+    tools: tools.map((tool) => ({ type: "function", function: { name: tool.name, description: tool.description, parameters: tool.input_schema } })),
+    messages: [
+      { role: "system", content: "Use tools carefully. 世界" },
+      { role: "user", content: "Find α and β" },
+      { role: "assistant", content: "Checking. ", tool_calls: [
+        { id: "call-1", type: "function", function: { name: "lookup", arguments: JSON.stringify({ values: ["α", null, [1, 2]], label: null }) } },
+        { id: "call-2", type: "function", function: { name: "lookup", arguments: JSON.stringify(["β", null]) } },
+      ] },
+      { role: "tool", name: "lookup", tool_call_id: "call-1", content: "found α" },
+      { role: "tool", name: "lookup", tool_call_id: "call-2", content: "timeout", is_error: true },
+      { role: "assistant", content: null, tool_calls: [{ id: "call-3", type: "function", function: { name: "lookup", arguments: JSON.stringify({ values: [], label: "retry" }) } }] },
+      { role: "tool", name: "lookup", tool_call_id: "call-3", content: "found β" },
+      { role: "assistant", content: "Done: α, β." },
+    ],
+  };
+}
+
+test("golden Anthropic and OpenAI requests decode to one canonical trajectory", () => {
+  const anthropic = decodeAnthropicRequest(anthropicFixture());
+  const openai = decodeOpenAIRequest(openAiFixture());
+  assert.deepEqual(openai, anthropic);
+  assert.deepEqual(anthropic, canonical);
+  assert.equal(canonicalTrajectoryFingerprint(openai), canonicalTrajectoryFingerprint(anthropic));
+});
+
+test("canonical request round trips through both native tool protocols", () => {
+  assert.deepEqual(decodeAnthropicRequest(encodeAnthropicRequest(canonical, { model: "anthropic-model" })), canonical);
+  assert.deepEqual(decodeOpenAIRequest(encodeOpenAIRequest(canonical, { model: "openai-model" })), canonical);
+});
+
+test("structured system and message text-part boundaries survive both protocols", () => {
+  const structured = {
+    schema_version: "understudy.tool_trajectory.v1",
+    system: [{ type: "text", text: "first" }, { type: "text", text: "second" }],
+    tools: [],
+    messages: [{ role: "user", parts: [{ type: "text", text: "a" }, { type: "text", text: "b" }] }],
+  };
+  assert.deepEqual(decodeAnthropicRequest(encodeAnthropicRequest(structured)), structured);
+  assert.deepEqual(decodeOpenAIRequest(encodeOpenAIRequest(structured)), structured);
+});
+
+test("non-streaming responses preserve mixed text, parallel calls, ids, and stop state", () => {
+  const expected = {
+    role: "assistant",
+    parts: [
+      { type: "text", text: "Working…" },
+      { type: "tool_call", id: "a", name: "lookup", arguments: { label: null, values: ["世界"] } },
+      { type: "tool_call", id: "b", name: "lookup", arguments: [null, "β"] },
+    ],
+    stop_reason: "tool_calls",
+  };
+  assert.deepEqual(decodeAnthropicResponse({ stop_reason: "tool_use", content: [
+    { type: "text", text: "Working…" },
+    { type: "tool_use", id: "a", name: "lookup", input: { label: null, values: ["世界"] } },
+    { type: "tool_use", id: "b", name: "lookup", input: [null, "β"] },
+  ] }), expected);
+  const openai = decodeOpenAIResponse({ choices: [{ finish_reason: "tool_calls", message: { content: "Working…", tool_calls: [
+    { id: "a", type: "function", function: { name: "lookup", arguments: JSON.stringify({ label: null, values: ["世界"] }) } },
+    { id: "b", type: "function", function: { name: "lookup", arguments: JSON.stringify([null, "β"]) } },
+  ] } }] });
+  assert.deepEqual(openai.parts.map(({ raw_arguments, ...part }) => part), expected.parts);
+  assert.equal(openai.stop_reason, expected.stop_reason);
+});
+
+test("malformed OpenAI arguments fail closed while retaining raw evidence", () => {
+  assert.throws(
+    () => decodeOpenAIResponse({ choices: [{ finish_reason: "tool_calls", message: { tool_calls: [{ id: "bad", type: "function", function: { name: "lookup", arguments: '{"x":' } }] } }] }),
+    (error) => {
+      assert.ok(error instanceof ProtocolTrajectoryError);
+      assert.equal(error.code, "malformed_tool_arguments");
+      assert.equal(error.details.raw_arguments, '{"x":');
+      assert.deepEqual(error.details.canonical_part, { type: "tool_call", id: "bad", name: "lookup", arguments: null, raw_arguments: '{"x":' });
+      return true;
+    },
+  );
+});
+
+test("local schema refs dereference deterministically and unsafe refs fail closed", () => {
+  const left = dereferenceLocalJsonSchema({ $defs: { leaf: { type: "string" } }, type: "array", items: { $ref: "#/$defs/leaf" } });
+  assert.deepEqual(left, { $defs: { leaf: { type: "string" } }, type: "array", items: { type: "string" } });
+  assert.equal(canonicalToolCatalogFingerprint([{ name: "x", input_schema: left }]), canonicalToolCatalogFingerprint([{ input_schema: { items: { type: "string" }, type: "array", $defs: { leaf: { type: "string" } } }, name: "x" }]));
+  assert.throws(() => dereferenceLocalJsonSchema({ $ref: "https://example.com/schema" }), (error) => error.code === "external_schema_ref");
+  assert.throws(() => dereferenceLocalJsonSchema({ $defs: { a: { $ref: "#/$defs/b" }, b: { $ref: "#/$defs/a" } }, $ref: "#/$defs/a" }), (error) => error.code === "cyclic_schema_ref");
+});
+
+test("trajectory validation rejects dropped, reordered, changed, orphan, and duplicate call ids", () => {
+  const mutate = (messages) => ({ ...canonical, messages });
+  assert.throws(() => validateTrajectory(mutate(canonical.messages.slice(0, 2))), (error) => error.code === "dropped_tool_result");
+  const reordered = structuredClone(canonical.messages);
+  reordered[2].parts.reverse();
+  assert.throws(() => validateTrajectory(mutate(reordered)), (error) => error.code === "tool_result_order");
+  const changed = structuredClone(canonical.messages);
+  changed[2].parts[0].call_id = "changed";
+  assert.throws(() => validateTrajectory(mutate(changed)), (error) => error.code === "tool_result_order");
+  assert.throws(() => validateTrajectory(mutate([{ role: "tool", parts: [{ type: "tool_result", call_id: "orphan", content: null, is_error: false }] }])), (error) => error.code === "orphan_tool_result");
+  const duplicate = structuredClone(canonical.messages);
+  duplicate[3].parts[0].id = "call-1";
+  assert.throws(() => validateTrajectory(mutate(duplicate)), (error) => error.code === "invalid_call_id");
+});
+
+test("fingerprints are deterministic, key-order independent, and structure sensitive", () => {
+  const first = canonicalTrajectoryFingerprint(canonical);
+  assert.equal(first, canonicalTrajectoryFingerprint(structuredClone(canonical)));
+  const changed = structuredClone(canonical);
+  changed.messages.at(-1).parts[0].text = "Different";
+  assert.notEqual(first, canonicalTrajectoryFingerprint(changed));
+});
+

--- a/tests/protocol-trajectory.test.mjs
+++ b/tests/protocol-trajectory.test.mjs
@@ -114,6 +114,22 @@ test("canonical request round trips through both native tool protocols", () => {
   assert.deepEqual(decodeOpenAIRequest(encodeOpenAIRequest(canonical, { model: "openai-model" })), canonical);
 });
 
+test("Anthropic mixed tool results and follow-up text convert without dropping either", () => {
+  const mixed = anthropicFixture();
+  mixed.messages[2].content.push({ type: "text", text: "Also continue with the next lookup." });
+  const decoded = decodeAnthropicRequest(mixed);
+  assert.deepEqual(decoded.messages.slice(2, 4), [
+    canonical.messages[2],
+    { role: "user", parts: [{ type: "text", text: "Also continue with the next lookup." }] },
+  ]);
+  const openai = encodeOpenAIRequest(decoded);
+  assert.deepEqual(openai.messages.slice(3, 6), [
+    { role: "tool", tool_call_id: "call-1", content: "found α" },
+    { role: "tool", tool_call_id: "call-2", content: "timeout", is_error: true },
+    { role: "user", content: "Also continue with the next lookup." },
+  ]);
+});
+
 test("structured system and message text-part boundaries survive both protocols", () => {
   const structured = {
     schema_version: "understudy.tool_trajectory.v1",
@@ -191,4 +207,3 @@ test("fingerprints are deterministic, key-order independent, and structure sensi
   changed.messages.at(-1).parts[0].text = "Different";
   assert.notEqual(first, canonicalTrajectoryFingerprint(changed));
 });
-


### PR DESCRIPTION
## Summary
- add a provider-neutral canonical multi-turn tool trajectory representation
- encode/decode Anthropic Messages and OpenAI Chat Completions without dropping tool history
- validate tool call/result lineage and fail closed on malformed arguments or schema references
- add deterministic trajectory and tool-catalog fingerprints

## Why
Cedar verifier reconstruction exposed a gap: provider-native multi-turn histories could be flattened or restarted, producing invalid benchmark comparisons. This adapter preserves the full trajectory across provider routes and gives verifier releases deterministic provenance.

## Validation
- `npm run build`
- `npm run typecheck`
- `node --test tests/protocol-trajectory.test.mjs` (8/8)
- `npm run check` (1,191 tests; 40 public skills; package smoke)