### PR TITLE
Retain sanitized gateway probe diagnostics

### DIFF
--- a/src/commands/gateway.ts
+++ b/src/commands/gateway.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { createHash } from "node:crypto";
 import kleur from "kleur";
 
 import { DEFAULT_GATEWAY_URL } from "../config/defaults.js";
@@ -129,6 +130,7 @@ async function runProbe(cmd: Command, opts: ProbeOpts): Promise<void> {
   const latencyMs = Date.now() - started;
   const text = await res.text();
   const requestId = res.headers.get("x-understudy-request-id");
+  const diagnostics = responseDiagnostics(res, text);
   const payload = {
     ok: res.ok,
     status: res.status,
@@ -141,6 +143,7 @@ async function runProbe(cmd: Command, opts: ProbeOpts): Promise<void> {
     workload: opts.workload ?? null,
     byok: Boolean(opts.byokEnv),
     response_kind: opts.stream ? "stream" : responseKind(text),
+    ...diagnostics,
   };
   if (!res.ok) process.exitCode = 1;
   if (isJsonMode(cmd)) {
@@ -156,6 +159,48 @@ async function runProbe(cmd: Command, opts: ProbeOpts): Promise<void> {
   process.stdout.write(`request_id ${requestId ?? "(none)"}\n`);
   process.stdout.write(`latency_ms ${latencyMs}\n`);
   process.stdout.write(`${res.ok ? kleur.green("response received") : kleur.red("response failed")}\n`);
+}
+
+function responseDiagnostics(res: Response, text: string): Record<string, string | null> {
+  let errorType: string | null = null;
+  let errorCode: string | null = null;
+  if (!res.ok) {
+    try {
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const error = parsed.error && typeof parsed.error === "object"
+        ? parsed.error as Record<string, unknown>
+        : parsed;
+      errorType = safeScalar(error.type);
+      errorCode = safeScalar(error.code);
+    } catch {
+      // The response hash still distinguishes non-JSON upstream failures.
+    }
+  }
+  return {
+    response_sha256: createHash("sha256").update(text).digest("hex"),
+    error_type: errorType,
+    error_code: errorCode,
+    retry_after: headerFirst(res.headers, ["retry-after"]),
+    rate_limit_limit: headerFirst(res.headers, ["x-ratelimit-limit-requests", "x-ratelimit-limit"]),
+    rate_limit_remaining: headerFirst(res.headers, ["x-ratelimit-remaining-requests", "x-ratelimit-remaining"]),
+    rate_limit_reset: headerFirst(res.headers, ["x-ratelimit-reset-requests", "x-ratelimit-reset"]),
+    upstream_request_id: headerFirst(res.headers, ["x-fireworks-request-id", "x-request-id"]),
+    deployment_id: headerFirst(res.headers, ["x-understudy-deployment-id", "x-fireworks-deployment-id"]),
+    deployment_state: headerFirst(res.headers, ["x-understudy-deployment-state", "x-fireworks-deployment-state"]),
+    cold_start: headerFirst(res.headers, ["x-understudy-cold-start", "x-fireworks-cold-start"]),
+  };
+}
+
+function safeScalar(value: unknown): string | null {
+  return typeof value === "string" || typeof value === "number" ? String(value).slice(0, 128) : null;
+}
+
+function headerFirst(headers: Headers, names: string[]): string | null {
+  for (const name of names) {
+    const value = headers.get(name);
+    if (value) return value.slice(0, 256);
+  }
+  return null;
 }
 
 function openAIProbeBody(model: string, maxTokens: number, stream: boolean): Record<string, unknown> {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -298,7 +298,22 @@ async function withHostedFixture(fn) {
       });
     }
     if (req.method === "GET" && url.pathname === "/eval-capture-req_123") return sendBytes(200, rawCapture);
-    if (req.method === "POST" && (url.pathname === "/v1/messages" || url.pathname === "/v1/chat/completions")) return send(200, { ok: true, content: "SECRET_COMPLETION" }, { "x-understudy-request-id": "req_probe" });
+    if (req.method === "POST" && (url.pathname === "/v1/messages" || url.pathname === "/v1/chat/completions")) {
+      if (body?.model === "fixture-error") {
+        return send(503, { error: { type: "upstream_capacity", code: "deployment_unavailable", message: "SECRET_PROVIDER_DETAIL" } }, {
+          "x-understudy-request-id": "req_error",
+          "x-fireworks-request-id": "fw_req_123",
+          "x-fireworks-deployment-id": "accounts/example/deployments/qwen",
+          "x-fireworks-deployment-state": "cold",
+          "x-fireworks-cold-start": "true",
+          "retry-after": "7",
+          "x-ratelimit-limit-requests": "64",
+          "x-ratelimit-remaining-requests": "0",
+          "x-ratelimit-reset-requests": "2s",
+        });
+      }
+      return send(200, { ok: true, content: "SECRET_COMPLETION" }, { "x-understudy-request-id": "req_probe" });
+    }
     return send(404, { message: `${req.method} ${url.pathname}` });
   });
 
@@ -2251,6 +2266,26 @@ class ScoreWithFeedback:
       assert.equal(buffered.status, 0, buffered.stderr);
       assert.equal(requests.at(-1).body.stream, false);
       assert.equal(JSON.parse(buffered.stdout).response_kind, "json");
+
+      const failed = await runWithEnvAsync([
+        "--json", "gateway", "probe", "--provider", "openai", "--model", "fixture-error", "--no-stream",
+      ], env, repo);
+      assert.notEqual(failed.status, 0);
+      const failedPayload = JSON.parse(failed.stdout);
+      assert.equal(failedPayload.status, 503);
+      assert.equal(failedPayload.request_id, "req_error");
+      assert.equal(failedPayload.error_type, "upstream_capacity");
+      assert.equal(failedPayload.error_code, "deployment_unavailable");
+      assert.equal(failedPayload.retry_after, "7");
+      assert.equal(failedPayload.rate_limit_limit, "64");
+      assert.equal(failedPayload.rate_limit_remaining, "0");
+      assert.equal(failedPayload.rate_limit_reset, "2s");
+      assert.equal(failedPayload.upstream_request_id, "fw_req_123");
+      assert.equal(failedPayload.deployment_id, "accounts/example/deployments/qwen");
+      assert.equal(failedPayload.deployment_state, "cold");
+      assert.equal(failedPayload.cold_start, "true");
+      assert.match(failedPayload.response_sha256, /^[0-9a-f]{64}$/);
+      assert.doesNotMatch(failed.stdout + failed.stderr, /SECRET_PROVIDER_DETAIL/);
 
       // An unreachable gateway must surface a non-zero exit code (scriptability).
       const healthDown = await runWithEnvAsync(["--json", "gateway", "health", "--gateway-url", "http://127.0.0.1:1"], env, repo);


### PR DESCRIPTION
## Summary
- hash probe response bodies without emitting provider messages
- retain sanitized error class, rate-limit, request, deployment, and cold-start headers
- cover failure receipts while proving secrets stay absent

## Validation
- `npm run build`
- focused gateway CLI test
- `npm run typecheck`

This closes the instrumentation gap exposed by the Cedar Qwen serving canary; it does not change routing or retry behavior.