### PR TITLE
fix(capture-import): emit forward-slash artifact references in workload cards

### DIFF
--- a/src/capture-import.ts
+++ b/src/capture-import.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { globalConfigDir } from "./config/paths.js";
 import { readXlsxRecords } from "./capture-import-xlsx.js";
 
@@ -1418,8 +1418,8 @@ function ratio(numerator: number, denominator: number): number {
 }
 
 function artifactReference(repo: string, path: string): string {
-  const repoRelative = relative(repo, path);
-  if (repoRelative === ".." || repoRelative.startsWith("../") || repoRelative.startsWith("..\\")) {
+  const repoRelative = relative(repo, path).split(sep).join("/");
+  if (repoRelative === ".." || repoRelative.startsWith("../")) {
     return path;
   }
   return repoRelative;


### PR DESCRIPTION
# Problem

`artifactReference()` in `src/capture-import.ts` returns `path.relative(repo, …)` verbatim when it builds the metadata-only workload card's discovery fields (`discovery.evidence_paths`, `capture_sources`, `redaction_manifest`). On Windows that embeds backslash-separated paths like:

```json
"evidence_paths": [".understudy\\capture-import\\redaction-manifest.json"]
```

The workload card is a portable artifact (shared with the gateway via `workloads create --from-card`, checked into repos, read by agents on any OS), so native separators leak platform-specific paths into its JSON contract. This is the same convention `src/benchmark-artifacts.ts` already normalizes away (`rel.split(sep).join("/")`) for emitted artifacts.

Found by running the test suite on Windows: `tests/cli.test.mjs` "builds a capture/import workload card from the scan manifest" asserts `.understudy/capture-import/redaction-manifest.json` and fails against the backslashed value.

# Fix

Normalize the repo-relative reference to forward slashes before returning it (`split(sep).join("/")`, matching the existing idiom in `benchmark-artifacts.ts`). The out-of-repo fallback branch is untouched. The pre-existing `../`-prefix check now runs after normalization, so it also correctly catches Windows `..\` escapes through one code path.

# Testing

On Windows 11, Node 24:

```
node --test --test-name-pattern="capture/import" tests/cli.test.mjs
exit 0 — tests 3, pass 3, fail 0
  (includes "builds a capture/import workload card from the scan manifest", previously failing)

node --test --test-name-pattern="workload card" tests/cli.test.mjs
exit 0 — tests 7, pass 7, fail 0

npm run typecheck → exit 0
```
