### PR TITLE
fix(benchmarks): split BENCHMARK_HUB_DATA_DIR on the platform path delimiter

### DIFF
--- a/apps/benchmark-hub/README.md
+++ b/apps/benchmark-hub/README.md
@@ -166,7 +166,8 @@ bun run start:demo # production server incl. repo demo data
 
 The server-side loader (`lib/data-core.ts`) scans:
 
-1. `BENCHMARK_HUB_DATA_DIR` — a colon-separated list of directories whose
+1. `BENCHMARK_HUB_DATA_DIR` — a list of directories (separated by the
+   platform path delimiter, `:` on POSIX / `;` on Windows) whose
    subdirectories are benchmarks; when unset, `~/.understudy/benchmarks`
 2. Only when `BENCHMARK_HUB_DEMO=1` (the `dev` and `start:demo` scripts set
    it): `<repo>/experiments/benchmark-hub-demo` (seeded demo data, writable

--- a/src/benchmark-hub-core.ts
+++ b/src/benchmark-hub-core.ts
@@ -78,7 +78,7 @@ export type { CalibrationSummary } from "./benchmark-hub-types.js";
 
 /**
  * Data-dir contract:
- * - BENCHMARK_HUB_DATA_DIR: colon-separated list of directories whose
+ * - BENCHMARK_HUB_DATA_DIR: list of directories (path.delimiter-separated) whose
  *   subdirectories are benchmarks. Each benchmark dir holds benchmark.json
  *   (understudy.benchmark.v1), optional rows-*.jsonl and/or rows/*.jsonl
  *   (understudy.eval_result.v1 lines), optional traces*.jsonl (message DAG
@@ -104,7 +104,7 @@ function demoEnabled(): boolean {
 function slugRoots(): { prefix: string; root: string; source: HubEntry["source"]; readOnly: boolean }[] {
   const roots: { prefix: string; root: string; source: HubEntry["source"]; readOnly: boolean }[] = [];
   const envDirs = (process.env.BENCHMARK_HUB_DATA_DIR ?? "")
-    .split(":")
+    .split(path.delimiter)
     .map((d) => d.trim())
     .filter(Boolean);
   if (envDirs.length > 0) {

--- a/src/benchmarks-mcp.ts
+++ b/src/benchmarks-mcp.ts
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, extname, join, resolve } from "node:path";
+import { basename, delimiter, extname, join, resolve } from "node:path";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -57,15 +57,15 @@ class ToolError extends Error {}
 /**
  * Point the loaders at the requested roots. Default (no extra roots, env
  * unset) is ~/.understudy/benchmarks — data-core's own default. Extra roots
- * are ADDED after the default, via the same colon-separated
+ * are ADDED after the default, via the same path.delimiter-separated
  * BENCHMARK_HUB_DATA_DIR contract the hub honors.
  */
 export function configureBenchmarksMcpRoots(extraRoots: string[]): void {
   if (extraRoots.length === 0) return;
   const defaults = process.env.BENCHMARK_HUB_DATA_DIR
-    ? process.env.BENCHMARK_HUB_DATA_DIR.split(":").filter(Boolean)
+    ? process.env.BENCHMARK_HUB_DATA_DIR.split(delimiter).filter(Boolean)
     : [join(homedir(), ".understudy", "benchmarks")];
-  process.env.BENCHMARK_HUB_DATA_DIR = [...defaults, ...extraRoots.map((r) => resolve(r))].join(":");
+  process.env.BENCHMARK_HUB_DATA_DIR = [...defaults, ...extraRoots.map((r) => resolve(r))].join(delimiter);
 }
 
 /* ---------------- shared summaries ---------------- */
@@ -699,7 +699,7 @@ const SLUG_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 
 function hubPrimaryRoot(): string {
   const roots = (process.env.BENCHMARK_HUB_DATA_DIR ?? join(homedir(), ".understudy", "benchmarks"))
-    .split(":")
+    .split(delimiter)
     .filter(Boolean);
   return roots[0] ?? join(homedir(), ".understudy", "benchmarks");
 }

--- a/tests/benchmarks-mcp.test.mjs
+++ b/tests/benchmarks-mcp.test.mjs
@@ -586,7 +586,7 @@ describe("server wiring", () => {
       configureBenchmarksMcpRoots([]);
       assert.equal(process.env.BENCHMARK_HUB_DATA_DIR, saved); // no-op without roots
       configureBenchmarksMcpRoots(["/tmp/extra-bench"]);
-      assert.equal(process.env.BENCHMARK_HUB_DATA_DIR, `${saved}:${path.resolve("/tmp/extra-bench")}`);
+      assert.equal(process.env.BENCHMARK_HUB_DATA_DIR, `${saved}${path.delimiter}${path.resolve("/tmp/extra-bench")}`);
     } finally {
       process.env.BENCHMARK_HUB_DATA_DIR = saved;
     }


### PR DESCRIPTION
# Problem

`BENCHMARK_HUB_DATA_DIR` is documented as a multi-root list, but every consumer parsed it by splitting on `":"` — the POSIX path-list separator:

- `src/benchmark-hub-core.ts` (`slugRoots`)
- `src/benchmarks-mcp.ts` (`configureBenchmarksMcpRoots`, `hubPrimaryRoot`)

On Windows there is no way to spell a colon-separated list of absolute directories: an absolute path like `C:\Users\me\.understudy\benchmarks` splits into `"C"` and `"\Users\me\.understudy\benchmarks"`. The first fragment becomes the `data` root (resolving to a nonexistent `<cwd>\C` directory) and the real directory lands under the `data2` prefix. Every slug lookup then fails with `unknown benchmark slug: data--<name> (use list_benchmarks)` — for the MCP server, the CLI, and the hub loaders alike.

I found this by running the test suite on Windows: ~31 tests across `tests/benchmarks-mcp.test.mjs`, `tests/experiment-lineage.test.mjs`, and `tests/benchmark-extension.test.mjs` failed with exactly this signature; the fixture sets `BENCHMARK_HUB_DATA_DIR` to a single absolute temp dir, which is enough to trigger the mis-split.

# Fix

Parse and join the env var with `path.delimiter` (`:` on POSIX, `;` on Windows). Behavior on POSIX is byte-for-byte unchanged; on Windows, single absolute paths now parse correctly and the documented multi-root list works with the platform separator. Also updated the contract comment/README wording and one test assertion that hardcoded the `:` join.

# Testing

On Windows 11, Node 24 (before → after):

```
node --test tests/benchmarks-mcp.test.mjs tests/experiment-lineage.test.mjs tests/benchmark-extension.test.mjs

before: exit 1 — 31 failures ("unknown benchmark slug: data--promoted", "fixture benchmark discovered through the shared loader", ...)
after:  exit 0 — tests 58, pass 58, fail 0, skipped 0

npm run typecheck
exit 0
```
