### PR TITLE
Upgrade DSPy GEPA workload bridge to DSPy 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,13 +709,19 @@ For GEPA/DSPy work, the CLI stays as the guide and gate surface while Python is
 used only for small local optimizer environments:
 
 ```bash
-understudy optimize-workload --uv
-uv venv .understudy/venvs/optimize
-uv pip install --python .understudy/venvs/optimize/bin/python 'gepa>=0.0.27,<0.1' 'dspy>=3.0.0'
+understudy optimize-workload adapter run --repo . --adapter dspy-gepa \
+  --samples samples.json --input-keys question --output-keys answer \
+  --model student-model --reflection-model reflection-model \
+  --budget-usd <approved-usd> \
+  --input-usd-per-million <conservative-input-price> \
+  --output-usd-per-million <conservative-output-price> \
+  --num-threads 1 --execute
 ```
 
-That environment is local runtime state. It is not package infrastructure and
-must not be committed.
+The adapter creates an approval-gated `uv run --no-project` runtime with exact
+`dspy==3.3.0` and `gepa[dspy]==0.1.1` packages. That environment, resumable
+logs, and owner-only optimizer receipts are local runtime state. They are not
+package infrastructure and must not be committed.
 
 For the exact before/after functionality ledger, see
 [`docs/current-functionality.md`](docs/current-functionality.md).

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -152,7 +152,7 @@ exposed through
 `optimize-workload adapter run --adapter dspy-gepa --execute`: it resolves the
 authenticated Understudy gateway key, passes it into the local `uv` runtime as
 environment, verifies exact `dspy==3.3.0` and `gepa[dspy]==0.1.1` installs,
-configures separate student/reflection DSPy LMs against the gateway, runs train/dev rows only,
+configures separate student/reflection DSPy LMs, runs train/dev rows only,
 excludes holdout, and writes `.understudy/optimize-workload/candidate.json`
 plus `proof-packet.json`. Live execution requires `--budget-usd`,
 `--input-usd-per-million`, and `--output-usd-per-million` before auth is
@@ -167,6 +167,15 @@ before provider execution. Missing usage, usage beyond the reservation, or a
 next call that could cross the cap produces an owner-only terminal run state
 instead of continuing. Recorded cost is attribution under the supplied token
 prices, not the provider's final bill.
+
+Program bridges may bind student and reflection to independent credential-free
+base URLs and credential environment-variable names. Missing role mappings use
+the Understudy Gateway. Receipts distinguish the CLI-requested alias, exact
+executed DSPy/LiteLLM model, and any provider response identity actually
+exposed; they do not infer ZDR from the route. Admission also keeps typed
+provider-free input rows (`input_bundle_sha256`) distinct from the endpoint's
+loaded executable policy (`endpoint_bundle_schema_version` and
+`endpoint_bundle_sha256`).
 
 For a program bridge, `--admission-only` runs offline admission plus one live
 canary and exits before GEPA; compilation separately requires the exact

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -56,7 +56,7 @@ understudy route-decision plan --workload-card .understudy/workload-discovery/wo
 understudy skills --search gepa
 understudy optimize-workload check --repo .
 understudy optimize-workload dry-run --repo .
-understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model gpt-4o-mini --budget-usd <approved-usd> --input-usd-per-million <input-price> --output-usd-per-million <output-price> --execute
+understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model student-model --reflection-model reflection-model --budget-usd <approved-usd> --input-usd-per-million <conservative-input-price> --output-usd-per-million <conservative-output-price> --num-threads 1 --execute
 understudy optimize-workload adapter run --repo . --adapter eval-input-gepa --manifest eval-input-manifest.json --execute
 understudy value report --workload-card .understudy/workload-discovery/workload-card.json --route-decision .understudy/route-decision/route-decision-packet.json --requests-per-month 10000
 ```
@@ -151,16 +151,27 @@ GEPA execution is exposed through named adapters. The live DSPy adapter is
 exposed through
 `optimize-workload adapter run --adapter dspy-gepa --execute`: it resolves the
 authenticated Understudy gateway key, passes it into the local `uv` runtime as
-environment, configures DSPy against the gateway, runs train/dev rows only,
+environment, verifies exact `dspy==3.3.0` and `gepa[dspy]==0.1.1` installs,
+configures separate student/reflection DSPy LMs against the gateway, runs train/dev rows only,
 excludes holdout, and writes `.understudy/optimize-workload/candidate.json`
 plus `proof-packet.json`. Live execution requires `--budget-usd`,
 `--input-usd-per-million`, and `--output-usd-per-million` before auth is
-resolved. The runtime disables client-side retries, shares one cumulative spend
+resolved. Advanced GEPA controls expose pareto selection, component selection,
+merge, minibatch, threads, seed, a config-bound resumable log directory, and
+stats. An opt-in `--program-bridge` supplies workload-owned student/train/val/
+metric/export behavior behind a fail-closed, provider-free bundle admission
+hook. The runtime persists exact package/config/program state and a canonical
+deployable bundle hash when exported. The runtime disables client-side retries, shares one cumulative spend
 ledger across DSPy LM copies, and reserves a conservative per-call upper bound
 before provider execution. Missing usage, usage beyond the reservation, or a
 next call that could cross the cap produces an owner-only terminal run state
 instead of continuing. Recorded cost is attribution under the supplied token
 prices, not the provider's final bill.
+
+For a program bridge, `--admission-only` runs offline admission plus one live
+canary and exits before GEPA; compilation separately requires the exact
+`--admission-receipt`. Workload dependencies come only from an exact locked
+project/pin receipt and are never promoted across workloads.
 
 The generic adapter registry is exposed through
 `optimize-workload adapter run`. The first registry-backed non-DSPy adapter

--- a/docs/optimize-workload-contract.md
+++ b/docs/optimize-workload-contract.md
@@ -181,6 +181,20 @@ deployments. Both independent LM instances share the same cumulative ledger,
 reserve before every request, disable retries, and fail closed on incomplete
 usage evidence.
 
+A bridge may route either LM independently with optional non-secret
+`inference_routes.student` and `inference_routes.reflection` objects. Each
+explicit object contains exactly `route_id`, credential-free `base_url`,
+`api_key_env`, `requested_model`, and `executed_model`. `requested_model` must
+equal the corresponding CLI model; `executed_model` is the exact DSPy/LiteLLM
+model identifier passed to that route. Missing role entries retain the
+Understudy Gateway default. The runtime reads credentials only from the named
+environment variables, executes each LM against its bound base URL, and records
+requested/executed/DSPy model identities plus URL/host hashes in config,
+admission, spend, export, and terminal receipts. Per-call provider-returned
+model and a recognized effective-model response header are recorded only when
+the response exposes them; otherwise each field is explicitly unavailable.
+Neither a route name nor `workload_capture: false` proves ZDR eligibility.
+
 ### Opt-in program bridge
 
 `--program-bridge path/to/bridge.py` plus a non-secret JSON
@@ -212,16 +226,25 @@ package/lock state, bridge/config hashes, budget allocation, model sampling,
 and resume configuration.
 
 Phase A returns a JSON-safe redacted receipt with `admitted: true` and a
-`bundle_validation` object proving zero validation network calls, the
-executable input bundle was actually loaded, all required typed fields were
-present, and the loaded hash matches `input_bundle_sha256`. It binds exact
-workload-adapter, tool-schema, and package/lock receipt SHA-256 values plus
-package versions. `typed_request_contract` attests typed `model`, `messages`,
-`tools`, and `sampling`. `oracle_contract` is discriminated: exact-message
-workloads require a materialized expected object and continuation/provenance;
+`bundle_validation` object proving zero validation network calls. Two semantic
+identities are kept separate: `input_bundle_sha256` binds the typed,
+provider-free optimizer/admission rows, while `loaded_bundle_schema_version`
+and `loaded_bundle_sha256` bind the executable policy bundle actually loaded by
+the endpoint. The bridge config must declare matching `input_bundle_sha256`,
+`endpoint_bundle_schema_version`, and `endpoint_bundle_sha256`; the validator
+never compares the typed-row hash to the executable-bundle hash. It also binds
+exact workload-adapter, tool-schema, and package/lock receipt SHA-256 values
+plus package versions. `typed_request_contract` attests typed `model`,
+`messages`, `tools`, and `sampling`. `oracle_contract` is discriminated:
+exact-message workloads require a materialized expected object and
+continuation/provenance;
 state-verifier workloads require typed task/initial state plus assertion,
 Prime-receipt, and reward-metric binding hashes and must not fabricate an
 expected assistant message for root tasks.
+
+For an exact-message workload, map the provider-free Phase-A request fixtures
+to `input_bundle_sha256` and the executable runtime policy artifact to the
+endpoint bundle fields. Neither identity aliases its package/lock receipt.
 
 Tool workloads additionally include `tool_contract_probe`. For an
 OpenAI-compatible tool call, `function.arguments` must remain a string on the

--- a/docs/optimize-workload-contract.md
+++ b/docs/optimize-workload-contract.md
@@ -35,11 +35,11 @@ Use `uv` when possible:
 
 ```bash
 understudy skills --search gepa
-uv venv .understudy/venvs/optimize
-uv pip install --python .understudy/venvs/optimize/bin/python 'gepa>=0.0.27,<0.1' 'dspy>=3.0.0'
+understudy optimize-workload adapter run --repo . --adapter dspy-gepa --help
 ```
 
-Do not create the env, install packages, or run provider calls without explicit
+The named adapter owns its exact `uv run --no-project` package set; do not
+preinstall a floating DSPy/GEPA environment. Do not install packages or run provider calls without explicit
 approval. TypeScript gates and skill-led inspection must fail closed on missing
 files, stale hashes, unapproved metrics, or touched holdout data.
 
@@ -124,7 +124,7 @@ Future TypeScript commands should follow this behavior:
 
 ```bash
 understudy optimize-workload dry-run --repo .
-understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model gpt-4o-mini --budget-usd <approved-usd> --input-usd-per-million <input-price> --output-usd-per-million <output-price> --execute
+understudy optimize-workload adapter run --repo . --adapter dspy-gepa --samples samples.json --input-keys question --output-keys answer --model student-model --reflection-model reflection-model --budget-usd <approved-usd> --input-usd-per-million <conservative-input-price> --output-usd-per-million <conservative-output-price> --num-threads 1 --execute
 understudy optimize-workload adapter run --repo . --adapter eval-input-gepa --manifest eval-input-manifest.json --execute
 ```
 
@@ -141,14 +141,16 @@ Required behavior:
 - Rubric scoring and DSPy scaffold/parity: keep as skill/reference guidance
   guidance unless a concrete adapter needs executable support.
 - DSPy GEPA adapter: expose through `adapter run`, require `--execute`, require
-  an explicit model/deployment, positive dollar cap, and non-zero user-supplied
+  explicit student and reflection model/deployments, positive dollar cap, and non-zero user-supplied
   token-price basis before resolving auth. Pass auth only through the child
   environment, disable client-side retries, and reserve a conservative
   price-basis upper bound before every request. Stop before a reservation could cross the
   cap; fail closed when usage is missing or exceeds the reservation. Run
   train/dev rows only, exclude holdout rows, and write owner-only candidate,
   proof, and terminal run-state artifacts with reservation and attribution
-  evidence. The attribution is not a provider-invoice claim.
+  evidence. The attribution is not a provider-invoice claim. The runtime is
+  exactly `dspy==3.3.0` plus `gepa[dspy]==0.1.1`; it records and verifies both
+  installed versions before any model call.
 - Eval-input GEPA adapter: require `--execute`, read a local manifest with
   `rows`, `inputs`, or `inputs_path`, support exact-match label and tool-call
   objectives, invoke upstream `gepa.optimize` through `uv`, run train/dev rows
@@ -157,6 +159,138 @@ Required behavior:
   model-backed path is added and approved.
 - Holdout access during optimization: mark the run contaminated and require a
   new split contract before any claim.
+
+### DSPy 3.3 GEPA controls
+
+The DSPy adapter forwards these GEPA controls without reimplementing GEPA:
+`--reflection-minibatch-size`, `--candidate-selection-strategy` (`pareto` or
+`current_best`), `--component-selector` (`round_robin` or `all`),
+`--use-merge`, `--max-merge-invocations`, `--num-threads`, `--seed`,
+`--log-dir`, and `--track-stats`. Student and reflection sampling are explicit
+and hash-bound with `--temperature`, `--reasoning-effort`,
+`--reflection-temperature`, and `--reflection-reasoning-effort` (conservative
+defaults: `0.1` and `none`). Start a new workload at `--num-threads 1`.
+The adapter always enables upstream `track_best_outputs` for result lineage.
+The log directory is owner-only and contains a config binding; an existing log
+directory is resumable only when the exact package, workload-source, data,
+admission, model, optimizer, and spend configuration hash matches.
+
+The single user-supplied input/output price basis covers both model names. It
+must therefore be a conservative upper bound for the student and reflection
+deployments. Both independent LM instances share the same cumulative ledger,
+reserve before every request, disable retries, and fail closed on incomplete
+usage evidence.
+
+### Opt-in program bridge
+
+`--program-bridge path/to/bridge.py` plus a non-secret JSON
+`--program-bridge-config` replaces the simple Signature/Predict scaffold with
+workload-owned components. The config schema is exactly
+`understudy.dspy_gepa_bridge_config.v1`; secret values are forbidden and
+credentials are referenced only by environment-variable name. The bridge is
+imported explicitly; no bridge is auto-discovered. A workload that needs Python
+dependencies supplies `--program-project` with committed `pyproject.toml` and
+`uv.lock`; execution uses `uv run --project ... --locked` and verifies every
+`workload_package_pins` distribution. These pins are workload-scoped. The
+generic adapter never upgrades or promotes a verifier/MCP version from one
+workload into another. It must define these functions:
+
+```python
+def admit_understudy_dspy_gepa(context) -> dict: ...
+def build_understudy_dspy_gepa(context) -> dict: ...
+def live_admit_understudy_dspy_gepa(context, program) -> dict: ...
+```
+
+Use two separate commands for a bridged run. First pass `--admission-only`.
+Phase A runs with socket connections blocked, builds the program, then Phase B
+runs exactly one live fixed-task canary and exits before `GEPA.compile` with
+zero optimizer student/reflection calls. It writes owner-only
+`admission-receipt.json`. Inspect that receipt, then invoke the compile command
+with `--admission-receipt <path>`. Compile fails before optimization unless the
+receipt hash binds the exact static config, offline receipt, live receipt,
+package/lock state, bridge/config hashes, budget allocation, model sampling,
+and resume configuration.
+
+Phase A returns a JSON-safe redacted receipt with `admitted: true` and a
+`bundle_validation` object proving zero validation network calls, the
+executable input bundle was actually loaded, all required typed fields were
+present, and the loaded hash matches `input_bundle_sha256`. It binds exact
+workload-adapter, tool-schema, and package/lock receipt SHA-256 values plus
+package versions. `typed_request_contract` attests typed `model`, `messages`,
+`tools`, and `sampling`. `oracle_contract` is discriminated: exact-message
+workloads require a materialized expected object and continuation/provenance;
+state-verifier workloads require typed task/initial state plus assertion,
+Prime-receipt, and reward-metric binding hashes and must not fabricate an
+expected assistant message for root tasks.
+
+Tool workloads additionally include `tool_contract_probe`. For an
+OpenAI-compatible tool call, `function.arguments` must remain a string on the
+wire, parse as valid JSON, and decode to an object. Record request and executed
+argument types/hashes plus any validation-exception hash; do not persist raw
+bodies. When a write/world delta is required, admission fails unless the probe
+both succeeds and changes world state. A parser failure after HTTP 200, a
+hash-only expectation, or a missing write is an admission failure, not model
+behavior.
+
+Both source-rollout and reflection prompts require renderer, tokenizer,
+checkpoint, route, token arithmetic, and complete task/eligible-route coverage
+proofs. Each gate requires `prompt_tokens + max_tokens + safety_margin <
+context_limit`; equality fails closed. Reflection feedback may contain only
+ordered redacted structural events
+(tool/method category, success/error type, mutation, and stop flags), plus a
+hash of the full native trace; arguments, URLs, secrets, and answer keys are
+excluded. Provider-free inline-versus-loaded deployment parity must prove exact
+messages/tools/sampling hashes, one bundle load, no outer policy, and no
+duplicate policy injection.
+
+`candidate_mutation_contract.enforcement_status` is currently
+`declared_not_enforced`, with `promotion_guarantee: false`. It documents the
+workload hook's intended per-proposal receipts but is not admission or promotion
+proof. For the final exported candidate, `mutation_claimed: true` enforces a
+changed hash and complete atomic evidence. A stable seed/no-change export uses
+`mutation_claimed: false`, `outcome: non_improved`, and
+`promotion_eligible: false`; it is valid output, not an artifact failure. Do not
+claim per-mutation persistence,
+unchanged-hash quarantine, or Pareto integrity until a runtime interceptor and
+audit tests enforce them.
+
+The builder receives `dspy`, separate `student_lm` and `reflection_lm`
+instances, the admitted receipt, configuration, local rows, and repo path. It
+returns:
+
+```python
+{
+    "student": student,
+    "trainset": trainset,
+    "valset": valset,
+    "metric": metric,  # returns ScoreWithFeedback
+    "teacher": None,
+    "export_candidate": export_candidate,  # optional callable
+    "program_state": {"redacted": "workload metadata"},  # optional JSON
+    "holdout_count_excluded": 0,
+}
+```
+
+DSPy 3.3.0 exposes `teacher` in the compile signature but its GEPA adapter
+rejects non-null teachers. The bridge field is retained for forward-compatible
+shape, but this pinned runtime fails explicitly when it is non-null. A workload
+may precompute teacher-derived examples or feedback before the approved run;
+it must not disguise an unmetered teacher call inside the bridge.
+
+When present, `export_candidate(optimized, export_dir, context)` writes a
+deployable bundle under the supplied owner-only directory and returns JSON-safe
+metadata containing `provenance` and `continuation_parent` (`null` for a root
+bundle). The runtime rejects symlinks/empty exports, hashes sorted relative
+paths, sizes, and file SHA-256 values, and records `bundle_sha256` in
+`bundle-manifest.json`, `candidate.json`, the proof packet, and terminal state.
+Metadata environment variables alone are not evidence that the executable
+bundle was loaded; that proof belongs in admission.
+
+Successful runs persist owner-only `package-state.json`, `config.json`,
+`admission-receipt.json`,
+`program-state.json`, `bundle-manifest.json` when exported, `run-state.json`,
+the candidate, and proof packet. These receipts contain hashes and redacted
+structure, never API keys or raw malformed response bodies.
 
 ## Claim Packet
 

--- a/docs/uv-python-bridge.md
+++ b/docs/uv-python-bridge.md
@@ -36,6 +36,22 @@ The current implementation is `src/optimize-workload.ts`: it generates
 `uv run --no-project` for approved named optimizer adapters such as
 `eval-input-gepa` and `dspy-gepa`.
 
+The live DSPy adapter installs exactly `dspy==3.3.0` and
+`gepa[dspy]==0.1.1`, verifies the installed distribution versions, and records
+them in an owner-only package receipt. Its optional `--program-bridge` is a
+workload file contract, not another package: a provider-free admission hook
+binds exact adapter/data/tool-schema/package hashes before separate metered
+student and reflection LMs are constructed. The builder can return a
+multi-component student, train/validation sets, a `ScoreWithFeedback` metric,
+and a deployable export callback. See
+[`optimize-workload-contract.md`](optimize-workload-contract.md) for the full
+admission and canonical bundle contract.
+
+Optimizer pins are generic adapter pins. Workload packages are accepted only
+from the workload's exact `pyproject.toml`/`uv.lock` and explicit distribution
+pins. The adapter never infers that one workload's verifier/MCP version is valid
+for another workload.
+
 ## Non-goals
 
 Do not reintroduce the old Python package shape:

--- a/docs/uv-python-bridge.md
+++ b/docs/uv-python-bridge.md
@@ -47,6 +47,12 @@ and a deployable export callback. See
 [`optimize-workload-contract.md`](optimize-workload-contract.md) for the full
 admission and canonical bundle contract.
 
+The bridge may declare independent student/reflection route base URLs and
+credential environment-variable names. The generated runtime executes those
+bindings and receipts both configured and response-exposed model identity. Its
+admission contract separately binds typed optimizer rows and the endpoint's
+loaded executable bundle; one hash is never used as proof of the other.
+
 Optimizer pins are generic adapter pins. Workload packages are accepted only
 from the workload's exact `pyproject.toml`/`uv.lock` and explicit distribution
 pins. The adapter never infers that one workload's verifier/MCP version is valid

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -120,7 +120,8 @@ validator kinds in [`reference.md`](reference.md):
    `optimize-workload adapter run --adapter <name> ... --execute`.
    `eval-input-gepa` runs upstream GEPA locally without provider calls unless a
    model-backed path is explicitly selected. `adapter run --adapter dspy-gepa
-   --execute` additionally requires an approved dollar cap and explicit input
+   --execute` uses exact `dspy==3.3.0` and `gepa[dspy]==0.1.1` packages and
+   additionally requires separate student/reflection model names, an approved dollar cap, and explicit input
    and output token prices before it resolves the Understudy API key. It passes
    auth to the child process through environment only, disables client-side
    retries, and reserves each request against one cumulative price-basis ledger before
@@ -134,6 +135,19 @@ validator kinds in [`reference.md`](reference.md):
    first result page; tighten the stop condition" or "answer omitted the date
    filter the question required; add it to the query plan" — rather than a bare
    `0`.
+   Start new GEPA runs with `--num-threads 1`; use pareto selection and opt into
+   merge only when the approved budget covers it. For a workload-owned program,
+   first pass `--program-bridge ... --admission-only`, inspect its hashed offline
+   and one-episode live receipt, then compile separately with the exact
+   `--admission-receipt`. Admission must fail unless provider-free validation proves the exact
+   executable bundle was loaded, typed request/expected/tool contracts passed,
+   package/adapter/tool-schema hashes match, and every required write produced
+   an actual world-state delta. Never score a hash-only expectation or an HTTP
+   200 response that failed local parsing as model behavior. The bridge metric
+   returns `ScoreWithFeedback`; its optional export callback writes a canonical,
+   provenance-bound deployable bundle.
+   Keep workload package/lock pins workload-scoped; never copy one workload's
+   verifier/MCP bump into another workload.
 5. Keep deterministic work in the TypeScript CLI and this skill's templates. Follow
    [`../../docs/optimize-workload-contract.md`](../../docs/optimize-workload-contract.md)
    for adapter, metric feedback, and claim packet details.
@@ -180,12 +194,14 @@ understudy skills --search gepa
 understudy optimize-workload adapter run --repo . --adapter eval-input-gepa --manifest eval-input-manifest.json --execute
 ```
 
-If approved, keep Python isolated under ignored local runtime state:
+If approved, let the named adapter create its exact ignored `uv` runtime:
 
 ```bash
-uv venv .understudy/venvs/optimize
-uv pip install --python .understudy/venvs/optimize/bin/python 'gepa>=0.0.27,<0.1' 'dspy>=3.0.0'
+understudy optimize-workload adapter run --repo . --adapter dspy-gepa --help
 ```
+
+Do not preinstall a floating DSPy/GEPA environment; the adapter pins and
+receipts its compatible package pair.
 
 ## Claim Rules
 

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -125,7 +125,12 @@ validator kinds in [`reference.md`](reference.md):
    and output token prices before it resolves the Understudy API key. It passes
    auth to the child process through environment only, disables client-side
    retries, and reserves each request against one cumulative price-basis ledger before
-   running train/dev rows through the gateway. Treat the resulting attribution
+   running train/dev rows. A program bridge may bind student and reflection to
+   independent credential-free routes by naming credential environment
+   variables; missing mappings use the Understudy Gateway. Receipt the
+   requested alias, exact executed DSPy/LiteLLM model, and only response model
+   identity actually exposed. Do not infer ZDR from a route name or
+   `workload_capture: false`. Treat the resulting attribution
    as a conservative cap under the supplied prices, not a provider invoice. GEPA's
    edge is natural-language feedback: the metric must return a diagnosis of
    *why* each failing row failed and what to change, not a bare score — bland
@@ -139,7 +144,8 @@ validator kinds in [`reference.md`](reference.md):
    merge only when the approved budget covers it. For a workload-owned program,
    first pass `--program-bridge ... --admission-only`, inspect its hashed offline
    and one-episode live receipt, then compile separately with the exact
-   `--admission-receipt`. Admission must fail unless provider-free validation proves the exact
+   `--admission-receipt`. Admission must fail unless provider-free validation
+   separately binds the typed input-row bundle and proves the exact endpoint
    executable bundle was loaded, typed request/expected/tool contracts passed,
    package/adapter/tool-schema hashes match, and every required write produced
    an actual world-state delta. Never score a hash-only expectation or an HTTP

--- a/skills/optimize-workload/reference.md
+++ b/skills/optimize-workload/reference.md
@@ -179,8 +179,18 @@ Three ways to optimize, picked by commitment and workload shape:
 3. **Program lane (opt-in).** The agent can scaffold a reusable DSPy program
    from local samples using the program-scaffold pattern, verify parity, then
    run the approval-gated `adapter run --adapter dspy-gepa --execute` path
-   against the Understudy gateway with an explicit dollar cap and input/output
-   token-price basis. Full GEPA optimization over that program is
+   against the Understudy gateway with exact `dspy==3.3.0` and
+   `gepa[dspy]==0.1.1`, separate student/reflection deployments, an explicit
+   dollar cap, and a conservative input/output token-price basis. A
+   `--program-bridge` may provide a multi-component student, trainset, valset,
+   `ScoreWithFeedback` metric, and deployable export callback. Before either LM
+   is used, its offline hook binds provider-free validation
+   of the loaded executable bundle to the workload-adapter source,
+   tool-schema, package receipt, typed request/expected fields, and any required
+   tool-write/world-state probe; an admission-only command then performs one
+   live canary and emits the exact receipt required by the later compile. The
+   optimizer records package/config/program
+   state and a canonical bundle SHA-256. Full GEPA optimization over that program is
    gated by parity: the scaffolded program must reproduce the incumbent
    baseline before optimization, or you optimize a reconstruction that diverges
    from production.

--- a/src/commands/optimize-workload.ts
+++ b/src/commands/optimize-workload.ts
@@ -57,17 +57,35 @@ export function registerOptimizeWorkloadCommand(program: Command): void {
     .option("--input-keys <keys>", "Comma-separated DSPy input keys")
     .option("--output-keys <keys>", "Comma-separated DSPy output keys")
     .option("--model <name>", "Optional deployment/model name")
+    .option("--reflection-model <name>", "Required separate DSPy reflection deployment/model")
     .option("--module <name>", "predict or cot", "predict")
     .option("--max-metric-calls <number>", "GEPA metric-call budget")
     .option("--split-key <field>", "Sample split field", "split")
     .option("--train-split <value>", "Train split value", "train")
     .option("--dev-split <value>", "Dev split value", "dev")
     .option("--max-tokens <number>", "Per-call max token cap", "256")
+    .option("--temperature <number>", "Student LM temperature", "0.1")
+    .option("--reasoning-effort <name>", "Student LM reasoning effort", "none")
+    .option("--reflection-temperature <number>", "Reflection LM temperature", "0.1")
+    .option("--reflection-reasoning-effort <name>", "Reflection LM reasoning effort", "none")
     .option("--budget-usd <amount>", "Required spend cap under the supplied DSPy token-price basis")
     .option("--input-usd-per-million <amount>", "Required input-token price basis for DSPy GEPA")
     .option("--output-usd-per-million <amount>", "Required output-token price basis for DSPy GEPA")
     .option("--score-objective <name>", "exact_match, tool_call, or mixed", "exact_match")
     .option("--reflection-minibatch-size <number>", "GEPA reflection minibatch size", "1")
+    .option("--candidate-selection-strategy <name>", "pareto or current_best", "pareto")
+    .option("--component-selector <name>", "round_robin or all", "round_robin")
+    .option("--use-merge", "Enable GEPA candidate merging")
+    .option("--max-merge-invocations <number>", "Maximum GEPA merge invocations", "5")
+    .option("--num-threads <number>", "GEPA worker threads", "1")
+    .option("--seed <number>", "GEPA random seed", "0")
+    .option("--log-dir <path>", "Owner-only GEPA log directory used for safe resume")
+    .option("--track-stats", "Persist upstream GEPA optimization statistics")
+    .option("--program-bridge <path>", "Opt-in Python program bridge implementing build_understudy_dspy_gepa(context)")
+    .option("--program-bridge-config <path>", "Required immutable JSON settings for an opt-in program bridge")
+    .option("--program-project <dir>", "Locked uv project containing workload bridge dependencies")
+    .option("--admission-only", "Run the two-phase bridge admission and stop before GEPA.compile")
+    .option("--admission-receipt <path>", "Exact hashed admission receipt required for a bridge compile")
     .option("--execute", "After explicit approval, create a uv env and run the adapter")
     .action(
       (options: {
@@ -78,17 +96,35 @@ export function registerOptimizeWorkloadCommand(program: Command): void {
         inputKeys?: string;
         outputKeys?: string;
         model?: string;
+        reflectionModel?: string;
         module?: string;
         maxMetricCalls?: string;
         splitKey?: string;
         trainSplit?: string;
         devSplit?: string;
         maxTokens?: string;
+        temperature?: string;
+        reasoningEffort?: string;
+        reflectionTemperature?: string;
+        reflectionReasoningEffort?: string;
         budgetUsd?: string;
         inputUsdPerMillion?: string;
         outputUsdPerMillion?: string;
         scoreObjective?: string;
         reflectionMinibatchSize?: string;
+        candidateSelectionStrategy?: string;
+        componentSelector?: string;
+        useMerge?: boolean;
+        maxMergeInvocations?: string;
+        numThreads?: string;
+        seed?: string;
+        logDir?: string;
+        trackStats?: boolean;
+        programBridge?: string;
+        programBridgeConfig?: string;
+        programProject?: string;
+        admissionOnly?: boolean;
+        admissionReceipt?: string;
         execute?: boolean;
       }) => {
         const result = runOptimizerAdapter({

--- a/src/optimize-workload.ts
+++ b/src/optimize-workload.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, relative, resolve } from "node:path";
 
@@ -74,17 +74,35 @@ type AdapterRunOptions = {
   inputKeys?: string[];
   outputKeys?: string[];
   model?: string;
+  reflectionModel?: string;
   module?: string;
   maxMetricCalls?: string;
   splitKey?: string;
   trainSplit?: string;
   devSplit?: string;
   maxTokens?: string;
+  temperature?: string;
+  reasoningEffort?: string;
+  reflectionTemperature?: string;
+  reflectionReasoningEffort?: string;
   budgetUsd?: string;
   inputUsdPerMillion?: string;
   outputUsdPerMillion?: string;
   scoreObjective?: string;
   reflectionMinibatchSize?: string;
+  candidateSelectionStrategy?: string;
+  componentSelector?: string;
+  useMerge?: boolean;
+  maxMergeInvocations?: string;
+  numThreads?: string;
+  seed?: string;
+  logDir?: string;
+  trackStats?: boolean;
+  programBridge?: string;
+  programBridgeConfig?: string;
+  programProject?: string;
+  admissionOnly?: boolean;
+  admissionReceipt?: string;
 };
 
 type OptimizerAuth = {
@@ -106,20 +124,44 @@ type UvAdapterSpec = {
 const adapterRegistry: Record<string, UvAdapterSpec> = {
   "dspy-gepa": {
     name: "dspy-gepa",
-    schemaVersion: "understudy.dspy_gepa_adapter.v1",
+    schemaVersion: "understudy.dspy_gepa_adapter.v2",
     runtimeCommand: "dspy-gepa",
-    packages: ["gepa>=0.0.27,<0.1", "dspy>=3.0.0", "litellm>=1.0.0"],
+    packages: ["dspy==3.3.0", "gepa[dspy]==0.1.1"],
     providerCalls: true,
     requiresAuth: () => true,
     buildArgs: (repo, options) => {
-      if (!options.samples) {
-        throw new Error("--samples is required for dspy-gepa");
+      if (!options.programBridge && !options.samples) {
+        throw new Error("--samples is required for dspy-gepa unless --program-bridge is supplied");
       }
-      if (!options.inputKeys?.length || !options.outputKeys?.length) {
-        throw new Error("--input-keys and --output-keys are required for dspy-gepa");
+      if (options.programBridge && !options.programBridgeConfig) {
+        throw new Error("--program-bridge-config is required with --program-bridge");
+      }
+      if (options.programBridgeConfig && !options.programBridge) {
+        throw new Error("--program-bridge-config requires --program-bridge");
+      }
+      if (options.programProject && !options.programBridge) {
+        throw new Error("--program-project requires --program-bridge");
+      }
+      if (options.admissionOnly && options.admissionReceipt) {
+        throw new Error("--admission-only and --admission-receipt are mutually exclusive");
+      }
+      if ((options.admissionOnly || options.admissionReceipt) && !options.programBridge) {
+        throw new Error("--admission-only and --admission-receipt require --program-bridge");
+      }
+      if (options.programBridge && !options.admissionOnly && !options.admissionReceipt) {
+        throw new Error("bridge compilation requires --admission-receipt from a prior --admission-only run");
+      }
+      if (!options.programBridge && (!options.inputKeys?.length || !options.outputKeys?.length)) {
+        throw new Error("--input-keys and --output-keys are required for dspy-gepa unless --program-bridge is supplied");
+      }
+      if ((options.inputKeys?.length && !options.outputKeys?.length) || (!options.inputKeys?.length && options.outputKeys?.length)) {
+        throw new Error("--input-keys and --output-keys must be supplied together");
       }
       if (!options.model) {
         throw new Error("--model is required for dspy-gepa");
+      }
+      if (!options.reflectionModel) {
+        throw new Error("--reflection-model is required for dspy-gepa");
       }
       const budgetUsd = requiredPositiveNumber(options.budgetUsd, "--budget-usd");
       const inputUsdPerMillion = requiredNonNegativeNumber(
@@ -133,22 +175,40 @@ const adapterRegistry: Record<string, UvAdapterSpec> = {
       if (inputUsdPerMillion === 0 && outputUsdPerMillion === 0) {
         throw new Error("dspy-gepa requires a non-zero input or output price basis");
       }
-      return [
+      const temperature = requiredNonNegativeNumber(options.temperature ?? "0.1", "--temperature");
+      const reflectionTemperature = requiredNonNegativeNumber(
+        options.reflectionTemperature ?? "0.1",
+        "--reflection-temperature",
+      );
+      const reasoningEffort = options.reasoningEffort ?? "none";
+      const reflectionReasoningEffort = options.reflectionReasoningEffort ?? "none";
+      const reasoningEfforts = ["none", "minimal", "low", "medium", "high"];
+      if (!reasoningEfforts.includes(reasoningEffort)) {
+        throw new Error("--reasoning-effort must be none, minimal, low, medium, or high");
+      }
+      if (!reasoningEfforts.includes(reflectionReasoningEffort)) {
+        throw new Error("--reflection-reasoning-effort must be none, minimal, low, medium, or high");
+      }
+      const candidateSelectionStrategy = options.candidateSelectionStrategy ?? "pareto";
+      if (!["pareto", "current_best"].includes(candidateSelectionStrategy)) {
+        throw new Error("--candidate-selection-strategy must be pareto or current_best");
+      }
+      const componentSelector = options.componentSelector ?? "round_robin";
+      if (!["round_robin", "all"].includes(componentSelector)) {
+        throw new Error("--component-selector must be round_robin or all");
+      }
+      const args = [
         "dspy-gepa",
         "--repo",
         repo,
-        "--samples",
-        resolve(options.samples),
-        "--input-keys",
-        options.inputKeys.join(","),
-        "--output-keys",
-        options.outputKeys.join(","),
         "--module",
         options.module ?? "predict",
         "--model",
         options.model,
+        "--reflection-model",
+        options.reflectionModel,
         "--max-metric-calls",
-        options.maxMetricCalls ?? "3",
+        String(positiveInteger(options.maxMetricCalls ?? "3", "--max-metric-calls")),
         "--split-key",
         options.splitKey ?? "split",
         "--train-split",
@@ -156,14 +216,66 @@ const adapterRegistry: Record<string, UvAdapterSpec> = {
         "--dev-split",
         options.devSplit ?? "dev",
         "--max-tokens",
-        options.maxTokens ?? "256",
+        String(positiveInteger(options.maxTokens ?? "256", "--max-tokens")),
+        "--temperature",
+        String(temperature),
+        "--reasoning-effort",
+        reasoningEffort,
+        "--reflection-temperature",
+        String(reflectionTemperature),
+        "--reflection-reasoning-effort",
+        reflectionReasoningEffort,
         "--budget-usd",
         String(budgetUsd),
         "--input-usd-per-million",
         String(inputUsdPerMillion),
         "--output-usd-per-million",
         String(outputUsdPerMillion),
+        "--reflection-minibatch-size",
+        String(positiveInteger(options.reflectionMinibatchSize ?? "1", "--reflection-minibatch-size")),
+        "--candidate-selection-strategy",
+        candidateSelectionStrategy,
+        "--component-selector",
+        componentSelector,
+        "--use-merge",
+        options.useMerge === true ? "true" : "false",
+        "--max-merge-invocations",
+        String(nonNegativeInteger(options.maxMergeInvocations ?? "5", "--max-merge-invocations")),
+        "--num-threads",
+        String(positiveInteger(options.numThreads ?? "1", "--num-threads")),
+        "--seed",
+        String(integer(options.seed ?? "0", "--seed")),
+        "--log-dir",
+        resolve(options.logDir ?? join(repo, optimizeDir, "dspy-gepa", "gepa-log")),
+        "--track-stats",
+        options.trackStats === true ? "true" : "false",
       ];
+      if (options.samples) {
+        args.push("--samples", resolve(options.samples));
+      }
+      if (options.inputKeys?.length && options.outputKeys?.length) {
+        args.push("--input-keys", options.inputKeys.join(","), "--output-keys", options.outputKeys.join(","));
+      }
+      if (options.programBridge) {
+        const bridgePath = requireRegularFile(options.programBridge, "--program-bridge");
+        const bridgeConfigPath = requireBridgeConfig(options.programBridgeConfig!);
+        args.push(
+          "--program-bridge",
+          bridgePath,
+          "--program-bridge-config",
+          bridgeConfigPath,
+        );
+      }
+      if (options.programProject) {
+        args.push("--program-project", requireLockedUvProject(options.programProject));
+      }
+      if (options.admissionOnly) {
+        args.push("--admission-only");
+      }
+      if (options.admissionReceipt) {
+        args.push("--admission-receipt", requireRegularFile(options.admissionReceipt, "--admission-receipt"));
+      }
+      return args;
     },
   },
   "eval-input-gepa": {
@@ -283,6 +395,106 @@ function requiredNonNegativeNumber(value: string | undefined, flag: string): num
     throw new Error(`${flag} must be a non-negative number`);
   }
   return parsed;
+}
+
+function integer(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${flag} must be an integer`);
+  }
+  return parsed;
+}
+
+function positiveInteger(value: string, flag: string): number {
+  const parsed = integer(value, flag);
+  if (parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function nonNegativeInteger(value: string, flag: string): number {
+  const parsed = integer(value, flag);
+  if (parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+const secretKeyPattern = /(?:^|[_-])(api[_-]?key|authorization|password|secret|token)(?:$|[_-])/i;
+const secretValuePattern = /^(?:bearer\s+|sk-[A-Za-z0-9]|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+const envNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function requireRegularFile(pathInput: string, flag: string): string {
+  const path = resolve(pathInput);
+  let metadata;
+  try {
+    metadata = lstatSync(path);
+  } catch {
+    throw new Error(`${flag} must point to an existing regular file`);
+  }
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new Error(`${flag} must point to a non-symlink regular file`);
+  }
+  return path;
+}
+
+function rejectBridgeConfigSecrets(value: unknown, path = "bridge_config"): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => rejectBridgeConfigSecrets(item, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = `${path}.${key}`;
+      if (/(?:_env|_env_var)$/i.test(key)) {
+        if (typeof child !== "string" || !envNamePattern.test(child)) {
+          throw new Error(`${childPath} must contain an environment variable name, not a credential`);
+        }
+      } else if (secretKeyPattern.test(key)) {
+        throw new Error(`${childPath} is a secret-bearing field; use an *_env variable name instead`);
+      }
+      rejectBridgeConfigSecrets(child, childPath);
+    }
+    return;
+  }
+  if (typeof value === "string" && secretValuePattern.test(value.trim())) {
+    throw new Error(`${path} appears to contain a credential`);
+  }
+}
+
+function requireBridgeConfig(pathInput: string): string {
+  const path = requireRegularFile(pathInput, "--program-bridge-config");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    throw new Error("--program-bridge-config must contain valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("--program-bridge-config must contain a JSON object");
+  }
+  if ((parsed as { schema_version?: unknown }).schema_version !== "understudy.dspy_gepa_bridge_config.v1") {
+    throw new Error("--program-bridge-config schema_version must be understudy.dspy_gepa_bridge_config.v1");
+  }
+  rejectBridgeConfigSecrets(parsed);
+  return path;
+}
+
+function requireLockedUvProject(pathInput: string): string {
+  const path = resolve(pathInput);
+  let metadata;
+  try {
+    metadata = lstatSync(path);
+  } catch {
+    throw new Error("--program-project must point to an existing directory");
+  }
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error("--program-project must point to a non-symlink directory");
+  }
+  requireRegularFile(join(path, "pyproject.toml"), "--program-project pyproject.toml");
+  requireRegularFile(join(path, "uv.lock"), "--program-project uv.lock");
+  return path;
 }
 
 export function optimizeWorkloadCheck(repoInput: string): GateResult {
@@ -446,7 +658,14 @@ export function runOptimizerAdapter(options: AdapterRunOptions): Record<string, 
     env.UNDERSTUDY_GATEWAY_URL = auth.gatewayUrl;
     env.UNDERSTUDY_AUTH_SOURCE = auth.source;
   }
-  const out = runUvPython(repo, runtimePath, args, adapter.packages, env);
+  const out = runUvPython(
+    repo,
+    runtimePath,
+    args,
+    adapter.packages,
+    env,
+    options.programProject ? resolve(options.programProject) : undefined,
+  );
   freezeCandidateIntoActiveExperiment(repo, out);
   return out;
 }
@@ -521,10 +740,15 @@ function runUvPython(
   args: string[],
   packages: string[] = [],
   env: Record<string, string> = {},
+  programProject?: string,
 ): Record<string, unknown> {
-  const uvArgs = ["run", "--no-project"];
-  for (const pkg of packages) {
-    uvArgs.push("--with", pkg);
+  const uvArgs = programProject
+    ? ["run", "--project", programProject, "--locked"]
+    : ["run", "--no-project"];
+  if (!programProject) {
+    for (const pkg of packages) {
+      uvArgs.push("--with", pkg);
+    }
   }
   uvArgs.push("python", runtimePath, ...args);
   const result = spawnSync("uv", uvArgs, {
@@ -571,7 +795,10 @@ function parseJsonFromNoisyStdout(stdout: string): unknown {
 
 function writeOptimizerRuntime(repo: string): string {
   const runtimePath = join(repo, runtimeDir, "optimizer_runtime.py");
-  mkdirSync(join(repo, runtimeDir), { recursive: true });
-  writeFileSync(runtimePath, optimizerRuntimeSource, "utf8");
+  const directory = join(repo, runtimeDir);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, 0o700);
+  writeFileSync(runtimePath, optimizerRuntimeSource, { encoding: "utf8", mode: 0o600 });
+  chmodSync(runtimePath, 0o600);
   return runtimePath;
 }

--- a/src/optimize-workload/runtime-source.ts
+++ b/src/optimize-workload/runtime-source.ts
@@ -2,12 +2,26 @@ export const optimizerRuntimeSource = String.raw`#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse
+import hashlib
+import importlib.metadata
+import importlib.util
 import json
 import math
 import os
+import platform
+import re
+import socket
 import threading
 from pathlib import Path
+from collections.abc import Callable, Mapping
+from types import MappingProxyType
 from typing import Any
+
+
+DSPY_PACKAGE_SPEC = "dspy==3.3.0"
+DSPY_VERSION = "3.3.0"
+GEPA_PACKAGE_SPEC = "gepa[dspy]==0.1.1"
+GEPA_VERSION = "0.1.1"
 
 
 def emit(payload: dict[str, Any]) -> None:
@@ -46,6 +60,22 @@ class SpendEvidenceError(RuntimeError):
     pass
 
 
+class RuntimePackageVersionError(RuntimeError):
+    pass
+
+
+class ResumeBindingError(RuntimeError):
+    pass
+
+
+class WorkloadAdmissionError(RuntimeError):
+    pass
+
+
+class UnsupportedTeacherError(RuntimeError):
+    pass
+
+
 def positive_float(value: Any, label: str) -> float:
     parsed = float(value)
     if not math.isfinite(parsed) or not parsed > 0:
@@ -58,6 +88,36 @@ def non_negative_float(value: Any, label: str) -> float:
     if not math.isfinite(parsed) or parsed < 0:
         raise ValueError(f"{label} must be non-negative")
     return parsed
+
+
+def positive_int_arg(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
+def non_negative_int_arg(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be a non-negative integer")
+    return parsed
+
+
+def non_negative_float_arg(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("value must be a finite non-negative number")
+    return parsed
+
+
+def bool_arg(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("value must be true or false")
 
 
 def input_token_ceiling_from_bytes(message_bytes: int, message_count: int) -> int:
@@ -112,6 +172,175 @@ def write_owner_only_json(path: Path, payload: dict[str, Any]) -> None:
         raise
     os.replace(temporary, path)
     path.chmod(0o600)
+
+
+def canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_sha256(payload: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def secure_owner_only_tree(root: Path) -> None:
+    if not root.exists():
+        return
+    if root.is_symlink():
+        raise ValueError("owner-only artifact roots cannot be symlinks")
+    if root.is_file():
+        root.chmod(0o600)
+        return
+    root.chmod(0o700)
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError("owner-only artifacts cannot contain symlinks")
+        path.chmod(0o700 if path.is_dir() else 0o600)
+
+
+def artifact_path(repo: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo.resolve()).as_posix()
+    except ValueError:
+        return str(path.resolve())
+
+
+def logical_path(repo: Path, path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(repo.resolve()).as_posix()
+    except ValueError:
+        return f"external/{resolved.name}"
+
+
+def json_safe_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must return a mapping")
+    normalized = dict(value)
+    canonical_json_bytes(normalized)
+    return normalized
+
+
+def require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must return a mapping")
+    return dict(value)
+
+
+def is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value.lower())
+    )
+
+
+_SECRET_CONFIG_KEY = re.compile(
+    r"(?:^|[_-])(?:api[_-]?key|authorization|password|secret|token)(?:$|[_-])",
+    re.IGNORECASE,
+)
+_SECRET_CONFIG_VALUE = re.compile(
+    r"^(?:bearer\s+|sk-[A-Za-z0-9]|-----BEGIN [A-Z ]*PRIVATE KEY-----)",
+    re.IGNORECASE,
+)
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def reject_bridge_config_secrets(value: Any, path: str = "bridge_config") -> None:
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_bridge_config_secrets(item, f"{path}[{index}]")
+        return
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise ValueError("program bridge config keys must be strings")
+            child_path = f"{path}.{key}"
+            if re.search(r"(?:_env|_env_var)$", key, re.IGNORECASE):
+                if not isinstance(child, str) or _ENV_NAME.fullmatch(child) is None:
+                    raise ValueError(f"{child_path} must be an environment variable name")
+            elif _SECRET_CONFIG_KEY.search(key):
+                raise ValueError(f"{child_path} is a secret-bearing field")
+            reject_bridge_config_secrets(child, child_path)
+        return
+    if isinstance(value, str) and _SECRET_CONFIG_VALUE.search(value.strip()):
+        raise ValueError(f"{path} appears to contain a credential")
+
+
+def load_bridge_config(path: Path) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("program bridge config must be a non-symlink regular JSON file")
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        raise ValueError("program bridge config must contain finite valid JSON") from error
+    if not isinstance(payload, dict):
+        raise ValueError("program bridge config must contain a JSON object")
+    if payload.get("schema_version") != "understudy.dspy_gepa_bridge_config.v1":
+        raise ValueError("program bridge config schema_version must be understudy.dspy_gepa_bridge_config.v1")
+    reject_bridge_config_secrets(payload)
+    canonical_json_bytes(payload)
+    return payload
+
+
+def freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({key: freeze_json(child) for key, child in value.items()})
+    if isinstance(value, list):
+        return tuple(freeze_json(child) for child in value)
+    return value
+
+
+def validate_budget_allocation(bridge_config: Mapping[str, Any], optimizer_cap_usd: float) -> dict[str, float]:
+    raw = bridge_config.get("budget_allocation")
+    if not isinstance(raw, Mapping):
+        raise ValueError("program bridge config requires budget_allocation")
+    required = (
+        "campaign_approved_max_usd",
+        "campaign_cap_usd",
+        "prior_experiment_spend_usd",
+        "optimizer_inference_cap_usd",
+        "endpoint_cap_usd",
+    )
+    parsed: dict[str, float] = {}
+    for key in required:
+        value = raw.get(key)
+        if isinstance(value, bool):
+            raise ValueError(f"budget_allocation.{key} must be numeric")
+        parsed[key] = float(value)
+        if not math.isfinite(parsed[key]) or parsed[key] < 0:
+            raise ValueError(f"budget_allocation.{key} must be finite and non-negative")
+    if parsed["campaign_cap_usd"] <= 0:
+        raise ValueError("budget_allocation.campaign_cap_usd must be positive")
+    if parsed["campaign_cap_usd"] > parsed["campaign_approved_max_usd"] + 1e-12:
+        raise ValueError("campaign cap exceeds the explicitly approved maximum")
+    if abs(parsed["optimizer_inference_cap_usd"] - optimizer_cap_usd) > 1e-12:
+        raise ValueError("bridge optimizer_inference_cap_usd must equal --budget-usd")
+    allocated = (
+        parsed["prior_experiment_spend_usd"]
+        + parsed["optimizer_inference_cap_usd"]
+        + parsed["endpoint_cap_usd"]
+    )
+    if allocated > parsed["campaign_cap_usd"] + 1e-12:
+        raise ValueError("prior spend plus optimizer and endpoint caps exceeds campaign cap")
+    parsed["campaign_remaining_after_allocations_usd"] = parsed["campaign_cap_usd"] - allocated
+    return parsed
 
 
 class SpendLedger:
@@ -219,6 +448,7 @@ class SpendLedger:
                 "usage_complete": self.usage_complete,
                 "client_num_retries": 0,
                 "provider_invoice_verified": False,
+                "budget_scope": "optimizer-student-and-reflection-lm-calls-only",
                 "price_basis": {
                     "source": "user-supplied",
                     "input_usd_per_million": self.input_usd_per_million,
@@ -263,8 +493,30 @@ def exact_match_feedback(output_keys: list[str], gold: Any, pred: Any) -> Any:
     return ScoreWithFeedback(score=score, feedback=feedback)
 
 
+def dspy_run_dir(args: argparse.Namespace) -> Path:
+    return Path(args.repo) / ".understudy" / "optimize-workload" / "dspy-gepa"
+
+
 def dspy_run_state_path(args: argparse.Namespace) -> Path:
-    return Path(args.repo) / ".understudy" / "optimize-workload" / "dspy-gepa" / "run-state.json"
+    return dspy_run_dir(args) / "run-state.json"
+
+
+def dspy_artifacts(args: argparse.Namespace) -> dict[str, str]:
+    repo = Path(args.repo)
+    run_dir = dspy_run_dir(args)
+    paths = {
+        "package_state_path": run_dir / "package-state.json",
+        "config_path": run_dir / "config.json",
+        "program_state_path": run_dir / "program-state.json",
+        "bundle_manifest_path": run_dir / "bundle-manifest.json",
+        "admission_receipt_path": run_dir / "admission-receipt.json",
+        "run_state_path": run_dir / "run-state.json",
+    }
+    return {
+        name: artifact_path(repo, path)
+        for name, path in paths.items()
+        if path.exists() or name in {"package_state_path", "config_path", "run_state_path"}
+    }
 
 
 def write_dspy_run_state(
@@ -272,18 +524,24 @@ def write_dspy_run_state(
     ledger: SpendLedger,
     status: str,
     reason: str | None,
+    extra: Mapping[str, Any] | None = None,
 ) -> None:
     evidence = ledger.evidence()
-    write_owner_only_json(dspy_run_state_path(args), {
-        "schema_version": "understudy.dspy_gepa_run_state.v1",
+    payload = {
+        "schema_version": "understudy.dspy_gepa_run_state.v2",
         "status": status,
         "reason": reason,
         "adapter": "dspy-gepa",
         "model": args.model,
+        "reflection_model": args.reflection_model,
         "provider_calls": evidence["calls_attempted"] > 0,
         "optimizer_execution": True,
         "spend_evidence": evidence,
-    })
+        "artifacts": dspy_artifacts(args),
+    }
+    if extra:
+        payload.update(dict(extra))
+    write_owner_only_json(dspy_run_state_path(args), payload)
 
 
 def emit_dspy_failure(
@@ -296,20 +554,766 @@ def emit_dspy_failure(
     write_dspy_run_state(args, ledger, status, reason)
     evidence = ledger.evidence()
     emit({
-        "schema_version": "understudy.dspy_gepa_adapter.v1",
+        "schema_version": "understudy.dspy_gepa_adapter.v2",
         "status": status,
         "reason": reason,
         "adapter": "dspy-gepa",
         "model": args.model,
+        "reflection_model": args.reflection_model,
         "provider_calls": evidence["calls_attempted"] > 0,
         "optimizer_execution": True,
         "spend_evidence": evidence,
-        "run_state_path": ".understudy/optimize-workload/dspy-gepa/run-state.json",
+        "artifacts": dspy_artifacts(args),
+        "run_state_path": artifact_path(Path(args.repo), dspy_run_state_path(args)),
     })
     raise SystemExit(exit_code)
 
 
+def require_exact_optimizer_packages(
+    workload_package_pins: Mapping[str, Any] | None = None,
+    project_state: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        actual = {
+            "dspy": importlib.metadata.version("dspy"),
+            "gepa": importlib.metadata.version("gepa"),
+        }
+    except importlib.metadata.PackageNotFoundError as error:
+        raise RuntimePackageVersionError("runtime-package-version-mismatch") from error
+    if actual != {"dspy": DSPY_VERSION, "gepa": GEPA_VERSION}:
+        raise RuntimePackageVersionError("runtime-package-version-mismatch")
+    workload_actual: dict[str, str] = {}
+    for distribution, expected in (workload_package_pins or {}).items():
+        if not isinstance(distribution, str) or not isinstance(expected, str) or not expected:
+            raise RuntimePackageVersionError("workload-package-pins-invalid")
+        try:
+            installed = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError as error:
+            raise RuntimePackageVersionError("workload-package-version-mismatch") from error
+        if installed != expected:
+            raise RuntimePackageVersionError("workload-package-version-mismatch")
+        workload_actual[distribution] = installed
+    payload = {
+        "schema_version": "understudy.dspy_gepa_package_state.v1",
+        "requested": [DSPY_PACKAGE_SPEC, GEPA_PACKAGE_SPEC],
+        "actual": actual,
+        "workload_actual": workload_actual,
+        "program_project": dict(project_state) if project_state else None,
+        "python": platform.python_version(),
+        "installer": "uv run --no-project",
+    }
+    payload["package_state_sha256"] = canonical_sha256(payload)
+    return payload
+
+
+def program_project_state(path: Path, repo: Path) -> dict[str, Any]:
+    if not path.is_dir() or path.is_symlink():
+        raise ValueError("program project must be a non-symlink directory")
+    pyproject = path / "pyproject.toml"
+    lock = path / "uv.lock"
+    for artifact in (pyproject, lock):
+        if not artifact.is_file() or artifact.is_symlink():
+            raise ValueError("program project requires regular pyproject.toml and uv.lock files")
+    return {
+        "logical_path": logical_path(repo, path),
+        "pyproject_sha256": file_sha256(pyproject),
+        "uv_lock_sha256": file_sha256(lock),
+        "locked": True,
+    }
+
+
+def load_program_bridge(path: Path) -> Any:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("program bridge must be a regular Python file")
+    module_name = f"understudy_dspy_gepa_bridge_{file_sha256(path)[:16]}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError("program bridge could not be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def validate_context_window_gate(
+    gate: Any,
+    *,
+    prompt_hash_field: str,
+    prompt_tokens_field: str,
+    context_limit_field: str,
+    overflow_reason: str,
+) -> None:
+    if not isinstance(gate, Mapping):
+        raise WorkloadAdmissionError("bundle-validation-requires-context-window-gate")
+    if gate.get("not_applicable") is True:
+        if not is_sha256(gate.get("proof_sha256")):
+            raise WorkloadAdmissionError("context-window-not-applicable-requires-proof")
+        return
+    numeric_fields = (
+        prompt_tokens_field,
+        "max_tokens",
+        "safety_margin",
+        context_limit_field,
+    )
+    for hash_key in (prompt_hash_field, "token_count_receipt_sha256"):
+        if not is_sha256(gate.get(hash_key)):
+            raise WorkloadAdmissionError("context-window-gate-requires-prompt-token-count-hashes")
+    numeric: dict[str, int] = {}
+    for field in numeric_fields:
+        value = gate.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise WorkloadAdmissionError("context-window-gate-has-invalid-token-counts")
+        numeric[field] = value
+    if numeric["max_tokens"] <= 0 or numeric[context_limit_field] <= 0:
+        raise WorkloadAdmissionError("context-window-gate-has-invalid-limits")
+    if (
+        numeric[prompt_tokens_field]
+        + numeric["max_tokens"]
+        + numeric["safety_margin"]
+        >= numeric[context_limit_field]
+    ):
+        raise WorkloadAdmissionError(overflow_reason)
+    for identity_name in ("renderer", "tokenizer", "checkpoint", "route"):
+        identity = gate.get(identity_name)
+        if (
+            not isinstance(identity, Mapping)
+            or not isinstance(identity.get("id"), str)
+            or not identity.get("id")
+            or not is_sha256(identity.get("sha256"))
+        ):
+            raise WorkloadAdmissionError("context-window-gate-requires-renderer-tokenizer-checkpoint-identities")
+    coverage = gate.get("coverage")
+    if not isinstance(coverage, Mapping):
+        raise WorkloadAdmissionError("context-window-gate-requires-coverage")
+    for hash_key in ("admitted_task_ids_sha256", "eligible_route_ids_sha256"):
+        if not is_sha256(coverage.get(hash_key)):
+            raise WorkloadAdmissionError("context-window-coverage-requires-task-route-hashes")
+    method = coverage.get("method")
+    if method == "all_admitted_tasks_and_eligible_routes":
+        count_fields = (
+            "admitted_task_count",
+            "covered_task_count",
+            "eligible_route_count",
+            "covered_route_count",
+        )
+        counts = {field: coverage.get(field) for field in count_fields}
+        if any(isinstance(value, bool) or not isinstance(value, int) or value <= 0 for value in counts.values()):
+            raise WorkloadAdmissionError("context-window-coverage-counts-invalid")
+        if (
+            counts["admitted_task_count"] != counts["covered_task_count"]
+            or counts["eligible_route_count"] != counts["covered_route_count"]
+        ):
+            raise WorkloadAdmissionError("context-window-coverage-incomplete")
+        if not is_sha256(coverage.get("complete_inventory_sha256")):
+            raise WorkloadAdmissionError("complete-context-inventory-requires-proof")
+    elif method == "conservative_bound":
+        if not is_sha256(coverage.get("proof_sha256")):
+            raise WorkloadAdmissionError("conservative-context-bound-requires-proof")
+    else:
+        raise WorkloadAdmissionError("context-window-coverage-method-invalid")
+    if not is_sha256(coverage.get("worst_case_row_sha256")):
+        raise WorkloadAdmissionError("context-window-coverage-requires-worst-case-row")
+
+
+def run_bridge_admission(module: Any, context: dict[str, Any]) -> dict[str, Any]:
+    hook = getattr(module, "admit_understudy_dspy_gepa", None)
+    if not callable(hook):
+        raise WorkloadAdmissionError("program-bridge-admission-hook-required")
+    network_attempts: list[str] = []
+
+    def blocked_network(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        network_attempts.append("socket")
+        raise WorkloadAdmissionError("admission-hook-attempted-network-call")
+
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+    original_create_connection = socket.create_connection
+    try:
+        socket.socket.connect = blocked_network
+        socket.socket.connect_ex = blocked_network
+        socket.create_connection = blocked_network
+        receipt = json_safe_mapping(hook(context), "admit_understudy_dspy_gepa(context)")
+    finally:
+        socket.socket.connect = original_connect
+        socket.socket.connect_ex = original_connect_ex
+        socket.create_connection = original_create_connection
+    if network_attempts:
+        raise WorkloadAdmissionError("admission-hook-attempted-network-call")
+    if receipt.get("admitted") is not True:
+        raise WorkloadAdmissionError("workload-admission-failed")
+    if not isinstance(receipt.get("live_admission_required"), bool):
+        raise WorkloadAdmissionError("offline-admission-must-declare-live-admission-required")
+    validation = receipt.get("bundle_validation")
+    if not isinstance(validation, Mapping) or validation.get("network_calls_made") != 0:
+        raise WorkloadAdmissionError("bundle-validation-must-attest-zero-network-calls")
+    if not is_sha256(validation.get("input_bundle_sha256")):
+        raise WorkloadAdmissionError("bundle-validation-requires-input-bundle-sha256")
+    if validation.get("executable_bundle_loaded") is not True:
+        raise WorkloadAdmissionError("bundle-validation-must-prove-executable-bundle-loaded")
+    if validation.get("loaded_bundle_sha256") != validation.get("input_bundle_sha256"):
+        raise WorkloadAdmissionError("loaded-bundle-sha256-mismatch")
+    if validation.get("required_bundle_fields_present") is not True:
+        raise WorkloadAdmissionError("bundle-validation-requires-all-bundle-fields")
+    if not is_sha256(validation.get("workload_adapter_sha256")):
+        raise WorkloadAdmissionError("bundle-validation-requires-workload-adapter-sha256")
+    if not is_sha256(validation.get("package_receipt_sha256")):
+        raise WorkloadAdmissionError("bundle-validation-requires-package-receipt-sha256")
+    if not is_sha256(validation.get("tool_schema_sha256")):
+        raise WorkloadAdmissionError("bundle-validation-requires-tool-schema-sha256")
+    if not isinstance(validation.get("package_versions"), Mapping):
+        raise WorkloadAdmissionError("bundle-validation-requires-package-versions")
+    config = context["config"]
+    program_bridge = config["program_bridge"]
+    if validation.get("workload_adapter_sha256") != program_bridge.get("sha256"):
+        raise WorkloadAdmissionError("workload-adapter-sha256-mismatch")
+    expected_package_receipt = (
+        program_bridge.get("project", {}).get("uv_lock_sha256")
+        if isinstance(program_bridge.get("project"), Mapping)
+        else config["packages"].get("package_state_sha256")
+    )
+    if validation.get("package_receipt_sha256") != expected_package_receipt:
+        raise WorkloadAdmissionError("package-receipt-sha256-mismatch")
+    bridge_config = context["bridge_config"]
+    for field in ("input_bundle_sha256", "tool_schema_sha256"):
+        if bridge_config.get(field) != validation.get(field):
+            raise WorkloadAdmissionError(f"{field.replace('_', '-')}-mismatch")
+    typed_contract = validation.get("typed_request_contract")
+    required_typed_checks = {
+        "model_typed": True,
+        "messages_typed": True,
+        "tools_typed": True,
+        "sampling_typed": True,
+    }
+    if not isinstance(typed_contract, Mapping) or any(
+        typed_contract.get(key) is not expected
+        for key, expected in required_typed_checks.items()
+    ):
+        raise WorkloadAdmissionError("typed-request-contract-validation-failed")
+    oracle = validation.get("oracle_contract")
+    if not isinstance(oracle, Mapping):
+        raise WorkloadAdmissionError("bundle-validation-requires-oracle-contract")
+    if oracle.get("kind") == "exact_assistant_message":
+        if any(
+            oracle.get(field) is not True
+            for field in (
+                "expected_is_materialized_object",
+                "expectation_hash_recomputed",
+                "continuation_parent_present",
+                "provenance_present",
+            )
+        ):
+            raise WorkloadAdmissionError("exact-assistant-message-oracle-contract-failed")
+    elif oracle.get("kind") == "state_verifier":
+        if (
+            oracle.get("task_typed") is not True
+            or oracle.get("initial_state_typed") is not True
+            or any(
+                not is_sha256(oracle.get(field))
+                for field in (
+                    "assertion_identity_sha256",
+                    "prime_receipt_sha256",
+                    "reward_metric_binding_sha256",
+                )
+            )
+            or (
+                oracle.get("is_continuation") is True
+                and not is_sha256(oracle.get("continuation_parent_sha256"))
+            )
+        ):
+            raise WorkloadAdmissionError("state-verifier-oracle-contract-failed")
+    else:
+        raise WorkloadAdmissionError("oracle-contract-kind-invalid")
+    tool_probe = validation.get("tool_contract_probe")
+    if isinstance(tool_probe, Mapping) and tool_probe.get("not_applicable") is not True:
+        required_probe_checks = {
+            "wire_arguments_type": "string",
+            "arguments_json_valid": True,
+            "decoded_arguments_type": "object",
+        }
+        if any(tool_probe.get(key) != expected for key, expected in required_probe_checks.items()):
+            raise WorkloadAdmissionError("tool-contract-probe-validation-failed")
+        for hash_key in (
+            "wire_arguments_sha256",
+            "request_semantic_sha256",
+            "executed_semantic_sha256",
+        ):
+            if not is_sha256(tool_probe.get(hash_key)):
+                raise WorkloadAdmissionError("tool-contract-probe-requires-argument-hashes")
+        if tool_probe.get("request_semantic_sha256") != tool_probe.get("executed_semantic_sha256"):
+            raise WorkloadAdmissionError("tool-contract-request-execution-semantics-changed")
+        nested_fields = tool_probe.get("nested_string_arguments", {})
+        if not isinstance(nested_fields, Mapping):
+            raise WorkloadAdmissionError("nested-string-arguments-must-be-a-mapping")
+        for field_receipt in nested_fields.values():
+            if not isinstance(field_receipt, Mapping) or field_receipt.get("wire_type") != "string":
+                raise WorkloadAdmissionError("nested-tool-argument-did-not-remain-a-string")
+            for hash_key in (
+                "wire_sha256",
+                "decoded_semantic_sha256",
+                "executed_semantic_sha256",
+            ):
+                if not is_sha256(field_receipt.get(hash_key)):
+                    raise WorkloadAdmissionError("nested-tool-argument-requires-hashes")
+            if field_receipt.get("decoded_semantic_sha256") != field_receipt.get("executed_semantic_sha256"):
+                raise WorkloadAdmissionError("nested-tool-argument-semantics-changed")
+        if tool_probe.get("required_world_state_change") is True:
+            if tool_probe.get("required_write_succeeded") is not True or tool_probe.get("world_state_changed") is not True:
+                raise WorkloadAdmissionError("required-world-state-change-probe-failed")
+            if tool_probe.get("mutation_scope") != "bounded_trajectory":
+                raise WorkloadAdmissionError("world-state-change-must-cover-bounded-trajectory")
+    elif not isinstance(tool_probe, Mapping):
+        raise WorkloadAdmissionError("bundle-validation-requires-tool-contract-probe")
+    validate_context_window_gate(
+        validation.get("context_window_gate"),
+        prompt_hash_field="source_prompt_sha256",
+        prompt_tokens_field="source_prompt_tokens",
+        context_limit_field="source_context_limit",
+        overflow_reason="source-renderer-context-window-overflow",
+    )
+    validate_context_window_gate(
+        validation.get("reflection_context_window_gate"),
+        prompt_hash_field="reflection_prompt_sha256",
+        prompt_tokens_field="reflection_prompt_tokens",
+        context_limit_field="reflection_context_limit",
+        overflow_reason="reflection-renderer-context-window-overflow",
+    )
+    trajectory_feedback = validation.get("trajectory_feedback_contract")
+    required_event_fields = [
+        "sequence_index",
+        "tool_or_method_category",
+        "succeeded",
+        "error_type",
+        "mutation_observed",
+        "stop_observed",
+    ]
+    required_excluded_fields = ["arguments", "urls", "secrets", "answer_keys"]
+    event_count = trajectory_feedback.get("event_count") if isinstance(trajectory_feedback, Mapping) else None
+    if (
+        not isinstance(trajectory_feedback, Mapping)
+        or trajectory_feedback.get("redacted") is not True
+        or trajectory_feedback.get("ordered_events") is not True
+        or trajectory_feedback.get("event_fields") != required_event_fields
+        or trajectory_feedback.get("excluded_fields") != required_excluded_fields
+        or isinstance(event_count, bool)
+        or not isinstance(event_count, int)
+        or event_count <= 0
+        or not is_sha256(trajectory_feedback.get("full_native_trace_sha256"))
+        or not is_sha256(trajectory_feedback.get("redacted_feedback_sha256"))
+        or trajectory_feedback.get("action_sequence_optimization_enabled") is not True
+    ):
+        raise WorkloadAdmissionError("trajectory-feedback-contract-failed")
+    deployment_parity = validation.get("deployment_parity")
+    if not isinstance(deployment_parity, Mapping):
+        raise WorkloadAdmissionError("bundle-validation-requires-deployment-parity")
+    if (
+        deployment_parity.get("network_calls_made") != 0
+        or deployment_parity.get("duplicate_policy_injection") is not False
+        or deployment_parity.get("loaded_bundle_once") is not True
+        or deployment_parity.get("official_eval_outer_policy_present") is not False
+    ):
+        raise WorkloadAdmissionError("provider-free-deployment-parity-failed")
+    for surface in ("messages", "tools", "sampling"):
+        inline_hash = deployment_parity.get(f"inline_{surface}_sha256")
+        loaded_hash = deployment_parity.get(f"loaded_bundle_{surface}_sha256")
+        if not is_sha256(inline_hash) or inline_hash != loaded_hash:
+            raise WorkloadAdmissionError(f"inline-loaded-{surface}-parity-failed")
+    mutation_contract = validation.get("candidate_mutation_contract")
+    required_mutation_fields = {
+        "candidate_hash",
+        "parent_hash",
+        "reflection_request_hash",
+        "reflection_output_hash",
+        "reflection_model",
+        "reflection_sampling_hash",
+        "checkpoint_hash",
+        "config_hash",
+        "evaluated_prompt_hash",
+        "rendered_request_hash",
+        "task_hash",
+        "trace_hash",
+        "world_progress_hash",
+        "score",
+    }
+    if (
+        not isinstance(mutation_contract, Mapping)
+        or mutation_contract.get("enforcement_status") != "declared_not_enforced"
+        or mutation_contract.get("promotion_guarantee") is not False
+        or not is_sha256(mutation_contract.get("contract_sha256"))
+        or mutation_contract.get("materialize_before_evaluate") is not True
+        or mutation_contract.get("atomic_persistence") is not True
+        or mutation_contract.get("require_changed_hash") is not True
+        or mutation_contract.get("same_hash_quarantine") != {
+            "evaluated": False,
+            "provider_calls": 0,
+            "pareto_eligible": False,
+            "promotion_eligible": False,
+        }
+        or mutation_contract.get("partial_artifact_quarantine") is not True
+        or mutation_contract.get("crash_resume_quarantine") is not True
+        or set(mutation_contract.get("receipt_fields", [])) != required_mutation_fields
+    ):
+        raise WorkloadAdmissionError("candidate-mutation-integrity-contract-failed")
+    return receipt
+
+
+def run_live_bridge_admission(
+    module: Any,
+    context: dict[str, Any],
+    program: Mapping[str, Any],
+    offline_admission: Mapping[str, Any],
+    budget_allocation: Mapping[str, float],
+) -> dict[str, Any] | None:
+    required = offline_admission.get("live_admission_required") is True
+    endpoint_cap = float(budget_allocation["endpoint_cap_usd"])
+    if not required:
+        if endpoint_cap != 0:
+            raise WorkloadAdmissionError("endpoint-cap-requires-live-admission")
+        return None
+    if endpoint_cap <= 0:
+        raise WorkloadAdmissionError("live-admission-requires-positive-endpoint-cap")
+    hook = getattr(module, "live_admit_understudy_dspy_gepa", None)
+    if not callable(hook):
+        raise WorkloadAdmissionError("live-program-bridge-admission-hook-required")
+    try:
+        receipt = json_safe_mapping(
+            hook(context, program),
+            "live_admit_understudy_dspy_gepa(context, program)",
+        )
+    except WorkloadAdmissionError:
+        raise
+    except Exception as error:
+        raise WorkloadAdmissionError("live-workload-admission-failed") from error
+    if (
+        receipt.get("admitted") is not True
+        or receipt.get("standard_verifiers") is not True
+        or receipt.get("optimizer_started") is not False
+        or receipt.get("episode_count") != 1
+        or not isinstance(receipt.get("fixed_task_id"), str)
+        or not receipt.get("fixed_task_id")
+        or receipt.get("same_student_metric_path") is not True
+    ):
+        raise WorkloadAdmissionError("live-admission-contract-failed")
+    preflight = receipt.get("preflight")
+    if not isinstance(preflight, Mapping) or any(
+        preflight.get(field) is not True
+        for field in ("health_ok", "models_loaded", "bundle_loaded")
+    ):
+        raise WorkloadAdmissionError("live-admission-preflight-failed")
+    expected_bundle_sha = offline_admission["bundle_validation"]["input_bundle_sha256"]
+    if preflight.get("loaded_bundle_sha256") != expected_bundle_sha:
+        raise WorkloadAdmissionError("live-admission-loaded-bundle-mismatch")
+    integer_counts: dict[str, int] = {}
+    for field in ("call_count", "node_count", "read_count", "write_count"):
+        value = receipt.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise WorkloadAdmissionError("live-admission-counts-invalid")
+        integer_counts[field] = value
+    if integer_counts["call_count"] <= 0 or integer_counts["node_count"] <= 0:
+        raise WorkloadAdmissionError("live-admission-has-no-observed-work")
+    assertion_fraction = receipt.get("assertion_fraction")
+    if (
+        isinstance(assertion_fraction, bool)
+        or not isinstance(assertion_fraction, (int, float))
+        or not math.isfinite(float(assertion_fraction))
+        or not 0 <= float(assertion_fraction) <= 1
+    ):
+        raise WorkloadAdmissionError("live-admission-assertion-fraction-invalid")
+    if receipt.get("parser_failure") is not False or receipt.get("tool_argument_contract_ok") is not True:
+        raise WorkloadAdmissionError("live-admission-parser-or-tool-contract-failed")
+    if receipt.get("required_world_state_change") is True:
+        if (
+            integer_counts["write_count"] <= 0
+            or receipt.get("world_state_changed") is not True
+            or receipt.get("mutation_scope") != "bounded_trajectory"
+        ):
+            raise WorkloadAdmissionError("live-admission-required-world-state-change-failed")
+    spend = receipt.get("endpoint_spend")
+    if not isinstance(spend, Mapping):
+        raise WorkloadAdmissionError("live-admission-requires-endpoint-spend")
+    attributed = spend.get("attributed_cost_usd")
+    if (
+        spend.get("cap_usd") != endpoint_cap
+        or spend.get("usage_complete") is not True
+        or spend.get("actual_call_count") != integer_counts["call_count"]
+        or isinstance(attributed, bool)
+        or not isinstance(attributed, (int, float))
+        or not math.isfinite(float(attributed))
+        or not 0 <= float(attributed) <= endpoint_cap
+    ):
+        raise WorkloadAdmissionError("live-admission-endpoint-spend-invalid")
+    receipt["receipt_sha256"] = canonical_sha256(receipt)
+    return receipt
+
+
+def admission_receipt_payload(
+    config_base: Mapping[str, Any],
+    offline_admission: Mapping[str, Any],
+    live_admission: Mapping[str, Any] | None,
+    resume_config_sha256: str,
+    config_sha256: str,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": "understudy.dspy_gepa_admission_receipt.v1",
+        "status": "admitted",
+        "optimizer_started": False,
+        "static_config_sha256": canonical_sha256(config_base),
+        "offline_admission_sha256": canonical_sha256(offline_admission),
+        "live_admission": dict(live_admission) if live_admission is not None else None,
+        "live_admission_sha256": (
+            canonical_sha256(live_admission) if live_admission is not None else None
+        ),
+        "resume_config_sha256": resume_config_sha256,
+        "config_sha256": config_sha256,
+    }
+    payload["receipt_sha256"] = canonical_sha256(payload)
+    return payload
+
+
+def load_admission_receipt(
+    path: Path,
+    config_base: Mapping[str, Any],
+    offline_admission: Mapping[str, Any],
+    resume_config_sha256: str,
+) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise WorkloadAdmissionError("admission-receipt-must-be-a-regular-file")
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise WorkloadAdmissionError("admission-receipt-invalid") from error
+    if not isinstance(receipt, dict):
+        raise WorkloadAdmissionError("admission-receipt-invalid")
+    claimed_sha = receipt.pop("receipt_sha256", None)
+    computed_sha = canonical_sha256(receipt)
+    receipt["receipt_sha256"] = claimed_sha
+    if (
+        receipt.get("schema_version") != "understudy.dspy_gepa_admission_receipt.v1"
+        or receipt.get("status") != "admitted"
+        or receipt.get("optimizer_started") is not False
+        or not is_sha256(claimed_sha)
+        or claimed_sha != computed_sha
+        or receipt.get("static_config_sha256") != canonical_sha256(config_base)
+        or receipt.get("offline_admission_sha256") != canonical_sha256(offline_admission)
+        or receipt.get("resume_config_sha256") != resume_config_sha256
+    ):
+        raise WorkloadAdmissionError("admission-receipt-binding-mismatch")
+    live = receipt.get("live_admission")
+    live_sha = receipt.get("live_admission_sha256")
+    if live is None:
+        if offline_admission.get("live_admission_required") is True or live_sha is not None:
+            raise WorkloadAdmissionError("admission-receipt-live-proof-missing")
+    else:
+        if not isinstance(live, Mapping) or not is_sha256(live_sha) or canonical_sha256(live) != live_sha:
+            raise WorkloadAdmissionError("admission-receipt-live-proof-invalid")
+        live_without_hash = dict(live)
+        live_claimed_sha = live_without_hash.pop("receipt_sha256", None)
+        if not is_sha256(live_claimed_sha) or canonical_sha256(live_without_hash) != live_claimed_sha:
+            raise WorkloadAdmissionError("admission-receipt-live-proof-invalid")
+    if not is_sha256(receipt.get("config_sha256")):
+        raise WorkloadAdmissionError("admission-receipt-config-hash-invalid")
+    return receipt
+
+
+def bind_resume_log(log_dir: Path, config_sha256: str) -> Path:
+    log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    secure_owner_only_tree(log_dir)
+    binding_path = log_dir / "understudy-resume-binding.json"
+    binding = {
+        "schema_version": "understudy.dspy_gepa_resume_binding.v1",
+        "config_sha256": config_sha256,
+        "dspy_version": DSPY_VERSION,
+        "gepa_version": GEPA_VERSION,
+    }
+    if binding_path.exists():
+        try:
+            existing = json.loads(binding_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise ResumeBindingError("resume-log-binding-invalid") from error
+        if existing != binding:
+            raise ResumeBindingError("resume-log-config-mismatch")
+    else:
+        write_owner_only_json(binding_path, binding)
+    return binding_path
+
+
+def optimized_program_state(optimized: Any, bridge_state: Any) -> dict[str, Any]:
+    dump_state = getattr(optimized, "dump_state", None)
+    if not callable(dump_state):
+        raise ValueError("optimized DSPy program must implement dump_state")
+    try:
+        state = dump_state(json_mode=True)
+    except TypeError:
+        state = dump_state()
+    canonical_json_bytes(state)
+    if bridge_state is not None:
+        canonical_json_bytes(bridge_state)
+    return {
+        "schema_version": "understudy.dspy_gepa_program_state.v1",
+        "program_class": optimized.__class__.__name__,
+        "program_module": optimized.__class__.__module__,
+        "dspy_state": state,
+        "bridge_state": bridge_state,
+        "dspy_version": DSPY_VERSION,
+        "gepa_version": GEPA_VERSION,
+    }
+
+
+def write_canonical_bundle(
+    args: argparse.Namespace,
+    optimized: Any,
+    exporter: Callable[..., Any],
+    export_context: dict[str, Any],
+    config_sha256: str,
+) -> dict[str, Any]:
+    run_dir = dspy_run_dir(args)
+    bundles_dir = run_dir / "candidate-bundles"
+    bundles_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    index = 0
+    while True:
+        suffix = "" if index == 0 else f"-{index}"
+        export_dir = bundles_dir / f"{config_sha256[:16]}{suffix}"
+        try:
+            export_dir.mkdir(mode=0o700)
+            break
+        except FileExistsError:
+            index += 1
+    export_result = exporter(optimized, export_dir, export_context)
+    metadata = {} if export_result is None else json_safe_mapping(export_result, "export_candidate")
+    if "provenance" not in metadata or not isinstance(metadata.get("provenance"), Mapping):
+        raise ValueError("export_candidate metadata must include provenance")
+    if "continuation_parent" not in metadata:
+        raise ValueError("export_candidate metadata must include continuation_parent (null for a root bundle)")
+    mutation = metadata.get("mutation_receipt")
+    if not isinstance(mutation, Mapping):
+        raise ValueError("export_candidate metadata must include mutation_receipt")
+    mutation_claimed = mutation.get("mutation_claimed")
+    if not isinstance(mutation_claimed, bool):
+        raise ValueError("mutation_receipt requires boolean mutation_claimed")
+    if mutation.get("outcome") not in {"improved", "non_improved"}:
+        raise ValueError("mutation_receipt requires improved or non_improved outcome")
+    if not isinstance(mutation.get("promotion_eligible"), bool):
+        raise ValueError("mutation_receipt requires boolean promotion_eligible")
+    mutation_hash_fields = (
+        "parent_component_sha256",
+        "candidate_component_sha256",
+        "candidate_persistence_sha256",
+        "optimizer_receipt_sha256",
+        "reflection_receipt_sha256",
+        "checkpoint_sha256",
+        "evaluated_prompt_sha256",
+        "checkpoint_evaluated_prompt_binding_sha256",
+        "world_progress_sha256",
+    )
+    if mutation_claimed:
+        if mutation.get("outcome") != "improved":
+            raise ValueError("claimed mutation must have improved outcome")
+        if any(not is_sha256(mutation.get(field)) for field in mutation_hash_fields):
+            raise ValueError("mutation_receipt requires complete SHA-256 evidence")
+        if mutation["parent_component_sha256"] == mutation["candidate_component_sha256"]:
+            raise ValueError("artifact_persistence_failure: candidate component matches parent")
+        if any(
+            mutation.get(field) is not True
+            for field in (
+                "candidate_persisted_before_evaluation",
+                "atomic_persistence",
+                "optimizer_reflection_bound",
+                "checkpoint_evaluated_prompt_bound",
+                "world_progress_observed",
+            )
+        ):
+            raise ValueError("artifact_persistence_failure: mutation evidence is incomplete")
+    else:
+        if mutation.get("outcome") != "non_improved" or mutation.get("promotion_eligible") is not False:
+            raise ValueError("unchanged export must be non_improved and non-promotable")
+        candidate_hash = mutation.get("candidate_component_sha256")
+        parent_hash = mutation.get("parent_component_sha256")
+        if not is_sha256(candidate_hash) or parent_hash not in (None, candidate_hash):
+            raise ValueError("unchanged export requires a root or same-hash parent")
+    secure_owner_only_tree(export_dir)
+    files = []
+    for path in sorted(export_dir.rglob("*"), key=lambda item: item.relative_to(export_dir).as_posix()):
+        if path.is_file():
+            files.append({
+                "path": path.relative_to(export_dir).as_posix(),
+                "size_bytes": path.stat().st_size,
+                "sha256": file_sha256(path),
+            })
+    if not files:
+        raise ValueError("export_candidate must write at least one file")
+    canonical = {
+        "schema_version": "understudy.dspy_gepa_bundle_content.v1",
+        "files": files,
+    }
+    bundle_sha256 = canonical_sha256(canonical)
+    manifest = {
+        "schema_version": "understudy.dspy_gepa_bundle_manifest.v1",
+        "bundle_path": artifact_path(Path(args.repo), export_dir),
+        "bundle_sha256": bundle_sha256,
+        "canonical_bundle_sha256": bundle_sha256,
+        "canonicalization": "sha256(canonical-json({schema_version,files[path,size_bytes,sha256]}))",
+        "files": files,
+        "export_metadata": metadata,
+        "config_sha256": config_sha256,
+        "budget_allocation": export_context["config"]["budget_allocation"],
+        "mutation_claimed": mutation_claimed,
+        "outcome": mutation["outcome"],
+        "promotion_eligible": mutation["promotion_eligible"],
+        "sampling": {
+            "student": export_context["config"]["inference"]["student_sampling"],
+            "reflection": export_context["config"]["inference"]["reflection_sampling"],
+        },
+    }
+    manifest_path = run_dir / "bundle-manifest.json"
+    write_owner_only_json(manifest_path, manifest)
+    return manifest
+
+
 def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
+    repo = Path(args.repo).resolve()
+    run_dir = dspy_run_dir(args)
+    run_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    program_bridge_path = Path(args.program_bridge).resolve() if args.program_bridge else None
+    program_bridge_config_path = (
+        Path(args.program_bridge_config).resolve() if args.program_bridge_config else None
+    )
+    if (program_bridge_path is None) != (program_bridge_config_path is None):
+        raise ValueError("program bridge and program bridge config must be supplied together")
+    if program_bridge_path is not None:
+        if args.admission_only == bool(args.admission_receipt):
+            raise WorkloadAdmissionError(
+                "bridge-run-requires-exactly-one-of-admission-only-or-admission-receipt"
+            )
+    elif args.admission_only or args.admission_receipt:
+        raise ValueError("admission controls require a program bridge")
+    bridge_config = (
+        load_bridge_config(program_bridge_config_path)
+        if program_bridge_config_path is not None
+        else {}
+    )
+    immutable_bridge_config = freeze_json(bridge_config)
+    project_path = Path(args.program_project).resolve() if args.program_project else None
+    if project_path is not None and program_bridge_path is None:
+        raise ValueError("program project requires a program bridge")
+    project_state = program_project_state(project_path, repo) if project_path is not None else None
+    workload_package_pins = bridge_config.get("workload_package_pins", {})
+    if project_path is not None and (
+        not isinstance(workload_package_pins, Mapping) or not workload_package_pins
+    ):
+        raise ValueError("locked program projects require workload_package_pins")
+    package_state = require_exact_optimizer_packages(workload_package_pins, project_state)
+    write_owner_only_json(run_dir / "package-state.json", package_state)
+    budget_allocation = (
+        validate_budget_allocation(bridge_config, ledger.budget_usd)
+        if program_bridge_path is not None
+        else {
+            "campaign_cap_usd": ledger.budget_usd,
+            "prior_experiment_spend_usd": 0.0,
+            "optimizer_inference_cap_usd": ledger.budget_usd,
+            "endpoint_cap_usd": 0.0,
+            "campaign_remaining_after_allocations_usd": 0.0,
+        }
+    )
+
     import dspy
 
     class BudgetedLM(dspy.LM):
@@ -380,69 +1384,340 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
     if not gateway_url:
         raise ValueError("UNDERSTUDY_GATEWAY_URL is required for dspy-gepa")
 
-    rows = load_rows(args.samples)
-    input_keys = split_keys(args.input_keys)
-    output_keys = split_keys(args.output_keys)
-    train_rows, dev_rows, holdout_count = split_train_dev(rows, args.split_key, args.train_split, args.dev_split)
-    for row in [*train_rows, *dev_rows]:
-        missing = [key for key in [*input_keys, *output_keys] if key not in row]
-        if missing:
-            raise ValueError(f"sample row is missing keys: {', '.join(missing)}")
+    rows = load_rows(args.samples) if args.samples else []
+    input_keys = split_keys(args.input_keys or "")
+    output_keys = split_keys(args.output_keys or "")
+    bridge_module = load_program_bridge(program_bridge_path) if program_bridge_path else None
 
-    lm = BudgetedLM(
+    if bridge_module is None:
+        if not rows or not input_keys or not output_keys:
+            raise ValueError("samples, input keys, and output keys are required without a program bridge")
+        train_rows, dev_rows, holdout_count = split_train_dev(
+            rows, args.split_key, args.train_split, args.dev_split,
+        )
+    else:
+        train_rows = []
+        dev_rows = []
+        holdout_count = len([
+            row for row in rows
+            if str(row.get(args.split_key, "")).lower() == "holdout"
+        ])
+
+    config_base = {
+        "schema_version": "understudy.dspy_gepa_config.v2",
+        "adapter_runtime_sha256": file_sha256(Path(__file__).resolve()),
+        "packages": package_state,
+        "student_model": args.model,
+        "reflection_model": args.reflection_model,
+        "module": args.module,
+        "samples": {
+            "logical_path": logical_path(repo, Path(args.samples)) if args.samples else None,
+            "sha256": file_sha256(Path(args.samples).resolve()) if args.samples else None,
+        },
+        "program_bridge": {
+            "logical_path": logical_path(repo, program_bridge_path) if program_bridge_path else None,
+            "sha256": file_sha256(program_bridge_path) if program_bridge_path else None,
+            "config_logical_path": logical_path(repo, program_bridge_config_path) if program_bridge_config_path else None,
+            "config_sha256": canonical_sha256(bridge_config) if program_bridge_config_path else None,
+            "config": bridge_config if program_bridge_config_path else None,
+            "project": project_state,
+            "builder": "build_understudy_dspy_gepa",
+            "admission_hook": "admit_understudy_dspy_gepa",
+        },
+        "input_keys": input_keys,
+        "output_keys": output_keys,
+        "split": {
+            "key": args.split_key,
+            "train": args.train_split,
+            "dev": args.dev_split,
+            "holdout_excluded": True,
+        },
+        "gepa": {
+            "max_metric_calls": args.max_metric_calls,
+            "reflection_minibatch_size": args.reflection_minibatch_size,
+            "candidate_selection_strategy": args.candidate_selection_strategy,
+            "component_selector": args.component_selector,
+            "use_merge": args.use_merge,
+            "max_merge_invocations": args.max_merge_invocations,
+            "num_threads": args.num_threads,
+            "seed": args.seed,
+            "track_stats": args.track_stats,
+            "track_best_outputs": True,
+            "log_dir": logical_path(repo, Path(args.log_dir)),
+        },
+        "inference": {
+            "max_tokens": args.max_tokens,
+            "student_sampling": {
+                "temperature": args.temperature,
+                "reasoning_effort": args.reasoning_effort,
+            },
+            "reflection_sampling": {
+                "temperature": args.reflection_temperature,
+                "reasoning_effort": args.reflection_reasoning_effort,
+            },
+            "cache": False,
+            "num_retries": 0,
+            "shared_cumulative_spend_ledger": True,
+            "optimizer_inference_cap_usd": ledger.budget_usd,
+            "input_usd_per_million": ledger.input_usd_per_million,
+            "output_usd_per_million": ledger.output_usd_per_million,
+            "price_basis_scope": "conservative-user-supplied-basis-for-both-models",
+        },
+        "budget_allocation": budget_allocation,
+    }
+    admission_context = {
+        "repo": repo,
+        "rows": rows,
+        "config": config_base,
+        "bridge_config": immutable_bridge_config,
+    }
+    offline_admission = (
+        run_bridge_admission(bridge_module, admission_context)
+        if bridge_module is not None
+        else {
+            "admitted": True,
+            "live_admission_required": False,
+            "kind": "built-in-samples-split-contract",
+            "bundle_validation": {"network_calls_made": 0},
+            "train_count": len(train_rows),
+            "dev_count": len(dev_rows),
+        }
+    )
+    resume_config_payload = {
+        **config_base,
+        "admission": {"offline": offline_admission, "live": "pending"},
+    }
+    resume_config_sha256 = canonical_sha256(resume_config_payload)
+    resume_config_payload["resume_config_sha256"] = resume_config_sha256
+    write_owner_only_json(run_dir / "config.json", resume_config_payload)
+    log_dir = Path(args.log_dir).resolve()
+    bind_resume_log(log_dir, resume_config_sha256)
+    prior_admission_receipt = (
+        load_admission_receipt(
+            Path(args.admission_receipt).resolve(),
+            config_base,
+            offline_admission,
+            resume_config_sha256,
+        )
+        if args.admission_receipt
+        else None
+    )
+    admitted_live_receipt = (
+        prior_admission_receipt.get("live_admission")
+        if prior_admission_receipt is not None
+        else None
+    )
+
+    student_lm = BudgetedLM(
         normalize_dspy_model(args.model),
         spend_ledger=ledger,
         api_key=api_key,
         api_base=normalize_gateway_url(gateway_url),
-        max_tokens=int(args.max_tokens),
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        reasoning_effort=args.reasoning_effort,
         cache=False,
         num_retries=0,
     )
-    dspy.configure(lm=lm)
-    signature = dspy.Signature(f"{', '.join(input_keys)} -> {', '.join(output_keys)}")
-    student = dspy.ChainOfThought(signature) if args.module == "cot" else dspy.Predict(signature)
+    reflection_lm = BudgetedLM(
+        normalize_dspy_model(args.reflection_model),
+        spend_ledger=ledger,
+        api_key=api_key,
+        api_base=normalize_gateway_url(gateway_url),
+        max_tokens=args.max_tokens,
+        temperature=args.reflection_temperature,
+        reasoning_effort=args.reflection_reasoning_effort,
+        cache=False,
+        num_retries=0,
+    )
+    if student_lm is reflection_lm:
+        raise ValueError("student and reflection LMs must be separate instances")
+    dspy.configure(lm=student_lm)
 
-    def to_example(row: dict[str, Any]) -> Any:
-        return dspy.Example(**{key: row[key] for key in [*input_keys, *output_keys]}).with_inputs(*input_keys)
+    exporter = None
+    bridge_state = None
+    baseline_feedback = None
+    if bridge_module is None:
+        for row in [*train_rows, *dev_rows]:
+            missing = [key for key in [*input_keys, *output_keys] if key not in row]
+            if missing:
+                raise ValueError(f"sample row is missing keys: {', '.join(missing)}")
+        signature = dspy.Signature(f"{', '.join(input_keys)} -> {', '.join(output_keys)}")
+        student = dspy.ChainOfThought(signature) if args.module == "cot" else dspy.Predict(signature)
 
-    trainset = [to_example(row) for row in train_rows]
-    devset = [to_example(row) for row in dev_rows]
+        def to_example(row: dict[str, Any]) -> Any:
+            return dspy.Example(
+                **{key: row[key] for key in [*input_keys, *output_keys]},
+            ).with_inputs(*input_keys)
 
-    baseline_prediction = student(**{key: train_rows[0][key] for key in input_keys})
-    baseline_feedback = exact_match_feedback(output_keys, trainset[0], baseline_prediction)
+        trainset = [to_example(row) for row in train_rows]
+        valset = [to_example(row) for row in dev_rows]
+        baseline_prediction = student(**{key: train_rows[0][key] for key in input_keys})
+        baseline_feedback = exact_match_feedback(output_keys, trainset[0], baseline_prediction)
 
-    def metric(gold: Any, pred: Any, trace: Any = None, pred_name: str | None = None, pred_trace: Any = None) -> Any:
-        return exact_match_feedback(output_keys, gold, pred)
+        def metric(gold: Any, pred: Any, trace: Any = None, pred_name: str | None = None, pred_trace: Any = None) -> Any:
+            return exact_match_feedback(output_keys, gold, pred)
+    else:
+        builder = getattr(bridge_module, "build_understudy_dspy_gepa", None)
+        if not callable(builder):
+            raise ValueError("program bridge must define build_understudy_dspy_gepa(context)")
+        bridge_context = {
+            **admission_context,
+            "admission": {"offline": offline_admission, "live": admitted_live_receipt},
+            "dspy": dspy,
+            "student_lm": student_lm,
+            "reflection_lm": reflection_lm,
+        }
+        program = require_mapping(builder(bridge_context), "build_understudy_dspy_gepa(context)")
+        for key in ("student", "trainset", "valset", "metric"):
+            if key not in program:
+                raise ValueError(f"program bridge result is missing {key}")
+        student = program["student"]
+        trainset = list(program["trainset"])
+        valset = list(program["valset"])
+        metric = program["metric"]
+        if not trainset or not valset or not callable(metric):
+            raise ValueError("program bridge requires non-empty trainset/valset and a callable metric")
+        teacher = program.get("teacher")
+        if teacher is not None:
+            raise UnsupportedTeacherError("dspy-3.3.0-gepa-teacher-not-supported")
+        exporter = program.get("export_candidate")
+        if exporter is not None and not callable(exporter):
+            raise ValueError("export_candidate must be callable")
+        bridge_state = program.get("program_state")
+        holdout_count = int(program.get("holdout_count_excluded", holdout_count))
+        if holdout_count < 0:
+            raise ValueError("holdout_count_excluded must be non-negative")
+
+    if bridge_module is None:
+        live_admission = None
+    elif args.admission_only:
+        live_admission = run_live_bridge_admission(
+            bridge_module,
+            bridge_context,
+            program,
+            offline_admission,
+            budget_allocation,
+        )
+    else:
+        live_admission = admitted_live_receipt
+    admission = {"offline": offline_admission, "live": live_admission}
+    config_payload = {
+        **config_base,
+        "admission": admission,
+        "resume_config_sha256": resume_config_sha256,
+    }
+    config_sha256 = canonical_sha256(config_payload)
+    config_payload["config_sha256"] = config_sha256
+    write_owner_only_json(run_dir / "config.json", config_payload)
+    if prior_admission_receipt is not None and prior_admission_receipt.get("config_sha256") != config_sha256:
+        raise WorkloadAdmissionError("admission-receipt-config-hash-mismatch")
+    if args.admission_only:
+        receipt = admission_receipt_payload(
+            config_base,
+            offline_admission,
+            live_admission,
+            resume_config_sha256,
+            config_sha256,
+        )
+        receipt_path = run_dir / "admission-receipt.json"
+        write_owner_only_json(receipt_path, receipt)
+        admission_spend_evidence = ledger.evidence()
+        admission_spend_evidence["sampling"] = {
+            "student": config_payload["inference"]["student_sampling"],
+            "reflection": config_payload["inference"]["reflection_sampling"],
+        }
+        write_dspy_run_state(
+            args,
+            ledger,
+            "admitted",
+            None,
+            {
+                "config_sha256": config_sha256,
+                "admission_receipt_sha256": receipt["receipt_sha256"],
+                "budget_allocation": budget_allocation,
+                "provider_calls": bool(live_admission and live_admission.get("call_count", 0) > 0),
+                "optimizer_provider_calls": False,
+                "endpoint_provider_calls": bool(live_admission and live_admission.get("call_count", 0) > 0),
+            },
+        )
+        emit({
+            "schema_version": "understudy.dspy_gepa_adapter.v2",
+            "status": "admitted",
+            "optimizer_started": False,
+            "provider_calls": bool(live_admission and live_admission.get("call_count", 0) > 0),
+            "optimizer_provider_calls": False,
+            "endpoint_provider_calls": bool(live_admission and live_admission.get("call_count", 0) > 0),
+            "config_sha256": config_sha256,
+            "admission_receipt_sha256": receipt["receipt_sha256"],
+            "admission_receipt_path": artifact_path(repo, receipt_path),
+            "run_state_path": artifact_path(repo, dspy_run_state_path(args)),
+            "spend_evidence": admission_spend_evidence,
+        })
+        return
 
     teleprompter = dspy.GEPA(
         metric=metric,
-        max_metric_calls=int(args.max_metric_calls),
-        reflection_minibatch_size=1,
-        reflection_lm=lm,
-        use_merge=False,
-        track_stats=False,
+        max_metric_calls=args.max_metric_calls,
+        reflection_minibatch_size=args.reflection_minibatch_size,
+        candidate_selection_strategy=args.candidate_selection_strategy,
+        reflection_lm=reflection_lm,
+        component_selector=args.component_selector,
+        use_merge=args.use_merge,
+        max_merge_invocations=args.max_merge_invocations,
+        num_threads=args.num_threads,
+        log_dir=str(log_dir),
+        track_stats=args.track_stats,
+        track_best_outputs=True,
+        seed=args.seed,
     )
-    optimized = teleprompter.compile(student, trainset=trainset, valset=devset)
+    optimized = teleprompter.compile(student, trainset=trainset, valset=valset)
+    program_state = optimized_program_state(optimized, bridge_state)
+    program_state["config_sha256"] = config_sha256
+    write_owner_only_json(run_dir / "program-state.json", program_state)
+
+    bundle_manifest = None
+    if exporter is not None:
+        export_context = {
+            "repo": repo,
+            "config": config_payload,
+            "bridge_config": immutable_bridge_config,
+            "admission": admission,
+            "program_state_path": run_dir / "program-state.json",
+        }
+        bundle_manifest = write_canonical_bundle(
+            args, optimized, exporter, export_context, config_sha256,
+        )
 
     spend_evidence = ledger.evidence()
+    spend_evidence["sampling"] = {
+        "student": config_payload["inference"]["student_sampling"],
+        "reflection": config_payload["inference"]["reflection_sampling"],
+    }
     candidate = {
-        "schema_version": "understudy.dspy_gepa_candidate.v1",
+        "schema_version": "understudy.dspy_gepa_candidate.v2",
         "adapter": "dspy-gepa",
         "model": args.model,
+        "reflection_model": args.reflection_model,
         "module": args.module,
+        "program_bridge": artifact_path(repo, program_bridge_path) if program_bridge_path else None,
         "input_keys": input_keys,
         "output_keys": output_keys,
         "train_count": len(trainset),
-        "dev_count": len(devset),
+        "dev_count": len(valset),
         "holdout_count_excluded": holdout_count,
-        "max_metric_calls": int(args.max_metric_calls),
-        "baseline_first_score": float(baseline_feedback.score),
-        "baseline_first_feedback": baseline_feedback.feedback,
+        "max_metric_calls": args.max_metric_calls,
+        "baseline_first_score": float(baseline_feedback.score) if baseline_feedback else None,
+        "baseline_first_feedback": baseline_feedback.feedback if baseline_feedback else None,
         "optimized_program_class": optimized.__class__.__name__,
+        "config_sha256": config_sha256,
+        "budget_allocation": budget_allocation,
+        "bundle_sha256": bundle_manifest["bundle_sha256"] if bundle_manifest else None,
+        "canonical_bundle_sha256": bundle_manifest["canonical_bundle_sha256"] if bundle_manifest else None,
+        "artifacts": dspy_artifacts(args),
         "spend_evidence": spend_evidence,
     }
-    optimize_dir = Path(args.repo) / ".understudy" / "optimize-workload"
-    optimize_dir.mkdir(parents=True, exist_ok=True)
+    optimize_dir = repo / ".understudy" / "optimize-workload"
     candidate_path = optimize_dir / "candidate.json"
     proof_path = optimize_dir / "proof-packet.json"
     write_owner_only_json(candidate_path, candidate)
@@ -457,34 +1732,51 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         "package_installs": True,
         "holdout_accessed_during_optimization": False,
         "train_count": len(trainset),
-        "dev_count": len(devset),
-        "candidate": ".understudy/optimize-workload/candidate.json",
+        "dev_count": len(valset),
+        "candidate": artifact_path(repo, candidate_path),
+        "config_sha256": config_sha256,
+        "budget_allocation": budget_allocation,
+        "bundle_sha256": bundle_manifest["bundle_sha256"] if bundle_manifest else None,
+        "artifacts": dspy_artifacts(args),
         "spend_evidence": spend_evidence,
     }
     write_owner_only_json(proof_path, proof)
-    write_dspy_run_state(args, ledger, "candidate-created", None)
+    extra = {
+        "config_sha256": config_sha256,
+        "budget_allocation": budget_allocation,
+        "bundle_sha256": bundle_manifest["bundle_sha256"] if bundle_manifest else None,
+    }
+    write_dspy_run_state(args, ledger, "candidate-created", None, extra)
     emit({
-        "schema_version": "understudy.dspy_gepa_adapter.v1",
+        "schema_version": "understudy.dspy_gepa_adapter.v2",
         "status": "candidate-created",
         "adapter": "dspy-gepa",
         "model": args.model,
+        "reflection_model": args.reflection_model,
         "provider_calls": spend_evidence["calls_attempted"] > 0,
         "optimizer_execution": True,
         "auth_source": os.environ.get("UNDERSTUDY_AUTH_SOURCE", "unknown"),
         "gateway_url_configured": True,
         "api_key_configured": True,
         "train_count": len(trainset),
-        "dev_count": len(devset),
+        "dev_count": len(valset),
         "holdout_count_excluded": holdout_count,
-        "max_metric_calls": int(args.max_metric_calls),
-        "candidate_path": ".understudy/optimize-workload/candidate.json",
-        "proof_packet_path": ".understudy/optimize-workload/proof-packet.json",
-        "run_state_path": ".understudy/optimize-workload/dspy-gepa/run-state.json",
+        "max_metric_calls": args.max_metric_calls,
+        "config_sha256": config_sha256,
+        "budget_allocation": budget_allocation,
+        "bundle_sha256": bundle_manifest["bundle_sha256"] if bundle_manifest else None,
+        "canonical_bundle_sha256": bundle_manifest["canonical_bundle_sha256"] if bundle_manifest else None,
+        "candidate_path": artifact_path(repo, candidate_path),
+        "proof_packet_path": artifact_path(repo, proof_path),
+        "run_state_path": artifact_path(repo, dspy_run_state_path(args)),
+        "artifacts": dspy_artifacts(args),
         "spend_evidence": spend_evidence,
     })
 
 
 def dspy_gepa(args: argparse.Namespace) -> None:
+    if args.log_dir is None:
+        args.log_dir = str(dspy_run_dir(args) / "gepa-log")
     ledger = SpendLedger(
         args.budget_usd,
         args.input_usd_per_million,
@@ -502,6 +1794,14 @@ def dspy_gepa(args: argparse.Namespace) -> None:
         )
     except SpendEvidenceError as error:
         emit_dspy_failure(args, ledger, "spend-evidence-error", str(error), 5)
+    except RuntimePackageVersionError:
+        emit_dspy_failure(args, ledger, "error", "runtime-package-version-mismatch", 3)
+    except ResumeBindingError as error:
+        emit_dspy_failure(args, ledger, "resume-blocked", str(error), 6)
+    except WorkloadAdmissionError as error:
+        emit_dspy_failure(args, ledger, "admission-blocked", str(error), 6)
+    except UnsupportedTeacherError as error:
+        emit_dspy_failure(args, ledger, "error", str(error), 3)
     except KeyboardInterrupt:
         emit_dspy_failure(args, ledger, "cancelled", "optimizer-cancelled", 130)
     except ImportError:
@@ -510,6 +1810,12 @@ def dspy_gepa(args: argparse.Namespace) -> None:
         emit_dspy_failure(args, ledger, "error", "invalid-runtime-input", 3)
     except Exception:
         emit_dspy_failure(args, ledger, "error", "optimizer-execution-failed", 3)
+    finally:
+        for root in (dspy_run_dir(args), Path(args.log_dir)):
+            try:
+                secure_owner_only_tree(root)
+            except (OSError, ValueError):
+                pass
 
 
 def load_json_or_jsonl(path: Path) -> Any:
@@ -835,24 +2141,54 @@ def budget_preflight(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
+    os.umask(0o077)
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
 
     dspy_gepa_parser = sub.add_parser("dspy-gepa")
     dspy_gepa_parser.add_argument("--repo", required=True)
-    dspy_gepa_parser.add_argument("--samples", required=True)
-    dspy_gepa_parser.add_argument("--input-keys", required=True)
-    dspy_gepa_parser.add_argument("--output-keys", required=True)
-    dspy_gepa_parser.add_argument("--module", default="predict")
+    dspy_gepa_parser.add_argument("--samples", default=None)
+    dspy_gepa_parser.add_argument("--input-keys", default="")
+    dspy_gepa_parser.add_argument("--output-keys", default="")
+    dspy_gepa_parser.add_argument("--module", choices=("predict", "cot"), default="predict")
     dspy_gepa_parser.add_argument("--model", required=True)
-    dspy_gepa_parser.add_argument("--max-metric-calls", default="3")
+    dspy_gepa_parser.add_argument("--reflection-model", required=True)
+    dspy_gepa_parser.add_argument("--max-metric-calls", type=positive_int_arg, default=3)
     dspy_gepa_parser.add_argument("--split-key", default="split")
     dspy_gepa_parser.add_argument("--train-split", default="train")
     dspy_gepa_parser.add_argument("--dev-split", default="dev")
-    dspy_gepa_parser.add_argument("--max-tokens", default="256")
+    dspy_gepa_parser.add_argument("--max-tokens", type=positive_int_arg, default=256)
+    dspy_gepa_parser.add_argument("--temperature", type=non_negative_float_arg, default=0.1)
+    dspy_gepa_parser.add_argument(
+        "--reasoning-effort", choices=("none", "minimal", "low", "medium", "high"), default="none",
+    )
+    dspy_gepa_parser.add_argument("--reflection-temperature", type=non_negative_float_arg, default=0.1)
+    dspy_gepa_parser.add_argument(
+        "--reflection-reasoning-effort",
+        choices=("none", "minimal", "low", "medium", "high"),
+        default="none",
+    )
     dspy_gepa_parser.add_argument("--budget-usd", required=True)
     dspy_gepa_parser.add_argument("--input-usd-per-million", required=True)
     dspy_gepa_parser.add_argument("--output-usd-per-million", required=True)
+    dspy_gepa_parser.add_argument("--reflection-minibatch-size", type=positive_int_arg, default=1)
+    dspy_gepa_parser.add_argument(
+        "--candidate-selection-strategy", choices=("pareto", "current_best"), default="pareto",
+    )
+    dspy_gepa_parser.add_argument(
+        "--component-selector", choices=("round_robin", "all"), default="round_robin",
+    )
+    dspy_gepa_parser.add_argument("--use-merge", type=bool_arg, default=False)
+    dspy_gepa_parser.add_argument("--max-merge-invocations", type=non_negative_int_arg, default=5)
+    dspy_gepa_parser.add_argument("--num-threads", type=positive_int_arg, default=1)
+    dspy_gepa_parser.add_argument("--seed", type=int, default=0)
+    dspy_gepa_parser.add_argument("--log-dir", default=None)
+    dspy_gepa_parser.add_argument("--track-stats", type=bool_arg, default=False)
+    dspy_gepa_parser.add_argument("--program-bridge", default=None)
+    dspy_gepa_parser.add_argument("--program-bridge-config", default=None)
+    dspy_gepa_parser.add_argument("--program-project", default=None)
+    dspy_gepa_parser.add_argument("--admission-only", action="store_true")
+    dspy_gepa_parser.add_argument("--admission-receipt", default=None)
     dspy_gepa_parser.set_defaults(func=dspy_gepa)
 
     eval_input_gepa_parser = sub.add_parser("eval-input-gepa")

--- a/src/optimize-workload/runtime-source.ts
+++ b/src/optimize-workload/runtime-source.ts
@@ -12,6 +12,7 @@ import platform
 import re
 import socket
 import threading
+from urllib.parse import urlsplit
 from pathlib import Path
 from collections.abc import Callable, Mapping
 from types import MappingProxyType
@@ -39,11 +40,6 @@ def load_rows(path: str) -> list[dict[str, Any]]:
     if isinstance(raw, dict) and isinstance(raw.get("rows"), list):
         return raw["rows"]
     raise ValueError("samples must be a JSON list or object with rows")
-
-
-def normalize_gateway_url(value: str) -> str:
-    base = value.rstrip("/")
-    return base if base.endswith("/v1") else f"{base}/v1"
 
 
 def normalize_dspy_model(value: str) -> str:
@@ -186,6 +182,163 @@ def canonical_json_bytes(payload: Any) -> bytes:
 
 def canonical_sha256(payload: Any) -> str:
     return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+def text_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def credential_free_api_base(value: Any, *, append_v1: bool) -> tuple[str, str]:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("LM route base_url must be a non-empty string")
+    base = value.strip().rstrip("/")
+    if append_v1 and not base.endswith("/v1"):
+        base = f"{base}/v1"
+    parsed = urlsplit(base)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("LM route base_url must be credential-free HTTP(S) without query or fragment")
+    default_port = 443 if parsed.scheme == "https" else 80
+    port = parsed.port or default_port
+    host_identity = f"{parsed.scheme.lower()}://{parsed.hostname.lower()}:{port}"
+    return base, host_identity
+
+
+def resolve_lm_route(
+    role: str,
+    requested_model: str,
+    bridge_config: Mapping[str, Any],
+    gateway_url: str | None,
+) -> tuple[dict[str, Any], str, str]:
+    route_map = bridge_config.get("inference_routes", {})
+    if not isinstance(route_map, Mapping):
+        raise ValueError("bridge_config.inference_routes must be a mapping")
+    if any(key not in {"student", "reflection"} for key in route_map.keys()):
+        raise ValueError("bridge_config.inference_routes supports only student and reflection")
+    configured = route_map.get(role)
+    if configured is None:
+        if not gateway_url:
+            raise ValueError(f"UNDERSTUDY_GATEWAY_URL is required for the default {role} route")
+        base_url, host_identity = credential_free_api_base(gateway_url, append_v1=True)
+        route_config = {
+            "route_id": "understudy-gateway",
+            "base_url": base_url,
+            "api_key_env": "UNDERSTUDY_API_KEY",
+            "requested_model": requested_model,
+            "executed_model": normalize_dspy_model(requested_model),
+        }
+    else:
+        if not isinstance(configured, Mapping):
+            raise ValueError(f"bridge_config.inference_routes.{role} must be a mapping")
+        required_fields = {
+            "route_id",
+            "base_url",
+            "api_key_env",
+            "requested_model",
+            "executed_model",
+        }
+        if set(configured.keys()) != required_fields:
+            raise ValueError(
+                f"bridge_config.inference_routes.{role} must contain exactly {sorted(required_fields)}"
+            )
+        route_config = dict(configured)
+        base_url, host_identity = credential_free_api_base(
+            route_config["base_url"], append_v1=False,
+        )
+    route_id = route_config.get("route_id")
+    api_key_env = route_config.get("api_key_env")
+    configured_requested_model = route_config.get("requested_model")
+    executed_model = route_config.get("executed_model")
+    if not isinstance(route_id, str) or not route_id.strip() or route_id != route_id.strip():
+        raise ValueError(f"{role} route_id must be a non-empty string")
+    if not isinstance(api_key_env, str) or _ENV_NAME.fullmatch(api_key_env) is None:
+        raise ValueError(f"{role} api_key_env must be an environment variable name")
+    if configured_requested_model != requested_model:
+        raise ValueError(f"{role} requested_model does not match the CLI model")
+    if (
+        not isinstance(executed_model, str)
+        or not executed_model.strip()
+        or executed_model != executed_model.strip()
+    ):
+        raise ValueError(f"{role} executed_model must be a non-empty string")
+    credential = os.environ.get(api_key_env)
+    if not credential:
+        raise ValueError(f"{api_key_env} is required for the {role} LM route")
+    dspy_model = normalize_dspy_model(executed_model)
+    if dspy_model != executed_model:
+        raise ValueError(f"{role} executed_model must be the exact DSPy/LiteLLM model identifier")
+    binding = {
+        "schema_version": "understudy.dspy_lm_route_binding.v1",
+        "role": role,
+        "route_id": route_id,
+        "requested_model": requested_model,
+        "executed_model": executed_model,
+        "dspy_model": dspy_model,
+        "base_url_sha256": text_sha256(base_url),
+        "base_host_sha256": text_sha256(host_identity),
+        "api_key_env": api_key_env,
+    }
+    receipt = {
+        **binding,
+        "route_binding_sha256": canonical_sha256(binding),
+        "credential_source": "environment",
+        "credential_present": True,
+        "provider_response_identity_scope": "per-call-spend-entry-when-exposed",
+    }
+    return receipt, credential, base_url
+
+
+def response_identity_receipt(response: Any) -> dict[str, Any]:
+    model = response.get("model") if isinstance(response, Mapping) else getattr(response, "model", None)
+    model_source = "response.model"
+    hidden = (
+        response.get("_hidden_params")
+        if isinstance(response, Mapping)
+        else getattr(response, "_hidden_params", None)
+    )
+    hidden = hidden if isinstance(hidden, Mapping) else {}
+    if not isinstance(model, str) or not model:
+        hidden_model = hidden.get("model_id")
+        model = hidden_model if isinstance(hidden_model, str) and hidden_model else None
+        model_source = "response._hidden_params.model_id"
+    headers = hidden.get("additional_headers")
+    headers = headers if isinstance(headers, Mapping) else {}
+    normalized_headers = {
+        str(key).lower(): value
+        for key, value in headers.items()
+        if isinstance(value, str) and value
+    }
+    effective_model = None
+    effective_header_name = None
+    for header_name in (
+        "x-understudy-effective-model",
+        "x-understudy-upstream-model",
+        "x-litellm-model-id",
+        "x-model-id",
+        "x-fireworks-model",
+    ):
+        if header_name in normalized_headers:
+            effective_header_name = header_name
+            effective_model = normalized_headers[header_name]
+            break
+    return {
+        "provider_returned_model": (
+            {"status": "observed", "source": model_source, "value": model}
+            if model is not None
+            else {"status": "unavailable-from-response"}
+        ),
+        "effective_model_header": (
+            {"status": "observed", "header": effective_header_name, "value": effective_model}
+            if effective_model is not None
+            else {"status": "unavailable-from-response"}
+        ),
+    }
 
 
 def file_sha256(path: Path) -> str:
@@ -382,7 +535,12 @@ class SpendLedger:
             self.output_usd_per_million,
         )
 
-    def reserve(self, input_token_ceiling: int, output_token_ceiling: int) -> int:
+    def reserve(
+        self,
+        input_token_ceiling: int,
+        output_token_ceiling: int,
+        call_identity: Mapping[str, Any] | None = None,
+    ) -> int:
         projected = self.projected_reservation(input_token_ceiling, output_token_ceiling)
         with self._lock:
             next_total = self.reserved_upper_bound_usd + projected
@@ -391,13 +549,18 @@ class SpendLedger:
             self.calls_attempted += 1
             call_id = self.calls_attempted
             self.reserved_upper_bound_usd = next_total
-            self.entries.append({
+            entry = {
                 "call_id": call_id,
                 "status": "reserved",
                 "input_token_ceiling": input_token_ceiling,
                 "output_token_ceiling": output_token_ceiling,
                 "reserved_upper_bound_usd": projected,
-            })
+            }
+            if call_identity is not None:
+                identity = dict(call_identity)
+                canonical_json_bytes(identity)
+                entry["configured_identity"] = identity
+            self.entries.append(entry)
             return call_id
 
     def mark_error(self, call_id: int) -> None:
@@ -406,7 +569,7 @@ class SpendLedger:
             self.usage_complete = False
 
     def complete(self, call_id: int, response: Any) -> None:
-        usage = getattr(response, "usage", None)
+        usage = response.get("usage") if isinstance(response, Mapping) else getattr(response, "usage", None)
         input_tokens = usage_token_count(usage, "prompt_tokens", "input_tokens")
         output_tokens = usage_token_count(usage, "completion_tokens", "output_tokens")
         with self._lock:
@@ -433,6 +596,7 @@ class SpendLedger:
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 "attributed_cost_usd": attributed,
+                "response_identity": response_identity_receipt(response),
             })
             self.calls_completed += 1
             self.attributed_cost_usd += attributed
@@ -750,8 +914,13 @@ def run_bridge_admission(module: Any, context: dict[str, Any]) -> dict[str, Any]
         raise WorkloadAdmissionError("bundle-validation-requires-input-bundle-sha256")
     if validation.get("executable_bundle_loaded") is not True:
         raise WorkloadAdmissionError("bundle-validation-must-prove-executable-bundle-loaded")
-    if validation.get("loaded_bundle_sha256") != validation.get("input_bundle_sha256"):
-        raise WorkloadAdmissionError("loaded-bundle-sha256-mismatch")
+    if not is_sha256(validation.get("loaded_bundle_sha256")):
+        raise WorkloadAdmissionError("bundle-validation-requires-loaded-endpoint-bundle-sha256")
+    if (
+        not isinstance(validation.get("loaded_bundle_schema_version"), str)
+        or not validation.get("loaded_bundle_schema_version")
+    ):
+        raise WorkloadAdmissionError("bundle-validation-requires-loaded-endpoint-bundle-schema")
     if validation.get("required_bundle_fields_present") is not True:
         raise WorkloadAdmissionError("bundle-validation-requires-all-bundle-fields")
     if not is_sha256(validation.get("workload_adapter_sha256")):
@@ -777,6 +946,15 @@ def run_bridge_admission(module: Any, context: dict[str, Any]) -> dict[str, Any]
     for field in ("input_bundle_sha256", "tool_schema_sha256"):
         if bridge_config.get(field) != validation.get(field):
             raise WorkloadAdmissionError(f"{field.replace('_', '-')}-mismatch")
+    if not is_sha256(bridge_config.get("endpoint_bundle_sha256")):
+        raise WorkloadAdmissionError("bridge-config-requires-endpoint-bundle-sha256")
+    if validation.get("loaded_bundle_sha256") != bridge_config.get("endpoint_bundle_sha256"):
+        raise WorkloadAdmissionError("loaded-endpoint-bundle-sha256-mismatch")
+    endpoint_schema = bridge_config.get("endpoint_bundle_schema_version")
+    if not isinstance(endpoint_schema, str) or not endpoint_schema:
+        raise WorkloadAdmissionError("bridge-config-requires-endpoint-bundle-schema")
+    if validation.get("loaded_bundle_schema_version") != endpoint_schema:
+        raise WorkloadAdmissionError("loaded-endpoint-bundle-schema-mismatch")
     typed_contract = validation.get("typed_request_contract")
     required_typed_checks = {
         "model_typed": True,
@@ -877,6 +1055,23 @@ def run_bridge_admission(module: Any, context: dict[str, Any]) -> dict[str, Any]
         context_limit_field="reflection_context_limit",
         overflow_reason="reflection-renderer-context-window-overflow",
     )
+    runtime_routes = config.get("inference", {}).get("routes")
+    if not isinstance(runtime_routes, Mapping):
+        raise WorkloadAdmissionError("runtime-route-bindings-missing")
+    for role, gate_name in (
+        ("student", "context_window_gate"),
+        ("reflection", "reflection_context_window_gate"),
+    ):
+        route_receipt = runtime_routes.get(role)
+        gate = validation.get(gate_name)
+        gate_route = gate.get("route") if isinstance(gate, Mapping) else None
+        if (
+            not isinstance(route_receipt, Mapping)
+            or not isinstance(gate_route, Mapping)
+            or gate_route.get("id") != route_receipt.get("route_id")
+            or gate_route.get("sha256") != route_receipt.get("route_binding_sha256")
+        ):
+            raise WorkloadAdmissionError(f"{role}-route-binding-mismatch")
     trajectory_feedback = validation.get("trajectory_feedback_contract")
     required_event_fields = [
         "sequence_index",
@@ -999,7 +1194,7 @@ def run_live_bridge_admission(
         for field in ("health_ok", "models_loaded", "bundle_loaded")
     ):
         raise WorkloadAdmissionError("live-admission-preflight-failed")
-    expected_bundle_sha = offline_admission["bundle_validation"]["input_bundle_sha256"]
+    expected_bundle_sha = offline_admission["bundle_validation"]["loaded_bundle_sha256"]
     if preflight.get("loaded_bundle_sha256") != expected_bundle_sha:
         raise WorkloadAdmissionError("live-admission-loaded-bundle-mismatch")
     integer_counts: dict[str, int] = {}
@@ -1262,6 +1457,7 @@ def write_canonical_bundle(
             "student": export_context["config"]["inference"]["student_sampling"],
             "reflection": export_context["config"]["inference"]["reflection_sampling"],
         },
+        "route_bindings": export_context["config"]["inference"]["routes"],
     }
     manifest_path = run_dir / "bundle-manifest.json"
     write_owner_only_json(manifest_path, manifest)
@@ -1317,9 +1513,20 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
     import dspy
 
     class BudgetedLM(dspy.LM):
-        def __init__(self, *lm_args: Any, spend_ledger: SpendLedger, **lm_kwargs: Any) -> None:
+        def __init__(
+            self,
+            *lm_args: Any,
+            spend_ledger: SpendLedger,
+            role: str,
+            route_receipt: Mapping[str, Any],
+            **lm_kwargs: Any,
+        ) -> None:
             self._spend_ledger = spend_ledger
+            self._role = role
+            self._route_receipt = dict(route_receipt)
             super().__init__(*lm_args, **lm_kwargs)
+            if getattr(self, "model", None) != self._route_receipt["dspy_model"]:
+                raise ValueError(f"{role} DSPy model does not match the bound executed model")
 
         def _output_token_ceiling(self, call_kwargs: dict[str, Any]) -> int:
             value = (
@@ -1345,6 +1552,16 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
             return self._spend_ledger.reserve(
                 input_token_ceiling_from_bytes(message_bytes, message_count),
                 self._output_token_ceiling(call_kwargs),
+                {
+                    "role": self._role,
+                    "route_id": self._route_receipt["route_id"],
+                    "route_binding_sha256": self._route_receipt["route_binding_sha256"],
+                    "requested_model": self._route_receipt["requested_model"],
+                    "executed_model": self._route_receipt["executed_model"],
+                    "dspy_model": self._route_receipt["dspy_model"],
+                    "base_url_sha256": self._route_receipt["base_url_sha256"],
+                    "base_host_sha256": self._route_receipt["base_host_sha256"],
+                },
             )
 
         def forward(
@@ -1377,12 +1594,13 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
             self._spend_ledger.complete(call_id, response)
             return response
 
-    api_key = os.environ.get("UNDERSTUDY_API_KEY")
     gateway_url = os.environ.get("UNDERSTUDY_GATEWAY_URL")
-    if not api_key:
-        raise ValueError("UNDERSTUDY_API_KEY is required for dspy-gepa")
-    if not gateway_url:
-        raise ValueError("UNDERSTUDY_GATEWAY_URL is required for dspy-gepa")
+    student_route, student_api_key, student_api_base = resolve_lm_route(
+        "student", args.model, bridge_config, gateway_url,
+    )
+    reflection_route, reflection_api_key, reflection_api_base = resolve_lm_route(
+        "reflection", args.reflection_model, bridge_config, gateway_url,
+    )
 
     rows = load_rows(args.samples) if args.samples else []
     input_keys = split_keys(args.input_keys or "")
@@ -1455,6 +1673,10 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
                 "temperature": args.reflection_temperature,
                 "reasoning_effort": args.reflection_reasoning_effort,
             },
+            "routes": {
+                "student": student_route,
+                "reflection": reflection_route,
+            },
             "cache": False,
             "num_retries": 0,
             "shared_cumulative_spend_ledger": True,
@@ -1509,10 +1731,12 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
     )
 
     student_lm = BudgetedLM(
-        normalize_dspy_model(args.model),
+        student_route["dspy_model"],
         spend_ledger=ledger,
-        api_key=api_key,
-        api_base=normalize_gateway_url(gateway_url),
+        role="student",
+        route_receipt=student_route,
+        api_key=student_api_key,
+        api_base=student_api_base,
         max_tokens=args.max_tokens,
         temperature=args.temperature,
         reasoning_effort=args.reasoning_effort,
@@ -1520,10 +1744,12 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         num_retries=0,
     )
     reflection_lm = BudgetedLM(
-        normalize_dspy_model(args.reflection_model),
+        reflection_route["dspy_model"],
         spend_ledger=ledger,
-        api_key=api_key,
-        api_base=normalize_gateway_url(gateway_url),
+        role="reflection",
+        route_receipt=reflection_route,
+        api_key=reflection_api_key,
+        api_base=reflection_api_base,
         max_tokens=args.max_tokens,
         temperature=args.reflection_temperature,
         reasoning_effort=args.reflection_reasoning_effort,
@@ -1627,6 +1853,7 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
             "student": config_payload["inference"]["student_sampling"],
             "reflection": config_payload["inference"]["reflection_sampling"],
         }
+        admission_spend_evidence["route_bindings"] = config_payload["inference"]["routes"]
         write_dspy_run_state(
             args,
             ledger,
@@ -1636,6 +1863,7 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
                 "config_sha256": config_sha256,
                 "admission_receipt_sha256": receipt["receipt_sha256"],
                 "budget_allocation": budget_allocation,
+                "route_bindings": config_payload["inference"]["routes"],
                 "provider_calls": bool(live_admission and live_admission.get("call_count", 0) > 0),
                 "optimizer_provider_calls": False,
                 "endpoint_provider_calls": bool(live_admission and live_admission.get("call_count", 0) > 0),
@@ -1652,6 +1880,7 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
             "admission_receipt_sha256": receipt["receipt_sha256"],
             "admission_receipt_path": artifact_path(repo, receipt_path),
             "run_state_path": artifact_path(repo, dspy_run_state_path(args)),
+            "route_bindings": config_payload["inference"]["routes"],
             "spend_evidence": admission_spend_evidence,
         })
         return
@@ -1694,6 +1923,7 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         "student": config_payload["inference"]["student_sampling"],
         "reflection": config_payload["inference"]["reflection_sampling"],
     }
+    spend_evidence["route_bindings"] = config_payload["inference"]["routes"]
     candidate = {
         "schema_version": "understudy.dspy_gepa_candidate.v2",
         "adapter": "dspy-gepa",
@@ -1713,6 +1943,7 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         "config_sha256": config_sha256,
         "budget_allocation": budget_allocation,
         "bundle_sha256": bundle_manifest["bundle_sha256"] if bundle_manifest else None,
+        "route_bindings": config_payload["inference"]["routes"],
         "canonical_bundle_sha256": bundle_manifest["canonical_bundle_sha256"] if bundle_manifest else None,
         "artifacts": dspy_artifacts(args),
         "spend_evidence": spend_evidence,
@@ -1745,6 +1976,7 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         "config_sha256": config_sha256,
         "budget_allocation": budget_allocation,
         "bundle_sha256": bundle_manifest["bundle_sha256"] if bundle_manifest else None,
+        "route_bindings": config_payload["inference"]["routes"],
     }
     write_dspy_run_state(args, ledger, "candidate-created", None, extra)
     emit({
@@ -1756,8 +1988,13 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         "provider_calls": spend_evidence["calls_attempted"] > 0,
         "optimizer_execution": True,
         "auth_source": os.environ.get("UNDERSTUDY_AUTH_SOURCE", "unknown"),
-        "gateway_url_configured": True,
-        "api_key_configured": True,
+        "lm_routes_configured": True,
+        "understudy_gateway_route_used": any(
+            route["route_id"] == "understudy-gateway"
+            for route in config_payload["inference"]["routes"].values()
+        ),
+        "credentials_configured": {"student": True, "reflection": True},
+        "route_bindings": config_payload["inference"]["routes"],
         "train_count": len(trainset),
         "dev_count": len(valset),
         "holdout_count_excluded": holdout_count,

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -532,6 +532,405 @@ function withOptimizerFixtureRepo(fn) {
   }
 }
 
+function writePythonDistributionMetadata(root) {
+  for (const [name, version] of [["dspy", "3.3.0"], ["gepa", "0.1.1"]]) {
+    const metadataDir = join(root, `${name}-${version}.dist-info`);
+    mkdirSync(metadataDir, { recursive: true });
+    writeFileSync(
+      join(metadataDir, "METADATA"),
+      `Metadata-Version: 2.1\nName: ${name}\nVersion: ${version}\n`,
+      "utf8",
+    );
+  }
+}
+
+function writeDspyGepaBridgeStubs(root) {
+  const dspyRoot = join(root, "dspy");
+  const gepaRoot = join(dspyRoot, "teleprompt", "gepa");
+  mkdirSync(gepaRoot, { recursive: true });
+  writePythonDistributionMetadata(root);
+  const workloadMetadata = join(root, "fixture_workload-1.2.3.dist-info");
+  mkdirSync(workloadMetadata);
+  writeFileSync(
+    join(workloadMetadata, "METADATA"),
+    "Metadata-Version: 2.1\nName: fixture-workload\nVersion: 1.2.3\n",
+    "utf8",
+  );
+  writeFileSync(join(dspyRoot, "__init__.py"), `
+import json
+import os
+from types import SimpleNamespace
+
+configured_lm = None
+
+def configure(lm):
+    global configured_lm
+    configured_lm = lm
+
+class LM:
+    def __init__(self, model, max_tokens=None, num_retries=3, **kwargs):
+        self.model = model
+        self.kwargs = {"max_tokens": max_tokens}
+        self.num_retries = num_retries
+        with open(os.environ["MODEL_SENTINEL"], "a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"model": model, "num_retries": num_retries}) + "\\n")
+    def forward(self, prompt=None, messages=None, **kwargs):
+        if self.num_retries != 0:
+            raise AssertionError("retries were not disabled")
+        return SimpleNamespace(usage={"prompt_tokens": 7, "completion_tokens": 3})
+
+class GEPA:
+    def __init__(self, reflection_lm=None, **kwargs):
+        self.reflection_lm = reflection_lm
+        self.kwargs = kwargs
+        serializable = dict(kwargs)
+        serializable["metric_callable"] = callable(serializable.pop("metric"))
+        serializable["reflection_model"] = reflection_lm.model
+        with open(os.environ["GEPA_KWARGS_SENTINEL"], "w", encoding="utf-8") as handle:
+            json.dump(serializable, handle, sort_keys=True)
+    def compile(self, student, trainset=None, valset=None):
+        prediction = student.run()
+        feedback = self.kwargs["metric"](trainset[0], prediction)
+        if not hasattr(feedback, "score") or not hasattr(feedback, "feedback"):
+            raise AssertionError("metric did not return ScoreWithFeedback")
+        self.reflection_lm.forward(prompt="reflect")
+        return student
+`, "utf8");
+  writeFileSync(join(dspyRoot, "teleprompt", "__init__.py"), "", "utf8");
+  writeFileSync(join(gepaRoot, "__init__.py"), "", "utf8");
+  writeFileSync(join(gepaRoot, "gepa_utils.py"), `
+class ScoreWithFeedback:
+    def __init__(self, score, feedback):
+        self.score = score
+        self.feedback = feedback
+`, "utf8");
+}
+
+function writeDspyGepaProgramBridge(
+  path,
+  {
+    worldStateChanged = true,
+    validOracle = true,
+    reflectionPromptTokens = 1200,
+    mutationClaimed = true,
+  } = {},
+) {
+  const passed = worldStateChanged ? "True" : "False";
+  const primeReceipt = validOracle ? `"${"b".repeat(64)}"` : "None";
+  const mutationClaimedPython = mutationClaimed ? "True" : "False";
+  const candidateHash = mutationClaimed ? "2".repeat(64) : "1".repeat(64);
+  const mutationOutcome = mutationClaimed ? "improved" : "non_improved";
+  const promotionEligible = mutationClaimed ? "True" : "False";
+  writeFileSync(path, `
+import json
+from types import SimpleNamespace
+from dspy.teleprompt.gepa.gepa_utils import ScoreWithFeedback
+
+def admit_understudy_dspy_gepa(context):
+    bridge_config = context["bridge_config"]
+    program_bridge = context["config"]["program_bridge"]
+    package_receipt_sha256 = (
+        program_bridge["project"]["uv_lock_sha256"]
+        if program_bridge["project"] is not None
+        else context["config"]["packages"]["package_state_sha256"]
+    )
+    return {
+        "admitted": True,
+        "live_admission_required": True,
+        "bundle_validation": {
+            "network_calls_made": 0,
+            "input_bundle_sha256": bridge_config["input_bundle_sha256"],
+            "executable_bundle_loaded": True,
+            "loaded_bundle_sha256": bridge_config["input_bundle_sha256"],
+            "required_bundle_fields_present": True,
+            "workload_adapter_sha256": program_bridge["sha256"],
+            "package_receipt_sha256": package_receipt_sha256,
+            "tool_schema_sha256": bridge_config["tool_schema_sha256"],
+            "package_versions": {"mcp": "fixture-1", "verifiers": "fixture-2"},
+            "typed_request_contract": {
+                "model_typed": True,
+                "messages_typed": True,
+                "tools_typed": True,
+                "sampling_typed": True,
+            },
+            "oracle_contract": {
+                "kind": "state_verifier",
+                "task_typed": True,
+                "initial_state_typed": True,
+                "assertion_identity_sha256": "${"a".repeat(64)}",
+                "prime_receipt_sha256": ${primeReceipt},
+                "reward_metric_binding_sha256": "${"c".repeat(64)}",
+                "is_continuation": False,
+            },
+            "tool_contract_probe": {
+                "wire_arguments_type": "string",
+                "arguments_json_valid": True,
+                "decoded_arguments_type": "object",
+                "wire_arguments_sha256": "${"c".repeat(64)}",
+                "request_semantic_sha256": "${"6".repeat(64)}",
+                "executed_semantic_sha256": "${"6".repeat(64)}",
+                "nested_string_arguments": {
+                    "body": {
+                        "wire_type": "string",
+                        "wire_sha256": "${"7".repeat(64)}",
+                        "decoded_semantic_sha256": "${"8".repeat(64)}",
+                        "executed_semantic_sha256": "${"8".repeat(64)}",
+                    },
+                },
+                "validation_exception_sha256": None,
+                "required_world_state_change": True,
+                "required_write_succeeded": True,
+                "world_state_changed": True,
+                "mutation_scope": "bounded_trajectory",
+            },
+            "context_window_gate": {
+                "source_prompt_sha256": "${"9".repeat(64)}",
+                "token_count_receipt_sha256": "${"0".repeat(64)}",
+                "source_prompt_tokens": 1000,
+                "max_tokens": 256,
+                "safety_margin": 128,
+                "source_context_limit": 4096,
+                "renderer": {"id": "fixture-renderer", "sha256": "${"f".repeat(64)}"},
+                "tokenizer": {"id": "fixture-tokenizer", "sha256": "${"1".repeat(64)}"},
+                "checkpoint": {"id": "fixture-checkpoint", "sha256": "${"2".repeat(64)}"},
+                "route": {"id": "fixture-route", "sha256": "${"d".repeat(64)}"},
+                "coverage": {
+                    "method": "all_admitted_tasks_and_eligible_routes",
+                    "admitted_task_ids_sha256": "${"e".repeat(64)}",
+                    "eligible_route_ids_sha256": "${"f".repeat(64)}",
+                    "admitted_task_count": 1,
+                    "covered_task_count": 1,
+                    "eligible_route_count": 1,
+                    "covered_route_count": 1,
+                    "complete_inventory_sha256": "${"1".repeat(64)}",
+                    "worst_case_row_sha256": "${"2".repeat(64)}",
+                },
+            },
+            "reflection_context_window_gate": {
+                "reflection_prompt_sha256": "${"3".repeat(64)}",
+                "token_count_receipt_sha256": "${"4".repeat(64)}",
+                "reflection_prompt_tokens": ${reflectionPromptTokens},
+                "max_tokens": 256,
+                "safety_margin": 128,
+                "reflection_context_limit": 8192,
+                "renderer": {"id": "fixture-reflection-renderer", "sha256": "${"5".repeat(64)}"},
+                "tokenizer": {"id": "fixture-reflection-tokenizer", "sha256": "${"6".repeat(64)}"},
+                "checkpoint": {"id": "fixture-reflection-checkpoint", "sha256": "${"7".repeat(64)}"},
+                "route": {"id": "fixture-reflection-route", "sha256": "${"8".repeat(64)}"},
+                "coverage": {
+                    "method": "all_admitted_tasks_and_eligible_routes",
+                    "admitted_task_ids_sha256": "${"9".repeat(64)}",
+                    "eligible_route_ids_sha256": "${"0".repeat(64)}",
+                    "admitted_task_count": 1,
+                    "covered_task_count": 1,
+                    "eligible_route_count": 1,
+                    "covered_route_count": 1,
+                    "complete_inventory_sha256": "${"a".repeat(64)}",
+                    "worst_case_row_sha256": "${"b".repeat(64)}",
+                },
+            },
+            "trajectory_feedback_contract": {
+                "redacted": True,
+                "ordered_events": True,
+                "event_fields": [
+                    "sequence_index",
+                    "tool_or_method_category",
+                    "succeeded",
+                    "error_type",
+                    "mutation_observed",
+                    "stop_observed",
+                ],
+                "excluded_fields": ["arguments", "urls", "secrets", "answer_keys"],
+                "event_count": 2,
+                "full_native_trace_sha256": "${"c".repeat(64)}",
+                "redacted_feedback_sha256": "${"d".repeat(64)}",
+                "action_sequence_optimization_enabled": True,
+            },
+            "deployment_parity": {
+                "network_calls_made": 0,
+                "inline_messages_sha256": "${"3".repeat(64)}",
+                "loaded_bundle_messages_sha256": "${"3".repeat(64)}",
+                "inline_tools_sha256": "${"4".repeat(64)}",
+                "loaded_bundle_tools_sha256": "${"4".repeat(64)}",
+                "inline_sampling_sha256": "${"5".repeat(64)}",
+                "loaded_bundle_sampling_sha256": "${"5".repeat(64)}",
+                "duplicate_policy_injection": False,
+                "loaded_bundle_once": True,
+                "official_eval_outer_policy_present": False,
+            },
+            "candidate_mutation_contract": {
+                "enforcement_status": "declared_not_enforced",
+                "promotion_guarantee": False,
+                "contract_sha256": "${"e".repeat(64)}",
+                "materialize_before_evaluate": True,
+                "atomic_persistence": True,
+                "require_changed_hash": True,
+                "same_hash_quarantine": {
+                    "evaluated": False,
+                    "provider_calls": 0,
+                    "pareto_eligible": False,
+                    "promotion_eligible": False,
+                },
+                "partial_artifact_quarantine": True,
+                "crash_resume_quarantine": True,
+                "receipt_fields": [
+                    "candidate_hash",
+                    "parent_hash",
+                    "reflection_request_hash",
+                    "reflection_output_hash",
+                    "reflection_model",
+                    "reflection_sampling_hash",
+                    "checkpoint_hash",
+                    "config_hash",
+                    "evaluated_prompt_hash",
+                    "rendered_request_hash",
+                    "task_hash",
+                    "trace_hash",
+                    "world_progress_hash",
+                    "score",
+                ],
+            },
+        },
+        "workload_smoke": {
+            "calls": 1,
+            "nodes": 1,
+            "assertion_fraction": 1.0,
+            "world_state_changed": ${passed},
+        },
+    }
+
+def live_admit_understudy_dspy_gepa(context, program):
+    bundle_sha256 = context["admission"]["offline"]["bundle_validation"]["input_bundle_sha256"]
+    endpoint_cap = context["bridge_config"]["budget_allocation"]["endpoint_cap_usd"]
+    return {
+        "admitted": True,
+        "standard_verifiers": True,
+        "optimizer_started": False,
+        "episode_count": 1,
+        "fixed_task_id": "fixture-write-task",
+        "same_student_metric_path": True,
+        "preflight": {
+            "health_ok": True,
+            "models_loaded": True,
+            "bundle_loaded": True,
+            "loaded_bundle_sha256": bundle_sha256,
+        },
+        "call_count": 1,
+        "node_count": 1,
+        "read_count": 1,
+        "write_count": 1 if ${passed} else 0,
+        "assertion_fraction": 1.0 if ${passed} else 0.0,
+        "parser_failure": False,
+        "tool_argument_contract_ok": True,
+        "required_world_state_change": True,
+        "world_state_changed": ${passed},
+        "mutation_scope": "bounded_trajectory",
+        "endpoint_spend": {
+            "cap_usd": endpoint_cap,
+            "attributed_cost_usd": 0.01,
+            "usage_complete": True,
+            "actual_call_count": 1,
+        },
+    }
+
+class Component:
+    def __init__(self, instructions):
+        self.signature = SimpleNamespace(instructions=instructions)
+
+class MultiComponentProgram:
+    def __init__(self, student_lm):
+        self.student_lm = student_lm
+        self.actor = Component("actor prompt")
+        self.advisor = Component("advisor prompt")
+        self.router = Component("router prompt")
+    def run(self):
+        self.student_lm.forward(prompt="student")
+        return SimpleNamespace(answer="ok")
+    def dump_state(self, json_mode=False):
+        return {
+            "actor": self.actor.signature.instructions,
+            "advisor": self.advisor.signature.instructions,
+            "router": self.router.signature.instructions,
+        }
+
+def metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
+    return ScoreWithFeedback(score=1.0, feedback="fixture passed")
+
+def export_candidate(program, export_dir, context):
+    (export_dir / "prompts.json").write_text(
+        json.dumps(program.dump_state(json_mode=True), sort_keys=True) + "\\n",
+        encoding="utf-8",
+    )
+    (export_dir / "deployment.json").write_text(
+        json.dumps({"format": "understudy-multicomponent-v1"}, sort_keys=True) + "\\n",
+        encoding="utf-8",
+    )
+    return {
+        "provenance": {
+            "input_bundle_sha256": "${"a".repeat(64)}",
+            "tool_schema_sha256": "${"b".repeat(64)}",
+        },
+        "continuation_parent": None,
+        "mutation_receipt": {
+            "mutation_claimed": ${mutationClaimedPython},
+            "outcome": "${mutationOutcome}",
+            "promotion_eligible": ${promotionEligible},
+            "parent_component_sha256": "${"1".repeat(64)}",
+            "candidate_component_sha256": "${candidateHash}",
+            "candidate_persistence_sha256": "${"3".repeat(64)}",
+            "optimizer_receipt_sha256": "${"4".repeat(64)}",
+            "reflection_receipt_sha256": "${"5".repeat(64)}",
+            "checkpoint_sha256": "${"6".repeat(64)}",
+            "evaluated_prompt_sha256": "${"7".repeat(64)}",
+            "checkpoint_evaluated_prompt_binding_sha256": "${"8".repeat(64)}",
+            "world_progress_sha256": "${"9".repeat(64)}",
+            "candidate_persisted_before_evaluation": True,
+            "atomic_persistence": True,
+            "optimizer_reflection_bound": True,
+            "checkpoint_evaluated_prompt_bound": True,
+            "world_progress_observed": True,
+        },
+    }
+
+def build_understudy_dspy_gepa(context):
+    try:
+        context["bridge_config"]["mutation"] = "forbidden"
+        raise AssertionError("bridge_config was mutable")
+    except TypeError:
+        pass
+    student = MultiComponentProgram(context["student_lm"])
+    return {
+        "student": student,
+        "trainset": [SimpleNamespace(answer="ok")],
+        "valset": [SimpleNamespace(answer="ok")],
+        "metric": metric,
+        "teacher": None,
+        "export_candidate": export_candidate,
+        "program_state": {"components": ["actor", "advisor", "router"]},
+        "holdout_count_excluded": 1,
+    }
+`, "utf8");
+}
+
+function writeDspyGepaBridgeConfig(path, overrides = {}) {
+  const payload = {
+    schema_version: "understudy.dspy_gepa_bridge_config.v1",
+    input_bundle_sha256: "a".repeat(64),
+    tool_schema_sha256: "b".repeat(64),
+    workload_package_pins: { "fixture-workload": "1.2.3" },
+    api_key_env: "UNDERSTUDY_AUTOMATIONBENCH_SERVICE_TOKEN",
+    budget_allocation: {
+      campaign_approved_max_usd: 5000,
+      campaign_cap_usd: 3,
+      prior_experiment_spend_usd: 0.25,
+      optimizer_inference_cap_usd: 1,
+      endpoint_cap_usd: 1,
+    },
+    ...overrides,
+  };
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
 describe("understudy CLI", () => {
   it("prints the public spine", () => {
     const result = run(["spine"]);
@@ -1057,10 +1456,12 @@ describe("understudy CLI", () => {
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
       ]);
       assert.equal(result.status, 1);
       const payload = JSON.parse(result.stdout);
-      assert.equal(payload.schema_version, "understudy.dspy_gepa_adapter.v1");
+      assert.equal(payload.schema_version, "understudy.dspy_gepa_adapter.v2");
       assert.equal(payload.status, "blocked");
       assert.equal(payload.provider_calls, false);
       assert.equal(payload.optimizer_execution, false);
@@ -1084,6 +1485,8 @@ describe("understudy CLI", () => {
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
         "--execute",
       ]);
       assert.notEqual(result.status, 0);
@@ -1109,6 +1512,8 @@ describe("understudy CLI", () => {
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
         "--budget-usd",
         "1",
         "--input-usd-per-million",
@@ -1120,6 +1525,113 @@ describe("understudy CLI", () => {
       assert.notEqual(result.status, 0);
       assert.match(result.stderr, /non-zero input or output price basis/);
       assert.doesNotMatch(result.stderr, /login|gateway|api key|uv run/i);
+    }));
+
+  it("invokes the DSPy registry adapter with exact compatible packages and advanced flags", () =>
+    withOptimizerFixtureRepo(({ repo, samplesPath }) => {
+      const fakeBin = join(repo, "fake-bin");
+      const uvArgsPath = join(repo, "uv-args.txt");
+      mkdirSync(fakeBin);
+      writeFileSync(join(fakeBin, "uv"), `#!/bin/sh
+printf '%s\n' "$@" > "$UV_ARGS_SENTINEL"
+printf '%s\n' '{"schema_version":"fixture.uv.v1","status":"fixture-ok"}'
+`, { encoding: "utf8", mode: 0o755 });
+      const result = runWithEnv([
+        "optimize-workload",
+        "adapter",
+        "run",
+        "--repo",
+        repo,
+        "--adapter",
+        "dspy-gepa",
+        "--samples",
+        samplesPath,
+        "--input-keys",
+        "question",
+        "--output-keys",
+        "answer",
+        "--model",
+        "student-deployment",
+        "--reflection-model",
+        "reflection-deployment",
+        "--budget-usd",
+        "1",
+        "--input-usd-per-million",
+        "1",
+        "--output-usd-per-million",
+        "2",
+        "--reflection-minibatch-size",
+        "2",
+        "--candidate-selection-strategy",
+        "pareto",
+        "--component-selector",
+        "all",
+        "--use-merge",
+        "--num-threads",
+        "1",
+        "--seed",
+        "42",
+        "--track-stats",
+        "--execute",
+      ], {
+        PATH: `${fakeBin}:${baseEnv.PATH}`,
+        UV_ARGS_SENTINEL: uvArgsPath,
+        UNDERSTUDY_API_KEY: "fixture-key",
+        UNDERSTUDY_GATEWAY_URL: "http://127.0.0.1:9",
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const uvArgs = readFileSync(uvArgsPath, "utf8").trim().split("\n");
+      assert.deepEqual(uvArgs.slice(0, 6), [
+        "run",
+        "--no-project",
+        "--with",
+        "dspy==3.3.0",
+        "--with",
+        "gepa[dspy]==0.1.1",
+      ]);
+      const flagValue = (flag) => uvArgs[uvArgs.indexOf(flag) + 1];
+      assert.equal(flagValue("--model"), "student-deployment");
+      assert.equal(flagValue("--reflection-model"), "reflection-deployment");
+      assert.equal(flagValue("--reflection-minibatch-size"), "2");
+      assert.equal(flagValue("--candidate-selection-strategy"), "pareto");
+      assert.equal(flagValue("--component-selector"), "all");
+      assert.equal(flagValue("--use-merge"), "true");
+      assert.equal(flagValue("--num-threads"), "1");
+      assert.equal(flagValue("--seed"), "42");
+      assert.equal(flagValue("--track-stats"), "true");
+
+      const bridgePath = join(repo, "locked-bridge.py");
+      const bridgeConfigPath = join(repo, "locked-bridge-config.json");
+      const programProject = join(repo, "locked-project");
+      writeDspyGepaProgramBridge(bridgePath);
+      writeDspyGepaBridgeConfig(bridgeConfigPath);
+      mkdirSync(programProject);
+      writeFileSync(join(programProject, "pyproject.toml"), "[project]\nname='locked-fixture'\nversion='0.0.1'\n", "utf8");
+      writeFileSync(join(programProject, "uv.lock"), "version = 1\nrevision = 1\n", "utf8");
+      const lockedResult = runWithEnv([
+        "optimize-workload", "adapter", "run", "--repo", repo, "--adapter", "dspy-gepa",
+        "--program-bridge", bridgePath,
+        "--program-bridge-config", bridgeConfigPath,
+        "--program-project", programProject,
+        "--model", "student-deployment",
+        "--reflection-model", "reflection-deployment",
+        "--budget-usd", "1",
+        "--input-usd-per-million", "1",
+        "--output-usd-per-million", "2",
+        "--admission-only",
+        "--execute",
+      ], {
+        PATH: `${fakeBin}:${baseEnv.PATH}`,
+        UV_ARGS_SENTINEL: uvArgsPath,
+        UNDERSTUDY_API_KEY: "fixture-key",
+        UNDERSTUDY_GATEWAY_URL: "http://127.0.0.1:9",
+      });
+      assert.equal(lockedResult.status, 0, lockedResult.stderr);
+      const lockedUvArgs = readFileSync(uvArgsPath, "utf8").trim().split("\n");
+      assert.deepEqual(lockedUvArgs.slice(0, 5), [
+        "run", "--project", programProject, "--locked", "python",
+      ]);
+      assert.equal(lockedUvArgs.includes("--with"), false);
     }));
 
   it("preflights cumulative DSPy reservations without importing DSPy or calling a provider", { skip: !pythonAvailable }, () =>
@@ -1140,6 +1652,8 @@ describe("understudy CLI", () => {
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
       ]);
       assert.equal(scaffold.status, 1);
       const runtime = join(repo, ".understudy", "optimize-workload", "uv-runtime", "optimizer_runtime.py");
@@ -1199,12 +1713,15 @@ describe("understudy CLI", () => {
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
       ]);
       assert.equal(scaffold.status, 1);
       const runtime = join(repo, ".understudy", "optimize-workload", "uv-runtime", "optimizer_runtime.py");
       const stubDir = join(repo, "python-stubs");
       const sentinel = join(repo, "provider-was-called");
       mkdirSync(stubDir, { recursive: true });
+      writePythonDistributionMetadata(stubDir);
       writeFileSync(join(stubDir, "dspy.py"), `
 import os
 
@@ -1257,6 +1774,8 @@ class ChainOfThought(Predict):
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
         "--max-tokens",
         "256",
         "--budget-usd",
@@ -1309,6 +1828,8 @@ class ChainOfThought(Predict):
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
       ]);
       assert.equal(scaffold.status, 1);
       const runtime = join(repo, ".understudy", "optimize-workload", "uv-runtime", "optimizer_runtime.py");
@@ -1317,6 +1838,7 @@ class ChainOfThought(Predict):
       const gepaRoot = join(dspyRoot, "teleprompt", "gepa");
       const sentinel = join(repo, "provider-call-count");
       mkdirSync(gepaRoot, { recursive: true });
+      writePythonDistributionMetadata(stubRoot);
       writeFileSync(join(dspyRoot, "__init__.py"), `
 import copy
 import os
@@ -1358,6 +1880,8 @@ class Predict:
     def __call__(self, **kwargs):
         configured_lm.forward(prompt=str(kwargs))
         return SimpleNamespace(answer="a1")
+    def dump_state(self, json_mode=False):
+        return {"signature": "question -> answer"}
 
 class ChainOfThought(Predict):
     pass
@@ -1391,6 +1915,8 @@ class ScoreWithFeedback:
         "answer",
         "--model",
         "synthetic-deployment",
+        "--reflection-model",
+        "synthetic-reflection-deployment",
         "--max-metric-calls",
         "2",
         "--max-tokens",
@@ -1438,6 +1964,271 @@ class ScoreWithFeedback:
       const proof = JSON.parse(readFileSync(proofPath, "utf8"));
       assert.equal(proof.holdout_accessed_during_optimization, false);
       assert.equal(proof.spend_evidence.calls_completed, 2);
+    }));
+
+  it("runs an admitted multi-component DSPy bridge with exact GEPA flags and a canonical bundle", { skip: !pythonAvailable }, () =>
+    withOptimizerFixtureRepo(({ repo }) => {
+      const bridgePath = join(repo, "program-bridge.py");
+      const badBridgePath = join(repo, "bad-program-bridge.py");
+      const badOracleBridgePath = join(repo, "bad-oracle-program-bridge.py");
+      const reflectionOverflowBridgePath = join(repo, "reflection-overflow-program-bridge.py");
+      const noChangeBridgePath = join(repo, "no-change-program-bridge.py");
+      const bridgeConfigPath = join(repo, "program-bridge-config.json");
+      const stubRoot = join(repo, "bridge-python-stubs");
+      const programProject = join(repo, "locked-program-project");
+      const modelSentinel = join(repo, "bridge-models.jsonl");
+      const kwargsSentinel = join(repo, "gepa-kwargs.json");
+      const logDir = join(repo, ".understudy", "optimizer-checkpoints", "fixture-gepa");
+      writeDspyGepaBridgeStubs(stubRoot);
+      writeDspyGepaProgramBridge(bridgePath);
+      writeDspyGepaProgramBridge(badBridgePath, { worldStateChanged: false });
+      writeDspyGepaProgramBridge(badOracleBridgePath, { validOracle: false });
+      // Equality fails closed: 7808 + 256 + 128 == 8192.
+      writeDspyGepaProgramBridge(reflectionOverflowBridgePath, { reflectionPromptTokens: 7808 });
+      writeDspyGepaProgramBridge(noChangeBridgePath, { mutationClaimed: false });
+      writeDspyGepaBridgeConfig(bridgeConfigPath);
+      mkdirSync(programProject);
+      writeFileSync(join(programProject, "pyproject.toml"), "[project]\nname='fixture-project'\nversion='0.0.1'\n", "utf8");
+      writeFileSync(join(programProject, "uv.lock"), "version = 1\nrevision = 1\n", "utf8");
+
+      const scaffold = run([
+        "optimize-workload",
+        "adapter",
+        "run",
+        "--repo",
+        repo,
+        "--adapter",
+        "dspy-gepa",
+        "--program-bridge",
+        bridgePath,
+        "--program-bridge-config",
+        bridgeConfigPath,
+        "--program-project",
+        programProject,
+        "--model",
+        "student-deployment",
+        "--reflection-model",
+        "reflection-deployment",
+      ]);
+      assert.equal(scaffold.status, 1, scaffold.stderr);
+      const runtime = join(repo, ".understudy", "optimize-workload", "uv-runtime", "optimizer_runtime.py");
+      const runtimeArgs = [
+        runtime,
+        "dspy-gepa",
+        "--repo",
+        repo,
+        "--program-bridge",
+        bridgePath,
+        "--program-bridge-config",
+        bridgeConfigPath,
+        "--program-project",
+        programProject,
+        "--model",
+        "student-deployment",
+        "--reflection-model",
+        "reflection-deployment",
+        "--max-metric-calls",
+        "7",
+        "--max-tokens",
+        "128",
+        "--budget-usd",
+        "1",
+        "--input-usd-per-million",
+        "1",
+        "--output-usd-per-million",
+        "2",
+        "--reflection-minibatch-size",
+        "2",
+        "--candidate-selection-strategy",
+        "pareto",
+        "--component-selector",
+        "all",
+        "--use-merge",
+        "true",
+        "--max-merge-invocations",
+        "4",
+        "--num-threads",
+        "1",
+        "--seed",
+        "42",
+        "--log-dir",
+        logDir,
+        "--track-stats",
+        "true",
+      ];
+      const runtimeEnv = {
+        ...baseEnv,
+        PYTHONPATH: stubRoot,
+        MODEL_SENTINEL: modelSentinel,
+        GEPA_KWARGS_SENTINEL: kwargsSentinel,
+        UNDERSTUDY_API_KEY: "fixture-key",
+        UNDERSTUDY_GATEWAY_URL: "http://127.0.0.1:9",
+        UNDERSTUDY_AUTH_SOURCE: "fixture",
+      };
+      const admission = spawnSync("python3", [...runtimeArgs, "--admission-only"], {
+        encoding: "utf8",
+        env: runtimeEnv,
+      });
+      assert.equal(admission.status, 0, admission.stderr || admission.stdout);
+      const admissionPayload = JSON.parse(admission.stdout);
+      assert.equal(admissionPayload.status, "admitted");
+      assert.equal(admissionPayload.optimizer_started, false);
+      assert.equal(admissionPayload.optimizer_provider_calls, false);
+      assert.equal(admissionPayload.endpoint_provider_calls, true);
+      assert.equal(admissionPayload.spend_evidence.calls_attempted, 0);
+      const admissionReceipt = join(
+        repo,
+        ".understudy",
+        "optimize-workload",
+        "dspy-gepa",
+        "admission-receipt.json",
+      );
+      assert.equal(statSync(admissionReceipt).mode & 0o777, 0o600);
+      rmSync(modelSentinel);
+
+      const compileArgs = [...runtimeArgs, "--admission-receipt", admissionReceipt];
+      const result = spawnSync("python3", compileArgs, { encoding: "utf8", env: runtimeEnv });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.schema_version, "understudy.dspy_gepa_adapter.v2");
+      assert.equal(payload.status, "candidate-created");
+      assert.equal(payload.model, "student-deployment");
+      assert.equal(payload.reflection_model, "reflection-deployment");
+      assert.equal(payload.holdout_count_excluded, 1);
+      assert.equal(payload.spend_evidence.calls_attempted, 2);
+
+      const models = readFileSync(modelSentinel, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      assert.deepEqual(models.map((item) => item.model), ["openai/student-deployment", "openai/reflection-deployment"]);
+      assert.deepEqual(models.map((item) => item.num_retries), [0, 0]);
+      const gepaKwargs = JSON.parse(readFileSync(kwargsSentinel, "utf8"));
+      assert.equal(gepaKwargs.max_metric_calls, 7);
+      assert.equal(gepaKwargs.reflection_minibatch_size, 2);
+      assert.equal(gepaKwargs.candidate_selection_strategy, "pareto");
+      assert.equal(gepaKwargs.component_selector, "all");
+      assert.equal(gepaKwargs.use_merge, true);
+      assert.equal(gepaKwargs.max_merge_invocations, 4);
+      assert.equal(gepaKwargs.num_threads, 1);
+      assert.equal(gepaKwargs.seed, 42);
+      assert.equal(gepaKwargs.track_stats, true);
+      assert.equal(gepaKwargs.track_best_outputs, true);
+      assert.equal(gepaKwargs.log_dir, realpathSync(logDir));
+      assert.equal(gepaKwargs.reflection_model, "openai/reflection-deployment");
+
+      const runDir = join(repo, ".understudy", "optimize-workload", "dspy-gepa");
+      const packageState = JSON.parse(readFileSync(join(runDir, "package-state.json"), "utf8"));
+      assert.deepEqual(packageState.requested, ["dspy==3.3.0", "gepa[dspy]==0.1.1"]);
+      assert.deepEqual(packageState.actual, { dspy: "3.3.0", gepa: "0.1.1" });
+      assert.deepEqual(packageState.workload_actual, { "fixture-workload": "1.2.3" });
+      assert.equal(packageState.program_project.locked, true);
+      assert.equal(packageState.program_project.uv_lock_sha256.length, 64);
+      const config = JSON.parse(readFileSync(join(runDir, "config.json"), "utf8"));
+      assert.equal(config.gepa.num_threads, 1);
+      assert.equal(config.gepa.use_merge, true);
+      const validation = config.admission.offline.bundle_validation;
+      assert.equal(validation.network_calls_made, 0);
+      assert.equal(validation.oracle_contract.kind, "state_verifier");
+      assert.equal(validation.tool_contract_probe.decoded_arguments_type, "object");
+      assert.equal(validation.tool_contract_probe.world_state_changed, true);
+      assert.equal(validation.deployment_parity.duplicate_policy_injection, false);
+      assert.equal(validation.context_window_gate.source_context_limit, 4096);
+      assert.equal(validation.reflection_context_window_gate.reflection_context_limit, 8192);
+      assert.equal(validation.trajectory_feedback_contract.action_sequence_optimization_enabled, true);
+      assert.equal(config.admission.live.standard_verifiers, true);
+      assert.equal(config.admission.live.optimizer_started, false);
+      assert.equal(config.admission.live.episode_count, 1);
+      assert.equal(config.budget_allocation.optimizer_inference_cap_usd, 1);
+      assert.equal(config.budget_allocation.endpoint_cap_usd, 1);
+      assert.equal(config.budget_allocation.campaign_remaining_after_allocations_usd, 0.75);
+      const programState = JSON.parse(readFileSync(join(runDir, "program-state.json"), "utf8"));
+      assert.deepEqual(programState.bridge_state.components, ["actor", "advisor", "router"]);
+      assert.equal(programState.dspy_state.actor, "actor prompt");
+      const manifest = JSON.parse(readFileSync(join(runDir, "bundle-manifest.json"), "utf8"));
+      assert.equal(manifest.files.length, 2);
+      assert.equal(manifest.bundle_sha256, payload.bundle_sha256);
+      assert.equal(manifest.canonical_bundle_sha256, payload.canonical_bundle_sha256);
+      const canonical = JSON.stringify({
+        files: manifest.files.map((item) => ({ path: item.path, sha256: item.sha256, size_bytes: item.size_bytes })),
+        schema_version: "understudy.dspy_gepa_bundle_content.v1",
+      });
+      assert.equal(createHash("sha256").update(canonical).digest("hex"), manifest.bundle_sha256);
+      assert.equal(manifest.export_metadata.continuation_parent, null);
+      assert.equal(manifest.export_metadata.provenance.tool_schema_sha256, "b".repeat(64));
+      assert.equal(manifest.mutation_claimed, true);
+      assert.equal(manifest.outcome, "improved");
+
+      for (const artifact of [
+        "package-state.json",
+        "config.json",
+        "program-state.json",
+        "bundle-manifest.json",
+        "run-state.json",
+      ]) {
+        assert.equal(statSync(join(runDir, artifact)).mode & 0o777, 0o600);
+      }
+      assert.equal(statSync(runDir).mode & 0o777, 0o700);
+      assert.equal(statSync(logDir).mode & 0o777, 0o700);
+
+      rmSync(modelSentinel);
+      const mismatchedResumeArgs = [...compileArgs];
+      mismatchedResumeArgs[mismatchedResumeArgs.indexOf("42")] = "43";
+      const mismatchedResume = spawnSync("python3", mismatchedResumeArgs, { encoding: "utf8", env: runtimeEnv });
+      assert.equal(mismatchedResume.status, 6, mismatchedResume.stderr || mismatchedResume.stdout);
+      assert.equal(JSON.parse(mismatchedResume.stdout).reason, "resume-log-config-mismatch");
+      assert.equal(existsSync(modelSentinel), false);
+
+      const badOracleArgs = [...runtimeArgs, "--admission-only"];
+      badOracleArgs[badOracleArgs.indexOf(bridgePath)] = badOracleBridgePath;
+      badOracleArgs[badOracleArgs.indexOf(logDir)] = `${logDir}-bad-oracle`;
+      const badOracle = spawnSync("python3", badOracleArgs, { encoding: "utf8", env: runtimeEnv });
+      assert.equal(badOracle.status, 6, badOracle.stderr || badOracle.stdout);
+      assert.equal(JSON.parse(badOracle.stdout).reason, "state-verifier-oracle-contract-failed");
+      assert.equal(existsSync(modelSentinel), false);
+
+      const reflectionOverflowArgs = [...runtimeArgs, "--admission-only"];
+      reflectionOverflowArgs[reflectionOverflowArgs.indexOf(bridgePath)] = reflectionOverflowBridgePath;
+      reflectionOverflowArgs[reflectionOverflowArgs.indexOf(logDir)] = `${logDir}-reflection-overflow`;
+      const reflectionOverflow = spawnSync("python3", reflectionOverflowArgs, { encoding: "utf8", env: runtimeEnv });
+      assert.equal(reflectionOverflow.status, 6, reflectionOverflow.stderr || reflectionOverflow.stdout);
+      assert.equal(JSON.parse(reflectionOverflow.stdout).reason, "reflection-renderer-context-window-overflow");
+      assert.equal(existsSync(modelSentinel), false);
+
+      const badAdmissionArgs = [...runtimeArgs, "--admission-only"];
+      badAdmissionArgs[badAdmissionArgs.indexOf(bridgePath)] = badBridgePath;
+      badAdmissionArgs[badAdmissionArgs.indexOf(logDir)] = `${logDir}-bad-admission`;
+      const badAdmission = spawnSync("python3", badAdmissionArgs, { encoding: "utf8", env: runtimeEnv });
+      assert.equal(badAdmission.status, 6, badAdmission.stderr || badAdmission.stdout);
+      const badAdmissionPayload = JSON.parse(badAdmission.stdout);
+      assert.equal(badAdmissionPayload.status, "admission-blocked");
+      assert.equal(badAdmissionPayload.reason, "live-admission-required-world-state-change-failed");
+      assert.equal(badAdmissionPayload.provider_calls, false);
+      const badAdmissionModels = readFileSync(modelSentinel, "utf8").trim().split("\n");
+      assert.equal(badAdmissionModels.length, 2);
+      assert.equal(badAdmissionPayload.spend_evidence.calls_attempted, 0);
+
+      rmSync(modelSentinel);
+      const noChangeAdmissionArgs = [...runtimeArgs, "--admission-only"];
+      noChangeAdmissionArgs[noChangeAdmissionArgs.indexOf(bridgePath)] = noChangeBridgePath;
+      noChangeAdmissionArgs[noChangeAdmissionArgs.indexOf(logDir)] = `${logDir}-no-change`;
+      const noChangeAdmission = spawnSync("python3", noChangeAdmissionArgs, {
+        encoding: "utf8",
+        env: runtimeEnv,
+      });
+      assert.equal(noChangeAdmission.status, 0, noChangeAdmission.stderr || noChangeAdmission.stdout);
+      rmSync(modelSentinel);
+      const noChangeCompileArgs = [
+        ...noChangeAdmissionArgs.slice(0, -1),
+        "--admission-receipt",
+        admissionReceipt,
+      ];
+      const noChangeCompile = spawnSync("python3", noChangeCompileArgs, {
+        encoding: "utf8",
+        env: runtimeEnv,
+      });
+      assert.equal(noChangeCompile.status, 0, noChangeCompile.stderr || noChangeCompile.stdout);
+      const noChangeManifest = JSON.parse(readFileSync(join(runDir, "bundle-manifest.json"), "utf8"));
+      assert.equal(noChangeManifest.mutation_claimed, false);
+      assert.equal(noChangeManifest.outcome, "non_improved");
+      assert.equal(noChangeManifest.promotion_eligible, false);
     }));
 
   it("blocks a registry optimizer adapter unless execution is explicit", () =>

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -572,12 +572,25 @@ class LM:
         self.model = model
         self.kwargs = {"max_tokens": max_tokens}
         self.num_retries = num_retries
+        self.api_base = kwargs.get("api_base")
         with open(os.environ["MODEL_SENTINEL"], "a", encoding="utf-8") as handle:
-            handle.write(json.dumps({"model": model, "num_retries": num_retries}) + "\\n")
+            handle.write(json.dumps({
+                "model": model,
+                "api_base": self.api_base,
+                "temperature": kwargs.get("temperature"),
+                "reasoning_effort": kwargs.get("reasoning_effort"),
+                "num_retries": num_retries,
+            }) + "\\n")
     def forward(self, prompt=None, messages=None, **kwargs):
         if self.num_retries != 0:
             raise AssertionError("retries were not disabled")
-        return SimpleNamespace(usage={"prompt_tokens": 7, "completion_tokens": 3})
+        return SimpleNamespace(
+            usage={"prompt_tokens": 7, "completion_tokens": 3},
+            model=f"provider-returned/{self.model}",
+            _hidden_params={
+                "additional_headers": {"x-model-id": f"effective/{self.model}"},
+            },
+        )
 
 class GEPA:
     def __init__(self, reflection_lm=None, **kwargs):
@@ -613,6 +626,9 @@ function writeDspyGepaProgramBridge(
     validOracle = true,
     reflectionPromptTokens = 1200,
     mutationClaimed = true,
+    validRouteBinding = true,
+    validInputBundleBinding = true,
+    validEndpointBundleBinding = true,
   } = {},
 ) {
   const passed = worldStateChanged ? "True" : "False";
@@ -621,6 +637,15 @@ function writeDspyGepaProgramBridge(
   const candidateHash = mutationClaimed ? "2".repeat(64) : "1".repeat(64);
   const mutationOutcome = mutationClaimed ? "improved" : "non_improved";
   const promotionEligible = mutationClaimed ? "True" : "False";
+  const reflectionRouteSha = validRouteBinding
+    ? 'runtime_routes["reflection"]["route_binding_sha256"]'
+    : `"${"0".repeat(64)}"`;
+  const inputBundleSha = validInputBundleBinding
+    ? 'bridge_config["input_bundle_sha256"]'
+    : `"${"0".repeat(64)}"`;
+  const endpointBundleSha = validEndpointBundleBinding
+    ? 'bridge_config["endpoint_bundle_sha256"]'
+    : `"${"0".repeat(64)}"`;
   writeFileSync(path, `
 import json
 from types import SimpleNamespace
@@ -629,6 +654,7 @@ from dspy.teleprompt.gepa.gepa_utils import ScoreWithFeedback
 def admit_understudy_dspy_gepa(context):
     bridge_config = context["bridge_config"]
     program_bridge = context["config"]["program_bridge"]
+    runtime_routes = context["config"]["inference"]["routes"]
     package_receipt_sha256 = (
         program_bridge["project"]["uv_lock_sha256"]
         if program_bridge["project"] is not None
@@ -639,9 +665,10 @@ def admit_understudy_dspy_gepa(context):
         "live_admission_required": True,
         "bundle_validation": {
             "network_calls_made": 0,
-            "input_bundle_sha256": bridge_config["input_bundle_sha256"],
+            "input_bundle_sha256": ${inputBundleSha},
             "executable_bundle_loaded": True,
-            "loaded_bundle_sha256": bridge_config["input_bundle_sha256"],
+            "loaded_bundle_schema_version": bridge_config["endpoint_bundle_schema_version"],
+            "loaded_bundle_sha256": ${endpointBundleSha},
             "required_bundle_fields_present": True,
             "workload_adapter_sha256": program_bridge["sha256"],
             "package_receipt_sha256": package_receipt_sha256,
@@ -693,7 +720,10 @@ def admit_understudy_dspy_gepa(context):
                 "renderer": {"id": "fixture-renderer", "sha256": "${"f".repeat(64)}"},
                 "tokenizer": {"id": "fixture-tokenizer", "sha256": "${"1".repeat(64)}"},
                 "checkpoint": {"id": "fixture-checkpoint", "sha256": "${"2".repeat(64)}"},
-                "route": {"id": "fixture-route", "sha256": "${"d".repeat(64)}"},
+                "route": {
+                    "id": runtime_routes["student"]["route_id"],
+                    "sha256": runtime_routes["student"]["route_binding_sha256"],
+                },
                 "coverage": {
                     "method": "all_admitted_tasks_and_eligible_routes",
                     "admitted_task_ids_sha256": "${"e".repeat(64)}",
@@ -716,7 +746,10 @@ def admit_understudy_dspy_gepa(context):
                 "renderer": {"id": "fixture-reflection-renderer", "sha256": "${"5".repeat(64)}"},
                 "tokenizer": {"id": "fixture-reflection-tokenizer", "sha256": "${"6".repeat(64)}"},
                 "checkpoint": {"id": "fixture-reflection-checkpoint", "sha256": "${"7".repeat(64)}"},
-                "route": {"id": "fixture-reflection-route", "sha256": "${"8".repeat(64)}"},
+                "route": {
+                    "id": runtime_routes["reflection"]["route_id"],
+                    "sha256": ${reflectionRouteSha},
+                },
                 "coverage": {
                     "method": "all_admitted_tasks_and_eligible_routes",
                     "admitted_task_ids_sha256": "${"9".repeat(64)}",
@@ -800,7 +833,7 @@ def admit_understudy_dspy_gepa(context):
     }
 
 def live_admit_understudy_dspy_gepa(context, program):
-    bundle_sha256 = context["admission"]["offline"]["bundle_validation"]["input_bundle_sha256"]
+    bundle_sha256 = context["admission"]["offline"]["bundle_validation"]["loaded_bundle_sha256"]
     endpoint_cap = context["bridge_config"]["budget_allocation"]["endpoint_cap_usd"]
     return {
         "admitted": True,
@@ -916,9 +949,27 @@ function writeDspyGepaBridgeConfig(path, overrides = {}) {
   const payload = {
     schema_version: "understudy.dspy_gepa_bridge_config.v1",
     input_bundle_sha256: "a".repeat(64),
+    endpoint_bundle_schema_version: "understudy.fixture_endpoint_bundle.v1",
+    endpoint_bundle_sha256: "d".repeat(64),
     tool_schema_sha256: "b".repeat(64),
     workload_package_pins: { "fixture-workload": "1.2.3" },
     api_key_env: "UNDERSTUDY_AUTOMATIONBENCH_SERVICE_TOKEN",
+    inference_routes: {
+      student: {
+        route_id: "fixture-understudy-student",
+        base_url: "http://127.0.0.1:9/v1",
+        api_key_env: "UNDERSTUDY_API_KEY",
+        requested_model: "student-deployment",
+        executed_model: "openai/student-deployment",
+      },
+      reflection: {
+        route_id: "fixture-fireworks-reflection",
+        base_url: "https://api.fireworks.ai/inference/v1",
+        api_key_env: "FIXTURE_FIREWORKS_API_KEY",
+        requested_model: "reflection-deployment",
+        executed_model: "openai/accounts/fireworks/models/reflection-deployment",
+      },
+    },
     budget_allocation: {
       campaign_approved_max_usd: 5000,
       campaign_cap_usd: 3,
@@ -1950,6 +2001,18 @@ class ScoreWithFeedback:
       assert.equal(payload.spend_evidence.provider_invoice_verified, false);
       assert.equal(payload.spend_evidence.attributed_cost_usd, 0.00004);
       assert.equal(payload.spend_evidence.entries.length, 2);
+      assert.equal(payload.route_bindings.student.route_id, "understudy-gateway");
+      assert.equal(payload.route_bindings.reflection.route_id, "understudy-gateway");
+      assert.equal(payload.route_bindings.student.requested_model, "synthetic-deployment");
+      assert.equal(payload.route_bindings.student.executed_model, "openai/synthetic-deployment");
+      assert.equal(
+        payload.spend_evidence.entries[0].response_identity.provider_returned_model.status,
+        "unavailable-from-response",
+      );
+      assert.equal(
+        payload.spend_evidence.entries[0].response_identity.effective_model_header.status,
+        "unavailable-from-response",
+      );
       assert.ok(
         payload.spend_evidence.attributed_cost_usd
           < payload.spend_evidence.reserved_upper_bound_usd,
@@ -1972,6 +2035,9 @@ class ScoreWithFeedback:
       const badBridgePath = join(repo, "bad-program-bridge.py");
       const badOracleBridgePath = join(repo, "bad-oracle-program-bridge.py");
       const reflectionOverflowBridgePath = join(repo, "reflection-overflow-program-bridge.py");
+      const badRouteBridgePath = join(repo, "bad-route-program-bridge.py");
+      const badInputBundleBridgePath = join(repo, "bad-input-bundle-program-bridge.py");
+      const badEndpointBundleBridgePath = join(repo, "bad-endpoint-bundle-program-bridge.py");
       const noChangeBridgePath = join(repo, "no-change-program-bridge.py");
       const bridgeConfigPath = join(repo, "program-bridge-config.json");
       const stubRoot = join(repo, "bridge-python-stubs");
@@ -1985,6 +2051,9 @@ class ScoreWithFeedback:
       writeDspyGepaProgramBridge(badOracleBridgePath, { validOracle: false });
       // Equality fails closed: 7808 + 256 + 128 == 8192.
       writeDspyGepaProgramBridge(reflectionOverflowBridgePath, { reflectionPromptTokens: 7808 });
+      writeDspyGepaProgramBridge(badRouteBridgePath, { validRouteBinding: false });
+      writeDspyGepaProgramBridge(badInputBundleBridgePath, { validInputBundleBinding: false });
+      writeDspyGepaProgramBridge(badEndpointBundleBridgePath, { validEndpointBundleBinding: false });
       writeDspyGepaProgramBridge(noChangeBridgePath, { mutationClaimed: false });
       writeDspyGepaBridgeConfig(bridgeConfigPath);
       mkdirSync(programProject);
@@ -2062,6 +2131,7 @@ class ScoreWithFeedback:
         MODEL_SENTINEL: modelSentinel,
         GEPA_KWARGS_SENTINEL: kwargsSentinel,
         UNDERSTUDY_API_KEY: "fixture-key",
+        FIXTURE_FIREWORKS_API_KEY: "fixture-fireworks-key",
         UNDERSTUDY_GATEWAY_URL: "http://127.0.0.1:9",
         UNDERSTUDY_AUTH_SOURCE: "fixture",
       };
@@ -2076,6 +2146,16 @@ class ScoreWithFeedback:
       assert.equal(admissionPayload.optimizer_provider_calls, false);
       assert.equal(admissionPayload.endpoint_provider_calls, true);
       assert.equal(admissionPayload.spend_evidence.calls_attempted, 0);
+      assert.equal(admissionPayload.route_bindings.student.requested_model, "student-deployment");
+      assert.equal(admissionPayload.route_bindings.student.executed_model, "openai/student-deployment");
+      assert.equal(admissionPayload.route_bindings.reflection.requested_model, "reflection-deployment");
+      assert.equal(
+        admissionPayload.route_bindings.reflection.executed_model,
+        "openai/accounts/fireworks/models/reflection-deployment",
+      );
+      assert.equal(admissionPayload.route_bindings.student.credential_present, true);
+      assert.equal(admissionPayload.route_bindings.reflection.credential_present, true);
+      assert.equal("base_url" in admissionPayload.route_bindings.reflection, false);
       const admissionReceipt = join(
         repo,
         ".understudy",
@@ -2098,7 +2178,14 @@ class ScoreWithFeedback:
       assert.equal(payload.spend_evidence.calls_attempted, 2);
 
       const models = readFileSync(modelSentinel, "utf8").trim().split("\n").map((line) => JSON.parse(line));
-      assert.deepEqual(models.map((item) => item.model), ["openai/student-deployment", "openai/reflection-deployment"]);
+      assert.deepEqual(models.map((item) => item.model), [
+        "openai/student-deployment",
+        "openai/accounts/fireworks/models/reflection-deployment",
+      ]);
+      assert.deepEqual(models.map((item) => item.api_base), [
+        "http://127.0.0.1:9/v1",
+        "https://api.fireworks.ai/inference/v1",
+      ]);
       assert.deepEqual(models.map((item) => item.num_retries), [0, 0]);
       const gepaKwargs = JSON.parse(readFileSync(kwargsSentinel, "utf8"));
       assert.equal(gepaKwargs.max_metric_calls, 7);
@@ -2112,7 +2199,10 @@ class ScoreWithFeedback:
       assert.equal(gepaKwargs.track_stats, true);
       assert.equal(gepaKwargs.track_best_outputs, true);
       assert.equal(gepaKwargs.log_dir, realpathSync(logDir));
-      assert.equal(gepaKwargs.reflection_model, "openai/reflection-deployment");
+      assert.equal(
+        gepaKwargs.reflection_model,
+        "openai/accounts/fireworks/models/reflection-deployment",
+      );
 
       const runDir = join(repo, ".understudy", "optimize-workload", "dspy-gepa");
       const packageState = JSON.parse(readFileSync(join(runDir, "package-state.json"), "utf8"));
@@ -2124,14 +2214,37 @@ class ScoreWithFeedback:
       const config = JSON.parse(readFileSync(join(runDir, "config.json"), "utf8"));
       assert.equal(config.gepa.num_threads, 1);
       assert.equal(config.gepa.use_merge, true);
+      assert.equal(config.inference.routes.student.route_id, "fixture-understudy-student");
+      assert.equal(config.inference.routes.reflection.route_id, "fixture-fireworks-reflection");
+      assert.equal(config.inference.routes.student.requested_model, "student-deployment");
+      assert.equal(config.inference.routes.student.executed_model, "openai/student-deployment");
+      assert.equal(config.inference.routes.reflection.requested_model, "reflection-deployment");
+      assert.equal(
+        config.inference.routes.reflection.executed_model,
+        "openai/accounts/fireworks/models/reflection-deployment",
+      );
       const validation = config.admission.offline.bundle_validation;
       assert.equal(validation.network_calls_made, 0);
+      assert.equal(validation.input_bundle_sha256, "a".repeat(64));
+      assert.equal(validation.loaded_bundle_sha256, "d".repeat(64));
+      assert.notEqual(validation.input_bundle_sha256, validation.loaded_bundle_sha256);
+      assert.equal(validation.loaded_bundle_schema_version, "understudy.fixture_endpoint_bundle.v1");
       assert.equal(validation.oracle_contract.kind, "state_verifier");
       assert.equal(validation.tool_contract_probe.decoded_arguments_type, "object");
       assert.equal(validation.tool_contract_probe.world_state_changed, true);
       assert.equal(validation.deployment_parity.duplicate_policy_injection, false);
       assert.equal(validation.context_window_gate.source_context_limit, 4096);
       assert.equal(validation.reflection_context_window_gate.reflection_context_limit, 8192);
+      assert.equal(validation.context_window_gate.route.id, config.inference.routes.student.route_id);
+      assert.equal(
+        validation.context_window_gate.route.sha256,
+        config.inference.routes.student.route_binding_sha256,
+      );
+      assert.equal(validation.reflection_context_window_gate.route.id, config.inference.routes.reflection.route_id);
+      assert.equal(
+        validation.reflection_context_window_gate.route.sha256,
+        config.inference.routes.reflection.route_binding_sha256,
+      );
       assert.equal(validation.trajectory_feedback_contract.action_sequence_optimization_enabled, true);
       assert.equal(config.admission.live.standard_verifiers, true);
       assert.equal(config.admission.live.optimizer_started, false);
@@ -2155,6 +2268,28 @@ class ScoreWithFeedback:
       assert.equal(manifest.export_metadata.provenance.tool_schema_sha256, "b".repeat(64));
       assert.equal(manifest.mutation_claimed, true);
       assert.equal(manifest.outcome, "improved");
+      assert.deepEqual(manifest.route_bindings, config.inference.routes);
+
+      const spendEntries = payload.spend_evidence.entries;
+      assert.equal(spendEntries[0].configured_identity.role, "student");
+      assert.equal(spendEntries[0].configured_identity.requested_model, "student-deployment");
+      assert.equal(spendEntries[0].configured_identity.executed_model, "openai/student-deployment");
+      assert.equal(spendEntries[1].configured_identity.role, "reflection");
+      assert.equal(spendEntries[1].configured_identity.requested_model, "reflection-deployment");
+      assert.equal(
+        spendEntries[1].configured_identity.executed_model,
+        "openai/accounts/fireworks/models/reflection-deployment",
+      );
+      assert.deepEqual(spendEntries[0].response_identity.provider_returned_model, {
+        status: "observed",
+        source: "response.model",
+        value: "provider-returned/openai/student-deployment",
+      });
+      assert.deepEqual(spendEntries[1].response_identity.effective_model_header, {
+        status: "observed",
+        header: "x-model-id",
+        value: "effective/openai/accounts/fireworks/models/reflection-deployment",
+      });
 
       for (const artifact of [
         "package-state.json",
@@ -2190,6 +2325,39 @@ class ScoreWithFeedback:
       const reflectionOverflow = spawnSync("python3", reflectionOverflowArgs, { encoding: "utf8", env: runtimeEnv });
       assert.equal(reflectionOverflow.status, 6, reflectionOverflow.stderr || reflectionOverflow.stdout);
       assert.equal(JSON.parse(reflectionOverflow.stdout).reason, "reflection-renderer-context-window-overflow");
+      assert.equal(existsSync(modelSentinel), false);
+
+      const badRouteArgs = [...runtimeArgs, "--admission-only"];
+      badRouteArgs[badRouteArgs.indexOf(bridgePath)] = badRouteBridgePath;
+      badRouteArgs[badRouteArgs.indexOf(logDir)] = `${logDir}-bad-route`;
+      const badRoute = spawnSync("python3", badRouteArgs, { encoding: "utf8", env: runtimeEnv });
+      assert.equal(badRoute.status, 6, badRoute.stderr || badRoute.stdout);
+      assert.equal(JSON.parse(badRoute.stdout).reason, "reflection-route-binding-mismatch");
+      assert.equal(existsSync(modelSentinel), false);
+
+      const badInputBundleArgs = [...runtimeArgs, "--admission-only"];
+      badInputBundleArgs[badInputBundleArgs.indexOf(bridgePath)] = badInputBundleBridgePath;
+      badInputBundleArgs[badInputBundleArgs.indexOf(logDir)] = `${logDir}-bad-input-bundle`;
+      const badInputBundle = spawnSync("python3", badInputBundleArgs, {
+        encoding: "utf8",
+        env: runtimeEnv,
+      });
+      assert.equal(badInputBundle.status, 6, badInputBundle.stderr || badInputBundle.stdout);
+      assert.equal(JSON.parse(badInputBundle.stdout).reason, "input-bundle-sha256-mismatch");
+      assert.equal(existsSync(modelSentinel), false);
+
+      const badEndpointBundleArgs = [...runtimeArgs, "--admission-only"];
+      badEndpointBundleArgs[badEndpointBundleArgs.indexOf(bridgePath)] = badEndpointBundleBridgePath;
+      badEndpointBundleArgs[badEndpointBundleArgs.indexOf(logDir)] = `${logDir}-bad-endpoint-bundle`;
+      const badEndpointBundle = spawnSync("python3", badEndpointBundleArgs, {
+        encoding: "utf8",
+        env: runtimeEnv,
+      });
+      assert.equal(badEndpointBundle.status, 6, badEndpointBundle.stderr || badEndpointBundle.stdout);
+      assert.equal(
+        JSON.parse(badEndpointBundle.stdout).reason,
+        "loaded-endpoint-bundle-sha256-mismatch",
+      );
       assert.equal(existsSync(modelSentinel), false);
 
       const badAdmissionArgs = [...runtimeArgs, "--admission-only"];


### PR DESCRIPTION
## What changed

- Pin the live optimizer runtime to `dspy==3.3.0` and `gepa[dspy]==0.1.1`, with exact runtime version receipts.
- Upgrade the DSPy GEPA adapter for separate student/reflection routes, deterministic optimizer controls, safe resume logs, and opt-in locked workload bridges.
- Add two-phase bridge admission, hash-bound receipts, canonical candidate bundles, and inference-route provenance.
- Expand public documentation and regression coverage for the v2 adapter contract.

## Why

The previous adapter accepted broad DSPy/GEPA version ranges and only supported a simple single-program path. DSPy 3.3.0 and GEPA 0.1.1 require an explicit compatibility contract, and workload-specific program bridges need fail-closed admission, spend, package, route, and artifact boundaries before optimizer execution.

## Developer impact

The standard `dspy-gepa` route now requires a separate `--reflection-model` and runs with exact upstream package versions. Advanced workloads can supply an opt-in Python bridge from a locked uv project, but compilation requires a prior hash-bound admission receipt. Holdout rows remain excluded from optimization.

## Review

Reviewed locally against `origin/main` for package integrity, credential handling, budget enforcement, train/dev/holdout separation, resumability, route provenance, and public OSS boundaries. No blocking findings remained.

## Validation

- `npm run check` — 1,185 tests passed
- `npm run skills:validate` — 40 public skills passed
- `npm run package:smoke` — passed
- `git diff --check origin/main...HEAD` — passed