### PR TITLE
Fix DSPy 3.3 GEPA runtime compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,8 @@ understudy optimize-workload adapter run --repo . --adapter dspy-gepa \
 ```
 
 The adapter creates an approval-gated `uv run --no-project` runtime with exact
-`dspy==3.3.0` and `gepa[dspy]==0.1.1` packages. That environment, resumable
+`dspy==3.3.0`, `gepa[dspy]==0.1.1`, and `cloudpickle==3.1.2` packages.
+Cloudpickle preserves resumable DSPy signature state. That environment, resumable
 logs, and owner-only optimizer receipts are local runtime state. They are not
 package infrastructure and must not be committed.
 

--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -151,7 +151,8 @@ GEPA execution is exposed through named adapters. The live DSPy adapter is
 exposed through
 `optimize-workload adapter run --adapter dspy-gepa --execute`: it resolves the
 authenticated Understudy gateway key, passes it into the local `uv` runtime as
-environment, verifies exact `dspy==3.3.0` and `gepa[dspy]==0.1.1` installs,
+environment, verifies exact `dspy==3.3.0`, `gepa[dspy]==0.1.1`, and
+`cloudpickle==3.1.2` installs,
 configures separate student/reflection DSPy LMs, runs train/dev rows only,
 excludes holdout, and writes `.understudy/optimize-workload/candidate.json`
 plus `proof-packet.json`. Live execution requires `--budget-usd`,

--- a/docs/optimize-workload-contract.md
+++ b/docs/optimize-workload-contract.md
@@ -149,7 +149,7 @@ Required behavior:
   train/dev rows only, exclude holdout rows, and write owner-only candidate,
   proof, and terminal run-state artifacts with reservation and attribution
   evidence. The attribution is not a provider-invoice claim. The runtime is
-  exactly `dspy==3.3.0` plus `gepa[dspy]==0.1.1`; it records and verifies both
+  exactly `dspy==3.3.0`, `gepa[dspy]==0.1.1`, and `cloudpickle==3.1.2`; it records and verifies all three
   installed versions before any model call.
 - Eval-input GEPA adapter: require `--execute`, read a local manifest with
   `rows`, `inputs`, or `inputs_path`, support exact-match label and tool-call

--- a/docs/uv-python-bridge.md
+++ b/docs/uv-python-bridge.md
@@ -37,7 +37,7 @@ The current implementation is `src/optimize-workload.ts`: it generates
 `eval-input-gepa` and `dspy-gepa`.
 
 The live DSPy adapter installs exactly `dspy==3.3.0` and
-`gepa[dspy]==0.1.1`, verifies the installed distribution versions, and records
+`gepa[dspy]==0.1.1` plus `cloudpickle==3.1.2`, verifies the installed distribution versions, and records
 them in an owner-only package receipt. Its optional `--program-bridge` is a
 workload file contract, not another package: a provider-free admission hook
 binds exact adapter/data/tool-schema/package hashes before separate metered

--- a/skills/optimize-workload/SKILL.md
+++ b/skills/optimize-workload/SKILL.md
@@ -120,7 +120,8 @@ validator kinds in [`reference.md`](reference.md):
    `optimize-workload adapter run --adapter <name> ... --execute`.
    `eval-input-gepa` runs upstream GEPA locally without provider calls unless a
    model-backed path is explicitly selected. `adapter run --adapter dspy-gepa
-   --execute` uses exact `dspy==3.3.0` and `gepa[dspy]==0.1.1` packages and
+   --execute` uses exact `dspy==3.3.0`, `gepa[dspy]==0.1.1`, and
+   `cloudpickle==3.1.2` packages and
    additionally requires separate student/reflection model names, an approved dollar cap, and explicit input
    and output token prices before it resolves the Understudy API key. It passes
    auth to the child process through environment only, disables client-side

--- a/skills/optimize-workload/reference.md
+++ b/skills/optimize-workload/reference.md
@@ -180,7 +180,7 @@ Three ways to optimize, picked by commitment and workload shape:
    from local samples using the program-scaffold pattern, verify parity, then
    run the approval-gated `adapter run --adapter dspy-gepa --execute` path
    against the Understudy gateway with exact `dspy==3.3.0` and
-   `gepa[dspy]==0.1.1`, separate student/reflection deployments, an explicit
+   `gepa[dspy]==0.1.1` plus `cloudpickle==3.1.2`, separate student/reflection deployments, an explicit
    dollar cap, and a conservative input/output token-price basis. A
    `--program-bridge` may provide a multi-component student, trainset, valset,
    `ScoreWithFeedback` metric, and deployable export callback. Before either LM

--- a/src/commands/optimize-workload.ts
+++ b/src/commands/optimize-workload.ts
@@ -80,7 +80,7 @@ export function registerOptimizeWorkloadCommand(program: Command): void {
     .option("--num-threads <number>", "GEPA worker threads", "1")
     .option("--seed <number>", "GEPA random seed", "0")
     .option("--log-dir <path>", "Owner-only GEPA log directory used for safe resume")
-    .option("--track-stats", "Persist upstream GEPA optimization statistics")
+    .option("--track-stats", "Persist upstream GEPA optimization statistics (required by DSPy 3.3 best-output tracking)")
     .option("--program-bridge <path>", "Opt-in Python program bridge implementing build_understudy_dspy_gepa(context)")
     .option("--program-bridge-config <path>", "Required immutable JSON settings for an opt-in program bridge")
     .option("--program-project <dir>", "Locked uv project containing workload bridge dependencies")

--- a/src/optimize-workload.ts
+++ b/src/optimize-workload.ts
@@ -126,7 +126,7 @@ const adapterRegistry: Record<string, UvAdapterSpec> = {
     name: "dspy-gepa",
     schemaVersion: "understudy.dspy_gepa_adapter.v2",
     runtimeCommand: "dspy-gepa",
-    packages: ["dspy==3.3.0", "gepa[dspy]==0.1.1"],
+    packages: ["dspy==3.3.0", "gepa[dspy]==0.1.1", "cloudpickle==3.1.2"],
     providerCalls: true,
     requiresAuth: () => true,
     buildArgs: (repo, options) => {
@@ -248,7 +248,7 @@ const adapterRegistry: Record<string, UvAdapterSpec> = {
         "--log-dir",
         resolve(options.logDir ?? join(repo, optimizeDir, "dspy-gepa", "gepa-log")),
         "--track-stats",
-        options.trackStats === true ? "true" : "false",
+        "true",
       ];
       if (options.samples) {
         args.push("--samples", resolve(options.samples));

--- a/src/optimize-workload/runtime-source.ts
+++ b/src/optimize-workload/runtime-source.ts
@@ -23,6 +23,8 @@ DSPY_PACKAGE_SPEC = "dspy==3.3.0"
 DSPY_VERSION = "3.3.0"
 GEPA_PACKAGE_SPEC = "gepa[dspy]==0.1.1"
 GEPA_VERSION = "0.1.1"
+CLOUDPICKLE_PACKAGE_SPEC = "cloudpickle==3.1.2"
+CLOUDPICKLE_VERSION = "3.1.2"
 
 
 def emit(payload: dict[str, Any]) -> None:
@@ -741,10 +743,15 @@ def require_exact_optimizer_packages(
         actual = {
             "dspy": importlib.metadata.version("dspy"),
             "gepa": importlib.metadata.version("gepa"),
+            "cloudpickle": importlib.metadata.version("cloudpickle"),
         }
     except importlib.metadata.PackageNotFoundError as error:
         raise RuntimePackageVersionError("runtime-package-version-mismatch") from error
-    if actual != {"dspy": DSPY_VERSION, "gepa": GEPA_VERSION}:
+    if actual != {
+        "dspy": DSPY_VERSION,
+        "gepa": GEPA_VERSION,
+        "cloudpickle": CLOUDPICKLE_VERSION,
+    }:
         raise RuntimePackageVersionError("runtime-package-version-mismatch")
     workload_actual: dict[str, str] = {}
     for distribution, expected in (workload_package_pins or {}).items():
@@ -759,7 +766,7 @@ def require_exact_optimizer_packages(
         workload_actual[distribution] = installed
     payload = {
         "schema_version": "understudy.dspy_gepa_package_state.v1",
-        "requested": [DSPY_PACKAGE_SPEC, GEPA_PACKAGE_SPEC],
+        "requested": [DSPY_PACKAGE_SPEC, GEPA_PACKAGE_SPEC, CLOUDPICKLE_PACKAGE_SPEC],
         "actual": actual,
         "workload_actual": workload_actual,
         "program_project": dict(project_state) if project_state else None,
@@ -1730,31 +1737,39 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         else None
     )
 
+    student_lm_kwargs = {
+        "api_key": student_api_key,
+        "api_base": student_api_base,
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "cache": False,
+        "num_retries": 0,
+    }
+    if args.reasoning_effort != "none":
+        student_lm_kwargs["reasoning_effort"] = args.reasoning_effort
     student_lm = BudgetedLM(
         student_route["dspy_model"],
         spend_ledger=ledger,
         role="student",
         route_receipt=student_route,
-        api_key=student_api_key,
-        api_base=student_api_base,
-        max_tokens=args.max_tokens,
-        temperature=args.temperature,
-        reasoning_effort=args.reasoning_effort,
-        cache=False,
-        num_retries=0,
+        **student_lm_kwargs,
     )
+    reflection_lm_kwargs = {
+        "api_key": reflection_api_key,
+        "api_base": reflection_api_base,
+        "max_tokens": args.max_tokens,
+        "temperature": args.reflection_temperature,
+        "cache": False,
+        "num_retries": 0,
+    }
+    if args.reflection_reasoning_effort != "none":
+        reflection_lm_kwargs["reasoning_effort"] = args.reflection_reasoning_effort
     reflection_lm = BudgetedLM(
         reflection_route["dspy_model"],
         spend_ledger=ledger,
         role="reflection",
         route_receipt=reflection_route,
-        api_key=reflection_api_key,
-        api_base=reflection_api_base,
-        max_tokens=args.max_tokens,
-        temperature=args.reflection_temperature,
-        reasoning_effort=args.reflection_reasoning_effort,
-        cache=False,
-        num_retries=0,
+        **reflection_lm_kwargs,
     )
     if student_lm is reflection_lm:
         raise ValueError("student and reflection LMs must be separate instances")
@@ -1899,6 +1914,7 @@ def _dspy_gepa_execute(args: argparse.Namespace, ledger: SpendLedger) -> None:
         track_stats=args.track_stats,
         track_best_outputs=True,
         seed=args.seed,
+        gepa_kwargs={"use_cloudpickle": True},
     )
     optimized = teleprompter.compile(student, trainset=trainset, valset=valset)
     program_state = optimized_program_state(optimized, bridge_state)

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -533,7 +533,7 @@ function withOptimizerFixtureRepo(fn) {
 }
 
 function writePythonDistributionMetadata(root) {
-  for (const [name, version] of [["dspy", "3.3.0"], ["gepa", "0.1.1"]]) {
+  for (const [name, version] of [["dspy", "3.3.0"], ["gepa", "0.1.1"], ["cloudpickle", "3.1.2"]]) {
     const metadataDir = join(root, `${name}-${version}.dist-info`);
     mkdirSync(metadataDir, { recursive: true });
     writeFileSync(
@@ -1622,7 +1622,6 @@ printf '%s\n' '{"schema_version":"fixture.uv.v1","status":"fixture-ok"}'
         "1",
         "--seed",
         "42",
-        "--track-stats",
         "--execute",
       ], {
         PATH: `${fakeBin}:${baseEnv.PATH}`,
@@ -1632,13 +1631,15 @@ printf '%s\n' '{"schema_version":"fixture.uv.v1","status":"fixture-ok"}'
       });
       assert.equal(result.status, 0, result.stderr);
       const uvArgs = readFileSync(uvArgsPath, "utf8").trim().split("\n");
-      assert.deepEqual(uvArgs.slice(0, 6), [
+      assert.deepEqual(uvArgs.slice(0, 8), [
         "run",
         "--no-project",
         "--with",
         "dspy==3.3.0",
         "--with",
         "gepa[dspy]==0.1.1",
+        "--with",
+        "cloudpickle==3.1.2",
       ]);
       const flagValue = (flag) => uvArgs[uvArgs.indexOf(flag) + 1];
       assert.equal(flagValue("--model"), "student-deployment");
@@ -2187,6 +2188,7 @@ class ScoreWithFeedback:
         "https://api.fireworks.ai/inference/v1",
       ]);
       assert.deepEqual(models.map((item) => item.num_retries), [0, 0]);
+      assert.deepEqual(models.map((item) => item.reasoning_effort), [null, null]);
       const gepaKwargs = JSON.parse(readFileSync(kwargsSentinel, "utf8"));
       assert.equal(gepaKwargs.max_metric_calls, 7);
       assert.equal(gepaKwargs.reflection_minibatch_size, 2);
@@ -2198,6 +2200,7 @@ class ScoreWithFeedback:
       assert.equal(gepaKwargs.seed, 42);
       assert.equal(gepaKwargs.track_stats, true);
       assert.equal(gepaKwargs.track_best_outputs, true);
+      assert.deepEqual(gepaKwargs.gepa_kwargs, { use_cloudpickle: true });
       assert.equal(gepaKwargs.log_dir, realpathSync(logDir));
       assert.equal(
         gepaKwargs.reflection_model,
@@ -2206,8 +2209,8 @@ class ScoreWithFeedback:
 
       const runDir = join(repo, ".understudy", "optimize-workload", "dspy-gepa");
       const packageState = JSON.parse(readFileSync(join(runDir, "package-state.json"), "utf8"));
-      assert.deepEqual(packageState.requested, ["dspy==3.3.0", "gepa[dspy]==0.1.1"]);
-      assert.deepEqual(packageState.actual, { dspy: "3.3.0", gepa: "0.1.1" });
+      assert.deepEqual(packageState.requested, ["dspy==3.3.0", "gepa[dspy]==0.1.1", "cloudpickle==3.1.2"]);
+      assert.deepEqual(packageState.actual, { dspy: "3.3.0", gepa: "0.1.1", cloudpickle: "3.1.2" });
       assert.deepEqual(packageState.workload_actual, { "fixture-workload": "1.2.3" });
       assert.equal(packageState.program_project.locked, true);
       assert.equal(packageState.program_project.uv_lock_sha256.length, 64);


### PR DESCRIPTION
## Summary

- omit DSPy `reasoning_effort` when the configured value is `none`
- enable GEPA stats required by DSPy best-output tracking
- pin and verify `cloudpickle==3.1.2`, then enable cloudpickle for resumable DSPy signatures
- extend runtime receipts, tests, and public docs

## Real runtime validation

Ran the built `dspy-gepa --execute` adapter against a local OpenAI-compatible synthetic gateway with the actual pinned environment (`dspy==3.3.0`, `gepa[dspy]==0.1.1`, `cloudpickle==3.1.2`). The run completed 4/4 model calls, created candidate and proof artifacts, used train/dev rows, and excluded the holdout row. No external provider calls or spend occurred.

## Checks

- `npm run check` (1,185 tests; 161 suites; 0 failures)
- `git diff --check`
- exact-version uv import smoke test
