### PR TITLE
Add public writing and LaTeX skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,276 +184,10 @@ the agent-run install/update/verify flow for every platform.
 Every path is local-only: installing an adapter does not authenticate, upload
 data, download model weights, or make provider calls.
 
-<a id="install-as-a-claude-code-plugin"></a>
-<details>
-<summary><b>Claude Code — install as a plugin (recommended)</b></summary>
-
-The skills in [`skills/`](skills/) ship as a Claude Code plugin, declared in
-[`.claude-plugin/`](.claude-plugin/) (`plugin.json` + `marketplace.json`).
-Installing it registers the public invocable skills, including the
-`understudy` orchestrator, onboarding, capture/eval, optimization, local
-model, distillation, RLM, and verifier-handoff workers.
-
-From a clone of this repo:
-
-```bash
-claude plugin marketplace add /path/to/understudy-agent-tools
-claude plugin install understudy@understudy-skills
-```
-
-Then run `/reload-plugins` in your Claude Code session to activate — **no
-restart required**. The equivalent interactive flow is `/plugin marketplace add
-<path>` then `/plugin install understudy@understudy-skills`. The
-[`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill automates
-this and reports whether the plugin is already installed. The older
-[`install-plugin`](skills/install-plugin/SKILL.md) skill remains as a Claude Code
-compatibility shim.
-
-After `/reload-plugins`, run `/understudy:onboard`. That is where the coding
-agent guides the first local model, launches the ladder climb, and handles any
-frontier comparison with explicit consent.
-
-Installing as a plugin is the recommended way to use Understudy: the skills are
-what let a coding agent explain what Understudy is and walk you from a trace to
-a shipped improvement. It is also fully reversible —
-
-```bash
-claude plugin uninstall understudy@understudy-skills
-claude plugin marketplace remove understudy-skills
-```
-
-— and nothing outside Claude Code's plugin registry is touched.
-
-</details>
-
-<a id="install-as-a-cursor-plugin"></a>
-<details>
-<summary><b>Cursor — install as a plugin</b></summary>
-
-The same skills ship as a Cursor plugin, declared in
-[`.cursor-plugin/plugin.json`](.cursor-plugin/plugin.json). Cursor discovers
-the repo's existing [`skills/`](skills/) tree from the plugin root, so there is
-no Cursor-specific fork of the playbooks.
-
-For local testing from a clone:
-
-```bash
-mkdir -p ~/.cursor/plugins/local
-ln -s /path/to/understudy-agent-tools ~/.cursor/plugins/local/understudy
-```
-
-Then restart Cursor or run **Developer: Reload Window**. In Cursor Settings ->
-Rules, the Understudy skills should appear under Agent Decides. To remove it:
-
-```bash
-rm -f ~/.cursor/plugins/local/understudy
-```
-
-The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
-contains the agent-run install/update/verify flow; ask for platform `cursor`.
-The older [`install-cursor-plugin`](skills/install-cursor-plugin/SKILL.md) skill
-remains as a compatibility shim.
-
-</details>
-
-<a id="install-as-a-codex-plugin"></a>
-<details>
-<summary><b>Codex — install as a plugin</b></summary>
-
-The same skills ship as a Codex plugin, declared in
-[`.codex-plugin/plugin.json`](.codex-plugin/plugin.json) and exposed through the
-repo marketplace at
-[`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json). The
-plugin points at the repo's existing [`skills/`](skills/) tree.
-
-From a clone of this repo:
-
-```bash
-codex plugin marketplace add /path/to/understudy-agent-tools
-```
-
-Then open Codex, run `/plugins`, choose the `understudy-skills` marketplace, and
-install or enable the `understudy` plugin. The
-[`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill contains
-the agent-run registration/verify flow; ask for platform `codex`. The older
-[`install-codex-plugin`](skills/install-codex-plugin/SKILL.md) skill remains as
-a compatibility shim.
-
-To remove the marketplace registration:
-
-```bash
-codex plugin marketplace remove understudy-skills
-```
-
-`AGENTS.md` remains repo guidance for Codex, but the Codex plugin is the
-reusable distribution unit for the skills.
-
-</details>
-
-<a id="install-as-opencode-skills"></a>
-<details>
-<summary><b>OpenCode — install as skills</b></summary>
-
-OpenCode loads `SKILL.md` files natively. This repo exposes the shared skill
-tree through [`.opencode/skills`](.opencode/skills), a symlink to
-[`skills/`](skills/), and ships a small
-[`/understudy-onboard`](.opencode/commands/understudy-onboard.md) command.
-
-This is an OpenCode skills/commands adapter, not an OpenCode JS/TS plugin.
-OpenCode plugins are for lifecycle hooks and custom behavior; Understudy only
-needs native skill discovery plus a command that routes into onboarding.
-[`.opencode/adapter.json`](.opencode/adapter.json) is an Understudy
-version/staleness sentinel for release checks, not a manifest consumed by
-OpenCode.
-
-For global local testing from a clone:
-
-```bash
-mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands
-for skill in /path/to/understudy-agent-tools/skills/*; do
-  [ -f "$skill/SKILL.md" ] || continue
-  dest=~/.config/opencode/skills/"$(basename "$skill")"
-  [ -e "$dest" ] || [ -L "$dest" ] || ln -s "$skill" "$dest"
-done
-[ -e ~/.config/opencode/commands/understudy-onboard.md ] || \
-  ln -s /path/to/understudy-agent-tools/.opencode/commands/understudy-onboard.md \
-    ~/.config/opencode/commands/understudy-onboard.md
-```
-
-Then restart OpenCode or open a new TUI session and run:
-
-```text
-/understudy-onboard
-```
-
-The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
-contains the agent-run install/update/verify flow; ask for platform `opencode`.
-The older [`install-opencode-plugin`](skills/install-opencode-plugin/SKILL.md)
-skill remains as a compatibility shim for the old name. Because symlink targets
-can live outside the current project, OpenCode may ask before reading linked
-external resources.
-
-To remove Understudy-owned symlinks:
-
-```bash
-find ~/.config/opencode/skills -type l -lname '*/understudy-agent-tools/skills/*' -delete
-rm -f ~/.config/opencode/commands/understudy-onboard.md
-```
-
-</details>
-
-<a id="install-as-hermes-skills"></a>
-<details>
-<summary><b>Hermes Agent — install as skills</b></summary>
-
-Hermes Agent (Nous Research) loads `SKILL.md` files natively and scans any
-directory listed in `skills.external_dirs` in `~/.hermes/config.yaml`. The
-shared skill tree already ships valid Hermes skills, so the adapter registers
-the directory rather than copying it. To keep the config entry stable across
-checkout or package moves, it registers a durable `~/.understudy/skills`
-symlink to [`skills/`](skills/) — a path indirection, not a fork.
-[`.hermes/adapter.json`](.hermes/adapter.json) is an Understudy
-version/staleness sentinel for release checks, not a manifest consumed by
-Hermes.
-
-For global local testing from a clone:
-
-```bash
-REPO=/path/to/understudy-agent-tools
-LINK="$HOME/.understudy/skills"
-mkdir -p "$HOME/.understudy"
-[ -e "$LINK" ] || ln -s "$REPO/skills" "$LINK"
-python3 - "${HERMES_HOME:-$HOME/.hermes}/config.yaml" "$LINK" <<'PY'
-import sys, os, yaml
-p, d = sys.argv[1], sys.argv[2]
-c = (yaml.safe_load(open(p)) or {}) if os.path.exists(p) else {}
-s = c.get("skills") if isinstance(c.get("skills"), dict) else {}
-c["skills"] = s
-e = s.get("external_dirs") or []
-e = [e] if isinstance(e, str) else (e if isinstance(e, list) else [])
-if d not in e:
-    e.append(d)
-s["external_dirs"] = e
-os.makedirs(os.path.dirname(p) or ".", exist_ok=True)
-yaml.safe_dump(c, open(p, "w"), sort_keys=False)
-PY
-```
-
-Then, in Hermes, rescan without restarting and start onboarding:
-
-```text
-/reload-skills
-/onboard
-```
-
-The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
-contains the agent-run install/update/verify flow; ask for platform `hermes`.
-Local `~/.hermes/skills/` entries win on name conflicts, so a few generically
-named skills may be shadowed by Hermes bundled skills.
-
-To remove the registration, drop the entry from `skills.external_dirs` and the
-symlink:
-
-```bash
-CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"
-LINK="$HOME/.understudy/skills"
-python3 - "$CONFIG" "$LINK" <<'PY'
-import sys, os, yaml
-p, d = sys.argv[1], sys.argv[2]
-c = (yaml.safe_load(open(p)) or {}) if os.path.exists(p) else {}
-s = c.get("skills") if isinstance(c.get("skills"), dict) else {}
-e = s.get("external_dirs") or []
-e = [e] if isinstance(e, str) else (e if isinstance(e, list) else [])
-s["external_dirs"] = [x for x in e if x != d]
-yaml.safe_dump(c, open(p, "w"), sort_keys=False)
-PY
-[ -L "$LINK" ] && rm -f "$LINK"
-```
-
-</details>
-
-<details>
-<summary><b>Devin — install as a global CLI</b></summary>
-
-Devin is a cloud-based coding agent: each session boots from a snapshot, so the
-install surface is a global CLI rather than a local plugin registration. Until
-the npm package is published, the public installer uses a temporary sparse
-checkout of the reviewed GitHub source, omits Desktop/Rust and other development
-trees, builds with production dependencies only, and installs the resulting npm
-tarball. Devin reads `AGENTS.md` as an injected repository rule and accesses the
-shared [`skills/`](skills/) tree from the installed package.
-[`.devin/adapter.json`](.devin/adapter.json) is an Understudy version/staleness
-sentinel for release checks, not a manifest consumed by Devin.
-
-Install the CLI without launching an interactive local agent (typically add
-the same command to the Devin environment blueprint for persistence):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/UnderstudyLabs/understudy-agent-tools/main/install.sh \
-  | bash -s -- --yes --agents devin --no-launch-agent
-```
-
-Then ask Devin:
-
-```text
-Use the Understudy onboarding skill for this project.
-```
-
-The [`install-agent-adapter`](skills/install-agent-adapter/SKILL.md) skill
-contains the agent-run install/verify flow; ask for platform `devin`. This path
-is local-only: installing the CLI does not authenticate, upload data, download
-model weights, or make provider calls.
-
-To remove:
-
-```bash
-npm uninstall -g @understudylabs/understudy-agent-tools
-```
-
-</details>
-
-Use the platform registry to see the current install/reload surface across
-agent clients:
+All adapters expose the same skill tree; there are no platform-specific forks.
+For manual setup, removal, or adapter internals, see
+[`docs/agent-platform-adapters.md`](docs/agent-platform-adapters.md). You can
+also inspect the live registry from the CLI:
 
 ```bash
 understudy platforms
@@ -475,85 +209,20 @@ understudy models runtime doctor  # verify the pinned Apple Silicon VLM engine
 `spine` prints the public workflow and points agents at
 `skills/understudy/SKILL.md`.
 
-Understudy Desktop does not depend on a user's global Python environment. On
-Apple Silicon, `understudy models runtime install` creates a private,
-commit-pinned MLX/VLM engine under `~/.understudy`; `doctor` verifies its
-provenance and the required Gemma compatibility fix, and `repair` reinstalls
-that exact runtime when first-use diagnostics fail.
-
-When Desktop is running, agents can use its authenticated local control plane
-without discovering ports or handling tokens themselves:
+When Understudy Desktop is running, the CLI can inspect its authenticated local
+control plane and run models without exposing ports or tokens:
 
 ```bash
 understudy desktop contract --json
-understudy desktop capabilities
 understudy desktop status --json
 understudy desktop model catalog --json
-understudy desktop download start understudy-small
-understudy desktop download status <download-id> --json
-understudy desktop slot add --json
-understudy desktop slot assign <slot-id> understudy-small
-understudy desktop slot warm <slot-id>
-understudy desktop chat --slot 9 --session my-task --run-id my-task-1 "Inspect this"
-understudy desktop chat --slot 9 --supervisor-slot 5 "Let the small model work first"
-understudy desktop chat --slot 9 --image screenshot.png "What is wrong here?"
-understudy desktop run cancel my-task-1
-understudy desktop run events my-task-1 --json
-understudy desktop supervisor-feedback --session my-task --run-id my-task-1 \
-  --marker my-task-1:intervention:0 --stage take_over --correct-action continue
-understudy desktop supervisor-feedback --session my-task --run-id my-task-1 \
-  --marker my-task-1:verdict:0 --stage stop --correct-action interrupt
-understudy desktop supervision export --reviewed-only --json
-understudy desktop supervision prepare-proof --proof ~/.understudy/proofs/<proof-id> --json
-understudy desktop tool-proof run --suite core \
-  --candidate local-main:7 --candidate local-fast:6 --repetitions 1
-understudy desktop tool-proof list --json
-understudy desktop tool-proof prepare --proof <proof-id> --json
+understudy desktop chat --slot <slot-id> --session my-task "Inspect this"
 ```
 
-The CLI reads the private mode-0600 `~/.understudy/desktop-api.json`, verifies
-the recorded PID and loopback health endpoint, and streams the canonical
-ConversationRuntime events. The desktop UI, REST API, CLI, and MCP use the same
-runtime and exact `run_id`; the CLI does not drive UI controls or create a
-second chat harness. `understudy desktop contract` prints the packaged OpenAPI
-3.1 contract even when Desktop is not running, so agents can plan calls without
-probing private implementation routes or handling the bearer token themselves.
-Model inventory, download, and residency commands use the versioned Desktop
-REST contract and fall back to the equivalent legacy routes for one release;
-they do not duplicate model-process ownership inside the CLI. MCP remains an
-adapter for agents that prefer tool calls, not the CLI's hidden transport.
-The supervision export is explicit and local-only. It writes content-addressed,
-owner-only correction-pair JSONL and metrics under
-`~/.understudy/exports/supervision/` without printing prompt or completion
-payloads to the terminal. Metrics use only provider-complete role attribution;
-missing or estimated usage is counted as excluded rather than treated as zero.
-The export also reports incomplete interventions and any journal or intervention
-rows omitted by its bounded recent-evidence window, so aggregates are never
-presented as all-time metrics when the safety cap was reached.
-`supervision prepare-proof` joins only exact proof/run/session/marker identities
-to those canonical pairs. It records deterministic structured-output scores
-separately from human judgment, keeps promotion and smoke proofs
-evaluation-only, and emits training-eligible rows only for a separately
-declared train or development split. The content-addressed JSONL and manifest
-remain owner-only and local; the command performs no upload. When at least two
-eligible rows exist, the same command also prepares an owner-only DSPy/GEPA
-handoff with a deterministic 75/25 train/dev split. Its inputs preserve the
-small-model partial, supervisor reason, and failed teacher attempt; its target
-is the frozen expected JSON. The handoff is preparation only: it performs no
-provider call and never admits promotion or smoke rows.
-Executing the provider-backed DSPy adapter additionally requires an approved
-dollar cap and explicit input/output token prices. Before every request, the
-runtime reserves a conservative upper bound from the serialized input bytes and
-the configured output-token ceiling; it disables client-side retries and stops
-before a request whose reservation could exceed the cap. Candidate, proof, and terminal
-run-state artifacts record the cumulative reservation, metered token
-attribution, and user-supplied price basis. This is a fail-closed cap under that
-declared basis, not a claim about the provider's final invoice.
-The strict tool proof is also local-only: Pi runs each selected model serially,
-the CLI restores the previous residency set in a `finally` path, and promotion
-requires the frozen 30-task suite repeated three times with complete owner-only
-result and canonical-event evidence. Failed exact calls can be projected into
-an immutable GEPA-first improvement packet without uploading local traces.
+`understudy desktop contract` prints the packaged OpenAPI 3.1 contract even
+when Desktop is not running. Model downloads, supervision exports, proof
+preparation, and tool-proof commands are explicit and local-only; use
+`understudy desktop --help` for the complete surface.
 
 ## The skill tree
 
@@ -572,6 +241,7 @@ live in each skill's `references/` directory:
 | **Train locally** | curate-trajectories, distill-classifier, local-distillation-lab (incl. the pedagogical arm) |
 | **RL handoff** | prepare-verifier-handoff (decide → author env → package → hand off) |
 | **Gateway & routing** | use-understudy-gateway (incl. the frontier-keys decision), ramp-and-verify, check-routing-health (self-service diagnostics) |
+| **Writing & papers** | deslop, latex-paper-polish |
 
 [`skills/README.md`](skills/README.md) is the authoritative index with
 per-skill descriptions — keep it in sync when adding skills. See

--- a/skills/README.md
+++ b/skills/README.md
@@ -260,6 +260,17 @@ shows headroom, no hosted RL until the local arms plateau.
   there provider errors", and "is this us?" — without asking the team. Uses
   the developer's existing `sk_*` key.
 
+## Writing & Papers
+
+- [`deslop`](deslop/SKILL.md) edits prose to remove formulaic AI patterns while
+  preserving the author's meaning, evidence, citations, uncertainty, and voice.
+  Detailed phrase, structure, trope, and before/after catalogs live in its
+  [`references/`](deslop/references/) directory.
+- [`latex-paper-polish`](latex-paper-polish/SKILL.md) prepares LaTeX papers and
+  PDFs for review or sharing through evidence-aware prose editing, local
+  compilation, warning triage, and page-flow fixes. It includes a local
+  inspection helper and uses `deslop` for the prose pass.
+
 ## Public Safety
 
 Default to the path with the highest expected progress toward the stated

--- a/skills/deslop/LICENSE
+++ b/skills/deslop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen D. Turner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: deslop
+description: Use when a user asks to "deslop", "de-AI", "make it sound human", remove AI patterns or tropes, clean up AI writing, review prose for authenticity, or draft substantial natural-sounding prose. Applies to papers, articles, memos, reports, newsletters, cover letters, and other edited writing.
+license: MIT; see LICENSE
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# Deslop: Remove AI Writing Patterns from Prose
+
+Strip predictable AI patterns from writing. Make prose sound like a specific human wrote it, not like a language model generated it.
+
+## Safety Gates
+
+Preserve the author's meaning, factual claims, citations, uncertainty, and
+voice. Do not invent sources, evidence, quotations, or personal experiences to
+make prose feel human. Flag a claim that needs verification instead of quietly
+strengthening, weakening, or deleting it.
+
+## When to Apply
+
+- Any request to "make it sound human" or "deslop" writing
+- Any prose (articles, blog posts, essays, memos, newsletters, reports) or scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses) where the user wants it to sound natural rather than AI-generated
+- Editing or revising existing text where the user wants it to sound natural rather than AI-generated
+- Reviewing text for AI tells
+
+## Core Rules
+
+### 1. Cut filler phrases
+
+Remove throat-clearing openers ("Here's the thing:"), emphasis crutches ("Let that sink in."), business jargon ("navigate the landscape"), and meta-commentary ("In this section, we'll explore..."). See [references/phrases.md](references/phrases.md) for the full catalog.
+
+### 2. Break formulaic structures
+
+Avoid binary contrasts ("Not X. Y."), negative listings ("Not a X. Not a Y. A Z."), dramatic fragmentation ("Speed. That's it. That's the tradeoff."), self-posed rhetorical questions ("The result? Devastating."), and anaphora/tricolon abuse. See [references/structures.md](references/structures.md) for patterns and fixes.
+
+### 3. Eliminate AI tropes
+
+Watch for the full catalog of AI writing tells: "quietly" and other magic adverbs, "delve" and its cousins, the "serves as" dodge, false ranges ("from X to Y" where the range is meaningless), superficial participle analyses ("highlighting its importance"), invented concept labels ("the supervision paradox"), grandiose stakes inflation, patronizing analogies, and false vulnerability. See [references/tropes.md](references/tropes.md) for the complete list with examples.
+
+### 4. Use active voice with human subjects
+
+Prefer active constructions with named actors. "The complaint becomes a fix" is wrong. "The team fixed it" is right. If no specific person fits, use "we" in scientific prose or "you" in blog posts.
+
+### 5. Be specific
+
+No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work. No vague attributions ("Experts argue..."). If you cannot name the expert, you do not have a source.
+
+In scientific writing, domain terminology is fine and expected. "Weighted interval score" is precise language, not jargon. The problem is business buzzwords ("leverage," "landscape," "ecosystem") and AI vocabulary tells ("delve," "tapestry," "nuanced") leaking into technical prose.
+
+### 6. Match register to context
+
+In blog posts and newsletters, put the reader in the room. "You" beats "People." Specifics beat abstractions. No narrator-from-a-distance voice.
+
+In scientific writing, maintain appropriate formality. Use "we" for your own work, cite specific authors instead of "researchers have shown," and avoid both the distant narrator ("It has long been recognized that...") and the overly casual blog voice. State claims and back them with citations.
+
+### 7. Vary rhythm
+
+Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes. Do not stack short punchy fragments for manufactured emphasis. Do not write listicles disguised as prose ("The first wall... The second wall...").
+
+### 8. Trust readers
+
+State facts directly. Skip softening, justification, hand-holding. No "Let's break this down." No "Think of it as..." No pedagogical voice unless the audience genuinely needs it. No fractal summaries (telling the reader what you are about to say, saying it, then summarizing what you said).
+
+### 9. Watch formatting tells
+
+No bold-first bullets (every list item starting with a bolded keyword). No unicode arrows. No em dashes. No signposted conclusions ("In conclusion..."). No "Despite these challenges..." formulas. These are strong AI signals.
+
+### 10. Do not dilute
+
+One point per section. Do not restate the same argument in ten different ways across thousands of words. Do not beat a single metaphor to death. Do not stack historical analogies for false authority ("Apple didn't build Uber. Facebook didn't build Spotify...").
+
+## Quick Checks
+
+Run these before delivering any prose:
+
+- Heavy use of adverbs or -ly words? Cut them.
+- Any passive voice? Find the actor, make them the subject.
+- Inanimate thing doing a human verb? Name the person.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Any self-posed rhetorical question answered immediately? Fold into a statement.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with a punchy one-liner? Vary it.
+- Em dash anywhere? Remove it. Use a comma or period or a parenthetical.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Any sentence starting with What/When/Where/Which/Who/Why/How as a crutch? Restructure.
+- Meta-joiners ("The rest of this essay...")? Delete.
+- "It's worth noting" or similar filler transitions? Delete.
+- Same metaphor used more than twice? Replace or cut repeats.
+- "Despite these challenges..." formula? Rewrite.
+- Bold-first bullet pattern? Remove bold leads.
+- Tricolon (three-item list)? Use two items or one.
+
+## Scoring
+
+When reviewing text, rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds like a specific human wrote it? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Reference Files
+
+Consult these for detailed catalogs when writing or editing:
+
+- [references/phrases.md](references/phrases.md): Phrases to remove or replace (throat-clearing, emphasis crutches, business jargon, adverbs, meta-commentary, vague declaratives)
+- [references/structures.md](references/structures.md): Structural patterns to avoid (binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, passive voice, rhythm problems)
+- [references/tropes.md](references/tropes.md): Full catalog of AI writing tropes (word choice, sentence structure, paragraph structure, tone, formatting, composition)
+- [references/examples.md](references/examples.md): Before/after transformations showing how to fix common patterns
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+**Quick inline example (scientific writing):**
+
+Before:
+> "It's worth noting that these findings have important implications for how we navigate the challenges of forecast ensembling moving forward. Despite these challenges, this work contributes meaningfully to the growing body of literature, highlighting the need for continued evaluation."
+
+After:
+> "If individual model rankings are unstable across geography and time, ensemble methods that weight models by past performance may not improve on equal-weight approaches."
+
+Changes: Replaced filler transition, vague declarative, "despite these challenges" formula, and superficial participle analysis with the specific implication.
+
+**Quick inline example (blog post):**
+
+Before:
+> "Here's the thing: most bioinformatics pipelines break in production. Not because the code is bad. Because the data is bad. Let that sink in."
+
+After:
+> "Most bioinformatics pipelines break in production. The code runs fine. The data doesn't match the assumptions baked into it."
+
+Changes: Removed opener, binary contrast, and emphasis crutch. Named the specific problem.

--- a/skills/deslop/references/examples.md
+++ b/skills/deslop/references/examples.md
@@ -1,0 +1,179 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast (Scientific)
+
+**Before:**
+> "Here's the thing: forecasting infectious disease is hard. Not because the models are complex. Because the data is complex. Let that sink in."
+
+**After:**
+> "Predicting infectious disease is hard. The models are tractable. The data, collected under shifting surveillance definitions and reporting lags, is not."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Named the specific problem with the data.
+
+---
+
+## Example 2: Filler + "Despite These Challenges" (Cover Letter)
+
+**Before:**
+> "It's worth noting that these findings have important implications for how we navigate the challenges of forecast ensembling moving forward. Despite these challenges, this work contributes meaningfully to the growing body of literature, highlighting the need for continued evaluation and underscoring the importance of robust benchmarking."
+
+**After:**
+> "If individual model rankings are unstable across geography and time, ensemble methods that weight models by past performance may not improve on equal-weight approaches."
+
+**Changes:** Replaced filler transition, vague declarative, "despite these challenges" formula, and two superficial participle phrases with the specific implication of the findings.
+
+---
+
+## Example 3: Grandiose Stakes + Landscape (Scientific)
+
+**Before:**
+> "In today's rapidly evolving genomic landscape, single-cell RNA sequencing has fundamentally reshaped how we think about cellular heterogeneity. This paradigm shift has far-reaching implications for our understanding of disease."
+
+**After:**
+> "Single-cell RNA sequencing reveals cell-type-specific expression patterns that bulk methods average out. In tumor samples, this distinction matters: rare resistant subpopulations visible in single-cell data disappear in bulk profiles."
+
+**Changes:** Eliminated "landscape," "paradigm shift," "fundamentally," and the vague stakes claim. Replaced with a concrete example of why the method matters.
+
+---
+
+## Example 4: Passive Voice + False Agency (Discussion Section)
+
+**Before:**
+> "It was observed that model performance degraded at longer forecast horizons. The uncertainty naturally increased as the prediction window expanded. These results emerged from our analysis of 54 state-level forecasts."
+
+**After:**
+> "We observed that model performance degraded at longer forecast horizons. Each additional week of lead time added roughly 15% to the mean WIS. We saw this pattern across all 54 state-level forecasts."
+
+**Changes:** Named the actor ("we"). Replaced false agency ("uncertainty naturally increased," "results emerged") with specific claims and a number.
+
+---
+
+## Example 5: Self-Posed Rhetorical Question (Blog Post)
+
+**Before:**
+> "What if I told you that most bioinformatics pipelines break in production? The result? Wasted compute and silent errors. The worst part? Nobody checks the intermediate outputs. Here's why that matters:"
+
+**After:**
+> "Most bioinformatics pipelines break in production, and the failures are quiet. The FASTQ passes QC. The alignment runs. But the reference genome version changed between runs, and the variant calls shift without warning."
+
+**Changes:** Removed rhetorical setup and three self-posed questions. Replaced with a specific failure scenario the reader can picture.
+
+---
+
+## Example 6: "Serves As" + Superficial Participle Analysis (Abstract)
+
+**Before:**
+> "The FluSight initiative serves as a foundational framework for influenza forecasting in the United States, contributing to public health preparedness and underscoring the importance of collaborative forecasting efforts."
+
+**After:**
+> "The FluSight initiative coordinates influenza forecasting across dozens of modeling groups in the United States. Since 2013, it has standardized targets, submission formats, and evaluation metrics."
+
+**Changes:** Replaced "serves as a foundational framework" with what FluSight does. Replaced two participle phrases with a specific fact.
+
+---
+
+## Example 7: Narrator Distance + Vague Declarative (Blog Post)
+
+**Before:**
+> "Nobody designed the current state of genomic data sharing. The reasons are structural. This is genuinely hard, and the implications are significant."
+
+**After:**
+> "You inherit a genomic data sharing system that grew by accretion: dbGaP for controlled access, GEO for expression, SRA for raw reads, ClinVar for variants. Each solves one problem. None talks to the others without custom glue code."
+
+**Changes:** Replaced narrator distance ("Nobody designed...") with "you." Replaced two vague declaratives with the specific structural problem.
+
+---
+
+## Example 8: Listicle in a Trench Coat (Discussion Section)
+
+**Before:**
+> "The first limitation of our study is the relatively short evaluation window. The second limitation is the lack of a standardized baseline across all forecasters. The third limitation is the potential for overfitting to the specific characteristics of the 2021-22 and 2022-23 seasons."
+
+**After:**
+> "Our evaluation covers only two seasons, and both followed the unusual post-COVID influenza dynamics that may not generalize. We also lacked a standardized baseline: each forecaster chose their own training data and feature set, making apples-to-apples comparison difficult."
+
+**Changes:** Replaced the numbered listicle structure with woven prose. Combined related points and added specificity about why the limitations matter.
+
+---
+
+## Example 9: One-Point Dilution (Blog Post)
+
+**Before:**
+> "Reproducibility matters. In fact, reproducibility is the most underrated quality in computational biology. When you make your analysis reproducible, you reduce errors. Fewer errors mean more trust. More trust means faster adoption. The lesson? Make it reproducible. Irreproducible analyses are the enemy of science. The best papers are the reproducible ones."
+
+**After:**
+> "Reproducible analyses catch errors earlier. When Beaulieu-Jones and Greene re-ran 68 papers from the PharmacoGenomics Knowledge Base, only 40% reproduced. The ones that failed had no shared code or pinned dependency versions."
+
+**Changes:** Eight sentences restating one point became three sentences with a specific supporting example and a number.
+
+---
+
+## Example 10: Historical Analogy Stacking (General)
+
+**Before:**
+> "Apple didn't build Uber. Facebook didn't build Spotify. Stripe didn't build Shopify. AWS didn't build Airbnb. Every major technological shift follows the same pattern."
+
+**After:**
+> "AWS sold infrastructure. Airbnb built a business on top of it. That split between platform and product repeats across the industry."
+
+**Changes:** One concrete example examined in depth instead of four name-drops. Named the specific pattern.
+
+---
+
+## Example 11: Anaphora Abuse (Grant Narrative)
+
+**Before:**
+> "We will develop novel computational methods. We will apply these methods to large-scale genomic datasets. We will validate our findings using independent cohorts. We will disseminate our tools through open-source repositories. We will train the next generation of computational biologists."
+
+**After:**
+> "We will develop and validate statistical methods for multi-ancestry fine-mapping using UK Biobank and TOPMed cohorts, then release them as an R package with documentation and tutorials suitable for graduate training."
+
+**Changes:** Collapsed five anaphoric sentences into one that names specific methods, datasets, and deliverables.
+
+---
+
+## Example 12: Dramatic Fragmentation (General)
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost: pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 13: False Vulnerability + Meta-Commentary (Blog Post)
+
+**Before:**
+> "And yes, since we're being honest: I've run plenty of analyses where the p-value was borderline and I squinted at it until it cooperated. I want to explore why that impulse is so common. In this post, I'll walk you through what I've learned."
+
+**After:**
+> "I've nudged a borderline p-value along by trying one more covariate. You probably have too. The question is what makes that feel acceptable in the moment, and the answer is usually that the rest of the analysis already 'looks right.'"
+
+**Changes:** Replaced false vulnerability with a specific, honest admission. Cut the meta-commentary ("In this post, I'll walk you through"). Stated the point instead of announcing it.
+
+---
+
+## Example 14: "It's Worth Noting" + Invented Concept Label (Scientific)
+
+**Before:**
+> "It's worth noting that this creates what might be called the 'calibration paradox': models that are well-calibrated at the national level may be poorly calibrated at the state level, reflecting broader trends in the tension between aggregation and granularity."
+
+**After:**
+> "National-level calibration does not guarantee state-level calibration. A model can produce well-calibrated 90% intervals for the US overall while consistently undercovering in states with smaller populations and noisier surveillance data."
+
+**Changes:** Cut the filler transition and the invented concept label. Replaced the superficial participle analysis with the specific mechanism (small states, noisy data).
+
+---
+
+## Example 15: "Imagine a World" + Patronizing Analogy (General)
+
+**Before:**
+> "Imagine a world where every meeting had a clear agenda. Think of it like a recipe: you wouldn't start cooking without knowing the ingredients. That's the promise of async-first communication. Let's unpack why this matters."
+
+**After:**
+> "Meetings without agendas waste time. A 15-person sync with no written agenda averages 47 minutes and produces no decisions (Atlassian, 2019). Writing the agenda forces the organizer to decide whether the meeting is necessary at all."
+
+**Changes:** Removed the "imagine" opener, the cooking analogy (which adds nothing), and the pedagogical "let's unpack." Replaced with a specific claim, a number, and the mechanism that makes agendas work.

--- a/skills/deslop/references/phrases.md
+++ b/skills/deslop/references/phrases.md
@@ -1,0 +1,215 @@
+# Phrases to Remove or Replace
+
+## Throat-Clearing Openers
+
+Remove these. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "Here's the kicker"
+- "Here's where it gets interesting"
+- "Here's what most people miss"
+- "Here's the deal"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Pedagogical Hand-Holding
+
+Phrases that assume the reader needs a teacher. Cut them.
+
+- "Let's break this down"
+- "Let's unpack this"
+- "Let's explore"
+- "Let's dive in"
+- "Let's delve into"
+- "Think of it as..."
+- "Think of it like..."
+- "Imagine a world where..."
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+| Leverage (verb) | Use |
+| Utilize | Use |
+| Robust | Strong, solid |
+| Streamline | Simplify |
+| Harness | Use, apply |
+| Paradigm | Model, approach |
+| Synergy | Cooperation, combined effect |
+| Ecosystem | System, field, community |
+| Framework | Structure, approach |
+
+## AI Vocabulary Tells
+
+Words that became dramatically overrepresented in AI-generated text. Avoid or replace.
+
+- "delve" (use: examine, look at, explore)
+- "tapestry" (use: mix, combination, range)
+- "certainly" (usually deletable)
+- "landscape" when meaning "field" or "situation"
+- "nuanced" (use: complex, subtle, specific)
+
+## The "Serves As" Dodge
+
+AI replaces simple "is" or "are" with pompous alternatives. Use the simple verb.
+
+| Avoid | Use instead |
+|-------|-------------|
+| serves as | is |
+| stands as | is |
+| marks (when meaning "is") | is |
+| represents (when meaning "is") | is |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+- "quietly" (AI's favorite for conveying subtle importance)
+- "remarkably"
+- "arguably"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "It bears mentioning"
+- "Notably"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The text should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+- "In conclusion" / "To sum up" / "In summary"
+- "As we've seen in this section..."
+- "And so we return to where we began."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## False Vulnerability
+
+Simulated self-awareness that reads as performative:
+
+- "And yes, I'm openly..."
+- "And yes, since we're being honest..."
+- "This is not a rant; it's a diagnosis"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## "The Truth Is Simple"
+
+Asserting clarity instead of demonstrating it:
+
+- "The reality is simpler"
+- "History is unambiguous on this point"
+- "History is clear, the metrics are clear, the examples are clear"
+- "but none of them is the real story. The real story is..."
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these or replace with the specific thing.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+## Vague Attributions
+
+Attributing claims to unnamed authorities. If you cannot name the source, you do not have one.
+
+- "Experts argue that..."
+- "Industry reports suggest that..."
+- "Observers have cited..."
+- "Several publications have noted..."
+
+## Grandiose Stakes Inflation
+
+Inflating every argument to world-historical significance. Scale claims to match the actual stakes.
+
+- "This will fundamentally reshape how we think about everything."
+- "will define the next era of computing"
+- "something entirely new"

--- a/skills/deslop/references/structures.md
+++ b/skills/deslop/references/structures.md
@@ -1,0 +1,257 @@
+# Structures to Avoid
+
+## Binary Contrasts (Negative Parallelism)
+
+The single most commonly identified AI writing tell. Creates false drama by framing everything as a surprising reframe. One in a piece can work; multiple instances per piece is a strong AI signal. Before LLMs, people did not write like this at scale.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Fix:** State Y directly. "The problem is Y." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A dramatic countdown through negation.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+| "Not ten. Not fifty. Five hundred." | Numerical countdown reveal |
+| "not recklessly, not completely, but enough" | Hedging disguised as precision |
+
+**Fix:** State Z. The reader does not need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity. RLHF training has pushed models toward "writing for readability" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required. No human writes first drafts this way.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+| "He published this. Openly. In a book." | Fragment stacking for emphasis |
+| "Platforms do." | Orphaned fragment as punchline |
+
+**Fix:** Complete sentences. Trust content over presentation.
+
+## Self-Posed Rhetorical Questions
+
+The model asks a question nobody was asking, then answers it for dramatic effect.
+
+| Pattern | Problem |
+|---------|---------|
+| "The result? Devastating." | Manufactured suspense |
+| "The worst part? Nobody saw it coming." | Same formula |
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Fix:** Make the point. Let readers draw conclusions.
+
+## Anaphora Abuse
+
+Repeating the same sentence opening multiple times in quick succession.
+
+| Pattern | Problem |
+|---------|---------|
+| "They assume that... They assume that... They assume that..." | Mechanical repetition |
+| "They could expose... They could offer... They could provide..." | List disguised as prose |
+| "They have built X, but not Y. They have built A, but not B." | Parallel structure stacking |
+
+**Fix:** Vary sentence openings. Combine related points into single sentences.
+
+## Tricolon Abuse
+
+Overuse of the rule-of-three pattern. A single tricolon is fine; multiple back-to-back tricolons are an AI pattern.
+
+| Pattern | Problem |
+|---------|---------|
+| "Products impress; platforms empower. Products solve; platforms create." | Parallel tricolon stacking |
+| "identity, payments, compute, distribution" | Extended lists masquerading as analysis |
+| "workflows, decisions, and interactions" | Three-item groupings everywhere |
+
+**Fix:** Use two items or one. Break the three-item habit.
+
+## False Agency
+
+Giving inanimate things human verbs. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | Someone fixed it. |
+| "a bet lives or dies in days" | Someone kills or ships the project. |
+| "the decision emerges" | Someone decides. |
+| "the culture shifts" | People change behavior. |
+| "the conversation moves toward" | Someone steers. |
+| "the data tells us" | Someone reads it and draws a conclusion. |
+| "the market rewards" | Buyers pay for things. |
+
+**Fix:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Fix:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Fix:** Find the actor. Put them at the front of the sentence.
+
+## Listicle in a Trench Coat
+
+Numbered or labeled points dressed up as continuous prose. The model writes a listicle but wraps each point in a paragraph starting with "The first... The second... The third..." to disguise the format.
+
+| Pattern | Problem |
+|---------|---------|
+| "The first wall is... The second wall is... The third wall is..." | Numbered list pretending to be prose |
+| "The second takeaway is... The third takeaway is..." | Same |
+
+**Fix:** If the content is a list, present it as a list. If it should be prose, weave the points together without numbering.
+
+## Superficial Participle Analyses
+
+Tacking a present participle phrase onto the end of a sentence to inject shallow analysis.
+
+| Pattern | Problem |
+|---------|---------|
+| "contributing to the region's rich cultural heritage" | Hollow significance-signaling |
+| "highlighting its enduring legacy" | Same |
+| "underscoring its role as a dynamic hub" | Same |
+| "reflecting broader trends in..." | Same |
+
+**Fix:** Either make a specific analytical claim or delete the participle phrase.
+
+## False Ranges
+
+"From X to Y" constructions where X and Y are not on any real scale. In legitimate use, "from X to Y" implies a spectrum with a meaningful middle. AI uses it to list two loosely related things.
+
+| Pattern | Problem |
+|---------|---------|
+| "From innovation to implementation to cultural transformation." | No real spectrum |
+| "From the singularity of the Big Bang to the grand cosmic web." | Grandiose range with nothing in between |
+| "From problem-solving to scientific discovery to artistic expression." | Fancy list, not a range |
+
+**Fix:** If the items are a list, list them. If there is a real spectrum, describe it.
+
+## Historical Analogy Stacking
+
+Rapid-fire listing of historical companies or tech revolutions to build false authority. Common in technical writing.
+
+| Pattern | Problem |
+|---------|---------|
+| "Apple didn't build Uber. Facebook didn't build Spotify." | Shotgun historical references |
+| "Every major shift -- the web, mobile, social, cloud -- followed..." | Revolution-listing |
+| "Take Spotify... Or consider Uber... Airbnb followed... Shopify is another..." | Sequential name-dropping |
+
+**Fix:** Use one example, examine it in depth. One well-analyzed case beats five name-drops.
+
+## "Despite Its Challenges..."
+
+AI acknowledges problems only to immediately dismiss them. Always follows the same beat.
+
+| Pattern | Problem |
+|---------|---------|
+| "Despite these challenges, the initiative continues to thrive." | Formulaic optimism |
+| "Despite its prosperity, [X] faces challenges typical of..." | Structured dismiss-and-pivot |
+
+**Fix:** If challenges are worth mentioning, analyze them. If they are not, skip them.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em dashes | Remove. Use commas or periods. |
+| Staccato fragmentation | Do not stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Formatting Tells
+
+| Pattern | Problem |
+|---------|---------|
+| Bold-first bullets | Every list item starting with a bolded keyword is an AI signal |
+| Unicode arrows (→) | Use -> or => or plain text instead |
+| Smart/curly quotes | Use straight quotes |
+| Signposted conclusions ("In conclusion...") | Let the writing conclude naturally |
+| Fractal summaries | Do not summarize what you are about to say, say it, then summarize what you said |
+
+## One-Point Dilution
+
+Making a single argument and restating it in ten different ways. The model pads a simple thesis to feel comprehensive by rephrasing the same idea with different metaphors, examples, and framings.
+
+**Fix:** State the point once, support it, move on. If the piece circles back to the same claim more than twice, cut the repetitions.
+
+## The Dead Metaphor
+
+Latching onto a single metaphor and using it in every paragraph. A human writer introduces a metaphor, uses it, and moves on. AI repeats the same metaphor 5-10 times.
+
+**Fix:** Use a metaphor once or twice. Then drop it.
+
+## Invented Concept Labels
+
+AI clusters invented compound labels that sound analytical without being grounded. It appends abstract problem-nouns (paradox, trap, creep, divide, vacuum, inversion) to domain words and uses them as if they are established terms.
+
+| Pattern | Problem |
+|---------|---------|
+| "the supervision paradox" | Invented term treated as established |
+| "the acceleration trap" | Same |
+| "workload creep" | Same |
+
+**Fix:** If the concept needs a name, define it. If it does not need a name, describe it in plain language.
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/skills/deslop/references/tropes.md
+++ b/skills/deslop/references/tropes.md
@@ -1,0 +1,327 @@
+# AI Writing Tropes to Avoid
+
+Add this file to your AI assistant's system prompt or context to help it avoid
+common AI writing patterns. Source: [tropes.fyi](https://tropes.fyi) by [ossama.is](https://ossama.is)
+
+---
+
+## Word Choice
+
+### "Quietly" and Other Magic Adverbs
+
+Overuse of "quietly" and similar adverbs to convey subtle importance or understated power. AI reaches for these adverbs to make mundane descriptions feel significant. Also includes: "deeply", "fundamentally", "remarkably", "arguably".
+
+**Avoid patterns like:**
+- "quietly orchestrating workflows, decisions, and interactions"
+- "the one that quietly suffocates everything else"
+- "a quiet intelligence behind it"
+
+### "Delve" and Friends
+
+Used to be the most infamous AI tell. "Delve" went from an uncommon English word to appearing in a staggering percentage of AI-generated text. Part of a family of overused AI vocabulary including "certainly", "utilize", "leverage" (as a verb), "robust", "streamline", and "harness".
+
+**Avoid patterns like:**
+- "Let's delve into the details..."
+- "Delving deeper into this topic..."
+- "We certainly need to leverage these robust frameworks..."
+
+### "Tapestry" and "Landscape"
+
+Overuse of ornate or grandiose nouns where simpler words would do. "Tapestry" is used to describe anything interconnected. "Landscape" is used to describe any field or domain. Other offenders: "paradigm", "synergy", "ecosystem", "framework".
+
+**Avoid patterns like:**
+- "The rich tapestry of human experience..."
+- "Navigating the complex landscape of modern AI..."
+- "The ever-evolving landscape of technology..."
+
+### The "Serves As" Dodge
+
+Replacing simple "is" or "are" with pompous alternatives like "serves as", "stands as", "marks", or "represents". AI avoids basic copulas because its repetition penalty pushes it toward fancier constructions (I've studied this!).
+
+**Avoid patterns like:**
+- "The building serves as a reminder of the city's heritage."
+- "Gallery 825 serves as LAAA's exhibition space for contemporary art."
+- "The station marks a pivotal moment in the evolution of regional transit."
+
+---
+
+## Sentence Structure
+
+### Negative Parallelism
+
+The "It's not X -- it's Y" pattern, often with an em dash. The single most commonly identified AI writing tell. Man I f*cking hate it. AI uses this to create false profundity by framing everything as a surprising reframe. One in a piece can be effective; ten in a blog post is a genuine insult to the reader. Before LLMs, people simply did not write like this at scale. Includes the causal variant "not because X, but because Y" where every explanation is framed as a surprise reveal, the em-dash dismissal "X -- not Y", and the cross-sentence reframe where the same noun is negated then repositioned: "The question isn't X. The question is Y."
+
+**Avoid patterns like:**
+- "It's not bold. It's backwards."
+- "Feeding isn't nutrition. It's dialysis."
+- "Half the bugs you chase aren't in your code. They're in your head."
+
+### "Not X. Not Y. Just Z."
+
+The dramatic countdown pattern. AI builds tension by negating two or more things before revealing the actual point. Creates a false sense of narrowing down to the truth.
+
+**Avoid patterns like:**
+- "Not a bug. Not a feature. A fundamental design flaw."
+- "Not ten. Not fifty. Five hundred and twenty-three lint violations across 67 files."
+- "not recklessly, not completely, but enough"
+
+### "The X? A Y."
+
+Self-posed rhetorical questions answered immediately in the next sentence or clause. The model asks a question nobody was asking, then answers it for dramatic effect. Thinks this is the epitome of great writing.
+
+**Avoid patterns like:**
+- "The result? Devastating."
+- "The worst part? Nobody saw it coming."
+- "The scary part? This attack vector is perfect for developers."
+
+### Anaphora Abuse
+
+Repeating the same sentence opening multiple times in quick succession.
+
+**Avoid patterns like:**
+- "They assume that users will pay... They assume that developers will build... They assume that ecosystems will emerge... They assume that..."
+- "They could expose... They could offer... They could provide... They could create... They could let... They could unlock..."
+- "They have built engines, but not vehicles. They have built power, but not leverage. They have built walls, but not doors."
+
+### Tricolon Abuse
+
+Overuse of the rule-of-three pattern, often extended to four or five. A single tricolon is elegant; three back-to-back tricolons are a pattern recognition failure.
+
+**Avoid patterns like:**
+- "Products impress people; platforms empower them. Products solve problems; platforms create worlds. Products scale linearly; platforms scale exponentially."
+- "identity, payments, compute, distribution"
+- "workflows, decisions, and interactions"
+
+### "It's Worth Noting"
+
+Filler transitions that signal nothing. AI uses these phrases to introduce new points without actually connecting them to the previous argument. Also includes: "It bears mentioning", "Importantly", "Interestingly", "Notably".
+
+**Avoid patterns like:**
+- "It's worth noting that this approach has limitations."
+- "Importantly, we must consider the broader implications."
+- "Interestingly, this pattern repeats across industries."
+
+### Superficial Analyses
+
+Tacking a present participle ("-ing") phrase onto the end of a sentence to inject shallow analysis that says nothing. The model attaches significance, legacy, or broader meaning to mundane facts using phrases like "highlighting its importance", "reflecting broader trends", or "contributing to the development of...".
+
+**Avoid patterns like:**
+- "contributing to the region's rich cultural heritage"
+- "This etymology highlights the enduring legacy of the community's resistance and the transformative power of unity in shaping its identity."
+- "underscoring its role as a dynamic hub of activity and culture"
+
+### False Ranges
+
+Using "from X to Y" constructions where X and Y aren't on any real scale. In legitimate use, "from X to Y" implies a spectrum with a meaningful middle. AI uses it as a fancy way to list two loosely related things. "From innovation to cultural transformation" -- what's in between???? Nothing!
+
+**Avoid patterns like:**
+- "From innovation to implementation to cultural transformation."
+- "From the singularity of the Big Bang to the grand cosmic web."
+- "From problem-solving and tool-making to scientific discovery, artistic expression, and technological innovation."
+
+---
+
+## Paragraph Structure
+
+### Short Punchy Fragments
+
+Excessive use of very short sentences or sentence fragments as standalone paragraphs for manufactured emphasis. RLHF training has pushed models toward "writing for readability" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required. It's an inhuman style. No real person writes first drafts this way because it doesn't match how humans think or speak.
+
+**Avoid patterns like:**
+- "He published this. Openly. In a book. As a priest."
+- "These weren't just products. And the software side matched. Then it professionalised. But I adapted."
+- "Platforms do."
+
+### Listicle in a Trench Coat
+
+Numbered or labeled points dressed up as continuous prose. The model writes what is essentially a listicle but wraps each point in a paragraph that starts with "The first... The second... The third..." to disguise the format. Perhaps you told it to stop generating lists and it decided to do this instead... still very common.
+
+**Avoid patterns like:**
+- "The first wall is the absence of a free, scoped API... The second wall is the lack of delegated access... The third wall is the absence of scoped permissions..."
+- "The second takeaway is that... The third takeaway is that... The fourth takeaway is that..."
+
+---
+
+## Tone
+
+### "Here's the Kicker"
+
+False suspense transitions that promise a revelation but deliver a point that did NOT need the buildup. The model uses these phrases to manufacture drama before an otherwise unremarkable observation LOL. Also includes: "Here's the thing", "Here's where it gets interesting", "Here's what most people miss", "Here's the starting point", "Here's the deal".
+
+**Avoid patterns like:**
+- "Here's the kicker."
+- "Here's the thing about AI adoption."
+- "Here's where it gets interesting."
+
+### "Think of It As..."
+
+The patronizing analogy. AI constantly reaches for "Think of it as..." or "It's like a..." to simplify concepts. The model defaults to teacher mode and assumes the reader needs a metaphor to understand anything. Often produces analogies that are less clear than the original concept.
+
+**Avoid patterns like:**
+- "Think of it like a highway system for data."
+- "Think of it as a Swiss Army knife for your workflow."
+- "It's like asking someone to buy a car they're only allowed to sit in while it's parked."
+
+### "Imagine a World Where..."
+
+The classic AI invitation to futurism. To sell the argument usually begins with "Imagine" followed by a list of wonderful things that will happen if the reader agrees with the premise.
+
+**Avoid patterns like:**
+- "Imagine a world where every tool you use -- your calendar, your inbox, your documents, your CRM, your code editor -- has a quiet intelligence behind it..."
+- "In that world, workflows stop being collections of manual steps and start becoming orchestrations."
+
+### False Vulnerability
+
+Simulated self-awareness or honesty that reads as performative. The model pretends to break the fourth wall or admit a bias, creating a false sense of authenticity. Real vulnerability is specific and uncomfortable; AI vulnerability is polished and risk-free!!!!
+
+**Avoid patterns like:**
+- "And yes, I'm openly in love with the platform model"
+- "And yes, since we're being honest: I'm looking at you, OpenAI, Google, Anthropic, Meta"
+- "This is not a rant; it's a diagnosis"
+
+### "The Truth Is Simple"
+
+Asserting that something is obvious, clear or simple instead of actually proving it. If you have to tell the reader your point is clear, it very likely isn't. Also includes the dramatic reveal variant: "but none of them is the real story. The real story is..." -- claiming privileged insight while waving away everything before it.
+
+**Avoid patterns like:**
+- "The reality is simpler and less flattering"
+- "History is unambiguous on this point"
+- "History is clear, the metrics are clear, the examples are clear"
+
+### Grandiose Stakes Inflation
+
+Everything is the most important thing ever. AI inflates the stakes of every argument to world-historical significance. A blog post about API pricing becomes a meditation on the fate of civilization.
+
+**Avoid patterns like:**
+- "This will fundamentally reshape how we think about everything."
+- "will define the next era of computing"
+- "something entirely new"
+
+### "Let's Break This Down"
+
+The pedagogical voice that assumes the reader needs hand-holding. AI defaults to a teacher-student dynamic even when writing for expert audiences. Also includes: "Let's unpack this", "Let's explore", "Let's dive in".
+
+**Avoid patterns like:**
+- "Let's break this down step by step."
+- "Let's unpack what this really means."
+- "Let's explore this idea further."
+
+### Vague Attributions
+
+Attributing claims to unnamed authorities instead of being specific. AI loves to invoke "experts", "observers", "industry reports", and "several publications" without naming anyone. It also inflates the quantity of sources -- presenting what one person said as a widely held view, or writing "several publications have cited" when it means two. If you can't name the expert, you don't have a source.
+
+**Avoid patterns like:**
+- "Experts argue that this approach has significant drawbacks."
+- "Industry reports suggest that adoption is accelerating."
+- "Observers have cited the initiative as a turning point."
+
+### Invented Concept Labels
+
+AI clusters invented compound labels that sound analytical without being grounded. It appends abstract problem-nouns (paradox, trap, creep, divide, vacuum, inversion) to domain words — "supervision paradox", "acceleration trap", "workload creep" — and uses them as if they're established, rigorously defined terms. They function as rhetorical shorthand: name a thing, skip the argument. Multiple such labels in the same piece is a strong signal of AI slop.
+
+**Avoid patterns like:**
+- "the supervision paradox"
+- "the acceleration trap"
+- "workload creep"
+
+---
+
+## Formatting
+
+### Em-Dash Addiction
+
+Compulsive overuse of em dashes for dramatic pauses, parenthetical asides and pivot points. A human writer might use 2-3 per piece (and naturally); AI will use 20+.
+
+**Avoid patterns like:**
+- "The problem -- and this is the part nobody talks about -- is systemic."
+- "The tinkerer spirit didn't die of natural causes -- it was bought out."
+- "Not recklessly, not completely -- but enough -- enough to matter."
+
+### Bold-First Bullets
+
+Every bullet point or list item starts with a bolded phrase or sentence. Extremely common in Claude and ChatGPT markdown output. Almost nobody formats lists this way when writing by hand. It's a telltale sign of AI-generated documentation and blog posts AND README files (especially with emojis).
+
+**Avoid patterns like:**
+- "Every single bullet point begins with a bold keyword."
+- "**Security**: Environment-based configuration with..."
+- "**Performance**: Lazy loading of expensive resources..."
+
+### Unicode Decoration
+
+Use of unicode arrows (->), smart/curly quotes, and other special characters that can't be easily typed on a standard keyboard. Real writers typing in a text editor produce straight quotes and -> or =>. Claude in particular loves the -> arrow.
+
+**Avoid patterns like:**
+- "Input → Processing → Output"
+- "This leads to better outcomes → which means higher engagement"
+- "“Smart quotes” instead of straight "quotes" that you’d actually type"
+
+---
+
+## Composition
+
+### Fractal Summaries
+
+"What I'm going to tell you; what I'm telling you; what I just told you" -- applied at every level of the document. Every subsection gets a summary. Every section gets a summary. The document itself gets a summary.
+
+**Avoid patterns like:**
+- "In this section, we'll explore... [3000 words later] ...as we've seen in this section."
+- "A conclusion that restates every point already made in the previous 3000 words"
+- "And so we return to where we began."
+
+### The Dead Metaphor
+
+Latching onto a single metaphor and beating it into the ground across the entire thing. A human writer would introduce a metaphor, use it then move on. AI will repeat the same metaphor 5-10 times.
+
+**Avoid patterns like:**
+- "The ecosystem needs ecosystems to build ecosystem value."
+- "Walls and doors used 30+ times in the same article"
+- "Every paragraph finds a way to say "primitives" again"
+
+### Historical Analogy Stacking
+
+ESPECIALLY COMMON IN TECHNICAL WRITING: Rapid-fire listing of historical companies or tech revolutions to build false authority.
+
+**Avoid patterns like:**
+- "Apple didn't build Uber. Facebook didn't build Spotify. Stripe didn't build Shopify. AWS didn't build Airbnb."
+- "Every major technological shift -- the web, mobile, social, cloud -- followed the same pattern."
+- "Take Spotify... Or consider Uber... Airbnb followed a similar path... Shopify is another example... Even Discord..."
+
+### One-Point Dilution
+
+Making a single argument and restating it in 10 different ways across thousands of words. The model pads a simple thesis to feel "comprehensive" by rephrasing the same idea with different metaphors, examples, and framings. An 800-word argument becomes 4000 words of circular repetition.
+
+**Avoid patterns like:**
+- "The same point, restated eight ways across 4000 words."
+- "Each section rephrases the thesis with a different metaphor but adds nothing new"
+
+### Content Duplication
+
+Repeating entire sections or paragraphs verbatim within the same piece. This happens when the model loses track of what it has already written, especially in longer pieces. A dead giveaway of unedited AI output. Less common nowadays.
+
+**Avoid patterns like:**
+- "The same section appeared twice, word-for-word identical."
+- "Paragraph 3 and paragraph 17 are the same sentence reworded"
+
+### The Signposted Conclusion
+
+Explicitly announcing the conclusion with "In conclusion", "To sum up", or "In summary". Competent writing doesn't need to tell you it's concluding. The reader can feel it. AI signals its structural moves because it's following a template, not writing organically.
+
+**Avoid patterns like:**
+- "In conclusion, the future of AI depends on..."
+- "To sum up, we've explored three key themes..."
+- "In summary, the evidence suggests..."
+
+### "Despite Its Challenges..."
+
+The rigid formula where AI acknowledges problems only to immediately dismiss them. Always follows the same beat: "Despite its [positive words], [subject] faces challenges..." then ends with "Despite these challenges, [optimistic conclusion].".
+
+**Avoid patterns like:**
+- "Despite these challenges, the initiative continues to thrive."
+- "Despite its industrial and residential prosperity, Korattur faces challenges typical of urban areas."
+- "Despite their promising applications, pyroelectric materials face several challenges that must be addressed for broader adoption."
+
+---
+
+Remember: any of these patterns used once might be fine. The problem is when
+multiple tropes appear together or when a single trope is used repeatedly.
+Write like a human: varied, imperfect, specific.

--- a/skills/latex-paper-polish/SKILL.md
+++ b/skills/latex-paper-polish/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: latex-paper-polish
+description: Polish LaTeX papers and PDFs through evidence proofreading, deslop-style prose cleanup, TeX compilation, warning triage, and layout fixes for widows, orphans, overfull boxes, trailing paragraphs, dense tables, captions, URLs, and artifact paths. Use when the user asks to prepare, review, polish, typeset, compile, or make a LaTeX paper/PDF shareable.
+metadata:
+  understudy:
+    mode: interactive
+    safety: local-first
+    cli_required: false
+---
+
+# LaTeX Paper Polish
+
+Use this skill for research notes, white papers, case studies, and technical PDFs where the goal is not only "compile the TeX" but "make the artifact credible and readable."
+
+This skill combines four passes:
+
+1. Evidence and claim proofreading.
+2. Deslop-style prose cleanup.
+3. TeX/PDF build and warning triage.
+4. Typesetting polish for page flow, tables, URLs, and dangling text.
+
+## Trigger
+
+Use this skill when the user asks for any of the following:
+
+- polish a LaTeX paper or PDF
+- compile or rebuild a paper
+- proofread a paper draft
+- deslop a paper
+- fix trailing paragraphs, widows, or orphans
+- make a PDF shareable
+- inspect LaTeX warnings
+- improve tables, appendix layout, claim sections, or evidence sections
+
+If the task explicitly mentions "deslop", also use the installed `deslop` skill.
+
+## Safety Gates
+
+Treat compilation as a local file operation. Do not install a TeX distribution,
+fetch remote assets, overwrite a canonical PDF, or publish a paper without the
+user's authorization. Preserve claims, citations, and uncertainty during prose
+and layout edits; a cleaner page must not imply stronger evidence.
+
+## Workflow
+
+### 1. Locate the Source and PDF
+
+Find the canonical `.tex` source before editing. If there are multiple related paper files, identify:
+
+- active source file
+- build output directory
+- current PDF path
+- web/public copy path, if any
+- data artifacts cited by the paper
+
+Do not assume the displayed PDF is generated from the nearest `.tex` file. Check filenames, timestamps, and build output.
+
+### 2. Preserve the Evidence Boundary
+
+Before changing prose, audit claims against local artifacts where feasible.
+
+Check whether the paper distinguishes:
+
+- measured result vs hypothesis
+- live provider run vs dry run
+- invoice/billing evidence vs response-usage estimate
+- row-matched vs payload-identical comparison
+- task-success ground truth vs teacher-imitation evidence
+- completion logprobs vs prompt logprobs
+- route health vs model quality
+- current snapshot vs durable provider conclusion
+
+Do not let typesetting edits upgrade the strength of a claim.
+
+### 3. Deslop the Prose
+
+Use the `deslop` skill rules for the prose pass. Keep the author's point of view and technical density.
+
+Prioritize:
+
+- removing throat-clearing
+- cutting grandiose market language unless backed by evidence
+- replacing "not X, but Y" structures with direct claims
+- removing repeated metaphors
+- turning vague nouns into concrete actors and artifacts
+- shortening paragraphs that restate a prior section
+- preserving quantified caveats and claim boundaries
+
+For scientific or technical prose, do not flatten domain terms. Fix the sentence, not the concept.
+
+### 4. Compile and Inspect
+
+Prefer the helper script:
+
+```bash
+python <skill-directory>/scripts/latex_paper_polish_check.py path/to/paper.tex --compile
+```
+
+Resolve `<skill-directory>` from this `SKILL.md`; do not assume a global or
+user-specific installation path.
+
+If the helper is not available, compile manually:
+
+```bash
+tectonic -X compile --keep-intermediates --outdir build paper.tex
+```
+
+Fallbacks, in order:
+
+```bash
+latexmk -pdf -interaction=nonstopmode -halt-on-error -outdir=build paper.tex
+pdflatex -interaction=nonstopmode -halt-on-error -output-directory=build paper.tex
+```
+
+Read the build log. Do not report "compiled" as "polished" until warnings and page-flow issues have been considered.
+
+### 5. Fix Page Flow
+
+Use these tools when appropriate:
+
+```tex
+\clubpenalty=10000
+\widowpenalty=10000
+\displaywidowpenalty=10000
+\raggedbottom
+```
+
+For stubborn page endings:
+
+- shorten the preceding paragraph first
+- condense or split a table
+- move a paragraph into the next section only if it improves meaning
+- use `\enlargethispage{\baselineskip}` sparingly
+- use `\clearpage` before appendices or chart blocks when it improves the paper
+- prefer rewriting over vertical-space hacks
+
+Avoid hiding poor structure with negative `\vspace`.
+
+### 6. Fix Tables and Long Lines
+
+Common fixes:
+
+- use `tabularx`, `array`, or fixed-width `p{}` columns for prose tables
+- reduce table font size only one step at a time
+- shorten labels before shrinking text
+- move long artifact paths to an appendix
+- wrap paths with `\path{...}` and ensure `hyperref` or `url` support
+- use `\url{...}` for URLs
+- avoid wide ranking tables if a compact claim table will do
+
+For overfull boxes from URLs or paths, prefer semantic wrapping over manual line breaks.
+
+### 7. Final Review
+
+Before handing back:
+
+- compile at least once after the last edit
+- note any remaining warnings
+- confirm PDF path and source path
+- summarize claim changes separately from layout changes
+- mention if build tooling was unavailable
+
+If the PDF will be shared externally, include a short "claim posture" note: what the paper can safely claim and what remains provisional.
+
+## Output Style
+
+Keep the final answer compact. Include:
+
+- source file changed
+- PDF rebuilt path
+- major prose/evidence changes
+- remaining warnings or risks
+
+Do not paste the paper into chat.
+
+## References
+
+- `references/checklist.md`
+- `scripts/latex_paper_polish_check.py`

--- a/skills/latex-paper-polish/references/checklist.md
+++ b/skills/latex-paper-polish/references/checklist.md
@@ -1,0 +1,51 @@
+# LaTeX Paper Polish Checklist
+
+## Evidence
+
+- Are all headline numbers tied to local artifacts, source tables, or cited references?
+- Does the paper separate measured route evidence from market-design hypotheses?
+- Does it identify row counts, splits, caps, provider settings, and run dates?
+- Does it avoid treating response-usage estimates as invoice reconciliation?
+- Does it say whether comparisons are row-matched, payload-identical, or neither?
+- Does it separate provider reliability from model quality?
+- Does it call out incomplete or partial runs?
+
+## Prose
+
+- Cut throat-clearing and repeated section summaries.
+- Replace vague nouns with actors: Understudy, provider, route, scorer, harness.
+- Remove repeated metaphors once the analogy is established.
+- Avoid "not X, but Y" unless the contrast is genuinely the point.
+- Keep caveats concrete and close to the claim they qualify.
+- Prefer one strong paragraph to three overlapping paragraphs.
+
+## Typesetting
+
+- Compile after edits.
+- Inspect overfull boxes, underfull boxes, undefined references, missing citations, and rerun warnings.
+- Watch for single lines at the top or bottom of pages.
+- Watch for section headings followed by only one or two lines before a page break.
+- Watch for final paragraphs dangling alone after a table.
+- Move long paths and artifact lists to an appendix.
+- Condense tables before shrinking text below readability.
+
+## LaTeX Knobs
+
+Use these near the preamble when the paper is prose-heavy:
+
+```tex
+\clubpenalty=10000
+\widowpenalty=10000
+\displaywidowpenalty=10000
+\raggedbottom
+```
+
+Use these only when needed and explain why in the final summary:
+
+```tex
+\enlargethispage{\baselineskip}
+\clearpage
+\sloppy
+```
+
+Prefer better prose and table design over spacing hacks.

--- a/skills/latex-paper-polish/scripts/latex_paper_polish_check.py
+++ b/skills/latex-paper-polish/scripts/latex_paper_polish_check.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Compile a LaTeX paper and summarize common polish warnings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+WARNING_PATTERNS = {
+    "overfull_hbox": re.compile(r"Overfull \\hbox.*", re.IGNORECASE),
+    "underfull_hbox": re.compile(r"Underfull \\hbox.*", re.IGNORECASE),
+    "underfull_vbox": re.compile(r"Underfull \\vbox.*", re.IGNORECASE),
+    "undefined_reference": re.compile(r"(Reference .* undefined|There were undefined references)", re.IGNORECASE),
+    "undefined_citation": re.compile(r"(Citation .* undefined|There were undefined citations)", re.IGNORECASE),
+    "rerun_needed": re.compile(r"(Rerun to get|Label\\(s\\) may have changed)", re.IGNORECASE),
+    "latex_error": re.compile(r"(! LaTeX Error:|! Package .* Error:|! Emergency stop)", re.IGNORECASE),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tex", type=Path, help="Path to the .tex file.")
+    parser.add_argument("--compile", action="store_true", help="Compile before inspecting logs.")
+    parser.add_argument("--outdir", type=Path, default=None, help="Build output directory.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON only.")
+    return parser.parse_args()
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    return proc.returncode, proc.stdout
+
+
+def compile_tex(tex: Path, outdir: Path) -> tuple[str | None, str]:
+    if shutil.which("tectonic"):
+        cmd = [
+            "tectonic",
+            "-X",
+            "compile",
+            "--keep-intermediates",
+            "--outdir",
+            str(outdir),
+            tex.name,
+        ]
+        code, output = run(cmd, tex.parent)
+        return ("tectonic" if code == 0 else None), output
+
+    if shutil.which("latexmk"):
+        cmd = [
+            "latexmk",
+            "-pdf",
+            "-interaction=nonstopmode",
+            "-halt-on-error",
+            f"-outdir={outdir}",
+            tex.name,
+        ]
+        code, output = run(cmd, tex.parent)
+        return ("latexmk" if code == 0 else None), output
+
+    if shutil.which("pdflatex"):
+        cmd = [
+            "pdflatex",
+            "-interaction=nonstopmode",
+            "-halt-on-error",
+            f"-output-directory={outdir}",
+            tex.name,
+        ]
+        code, output = run(cmd, tex.parent)
+        if code == 0:
+            code, output2 = run(cmd, tex.parent)
+            output += "\n" + output2
+        return ("pdflatex" if code == 0 else None), output
+
+    return None, "No LaTeX compiler found: expected tectonic, latexmk, or pdflatex."
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def inspect_log(log_text: str) -> dict[str, list[str]]:
+    warnings: dict[str, list[str]] = {key: [] for key in WARNING_PATTERNS}
+    for line in log_text.splitlines():
+        stripped = line.strip()
+        for key, pattern in WARNING_PATTERNS.items():
+            if pattern.search(stripped):
+                warnings[key].append(stripped)
+    return warnings
+
+
+def inspect_source(tex_text: str) -> dict[str, object]:
+    lines = tex_text.splitlines()
+    long_lines = [
+        {"line": i + 1, "chars": len(line), "text": line[:180]}
+        for i, line in enumerate(lines)
+        if len(line) > 140 and not line.lstrip().startswith("%")
+    ]
+    trailing_whitespace = [
+        i + 1 for i, line in enumerate(lines) if line.rstrip() != line
+    ]
+    preamble_checks = {
+        "clubpenalty": "\\clubpenalty" in tex_text,
+        "widowpenalty": "\\widowpenalty" in tex_text,
+        "displaywidowpenalty": "\\displaywidowpenalty" in tex_text,
+        "raggedbottom": "\\raggedbottom" in tex_text,
+    }
+    return {
+        "line_count": len(lines),
+        "long_lines": long_lines[:30],
+        "long_line_count": len(long_lines),
+        "trailing_whitespace_lines": trailing_whitespace[:50],
+        "trailing_whitespace_count": len(trailing_whitespace),
+        "preamble_checks": preamble_checks,
+    }
+
+
+def find_log(tex: Path, outdir: Path) -> Path:
+    return outdir / f"{tex.stem}.log"
+
+
+def main() -> int:
+    args = parse_args()
+    tex = args.tex.expanduser().resolve()
+    if not tex.exists():
+        print(f"missing tex file: {tex}", file=sys.stderr)
+        return 2
+    if tex.suffix.lower() != ".tex":
+        print(f"expected a .tex file: {tex}", file=sys.stderr)
+        return 2
+
+    outdir = (args.outdir or tex.parent / "build").expanduser().resolve()
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    compile_status = None
+    compile_output = ""
+    if args.compile:
+        compile_status, compile_output = compile_tex(tex, outdir)
+
+    log_path = find_log(tex, outdir)
+    log_text = read_text(log_path)
+    if not log_text and compile_output:
+        log_text = compile_output
+
+    result = {
+        "tex": str(tex),
+        "pdf": str(outdir / f"{tex.stem}.pdf"),
+        "log": str(log_path) if log_path.exists() else None,
+        "compiled_with": compile_status,
+        "compile_requested": args.compile,
+        "compile_succeeded": bool(compile_status) if args.compile else None,
+        "source": inspect_source(read_text(tex)),
+        "warnings": inspect_log(log_text),
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0 if result.get("compile_succeeded") is not False else 1
+
+    print(f"TeX: {result['tex']}")
+    print(f"PDF: {result['pdf']}")
+    if args.compile:
+        print(f"Compile: {'ok' if compile_status else 'failed'} ({compile_status or 'no compiler/error'})")
+    source = result["source"]
+    print(f"Lines: {source['line_count']}")
+    print(f"Long lines >140 chars: {source['long_line_count']}")
+    print(f"Trailing whitespace lines: {source['trailing_whitespace_count']}")
+    print("Preamble checks:")
+    for key, value in source["preamble_checks"].items():
+        print(f"  {key}: {'yes' if value else 'missing'}")
+    print("Warnings:")
+    for key, values in result["warnings"].items():
+        print(f"  {key}: {len(values)}")
+        for value in values[:5]:
+            print(f"    {value}")
+    return 0 if result.get("compile_succeeded") is not False else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add the public `deslop` skill with its detailed pattern references and preserved upstream MIT license
- add `latex-paper-polish` with evidence-aware editing guidance, a review checklist, and a local warning-inspection helper
- register both skills in the public catalog
- shorten the root README by moving duplicated adapter details behind the authoritative adapter documentation and condensing the Desktop operator reference

## Why

The writing and paper-polish workflows were useful local skills but were missing from the shared OSS package. The root README had also grown into an implementation reference that obscured the install and first-run path.

## Validation

- `npm run build`
- `npm run typecheck`
- `node --test --test-concurrency=1 tests/*.test.mjs` (1,211 passed)
- `npm run skills:validate` (43 public skills)
- `npm run package:smoke`
- `git diff --check`

Note: the repository's default parallel `npm test` currently has a baseline race in which tests manipulating `dist/` cause 82 unrelated CLI failures. The same suite passes completely with serial test execution.
