### PR TITLE
Create gateway workloads from local workload cards

### DIFF
--- a/docs/current-functionality.md
+++ b/docs/current-functionality.md
@@ -31,6 +31,7 @@ understudy doctor --hosted
 understudy models list --json
 understudy workloads list
 understudy workloads create classify --capture
+understudy workloads create --from-card .understudy/workload-discovery/workload-card.json --project-id <project-id>
 understudy workloads show classify
 understudy workloads update classify --capture off
 understudy workloads route <workload-id> --project-id <project-id> --model-id glm-5.1 --traffic-pct 10

--- a/skills/use-understudy-gateway/SKILL.md
+++ b/skills/use-understudy-gateway/SKILL.md
@@ -154,12 +154,20 @@ models by public id.
    understudy models list --json
    ```
 
-2. Ensure the eval workload has **no route configured**. A route dialed to 0%
-   still counts as configured and prevents request-time catalog resolution.
+2. Ensure the eval workload exists on the gateway, then has **no route
+   configured**. A route dialed to 0% still counts as configured and prevents
+   request-time catalog resolution. Register from the local card if needed,
+   then clear:
 
    ```sh
-   understudy workloads route <workload-id> --project-id <project-id> --clear
+   understudy workloads create --project-id <project-id> \
+     --from-card .understudy/workload-discovery/workload-card.json
+   understudy workloads route <workload-name> --project-id <project-id> --clear
    ```
+
+   Use the card's `workload_name` when set, otherwise its `workload_id`, as
+   `<workload-name>`. Skip create if `understudy workloads list` already shows
+   that name.
 
 3. Run the frozen eval once per catalog model by changing only the request-body
    `model` value. Send `x-understudy-project` and `x-understudy-workload` on
@@ -223,26 +231,39 @@ comparing a workload's quality and cost across the split.
    only if the headers are absent. Exclude runs where the requested and
    effective models disagree.
 
-2. Route a workload to a model at a traffic percentage — a per-request split
-   where that share goes to the routed model and the rest stays on passthrough.
-   Pick a bounded share (e.g. 30%) to keep the comparison small.
+2. Register the local workload card on the gateway if it is not already there.
+   A local `workload-card.json` is only on disk until create runs — routing a
+   card id that was never registered returns not-found.
 
    ```sh
-   understudy workloads route <workload-id> --project-id <project-id> --model-id gemma-4-12b --traffic-pct 30
+   understudy workloads create --project-id <project-id> \
+     --from-card .understudy/workload-discovery/workload-card.json
+   ```
+
+   Skip create when `understudy workloads list` already shows the card's
+   `workload_name` (or `workload_id` when name is null).
+
+3. Route a workload to a model at a traffic percentage — a per-request split
+   where that share goes to the routed model and the rest stays on passthrough.
+   Pick a bounded share (e.g. 30%) to keep the comparison small. Use the same
+   name create used (card `workload_name` or `workload_id`):
+
+   ```sh
+   understudy workloads route <workload-name> --project-id <project-id> --model-id gemma-4-12b --traffic-pct 30
    ```
 
    Clearing the route (`--clear` in place of the model/traffic flags) returns the
    workload to full passthrough. The hosted split semantics are documented at
    [docs.understudylabs.com/concepts/routing](https://docs.understudylabs.com/concepts/routing).
 
-3. Run the eval through the gateway so the routed model serves its share. Any
+4. Run the eval through the gateway so the routed model serves its share. Any
    local command works; an eval harness like a verifiers `vf-eval` run is typical.
 
    ```sh
    understudy run -- vf-eval <eval-id>
    ```
 
-4. Prerequisite for a frontier comparison. For the split to compare the routed
+5. Prerequisite for a frontier comparison. For the split to compare the routed
    model against a frontier model, the non-routed (passthrough) share must have a
    configured managed provider key or BYO key; the managed catalog only resolves
    on no-route workloads. Without passthrough credentials, those non-routed

--- a/src/commands/workloads.ts
+++ b/src/commands/workloads.ts
@@ -8,6 +8,7 @@ import { trackControlPlaneAction } from "../internal/telemetry.js";
 import {
   listWorkloads,
   parseTrafficPct,
+  readWorkloadCardName,
   resolveWorkload,
   setWorkloadRoute,
   WorkloadSchema,
@@ -22,6 +23,7 @@ interface WorkloadOpts extends ProjectResolutionOptions {}
 
 interface CreateOpts extends WorkloadOpts {
   capture?: boolean;
+  fromCard?: string;
 }
 
 interface UpdateOpts extends WorkloadOpts {
@@ -46,11 +48,12 @@ export function registerWorkloadsCommand(program: Command): void {
       await runAction(this, () => runList(this, opts));
     });
 
-  addProjectOptions(workloads.command("create <name>")
+  addProjectOptions(workloads.command("create [name]")
     .description("Create a workload in a project.")
+    .option("--from-card <path>", "Register a workload using name from a local workload-card.json.")
     .option("--capture", "Enable hosted capture for this workload.")
     .option("--no-capture", "Disable hosted capture for this workload."))
-    .action(async function (this: Command, name: string, opts: CreateOpts) {
+    .action(async function (this: Command, name: string | undefined, opts: CreateOpts) {
       await runAction(this, () => runCreate(this, name, opts));
     });
 
@@ -103,8 +106,15 @@ async function runList(cmd: Command, opts: WorkloadOpts): Promise<void> {
   printWorkloadTable(workloads);
 }
 
-async function runCreate(cmd: Command, name: string, opts: CreateOpts): Promise<void> {
-  validateWorkloadName(name);
+async function runCreate(cmd: Command, name: string | undefined, opts: CreateOpts): Promise<void> {
+  if (name && opts.fromCard) {
+    throw new Error("Pass either a workload name or --from-card, not both.");
+  }
+  const resolvedName = opts.fromCard ? readWorkloadCardName(opts.fromCard) : name;
+  if (!resolvedName) {
+    throw new Error("Pass a workload name or --from-card <path>.");
+  }
+  validateWorkloadName(resolvedName);
   const project = await resolveProject(opts);
   const captureEnabled = Boolean(opts.capture);
   const res = await request(
@@ -112,7 +122,7 @@ async function runCreate(cmd: Command, name: string, opts: CreateOpts): Promise<
       url: `/admin/v1/orgs/${project.auth.orgId}/projects/${encodeURIComponent(project.projectId)}/workloads`,
       orgId: project.auth.orgId,
       method: "POST",
-      body: { name, capture_enabled: captureEnabled },
+      body: { name: resolvedName, capture_enabled: captureEnabled },
     },
     CreateWorkloadResponseSchema,
   );

--- a/src/internal/workloads.ts
+++ b/src/internal/workloads.ts
@@ -141,3 +141,35 @@ export function parseTrafficPct(value: string | number | undefined, fallback = 1
   }
   return parsed;
 }
+
+const WorkloadCardNameSchema = z.object({
+  workload_id: z.string().optional().nullable(),
+  workload_name: z.string().optional().nullable(),
+}).passthrough();
+
+/** Resolve a gateway workload name from a local workload-card.json. */
+export function readWorkloadCardName(cardPath: string): string {
+  let raw: string;
+  try {
+    raw = readFileSync(cardPath, "utf8");
+  } catch {
+    throw new Error(`Could not read workload card at ${cardPath}.`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in workload card at ${cardPath}.`);
+  }
+  const card = WorkloadCardNameSchema.parse(parsed);
+  const fromName = typeof card.workload_name === "string" ? card.workload_name.trim() : "";
+  const fromId = typeof card.workload_id === "string" ? card.workload_id.trim() : "";
+  const name = fromName || fromId;
+  if (!name) {
+    throw new Error(`Workload card at ${cardPath} has no usable workload_name or workload_id.`);
+  }
+  if (!WORKLOAD_NAME_PATTERN.test(name)) {
+    throw new Error(`Invalid workload name "${name}". Must match /^[a-z0-9][a-z0-9_-]{0,62}$/.`);
+  }
+  return name;
+}

--- a/src/internal/workloads.ts
+++ b/src/internal/workloads.ts
@@ -143,6 +143,7 @@ export function parseTrafficPct(value: string | number | undefined, fallback = 1
 }
 
 const WorkloadCardNameSchema = z.object({
+  schema_version: z.literal("understudy.workload_card.v1"),
   workload_id: z.string().optional().nullable(),
   workload_name: z.string().optional().nullable(),
 }).passthrough();

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -2899,6 +2899,22 @@ class ScoreWithFeedback:
         "rehearsal",
       ], env, repo);
       assert.notEqual(missing.status, 0);
+
+      const wrongSchema = join(cardDir, "wrong-schema.json");
+      writeFileSync(wrongSchema, `${JSON.stringify({
+        schema_version: "other.workload_card.v1",
+        workload_name: "support_triage",
+      })}\n`);
+      const invalidSchema = await runWithEnvAsync([
+        "workloads",
+        "create",
+        "--from-card",
+        wrongSchema,
+        "--project",
+        "rehearsal",
+      ], env, repo);
+      assert.notEqual(invalidSchema.status, 0);
+      assert.match(`${invalidSchema.stderr}${invalidSchema.stdout}`, /schema_version|workload_card/i);
       assert.match(`${missing.stderr}${missing.stdout}`, /missing-card|ENOENT|not found|unreadable|Could not read/i);
     });
   });

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -2830,6 +2830,79 @@ class ScoreWithFeedback:
     });
   });
 
+  it("creates a workload from a local workload card", async () => {
+    await withHostedFixture(async ({ home, repo, requests }) => {
+      const env = { HOME: home, USERPROFILE: home };
+      const cardDir = join(repo, ".understudy", "workload-discovery");
+      mkdirSync(cardDir, { recursive: true });
+      const cardPath = join(cardDir, "workload-card.json");
+      writeFileSync(cardPath, `${JSON.stringify({
+        schema_version: "understudy.workload_card.v1",
+        workload_id: "workload-001",
+        workload_name: null,
+      }, null, 2)}\n`);
+
+      const create = await runWithEnvAsync([
+        "--json",
+        "workloads",
+        "create",
+        "--from-card",
+        cardPath,
+        "--project",
+        "rehearsal",
+      ], env, repo);
+      assert.equal(create.status, 0, create.stderr);
+      const created = JSON.parse(create.stdout);
+      assert.equal(created.name, "workload-001");
+      assert.equal(created.id, "usp_workload-001");
+      assert.equal(requests.at(-1).method, "POST");
+      assert.equal(requests.at(-1).path, "/admin/v1/orgs/org_1/projects/proj_1/workloads");
+      assert.deepEqual(requests.at(-1).body, { name: "workload-001", capture_enabled: false });
+
+      const namedCard = join(cardDir, "named-card.json");
+      writeFileSync(namedCard, `${JSON.stringify({
+        schema_version: "understudy.workload_card.v1",
+        workload_id: "workload-001",
+        workload_name: "support_triage",
+      }, null, 2)}\n`);
+      const createNamed = await runWithEnvAsync([
+        "workloads",
+        "create",
+        "--from-card",
+        namedCard,
+        "--capture",
+        "--project",
+        "rehearsal",
+      ], env, repo);
+      assert.equal(createNamed.status, 0, createNamed.stderr);
+      assert.match(createNamed.stdout, /Created workload support_triage/);
+      assert.deepEqual(requests.at(-1).body, { name: "support_triage", capture_enabled: true });
+
+      const both = await runWithEnvAsync([
+        "workloads",
+        "create",
+        "support_triage",
+        "--from-card",
+        cardPath,
+        "--project",
+        "rehearsal",
+      ], env, repo);
+      assert.notEqual(both.status, 0);
+      assert.match(`${both.stderr}${both.stdout}`, /from-card|one source|not both/i);
+
+      const missing = await runWithEnvAsync([
+        "workloads",
+        "create",
+        "--from-card",
+        join(repo, "missing-card.json"),
+        "--project",
+        "rehearsal",
+      ], env, repo);
+      assert.notEqual(missing.status, 0);
+      assert.match(`${missing.stderr}${missing.stdout}`, /missing-card|ENOENT|not found|unreadable|Could not read/i);
+    });
+  });
+
   it("redacts capture payloads by default and writes full payloads only to files", async () => {
     await withHostedFixture(async ({ home, repo }) => {
       const env = { HOME: home, USERPROFILE: home };


### PR DESCRIPTION
Supersedes #378 with the original capability rebased onto current main and an additional fail-closed schema-version check.

Adds `understudy workloads create --from-card <path>` so the local capture/import workflow can create the corresponding hosted gateway workload without manually retyping its name. The command keeps TypeScript in control of validation and the authenticated request.

Validation:
- `npm run build`
- `node --test tests/cli.test.mjs` (89/89)
- `npm run skills:validate` (41 skills)
- `git diff --check`

Credit to @VishnuRachakonda for the original implementation in #378.