### PR TITLE
fix(rigor): make --changed-only dir filtering work outside POSIX

### DIFF
--- a/src/rigor-report.ts
+++ b/src/rigor-report.ts
@@ -15,7 +15,7 @@
  */
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { validateBenchmarkManifest } from "./benchmark.js";
 import { readJsonlFile, readRunEvents } from "./benchmark-artifacts.js";
 import {
@@ -625,11 +625,22 @@ export function filterChangedBenchmarkDirs(dirs: string[], baseRef?: string): { 
   let changed: string[];
   let base: string | null = null;
   try {
-    base = baseRef ?? execSync("git merge-base HEAD origin/main 2>/dev/null || git rev-parse HEAD~1", { encoding: "utf8", shell: "/bin/sh" }).trim();
+    if (!baseRef) {
+      try {
+        base = execSync("git merge-base HEAD origin/main", { encoding: "utf8" }).trim();
+      } catch {
+        base = execSync("git rev-parse HEAD~1", { encoding: "utf8" }).trim();
+      }
+    } else {
+      base = baseRef;
+    }
     const repoRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
     changed = execSync(`git diff --name-only ${base} HEAD`, { encoding: "utf8" }).split("\n").filter(Boolean).map((file) => resolve(repoRoot, file));
   } catch {
     return { dirs, base: null };
   }
-  return { dirs: dirs.filter((dir) => changed.some((file) => file.startsWith(`${resolve(dir)}/`) || file === resolve(dir))), base };
+  return { dirs: dirs.filter((dir) => {
+    const absolute = resolve(dir);
+    return changed.some((file) => file === absolute || file.startsWith(`${absolute}${sep}`));
+  }), base };
 }


### PR DESCRIPTION
# Problem

`benchmarks rigor --ci --changed-only` silently degenerates on Windows. Two independent POSIX-only assumptions in `filterChangedBenchmarkDirs()` (`src/rigor-report.ts`):

1. The changed-file prefix check compared against `` `${resolve(dir)}/` `` — a hardcoded forward slash appended to a native-separated absolute path. On Windows `resolve()` yields backslashes, so `C:\repo\bench-a\file` never starts with `C:\repo\bench-a/`, every genuinely touched benchmark dir is filtered out, and CI checks nothing (the opposite failure mode of the documented fail-open fallback, and much quieter).
2. The merge-base lookup ran through an explicit POSIX shell (`shell: "/bin/sh"`) to get `2>/dev/null` + `||` chaining. `/bin/sh` doesn't exist on Windows, so the whole lookup throws and the function falls back to "everything changed".

Found by running the test suite on Windows: both `tests/rigor-ci.test.mjs` cases — "keeps exactly the dirs touched since the base ref" (actual `[]`, expected `[...bench-a]`) and "resolves git's repo-root-relative paths correctly from a subdirectory cwd" — fail at these lines.

# Fix

- Compare `file === resolve(dir)` or `file.startsWith(resolve(dir) + sep)` so the boundary respects the platform separator.
- Split the fallback chain into two `execSync` calls (`git merge-base HEAD origin/main`, falling back to `git rev-parse HEAD~1` on failure) with no explicit shell. Same resolution order as before; Node's default shell handles both commands on POSIX and Windows.

POSIX behavior is unchanged: identical base-ref selection, identical dir ordering, same fail-open catch.

# Testing

On Windows 11, Node 24:

```
node --test tests/rigor-ci.test.mjs tests/rigor-report.test.mjs

before: exit 1 — "keeps exactly the dirs touched since the base ref" and
        "resolves git's repo-root-relative paths correctly from a subdirectory cwd" fail
after:  exit 0 — tests 23, pass 23, fail 0

npm run typecheck → exit 0
```
